### PR TITLE
[REVIEW] Minor tweaks in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-## common
+## Common
 __pycache__
 *.pyc
 *.a
@@ -13,7 +13,7 @@ __pycache__
 DartConfiguration.tcl
 .DS_Store
 
-##build
+## Python build directories & artifacts
 htmlcov
 dist/
 cudf.egg-info/
@@ -25,9 +25,10 @@ python/cudf/bindings/*.cpp
 *.orig
 *.rej
 
-## libgdf
+## C++ build directories & artifacts
 CMakeFiles/
 Debug
+build/
 cpp/build/
 cpp/include/cudf/ipc_generated/*.h
 cpp/thirdparty/googletest/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,13 @@
 - PR #426 Removed sort-based groupby and refactored existing groupby APIs. Also improves C++/CUDA compile time.
 - PR #500 Improved the concurrent hash map class to support partitioned (multi-pass) hash table building.
 - PR #465 Added templated C++ API for RMM to avoid explicit cast to `void**`
+- PR #513 `.gitignore` tweaks
 
 ## Bug Fixes
+
 - PR #473 Added missing <random> include
 - PR #495 Updated README to correct where cffi pytest should be executed.
 - PR #537 Fix CMAKE_CUDA_STANDARD_REQURIED typo in CMakeLists.txt
-
 
 # cuDF 0.4.0 (05 Dec 2018)
 


### PR DESCRIPTION
This is for convenience-of-build, only.

* Now ignoring `build/` just like `cpp/build` in case we don't build within the subdirectory
* Comment tweaks
