### PR TITLE
[REVIEW] Concatenation illegal memory access with nulls

### DIFF
--- a/python/cudf/dataframe/column.py
+++ b/python/cudf/dataframe/column.py
@@ -48,8 +48,9 @@ class Column(object):
         # Concatenate data
         mem = rmm.device_array(shape=newsize, dtype=head.data.dtype)
         data = Buffer.from_empty(mem, size=newsize)
+        mask = utils.make_mask(newsize)
 
-        col = head.replace(data=data, mask=None, null_count=0)
+        col = head.replace(data=data, mask=mask, null_count=0)
 
         if newsize > 0:
             col = _gdf._column_concat(objs, col)

--- a/python/cudf/tests/test_multi.py
+++ b/python/cudf/tests/test_multi.py
@@ -3,10 +3,11 @@
 import pytest
 
 import pandas as pd
+import numpy as np
 import cudf as gd
 
 
-def make_frames(index=None):
+def make_frames(index=None, nulls='none'):
     df = pd.DataFrame({'x': range(10),
                        'y': list(map(float, range(10))),
                        'z': list('abcde')*2})
@@ -15,6 +16,15 @@ def make_frames(index=None):
                         'y': list(map(float, range(10, 20))),
                         'z': list('edcba')*2})
     df2.z = df2.z.astype('category')
+    if nulls == 'all':
+        df.y = np.full_like(df.y, np.nan)
+        df2.y = np.full_like(df2.y, np.nan)
+    if nulls == 'some':
+        mask = np.arange(10)
+        np.random.shuffle(mask)
+        mask = mask[:5]
+        df.y[mask] = np.nan
+        df2.y[mask] = np.nan
     gdf = gd.DataFrame.from_pandas(df)
     gdf2 = gd.DataFrame.from_pandas(df2)
     if index:
@@ -25,9 +35,12 @@ def make_frames(index=None):
     return df, df2, gdf, gdf2
 
 
+@pytest.mark.parametrize('nulls', ['none', 'some', 'all'])
 @pytest.mark.parametrize('index', [False, 'z', 'y'])
-def test_concat(index):
-    df, df2, gdf, gdf2 = make_frames(index)
+def test_concat(index, nulls):
+    if index == 'y' and nulls in ('some', 'all'):
+        pytest.mark.skip(reason='nulls in columns, dont index')
+    df, df2, gdf, gdf2 = make_frames(index, nulls=nulls)
     # Make empty frame
     gdf_empty1 = gdf2[:0]
     assert len(gdf_empty1) == 0

--- a/python/cudf/tests/test_multi.py
+++ b/python/cudf/tests/test_multi.py
@@ -39,7 +39,7 @@ def make_frames(index=None, nulls='none'):
 @pytest.mark.parametrize('index', [False, 'z', 'y'])
 def test_concat(index, nulls):
     if index == 'y' and nulls in ('some', 'all'):
-        pytest.mark.skip(reason='nulls in columns, dont index')
+        pytest.skip('nulls in columns, dont index')
     df, df2, gdf, gdf2 = make_frames(index, nulls=nulls)
     # Make empty frame
     gdf_empty1 = gdf2[:0]


### PR DESCRIPTION
After merging the change to concatenation it triggers an illegal memory access when there are nulls / a validity mask. I've added more comprehensive tests that trigger this here to make triaging easier.

cc @dantegd @harrism 