### PR TITLE
[WIP] Add Managed Memory support to RMM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,4 @@
 	url = https://github.com/moderngpu/moderngpu.git
 [submodule "cpp/thirdparty/cnmem"]
 	path = cpp/thirdparty/cnmem
-	url = https://github.com/harrism/cnmem.git
-	branch = uvm-pool
+	url = https://github.com/NVIDIA/cnmem.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "cpp/thirdparty/moderngpu"]
 	path = cpp/thirdparty/moderngpu
 	url = https://github.com/moderngpu/moderngpu.git
+[submodule "cpp/thirdparty/cnmem"]
+	path = cpp/thirdparty/cnmem
+	url = https://github.com/harrism/cnmem.git
+	branch = uvm-pool

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "cpp/thirdparty/moderngpu"]
 	path = cpp/thirdparty/moderngpu
 	url = https://github.com/moderngpu/moderngpu.git
-[submodule "cpp/thirdparty/cnmem"]
-	path = cpp/thirdparty/cnmem
-	url = https://github.com/NVIDIA/cnmem.git

--- a/cpp/python/librmm_cffi/librmm_config.py
+++ b/cpp/python/librmm_cffi/librmm_config.py
@@ -25,6 +25,13 @@
 # False means to use default cudaMalloc
 use_pool_allocator = False
 
+# Whether to use managed memory for base allocation
+# True means to use cudaMallocManaged
+# False means to use cudaMalloc
+# Can be combined with use_pool_allocator to 
+# create a managed memory pool allocator
+use_managed_memory = False
+
 # When `use_pool_allocator` is true, this indicates the initial pool size.
 # Zero is used to indicate the default size, which currently is 1/2 total GPU
 # memory.

--- a/cpp/python/librmm_cffi/wrapper.py
+++ b/cpp/python/librmm_cffi/wrapper.py
@@ -77,8 +77,14 @@ class _RMMWrapper(object):
         """Initializes the RMM library using the options set in the
            librmm_config module
         """
+        allocation_mode = 0
+        if rmm_cfg.use_pool_allocator:
+            allocation_mode = allocation_mode | self.PoolAllocation
+        if rmm_cfg.use_managed_memory:
+            allocation_mode = allocation_mode | self.CudaManagedMemory
+        
         opts = self._ffi.new("rmmOptions_t *",
-                             [rmm_cfg.use_pool_allocator,
+                             [allocation_mode,
                               rmm_cfg.initial_pool_size,
                               rmm_cfg.enable_logging])
         return self.rmmInitialize(opts)

--- a/cpp/python/tests/test_rmm.py
+++ b/cpp/python/tests/test_rmm.py
@@ -4,15 +4,11 @@ from itertools import product
 import numpy as np
 
 from librmm_cffi import librmm as rmm
+from librmm_cffi import librmm_config as rmm_cfg
 
 from .utils import gen_rand
 
-_dtypes = [np.int32]
-_nelems = [1, 2, 7, 8, 9, 32, 128]
-
-
-@pytest.mark.parametrize('dtype,nelem', list(product(_dtypes, _nelems)))
-def test_rmm_alloc(dtype, nelem):
+def array_tester(dtype, nelem):
     # data
     h_in = gen_rand(dtype, nelem)
     h_result = gen_rand(dtype, nelem)
@@ -29,6 +25,25 @@ def test_rmm_alloc(dtype, nelem):
     print(h_result)
 
     np.testing.assert_array_equal(h_result, h_in)
+
+_dtypes = [np.int32]
+_nelems = [1, 2, 7, 8, 9, 32, 128]
+
+
+@pytest.mark.parametrize('dtype,nelem', list(product(_dtypes, _nelems)))
+def test_rmm_alloc(dtype, nelem):
+    array_tester(dtype, nelem)
+
+
+@pytest.mark.parametrize('managed, pool', 
+                         list(product([False, True], [False, True])))
+def test_rmm_modes(managed, pool):
+    rmm.finalize()
+    rmm_cfg.use_managed_memory = managed
+    rmm_cfg.use_pool_allocator = pool
+    rmm.initialize()
+
+    array_tester(np.int32, 128)
 
 
 def test_rmm_csv_log():

--- a/cpp/src/rmm/memory.cpp
+++ b/cpp/src/rmm/memory.cpp
@@ -107,7 +107,12 @@ namespace rmm
 
     inline bool usePoolAllocator()
     {
-        return Manager::getOptions().allocation_mode == PoolAllocation;
+        return Manager::getOptions().allocation_mode & PoolAllocation;
+    }
+
+    inline bool useManagedMemory()
+    {
+        return Manager::getOptions().allocation_mode & CudaManagedMemory;
     }
 };
 
