### PR TITLE
[REVIEW] ENH Add file/line location logging and convenience macros for RMM

### DIFF
--- a/libgdf/include/memory.h
+++ b/libgdf/include/memory.h
@@ -18,9 +18,9 @@
  * @brief Device Memory Manager public interface. 
  * 
  * Efficient allocation, deallocation and tracking of GPU memory.
- * ---------------------------------------------------------------------------**/
+ * --------------------------------------------------------------------------**/
 
-#pragma once
+#pragma once 
 
 typedef struct CUstream_st *cudaStream_t;
 typedef long int offset_t; // would prefer ptrdiff_t but can't #include <stddef.h>
@@ -28,7 +28,7 @@ typedef long int offset_t; // would prefer ptrdiff_t but can't #include <stddef.
 
 /** ---------------------------------------------------------------------------*
  * @brief RMM error codes
- * ---------------------------------------------------------------------------**/
+ * --------------------------------------------------------------------------**/
 typedef enum
 {
   RMM_SUCCESS = 0,            //< Success result
@@ -61,7 +61,7 @@ typedef struct
  * @param[in] options Structure of options for the memory manager. Defaults are 
  *                    used if it is null.
  * @return rmmError_t RMM_SUCCESS or RMM_ERROR_CUDA_ERROR on any CUDA error.
- * ---------------------------------------------------------------------------**/
+ * --------------------------------------------------------------------------**/
 rmmError_t rmmInitialize(rmmOptions_t *options);
 
 /** ---------------------------------------------------------------------------*
@@ -77,7 +77,7 @@ rmmError_t rmmFinalize();
  * 
  * @param errcode The error returned by an RMM function
  * @return const char* The input error code in string form
- * ---------------------------------------------------------------------------**/
+ * --------------------------------------------------------------------------**/
 const char * rmmGetErrorString(rmmError_t errcode);
 
 /** ---------------------------------------------------------------------------*
@@ -86,12 +86,15 @@ const char * rmmGetErrorString(rmmError_t errcode);
  * @param[out] ptr Returned pointer
  * @param[in] size The size in bytes of the allocated memory region
  * @param[in] stream The stream in which to synchronize this command
+ * @param[in] file The filename location of the call to this function, for tracking
+ * @param[in] line The line number of the call to this function, for tracking
  * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if rmmInitialize
  *                    has not been called, RMM_ERROR_INVALID_ARGUMENT if ptr is
  *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
  *                    requested size, or RMM_CUDA_ERROR on any other CUDA error.
- * ---------------------------------------------------------------------------**/
-rmmError_t rmmAlloc(void **ptr, size_t size, cudaStream_t stream);
+ * --------------------------------------------------------------------------**/
+rmmError_t rmmAlloc(void **ptr, size_t size, cudaStream_t stream,
+                    const char* file, unsigned int line);
 
 /** ---------------------------------------------------------------------------*
  * @brief Reallocate device memory block to new size and recycle any remaining
@@ -100,24 +103,30 @@ rmmError_t rmmAlloc(void **ptr, size_t size, cudaStream_t stream);
  * @param[out] ptr Returned pointer
  * @param[in] new_size The size in bytes of the allocated memory region
  * @param[in] stream The stream in which to synchronize this command
+ * @param[in] file The filename location of the call to this function, for tracking
+ * @param[in] line The line number of the call to this function, for tracking
  * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if rmmInitialize
  *                    has not been called, RMM_ERROR_INVALID_ARGUMENT if ptr is
  *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
  *                    requested size, or RMM_ERROR_CUDA_ERROR on any other CUDA
  *                    error.
- * ---------------------------------------------------------------------------**/
-rmmError_t rmmRealloc(void **ptr, size_t new_size, cudaStream_t stream);
+ * --------------------------------------------------------------------------**/
+rmmError_t rmmRealloc(void **ptr, size_t new_size, cudaStream_t stream,
+                      const char* file, unsigned int line);
 
 /** ---------------------------------------------------------------------------*
  * @brief Release device memory and recycle the associated memory.
  * 
  * @param[in] ptr The pointer to free
  * @param[in] stream The stream in which to synchronize this command
+ * @param[in] file The filename location of the call to this function, for tracking
+ * @param[in] line The line number of the call to this function, for tracking
  * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if rmmInitialize
  *                    has not been called,or RMM_ERROR_CUDA_ERROR on any CUDA
  *                    error.
- * ---------------------------------------------------------------------------**/
-rmmError_t rmmFree(void *ptr, cudaStream_t stream);
+ * --------------------------------------------------------------------------**/
+rmmError_t rmmFree(void *ptr, cudaStream_t stream,
+                   const char* file, unsigned int line);
 
 /** ---------------------------------------------------------------------------*
  * @brief Get the offset of ptr from its base allocation.
@@ -134,7 +143,7 @@ rmmError_t rmmFree(void *ptr, cudaStream_t stream);
  * @param[in] stream The stream originally passed to rmmAlloc or rmmRealloc for
  *                   ptr.
  * @return rmmError_t RMM_SUCCESS if all goes well
- * ---------------------------------------------------------------------------**/
+ * --------------------------------------------------------------------------**/
 rmmError_t rmmGetAllocationOffset(offset_t *offset,
                                   void *ptr,
                                   cudaStream_t stream);
@@ -154,7 +163,7 @@ rmmError_t rmmGetAllocationOffset(offset_t *offset,
  * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if rmmInitialize
  *                    has not been called, or RMM_ERROR_CUDA_ERROR on any CUDA
  *                    error
- * ---------------------------------------------------------------------------**/
+ * --------------------------------------------------------------------------**/
 rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream);
 
 /** ---------------------------------------------------------------------------*
@@ -164,14 +173,14 @@ rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream);
  * 
  * @param filename The full path and filename to write.
  * @return rmmError_t RMM_SUCCESS or RMM_ERROR_IO on output failure.
- * ---------------------------------------------------------------------------**/
+ * --------------------------------------------------------------------------**/
 rmmError_t rmmWriteLog(const char* filename);
 
 /** ---------------------------------------------------------------------------*
  * @brief Get the size of the CSV log string in memory.
  * 
  * @return size_t The size of the log (as a C string) in memory.
- * ---------------------------------------------------------------------------**/
+ * --------------------------------------------------------------------------**/
 size_t rmmLogSize();
 
 /** ---------------------------------------------------------------------------*
@@ -180,5 +189,5 @@ size_t rmmLogSize();
  * @param[out] buffer The buffer into which to store the CSV log string.
  * @param[in] buffer_size The size allocated for buffer.
  * @return rmmError_t RMM_SUCCESS, or RMM_IO_ERROR on any failure.
- * ---------------------------------------------------------------------------**/
+ * --------------------------------------------------------------------------**/
 rmmError_t rmmGetLog(char* buffer, size_t buffer_size);

--- a/libgdf/include/rmm.h
+++ b/libgdf/include/rmm.h
@@ -1,5 +1,20 @@
+#ifndef RMM_H
+#define RMM_H
+
 #include <cuda_runtime_api.h>
 
 extern "C" {
 #include "memory.h"
 }
+
+/** ---------------------------------------------------------------------------*
+ * @brief Device memory alloc / realloc / free macros that pass the calling file
+ * and line number to RMM for tracking.
+ * ---------------------------------------------------------------------------**/
+#define RMM_ALLOC(ptr, sz, stream) rmmAlloc((ptr), (sz), (stream), \
+                                            __FILE__, __LINE__)
+#define RMM_REALLOC(ptr, new_sz, stream) rmmRealloc((ptr), (new_sz), (stream), \
+                                                    __FILE__, __LINE__)
+#define RMM_FREE(ptr, stream) rmmFree((ptr), (stream), __FILE__, __LINE__)
+
+#endif // RMM_H

--- a/libgdf/python/librmm_cffi/wrapper.py
+++ b/libgdf/python/librmm_cffi/wrapper.py
@@ -15,6 +15,7 @@
 import numpy as np
 from numba import cuda
 import ctypes
+import inspect
 from librmm_cffi import librmm_config as rmm_cfg
 
 class RMMError(Exception):
@@ -78,12 +79,67 @@ class _RMMWrapper(object):
                              [rmm_cfg.use_pool_allocator, 
                               rmm_cfg.initial_pool_size, 
                               rmm_cfg.enable_logging])
+        print(rmm_cfg.use_pool_allocator)
+        print(rmm_cfg.initial_pool_size)
+        print(rmm_cfg.enable_logging)
         return self.rmmInitialize(opts)
 
     def finalize(self):
         """Finalizes the RMM library, freeing all allocated memory
         """
         return self.rmmFinalize()
