### PR TITLE
Update reductions.cu to use type_dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  - PR #266 use faster CUDA-accelerated DataFrame column/Series concatenation.
  - PR #379 new C++ `type_dispatcher` reduces code complexity in supporting many data types.
  - PR #349 Improve performance for creating columns from memoryview objects
+ - PR #445 Update reductions to use type_dispatcher. Adds integer types support to sum_of_squares. 
  
 ## Bug Fixes
 

--- a/cpp/include/cudf/functions.h
+++ b/cpp/include/cudf/functions.h
@@ -697,43 +697,103 @@ The following reduction functions use the result array as a temporary working
 space.  Use gdf_reduce_optimal_output_size() to get its optimal size.
 */
 
+
+/* --------------------------------------------------------------------------*
+ * @brief  Reports the intermediate buffer size in elements required for 
+ *         all cuDF reduction operations (gdf_sum, gdf_product, 
+ *         gdf_sum_of_squares, gdf_min and gdf_max)
+ * * 
+ * @return  The size of output/intermediate buffer to allocate for reductions
+ * 
+ * @todo Reductions should be re-implemented to use an atomic add for each
+ *       block sum rather than launch a second kernel. When that happens, this
+ *       function can go away and the output can be a single element.
+ * --------------------------------------------------------------------------*/
 unsigned int gdf_reduce_optimal_output_size();
 