@@ -150,6 +155,7 @@ rmmError_t rmmInitialize(rmmOptions_t *options)
         cudaStream_t streams[1]; streams[0] = 0;
         dev.streams = streams;
         dev.streamSizes = 0;
+        unsigned flags = rmm::useManagedMemory() ? CNMEM_FLAGS_MANAGED : 0;
         RMM_CHECK_CNMEM( cnmemInit(1, &dev, 0) );
     }
     return RMM_SUCCESS;

--- a/cpp/src/rmm/memory.h
+++ b/cpp/src/rmm/memory.h
@@ -41,12 +41,25 @@ typedef enum
   N_RMM_ERROR                 //< Count of error types
 } rmmError_t;
 
+/** ---------------------------------------------------------------------------*
+ * @brief RMM allocation mode settings
+ *
+ * These settings can be ORed together. For example to use a pool of managed
+ * memory, use `mode = PoolAlloction | CudaManagedMemory`.
+ * --------------------------------------------------------------------------**/
 typedef enum
 {
   CudaDefaultAllocation = 0,  //< Use cudaMalloc for allocation
-  PoolAllocation,             //< Use pool suballocation strategy
+  PoolAllocation        = 1,  //< Use pool suballocation strategy
+  CudaManagedMemory     = 2,  //< Use cudaMallocManaged rather than cudaMalloc
 } rmmAllocationMode_t;
 
+/** ---------------------------------------------------------------------------*
+ * @brief Options for initializing the memory manager
+ *
+ * If set to zero, initial_pool_size defaults to half of the total GPU memory
+ * for the current device.
+ * --------------------------------------------------------------------------**/
 typedef struct
 {
   rmmAllocationMode_t allocation_mode; //< Allocation strategy to use

--- a/cpp/src/rmm/memory_manager.h
+++ b/cpp/src/rmm/memory_manager.h
@@ -143,7 +143,8 @@ namespace rmm
             std::lock_guard<std::mutex> guard(streams_mutex);
             if (registered_streams.empty() || 0 == registered_streams.count(stream)) {
                 registered_streams.insert(stream);
-                if (stream && PoolAllocation == options.allocation_mode) // don't register the null stream with CNMem
+                // don't register the null stream with CNMem
+                if (stream && (PoolAllocation | options.allocation_mode)) 
                     RMM_CHECK_CNMEM( cnmemRegisterStream(stream) );
             }
             return RMM_SUCCESS;

--- a/cpp/tests/rmm/memory_tests.cpp
+++ b/cpp/tests/rmm/memory_tests.cpp
@@ -46,6 +46,17 @@ struct MemoryManagerTest :
     const size_t size_pb = size_t{1}<<50;
 };
 
+rmmAllocationMode_t modes[] = 
+    {
+        CudaDefaultAllocation, 
+        CudaManagedMemory,
+        PoolAllocation, 
+        static_cast<rmmAllocationMode_t>(PoolAllocation | CudaManagedMemory)
+    };
+INSTANTIATE_TEST_CASE_P(TestAllocationModes, 
+                        MemoryManagerTest, 
+                        ::testing::ValuesIn(modes));
+
 // Init / Finalize tests
 
 TEST_P(MemoryManagerTest, Initialize) {
@@ -191,8 +202,3 @@ TEST_P(MemoryManagerTest, AllocationOffset) {
     ASSERT_SUCCESS( RMM_FREE(a, stream) );
     ASSERT_SUCCESS( RMM_FREE(b, stream) );
 }
-
-rmmAllocationMode_t modes[]= {CudaDefaultAllocation, 
-                              PoolAllocation, 
-                              static_cast<rmmAllocationMode_t>(PoolAllocation | CudaManagedMemory)};
-INSTANTIATE_TEST_CASE_P(TestAllocationModes, MemoryManagerTest, ::testing::ValuesIn(modes));


### PR DESCRIPTION
This PR adds an option to `rmmInitialize` to use `cudaMallocManaged` (+ `cudaMemPrefetchAsync`) as the base allocator for RMM rather than `cudaMalloc`.

```
rmmAllocationMode_t mode = CudaManagedMemory | PoolAllocation;
rmmOptions_t options {mode, 0, false};
rmmInitialize(&options);
```

The code above will initialize RMM with a managed memory pool. Removing `PoolAllocation` will cause it to allocate without a pool by calling directly to cudaMallocManaged().

Tests are also expanded to run all tests with all allocation modes.

Note this depends on new functionality I added to cnmem with this PR (already merged): https://github.com/NVIDIA/cnmem/pull/7

Support for multiple simultaneous pools with different modes is future work.