### PR TITLE
[WIP] Corrected bug that made all series be considered booleans for indexing

### DIFF
--- a/cudf/columnops.py
+++ b/cudf/columnops.py
@@ -115,6 +115,10 @@ def column_select_by_boolmask(column, boolmask):
 
 
 def column_select_by_position(column, positions):
+    """Select by a series of dtype int64 indicating positions.
+
+    Returns (selected_column, selected_positions)
+    """
     from .numerical import NumericalColumn
     assert column.null_count == 0
 

--- a/cudf/columnops.py
+++ b/cudf/columnops.py
@@ -114,6 +114,20 @@ def column_select_by_boolmask(column, boolmask):
                                             dtype=selected_index.dtype)
 
 
+def column_select_by_position(column, positions):
+    from .numerical import NumericalColumn
+    assert column.null_count == 0
+
+    selvals = cudautils.gather(column.data.to_gpu_array(),
+                               positions.data.to_gpu_array())
+
+    selected_values = column.replace(data=Buffer(selvals))
+    selected_index = Buffer(positions.data.to_gpu_array())
+
+    return selected_values, NumericalColumn(data=selected_index,
+                                            dtype=selected_index.dtype)
+
+
 def as_column(arbitrary):
     """Create a Column from an arbitrary object
 

--- a/cudf/cudautils.py
+++ b/cudf/cudautils.py
@@ -279,11 +279,14 @@ def compact_mask_bytes(boolbytes):
     """Convert booleans (in bytes) to a bitmask
     """
     bits = make_mask(boolbytes.size)
+    # print(bits.copy_to_host())
     if bits.size > 0:
         # Fill zero
+        print("filling zero")
         gpu_fill_value.forall(bits.size)(bits, 0)
         # Compact
         gpu_compact_mask_bytes.forall(bits.size)(boolbytes, bits)
+    # print(bits.copy_to_host())
     return bits
 
 

--- a/cudf/series.py
+++ b/cudf/series.py
@@ -181,9 +181,14 @@ class Series(object):
 
     def __getitem__(self, arg):
         if isinstance(arg, Series):
-            selvals, selinds = columnops.column_select_by_boolmask(
+            if arg.dtype == np.int64:
+                selvals, selinds = columnops.column_select_by_position(
                 self._column, arg)
-            index = self.index.take(selinds.to_gpu_array())
+                index = self.index.take(selinds.to_gpu_array())
+            else:
+                selvals, selinds = columnops.column_select_by_boolmask(
+                self._column, arg)
+                index = self.index.take(selinds.to_gpu_array())
             return self._copy_construct(data=selvals, index=index)
 
         elif isinstance(arg, slice):


### PR DESCRIPTION
Corrected bug that made all series be considered booleans for indexing, allowing using numerical series for indexing: 

```data = gd.Series([1,2,3,4,5])
idx = gd.Series([0,0,0,1,0])
print(data[idx])

0    1
0    1
0    1
1    2
0    1 