### PR TITLE
[REVIEW] Removes noexcept from managed_allocator & a CMakeLists fix for NVstrings

### DIFF
--- a/libgdf/CMakeLists.txt
+++ b/libgdf/CMakeLists.txt
@@ -175,10 +175,10 @@ else()
   target_link_libraries(gdf arrow rmm)
 endif()
 
-# Find libNVStrings.so, provided by rapidsai conda package
-find_library(NVSTRING_LIBRARY NVStrings HINTS $ENV{CONDA_PREFIX}/lib)
-include_directories(BEFORE SYSTEM $ENV{CONDA_PREFIX}/include)
-target_link_libraries(gdf ${NVSTRING_LIBRARY})
+find_library(NVSTRINGS_LIBRARY NVStrings HINTS $ENV{NVSTRINGS_ROOT}/lib $ENV{CONDA_PREFIX}/lib)
+find_path(NVSTRINGS_INCLUDE_DIR NVStrings.h HINTS $ENV{NVSTRINGS_ROOT}/include $ENV{CONDA_PREFIX}/include)
+include_directories(BEFORE SYSTEM ${NVSTRINGS_INCLUDE_DIR})
+target_link_libraries(gdf ${NVSTRINGS_LIBRARY})
 
 # Command to symlink files into the build directory
 add_custom_command(  # link the include directory

--- a/libgdf/src/hashmap/managed_allocator.cuh
+++ b/libgdf/src/hashmap/managed_allocator.cuh
@@ -41,7 +41,7 @@ struct managed_allocator {
           } 
           return ptr;
       }
-      void deallocate(T* p, std::size_t) const noexcept {
+      void deallocate(T* p, std::size_t) const {
         cudaFree(p);
       }
 };
@@ -73,7 +73,7 @@ struct legacy_allocator {
 
           return ptr;
       }
-      void deallocate(T* p, std::size_t) const noexcept {
+      void deallocate(T* p, std::size_t) const {
           rmmError_t result = RMM_FREE(p, 0); // TODO: non-default stream
           if ( RMM_SUCCESS != result) throw std::runtime_error("legacy_allocator: RMM Memory Manager Error");
       }


### PR DESCRIPTION
Fixes two minor issues I noticed today in trying to build libgdf using the cudf master branch (each issue in a separate file): #362 and #363 .

Note: I have only checked that this _builds_, I haven't run any tests, so caveat emptor.