### PR TITLE
[REVIEW] Feature/10 min to cudf

### DIFF
--- a/conda/environments/builddocs_py35.yml
+++ b/conda/environments/builddocs_py35.yml
@@ -17,8 +17,8 @@ dependencies:
 - nvstrings
 - pandas=0.20.*
 - pyarrow=0.10.*
-- pip:
-  - numpydoc
-  - sphinx
-  - sphinx-rtd-theme
-  - sphinxcontrib-websupport
+- ipython
+- numpydoc
+- sphinx
+- sphinx_rtd_theme
+- sphinxcontrib-websupport

--- a/docs/requirement.txt
+++ b/docs/requirement.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx_rtd_theme
 numpydoc
+ipython

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -179,6 +179,23 @@ CSV
 ~~~~
 
 
+We can write to a CSV file by first sending data to a pandas Dataframe on the host.
+
+.. ipython:: python
+
+    df.to_pandas().to_csv('foo.txt', index=False)
+
+
+Reading from a csv file. `read_csv` requires explicit types, and can accept different delimiters and line terminators.
+
+
+.. ipython:: python
+
+    df = cudf.read_csv('foo.txt', delimiter=',',
+            names=['a', 'b', 'c'], dtype=['int64', 'int64', 'int64'],
+            skiprows=1)
+    print(df)
+
 HDF5
 ~~~~~~~~~
 

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -113,8 +113,18 @@ Operations
 Stats
 ~~~~~~~~~~~~~~~~~~~~~
 
-Apply
+Applymap
 ~~~~~~~~~~~~~~~~~~~~~
+
+Applying functions to a `Series`:
+
+.. ipython:: python
+
+    def add_ten(num):
+        return num + 10
+
+    print(df['a'].applymap(add_ten))
+
 
 Histogramming
 ~~~~~~~~~~~~~~~~~~~~~
@@ -166,9 +176,6 @@ Categoricals
 
 Plotting
 ------------
-Coming in a future release.
-
-
 
 
 Getting Data In/Out

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -20,12 +20,12 @@ Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF, geared
 Object Creation
 ---------------
 
-Creating a `Series`
+Creating a `Series`.
 
 .. ipython:: python
 
-  s = cudf.Series([1,2,3,None,4])
-  print(s)
+    s = cudf.Series([1,2,3,None,4])
+    print(s)
 
 Creating a `Dataframe` from a list of tuples.
 
@@ -48,13 +48,13 @@ Creating a `Dataframe` from a pandas Dataframe.
 Viewing Data
 -------------
 
-Examples of how to view the top rows of the GPU dataframe:
+Viewing the top rows of the GPU dataframe.
 
 .. ipython:: python
 
     print(df.head(2))
 
-Sorting by values:
+Sorting by values.
 
 .. ipython:: python
 
@@ -67,7 +67,7 @@ Selection
 Getting
 ~~~~~~~~~~~~~~
 
-Selecting a single column, which yields a `cudf.Series`, equivalent to `df.a`:
+Selecting a single column, which yields a `cudf.Series`, equivalent to `df.a`.
 
 .. ipython:: python
 
@@ -78,7 +78,7 @@ Selecting a single column, which yields a `cudf.Series`, equivalent to `df.a`:
 Selection by Label
 ~~~~~~~~~~~~~~~~~~~~~
 
-Select rows from index 2 to index 5 from columns 'a' and 'b'.
+Selecting rows from index 2 to index 5 from columns 'a' and 'b'.
 
 .. ipython:: python
 
@@ -87,10 +87,26 @@ Select rows from index 2 to index 5 from columns 'a' and 'b'.
 
 
 Selection by Position
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 Boolean Indexing
 ~~~~~~~~~~~~~~~~~~~~~
+
+Selecting rows in a `Series` by direct boolean indexing, if there are no missing values.
+
+.. ipython:: python
+
+    print(df.b[df.b > 15])
+
+
+Selecting values from a DataFrame where a boolean condition is met, via the `query` API.
+
+.. ipython:: python
+
+    print(df.query("b == 3"))
+
+Supported logical operators include `>`, `<`, `>=`, `<=`, `==`, and `!=`.
+
 
 Setting
 ~~~~~~~~~~~~~~~~~~~~~
@@ -99,17 +115,30 @@ Setting
 Missing Data
 ------------
 
