### PR TITLE
Fix & circumvent some libgdf test issues

### DIFF
--- a/libgdf/src/tests/CMakeLists.txt
+++ b/libgdf/src/tests/CMakeLists.txt
@@ -16,6 +16,13 @@
 # limitations under the License.
 #=============================================================================
 
+set(SKIP_MISBEHAVING_TESTS OFF CACHE bool "Do not run tests which are known to take an extremely long time, thrash a lot, or have other problematic side-effects")
+
+if(SKIP_MISBEHAVING_TESTS)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSKIP_MISBEHAVING_TESTS")
+	set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DSKIP_MISBEHAVING_TESTS")
+endif()
+
 #pass the dependency libraries as optional arguments using ${ARGN}
 #NOTE the order of libraries matter, so try to link first with the most high level lib
 function(configure_test TEST_NAME Tests_SRCS)

--- a/libgdf/src/tests/join/join-tests.cu
+++ b/libgdf/src/tests/join/join-tests.cu
@@ -736,13 +736,18 @@ TYPED_TEST(MaxJoinTest, HugeJoinSize)
   // a 34GB hash table. Therefore, use a 2^29 input to make sure we can handle big 
   // inputs until we can better handle OOM errors
   // The CI Server only has a 16GB GPU, therefore need to use 2^29 input size
-  const size_t right_table_size = 1<<29;
+
+  constexpr const double ratio_of_right_table_size_to_available_memory = 0.033;
+  size_t free_mem_in_bytes;
+  auto status = cudaMemGetInfo(&free_mem_in_bytes, nullptr);
+  EXPECT_EQ(status, cudaSuccess);
+  size_t right_table_size = free_mem_in_bytes * ratio_of_right_table_size_to_available_memory;
   this->create_input(100, RAND_MAX,
                      right_table_size, RAND_MAX);
   std::vector<result_type> gdf_result = this->compute_gdf_result();
 }
 
-TYPED_TEST(MaxJoinTest, InputTooLarge)
+TYPED_TEST(MaxJoinTest, DISABLED_InputTooLarge)
 {
     const size_t right_table_size = static_cast<size_t>(std::numeric_limits<int>::max());
     this->create_input(100, RAND_MAX,

--- a/libgdf/src/tests/join/join-tests.cu
+++ b/libgdf/src/tests/join/join-tests.cu
@@ -747,7 +747,11 @@ TYPED_TEST(MaxJoinTest, HugeJoinSize)
   std::vector<result_type> gdf_result = this->compute_gdf_result();
 }
 
+#ifndef SKIP_MISBEHAVING_TESTS
+TYPED_TEST(MaxJoinTest, InputTooLarge)
+#else
 TYPED_TEST(MaxJoinTest, DISABLED_InputTooLarge)
+#endif
 {
     const size_t right_table_size = static_cast<size_t>(std::numeric_limits<int>::max());
     this->create_input(100, RAND_MAX,


### PR DESCRIPTION
A redo of PR #376 

* Regarding issue #369: The `HugeJoinSize` test now uses a right-hand-side column size of about 3% of the free memory size in bytes - which is about the same as the previous column size for a 16 GB machine, but won't fail on machines with smaller device global memory.
* Regarding issue #375: The problematic test is enabled by default, but a (cached) CMake option will disable it (to make life easier during routine development work).

Tests now pass. The join tests still take a lot of time (14 sec on my machine), but it's at least tolerable.

@percy: Implemented your idea.
@harrism : Hopefully this addresses your concern