+
+    def _get_caller(self):
+        """Finds the file and line number of the caller (first caller outside
+           this file.)
+        """
+        stack = inspect.stack()
+        # Go up stack to find first caller outside this file (more useful)
+        caller_i = next(x for x in range(len(stack)) 
+                        if 'wrapper.py' not in stack[x][1])
+        caller = stack[caller_i][1:3]
+        file = self._ffi.new("char[]", len(caller[0]))
+        file[0:len(caller[0])] = caller[0].encode()
+        line = self._ffi.cast("int", caller[1])
+        return file, line
+
+    def rmmAlloc(self, size, stream):
+        """Allocates size bytes using the RMM memory manager.
+        """ 
+        file, line = self._get_caller()
+
+        print("Alloc {} bytes", size, self._ffi.string(file))
+                 
+        # Call RMM to allocate
+        ptr = self._ffi.new("void **")
+        stream = self._ffi.cast("cudaStream_t", stream)
+        self._api.rmmAlloc(ptr, size, stream, file, line)
+        return self._ffi.cast("uintptr_t*", ptr)[0]
+
+    def rmmRealloc(self, new_size, stream): 
+        """Reallocates new_size bytes using the RMM memory manager.
+        """ 
+        file, line = self._get_caller()
+         
+        # Call RMM to reaallocate
+        ptr = self._ffi.new("void **")
+        stream = self._ffi.cast("cudaStream_t", stream)
+        self._api.rmmRealloc(ptr, new_size, stream, file, line)
+        return self._ffi.cast("uintptr_t*", ptr)[0]
+
+    def rmmFree(self, ptr, stream):
+        """Deallocates ptr, which was allocated using rmmAlloc
+        """
+        #import pdb; pdb.set_trace()
+
+        file, line = self._get_caller()
+
+        print("Free", self._ffi.string(file), int(line))
+         
+        # Call RMM to free
+        ptr = self._ffi.cast("void*", ptr)
+        stream = self._ffi.cast("cudaStream_t", stream)
+        self._api.rmmFree(ptr, stream, file, line)
 
     def csv_log(self):
         """Returns a CSV log of all events logged by RMM, if logging is 
@@ -138,10 +194,8 @@ class _RMMWrapper(object):
         datasize = cuda.driver.memory_size_from_info(shape, strides,
                                                      dtype.itemsize)
 
-        ptr = self._ffi.new("void **")
-        self._api.rmmAlloc(ptr, datasize,
-                           self._ffi.cast("cudaStream_t", stream))
-        addr = self._ffi.cast("uintptr_t*", ptr)[0]
+        addr = self.rmmAlloc(datasize, stream)       
+        
         # Note Numba will call the finalizer to free the device memory
         # allocated above
         return self._array_helper(addr=addr, datasize=datasize,
@@ -226,7 +280,5 @@ class _RMMWrapper(object):
         def finalizer():
             """Invoked when the MemoryPointer is freed
             """
-            cptr = self._ffi.cast("void*", handle)
-            return self._api.rmmFree(cptr, self._ffi.cast("cudaStream_t",
-                                                            stream))
+            return self.rmmFree(handle, stream)
         return finalizer

--- a/libgdf/python/librmm_cffi/wrapper.py
+++ b/libgdf/python/librmm_cffi/wrapper.py
@@ -107,9 +107,7 @@ class _RMMWrapper(object):
         """Allocates size bytes using the RMM memory manager.
         """ 
         file, line = self._get_caller()
-
-        print("Alloc {} bytes", size, self._ffi.string(file))
-                 
+                
         # Call RMM to allocate
         ptr = self._ffi.new("void **")
         stream = self._ffi.cast("cudaStream_t", stream)
@@ -130,11 +128,7 @@ class _RMMWrapper(object):
     def rmmFree(self, ptr, stream):
         """Deallocates ptr, which was allocated using rmmAlloc
         """
-        #import pdb; pdb.set_trace()
-
         file, line = self._get_caller()
-
-        print("Free", self._ffi.string(file), int(line))
          
         # Call RMM to free
         ptr = self._ffi.cast("void*", ptr)

--- a/libgdf/python/librmm_cffi/wrapper.py
+++ b/libgdf/python/librmm_cffi/wrapper.py
@@ -79,9 +79,6 @@ class _RMMWrapper(object):
                              [rmm_cfg.use_pool_allocator, 
                               rmm_cfg.initial_pool_size, 
                               rmm_cfg.enable_logging])
-        print(rmm_cfg.use_pool_allocator)
-        print(rmm_cfg.initial_pool_size)
-        print(rmm_cfg.enable_logging)
         return self.rmmInitialize(opts)
 
     def finalize(self):

--- a/libgdf/python/tests/test_rmm.py
+++ b/libgdf/python/tests/test_rmm.py
@@ -51,4 +51,4 @@ def test_rmm_csv_log():
 
     assert(csv.find("Event Type,Device ID,Address,Stream,Size (bytes),"
                     "Free Memory,Total Memory,Current Allocs,Start,End,Elapsed,"
-                    "File,Line") >= 0)
+                    "Location") >= 0)

--- a/libgdf/python/tests/test_rmm.py
+++ b/libgdf/python/tests/test_rmm.py
@@ -49,4 +49,6 @@ def test_rmm_csv_log():
 
     print(csv[:1000])
 
-    assert(csv.find("Event Type,Device ID,Address,Stream,Size (bytes),Free Memory,Total Memory,Current Allocs,Start,End,Elapsed") >= 0)
+    assert(csv.find("Event Type,Device ID,Address,Stream,Size (bytes),"
+                    "Free Memory,Total Memory,Current Allocs,Start,End,Elapsed,"
+                    "File,Line") >= 0)

--- a/libgdf/src/column.cpp
+++ b/libgdf/src/column.cpp
@@ -221,8 +221,8 @@ gdf_error gdf_column_view_augmented(gdf_column *column,
  * ---------------------------------------------------------------------------**/
 gdf_error gdf_column_free(gdf_column *column) 
 {
-  RMM_TRY( rmmFree(column->data, 0)  );
-  RMM_TRY( rmmFree(column->valid, 0) );
+  RMM_TRY( RMM_FREE(column->data, 0)  );
+  RMM_TRY( RMM_FREE(column->valid, 0) );
   return GDF_SUCCESS;
 }
 

--- a/libgdf/src/groupby/groupby.cuh
+++ b/libgdf/src/groupby/groupby.cuh
@@ -288,7 +288,7 @@ gdf_column create_gdf_column(const size_t size)
 
   // Allocate the buffer for the column
   // TODO error checking?
-  rmmAlloc((void**)&the_column.data, the_column.size * sizeof(col_type), 0); // TODO: non-default stream?
+  RMM_ALLOC((void**)&the_column.data, the_column.size * sizeof(col_type), 0); // TODO: non-default stream?
   
   return the_column;
 }
@@ -379,8 +379,8 @@ gdf_error multi_pass_avg(int ncols,
   }
 
   // Free intermediate storage
-  RMM_TRY( rmmFree(count_output.data, 0) );
-  RMM_TRY( rmmFree(sum_output.data, 0) );
+  RMM_TRY( RMM_FREE(count_output.data, 0) );
+  RMM_TRY( RMM_FREE(sum_output.data, 0) );
   
   return GDF_SUCCESS;
 }

--- a/libgdf/src/groupby/hash/groupby_compute_api.h
+++ b/libgdf/src/groupby/hash/groupby_compute_api.h
@@ -185,7 +185,7 @@ gdf_error GroupbyHash(gdf_table<size_type> const & groupby_input_table,
 
   // Used by threads to coordinate where to write their results
   size_type * global_write_index{nullptr};
-  RMM_TRY(rmmAlloc((void**)&global_write_index, sizeof(size_type), 0)); // TODO: non-default stream?
+  RMM_TRY(RMM_ALLOC((void**)&global_write_index, sizeof(size_type), 0)); // TODO: non-default stream?
   CUDA_TRY(cudaMemset(global_write_index, 0, sizeof(size_type)));
 
   const dim3 extract_grid_size ((hash_table_size + THREAD_BLOCK_SIZE - 1) / THREAD_BLOCK_SIZE, 1, 1);
@@ -204,7 +204,7 @@ gdf_error GroupbyHash(gdf_table<size_type> const & groupby_input_table,
   // At the end of the extraction kernel, the global write index will be equal to
   // the size of the output. Update the output size.
   CUDA_TRY( cudaMemcpy(out_size, global_write_index, sizeof(size_type), cudaMemcpyDeviceToHost) );
-  RMM_TRY( rmmFree(global_write_index, 0) );
+  RMM_TRY( RMM_FREE(global_write_index, 0) );
   groupby_output_table.set_column_length(*out_size);
 
   // Optionally sort the groupby/aggregation result columns

--- a/libgdf/src/hashing.cu
+++ b/libgdf/src/hashing.cu
@@ -414,7 +414,7 @@ gdf_error hash_partition_gdf_table(gdf_table<size_type> const & input_table,
 
   // Allocate array to hold which partition each row belongs to
   size_type * row_partition_numbers{nullptr};
-  RMM_TRY( rmmAlloc((void**)&row_partition_numbers, num_rows * sizeof(hash_value_type), 0) ); // TODO: non-default stream?
+  RMM_TRY( RMM_ALLOC((void**)&row_partition_numbers, num_rows * sizeof(hash_value_type), 0) ); // TODO: non-default stream?
   
   // Array to hold the size of each partition computed by each block
   //  i.e., { {block0 partition0 size, block1 partition0 size, ...}, 
@@ -422,11 +422,11 @@ gdf_error hash_partition_gdf_table(gdf_table<size_type> const & input_table,
   //          ...
   //          {block0 partition(num_partitions-1) size, block1 partition(num_partitions -1) size, ...} }
   size_type * block_partition_sizes{nullptr};
-  RMM_TRY(rmmAlloc((void**)&block_partition_sizes, (grid_size * num_partitions) * sizeof(size_type), 0) );
+  RMM_TRY(RMM_ALLOC((void**)&block_partition_sizes, (grid_size * num_partitions) * sizeof(size_type), 0) );
 
   // Holds the total number of rows in each partition
   size_type * global_partition_sizes{nullptr};
-  RMM_TRY( rmmAlloc((void**)&global_partition_sizes, num_partitions * sizeof(size_type), 0) );
+  RMM_TRY( RMM_ALLOC((void**)&global_partition_sizes, num_partitions * sizeof(size_type), 0) );
   CUDA_TRY( cudaMemsetAsync(global_partition_sizes, 0, num_partitions * sizeof(size_type)) );
 
   // If the number of partitions is a power of two, we can compute the partition 
@@ -525,12 +525,12 @@ gdf_error hash_partition_gdf_table(gdf_table<size_type> const & input_table,
 
   CUDA_CHECK_LAST();
 
-  RMM_TRY(rmmFree(row_partition_numbers, 0));
-  RMM_TRY(rmmFree(block_partition_sizes, 0));
+  RMM_TRY(RMM_FREE(row_partition_numbers, 0));
+  RMM_TRY(RMM_FREE(block_partition_sizes, 0));
 
   cudaStreamSynchronize(s1);
   cudaStreamDestroy(s1);
-  RMM_TRY(rmmFree(global_partition_sizes, 0));
+  RMM_TRY(RMM_FREE(global_partition_sizes, 0));
 
   return GDF_SUCCESS;
 }

--- a/libgdf/src/hashmap/managed_allocator.cuh
+++ b/libgdf/src/hashmap/managed_allocator.cuh
@@ -61,7 +61,7 @@ struct legacy_allocator {
 
       T* allocate(std::size_t n) const {
           T* ptr = 0;
-          rmmError_t result = rmmAlloc( (void**)&ptr, n*sizeof(T), 0 ); // TODO non-default stream?
+          rmmError_t result = RMM_ALLOC( (void**)&ptr, n*sizeof(T), 0 ); // TODO non-default stream?
           if( RMM_SUCCESS != result || nullptr == ptr ) 
           {
             std::cerr << "ERROR: RMM call in line " << __LINE__ << "of file " 
@@ -74,7 +74,7 @@ struct legacy_allocator {
           return ptr;
       }
       void deallocate(T* p, std::size_t) const noexcept {
-          rmmError_t result = rmmFree(p, 0); // TODO: non-default stream
+          rmmError_t result = RMM_FREE(p, 0); // TODO: non-default stream
           if ( RMM_SUCCESS != result) throw std::runtime_error("legacy_allocator: RMM Memory Manager Error");
       }
 };

--- a/libgdf/src/hashops.cu
+++ b/libgdf/src/hashops.cu
@@ -93,23 +93,21 @@ gdf_error gpu_hash_columns(gdf_column ** columns_to_hash, int num_columns, gdf_c
 
 	//copy widths into device memory
 	int * widths;
-	RMM_TRY( rmmAlloc((void**)&widths,sizeof(int) * num_columns, *stream) ); 
+	RMM_TRY( RMM_ALLOC((void**)&widths,sizeof(int) * num_columns, *stream) ); 
 	int * host_widths = new int[num_columns];
 	for(int i = 0; i <  num_columns; i++){
 		get_column_byte_width(columns_to_hash[i], &host_widths[i]);
 	}
 	CUDA_TRY( cudaMemcpyAsync(widths,host_widths,sizeof(int) * num_columns,cudaMemcpyHostToDevice,*stream) );
 
-
 	//copy addresses into device memory
 	void ** pointers;
-	RMM_TRY( rmmAlloc((void**)&pointers,sizeof(void *) * num_columns, *stream) ); 
+	RMM_TRY( RMM_ALLOC((void**)&pointers,sizeof(void *) * num_columns, *stream) ); 
 	void ** data_holder = new void *[num_columns];
 	for(int i = 0; i <  num_columns; i++){
 		data_holder[i] = columns_to_hash[i]->data;
 	}
 	CUDA_TRY( cudaMemcpyAsync(pointers,data_holder,sizeof(void *) * num_columns,cudaMemcpyHostToDevice,*stream) );
-
 
 	rmm_temp_allocator allocator(*stream);
 
@@ -134,11 +132,9 @@ gdf_error gpu_hash_columns(gdf_column ** columns_to_hash, int num_columns, gdf_c
 						columns_to_hash[i]->valid, *stream, num_values);
 		}
 	}
-
-
 	
-	RMM_TRY( rmmFree(widths, *stream) ); 
-	RMM_TRY( rmmFree(pointers, *stream) );
+	RMM_TRY( RMM_FREE(widths, *stream) ); 
+	RMM_TRY( RMM_FREE(pointers, *stream) );
 	delete[] host_widths;
 	delete[] data_holder;
 

--- a/libgdf/src/io/convert/gdf-to-csr.cu
+++ b/libgdf/src/io/convert/gdf-to-csr.cu
@@ -105,7 +105,7 @@ gdf_error gdf_to_csr(gdf_column **gdfData, int numCol, csr_gdf *csrReturn) {
 
 	// Allocate space for the offset - this will eventually be IA - dtype is long since the sum of all column elements could be larger than int32
 	gdf_size_type * offsets;
-    RMM_TRY(rmmAlloc((void**)&offsets, (numRows + 2) * sizeof(int64_t), 0)); // TODO: non-default stream?
+    RMM_TRY(RMM_ALLOC((void**)&offsets, (numRows + 2) * sizeof(int64_t), 0)); // TODO: non-default stream?
     CUDA_TRY(cudaMemset(offsets, 0, ( sizeof(int64_t) * (numRows + 2) ) ));
 
     // do a pass over each columns, and have each column updates the row count
@@ -132,11 +132,11 @@ gdf_error gdf_to_csr(gdf_column **gdfData, int numCol, csr_gdf *csrReturn) {
 	//--------------------------------------------------------------------------------------
 	// now start creating output data
     size_t * IA;
-    RMM_TRY(rmmAlloc((void**)&IA, (numRows + 2) * sizeof(gdf_size_type), 0));
+    RMM_TRY(RMM_ALLOC((void**)&IA, (numRows + 2) * sizeof(gdf_size_type), 0));
     CUDA_TRY(cudaMemcpy(IA, offsets, ( sizeof(gdf_size_type) * (numRows + 2) ), cudaMemcpyDeviceToDevice) );
 
     int64_t * 	JA;
-    RMM_TRY( rmmAlloc((void**)&JA, (sizeof(int64_t) * nnz), 0));
+    RMM_TRY( RMM_ALLOC((void**)&JA, (sizeof(int64_t) * nnz), 0));
 
     //----------------------------------------------------------------------------------
     // Now just missing A and the moving of data
@@ -172,13 +172,13 @@ gdf_error gdf_to_csr(gdf_column **gdfData, int numCol, csr_gdf *csrReturn) {
     		status = runConverter<double>(gdfData, csrReturn, offsets);
     	    break;
     	default:
-    		RMM_TRY(rmmFree(IA, 0));
-    		RMM_TRY(rmmFree(JA, 0));
-    		RMM_TRY(rmmFree(offsets, 0));
+    		RMM_TRY(RMM_FREE(IA, 0));
+    		RMM_TRY(RMM_FREE(JA, 0));
+    		RMM_TRY(RMM_FREE(offsets, 0));
     		return GDF_UNSUPPORTED_DTYPE;
     }
 
-    RMM_TRY(rmmFree(offsets, 0));
+    RMM_TRY(RMM_FREE(offsets, 0));
 
 	return status;
 }
@@ -206,7 +206,7 @@ gdf_error runConverter(gdf_column **gdfData, csr_gdf *csrReturn, gdf_size_type *
     int blocks  = (numRows + threads - 1) / threads;
 
 	T *			A;
-	RMM_TRY(rmmAlloc((void**)&A, (sizeof(T) * csrReturn->nnz), 0));
+	RMM_TRY(RMM_ALLOC((void**)&A, (sizeof(T) * csrReturn->nnz), 0));
 	CUDA_TRY(cudaMemset(A, 0, (sizeof(T) * csrReturn->nnz)));
 
     // Now start moving the data and creating the CSR

--- a/libgdf/src/io/csv/csv-reader.cu
+++ b/libgdf/src/io/csv/csv-reader.cu
@@ -443,7 +443,7 @@ gdf_error allocateGdfDataSpace(gdf_column *gdf) {
 	long num_bitmaps = (N + 31) / 8;			// 8 bytes per bitmap
 
 	//--- allocate space for the valid bitmaps
-	RMM_TRY( rmmAlloc((void**)&gdf->valid, (sizeof(gdf_valid_type) 	* num_bitmaps), 0) );
+	RMM_TRY( RMM_ALLOC((void**)&gdf->valid, (sizeof(gdf_valid_type) 	* num_bitmaps), 0) );
 	CUDA_TRY(cudaMemset(gdf->valid, 0, (sizeof(gdf_valid_type) 	* num_bitmaps)) );
 
 	//--- Allocate space for the data
@@ -457,7 +457,7 @@ gdf_error allocateGdfDataSpace(gdf_column *gdf) {
 		else return result;
 	}
 	
-	RMM_TRY( rmmAlloc((void**)&gdf->data, bytes_per_element * N, 0) );
+	RMM_TRY( RMM_ALLOC((void**)&gdf->data, bytes_per_element * N, 0) );
 
 	return gdf_error::GDF_SUCCESS;
 }

--- a/libgdf/src/io/csv/csv-reader.cu
+++ b/libgdf/src/io/csv/csv-reader.cu
@@ -266,7 +266,7 @@ gdf_error read_csv(csv_read_arg *args)
 
 	//-----------------------------------------------------------------------------
 	//-- Allocate space to hold the record starting point
-	RMM_TRY( rmmAlloc((void**)&(raw_csv->recStart), (sizeof(unsigned long long) * (raw_csv->num_records + 1)), 0) ); 
+	RMM_TRY( RMM_ALLOC((void**)&(raw_csv->recStart), (sizeof(unsigned long long) * (raw_csv->num_records + 1)), 0) ); 
 	CUDA_TRY( cudaMemset(raw_csv->d_num_records,	0, 		(sizeof(unsigned long long) )) ) ;
 
 	//-----------------------------------------------------------------------------
@@ -349,7 +349,7 @@ gdf_error read_csv(csv_read_arg *args)
 
 
 		raw_csv->h_parseCol = (bool*)malloc(sizeof(bool) * (h_num_cols));
-		RMM_TRY( rmmAlloc ((void**)&raw_csv->d_parseCol,(sizeof(bool) * (h_num_cols)),0 ) );
+		RMM_TRY( RMM_ALLOC((void**)&raw_csv->d_parseCol,(sizeof(bool) * (h_num_cols)),0 ) );
 		for (int i = 0; i<h_num_cols; i++)
 			raw_csv->h_parseCol[i]=true;
 
@@ -390,7 +390,7 @@ gdf_error read_csv(csv_read_arg *args)
 	}
 	else {
 		raw_csv->h_parseCol = (bool*)malloc(sizeof(bool) * (args->num_cols));
-		RMM_TRY( rmmAlloc ((void**)&raw_csv->d_parseCol,(sizeof(bool) * (args->num_cols)),0 ) );
+		RMM_TRY( RMM_ALLOC((void**)&raw_csv->d_parseCol,(sizeof(bool) * (args->num_cols)),0 ) );
 
 		for (int i = 0; i<raw_csv->num_actual_cols; i++){
 			raw_csv->h_parseCol[i]=true;
@@ -453,7 +453,7 @@ gdf_error read_csv(csv_read_arg *args)
 		column_data_t *d_ColumnData,*h_ColumnData;
 
 		h_ColumnData = (column_data_t*)malloc(sizeof(column_data_t) * (raw_csv->num_active_cols));
-		RMM_TRY( rmmAlloc ((void**)&d_ColumnData,(sizeof(column_data_t) * (raw_csv->num_active_cols)),0 ) );
+		RMM_TRY( RMM_ALLOC((void**)&d_ColumnData,(sizeof(column_data_t) * (raw_csv->num_active_cols)),0 ) );
 
 		CUDA_TRY( cudaMemset(d_ColumnData,	0, 	(sizeof(column_data_t) * (raw_csv->num_active_cols)) ) ) ;
 
@@ -489,7 +489,7 @@ gdf_error read_csv(csv_read_arg *args)
 		raw_csv->dtypes=d_detectedTypes;
 
 		free(h_ColumnData);
-		RMM_TRY( rmmFree ( d_ColumnData, 0 ) );
+		RMM_TRY( RMM_FREE( d_ColumnData, 0 ) );
 	}
 	else{
 		for ( int x = 0; x < raw_csv->num_actual_cols; x++) {
@@ -523,10 +523,10 @@ gdf_error read_csv(csv_read_arg *args)
 	h_data 			= (void**)malloc (	sizeof(void*)* (raw_csv->num_active_cols));
 	h_valid 		= (gdf_valid_type**)malloc (	sizeof(gdf_valid_type*)* (raw_csv->num_active_cols));
 
-	RMM_TRY( rmmAlloc ((void**)&d_dtypes, 		(sizeof(gdf_dtype) 			* raw_csv->num_active_cols), 0 ) );
-	RMM_TRY( rmmAlloc ((void**)&d_data, 		(sizeof(void *)				* raw_csv->num_active_cols), 0 ) );
-	RMM_TRY( rmmAlloc ((void**)&d_valid, 		(sizeof(gdf_valid_type *)	* raw_csv->num_active_cols), 0 ) );
-	RMM_TRY( rmmAlloc ((void**)&d_valid_count, 	(sizeof(unsigned long long) * raw_csv->num_active_cols), 0 ) );
+	RMM_TRY( RMM_ALLOC((void**)&d_dtypes, 		(sizeof(gdf_dtype) 			* raw_csv->num_active_cols), 0 ) );
+	RMM_TRY( RMM_ALLOC((void**)&d_data, 		(sizeof(void *)				* raw_csv->num_active_cols), 0 ) );
+	RMM_TRY( RMM_ALLOC((void**)&d_valid, 		(sizeof(gdf_valid_type *)	* raw_csv->num_active_cols), 0 ) );
+	RMM_TRY( RMM_ALLOC((void**)&d_valid_count, 	(sizeof(unsigned long long) * raw_csv->num_active_cols), 0 ) );
 	CUDA_TRY( cudaMemset(d_valid_count,	0, 		(sizeof(unsigned long long)	* raw_csv->num_active_cols)) );
 
 
@@ -540,10 +540,10 @@ gdf_error read_csv(csv_read_arg *args)
 
 	if (stringColCount > 0 ) {
 		h_str_cols = (string_pair**) malloc ((sizeof(string_pair *)	* stringColCount));
-		RMM_TRY( rmmAlloc ((void**)&d_str_cols, 	(sizeof(string_pair *)		* stringColCount), 0) );
+		RMM_TRY( RMM_ALLOC((void**)&d_str_cols, 	(sizeof(string_pair *)		* stringColCount), 0) );
 
 		for (int col = 0; col < stringColCount; col++) {
-			RMM_TRY( rmmAlloc ((void**)(h_str_cols + col), sizeof(string_pair) * (raw_csv->num_records), 0) );
+			RMM_TRY( RMM_ALLOC((void**)(h_str_cols + col), sizeof(string_pair) * (raw_csv->num_records), 0) );
 		}
 
 		CUDA_TRY(cudaMemcpy(d_str_cols, h_str_cols, sizeof(string_pair *)	* stringColCount, cudaMemcpyHostToDevice));
@@ -592,7 +592,7 @@ gdf_error read_csv(csv_read_arg *args)
 
 		gdf->data = (void*)NVStrings::create_from_index(h_str_cols[stringColCount],size_t(raw_csv->num_records));
 
-		RMM_TRY( rmmFree ( h_str_cols [stringColCount], 0 ) );
+		RMM_TRY( RMM_FREE( h_str_cols [stringColCount], 0 ) );
 
 		stringColCount++;
 	}
@@ -614,16 +614,16 @@ gdf_error read_csv(csv_read_arg *args)
 	free(raw_csv->h_parseCol);
 
 	if (d_str_cols != NULL)
-		RMM_TRY( rmmFree ( d_str_cols, 0 ) ); 
+		RMM_TRY( RMM_FREE( d_str_cols, 0 ) ); 
 
-	RMM_TRY( rmmFree ( d_valid, 0 ) );
-	RMM_TRY( rmmFree ( d_valid_count, 0 ) );
-	RMM_TRY( rmmFree ( d_dtypes, 0 ) );
-	RMM_TRY( rmmFree ( d_data, 0 ) ); 
+	RMM_TRY( RMM_FREE( d_valid, 0 ) );
+	RMM_TRY( RMM_FREE( d_valid_count, 0 ) );
+	RMM_TRY( RMM_FREE( d_dtypes, 0 ) );
+	RMM_TRY( RMM_FREE( d_data, 0 ) ); 
 
-	RMM_TRY( rmmFree ( raw_csv->recStart, 0 ) ); 
-	RMM_TRY( rmmFree ( raw_csv->d_parseCol, 0 ) ); 
-	RMM_TRY( rmmFree ( raw_csv->d_num_records, 0 ) ); 
+	RMM_TRY( RMM_FREE( raw_csv->recStart, 0 ) ); 
+	RMM_TRY( RMM_FREE( raw_csv->d_parseCol, 0 ) ); 
+	RMM_TRY( RMM_FREE( raw_csv->d_num_records, 0 ) ); 
 	CUDA_TRY( cudaFree ( raw_csv->data) );
 
 
@@ -670,9 +670,9 @@ gdf_error updateRawCsv( const char * data, long num_bytes, raw_csv_t * raw ) {
 	int num_bits = (num_bytes + 63) / 64;
 
 	CUDA_TRY( cudaMallocManaged ((void**)&raw->data, 		(sizeof(char)		* num_bytes)));
-	// RMM_TRY( rmmAlloc ((void**)&raw->data, 		(sizeof(char)		* num_bytes),0 ));
+	// RMM_TRY( RMM_ALLOC((void**)&raw->data, 		(sizeof(char)		* num_bytes),0 ));
 
-	RMM_TRY( rmmAlloc((void**)&raw->d_num_records, sizeof(unsigned long long),0) );
+	RMM_TRY( RMM_ALLOC((void**)&raw->d_num_records, sizeof(unsigned long long),0) );
 
 	CUDA_TRY( cudaMemcpy(raw->data, data, num_bytes, cudaMemcpyHostToDevice));
 	CUDA_TRY( cudaMemset(raw->d_num_records,0, ((sizeof(long)) )) );
@@ -692,12 +692,7 @@ gdf_error allocateGdfDataSpace(gdf_column *gdf) {
 	long num_bitmaps = (N + 31) / 8;			// 8 bytes per bitmap
 
 	//--- allocate space for the valid bitmaps
-<<<<<<< HEAD
-	RMM_TRY( RMM_ALLOC((void**)&gdf->valid, (sizeof(gdf_valid_type) 	* num_bitmaps), 0) );
-=======
- 	RMM_TRY( rmmAlloc((void**)&(gdf->valid), (sizeof(gdf_valid_type) 	* num_bitmaps), 0) ); 
-
->>>>>>> master
+	RMM_TRY( RMM_ALLOC((void**)&gdf->valid, (sizeof(gdf_valid_type) * num_bitmaps), 0) );
 	CUDA_TRY(cudaMemset(gdf->valid, 0, (sizeof(gdf_valid_type) 	* num_bitmaps)) );
 
 	int elementSize=0;

--- a/libgdf/src/join/hash/join_compute_api.h
+++ b/libgdf/src/join/hash/join_compute_api.h
@@ -117,9 +117,9 @@ gdf_error expand_buffer(
     }
     data_type * new_buffer{nullptr};
     data_type * old_buffer = *buffer;
-    RMM_TRY( rmmAlloc((void**)&new_buffer, requested_size*sizeof(data_type), 0) );
+    RMM_TRY( RMM_ALLOC((void**)&new_buffer, requested_size*sizeof(data_type), 0) );
     CUDA_TRY( cudaMemcpy(new_buffer, old_buffer, buffer_size*sizeof(data_type), cudaMemcpyDeviceToDevice) );
-    RMM_TRY( rmmFree(old_buffer, 0) );
+    RMM_TRY( RMM_FREE(old_buffer, 0) );
     *buffer = new_buffer;
     *buffer_capacity = requested_size;
 
@@ -451,7 +451,7 @@ gdf_error compute_hash_join(
 
   // Allocate device global counter used by threads to determine output write location
   size_type *d_global_write_index{nullptr};
-  RMM_TRY( rmmAlloc((void**)&d_global_write_index, sizeof(size_type), 0) ); // TODO non-default stream?
+  RMM_TRY( RMM_ALLOC((void**)&d_global_write_index, sizeof(size_type), 0) ); // TODO non-default stream?
  
   // Because we only have an estimate of the output size, we may need to probe the
   // hash table multiple times until we've found an output buffer size that is large enough
@@ -462,8 +462,8 @@ gdf_error compute_hash_join(
     output_r_ptr = nullptr;
 
     // Allocate temporary device buffer for join output
-    RMM_TRY( rmmAlloc((void**)&output_l_ptr, estimated_join_output_size*sizeof(output_index_type), 0) );
-    RMM_TRY( rmmAlloc((void**)&output_r_ptr, estimated_join_output_size*sizeof(output_index_type), 0) );
+    RMM_TRY( RMM_ALLOC((void**)&output_l_ptr, estimated_join_output_size*sizeof(output_index_type), 0) );
+    RMM_TRY( RMM_ALLOC((void**)&output_r_ptr, estimated_join_output_size*sizeof(output_index_type), 0) );
     CUDA_TRY( cudaMemsetAsync(d_global_write_index, 0, sizeof(size_type), 0) );
 
     const size_type probe_grid_size{(probe_table_num_rows + block_size -1)/block_size};
@@ -495,8 +495,8 @@ gdf_error compute_hash_join(
       cont = true;
       estimated_join_output_size *= 2;
       // Free the old buffers to prevent a memory leak on the new allocation
-      RMM_TRY( rmmFree(output_l_ptr, 0) );
-      RMM_TRY( rmmFree(output_r_ptr, 0) );
+      RMM_TRY( RMM_FREE(output_l_ptr, 0) );
+      RMM_TRY( RMM_FREE(output_r_ptr, 0) );
     }
     else
     {
@@ -505,7 +505,7 @@ gdf_error compute_hash_join(
   }
 
   // free memory used for the counters
-  RMM_TRY( rmmFree(d_global_write_index, 0) );
+  RMM_TRY( RMM_FREE(d_global_write_index, 0) );
 
   if (join_type == JoinType::FULL_JOIN) {
       append_full_join_indices(
@@ -522,12 +522,12 @@ gdf_error compute_hash_join(
   if (estimated_join_output_size > h_actual_found) {
       output_index_type *copy_output_l_ptr{nullptr};
       output_index_type *copy_output_r_ptr{nullptr};
-      RMM_TRY( rmmAlloc((void**)&copy_output_l_ptr, h_actual_found*sizeof(output_index_type), 0) ); // TODO non-default stream?
-      RMM_TRY( rmmAlloc((void**)&copy_output_r_ptr, h_actual_found*sizeof(output_index_type), 0) );
+      RMM_TRY( RMM_ALLOC((void**)&copy_output_l_ptr, h_actual_found*sizeof(output_index_type), 0) ); // TODO non-default stream?
+      RMM_TRY( RMM_ALLOC((void**)&copy_output_r_ptr, h_actual_found*sizeof(output_index_type), 0) );
       CUDA_TRY( cudaMemcpy(copy_output_l_ptr, output_l_ptr, h_actual_found*sizeof(output_index_type), cudaMemcpyDeviceToDevice) );
       CUDA_TRY( cudaMemcpy(copy_output_r_ptr, output_r_ptr, h_actual_found*sizeof(output_index_type), cudaMemcpyDeviceToDevice) );
-      RMM_TRY( rmmFree(output_l_ptr, 0) );
-      RMM_TRY( rmmFree(output_r_ptr, 0) );
+      RMM_TRY( RMM_FREE(output_l_ptr, 0) );
+      RMM_TRY( RMM_FREE(output_r_ptr, 0) );
       output_l_ptr = copy_output_l_ptr;
       output_r_ptr = copy_output_r_ptr;
   }

--- a/libgdf/src/join/joining.cu
+++ b/libgdf/src/join/joining.cu
@@ -184,7 +184,7 @@ gdf_error allocValueBuffer(data_type ** buffer,
                            const size_type buffer_length,
                            const data_type value) 
 {
-    RMM_TRY( rmmAlloc((void**)buffer, buffer_length*sizeof(data_type), 0) );
+    RMM_TRY( RMM_ALLOC((void**)buffer, buffer_length*sizeof(data_type), 0) );
     thrust::fill(thrust::device, *buffer, *buffer + buffer_length, value);
     return GDF_SUCCESS;
 }
@@ -204,7 +204,7 @@ template <typename data_type,
 gdf_error allocSequenceBuffer(data_type ** buffer,
                          const size_type buffer_length) 
 {
-    RMM_TRY( rmmAlloc((void**)buffer, buffer_length*sizeof(data_type), 0) );
+    RMM_TRY( RMM_ALLOC((void**)buffer, buffer_length*sizeof(data_type), 0) );
     thrust::sequence(thrust::device, *buffer, *buffer + buffer_length);
     return GDF_SUCCESS;
 }
@@ -417,15 +417,15 @@ gdf_error construct_join_output_df(
     for (int i = 0; i < left_table_end; ++i) {
         gdf_column_view(result_cols[i], nullptr, nullptr, join_size, lnonjoincol[i]->dtype);
         int col_width; get_column_byte_width(result_cols[i], &col_width);
-        RMM_TRY( rmmAlloc((void**)&(result_cols[i]->data), col_width * join_size, 0) ); // TODO: non-default stream?
-        RMM_TRY( rmmAlloc((void**)&(result_cols[i]->valid), sizeof(gdf_valid_type)*gdf_get_num_chars_bitmask(join_size), 0) );
+        RMM_TRY( RMM_ALLOC((void**)&(result_cols[i]->data), col_width * join_size, 0) ); // TODO: non-default stream?
+        RMM_TRY( RMM_ALLOC((void**)&(result_cols[i]->valid), sizeof(gdf_valid_type)*gdf_get_num_chars_bitmask(join_size), 0) );
         CUDA_TRY( cudaMemset(result_cols[i]->valid, 0, sizeof(gdf_valid_type)*gdf_get_num_chars_bitmask(join_size)) );
     }
     for (int i = right_table_begin; i < result_num_cols; ++i) {
         gdf_column_view(result_cols[i], nullptr, nullptr, join_size, rnonjoincol[i - right_table_begin]->dtype);
         int col_width; get_column_byte_width(result_cols[i], &col_width);
-        RMM_TRY( rmmAlloc((void**)&(result_cols[i]->data), col_width * join_size, 0) ); // TODO: non-default stream?
-        RMM_TRY( rmmAlloc((void**)&(result_cols[i]->valid), sizeof(gdf_valid_type)*gdf_get_num_chars_bitmask(join_size), 0) );
+        RMM_TRY( RMM_ALLOC((void**)&(result_cols[i]->data), col_width * join_size, 0) ); // TODO: non-default stream?
+        RMM_TRY( RMM_ALLOC((void**)&(result_cols[i]->valid), sizeof(gdf_valid_type)*gdf_get_num_chars_bitmask(join_size), 0) );
         CUDA_TRY( cudaMemset(result_cols[i]->valid, 0, sizeof(gdf_valid_type)*gdf_get_num_chars_bitmask(join_size)) );
     }
     //create joined output column data buffers
@@ -433,8 +433,8 @@ gdf_error construct_join_output_df(
         int i = left_table_end + join_index;
         gdf_column_view(result_cols[i], nullptr, nullptr, join_size, left_cols[left_join_cols[join_index]]->dtype);
         int col_width; get_column_byte_width(result_cols[i], &col_width);
-        RMM_TRY( rmmAlloc((void**)&(result_cols[i]->data), col_width * join_size, 0) ); // TODO: non-default stream?
-        RMM_TRY( rmmAlloc((void**)&(result_cols[i]->valid), sizeof(gdf_valid_type)*gdf_get_num_chars_bitmask(join_size), 0) );
+        RMM_TRY( RMM_ALLOC((void**)&(result_cols[i]->data), col_width * join_size, 0) ); // TODO: non-default stream?
+        RMM_TRY( RMM_ALLOC((void**)&(result_cols[i]->valid), sizeof(gdf_valid_type)*gdf_get_num_chars_bitmask(join_size), 0) );
         CUDA_TRY( cudaMemset(result_cols[i]->valid, 0, sizeof(gdf_valid_type)*gdf_get_num_chars_bitmask(join_size)) );
     }
 
@@ -518,8 +518,8 @@ gdf_error join_call_compute_df(
     using gdf_col_pointer = typename std::unique_ptr<gdf_column, std::function<void(gdf_column*)>>;
     auto gdf_col_deleter = [](gdf_column* col){
         col->size = 0;
-        if (col->data)  { rmmFree(col->data, 0);  }
-        if (col->valid) { rmmFree(col->valid, 0); }
+        if (col->data)  { RMM_FREE(col->data, 0);  }
+        if (col->valid) { RMM_FREE(col->valid, 0); }
     };
     gdf_col_pointer l_index_temp, r_index_temp;
 

--- a/libgdf/src/join/joining.h
+++ b/libgdf/src/join/joining.h
@@ -85,7 +85,7 @@ public:
     void *p = nullptr;
     if(size) {
       if (memory_space_device == space) {
-        if (RMM_SUCCESS != rmmAlloc(&p, size, stream()))
+        if (RMM_SUCCESS != RMM_ALLOC(&p, size, stream()))
           throw cuda_exception_t(cudaPeekAtLastError());
       }
       else {
@@ -99,7 +99,7 @@ public:
   virtual void free(void* p, memory_space_t space) {
     if (p) {
       if (memory_space_device == space) {
-        if (RMM_SUCCESS != rmmFree(p, stream()))
+        if (RMM_SUCCESS != RMM_FREE(p, stream()))
           throw cuda_exception_t(cudaPeekAtLastError());
       }
       else {

--- a/libgdf/src/join/sort/sort-join.cuh
+++ b/libgdf/src/join/sort/sort-join.cuh
@@ -113,8 +113,8 @@ compute_joined_indices(const _join_bounds &bounds,
     int output_npairs = join_count + append_count;
     int *output_l_ptr, *output_r_ptr;
     // TODO: error checking?
-    rmmAlloc((void**)&output_l_ptr, output_npairs*sizeof(int), 0); // TODO non-default stream?
-    rmmAlloc((void**)&output_r_ptr, output_npairs*sizeof(int), 0);
+    RMM_ALLOC((void**)&output_l_ptr, output_npairs*sizeof(int), 0); // TODO non-default stream?
+    RMM_ALLOC((void**)&output_r_ptr, output_npairs*sizeof(int), 0);
     
     if (isInner){
         // Use load-balancing search on the segments. The output is a pair with

--- a/libgdf/src/memory/memory.cpp
+++ b/libgdf/src/memory/memory.cpp
@@ -66,7 +66,7 @@ namespace rmm
         : event(event), device(0), ptr(ptr), size(size), stream(stream),
           usageLogging(usageLogging), line(line)
         {
-            //if (filename) file = filename;
+            if (filename) file = filename;
             if (Manager::getOptions().enable_logging)
             {
                 cudaGetDevice(&device);
@@ -87,9 +87,9 @@ namespace rmm
                 Logger::TimePt end = std::chrono::system_clock::now();
                 size_t freeMem = 0, totalMem = 0;
                 if (usageLogging) rmmGetInfo(&freeMem, &totalMem, stream);
-                /*Manager::getLogger().record(event, device, ptr, start, end,
+                Manager::getLogger().record(event, device, ptr, start, end,
                                             freeMem, totalMem, size, stream,
-                                            file, line);*/
+                                            file, line);
             }
         }
 

--- a/libgdf/src/memory/memory_manager.cpp
+++ b/libgdf/src/memory/memory_manager.cpp
@@ -42,11 +42,9 @@ namespace rmm
             current_allocations.insert(ptr);
         else if (Free == event)
             current_allocations.erase(ptr);
-        std::cout << filename << ":" << line << std::endl;
-        /*events.push_back({event, deviceId, ptr, size, stream, 
+        events.push_back({event, deviceId, ptr, size, stream, 
                          freeMem, totalMem, current_allocations.size(), 
-                         start, end, filename, line});*/
-        //std::cout << "after\n";
+                         start, end, filename, line});
     }
 
     /** -----------------------------------------------------------------------*
@@ -58,7 +56,7 @@ namespace rmm
     void Logger::to_csv(std::ostream &csv)
     {
         csv << "Event Type,Device ID,Address,Stream,Size (bytes),Free Memory,"
-            << "Total Memory,Current Allocs,Start,End,Elapsed,File,Line\n";
+            << "Total Memory,Current Allocs,Start,End,Elapsed,Location\n";
 
         for (auto& e : events)
         {

--- a/libgdf/src/memory/memory_manager.h
+++ b/libgdf/src/memory/memory_manager.h
@@ -20,7 +20,8 @@
  * Note: assumes at least C++11
  * ---------------------------------------------------------------------------**/
 
-#pragma once
+#ifndef MEMORY_MANAGER_H
+#define MEMORY_MANAGER_H
 
 #include <vector>
 #include <chrono>
@@ -76,7 +77,9 @@ namespace rmm
         void record(MemEvent_t event, int deviceId, void* ptr,
                     TimePt start, TimePt end, 
                     size_t freeMem, size_t totalMem,
-                    size_t size=0, cudaStream_t stream=0);
+                    size_t size, cudaStream_t stream,
+                    std::string filename,
+                    unsigned int line);
 
         void clear();
         
@@ -96,6 +99,8 @@ namespace rmm
             size_t currentAllocations;
             TimePt start;
             TimePt end;
+            std::string filename;
+            unsigned int line;
         };
         
         TimePt base_time;
@@ -107,14 +112,16 @@ namespace rmm
     {
     public:
         static Manager& getInstance(){
-            // Myers' singleton. Thread safe and unique in C++11 -- Note, C++11 required!
+            // Myers' singleton. Thread safe and unique. Note: C++11 required.
             static Manager instance;
             return instance;
         }
 
         static Logger& getLogger() { return getInstance().logger; }
 
-        static void setOptions(const rmmOptions_t &options) { getInstance().options = options; }
+        static void setOptions(const rmmOptions_t &options) { 
+            getInstance().options = options; 
+        }
         static rmmOptions_t getOptions() { return getInstance().options; }
 
         void finalize() {
@@ -155,3 +162,5 @@ namespace rmm
         rmmOptions_t options;
     };    
 }
+
+#endif // MEMORY_MANAGER_H

--- a/libgdf/src/scan.cu
+++ b/libgdf/src/scan.cu
@@ -20,11 +20,11 @@ struct Scan {
         void *temp_storage = NULL;
         size_t temp_storage_bytes = 0;
         scan_function(temp_storage, temp_storage_bytes, inp, out, size);
-        RMM_TRY( rmmAlloc(&temp_storage, temp_storage_bytes, 0) ); // TODO: non-default stream
+        RMM_TRY( RMM_ALLOC(&temp_storage, temp_storage_bytes, 0) ); // TODO: non-default stream
         // Do scan
         scan_function(temp_storage, temp_storage_bytes, inp, out, size);
         // Cleanup
-        RMM_TRY( rmmFree(temp_storage, 0) ); // TODO: non-default stream
+        RMM_TRY( RMM_FREE(temp_storage, 0) ); // TODO: non-default stream
 
         return GDF_SUCCESS;
     }

--- a/libgdf/src/segmented_sorting.cu
+++ b/libgdf/src/segmented_sorting.cu
@@ -32,15 +32,15 @@ struct SegmentedRadixSortPlan{
     gdf_error setup(size_t sizeof_key, size_t sizeof_val) {
         back_key_size = num_items * sizeof_key;
         back_val_size = num_items * sizeof_val;
-        RMM_TRY( rmmAlloc(&back_key, back_key_size, stream) ); // TODO: non-default stream
-        RMM_TRY( rmmAlloc(&back_val, back_val_size, stream) );
+        RMM_TRY( RMM_ALLOC(&back_key, back_key_size, stream) ); // TODO: non-default stream
+        RMM_TRY( RMM_ALLOC(&back_val, back_val_size, stream) );
         return GDF_SUCCESS;
     }
 
     gdf_error teardown() {
-        RMM_TRY(rmmFree(back_key, stream));
-        RMM_TRY(rmmFree(back_val, stream));
-        RMM_TRY(rmmFree(storage, stream));
+        RMM_TRY(RMM_FREE(back_key, stream));
+        RMM_TRY(RMM_FREE(back_val, stream));
+        RMM_TRY(RMM_FREE(storage, stream));
         return GDF_SUCCESS;
     }
 };
@@ -148,7 +148,7 @@ struct SegmentedRadixSort {
         } else {
             // We have not operated.
             // Just checking for temporary storage requirement
-            RMM_TRY( rmmAlloc(&plan->storage, plan->storage_bytes, plan->stream) ); // TODO: non-default stream
+            RMM_TRY( RMM_ALLOC(&plan->storage, plan->storage_bytes, plan->stream) ); // TODO: non-default stream
             CUDA_CHECK_LAST();
             // Now that we have allocated, do real work.
             return sort(plan, d_key_buf, d_value_buf, num_segments,

--- a/libgdf/src/sorting.cu
+++ b/libgdf/src/sorting.cu
@@ -31,15 +31,15 @@ struct RadixSortPlan{
     gdf_error setup(size_t sizeof_key, size_t sizeof_val) {
         back_key_size = num_items * sizeof_key;
         back_val_size = num_items * sizeof_val;
-        RMM_TRY( rmmAlloc(&back_key, back_key_size, stream) ); // TODO: non-default stream
-        RMM_TRY( rmmAlloc(&back_val, back_val_size, stream) );
+        RMM_TRY( RMM_ALLOC(&back_key, back_key_size, stream) ); // TODO: non-default stream
+        RMM_TRY( RMM_ALLOC(&back_val, back_val_size, stream) );
         return GDF_SUCCESS;
     }
 
     gdf_error teardown() {
-        RMM_TRY( rmmFree(back_key, stream) );
-        RMM_TRY( rmmFree(back_val, stream) );
-        RMM_TRY( rmmFree(storage, stream) );
+        RMM_TRY( RMM_FREE(back_key, stream) );
+        RMM_TRY( RMM_FREE(back_val, stream) );
+        RMM_TRY( RMM_FREE(storage, stream) );
         return GDF_SUCCESS;
     }
 };
@@ -127,7 +127,7 @@ struct RadixSort {
         } else {
             // We have not operated.
             // Just checking for temporary storage requirement
-            RMM_TRY( rmmAlloc(&plan->storage, plan->storage_bytes, plan->stream) ); // TODO: non-default stream
+            RMM_TRY( RMM_ALLOC(&plan->storage, plan->storage_bytes, plan->stream) ); // TODO: non-default stream
             CUDA_CHECK_LAST();
             // Now that we have allocated, do real work.
             return sort(plan, d_key_buf, d_value_buf);

--- a/libgdf/src/tests/filterops_numeric/helper/utils.cu
+++ b/libgdf/src/tests/filterops_numeric/helper/utils.cu
@@ -53,8 +53,8 @@ gdf_valid_type* gen_gdf_valid(size_t column_size, size_t init_value)
 
 
 void delete_gdf_column(gdf_column * column){
-    rmmFree(column->data, 0);
-    rmmFree(column->valid, 0);
+    RMM_FREE(column->data, 0);
+    RMM_FREE(column->valid, 0);
 }
 
 gdf_size_type count_zero_bits(gdf_valid_type *valid, size_t column_size)

--- a/libgdf/src/tests/filterops_numeric/helper/utils.cuh
+++ b/libgdf/src/tests/filterops_numeric/helper/utils.cuh
@@ -80,7 +80,7 @@ template <typename RawType, typename PointerType>
 auto init_device_vector(gdf_size_type num_elements) -> std::tuple<RawType *, thrust::device_ptr<PointerType>>
 {
     RawType *device_pointer;
-    rmmError_t rmm_error = rmmAlloc((void **)&device_pointer, sizeof(PointerType) * num_elements, 0);
+    rmmError_t rmm_error = RMM_ALLOC((void **)&device_pointer, sizeof(PointerType) * num_elements, 0);
     EXPECT_TRUE(rmm_error == RMM_SUCCESS);
     thrust::device_ptr<PointerType> device_wrapper = thrust::device_pointer_cast((PointerType *)device_pointer);
     return std::make_tuple(device_pointer, device_wrapper);
@@ -121,7 +121,7 @@ gdf_column convert_to_device_gdf_column (gdf_column *column) {
     size_t n_bytes = get_number_of_bytes_for_valid(column_size);
 
     gdf_valid_type *valid_value_pointer;
-    rmmAlloc((void **)&valid_value_pointer, n_bytes, 0);
+    RMM_ALLOC((void **)&valid_value_pointer, n_bytes, 0);
     cudaMemcpy(valid_value_pointer, host_valid, n_bytes, cudaMemcpyHostToDevice);
 
     gdf_column output;
@@ -184,7 +184,7 @@ gdf_column gen_gdb_column(size_t column_size, ValueType init_value)
     size_t n_bytes = get_number_of_bytes_for_valid(column_size);
 
     gdf_valid_type *valid_value_pointer;
-    rmmAlloc((void **)&valid_value_pointer, n_bytes, 0);
+    RMM_ALLOC((void **)&valid_value_pointer, n_bytes, 0);
     cudaMemcpy(valid_value_pointer, host_valid, n_bytes, cudaMemcpyHostToDevice);
    // std::cout << "3. gen_gdb_column\n"; 
     

--- a/libgdf/src/tests/filterops_numeric/test_example.cu
+++ b/libgdf/src/tests/filterops_numeric/test_example.cu
@@ -42,9 +42,9 @@ TEST_F(Example, Equals)
 	char *data_left;
 	char *data_right;
 	char *data_out;
-	rmmError_t rmm_error = rmmAlloc((void **)&data_left, sizeof(int8_t) * num_elements, 0);
-	rmm_error = rmmAlloc((void **)&data_right, sizeof(int8_t) * num_elements, 0);
-	rmm_error = rmmAlloc((void **)&data_out, sizeof(int8_t) * num_elements, 0);
+	rmmError_t rmm_error = RMM_ALLOC((void **)&data_left, sizeof(int8_t) * num_elements, 0);
+	rmm_error = RMM_ALLOC((void **)&data_right, sizeof(int8_t) * num_elements, 0);
+	rmm_error = RMM_ALLOC((void **)&data_out, sizeof(int8_t) * num_elements, 0);
 	ASSERT_EQ(rmm_error, RMM_SUCCESS);
 
 	int8_t int8_value = 2;
@@ -56,11 +56,11 @@ TEST_F(Example, Equals)
 
 	*valid = 255;
 	gdf_valid_type *valid_device;
-	rmm_error = rmmAlloc((void **)&valid_device, 1, 0);
+	rmm_error = RMM_ALLOC((void **)&valid_device, 1, 0);
 	cudaMemcpy(valid_device, valid, sizeof(gdf_valid_type), cudaMemcpyHostToDevice);
 	
 	gdf_valid_type *valid_out;
-	rmm_error = rmmAlloc((void **)&valid_out, 1, 0);
+	rmm_error = RMM_ALLOC((void **)&valid_out, 1, 0);
 	gdf_column lhs;
 	gdf_error error = gdf_column_view_augmented(&lhs, (void *)data_left, valid_device, num_elements, GDF_INT8, 0);
 	gdf_column rhs;
@@ -83,11 +83,11 @@ TEST_F(Example, Equals)
 	std::cout << "Output static_i8" << std::endl;
 	print_column(&output);
 
-	rmmFree(data_left, 0);
-	rmmFree(data_right, 0);
-	rmmFree(data_out, 0);
-	rmmFree(valid_device, 0);
-	rmmFree(valid_out, 0); 
+	RMM_FREE(data_left, 0);
+	RMM_FREE(data_right, 0);
+	RMM_FREE(data_out, 0);
+	RMM_FREE(valid_device, 0);
+	RMM_FREE(valid_out, 0); 
 	delete valid;
 
 	EXPECT_EQ(1, 1);

--- a/libgdf/src/tests/groupby/groupby-test.cu
+++ b/libgdf/src/tests/groupby/groupby-test.cu
@@ -116,11 +116,11 @@ struct GroupTest : public GdfTest {
 
     // Create a new instance of a gdf_column with a custom deleter that will free
     // the associated device memory when it eventually goes out of scope
-    auto deleter = [](gdf_column* col){col->size = 0; rmmFree(col->data, 0);};
+    auto deleter = [](gdf_column* col){col->size = 0; RMM_FREE(col->data, 0);};
     gdf_col_pointer the_column{new gdf_column, deleter};
 
     // Allocate device storage for gdf_column and copy contents from host_vector
-    rmmAlloc(&(the_column->data), host_vector.size() * sizeof(col_type), 0);
+    RMM_ALLOC(&(the_column->data), host_vector.size() * sizeof(col_type), 0);
     cudaMemcpy(the_column->data, host_vector.data(), host_vector.size() * sizeof(col_type), cudaMemcpyHostToDevice);
 
     // Fill the gdf_column members

--- a/libgdf/src/tests/hashing/gdf_test_utils.cuh
+++ b/libgdf/src/tests/hashing/gdf_test_utils.cuh
@@ -53,11 +53,11 @@ gdf_col_pointer create_gdf_column(std::vector<col_type> const & host_vector)
 
   // Create a new instance of a gdf_column with a custom deleter that will free
   // the associated device memory when it eventually goes out of scope
-  auto deleter = [](gdf_column* col){col->size = 0; rmmFree(col->data, 0);};
+  auto deleter = [](gdf_column* col){col->size = 0; RMM_FREE(col->data, 0);};
   gdf_col_pointer the_column{new gdf_column, deleter};
 
   // Allocate device storage for gdf_column and copy contents from host_vector
-  rmmAlloc(&(the_column->data), host_vector.size() * sizeof(col_type), 0);
+  RMM_ALLOC(&(the_column->data), host_vector.size() * sizeof(col_type), 0);
   cudaMemcpy(the_column->data, host_vector.data(), host_vector.size() * sizeof(col_type), cudaMemcpyHostToDevice);
 
   // Fill the gdf_column members

--- a/libgdf/src/tests/join/join-tests.cu
+++ b/libgdf/src/tests/join/join-tests.cu
@@ -135,17 +135,17 @@ struct JoinTest : public GdfTest
 
     // Create a new instance of a gdf_column with a custom deleter that will free
     // the associated device memory when it eventually goes out of scope
-    auto deleter = [](gdf_column* col){col->size = 0; rmmFree(col->data, 0); rmmFree(col->valid, 0); };
+    auto deleter = [](gdf_column* col){col->size = 0; RMM_FREE(col->data, 0); RMM_FREE(col->valid, 0); };
     gdf_col_pointer the_column{new gdf_column, deleter};
 
     // Allocate device storage for gdf_column and copy contents from host_vector
-    rmmAlloc(&(the_column->data), host_vector.size() * sizeof(col_type), 0);
+    RMM_ALLOC(&(the_column->data), host_vector.size() * sizeof(col_type), 0);
     cudaMemcpy(the_column->data, host_vector.data(), host_vector.size() * sizeof(col_type), cudaMemcpyHostToDevice);
 
     // Allocate device storage for gdf_column.valid
     if (host_valid != nullptr) {
       int valid_size = gdf_get_num_chars_bitmask(host_vector.size());
-      rmmAlloc((void**)&(the_column->valid), valid_size, 0);
+      RMM_ALLOC((void**)&(the_column->valid), valid_size, 0);
       cudaMemcpy(the_column->valid, host_valid, valid_size, cudaMemcpyHostToDevice);
     } else {
         the_column->valid = nullptr;

--- a/libgdf/src/tests/memory/memory_tests.cpp
+++ b/libgdf/src/tests/memory/memory_tests.cpp
@@ -59,17 +59,17 @@ TEST_F(MemoryManagerTest, Finalize) {
 
 TEST_F(MemoryManagerTest, AllocateZeroBytes) {
     char *a = 0;
-    ASSERT_SUCCESS(rmmAlloc((void**)&a, 0, stream));
+    ASSERT_SUCCESS(RMM_ALLOC((void**)&a, 0, stream));
 }
 
 TEST_F(MemoryManagerTest, NullPtrAllocateZeroBytes) {
-    ASSERT_SUCCESS(rmmAlloc(0, 0, stream));
+    ASSERT_SUCCESS(RMM_ALLOC(0, 0, stream));
 }
 
 // Bad argument tests
 
 TEST_F(MemoryManagerTest, NullPtrInvalidArgument) {
-    rmmError_t res = rmmAlloc(0, 4, stream);
+    rmmError_t res = RMM_ALLOC(0, 4, stream);
     ASSERT_FAILURE(res);
     ASSERT_EQ(RMM_ERROR_INVALID_ARGUMENT, res);
 }
@@ -78,26 +78,26 @@ TEST_F(MemoryManagerTest, NullPtrInvalidArgument) {
 
 TEST_F(MemoryManagerTest, AllocateWord) {
     char *a = 0;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, size_word, stream) );
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_word, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, AllocateKB) {
     char *a = 0;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, size_kb, stream) );
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_kb, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, AllocateMB) {
     char *a = 0;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, size_mb, stream) );
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_mb, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, AllocateGB) {
     char *a = 0;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, size_gb, stream) );
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_gb, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, AllocateTB) {
@@ -106,54 +106,54 @@ TEST_F(MemoryManagerTest, AllocateTB) {
     ASSERT_SUCCESS( rmmGetInfo(&freeBefore, &totalBefore, stream) );
     
     if (size_tb > freeBefore) {
-        ASSERT_FAILURE( rmmAlloc((void**)&a, size_tb, stream) );
+        ASSERT_FAILURE( RMM_ALLOC((void**)&a, size_tb, stream) );
     }
     else {
-        ASSERT_SUCCESS( rmmAlloc((void**)&a, size_tb, stream) );
+        ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_tb, stream) );
     }
     
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 
 TEST_F(MemoryManagerTest, AllocateTooMuch) {
     char *a = 0;
-    ASSERT_FAILURE( rmmAlloc((void**)&a, size_pb, stream) );
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_FAILURE( RMM_ALLOC((void**)&a, size_pb, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, FreeZero) {
-    ASSERT_SUCCESS( rmmFree(0, stream) );
+    ASSERT_SUCCESS( RMM_FREE(0, stream) );
 }
 
 // Reallocation tests
 
 TEST_F(MemoryManagerTest, ReallocateSmaller) {
     char *a = 0;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, size_mb, stream) );
-    ASSERT_SUCCESS( rmmRealloc((void**)&a, size_mb / 2, stream) );
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_mb, stream) );
+    ASSERT_SUCCESS( RMM_REALLOC((void**)&a, size_mb / 2, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, ReallocateMuchSmaller) {
     char *a = 0;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, size_gb, stream) );
-    ASSERT_SUCCESS( rmmRealloc((void**)&a, size_kb, stream) );
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_gb, stream) );
+    ASSERT_SUCCESS( RMM_REALLOC((void**)&a, size_kb, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, ReallocateLarger) {
     char *a = 0;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, size_mb, stream) );
-    ASSERT_SUCCESS( rmmRealloc((void**)&a, size_mb * 2, stream) );
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_mb, stream) );
+    ASSERT_SUCCESS( RMM_REALLOC((void**)&a, size_mb * 2, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, ReallocateMuchLarger) {
     char *a = 0;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, size_kb, stream) );
-    ASSERT_SUCCESS( rmmRealloc((void**)&a, size_gb, stream) );
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_kb, stream) );
+    ASSERT_SUCCESS( RMM_REALLOC((void**)&a, size_gb, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, GetInfo) {
@@ -164,7 +164,7 @@ TEST_F(MemoryManagerTest, GetInfo) {
 
     char *a = 0;
     size_t sz = size_gb / 2;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, sz, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, sz, stream) );
 
     // make sure the available free memory goes down after an allocation
     size_t freeAfter = 0, totalAfter = 0;
@@ -172,14 +172,14 @@ TEST_F(MemoryManagerTest, GetInfo) {
     ASSERT_GE(totalAfter, totalBefore);
     ASSERT_LE(freeAfter, freeBefore);
 
-    ASSERT_SUCCESS( rmmFree(a, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TEST_F(MemoryManagerTest, AllocationOffset) {
     char *a = nullptr, *b = nullptr;
     ptrdiff_t offset = -1;
-    ASSERT_SUCCESS( rmmAlloc((void**)&a, size_kb, stream) );
-    ASSERT_SUCCESS( rmmAlloc((void**)&b, size_kb, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&a, size_kb, stream) );
+    ASSERT_SUCCESS( RMM_ALLOC((void**)&b, size_kb, stream) );
 
     ASSERT_SUCCESS( rmmGetAllocationOffset(&offset, a, stream) );
     ASSERT_GE(offset, 0);
@@ -187,6 +187,6 @@ TEST_F(MemoryManagerTest, AllocationOffset) {
     ASSERT_SUCCESS( rmmGetAllocationOffset(&offset, b, stream) );
     ASSERT_GE(offset, 0);
 
-    ASSERT_SUCCESS( rmmFree(a, stream) );
-    ASSERT_SUCCESS( rmmFree(b, stream) );
+    ASSERT_SUCCESS( RMM_FREE(a, stream) );
+    ASSERT_SUCCESS( RMM_FREE(b, stream) );
 }

--- a/libgdf/src/tests/test_utils/gdf_test_utils.cuh
+++ b/libgdf/src/tests/test_utils/gdf_test_utils.cuh
@@ -183,20 +183,20 @@ gdf_col_pointer create_gdf_column(std::vector<col_type> const & host_vector,
   // the associated device memory when it eventually goes out of scope
   auto deleter = [](gdf_column* col){
                                       col->size = 0; 
-                                      if(nullptr != col->data){rmmFree(col->data, 0);} 
-                                      if(nullptr != col->valid){rmmFree(col->valid, 0);}
+                                      if(nullptr != col->data){RMM_FREE(col->data, 0);} 
+                                      if(nullptr != col->valid){RMM_FREE(col->valid, 0);}
                                     };
   gdf_col_pointer the_column{new gdf_column, deleter};
 
   // Allocate device storage for gdf_column and copy contents from host_vector
-  rmmAlloc(&(the_column->data), host_vector.size() * sizeof(col_type), 0);
+  RMM_ALLOC(&(the_column->data), host_vector.size() * sizeof(col_type), 0);
   cudaMemcpy(the_column->data, host_vector.data(), host_vector.size() * sizeof(col_type), cudaMemcpyHostToDevice);
 
   // If a validity bitmask vector was passed in, allocate device storage 
   // and copy its contents from the host vector
   if(valid_vector.size() > 0)
   {
-    rmmAlloc((void**)&(the_column->valid), valid_vector.size() * sizeof(gdf_valid_type), 0);
+    RMM_ALLOC((void**)&(the_column->valid), valid_vector.size() * sizeof(gdf_valid_type), 0);
     cudaMemcpy(the_column->valid, valid_vector.data(), valid_vector.size() * sizeof(gdf_valid_type), cudaMemcpyHostToDevice);
   }
   else

--- a/libgdf/src/thrust_rmm_allocator.h
+++ b/libgdf/src/thrust_rmm_allocator.h
@@ -43,11 +43,11 @@ class rmm_allocator : public thrust::device_malloc_allocator<T>
     {
       value_type* result = nullptr;
   
-      rmmError_t error = rmmAlloc((void**)&result, n*sizeof(value_type), stream);
+      rmmError_t error = RMM_ALLOC((void**)&result, n*sizeof(value_type), stream);
      
       if(error != RMM_SUCCESS)
       {
-        throw thrust::system_error(error, thrust::cuda_category(), "rmm_allocator::allocate(): rmmAlloc");
+        throw thrust::system_error(error, thrust::cuda_category(), "rmm_allocator::allocate(): RMM_ALLOC");
       }
   
       return thrust::device_pointer_cast(result);
@@ -55,11 +55,11 @@ class rmm_allocator : public thrust::device_malloc_allocator<T>
   
     inline void deallocate(pointer ptr, size_t)
     {
-      rmmError_t error = rmmFree(thrust::raw_pointer_cast(ptr), stream);
+      rmmError_t error = RMM_FREE(thrust::raw_pointer_cast(ptr), stream);
   
       if(error != RMM_SUCCESS)
       {
-        throw thrust::system_error(error, thrust::cuda_category(), "rmm_allocator::deallocate(): rmmFree");
+        throw thrust::system_error(error, thrust::cuda_category(), "rmm_allocator::deallocate(): RMM_FREE");
       }
     }
 

--- a/libgdf/src/validops.cu
+++ b/libgdf/src/validops.cu
@@ -161,7 +161,7 @@ gdf_error gdf_count_nonzero_mask(gdf_valid_type const * masks, int num_rows, int
     // Cast validity buffer to 4 byte type
     valid32_t const * masks32 = reinterpret_cast<valid32_t const *>(masks);
 
-    RMM_TRY(rmmAlloc((void**)&d_count, sizeof(int), count_stream));
+    RMM_TRY(RMM_ALLOC((void**)&d_count, sizeof(int), count_stream));
     CUDA_TRY(cudaMemsetAsync(d_count, 0, sizeof(int), count_stream));
 
     const int grid_size = (num_masks32 + block_size - 1)/block_size;
@@ -171,7 +171,7 @@ gdf_error gdf_count_nonzero_mask(gdf_valid_type const * masks, int num_rows, int
     CUDA_TRY( cudaGetLastError() );
 
     CUDA_TRY(cudaMemcpyAsync(&h_count, d_count, sizeof(int), cudaMemcpyDeviceToHost, count_stream));
-    RMM_TRY(rmmFree(d_count, count_stream));
+    RMM_TRY(RMM_FREE(d_count, count_stream));
     CUDA_TRY(cudaStreamSynchronize(count_stream));
     CUDA_TRY(cudaStreamDestroy(count_stream));
   }

--- a/libgdf/src/windowedops.cu
+++ b/libgdf/src/windowedops.cu
@@ -97,12 +97,12 @@ void multi_col_order_by(size_t nrows,
 			cudaStream_t stream = NULL)*/
 
 	void ** device_order_columns;
-	RMM_TRY( rmmAlloc(&device_order_columns,sizeof(void *) * num_window_order_columns + 1, stream) );
+	RMM_TRY( RMM_ALLOC(&device_order_columns,sizeof(void *) * num_window_order_columns + 1, stream) );
 
 	//copy copy device pointers
 
 	int * device_column_types;
-	RMM_TRY( rmmAlloc((void**)&device_column_types,sizeof(int) * num_window_order_columns + 1, stream) );
+	RMM_TRY( RMM_ALLOC((void**)&device_column_types,sizeof(int) * num_window_order_columns + 1, stream) );
 
 	gdf_column** order_by_cols = new gdf_column*[num_window_order_columns + 1];
 	for(int i = 0; i < num_window_order_columns; i++){
@@ -114,7 +114,7 @@ void multi_col_order_by(size_t nrows,
 				 device_order_columns, device_column_types, stream);
 
 	gdf_size_type * device_index_outputs;
-	RMM_TRY( rmmAlloc((void**)&device_index_outputs, sizeof(gdf_size_type) * num_rows, stream) );
+	RMM_TRY( RMM_ALLOC((void**)&device_index_outputs, sizeof(gdf_size_type) * num_rows, stream) );
 
 	multi_col_order_by(num_rows, num_window_order_columns + 1, device_order_columns,
 			           device_column_types, device_index_outputs, stream);
@@ -123,8 +123,8 @@ void multi_col_order_by(size_t nrows,
 	//process reduction
 
 	delete[] order_by_cols;
-	RMM_TRY( rmmFree(device_order_columns, stream) );
-	RMM_TRY( rmmFree(device_column_types, stream) );
+	RMM_TRY( RMM_FREE(device_order_columns, stream) );
+	RMM_TRY( RMM_FREE(device_column_types, stream) );
 
 	//no stable sort by the hash of the partition column
 


### PR DESCRIPTION
Modifies `rmmAlloc`, `rmmFree`, and `rmmRealloc` to take required file name and line number parameters, and adds convenience macros that call them using the preprocessor to get the file and line number of the caller.

Also does the equivalent in the RMM Python API by using the Python `inspect` module. The CSV log now reports the location of each event.

Since this changes every call to RMM to one of the macros, it touches a lot of files on the C++ side (but not a lot on the Python side)