+Missing data can be replaced by using the `fillna` method.
+
+.. ipython:: python
+
+    print(s.fillna(999))
+
 
 Operations
 ------------
 
 Stats
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~
+
+Calculating descriptive statistics (operations in general exclude missing data).
+
+.. ipython:: python
+
+    print(s.mean(), s.var(), s.sum_of_squares())
+
 
 Applymap
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~
 
-Applying functions to a `Series`:
+Applying functions to a `Series`.
 
 .. ipython:: python
 
@@ -133,11 +162,19 @@ Merge
 Concat
 ~~~~~~~~~~~~~~~~~~~~~
 
+You can concatenate `Series` and `DataFrames` row-wise.
+
+.. ipython:: python
+
+    print(cudf.concat([s, s]))
+
+    print(cudf.concat([df.head(), df.head()], ignore_index=True))
+
 
 Join
 ~~~~~~~~~~~~~~~~~~~~~
 
-SQL style merges, similar to pandas.
+You can also do SQL style merges.
 
 .. ipython:: python
 
@@ -155,6 +192,12 @@ SQL style merges, similar to pandas.
 
 Append
 ~~~~~~~~~~~~~~~~~~~~~
+
+You can append values from another `Series` or array-like object. Appending `Series` with nulls is not yet supported, but can be done using the `concat` method.
+
+.. ipython:: python
+
+    print(df.a.head().append(df.b.head()))
 
 
 Grouping
@@ -187,12 +230,11 @@ Plotting
 
 
 Getting Data In/Out
-------------
+------------------------
 
 
 CSV
 ~~~~
-
 
 We can write to a CSV file by first sending data to a pandas Dataframe on the host.
 
@@ -201,8 +243,7 @@ We can write to a CSV file by first sending data to a pandas Dataframe on the ho
     df.to_pandas().to_csv('foo.txt', index=False)
 
 
-Reading from a csv file. `read_csv` requires explicit types, and can accept different delimiters and line terminators.
-
+Reading from a csv file. 
 
 .. ipython:: python
 
@@ -210,6 +251,7 @@ Reading from a csv file. `read_csv` requires explicit types, and can accept diff
             names=['a', 'b', 'c'], dtype=['int64', 'int64', 'int64'],
             skiprows=1)
     print(df)
+
 
 HDF5
 ~~~~~~~~~
@@ -222,3 +264,4 @@ Excel
 
 Gotchas
 --------
+

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -21,14 +21,14 @@ Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF, geared
 Object Creation
 ---------------
 
-Series
+Creating a `Series`
 
 .. ipython:: python
 
   s = cudf.Series([1,2,3,None,4])
   print(s)
 
-Dataframe from dictionary
+Creating a `Dataframe` from a list of tuples.
 
 .. ipython:: python
 
@@ -37,7 +37,7 @@ Dataframe from dictionary
     ('c', list(range(20)))])
     print(df)
 
-Dataframe from pandas 
+Creating a `Dataframe` from a pandas Dataframe. 
 
 .. ipython:: python
 
@@ -78,9 +78,11 @@ Selecting a single column, which yields a `cudf.Series`, equivalent to `df.a`:
 
 Selection by Label
 ~~~~~~~~~~~~~~~~~~~~~
+
+Select rows from index 2 to index 5 from columns 'a' and 'b'.
+
 .. ipython:: python
 
-    # get rows from index 2 to index 5 from 'a' and 'b' columns.
     print(df.loc[2:5, ['a', 'b']])
 
 

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -36,16 +36,6 @@ Creating a `DataFrame` by specifying values for each column
     ('c', list(range(20)))])
     print(df)
 
-Creating a `DataFrame` by specifying values for each row
-
-.. ipython:: python
-
-    gdf = cudf.DataFrame.from_records(
-    [[4, 7, 10],
-    [5, 8, 11],
-    [6, 9, 12]],
-    index=[1, 2, 3], columns=[‘a’, ‘b’, ‘c’])
-    print(gdf)
 
 Creating a `Dataframe` from a pandas Dataframe. 
 
@@ -166,7 +156,7 @@ Counting the number of rows with each unique value of variable
 
 .. ipython:: python
 
-    df.a.value_counts()
+    print(df.a.value_counts())
 
 
 String Methods
