### PR TITLE
[REVIEW] Update README to correct cffi pytest failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #426 Removed sort-based groupby and refactored existing groupby APIs. Also improves C++/CUDA compile time.
  
 ## Bug Fixes
+- PR #495 Updated README to correct where cffi pytest should be executed.
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ $ make install                                      # install the libraries libr
 $ make test
 ```
 
-- Build and install cffi bindings:
+- Build, install, and test cffi bindings:
 ```bash
 $ make python_cffi                                  # build CFFI bindings for librmm.so, libcudf.so
 $ make install_python                               # build & install CFFI python bindings. Depends on cffi package from PyPi or Conda
-$ py.test -v                                        # optional, run python tests on low-level python bindings
+$ cd python && py.test -v                           # optional, run python tests on low-level python bindings
 ```
 
 - 4. Build the `cudf` python package, in the `python` folder:


### PR DESCRIPTION
fixes: https://github.com/rapidsai/cudf/issues/494

A slight error in the cuDF README results in an error leading one to believe the `pyarrow` is missing. However, the error is really just a result of running `pytest` in the wrong directory.