### PR TITLE
[REVIEW] Properly cast string dtypes to programmatic dtypes when instantiating columns

### DIFF
--- a/python/cudf/bindings/cudf_cpp.pyx
+++ b/python/cudf/bindings/cudf_cpp.pyx
@@ -92,10 +92,8 @@ cdef gdf_column* column_view_from_column(col):
 
     if pd.api.types.is_categorical_dtype(col.dtype):
         c_dtype = GDF_INT8
-    elif col.dtype != np.bool_:
-        c_dtype = dtypes[col.dtype.type]
     else:
-        c_dtype = dtypes[col.dtype]
+        c_dtype = dtypes[col.dtype.type]
 
     gdf_column_view_augmented(<gdf_column*>c_col,
                               <void*> data_ptr,

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -34,7 +34,7 @@ class TypedColumnBase(Column):
         dtype = kwargs.pop('dtype')
         super(TypedColumnBase, self).__init__(**kwargs)
         # Logical dtype
-        self._dtype = np.dtype(dtype)
+        self._dtype = pd.api.types.pandas_dtype(dtype)
 
     @property
     def dtype(self):

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -34,7 +34,7 @@ class TypedColumnBase(Column):
         dtype = kwargs.pop('dtype')
         super(TypedColumnBase, self).__init__(**kwargs)
         # Logical dtype
-        self._dtype = dtype
+        self._dtype = np.dtype(dtype)
 
     @property
     def dtype(self):

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -152,7 +152,6 @@ def test_dataframe_basic():
     np.testing.assert_equal(mat, expect)
 
 
-@pytest.mark.skip(reason="test segfault")
 def test_dataframe_column_name_indexing():
     df = DataFrame()
     data = np.asarray(range(10), dtype=np.int32)

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -152,6 +152,7 @@ def test_dataframe_basic():
     np.testing.assert_equal(mat, expect)
 
 
+@pytest.mark.skip(reason="test segfault")
 def test_dataframe_column_name_indexing():
     df = DataFrame()
     data = np.asarray(range(10), dtype=np.int32)


### PR DESCRIPTION
Fixes #415 