### PR TITLE
[REVIEW] FIX out-of-bounds access error in reductions.cu

### DIFF
--- a/libgdf/src/reductions.cu
+++ b/libgdf/src/reductions.cu
@@ -44,12 +44,9 @@ void gpu_reduction_op(const T *data, const gdf_valid_type *mask,
         int i = base + tid;
         // load
         T loaded = identity;
-        if (i < size)
+        if (i < size && gdf_is_valid(mask, i))
             loaded = loader(data, i);
-        // set invalid location to identity
-        if ( !gdf_is_valid(mask, i) ) {
-             loaded = identity;
-        }
+            
         // Block reduce
         T temp = BlockReduce(temp_storage).Reduce(loaded, functor);
         // Add current block


### PR DESCRIPTION
Running `cuda-memcheck make pytest` turned up this error. Fix is trivial: only call `gdf_is_valid()` for indices less than the number of rows.
