### PR TITLE
[REVIEW] Add handling pyarrow boolean arrays in input/out, add tests; Fixes #322

### DIFF
--- a/cudf/columnops.py
+++ b/cudf/columnops.py
@@ -222,6 +222,23 @@ def as_column(arbitrary):
                           "be typecast to a Date64 value", UserWarning)
             arbitrary = arbitrary.cast(pa.date64())
             data = as_column(arbitrary)
+        elif isinstance(arbitrary, pa.BooleanArray):
+            # Arrow uses 1 bit per value while we use int8
+            dtype = np.dtype(np.bool)
+            arbitrary = arbitrary.cast(pa.int8())
+            if arbitrary.buffers()[0]:
+                pamask = Buffer(np.array(arbitrary.buffers()[0]))
+            else:
+                pamask = None
+            padata = Buffer(np.array(arbitrary.buffers()[1]).view(
+                dtype
+            ))
+            data = numerical.NumericalColumn(
+                data=padata,
+                mask=pamask,
+                null_count=arbitrary.null_count,
+                dtype=dtype
+            )
         else:
             if arbitrary.buffers()[0]:
                 pamask = Buffer(np.array(arbitrary.buffers()[0]))

--- a/cudf/numerical.py
+++ b/cudf/numerical.py
@@ -143,7 +143,7 @@ class NumericalColumn(columnops.TypedColumnBase):
             mask = pa.py_buffer(self.nullmask.mem.copy_to_host())
         data = pa.py_buffer(self.data.mem.copy_to_host())
         pa_dtype = _gdf.np_to_pa_dtype(self.dtype)
-        return pa.Array.from_buffers(
+        out = pa.Array.from_buffers(
             type=pa_dtype,
             length=len(self),
             buffers=[
@@ -152,6 +152,10 @@ class NumericalColumn(columnops.TypedColumnBase):
             ],
             null_count=self.null_count
         )
+        if self.dtype == np.bool:
+            return out.cast(pa.bool_())
+        else:
+            return out
 
     def _unique_segments(self):
         """ Common code for unique, unique_count and value_counts"""

--- a/cudf/tests/test_dataframe.py
+++ b/cudf/tests/test_dataframe.py
@@ -747,7 +747,8 @@ def test_from_arrow(nelem, data_type):
 @pytest.mark.parametrize('nelem', [0, 2, 3, 100, 1000])
 @pytest.mark.parametrize(
     'data_type',
-    ['int8', 'int16', 'int32', 'int64', 'float32', 'float64', 'datetime64[ms]']
+    ['bool', 'int8', 'int16', 'int32', 'int64',
+     'float32', 'float64', 'datetime64[ms]']
 )
 def test_to_arrow(nelem, data_type):
     df = pd.DataFrame(
@@ -798,7 +799,8 @@ def test_to_arrow(nelem, data_type):
 
 @pytest.mark.parametrize(
     'data_type',
-    ['int8', 'int16', 'int32', 'int64', 'float32', 'float64', 'datetime64[ms]']
+    ['bool', 'int8', 'int16', 'int32', 'int64',
+     'float32', 'float64', 'datetime64[ms]']
 )
 def test_to_from_arrow_nulls(data_type):
     if data_type == 'datetime64[ms]':


### PR DESCRIPTION
Needed to add typecasting to/from int8 for booleans to be properly handled since Arrow uses a bit array