@@ -228,8 +218,30 @@ Groupbys involve one or more of the following steps:
 
 .. ipython:: python
 
-    df['agg_col'] = [1 if x % 2 == 0 else 0 for x in range(len(df))]
-    print(df.groupby('agg_col').sum())
+    df['agg_col1'] = [1 if x % 2 == 0 else 0 for x in range(len(df))]
+    df['agg_col2'] = [1 if x % 3 == 0 else 0 for x in range(len(df))]
+
+Grouping and then applying the `sum` function to the resulting groups.
+
+
+.. ipython:: python
+
+    print(df.groupby('agg_col1').sum())
+
+
+Grouping hierarchically then applying the `sum` function to the resulting groups.
+
+.. ipython:: python
+
+    print(df.groupby(['agg_col1', 'agg_col2']).sum())
+
+
+Grouping and applying statistical functions to specific columns, using `agg`.
+
+.. ipython:: python
+
+    print(df.groupby('agg_col1').agg({'a':'max', 'b':'mean', 'c':'sum'}))
+
 
 Reshaping
 ------------
@@ -245,14 +257,49 @@ Pivot Tables
 
 Time Series
 ------------
+cuDF supports `datetime` typed columns, which allow users to interact with and filter data based on specific timestamps.
+
+.. ipython:: python
+
+    import datetime as dt
+
+    date_df = cudf.DataFrame()
+    date_df['date'] = pd.date_range('11/20/2018', periods=72, freq='D')
+    date_df['value'] = np.random.sample(len(date_df))
+
+    search_date = dt.datetime.strptime('2018-11-23', '%Y-%m-%d')
+    print(date_df.query('date <= @search_date'))
 
 
 Categoricals
 ------------
 
+cuDF supports categorical columns.
+
+.. ipython:: python
+
+    pdf = pd.DataFrame({"id":[1,2,3,4,5,6], "grade":['a', 'b', 'b', 'a', 'a', 'e']})
+    pdf["grade"] = pdf["grade"].astype("category")
+
+    gdf = cudf.DataFrame.from_pandas(pdf)
+    print(gdf)
+
+
+Accessing the categories of a column.
+
+.. ipython:: python
+
+    print(gdf.grade.cat.categories)
+
+Accessing the underlying code values of each categorical observation.
+
+.. ipython:: python
+
+    print(gdf.grade.cat.codes)
 
 Plotting
 ------------
+
 
 
 Getting Data In/Out
@@ -279,11 +326,11 @@ Reading from a csv file.
     print(df)
 
 
-HDF5
+Parquet
 ~~~~~~~~~
 
 
-Excel
+ORC
 ~~~~~~~~~
 
 

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -37,7 +37,7 @@ Creating a `DataFrame` by specifying values for each column
     print(df)
 
 
-Creating a `Dataframe` from a pandas Dataframe. 
+Creating a `Dataframe` from a pandas `Dataframe`. 
 
 .. ipython:: python
 
@@ -106,14 +106,14 @@ Selecting elements of a `Series` with direct index access.
 Boolean Indexing
 ~~~~~~~~~~~~~~~~~~~~~
 
-Selecting rows in a `Series` by direct boolean indexing, if there are no missing values.
+Selecting rows in a `Series` by direct Boolean indexing.
 
 .. ipython:: python
 
     print(df.b[df.b > 15])
 
 
-Selecting values from a DataFrame where a boolean condition is met, via the `query` API.
+Selecting values from a `DataFrame` where a Boolean condition is met, via the `query` API.
 
 .. ipython:: python
 
@@ -142,7 +142,7 @@ Operations
 Stats
 ~~~~~~~~~
 
-Calculating descriptive statistics (operations in general exclude missing data).
+Calculating descriptive statistics for a `Series`.
 
 .. ipython:: python
 
@@ -165,7 +165,7 @@ Applying functions to a `Series`.
 Histogramming
 ~~~~~~~~~~~~~~~~~~~~~
 
-Counting the number of rows with each unique value of variable
+Counting the number of occurrences of each unique value of variable.
 
 .. ipython:: python
 
@@ -182,7 +182,7 @@ Merge
 Concat
 ~~~~~~~~~~~~~~~~~~~~~
 
-You can concatenate `Series` and `DataFrames` row-wise.
+Concatenating `Series` and `DataFrames` row-wise.
 
 .. ipython:: python
 
