### PR TITLE
[REVIEW] Improve Dockerfile: install libcudf cffi bindings, add pytest, remove unused cmake flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 
  - PR #444 Fix csv_test CUDA too many resources requested fail. 
  - PR #396 added missing output buffer in validity tests for groupbys.
- - PR #408 Docker file updates for source reorganization
+ - PR #408 Dockerfile updates for source reorganization
+ - PR #437 Add cffi to Dockerfile conda env, fixes "cannot import name 'librmm'"
  - PR #417 Fix `map_test` failure with CUDA 10
  - PR #414 Fix CMake installation include file paths
  - PR #418 Properly cast string dtypes to programmatic dtypes when instantiating columns

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,7 @@ RUN source activate cudf && \
     cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} && \
     make -j install && \
     make python_cffi && \
-    make install_python && \
-    cd python && \
-    python setup.py install
+    make install_python
 
 # cuDF build/install
 RUN source activate cudf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,15 +33,17 @@ ARG NUMPY_VERSION=1.14.3
 # Locked to Pandas 0.20.3 by https://github.com/rapidsai/cudf/issues/118
 ARG PANDAS_VERSION=0.20.3
 ARG PYARROW_VERSION=0.10.0
+ARG CYTHON_VERSION=0.29.1
 RUN conda install -n cudf -y -c numba -c conda-forge -c nvidia -c rapidsai -c defaults \
       numba=${NUMBA_VERSION} \
       numpy=${NUMPY_VERSION} \
       pandas=${PANDAS_VERSION} \
       pyarrow=${PYARROW_VERSION} \
+      cython=${CYTHON_VERSION} \
       nvstrings \
       cmake=3.12 \
       gtest=1.8.0 \
-      cython \
+      cffi \
       pytest
 
 # Clone cuDF repo
@@ -58,9 +60,7 @@ RUN source activate cudf && \
     cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} && \
     make -j install && \
     make python_cffi && \
-    make install_python && \
-    cd /cudf/cpp/build/python && \
-    python setup.py install
+    make install_python
 
 # cuDF build/install
 RUN source activate cudf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,9 @@ RUN source activate cudf && \
     cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} && \
     make -j install && \
     make python_cffi && \
-    make install_python
+    make install_python && \
+    cd /cudf/cpp/build/python && \
+    python setup.py install
 
 # cuDF build/install
 RUN source activate cudf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN conda install -n cudf -y -c numba -c conda-forge -c nvidia -c rapidsai -c de
       nvstrings \
       cmake=3.12 \
       gtest=1.8.0 \
-      cython
+      cython \
+      pytest
 
 # Clone cuDF repo
 ARG CUDF_REPO=https://github.com/rapidsai/cudf
@@ -51,14 +52,15 @@ RUN git clone --recurse-submodules -b ${CUDF_BRANCH} ${CUDF_REPO} /cudf
 # libcudf build/install
 ENV CC=/usr/bin/gcc-${CC}
 ENV CXX=/usr/bin/g++-${CXX}
-ARG HASH_JOIN=ON
 RUN source activate cudf && \
     mkdir -p /cudf/cpp/build && \
     cd /cudf/cpp/build && \
-    cmake .. -DHASH_JOIN=${HASH_JOIN} -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} && \
-    make -j2 install && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} && \
+    make -j install && \
     make python_cffi && \
-    make install_python
+    make install_python && \
+    cd python && \
+    python setup.py install
 
 # cuDF build/install
 RUN source activate cudf && \

--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ $ cd python && py.test -v                           # optional, run python tests
 ```bash
 $ cd ../../python
 $ python setup.py build_ext --inplace
-# necessary if your dev work continues outside of cudf/cpp/build/python
-$ python setup.py install
 ```
 
 To run Python tests (Optional):

--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ $ make test
 Build and install cffi bindings:
 ```bash
 $ make python_cffi                                  # build CFFI bindings for librmm.so, libcudf.so
-$ make install_python                               # build python bindings
-$ cd python && python setup.py install              # install python bindings to site-packages folder
+$ make install_python                               # build & install CFFI python bindings. Depends on cffi package from PyPi or Conda
 $ py.test -v                                        # optional, run python tests on low-level python bindings
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ $ make test
 Build and install cffi bindings:
 ```bash
 $ make python_cffi                                  # build CFFI bindings for librmm.so, libcudf.so
-$ make install_python                               # install python bindings into site-packages
-$ cd python && py.test -v                           # optional, run python tests on low-level python bindings
+$ make install_python                               # build python bindings
+$ cd python && python setup.py install              # install python bindings to site-packages folder
+$ py.test -v                                        # optional, run python tests on low-level python bindings
 ```
 
 4. Build the `cudf` python package, in the `python` folder:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ $ cd python && py.test -v                           # optional, run python tests
 ```bash
 $ cd ../../python
 $ python setup.py build_ext --inplace
+# necessary if your dev work continues outside of cudf/cpp/build/python
+$ python setup.py install
 ```
 
 To run Python tests (Optional):

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -194,7 +194,7 @@ target_link_libraries(cudf rmm "${ARROW_LIB}")
 add_custom_command(OUTPUT PYTHON_CFFI
                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/../python ${CMAKE_BINARY_DIR}/python
-                   COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/python python setup.py install
+                   COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/python python setup.py build_ext --inplace
                    VERBATIM)
 
 add_custom_target(python_cffi DEPENDS cudf PYTHON_CFFI)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -194,7 +194,7 @@ target_link_libraries(cudf rmm "${ARROW_LIB}")
 add_custom_command(OUTPUT PYTHON_CFFI
                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/../python ${CMAKE_BINARY_DIR}/python
-                   COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/python python setup.py build_ext --inplace
+                   COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/python python setup.py install
                    VERBATIM)
 
 add_custom_target(python_cffi DEPENDS cudf PYTHON_CFFI)


### PR DESCRIPTION
fixes #431 

Additions:
Add pytest & steps to install libcudf cffi bindings to the cudf conda environment

Removed:
Unused libgdf HASH_JOIN CMake argument
'-j2' argument to build - not sure if 2 core restriction was added by accident, or whether there's a community preference to limit cores used during build