-gdf_error gdf_sum_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_sum_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_sum_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_sum_i64(gdf_column *col, int64_t *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_sum_i32(gdf_column *col, int32_t *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_sum_i8(gdf_column *col, int8_t *dev_result, gdf_size_type dev_result_size);
+/* --------------------------------------------------------------------------*
+ * @brief  Computes the sum of the values in all rows of a column
+ * 
+ * @param[in] col Input column
+ * @param[out] dev_result The output sum 
+ * @param[in] dev_result_size The size of dev_result in elements, which should
+ *                            be computed using gdf_reduce_optimal_output_size
+ *                            This is used as intermediate storage, and the 
+ *                            first element contains the total result
+ * 
+ * @return    GDF_SUCCESS if the operation was successful, otherwise an 
+ *            appropriate error code. 
+ * 
+ * --------------------------------------------------------------------------*/
+gdf_error gdf_sum(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
 
-gdf_error gdf_product_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_product_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_product_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_product_i64(gdf_column *col, int64_t *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_product_i32(gdf_column *col, int32_t *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_product_i8(gdf_column *col, int8_t *dev_result, gdf_size_type dev_result_size);
+/* --------------------------------------------------------------------------*
+ * @brief  Computes the multiplicative product of the values in all rows of 
+ *         a column
+ * 
+ * @param[in] col Input column
+ * @param[out] dev_result The output product
+ * @param[in] dev_result_size The size of dev_result in elements, which should
+ *                            be computed using gdf_reduce_optimal_output_size
+ *                            This is used as intermediate storage, and the 
+ *                            first element contains the total result
+ * 
+ * @return    GDF_SUCCESS if the operation was successful, otherwise an 
+ *            appropriate error code. 
+ * --------------------------------------------------------------------------*/
+gdf_error gdf_product(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
 
-/* sum squared is useful for variance implementation */
-gdf_error gdf_sum_squared_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_sum_squared_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_sum_squared_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size);
+/* --------------------------------------------------------------------------*
+ * @brief  Computes the sum of squares of the values in all rows of a column
+ * 
+ * Sum of squares is useful for variance implementation.
+ * 
+ * @param[in] col Input column
+ * @param[out] dev_result The output sum of squares
+ * @param[in] dev_result_size The size of dev_result in elements, which should
+ *                            be computed using gdf_reduce_optimal_output_size
+ *                            This is used as intermediate storage, and the 
+ *                            first element contains the total result
+ * 
+ * @return    GDF_SUCCESS if the operation was successful, otherwise an 
+ *            appropriate error code. 
+ * 
+ * @todo could be implemented using inner_product if that function is 
+ *       implemented
+ * --------------------------------------------------------------------------*/
+gdf_error gdf_sum_of_squares(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
 
+/* --------------------------------------------------------------------------*
+ * @brief  Computes the minimum of the values in all rows of a column
+ * 
+ * @param[in] col Input column
+ * @param[out] dev_result The output minimum
+ * @param[in] dev_result_size The size of dev_result in elements, which should
+ *                            be computed using gdf_reduce_optimal_output_size
+ *                            This is used as intermediate storage, and the 
+ *                            first element contains the total result
+ * 
+ * @return    GDF_SUCCESS if the operation was successful, otherwise an 
+ *            appropriate error code. 
+ * 
+ * --------------------------------------------------------------------------*/
+gdf_error gdf_min(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
 
-gdf_error gdf_min_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_min_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_min_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_min_i64(gdf_column *col, int64_t *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_min_i32(gdf_column *col, int32_t *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_min_i8(gdf_column *col, int8_t *dev_result, gdf_size_type dev_result_size);
-
-gdf_error gdf_max_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_max_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_max_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_max_i64(gdf_column *col, int64_t *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_max_i32(gdf_column *col, int32_t *dev_result, gdf_size_type dev_result_size);
-gdf_error gdf_max_i8(gdf_column *col, int8_t *dev_result, gdf_size_type dev_result_size);
-
-
+/* --------------------------------------------------------------------------*
+ * @brief  Computes the maximum of the values in all rows of a column
+ * 
+ * @param[in] col Input column
+ * @param[out] dev_result The output maximum
+ * @param[in] dev_result_size The size of dev_result in elements, which should
+ *                            be computed using gdf_reduce_optimal_output_size
+ *                            This is used as intermediate storage, and the 
+ *                            first element contains the total result
+ * 
+ * @return    GDF_SUCCESS if the operation was successful, otherwise an 
+ *            appropriate error code. 
+ * 
+ * --------------------------------------------------------------------------*/
+gdf_error gdf_max(gdf_column *col, void *dev_result, gdf_size_type dev_result_size);
 
 
 /*

--- a/cpp/python/tests/test_reductions.py
+++ b/cpp/python/tests/test_reductions.py
@@ -108,12 +108,10 @@ accuracy_for_dtype = {
     np.float64: 6,
     np.float32: 5
 }
-params_real_only = list(product([np.float64, np.float32], params_sizes))
 
 
-@pytest.mark.parametrize('dtype,nelem', params_real_only)
-def test_sum_squared(dtype, nelem):
-    decimal = accuracy_for_dtype[dtype]
+@pytest.mark.parametrize('dtype,nelem', params)
+def test_sum_of_squares(dtype, nelem):
     data = gen_rand(dtype, nelem)
     d_data = rmm.to_device(data)
     d_result = rmm.device_array(libgdf.gdf_reduce_optimal_output_size(),
@@ -132,7 +130,13 @@ def test_sum_squared(dtype, nelem):
     print('expect:', expect)
     print('got:', got)
 
-    np.testing.assert_array_almost_equal(expect, got, decimal=decimal)
+    if np.dtype(dtype).kind == 'i': 
+        if 0 <= expect <= np.iinfo(dtype).max:
+            np.testing.assert_array_almost_equal(expect, got)
+        else:
+            print('overflow, passing')
+    else:
+        np.testing.assert_array_almost_equal(expect, got, decimal=accuracy_for_dtype[dtype])
 
 
 @pytest.mark.parametrize('dtype,nelem', params)

--- a/cpp/python/tests/test_reductions.py
+++ b/cpp/python/tests/test_reductions.py
@@ -136,7 +136,7 @@ def test_sum_of_squares(dtype, nelem):
         else:
             print('overflow, passing')
     else:
-        np.testing.assert_array_almost_equal(expect, got, 
+        np.testing.assert_array_almost_equal(expect, got,
                                              decimal=accuracy_for_dtype[dtype])
 
 

--- a/cpp/python/tests/test_reductions.py
+++ b/cpp/python/tests/test_reductions.py
@@ -38,7 +38,7 @@ def test_sum(dtype, nelem):
     libgdf.gdf_column_view(col_data, unwrap_devary(d_data), ffi.NULL, nelem,
                            gdf_dtype)
 
-    libgdf.gdf_sum_generic(col_data, unwrap_devary(d_result), d_result.size)
+    libgdf.gdf_sum(col_data, unwrap_devary(d_result), d_result.size)
     got = d_result.copy_to_host()[0]
     expect = dtype(data.sum())
 
@@ -70,8 +70,7 @@ def test_product(dtype, nelem):
     libgdf.gdf_column_view(col_data, unwrap_devary(d_data), ffi.NULL, nelem,
                            gdf_dtype)
 
-    libgdf.gdf_product_generic(col_data, unwrap_devary(d_result),
-                               d_result.size)
+    libgdf.gdf_product(col_data, unwrap_devary(d_result), d_result.size)
     got = d_result.copy_to_host()[0]
     expect = np.product(data)
 
@@ -96,7 +95,7 @@ def test_sum_masked(nelem):
     gdf_dtype = get_dtype(dtype)
     libgdf.gdf_column_view(col_data, unwrap_devary(d_data),
                            unwrap_devary(d_mask), nelem, gdf_dtype)
-    libgdf.gdf_sum_generic(col_data, unwrap_devary(d_result), d_result.size)
+    libgdf.gdf_sum(col_data, unwrap_devary(d_result), d_result.size)
 
     got = d_result.copy_to_host()[0]
     boolmask = buffer_as_bits(mask)[:nelem]
@@ -126,8 +125,7 @@ def test_sum_squared(dtype, nelem):
     libgdf.gdf_column_view(col_data, unwrap_devary(d_data), ffi.NULL, nelem,
                            gdf_dtype)
 
-    libgdf.gdf_sum_squared_generic(col_data, unwrap_devary(d_result),
-                                   d_result.size)
+    libgdf.gdf_sum_of_squares(col_data, unwrap_devary(d_result), d_result.size)
     got = d_result.copy_to_host()[0]
     expect = (data ** 2).sum()
 
@@ -150,7 +148,7 @@ def test_min(dtype, nelem):
     libgdf.gdf_column_view(col_data, unwrap_devary(d_data), ffi.NULL, nelem,
                            gdf_dtype)
 
-    libgdf.gdf_min_generic(col_data, unwrap_devary(d_result), d_result.size)
+    libgdf.gdf_min(col_data, unwrap_devary(d_result), d_result.size)
     got = d_result.copy_to_host()[0]
     expect = data.min()
 
@@ -173,7 +171,7 @@ def test_max(dtype, nelem):
     libgdf.gdf_column_view(col_data, unwrap_devary(d_data), ffi.NULL, nelem,
                            gdf_dtype)
 
-    libgdf.gdf_max_generic(col_data, unwrap_devary(d_result), d_result.size)
+    libgdf.gdf_max(col_data, unwrap_devary(d_result), d_result.size)
     got = d_result.copy_to_host()[0]
     expect = data.max()
 

--- a/cpp/python/tests/test_reductions.py
+++ b/cpp/python/tests/test_reductions.py
@@ -130,13 +130,14 @@ def test_sum_of_squares(dtype, nelem):
     print('expect:', expect)
     print('got:', got)
 
-    if np.dtype(dtype).kind == 'i': 
+    if np.dtype(dtype).kind == 'i':
         if 0 <= expect <= np.iinfo(dtype).max:
             np.testing.assert_array_almost_equal(expect, got)
         else:
             print('overflow, passing')
     else:
-        np.testing.assert_array_almost_equal(expect, got, decimal=accuracy_for_dtype[dtype])
+        np.testing.assert_array_almost_equal(expect, got, 
+                                             decimal=accuracy_for_dtype[dtype])
 
 
 @pytest.mark.parametrize('dtype,nelem', params)

--- a/cpp/python/tests/utils.py
+++ b/cpp/python/tests/utils.py
@@ -41,6 +41,10 @@ def gen_rand(dtype, size, **kwargs):
             return res
         else:
             return (res * 2 - 1)
+    elif dtype == np.int8:
+        low = kwargs.get('low', -32)
+        high = kwargs.get('high', 32)
+        return np.random.randint(low=low, high=high, size=size).astype(dtype)
     elif dtype.kind == 'i':
         low = kwargs.get('low', -10000)
         high = kwargs.get('high', 10000)

--- a/cpp/src/dataframe/type_dispatcher.hpp
+++ b/cpp/src/dataframe/type_dispatcher.hpp
@@ -83,6 +83,7 @@
 /* ----------------------------------------------------------------------------*/
 namespace cudf{
 
+#pragma hd_warning_disable
 template < class functor_t, 
            typename... Ts>
 CUDA_HOST_DEVICE_CALLABLE
@@ -104,6 +105,7 @@ decltype(auto) type_dispatcher(gdf_dtype dtype,
     case GDF_DATE64:    { return f.template operator()< date64 >(std::forward<Ts>(args)...); }
     case GDF_TIMESTAMP: { return f.template operator()< timestamp >(std::forward<Ts>(args)...); }
     case GDF_CATEGORY:  { return f.template operator()< category >(std::forward<Ts>(args)...); }
+    default:            { assert(false && "type_dispatcher: invalid gdf_type"); }
     //case GDF_STRING:    { return f.template operator()< enum_map<GDF_STRING> >(std::forward<Ts>(args)...); }
   }
 
@@ -115,44 +117,6 @@ decltype(auto) type_dispatcher(gdf_dtype dtype,
   using return_type = decltype(f.template operator()<int8_t>(std::forward<Ts>(args)...));
   return return_type();
 }
-
-
-// Only difference is lack of CUDA_HOST_DEVICE_CALLABLE
-template < class functor_t, 
-           typename... Ts>
-decltype(auto) host_type_dispatcher(gdf_dtype dtype, 
-                                    functor_t f, 
-                                    Ts&&... args)
-{
-  switch(dtype)
-  {
-    // The .template is known as a "template disambiguator" 
-    // See here for more information: https://stackoverflow.com/questions/3786360/confusing-template-error
-    case GDF_INT8:      { return f.template operator()< int8_t >(std::forward<Ts>(args)...); }
-    case GDF_INT16:     { return f.template operator()< int16_t >(std::forward<Ts>(args)...); }
-    case GDF_INT32:     { return f.template operator()< int32_t >(std::forward<Ts>(args)...); }
-    case GDF_INT64:     { return f.template operator()< int64_t >(std::forward<Ts>(args)...); }
-    case GDF_FLOAT32:   { return f.template operator()< float >(std::forward<Ts>(args)...); }
-    case GDF_FLOAT64:   { return f.template operator()< double >(std::forward<Ts>(args)...); }
-    case GDF_DATE32:    { return f.template operator()< date32 >(std::forward<Ts>(args)...); }
-    case GDF_DATE64:    { return f.template operator()< date64 >(std::forward<Ts>(args)...); }
-    case GDF_TIMESTAMP: { return f.template operator()< timestamp >(std::forward<Ts>(args)...); }
-    case GDF_CATEGORY:  { return f.template operator()< category >(std::forward<Ts>(args)...); }
-    case GDF_STRING:    // had to add these to avoid host-compiler warnings that aren't there  
-    case GDF_invalid:   // when compiling __host__ __device code for some reason...
-    case N_GDF_TYPES:   // TODO: find a better way than passing void*...
-                        { return f.template operator()< void* >(std::forward<Ts>(args)...); }
-  }
-
-  // This will only fire with a DEBUG build
-  assert(0 && "type_dispatcher: invalid gdf_dtype");
-
-  // Need to find out what the return type is in order to have a default return value
-  // and solve the compiler warning for lack of a default return
-  using return_type = decltype(f.template operator()<int8_t>(std::forward<Ts>(args)...));
-  return return_type();
-}
-
 
 } // namespace cudf
 

--- a/cpp/src/reductions/reductions.cu
+++ b/cpp/src/reductions/reductions.cu
@@ -1,13 +1,14 @@
 #include "cudf.h"
 #include "utilities/cudf_utils.h"
 #include "utilities/error_utils.h"
+#include "dataframe/type_dispatcher.hpp"
 
 #include <cub/block/block_reduce.cuh>
 
 #include <limits>
+#include <type_traits>
 
 #define REDUCTION_BLOCK_SIZE 128
-
 
 struct IdentityLoader{
     template<typename T>
@@ -132,6 +133,9 @@ struct DeviceSum {
     T operator() (const T &lhs, const T &rhs) {
         return lhs + rhs;
     }
+
+    template<typename T>
+    static constexpr T identity = static_cast<T>(0);
 };
 
 struct DeviceProduct {
@@ -143,12 +147,14 @@ struct DeviceProduct {
     T operator() (const T &lhs, const T &rhs) {
         return lhs * rhs;
     }
+
+    template<typename T>
+    static constexpr T identity = static_cast<T>(1);
 };
 
-
-struct DeviceSumSquared {
+struct DeviceSumOfSquares {
     struct Loader {
-        template <typename T>
+        template<typename T>
         __device__
         T operator() (const T* ptr, int pos) const {
             T val = ptr[pos];   // load
@@ -163,8 +169,10 @@ struct DeviceSumSquared {
     T operator() (const T &lhs, const T &rhs) const {
         return lhs + rhs;
     }
-};
 
+    template<typename T>
+    static constexpr T identity = static_cast<T>(0);
+};
 
 struct DeviceMin {
     typedef IdentityLoader Loader;
@@ -175,8 +183,10 @@ struct DeviceMin {
     T operator() (const T &lhs, const T &rhs) {
         return lhs <= rhs? lhs: rhs;
     }
-};
 
+    template<typename T>
+    static constexpr T identity = std::numeric_limits<T>::max();
+};
 
 struct DeviceMax {
     typedef IdentityLoader Loader;
@@ -187,80 +197,54 @@ struct DeviceMax {
     T operator() (const T &lhs, const T &rhs) {
         return lhs >= rhs? lhs: rhs;
     }
+
+    template<typename T>
+    static constexpr T identity = std::numeric_limits<T>::lowest();
 };
 
-#define DEF_REDUCE_OP_NUM(F)                                                      \
-gdf_error F##_generic(gdf_column *col, void *dev_result,                          \
-                          gdf_size_type dev_result_size) {                        \
-    switch ( col->dtype ) {                                                       \
-    case GDF_FLOAT64: return F##_f64(col, (double*)dev_result, dev_result_size);  \
-    case GDF_FLOAT32: return F##_f32(col, (float*)dev_result, dev_result_size);   \
-    case GDF_INT64:   return F##_i64(col, (int64_t*)dev_result, dev_result_size); \
-    case GDF_INT32:   return F##_i32(col, (int32_t*)dev_result, dev_result_size); \
-    case GDF_INT8:    return F##_i8(col,  (int8_t*)dev_result, dev_result_size);  \
-    default:          return GDF_UNSUPPORTED_DTYPE;                               \
-    }                                                                             \
+template <typename Op>
+struct ReduceDispatcher {
+    template <typename T,
+              typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+    gdf_error operator()(gdf_column *col, void *dev_result, gdf_size_type dev_result_size) {
+        T identity = Op::template identity<T>;
+        return ReduceOp<T, Op>::launch(col, identity, reinterpret_cast<T*>(dev_result), dev_result_size); 
+    }
+
+    template <typename T,
+              typename std::enable_if_t<!std::is_arithmetic<T>::value, T>* = nullptr>
+    gdf_error operator()(gdf_column *col, void *dev_result, gdf_size_type dev_result_size) {
+        return GDF_UNSUPPORTED_DTYPE;
+    }
+};
+
+
+gdf_error gdf_sum(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+{   
+    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceSum>(), col, dev_result, dev_result_size);
 }
 
-#define DEF_REDUCE_OP_REAL(F)                                                     \
-gdf_error F##_generic(gdf_column *col, void *dev_result,                          \
-                          gdf_size_type dev_result_size) {                        \
-    switch ( col->dtype ) {                                                       \
-    case GDF_FLOAT64: return F##_f64(col, (double*)dev_result, dev_result_size);  \
-    case GDF_FLOAT32: return F##_f32(col, (float*)dev_result, dev_result_size);   \
-    default:          return GDF_UNSUPPORTED_DTYPE;                               \
-    }                                                                             \
+gdf_error gdf_product(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+{
+    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceProduct>(), col, dev_result, dev_result_size);
 }
 
-#define DEF_REDUCE_IMPL(F, OP, T, ID)                                         \
-gdf_error F(gdf_column *col, T *dev_result, gdf_size_type dev_result_size) {  \
-    return ReduceOp<T, OP>::launch(col, ID, dev_result, dev_result_size);     \
+gdf_error gdf_sum_of_squares(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+{
+    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceSumOfSquares>(), col, dev_result, dev_result_size);
+}
+
+gdf_error gdf_min(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+{
+    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceMin>(), col, dev_result, dev_result_size);
+}
+
+gdf_error gdf_max(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+{
+    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceMax>(), col, dev_result, dev_result_size);
 }
 
 
 unsigned int gdf_reduce_optimal_output_size() {
     return REDUCTION_BLOCK_SIZE;
 }
-
-
-/* Sum */
-
-DEF_REDUCE_OP_NUM(gdf_sum)
-DEF_REDUCE_IMPL(gdf_sum_f64, DeviceSum, double, 0)
-DEF_REDUCE_IMPL(gdf_sum_f32, DeviceSum, float, 0)
-DEF_REDUCE_IMPL(gdf_sum_i64, DeviceSum, int64_t, 0)
-DEF_REDUCE_IMPL(gdf_sum_i32, DeviceSum, int32_t, 0)
-DEF_REDUCE_IMPL(gdf_sum_i8,  DeviceSum, int8_t, 0)
-
-/* Product */
-
-DEF_REDUCE_OP_NUM(gdf_product)
-DEF_REDUCE_IMPL(gdf_product_f64, DeviceProduct, double, 1)
-DEF_REDUCE_IMPL(gdf_product_f32, DeviceProduct, float, 1)
-DEF_REDUCE_IMPL(gdf_product_i64, DeviceProduct, int64_t, 1)
-DEF_REDUCE_IMPL(gdf_product_i32, DeviceProduct, int32_t, 1)
-DEF_REDUCE_IMPL(gdf_product_i8,  DeviceProduct, int8_t, 1)
-
-/* Sum Squared */
-
-DEF_REDUCE_OP_REAL(gdf_sum_squared)
-DEF_REDUCE_IMPL(gdf_sum_squared_f64, DeviceSumSquared, double, 0)
-DEF_REDUCE_IMPL(gdf_sum_squared_f32, DeviceSumSquared, float, 0)
-
-/* Min */
-
-DEF_REDUCE_OP_NUM(gdf_min)
-DEF_REDUCE_IMPL(gdf_min_f64, DeviceMin, double, std::numeric_limits<double>::max())
-DEF_REDUCE_IMPL(gdf_min_f32, DeviceMin, float, std::numeric_limits<float>::max())
-DEF_REDUCE_IMPL(gdf_min_i64, DeviceMin, int64_t, std::numeric_limits<int64_t>::max())
-DEF_REDUCE_IMPL(gdf_min_i32, DeviceMin, int32_t, std::numeric_limits<int32_t>::max())
-DEF_REDUCE_IMPL(gdf_min_i8, DeviceMin, int8_t, std::numeric_limits<int8_t>::max())
-
-/* Max */
-
-DEF_REDUCE_OP_NUM(gdf_max)
-DEF_REDUCE_IMPL(gdf_max_f64, DeviceMax, double, std::numeric_limits<double>::lowest())
-DEF_REDUCE_IMPL(gdf_max_f32, DeviceMax, float, std::numeric_limits<float>::lowest())
-DEF_REDUCE_IMPL(gdf_max_i64, DeviceMax, int64_t, std::numeric_limits<int64_t>::lowest())
-DEF_REDUCE_IMPL(gdf_max_i32, DeviceMax, int32_t, std::numeric_limits<int32_t>::lowest())
-DEF_REDUCE_IMPL(gdf_max_i8, DeviceMax, int8_t,  std::numeric_limits<int8_t>::lowest())

--- a/cpp/src/reductions/reductions.cu
+++ b/cpp/src/reductions/reductions.cu
@@ -225,31 +225,44 @@ struct ReduceDispatcher {
 };
 
 
-gdf_error gdf_sum(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+gdf_error gdf_sum(gdf_column *col,
+                  void *dev_result,
+                  gdf_size_type dev_result_size)
 {   
-    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceSum>(), col, dev_result, dev_result_size);
+    return cudf::type_dispatcher(col->dtype, ReduceDispatcher<DeviceSum>(),
+                                 col, dev_result, dev_result_size);
 }
 
-
-gdf_error gdf_product(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+gdf_error gdf_product(gdf_column *col,
+                      void *dev_result,
+                      gdf_size_type dev_result_size)
 {
-    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceProduct>(), col, dev_result, dev_result_size);
+    return cudf::type_dispatcher(col->dtype, ReduceDispatcher<DeviceProduct>(),
+                                 col, dev_result, dev_result_size);
 }
 
-
-gdf_error gdf_sum_of_squares(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+gdf_error gdf_sum_of_squares(gdf_column *col,
+                             void *dev_result,
+                             gdf_size_type dev_result_size)
 {
-    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceSumOfSquares>(), col, dev_result, dev_result_size);
+    return cudf::type_dispatcher(col->dtype, ReduceDispatcher<DeviceSumOfSquares>(),
+                                 col, dev_result, dev_result_size);
 }
 
-gdf_error gdf_min(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+gdf_error gdf_min(gdf_column *col,
+                  void *dev_result,
+                  gdf_size_type dev_result_size)
 {
-    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceMin>(), col, dev_result, dev_result_size);
+    return cudf::type_dispatcher(col->dtype, ReduceDispatcher<DeviceMin>(),
+                                 col, dev_result, dev_result_size);
 }
 
-gdf_error gdf_max(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+gdf_error gdf_max(gdf_column *col,
+                  void *dev_result,
+                  gdf_size_type dev_result_size)
 {
-    return cudf::host_type_dispatcher(col->dtype, ReduceDispatcher<DeviceMax>(), col, dev_result, dev_result_size);
+    return cudf::type_dispatcher(col->dtype, ReduceDispatcher<DeviceMax>(),
+                                 col, dev_result, dev_result_size);
 }
 
 

--- a/python/cudf/bindings/cudf_cpp.pxd
+++ b/python/cudf/bindings/cudf_cpp.pxd
@@ -576,39 +576,12 @@ cdef extern from "cudf.h" nogil:
 
     cdef unsigned int gdf_reduce_optimal_output_size()
 
-    cdef gdf_error gdf_sum_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_sum_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_sum_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_sum_i64(gdf_column *col, int64_t *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_sum_i32(gdf_column *col, int32_t *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_sum_i8(gdf_column *col, int8_t *dev_result, gdf_size_type dev_result_size)
-
-    cdef gdf_error gdf_product_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_product_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_product_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_product_i64(gdf_column *col, int64_t *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_product_i32(gdf_column *col, int32_t *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_product_i8(gdf_column *col, int8_t *dev_result, gdf_size_type dev_result_size)
-
-    cdef gdf_error gdf_sum_squared_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_sum_squared_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_sum_squared_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size)
-
-
-    cdef gdf_error gdf_min_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_min_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_min_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_min_i64(gdf_column *col, int64_t *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_min_i32(gdf_column *col, int32_t *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_min_i8(gdf_column *col, int8_t *dev_result, gdf_size_type dev_result_size)
-
-    cdef gdf_error gdf_max_generic(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_max_f64(gdf_column *col, double *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_max_f32(gdf_column *col, float *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_max_i64(gdf_column *col, int64_t *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_max_i32(gdf_column *col, int32_t *dev_result, gdf_size_type dev_result_size)
-    cdef gdf_error gdf_max_i8(gdf_column *col, int8_t *dev_result, gdf_size_type dev_result_size)
-
+    cdef gdf_error gdf_sum(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+    cdef gdf_error gdf_product(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+    cdef gdf_error gdf_sum_of_squares(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+    cdef gdf_error gdf_min(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+    cdef gdf_error gdf_max(gdf_column *col, void *dev_result, gdf_size_type dev_result_size)
+    
     cdef gdf_error gpu_comparison_static_i8(gdf_column *lhs, int8_t value, gdf_column *output,gdf_comparison_operator operation)
     cdef gdf_error gpu_comparison_static_i16(gdf_column *lhs, int16_t value, gdf_column *output,gdf_comparison_operator operation)
     cdef gdf_error gpu_comparison_static_i32(gdf_column *lhs, int32_t value, gdf_column *output,gdf_comparison_operator operation)

--- a/python/cudf/bindings/reduce.pyx
+++ b/python/cudf/bindings/reduce.pyx
@@ -31,10 +31,10 @@ from libcpp.string  cimport string as cstring
 ctypedef gdf_error (*reduce_type)(gdf_column*, void*, gdf_size_type)
 
 cdef cmap[cstring, reduce_type] _REDUCE_FUNCTIONS
-_REDUCE_FUNCTIONS[b'max'] = gdf_max_generic
-_REDUCE_FUNCTIONS[b'min'] = gdf_min_generic
-_REDUCE_FUNCTIONS[b'sum'] = gdf_sum_generic
-_REDUCE_FUNCTIONS[b'sum_squared'] = gdf_sum_squared_generic
+_REDUCE_FUNCTIONS[b'max'] = gdf_max
+_REDUCE_FUNCTIONS[b'min'] = gdf_min
+_REDUCE_FUNCTIONS[b'sum'] = gdf_sum
+_REDUCE_FUNCTIONS[b'sum_of_squares'] = gdf_sum_of_squares
 
 
 def apply_reduce(reduction, col):

--- a/python/cudf/dataframe/numerical.py
+++ b/python/cudf/dataframe/numerical.py
@@ -228,7 +228,7 @@ class NumericalColumn(columnops.TypedColumnBase):
         return mu, var
 
     def sum_of_squares(self):
-        return cpp_reduce.apply_reduce('sum_squared', self)
+        return cpp_reduce.apply_reduce('sum_of_squares', self)
 
     def applymap(self, udf, out_dtype=None):
         """Apply a elemenwise function to transform the values in the Column.


### PR DESCRIPTION
This PR refactors reductions.cu to use `type_dispatcher`. It simplifies the public cuDF reductions API to just 5 functions: `gdf_sum`, `gdf_product`, `gdf_min`, `gdf_max`, and `gdf_sum_of_squares` (note *not* `gdf_sum_squared`, which has a different mathematical meaning!)

I also improved public API documentation for these functions.

This should fix #419, @beckernick 

I also expanded the libcudf test_reductions.py test to test sum_of_squares for integer types (handling overflow cases and ignoring the sum comparison when it overflows). So this should now also fix #421 and #443 (which I filed before I realized reductions unit tests were written as pytests).

Note that I had to duplicate `type_dispatcher` to `host_type_dispatcher` to avoid host/device errors (adding pragmas didn't help). I believe this is the right thing to do since functions can't be overloaded on __host__ / __device__, and it will be common to want to do type dispatch on the host side (in this case I need to dispatch a functor that launches a kernel).  I expect @jrhemstad to have an opinion on this. :) We may want to rename `type_dispatcher` to `device_type_dispatcher` for consistency. We may even want to put the guts in a header or macro that gets included after the name of each, to avoid code duplication.  On the host side, I had to add unused types to the switch statement in the dispatcher because the compiler complained if they weren't there. I'm not sure if how I did it is safe...

@jrhemstad please review C++
@dantegd please review my Cython changes (trivial)