### PR TITLE
[REVIEW] Adding support to read strings with delimiters

### DIFF
--- a/cpp/include/cudf/io_types.h
+++ b/cpp/include/cudf/io_types.h
@@ -36,7 +36,7 @@ typedef struct {
   /*
    * Input arguments - all data is in the host
    */
-  char			*file_path;					/**< file location to read from	- currently the file cannot be compressed 							*/
+  const char	*file_path;					/**< file location to read from	- currently the file cannot be compressed 							*/
   char			*buffer	;					// process data from a buffer,  pointer to Host memory
   char			*object	;					// this is a URL path
 
@@ -79,16 +79,15 @@ typedef struct {
 
   char			decimal;					// the decimal point character
 
-  char			*quotechar;					// single character 	character to use as a quote
-  bool			doublequote;				// whether to treat two quotes as a quote in a string or empty
+  char			quotechar;					/**< define the character used to denote start and end of a quoted item								*/
+  bool			quoting;					/**< treat string fields as quoted item and remove the first and last quotechar						*/
+  bool			nodoublequote;				// indicate to not interpret two consecutive quotechar as a single quotechar
 
   char			escapechar;					// single char	- char used as the escape character
 
   char			comment;					// single char	- treat line or remainder of line as an unprocessed comment
 
   char			*encoding;					// the data encoding, NULL = UTF-8
-
-  bool			quoting;					// TRUE: keep the quotes in the text. FALSE: remove the quotes from the strings. Only for quotes starting and ending the strings.
 
 } csv_read_arg;
 

--- a/cpp/include/cudf/io_types.h
+++ b/cpp/include/cudf/io_types.h
@@ -81,7 +81,7 @@ typedef struct {
 
   char			quotechar;					/**< define the character used to denote start and end of a quoted item								*/
   bool			quoting;					/**< treat string fields as quoted item and remove the first and last quotechar						*/
-  bool			nodoublequote;				// indicate to not interpret two consecutive quotechar as a single quotechar
+  bool			doublequote;				/**< indicates whether to interpret two consecutive quotechar inside a field as a single quotechar	*/
 
   char			escapechar;					// single char	- char used as the escape character
 
@@ -104,7 +104,6 @@ typedef struct {
  * keep_date_col	- will not maintain raw data
  * date_parser		- there is only this parser
  * float_precision	- there is only one converter that will cover all specified values
- * quoting			- this is for out
  * dialect			- not used
  *
  */

--- a/cpp/include/cudf/io_types.h
+++ b/cpp/include/cudf/io_types.h
@@ -88,6 +88,8 @@ typedef struct {
 
   char			*encoding;					// the data encoding, NULL = UTF-8
 
+  bool			keepQuotes;					// TRUE: keep the quotes in the text. FALSE: remove the quotes from the strings. Only for quotes starting and ending the strings.
+
 } csv_read_arg;
 
 

--- a/cpp/include/cudf/io_types.h
+++ b/cpp/include/cudf/io_types.h
@@ -88,7 +88,7 @@ typedef struct {
 
   char			*encoding;					// the data encoding, NULL = UTF-8
 
-  bool			keepQuotes;					// TRUE: keep the quotes in the text. FALSE: remove the quotes from the strings. Only for quotes starting and ending the strings.
+  bool			quoting;					// TRUE: keep the quotes in the text. FALSE: remove the quotes from the strings. Only for quotes starting and ending the strings.
 
 } csv_read_arg;
 

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -960,9 +960,17 @@ __global__ void convertCsvToGdf(
 
 		if(start>stop)
 			break;
-
+		bool quotation=false;
+		if(raw_csv[pos]=='\"'){
+		  quotation=true;
+		  pos++;
+		}
+ 
 		while(true){
 			if(raw_csv[pos]==delim){
+			  if(quotation==false)
+				break;
+			  else if ((pos-1) >= start && raw_csv[pos-1]=='\"' )
 				break;
 			}
 			else if (raw_csv[pos] == terminator){
@@ -1149,11 +1157,19 @@ __global__ void dataTypeDetection(
 
 		if(start>stop)
 			break;
-
+ 
+		bool quotation=false;
+		if(raw_csv[pos]=='\"'){
+		  quotation=true;
+		  pos++;
+		}
+ 
 		// Finding the breaking point for each column
 		while(true){
-
 			if(raw_csv[pos]==delim){
+			  if(quotation==false)
+				break;
+			  else if ((pos-1) >= start && raw_csv[pos-1]=='\"' )
 				break;
 			}
 			else if (raw_csv[pos] == terminator){

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -979,12 +979,22 @@ __global__ void convertCsvToGdf(
 				break;
 			}
 			else if (raw_csv[pos] == terminator){
+ 			  if(quotation==false)
+				break;
+			  else if ((pos-1) >= start && raw_csv[pos-1]=='\"' )
 				break;
 			}
             else if(raw_csv[pos] == '\r' &&  ((pos+1) < stop && raw_csv[pos+1]=='\n')){
-            	stop--;
+  			  if(quotation==false){
+				stop--;
+				break;
+			  }
+			  else if ((pos-1) >= start && raw_csv[pos-1]=='\"' ){
+             	stop--;
                 break;
-            }
+    		  
+			  }
+           }
 			if(pos>=stop)
 				break;
 			pos++;
@@ -1174,7 +1184,7 @@ __global__ void dataTypeDetection(
 		}
  
 		// Finding the breaking point for each column
-		while(true){
+ 		while(true){
 			if(raw_csv[pos]==delim){
 			  if(quotation==false)
 				break;
@@ -1182,17 +1192,27 @@ __global__ void dataTypeDetection(
 				break;
 			}
 			else if (raw_csv[pos] == terminator){
+ 			  if(quotation==false)
+				break;
+			  else if ((pos-1) >= start && raw_csv[pos-1]=='\"' )
 				break;
 			}
             else if(raw_csv[pos] == '\r' &&  ((pos+1) < stop && raw_csv[pos+1]=='\n')){
-            	stop--;
+  			  if(quotation==false){
+				stop--;
+				break;
+			  }
+			  else if ((pos-1) >= start && raw_csv[pos-1]=='\"' ){
+             	stop--;
                 break;
-            }
-			if(pos>stop)
+    		  
+			  }
+           }
+			if(pos>=stop)
 				break;
 			pos++;
 		}
-
+ 
 
 		// Checking if this is a column that the user wants --- user can filter columns
 		if(parseCol[col]==true){

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -219,7 +219,7 @@ gdf_error read_csv(csv_read_arg *args)
 	raw_csv->num_actual_cols	= args->num_cols;
 	raw_csv->num_active_cols	= args->num_cols;
 	raw_csv->num_records		= 0;
-	raw_csv->keepQuotes			= args->keepQuotes;
+	raw_csv->keepQuotes			= args->quoting;
 
 
 	if ( args->delim_whitespace == true) {

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -1062,11 +1062,12 @@ __global__ void convertCsvToGdf(
 					}
 						break;
 					case gdf_dtype::GDF_STRING:{
+						size_t q=0;
  						if (quotation==true && keepQuotes==false){
-						  start++; pos--;
+						  start++; q=1;
 						}
     					str_cols[stringCol][rec_id].first 	= raw_csv+start;
-						str_cols[stringCol][rec_id].second 	= size_t(pos-start);
+						str_cols[stringCol][rec_id].second 	= size_t(pos-start-q);
 						stringCol++;
 					}
 						break;

--- a/cpp/tests/io/csv/csv_test.cu
+++ b/cpp/tests/io/csv/csv_test.cu
@@ -289,6 +289,7 @@ TEST(gdf_csv_test, QuotedStrings)
 		args.lineterminator = '\n';
 		args.quotechar		= '`';
 		args.quoting		= true;	// strip outermost quotechar
+		args.doublequote	= true;	// replace double quotechar with single
 		args.skiprows		= 1;
 
 		error = read_csv(&args);
@@ -351,7 +352,7 @@ TEST(gdf_csv_test, KeepFullQuotedStrings)
 		args.lineterminator = '\n';
 		args.quotechar		= '\"';
 		args.quoting		= false;	// do not strip outermost quotechar
-		args.nodoublequote	= true;		// do not replace double quotechar with single
+		args.doublequote	= false;	// do not replace double quotechar with single
 		args.skiprows		= 1;
 
 		error = read_csv(&args);

--- a/cpp/tests/io/csv/csv_test.cu
+++ b/cpp/tests/io/csv/csv_test.cu
@@ -273,7 +273,7 @@ TEST(gdf_csv_test, QuotedStrings)
 
 	std::ofstream outfile(fname, std::ofstream::out);
 	outfile << names[0] << ',' << names[1] << ',' << '\n';
-	outfile << "10,`abc, def, ghi`" << '\n';
+	outfile << "10,`abc,\ndef, ghi`" << '\n';
 	outfile << "20,`jkl, ``mno``, pqr`" << '\n';
 	outfile << "30,stu `vwx` yz" << '\n';
 	outfile.close();
@@ -314,7 +314,7 @@ TEST(gdf_csv_test, QuotedStrings)
 			strings[i] = new char[stringLengths[i]];
 		}
 		EXPECT_EQ( stringList->to_host(strings.get(), 0, stringCount), 0 );
-		EXPECT_STREQ( strings[0], "abc, def, ghi" );
+		EXPECT_STREQ( strings[0], "abc,\ndef, ghi" );
 		EXPECT_STREQ( strings[1], "jkl, `mno`, pqr" );
 		EXPECT_STREQ( strings[2], "stu `vwx` yz" );
 		for (size_t i = 0; i < stringCount; ++i) {
@@ -335,7 +335,7 @@ TEST(gdf_csv_test, KeepFullQuotedStrings)
 
 	std::ofstream outfile(fname, std::ofstream::out);
 	outfile << names[0] << ',' << names[1] << ',' << '\n';
-	outfile << "10,\"abc, def, ghi\"" << '\n';
+	outfile << "10,\"abc,\ndef, ghi\"" << '\n';
 	outfile << "20,\"jkl, \"\"mno\"\", pqr\"" << '\n';
 	outfile << "30,stu \"vwx\" yz" << '\n';
 	outfile.close();
@@ -377,7 +377,7 @@ TEST(gdf_csv_test, KeepFullQuotedStrings)
 			strings[i] = new char[stringLengths[i]];
 		}
 		EXPECT_EQ( stringList->to_host(strings.get(), 0, stringCount), 0 );
-		EXPECT_STREQ( strings[0], "\"abc, def, ghi\"" );
+		EXPECT_STREQ( strings[0], "\"abc,\ndef, ghi\"" );
 		EXPECT_STREQ( strings[1], "\"jkl, \"\"mno\"\", pqr\"" );
 		EXPECT_STREQ( strings[2], "stu \"vwx\" yz" );
 		for (size_t i = 0; i < stringCount; ++i) {

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -19,7 +19,7 @@ def _wrap_string(text):
 
 
 def read_csv(filepath, lineterminator='\n',
-             quotechar='\0', quoting=True, doublequote=True,
+             quotechar='"', quoting=True, doublequote=True,
              delimiter=',', sep=None, delim_whitespace=False,
              skipinitialspace=False, names=None, dtype=None,
              skipfooter=0, skiprows=0, dayfirst=False):
@@ -43,14 +43,14 @@ def read_csv(filepath, lineterminator='\n',
     dtype : list of str or dict of {col: dtype}, default None
         List of data types in the same order of the column names
         or a dictionary with column_name:dtype (pandas style).
-    quotechar : char, default '\0' (empty)
+    quotechar : char, default '"'
         Character to indicate start and end of quote item.
     quoting : bool, default True
         If True, start and end quotechar are removed from returned strings
         If False, start and end quotechar are kept in returned strings
     doublequote : bool, default True
-        When quotechar is specified and quoting is True, indicate whether or not
-        to interpret two consecutive quotechar inside fields as single quotechar
+        When quotechar is specified and quoting is True, indicates whether to
+        interpret two consecutive quotechar inside fields as single quotechar
     skiprows : int, default 0
         Number of rows to be skipped from the start of file.
     skipfooter : int, default 0
@@ -155,7 +155,7 @@ def read_csv(filepath, lineterminator='\n',
 
 
 def read_csv_strings(filepath, lineterminator='\n',
-                     quotechar='\0', quoting=True, doublequote=True,
+                     quotechar='"', quoting=True, doublequote=True,
                      delimiter=',', sep=None, delim_whitespace=False,
                      skipinitialspace=False, names=None, dtype=None,
                      skipfooter=0, skiprows=0, dayfirst=False):

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -18,7 +18,7 @@ def _wrap_string(text):
         return ffi.new("char[]", text.encode())
 
 
-def read_csv(filepath, lineterminator='\n', quoting=True,
+def read_csv(filepath, lineterminator='\n', quotechar='\0', quoting=True,
              delimiter=',', sep=None, delim_whitespace=False,
              skipinitialspace=False, names=None, dtype=None,
              skipfooter=0, skiprows=0, dayfirst=False):
@@ -42,9 +42,11 @@ def read_csv(filepath, lineterminator='\n', quoting=True,
     dtype : list of str or dict of {col: dtype}, default None
         List of data types in the same order of the column names
         or a dictionary with column_name:dtype (pandas style).
-    quoting : bool
-        If True, quotes will be removed from start and end of string fields
-        If False, quotes will be included in returned nvstrings entries
+    quotechar : char, default '\0' (empty)
+        Character to indicate start and end of quote item.
+    quoting : bool, default True
+        If True, start and end quotechar are removed from returned strings
+        If False, start and end quotechar are kept in returned strings
     skiprows : int, default 0
         Number of rows to be skipped from the start of file.
     skipfooter : int, default 0
@@ -111,13 +113,14 @@ def read_csv(filepath, lineterminator='\n', quoting=True,
 
     csv_reader.delimiter = delimiter.encode()
     csv_reader.lineterminator = lineterminator.encode()
+    csv_reader.quotechar = quotechar.encode()
+    csv_reader.quoting = quoting
     csv_reader.delim_whitespace = delim_whitespace
     csv_reader.skipinitialspace = skipinitialspace
     csv_reader.dayfirst = dayfirst
     csv_reader.num_cols = len(names)
     csv_reader.skiprows = skiprows
     csv_reader.skipfooter = skipfooter
-    csv_reader.quoting = quoting
 
     # Call read_csv
     libgdf.read_csv(csv_reader)
@@ -146,7 +149,7 @@ def read_csv(filepath, lineterminator='\n', quoting=True,
     return df
 
 
-def read_csv_strings(filepath, lineterminator='\n', quoting=True,
+def read_csv_strings(filepath, lineterminator='\n', quotechar='\0', quoting=True,
                      delimiter=',', sep=None, delim_whitespace=False,
                      skipinitialspace=False, names=None, dtype=None,
                      skipfooter=0, skiprows=0, dayfirst=False):
@@ -235,13 +238,14 @@ def read_csv_strings(filepath, lineterminator='\n', quoting=True,
 
     csv_reader.delimiter = delimiter.encode()
     csv_reader.lineterminator = lineterminator.encode()
+    csv_reader.quotechar = quotechar.encode()
+    csv_reader.quoting = quoting
     csv_reader.delim_whitespace = delim_whitespace
     csv_reader.skipinitialspace = skipinitialspace
     csv_reader.dayfirst = dayfirst
     csv_reader.num_cols = len(names)
     csv_reader.skiprows = skiprows
     csv_reader.skipfooter = skipfooter
-    csv_reader.quoting = quoting
 
     # Call read_csv
     libgdf.read_csv(csv_reader)

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -18,7 +18,7 @@ def _wrap_string(text):
         return ffi.new("char[]", text.encode())
 
 
-def read_csv(filepath, lineterminator='\n', quoting = True,
+def read_csv(filepath, lineterminator='\n', quoting=True,
              delimiter=',', sep=None, delim_whitespace=False,
              skipinitialspace=False, names=None, dtype=None,
              skipfooter=0, skiprows=0, dayfirst=False):
@@ -42,6 +42,9 @@ def read_csv(filepath, lineterminator='\n', quoting = True,
     dtype : list of str or dict of {col: dtype}, default None
         List of data types in the same order of the column names
         or a dictionary with column_name:dtype (pandas style).
+    quoting : bool
+        If True, quotes will be removed from start and end of string fields
+        If False, quotes will be included in returned nvstrings entries
     skiprows : int, default 0
         Number of rows to be skipped from the start of file.
     skipfooter : int, default 0
@@ -143,7 +146,7 @@ def read_csv(filepath, lineterminator='\n', quoting = True,
     return df
 
 
-def read_csv_strings(filepath, lineterminator='\n', quoting = True,
+def read_csv_strings(filepath, lineterminator='\n', quoting=True,
                      delimiter=',', sep=None, delim_whitespace=False,
                      skipinitialspace=False, names=None, dtype=None,
                      skipfooter=0, skiprows=0, dayfirst=False):

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -143,7 +143,7 @@ def read_csv(filepath, lineterminator='\n', quoting = True,
     return df
 
 
-def read_csv_strings(filepath, lineterminator='\n',
+def read_csv_strings(filepath, lineterminator='\n', quoting = True,
                      delimiter=',', sep=None, delim_whitespace=False,
                      skipinitialspace=False, names=None, dtype=None,
                      skipfooter=0, skiprows=0, dayfirst=False):
@@ -238,6 +238,7 @@ def read_csv_strings(filepath, lineterminator='\n',
     csv_reader.num_cols = len(names)
     csv_reader.skiprows = skiprows
     csv_reader.skipfooter = skipfooter
+    csv_reader.quoting = quoting
 
     # Call read_csv
     libgdf.read_csv(csv_reader)

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -155,7 +155,7 @@ def read_csv_strings(filepath, lineterminator='\n', quotechar='\0', quoting=True
                      skipfooter=0, skiprows=0, dayfirst=False):
 
     import nvstrings
-    from .series import Series
+    from cudf.dataframe.series import Series
 
     """
     **Experimental**: This function provided only as an alpha way of providing

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -18,7 +18,7 @@ def _wrap_string(text):
         return ffi.new("char[]", text.encode())
 
 
-def read_csv(filepath, lineterminator='\n',
+def read_csv(filepath, lineterminator='\n', quoting = True,
              delimiter=',', sep=None, delim_whitespace=False,
              skipinitialspace=False, names=None, dtype=None,
              skipfooter=0, skiprows=0, dayfirst=False):
@@ -114,6 +114,7 @@ def read_csv(filepath, lineterminator='\n',
     csv_reader.num_cols = len(names)
     csv_reader.skiprows = skiprows
     csv_reader.skipfooter = skipfooter
+    csv_reader.quoting = quoting
 
     # Call read_csv
     libgdf.read_csv(csv_reader)

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -18,7 +18,8 @@ def _wrap_string(text):
         return ffi.new("char[]", text.encode())
 
 
-def read_csv(filepath, lineterminator='\n', quotechar='\0', quoting=True,
+def read_csv(filepath, lineterminator='\n',
+             quotechar='\0', quoting=True, doublequote=True,
              delimiter=',', sep=None, delim_whitespace=False,
              skipinitialspace=False, names=None, dtype=None,
              skipfooter=0, skiprows=0, dayfirst=False):
@@ -47,6 +48,9 @@ def read_csv(filepath, lineterminator='\n', quotechar='\0', quoting=True,
     quoting : bool, default True
         If True, start and end quotechar are removed from returned strings
         If False, start and end quotechar are kept in returned strings
+    doublequote : bool, default True
+        When quotechar is specified and quoting is True, indicate whether or not
+        to interpret two consecutive quotechar inside fields as single quotechar
     skiprows : int, default 0
         Number of rows to be skipped from the start of file.
     skipfooter : int, default 0
@@ -115,6 +119,7 @@ def read_csv(filepath, lineterminator='\n', quotechar='\0', quoting=True,
     csv_reader.lineterminator = lineterminator.encode()
     csv_reader.quotechar = quotechar.encode()
     csv_reader.quoting = quoting
+    csv_reader.doublequote = doublequote
     csv_reader.delim_whitespace = delim_whitespace
     csv_reader.skipinitialspace = skipinitialspace
     csv_reader.dayfirst = dayfirst
@@ -149,7 +154,8 @@ def read_csv(filepath, lineterminator='\n', quotechar='\0', quoting=True,
     return df
 
 
-def read_csv_strings(filepath, lineterminator='\n', quotechar='\0', quoting=True,
+def read_csv_strings(filepath, lineterminator='\n',
+                     quotechar='\0', quoting=True, doublequote=True,
                      delimiter=',', sep=None, delim_whitespace=False,
                      skipinitialspace=False, names=None, dtype=None,
                      skipfooter=0, skiprows=0, dayfirst=False):
@@ -240,6 +246,7 @@ def read_csv_strings(filepath, lineterminator='\n', quotechar='\0', quoting=True
     csv_reader.lineterminator = lineterminator.encode()
     csv_reader.quotechar = quotechar.encode()
     csv_reader.quoting = quoting
+    csv_reader.doublequote = doublequote
     csv_reader.delim_whitespace = delim_whitespace
     csv_reader.skipinitialspace = skipinitialspace
     csv_reader.dayfirst = dayfirst

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -198,7 +198,7 @@ def test_csv_reader_strings_quotechars(tmpdir):
 
     names = ['text', 'int']
     dtypes = ['str', 'int']
-    lines = [','.join(names), '"a,",0', '"b ""c"" d",0', 'e,0', '"f,,!.,",0']
+    lines = [','.join(names), '"a,\n",0', '"b ""c"" d",0', 'e,0', '"f,,!.,",0']
 
     with open(str(fname), 'w') as fp:
         fp.write('\n'.join(lines) + '\n')
@@ -209,7 +209,7 @@ def test_csv_reader_strings_quotechars(tmpdir):
     assert(len(cols) == 2)
     assert(type(cols[0]) == nvstrings.nvstrings)
     assert(type(cols[1]) == cudf.Series)
-    assert(cols[0].sublist([0]).to_host()[0] == 'a,')
+    assert(cols[0].sublist([0]).to_host()[0] == 'a,\n')
     assert(cols[0].sublist([1]).to_host()[0] == 'b "c" d')
     assert(cols[0].sublist([2]).to_host()[0] == 'e')
     assert(cols[0].sublist([3]).to_host()[0] == 'f,,!.,')

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -204,7 +204,7 @@ def test_csv_reader_strings_quotechars(tmpdir):
         fp.write('\n'.join(lines) + '\n')
 
     cols = read_csv_strings(str(fname), names=names, dtype=dtypes, skiprows=1,
-	                        quotechar='\"', quoting=True)
+                            quotechar='\"', quoting=True)
 
     assert(len(cols) == 2)
     assert(type(cols[0]) == nvstrings.nvstrings)

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -7,6 +7,9 @@ import numpy as np
 import pandas as pd
 
 from cudf import read_csv
+from cudf.io import read_csv_strings
+import cudf
+import nvstrings
 
 
 def make_numeric_dataframe(nrows, dtype):
@@ -167,3 +170,52 @@ def test_csv_reader_negative_vals(tmpdir):
     np.testing.assert_allclose(zero, df['0'])
     np.testing.assert_allclose(one, df['1'])
     np.testing.assert_allclose(two, df['2'])
+
+
+def test_read_csv_strings(tmpdir):
+    fname = "tmp_csvreader_file6.csv"
+
+    names = ['text', 'int']
+    dtypes = ['str', 'int']
+    lines = [','.join(names), 'a,0', 'b,0', 'c,0', 'd,0']
+    with open(fname, 'w') as fp:
+        fp.write('\n'.join(lines)+'\n')
+
+    cols = read_csv_strings(fname, names=names, dtype=dtypes, skiprows=1)
+    assert(len(cols) == 2)
+    assert(type(cols[0]) == nvstrings.nvstrings)
+    assert(type(cols[1]) == cudf.Series)
+    assert(cols[0].sublist([0]).to_host()[0] == 'a')
+    assert(cols[0].sublist([1]).to_host()[0] == 'b')
+    assert(cols[0].sublist([2]).to_host()[0] == 'c')
+    assert(cols[0].sublist([3]).to_host()[0] == 'd')
+
+
+def test_read_csv_strings_quotechars(tmpdir):
+    fname = "tmp_csvreader_file7.csv"
+
+    names = ['text', 'int']
+    dtypes = ['str', 'int']
+    lines = [','.join(names), '"a,",0', '"b",0', 'c,0', '"d,,!.,",0']
+    with open(fname, 'w') as fp:
+        fp.write('\n'.join(lines)+'\n')
+
+    cols = read_csv_strings(fname, names=names, dtype=dtypes, skiprows=1)
+    assert(len(cols) == 2)
+    assert(type(cols[0]) == nvstrings.nvstrings)
+    assert(type(cols[1]) == cudf.Series)
+    assert(cols[0].sublist([0]).to_host()[0] == 'a,')
+    assert(cols[0].sublist([1]).to_host()[0] == 'b')
+    assert(cols[0].sublist([2]).to_host()[0] == 'c')
+    assert(cols[0].sublist([3]).to_host()[0] == 'd,,!.,')
+
+    cols = read_csv_strings(
+                            fname, names=names, dtype=dtypes, skiprows=1,
+                            quoting=True)
+    assert(len(cols) == 2)
+    assert(type(cols[0]) == nvstrings.nvstrings)
+    assert(type(cols[1]) == cudf.Series)
+    assert(cols[0].sublist([0]).to_host()[0] == '"a,"')
+    assert(cols[0].sublist([1]).to_host()[0] == '"b"')
+    assert(cols[0].sublist([2]).to_host()[0] == '"c"')
+    assert(cols[0].sublist([3]).to_host()[0] == '"d,,!.,"')

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from cudf import read_csv
-from cudf.io import read_csv_strings
+from cudf.io.csv import read_csv_strings
 import cudf
 import nvstrings
 


### PR DESCRIPTION
String columns can now be read in with quotation marks at the beginning and end of the string. The quotation marks can be kept or removed based on user preference.
Also, if the string within the quotation mark has a field delimiter, that delimiter is ignored and not does not terminate the field.