### PR TITLE
[WIP] ImportError: cannot import name 'librmm' resolved in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,14 @@ RUN conda create -n cudf python=${PYTHON_VERSION}
 
 ARG NUMBA_VERSION=0.40.0
 ARG NUMPY_VERSION=1.14.3
+ARG CYYHON_VERSION=0.29.1 
 # Locked to Pandas 0.20.3 by https://github.com/rapidsai/cudf/issues/118
 ARG PANDAS_VERSION=0.20.3
 ARG PYARROW_VERSION=0.10.0
 RUN conda install -n cudf -y -c numba -c conda-forge -c nvidia -c rapidsai -c defaults \
       numba=${NUMBA_VERSION} \
       numpy=${NUMPY_VERSION} \
+      cython=${CYYHON_VERSION}\
       pandas=${PANDAS_VERSION} \
       pyarrow=${PYARROW_VERSION} \
       nvstrings \
@@ -61,6 +63,8 @@ RUN source activate cudf && \
     make install_python
 
 # cuDF build/install
-RUN source activate cudf && \
-    cd /cudf/python && \
-    python setup.py install
+#RUN source activate cudf && \
+#    cd /cudf/python && \
+#    python setup.py install
+RUN conda install -c nvidia -c rapidsai -c numba -c conda-forge -c defaults cudf=0.3.0
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,7 @@ RUN conda install -n cudf -y -c numba -c conda-forge -c nvidia -c rapidsai -c de
       pyarrow=${PYARROW_VERSION} \
       nvstrings \
       cmake=3.12 \
-      gtest=1.8.0 \
-      cython
+      gtest=1.8.0
 
 # Clone cuDF repo
 ARG CUDF_REPO=https://github.com/rapidsai/cudf


### PR DESCRIPTION
Even after the changes in the Dockerfile in #404
I encountered the same errors while importing cudf library !!

root@f33fa2ff1be4:/# source activate cudf
(cudf) root@f33fa2ff1be4:/# python -c "import cudf"
Traceback (most recent call last):
File "", line 1, in
File "/conda/envs/cudf/lib/python3.6/site-packages/cudf-0.3.0+138.gdae6026-py3.6-linux-x86_64.egg/cudf/init.py", line 2, in
from cudf import dataframe # noqa: F401
File "/conda/envs/cudf/lib/python3.6/site-packages/cudf-0.3.0+138.gdae6026-py3.6-linux-x86_64.egg/cudf/dataframe/init.py", line 1, in
from cudf.dataframe import (buffer, dataframe, series, # noqa: F401
File "/conda/envs/cudf/lib/python3.6/site-packages/cudf-0.3.0+138.gdae6026-py3.6-linux-x86_64.egg/cudf/dataframe/buffer.py", line 3, in
from librmm_cffi import librmm as rmm
ImportError: cannot import name 'librmm'
(cudf) root@f33fa2ff1be4:/#

A turn around was to install cudf directly using 'conda install' as described in the README.md file
By doing this I can import cudf in the docker container without a problem 
Hop this helped  
Best regards