### PR TITLE
[REVIEW] Preserve categorical dtype after groupby-agg (Fixes #288)

### DIFF
--- a/cudf/categorical.py
+++ b/cudf/categorical.py
@@ -73,6 +73,7 @@ class CategoricalColumn(columnops.TypedColumnBase):
         """
         categories = kwargs.pop('categories')
         ordered = kwargs.pop('ordered')
+        kwargs.update({'dtype' : pd.core.dtypes.dtypes.CategoricalDtype()})
         super(CategoricalColumn, self).__init__(**kwargs)
         self._categories = tuple(categories)
         self._ordered = bool(ordered)
@@ -198,8 +199,7 @@ class CategoricalColumn(columnops.TypedColumnBase):
             data=Buffer(list(range(0, len(self._categories))),
                         categorical=True),
             categories=self._categories,
-            ordered=self._ordered,
-            dtype=self.dtype)
+            ordered=self._ordered)
 
     def unique_count(self, method='sort'):
         if method is not 'sort':
@@ -301,7 +301,7 @@ def pandas_categorical_as_column(categorical, codes=None):
     #       https://github.com/pandas-dev/pandas/pull/16015
     valid_codes = codes != -1
     buf = Buffer(codes)
-    params = dict(data=buf, dtype=categorical.dtype,
+    params = dict(data=buf,
                   categories=categorical.categories,
                   ordered=categorical.ordered)
     if not np.all(valid_codes):

--- a/cudf/categorical.py
+++ b/cudf/categorical.py
@@ -73,7 +73,7 @@ class CategoricalColumn(columnops.TypedColumnBase):
         """
         categories = kwargs.pop('categories')
         ordered = kwargs.pop('ordered')
-        kwargs.update({'dtype' : pd.core.dtypes.dtypes.CategoricalDtype()})
+        kwargs.update({'dtype': pd.core.dtypes.dtypes.CategoricalDtype()})
         super(CategoricalColumn, self).__init__(**kwargs)
         self._categories = tuple(categories)
         self._ordered = bool(ordered)

--- a/cudf/columnops.py
+++ b/cudf/columnops.py
@@ -185,7 +185,6 @@ def as_column(arbitrary):
                 null_count=arbitrary.null_count,
                 categories=arbitrary.dictionary.to_pylist(),
                 ordered=arbitrary.type.ordered,
-                dtype="category"  # What's the correct way to specify this?
             )
         elif isinstance(arbitrary, pa.TimestampArray):
             arbitrary = arbitrary.cast(pa.timestamp('ms'))

--- a/cudf/dataframe.py
+++ b/cudf/dataframe.py
@@ -805,7 +805,6 @@ class DataFrame(object):
             elif on[idx] in col_cats.keys():
                 df[on[idx]] = CategoricalColumn(data=Buffer(cols[idx + gap]),
                                                 categories=col_cats[on[idx]],
-                                                dtype='category',
                                                 ordered=False,
                                                 mask=Buffer(valids[idx]))
             else:
@@ -825,7 +824,6 @@ class DataFrame(object):
                 elif f_n in col_cats.keys():
                     df[f_n] = CategoricalColumn(data=Buffer(cols[idx]),
                                                 categories=col_cats[f_n],
-                                                dtype='category',
                                                 ordered=False,
                                                 mask=Buffer(valids[idx]))
                 else:
@@ -846,7 +844,6 @@ class DataFrame(object):
                 elif f_n in col_cats.keys():
                     df[f_n] = CategoricalColumn(data=Buffer(cols[idx]),
                                                 categories=col_cats[f_n],
-                                                dtype='categorical',
                                                 ordered=False,
                                                 mask=Buffer(valids[idx]))
                 else:
@@ -979,7 +976,6 @@ class DataFrame(object):
         if cat_join:
             df[idx_col_name] = CategoricalColumn(data=df[idx_col_name].data,
                                                  categories=cats,
-                                                 dtype='categorical',
                                                  ordered=False)
 
         df = df.set_index(idx_col_name)

--- a/cudf/libgdf_groupby.py
+++ b/cudf/libgdf_groupby.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
 import numpy as np
