### PR TITLE
Some common-sense additions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ## common
 __pycache__
 *.pyc
+*.a
 *.o
 *.so
 *.dylib
@@ -9,18 +10,29 @@ __pycache__
 .vscode
 *.swp
 *.pytest_cache
-##build
+DartConfiguration.tcl
 htmlcov
+dist/
+cudf.egg-info/
+
+## Patching
+*.diff
+*.orig
+*.rej
 
 ## libgdf
+CMakeFiles/
 Debug
-/libgdf/thirdparty/googletest/
-/libgdf/include/gdf/ipc/File_generated.h
-/libgdf/include/gdf/ipc/Message_generated.h
-/libgdf/include/gdf/ipc/Schema_generated.h
-/libgdf/include/gdf/ipc/Tensor_generated.h
-/libgdf/python/libgdf_cffi/libgdf_cffi.py
-/libgdf/python/librmm_cffi/librmm_cffi.py
+libgdf/build/
+libgdf/thirdparty/googletest/
+libgdf/include/gdf/ipc/File_generated.h
+libgdf/include/gdf/ipc/Message_generated.h
+libgdf/include/gdf/ipc/Schema_generated.h
+libgdf/include/gdf/ipc/Tensor_generated.h
+libgdf/python/libgdf_cffi/libgdf_cffi.py
+libgdf/python/librmm_cffi/librmm_cffi.py
 
-## eclipse
+## Eclipse IDE
 .project
+.cproject
+.settings


### PR DESCRIPTION
cudf has a `.gitignore` file, but it's missing some common-sense entries which cause untracked files which should definitely be ignored, even as we build parts of it (e.g. libgdf). So, I've taken the liberty of making several common-sense additions:

* Patch-related extensions (`.diff`, `.rej`, `.orig`)
* Eclipse-IDE-related hidden files (`.cproject`, `.settings`)
* Static (in addition to dynamic) compiled libraries
* CMake-build-related folders for libgdf