@@ -194,7 +194,7 @@ You can concatenate `Series` and `DataFrames` row-wise.
 Join
 ~~~~~~~~~~~~~~~~~~~~~
 
-You can also do SQL style merges.
+Performing SQL style merges.
 
 .. ipython:: python
 
@@ -213,7 +213,7 @@ You can also do SQL style merges.
 Append
 ~~~~~~~~~~~~~~~~~~~~~
 
-You can append values from another `Series` or array-like object. Appending `Series` with nulls is not yet supported, but can be done using the `concat` method.
+Appending values from another `Series` or array-like object. `Append` does not support `Series` with nulls. This can be done using the `concat` method.
 
 .. ipython:: python
 
@@ -259,14 +259,6 @@ Grouping and applying statistical functions to specific columns, using `agg`.
 Reshaping
 ------------
 
-Stack
-~~~~~~~~~~~~~~~~~~~~~
-
-
-Pivot Tables
-~~~~~~~~~~~~~~~~~~~~~
-
-
 
 Time Series
 ------------
@@ -309,6 +301,7 @@ Accessing the underlying code values of each categorical observation.
 .. ipython:: python
 
     print(gdf.grade.cat.codes)
+
 
 Plotting
 ------------
@@ -360,7 +353,7 @@ Getting Data In/Out
 CSV
 ~~~~
 
-We can write to a CSV file by first sending data to a pandas Dataframe on the host.
+We can write to a CSV file by first sending data to a pandas `Dataframe` on the host.
 
 .. ipython:: python
 
@@ -391,7 +384,7 @@ ORC
 Gotchas
 --------
 
-If you are attempting to perform Boolean indexing or using the `query` API, you might see an exception like:
+If you are attempting to perform Boolean indexing directly or using the `query` API, you might see an exception like:
 
 .. code-block:: python
 

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -17,14 +17,6 @@ Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF, geared
    #### created November, 2018
    #### Nick Becker (NVIDIA), 
 
-This is a basic example
-
-
-.. ipython:: python
-
-    x = 2
-    x**3
-
 
 Object Creation
 ---------------

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -390,13 +390,7 @@ If you are attempting to perform Boolean indexing directly or using the `query` 
 
     ---------------------------------------------------------------------------
     AssertionError                            Traceback (most recent call last)
-    <ipython-input-8-1123dfd98f02> in <module>()
-    ----> 1 d.query("a > 3")
-
    ...