-import pandas as pd
 import collections
+
+from pandas.api.types import is_categorical_dtype
 
 from .dataframe import DataFrame, Series
 from .buffer import Buffer
@@ -138,7 +139,8 @@ class LibGdfGroupby(object):
                 for i, thisBy in enumerate(self._by):
                     result[thisBy] = out_col_values_series[i][
                         :num_row_results]
-                    if pd.api.types.is_categorical_dtype(self._df[thisBy].dtype):
+
+                    if is_categorical_dtype(self._df[thisBy].dtype):
                         result[thisBy] = CategoricalColumn(
                             data=result[thisBy].data,
                             categories=self._df[thisBy].cat.categories,

--- a/cudf/libgdf_groupby.py
+++ b/cudf/libgdf_groupby.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
 import numpy as np
+import pandas as pd
 import collections
 
 from .dataframe import DataFrame, Series
@@ -137,12 +138,11 @@ class LibGdfGroupby(object):
                 for i, thisBy in enumerate(self._by):
                     result[thisBy] = out_col_values_series[i][
                         :num_row_results]
-                    if self._df[thisBy].dtype == 'category':
+                    if pd.api.types.is_categorical_dtype(self._df[thisBy].dtype):
                         result[thisBy] = CategoricalColumn(
                             data=result[thisBy].data,
                             categories=self._df[thisBy].cat.categories,
-                            ordered=self._df[thisBy].cat.ordered,
-                            dtype='category')
+                            ordered=self._df[thisBy].cat.ordered)
 
             out_col_agg_series.data.size = num_row_results
             out_col_agg_series = out_col_agg_series.reset_index()

--- a/cudf/libgdf_groupby.py
+++ b/cudf/libgdf_groupby.py
@@ -5,6 +5,7 @@ import collections
 
 from .dataframe import DataFrame, Series
 from .buffer import Buffer
+from .categorical import CategoricalColumn
 
 from libgdf_cffi import ffi, libgdf
 from librmm_cffi import librmm as rmm
@@ -132,9 +133,15 @@ class LibGdfGroupby(object):
             num_row_results = out_col_agg.size
 
             if first_run:
-                for i in range(0, ncols):
-                    result[self._by[i]] = out_col_values_series[i][
+                for i, thisBy in enumerate(self._by):
+                    result[thisBy] = out_col_values_series[i][
                         :num_row_results]
+                    if self._df[thisBy].dtype == 'category':
+                        result[thisBy] = CategoricalColumn(
+                            data=result[thisBy].data,
+                            categories=self._df[thisBy].cat.categories,
+                            ordered=self._df[thisBy].cat.ordered,
+                            dtype='category')
 
             out_col_agg_series.data.size = num_row_results
             out_col_agg_series = out_col_agg_series.reset_index()

--- a/cudf/tests/test_groupby.py
+++ b/cudf/tests/test_groupby.py
@@ -117,7 +117,8 @@ def test_groupby_agg_min_max_dictargs(nelem, method):
     np.testing.assert_array_almost_equal(expect_max, got_max)
 
 
-def test_groupby_cats():
+@pytest.mark.parametrize('method', get_methods())
+def test_groupby_cats(method):
     df = DataFrame()
     df['cats'] = pd.Categorical(list('aabaacaab'))
     df['vals'] = np.random.random(len(df))
@@ -125,9 +126,13 @@ def test_groupby_cats():
     cats = np.asarray(list(df['cats']))
     vals = df['vals'].to_array()
 
-    grouped = df.groupby(['cats'], method="cudf").mean()
+    grouped = df.groupby(['cats'], method=method).mean()
 
-    got_vals = grouped['vals']
+    if method == 'cudf':
+        got_vals = grouped['vals']
+    else:
+        got_vals = grouped['mean_vals']
+
     got_cats = grouped['cats']
 
     for c, v in zip(got_cats, got_vals):


### PR DESCRIPTION
Currently after a groupby-agg, the dtype of categorical columns is changed to `int8`. This fix converts them back to categorical dtype.

Also adds tests for `sort` and `hash` based groupby for categoricals.