### PR TITLE
[REVIEW] RTD build update to fix missing libcuda.so error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <div align="left"><img src="img/rapids_logo.png" width="90px"/>&nbsp;cuDF - GPU DataFrames</div>
 
-[![Build Status](http://18.191.94.64/buildStatus/icon?job=cudf-master)](http://18.191.94.64/job/cudf-master/)&nbsp;&nbsp;[![Documentation Status](https://readthedocs.org/projects/cudf/badge/?version=latest)](https://rapidsai.github.io/docs/cuDF/index.html)
+[![Build Status](http://18.191.94.64/buildStatus/icon?job=cudf-master)](http://18.191.94.64/job/cudf-master/)&nbsp;&nbsp;[![Documentation Status](https://readthedocs.org/projects/cudf/badge/?version=latest)](https://cudf.readthedocs.io/en/latest/)
 
 The [RAPIDS](https://rapids.ai) cuDF library is a GPU DataFrame manipulation library based on Apache Arrow that accelerates loading, filtering, and manipulation of data for model training data preparation. The RAPIDS GPU DataFrame provides a pandas-like API that will be familiar to data scientists, so they can now build GPU-accelerated workflows more easily.
 

--- a/conda_environments/builddocs_py35.yml
+++ b/conda_environments/builddocs_py35.yml
@@ -3,11 +3,13 @@ channels:
 - rapidsai
 - conda-forge
 - numba
+- mikewendt
 - defaults
 dependencies:
 - python=3.5.*
 - pytest
 - cudatoolkit=9.2
+- nvdriver=396.44
 - libgdf=0.2.0.*
 - libgdf_cffi=0.2.0.*
 - numba>=0.40.0dev

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-Welcome to pygdf's documentation!
+Welcome to cuDF's documentation!
 =================================
 
 .. toctree::

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,10 @@
+build:
+   image: latest
+
 python:
    version: 3.5
 
 conda:
-    file: conda_environments/builddocs_py35.yml
+   file: conda_environments/builddocs_py35.yml
 
 


### PR DESCRIPTION
Created custom conda pkg with the libraries from the 396.44 driver to allow these CPU builds to succeed without having to force install a driver.

Docs off of this branch for inspection: https://cudf.readthedocs.io/en/fix-rtd-builds/index.html