-
-    /conda/envs/cudf/lib/python3.5/site-packages/cudf/columnops.py in column_select_by_boolmask(column, boolmask)
-        102     """
         103     from .numerical import NumericalColumn
     --> 104     assert column.null_count == 0  # We don't properly handle the boolmask yet
         105     boolbits = cudautils.compact_mask_bytes(boolmask.to_gpu_array())

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -372,7 +372,8 @@ Reading from a csv file.
 .. ipython:: python
 
     df = cudf.read_csv('foo.txt', delimiter=',',
-            names=['a', 'b', 'c'], dtype=['int64', 'int64', 'int64'],
+            names=['a', 'b', 'c', 'a1', 'a2'],
+            dtype=['int64', 'int64', 'int64', 'int64', 'int64'],
             skiprows=1)
     print(df)
 

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -13,7 +13,8 @@ Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF, geared
    np.random.seed(12)
 
    #### Portions of this were borrowed from the
-   #### cuDF cheatsheet and existing documentation.
+   #### cuDF cheatsheet, existing cuDF documentation,
+   #### and 10 Minutes to Pandas.
    #### Created November, 2018.
 
 
@@ -27,7 +28,7 @@ Creating a `Series`.
     s = cudf.Series([1,2,3,None,4])
     print(s)
 
-Creating a `DataFrame` by specifying values for each column
+Creating a `DataFrame` by specifying values for each column.
 
 .. ipython:: python
 
@@ -213,7 +214,7 @@ Performing SQL style merges.
 Append
 ~~~~~~~~~~~~~~~~~~~~~
 
-Appending values from another `Series` or array-like object. `Append` does not support `Series` with nulls. This can be done using the `concat` method.
+Appending values from another `Series` or array-like object. `Append` does not support `Series` with nulls. For handling null values, use the `concat` method.
 
 .. ipython:: python
 
@@ -234,7 +235,7 @@ Groupbys involve one or more of the following steps:
     df['agg_col1'] = [1 if x % 2 == 0 else 0 for x in range(len(df))]
     df['agg_col2'] = [1 if x % 3 == 0 else 0 for x in range(len(df))]
 
-Grouping and then applying the `sum` function to the resulting groups.
+Grouping and then applying the `sum` function to the grouped data.
 
 
 .. ipython:: python
@@ -242,7 +243,7 @@ Grouping and then applying the `sum` function to the resulting groups.
     print(df.groupby('agg_col1').sum())
 
 
-Grouping hierarchically then applying the `sum` function to the resulting groups.
+Grouping hierarchically then applying the `sum` function to grouped data.
 
 .. ipython:: python
 

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -7,8 +7,9 @@ Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF, geared
    :suppress:
 
    import os
-   import cudf
    import numpy as np
+   import pandas as pd
+   import cudf
    np.random.seed(12)
 
    #### portions of this were borrowed from the
@@ -28,19 +29,45 @@ This is a basic example
 Object Creation
 ---------------
 
+Series
+
 .. ipython:: python
 
-    gdf = cudf.DataFrame({
-    'a':[1,2,3],
-    'b':[4,5,6],
-    'c':[7,8,9]
-    })
+  s = cudf.Series([1,2,3,None,4])
+  print(s)
+
+Dataframe from dictionary
+
+.. ipython:: python
+
+    df = cudf.DataFrame([('a', list(range(20))),
+    ('b', list(reversed(range(20)))),
+    ('c', list(range(20)))])
+    print(df)
+
+Dataframe from pandas 
+
+.. ipython:: python
+
+    pdf = pd.DataFrame({'a': [0, 1, 2, 3],'b': [0.1, 0.2, None, 0.3]})
+    gdf = cudf.DataFrame.from_pandas(pdf)
     print(gdf)
 
-test
 
 Viewing Data
 -------------
+
+Examples of how to view the top rows of the GPU dataframe:
+
+.. ipython:: python
+
+    print(df.head(2))
+
+Sorting by values:
+
+.. ipython:: python
+
+    print(df.sort_values(by='a', ascending=False))
 
 
 Selection
@@ -49,8 +76,21 @@ Selection
 Getting
 ~~~~~~~~~~~~~~
 
+Selecting a single column, which yields a `cudf.Series`, equivalent to `df.a`:
+
+.. ipython:: python
+
+    print(df['a'])
+
+
+
 Selection by Label
 ~~~~~~~~~~~~~~~~~~~~~
+.. ipython:: python
+
+    # get rows from index 2 to index 5 from 'a' and 'b' columns.
+    print(df.loc[2:5, ['a', 'b']])
+
 
 
 Selection by Position

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -137,6 +137,21 @@ Concat
 Join
 ~~~~~~~~~~~~~~~~~~~~~
 
+SQL style merges, similar to pandas.
+
+.. ipython:: python
+
+    df_a = cudf.DataFrame()
+    df_a['key'] = [0, 1, 2, 3, 4]
+    df_a['vals_a'] = [float(i + 10) for i in range(5)]
+
+    df_b = cudf.DataFrame()
+    df_b['key'] = [1, 2, 4]
+    df_b['vals_b'] = [float(i+10) for i in range(3)]
+
+    df_merged = df_a.merge(df_b, on=['key'], how='left')
+    print(df_merged.sort_values('key'))
+
 
 Append
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -12,10 +12,9 @@ Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF, geared
    import cudf
    np.random.seed(12)
 
-   #### portions of this were borrowed from the
-   #### cuDF cheatsheet and existing docs
-   #### created November, 2018
-   #### Nick Becker (NVIDIA), 
+   #### Portions of this were borrowed from the
+   #### cuDF cheatsheet and existing documentation.
+   #### Created November, 2018.
 
 
 Object Creation

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -1,0 +1,152 @@
+10 Minutes to cuDF
+=======================
+
+Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF, geared mainly for new users.
+
+.. ipython:: python
+   :suppress:
+
+   import os
+   import cudf
+   import numpy as np
+   np.random.seed(12)
+
+   #### portions of this were borrowed from the
+   #### cuDF cheatsheet and existing docs
+   #### created November, 2018
+   #### Nick Becker (NVIDIA), 
+
+This is a basic example
+
+
+.. ipython:: python
+
+    x = 2
+    x**3
+
+
+Object Creation
+---------------
+
+.. ipython:: python
+
+    gdf = cudf.DataFrame({
+    'a':[1,2,3],
+    'b':[4,5,6],
+    'c':[7,8,9]
+    })
+    print(gdf)
+
+test
+
+Viewing Data
+-------------
+
+
+Selection
+------------
+
+Getting
+~~~~~~~~~~~~~~
+
+Selection by Label
+~~~~~~~~~~~~~~~~~~~~~
+
+
+Selection by Position
+~~~~~~~~~~~~~~~~~~~~~
+
+Boolean Indexing
+~~~~~~~~~~~~~~~~~~~~~
+
+Setting
+~~~~~~~~~~~~~~~~~~~~~
+
+
+Missing Data
+------------
+
+
+Operations
+------------
+
+Stats
+~~~~~~~~~~~~~~~~~~~~~
+
+Apply
+~~~~~~~~~~~~~~~~~~~~~
+
+Histogramming
+~~~~~~~~~~~~~~~~~~~~~
+
+
+String Methods
+~~~~~~~~~~~~~~~~~~~~~
+
+
+Merge
+------------
+
+Concat
+~~~~~~~~~~~~~~~~~~~~~
+
+
+Join
+~~~~~~~~~~~~~~~~~~~~~
+
+
+Append
+~~~~~~~~~~~~~~~~~~~~~
+
+
+Grouping
+------------
+
+
+
+Reshaping
+------------
+
+Stack
+~~~~~~~~~~~~~~~~~~~~~
+
+
+Pivot Tables
+~~~~~~~~~~~~~~~~~~~~~
+
+
+
+Time Series
+------------
+
+
+Categoricals
+------------
+
+
+Plotting
+------------
+Coming in a future release.
+
+
+
+
+Getting Data In/Out
+------------
+
+
+CSV
+~~~~
+
+
+HDF5
+~~~~~~~~~
+
+
+Excel
+~~~~~~~~~
+
+
+
+Gotchas
+--------

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -27,7 +27,7 @@ Creating a `Series`.
     s = cudf.Series([1,2,3,None,4])
     print(s)
 
-Creating a `Dataframe` from a list of tuples.
+Creating a `DataFrame` by specifying values for each column
 
 .. ipython:: python
 
@@ -35,6 +35,17 @@ Creating a `Dataframe` from a list of tuples.
     ('b', list(reversed(range(20)))),
     ('c', list(range(20)))])
     print(df)
+
+Creating a `DataFrame` by specifying values for each row
+
+.. ipython:: python
+
+    gdf = cudf.DataFrame.from_records(
+    [[4, 7, 10],
+    [5, 8, 11],
+    [6, 9, 12]],
+    index=[1, 2, 3], columns=[‘a’, ‘b’, ‘c’])
+    print(gdf)
 
 Creating a `Dataframe` from a pandas Dataframe. 
 
@@ -151,6 +162,12 @@ Applying functions to a `Series`.
 Histogramming
 ~~~~~~~~~~~~~~~~~~~~~
 
+Counting the number of rows with each unique value of variable
+
+.. ipython:: python
+
+    df.a.value_counts()
+
 
 String Methods
 ~~~~~~~~~~~~~~~~~~~~~
@@ -203,7 +220,16 @@ You can append values from another `Series` or array-like object. Appending `Ser
 Grouping
 ------------
 
+Groupbys involve one or more of the following steps:
 
+    - Splitting the data into groups based on some criteria
+    - Applying a function to each group independently
+    - Combining the results into a data structure
+
+.. ipython:: python
+
+    df['agg_col'] = [1 if x % 2 == 0 else 0 for x in range(len(df))]
+    print(df.groupby('agg_col').sum())
 
 Reshaping
 ------------

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -90,6 +90,19 @@ Selecting rows from index 2 to index 5 from columns 'a' and 'b'.
 Selection by Position
 ~~~~~~~~~~~~~~~~~~~~~~
 
+Selecting by integer slicing, like numpy/pandas.
+
+.. ipython:: python
+
+    print(df[3:5])
+
+Selecting elements of a `Series` with direct index access.
+
+.. ipython:: python
+
+    print(s[2])
+
+
 Boolean Indexing
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -110,7 +123,7 @@ Supported logical operators include `>`, `<`, `>=`, `<=`, `==`, and `!=`.
 
 
 Setting
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
 
 Missing Data
@@ -302,6 +315,44 @@ Plotting
 
 
 
+Converting Data Representation
+--------------------------------
+
+
+Pandas
+~~~~~~~~
+
+Converting a cuDF `DataFrame` to a pandas `DataFrame`.
+
+.. ipython:: python
+
+    print(df.head().to_pandas())
+
+Numpy
+~~~~~~~~
+
+Converting a cuDF `DataFrame` to a numpy `rec.array`.
+
+.. ipython:: python
+
+    print(df.to_records())
+
+Converting a cuDF `Series` to a numpy `ndarray`.
+
+.. ipython:: python
+
+    print(df['a'].to_array())
+
+Arrow
+~~~~~~~~
+
+Converting a cuDF `DataFrame` to an PyArrow `Table`.
+
+.. ipython:: python
+
+    print(df.to_arrow())
+
+
 Getting Data In/Out
 ------------------------
 
@@ -332,6 +383,7 @@ Parquet
 
 ORC
 ~~~~~~~~~
+
 
 
 

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -224,11 +224,7 @@ Appending values from another `Series` or array-like object. `Append` does not s
 Grouping
 ------------
 
-Groupbys involve one or more of the following steps:
-
-    - Splitting the data into groups based on some criteria
-    - Applying a function to each group independently
-    - Combining the results into a data structure
+Like pandas, cuDF supports the Split-Apply-Combine groupby paradigm.
 
 .. ipython:: python
 
@@ -340,7 +336,7 @@ Converting a cuDF `Series` to a numpy `ndarray`.
 Arrow
 ~~~~~~~~
 
-Converting a cuDF `DataFrame` to an PyArrow `Table`.
+Converting a cuDF `DataFrame` to a PyArrow `Table`.
 
 .. ipython:: python
 
@@ -354,7 +350,7 @@ Getting Data In/Out
 CSV
 ~~~~
 
-We can write to a CSV file by first sending data to a pandas `Dataframe` on the host.
+Writing to a CSV file, by first sending data to a pandas `Dataframe` on the host.
 
 .. ipython:: python
 

--- a/docs/source/10min.rst
+++ b/docs/source/10min.rst
@@ -391,3 +391,24 @@ ORC
 Gotchas
 --------
 
+If you are attempting to perform Boolean indexing or using the `query` API, you might see an exception like:
+
+.. code-block:: python
+
+    ---------------------------------------------------------------------------
+    AssertionError                            Traceback (most recent call last)
+    <ipython-input-8-1123dfd98f02> in <module>()
+    ----> 1 d.query("a > 3")
+
+   ...
+
+    /conda/envs/cudf/lib/python3.5/site-packages/cudf/columnops.py in column_select_by_boolmask(column, boolmask)
+        102     """
+        103     from .numerical import NumericalColumn
+    --> 104     assert column.null_count == 0  # We don't properly handle the boolmask yet
+        105     boolbits = cudautils.compact_mask_bytes(boolmask.to_gpu_array())
+        106     indices = cudautils.arange(len(boolmask))
+
+    AssertionError: 
+
+Boolean indexing a `Series` containing null values will cause this error. Consider filling or removing the missing values.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,10 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'numpydoc',
+    'IPython.sphinxext.ipython_console_highlighting',
+    'IPython.sphinxext.ipython_directive',
 ]
+ipython_mplbackend = None
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,7 @@ Welcome to cuDF's documentation!
 
    api.rst
    developer.rst
+   10min.rst
 
 Indices and tables
 ==================


### PR DESCRIPTION
### Summary of Changes

This PR adds a "10 Minutes to cuDF" section to the documentation, analogous to the ["10 Minutes to Pandas"](https://pandas.pydata.org/pandas-docs/stable/10min.html) documentation. Examples are drawn from the cuDF cheatsheet, existing documentation, and the Pandas documentation.

To support this new documentation, the PR adds `ipython` to the docs requirements file (for the ipython sphinx extensions) and updates `conf.py` and `index.rst` accordingly.

This documentation is currently in its own `rst` file, though it could naturally be moved to the Developer Documentation section.
