### PR TITLE
[REVIEW] Add assert_eq and test reductions and binary operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PR #472 RMM: Created centralized rmm::device_vector alias and rmm::exec_policy
 - PR #426 Removed sort-based groupby and refactored existing groupby APIs. Also improves C++/CUDA compile time.
 - PR #465 Added templated C++ API for RMM to avoid explicit cast to `void**`
+- PR #521 Add `assert_eq` function for testing
 
 ## Bug Fixes
 - PR #495 Updated README to correct where cffi pytest should be executed.
@@ -31,13 +32,13 @@
  - PR #266 use faster CUDA-accelerated DataFrame column/Series concatenation.
  - PR #379 new C++ `type_dispatcher` reduces code complexity in supporting many data types.
  - PR #349 Improve performance for creating columns from memoryview objects
- - PR #445 Update reductions to use type_dispatcher. Adds integer types support to sum_of_squares. 
+ - PR #445 Update reductions to use type_dispatcher. Adds integer types support to sum_of_squares.
  - PR #448 Improve installation instructions in README.md
  - PR #456 Change default CMake build to Release, and added option for disabling compilation of tests
- 
+
 ## Bug Fixes
 
- - PR #444 Fix csv_test CUDA too many resources requested fail. 
+ - PR #444 Fix csv_test CUDA too many resources requested fail.
  - PR #396 added missing output buffer in validity tests for groupbys.
  - PR #408 Dockerfile updates for source reorganization
  - PR #437 Add cffi to Dockerfile conda env, fixes "cannot import name 'librmm'"
@@ -45,7 +46,7 @@
  - PR #414 Fix CMake installation include file paths
  - PR #418 Properly cast string dtypes to programmatic dtypes when instantiating columns
  - PR #427 Fix and tests for Concatenation illegal memory access with nulls
- 
+
 
 # cuDF 0.3.0 (23 Nov 2018)
 
@@ -54,18 +55,18 @@
  - PR #336 CSV Reader string support
 
 ## Improvements
- 
+
  - PR #354 source code refactored for better organization. CMake build system overhaul. Beginning of transition to Cython bindings.
  - PR #290 Add support for typecasting to/from datetime dtype
  - PR #323 Add handling pyarrow boolean arrays in input/out, add tests
  - PR #325 GDF_VALIDITY_UNSUPPORTED now returned for algorithms that don't support non-empty valid bitmasks
- - PR #381 Faster InputTooLarge Join test completes in ms rather than minutes. 
+ - PR #381 Faster InputTooLarge Join test completes in ms rather than minutes.
  - PR #373 .gitignore improvements
  - PR #367 Doc cleanup & examples for DataFrame methods
  - PR #333 Add Rapids Memory Manager documentation
  - PR #321 Rapids Memory Manager adds file/line location logging and convenience macros
  - PR #334 Implement DataFrame `__copy__` and `__deepcopy__`
- - PR #271 Add NVTX ranges to pygdf 
+ - PR #271 Add NVTX ranges to pygdf
  - PR #311 Document system requirements for conda install
 
 ## Bug Fixes
@@ -77,9 +78,9 @@
  - PR #351 replace conda env configuration for developers
  - PRs #346 #360 Fix CSV reading of negative numbers
  - PR #342 Fix CMake to use conda-installed nvstrings
- - PR #341 Preserve categorical dtype after groupby aggregations 
+ - PR #341 Preserve categorical dtype after groupby aggregations
  - PR #315 ReadTheDocs build update to fix missing libcuda.so
- - PR #320 FIX out-of-bounds access error in reductions.cu 
+ - PR #320 FIX out-of-bounds access error in reductions.cu
  - PR #319 Fix out-of-bounds memory access in libcudf count_valid_bits
  - PR #303 Fix printing empty dataframe
 

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -1010,6 +1010,7 @@ def df():
     return pd.DataFrame({'x': range(10),
                          'y': range(10)})
 
+
 @pytest.fixture
 def gf(df):
     return gd.DataFrame.from_pandas(df)
@@ -1025,7 +1026,8 @@ def gf(df):
     pytest.param(lambda df: df.size, marks=pytest.mark.xfail()),
 ])
 @pytest.mark.parametrize('accessor', [
-    pytest.param(lambda df: df, marks=pytest.mark.xfail(reason="dataframe reductions not yet supported")),
+    pytest.param(lambda df: df, marks=pytest.mark.xfail(
+        reason="dataframe reductions not yet supported")),
     lambda df: df.x,
 ])
 def test_reductions(df, gf, accessor, func):

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
+import operator
 import pytest
 
 import numpy as np
@@ -17,6 +18,7 @@ from cudf.settings import set_options
 from itertools import combinations
 
 from . import utils
+from .utils import assert_eq
 
 
 def test_buffer_basic():
@@ -1001,3 +1003,60 @@ def test_dataframe_shape_empty():
     gdf = DataFrame()
 
     assert pdf.shape == gdf.shape
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame({'x': range(10),
+                         'y': range(10)})
+
+@pytest.fixture
+def gf(df):
+    return gd.DataFrame.from_pandas(df)
+
+
+@pytest.mark.parametrize('func', [
+    lambda df: df.mean(),
+    lambda df: df.sum(),
+    lambda df: df.min(),
+    lambda df: df.max(),
+    lambda df: df.std(),
+    lambda df: df.count(),
+    pytest.param(lambda df: df.size, marks=pytest.mark.xfail()),
+])
+@pytest.mark.parametrize('accessor', [
+    pytest.param(lambda df: df, marks=pytest.mark.xfail(reason="dataframe reductions not yet supported")),
+    lambda df: df.x,
+])
+def test_reductions(df, gf, accessor, func):
+    assert_eq(func(accessor(df)), func(accessor(gf)))
+
+
+@pytest.mark.parametrize('left', [
+    pytest.param(lambda df: df, marks=pytest.mark.xfail()),
+    lambda df: df.x,
+    lambda df: 3,
+])
+@pytest.mark.parametrize('right', [
+    pytest.param(lambda df: df, marks=pytest.mark.xfail()),
+    lambda df: df.x,
+    lambda df: 3,
+])
+@pytest.mark.parametrize('binop', [
+    operator.add,
+    operator.mul,
+    pytest.param(operator.floordiv, marks=pytest.mark.xfail()),
+    pytest.param(operator.truediv, marks=pytest.mark.xfail()),
+    pytest.param(operator.mod, marks=pytest.mark.xfail()),
+    pytest.param(operator.pow, marks=pytest.mark.xfail()),
+    operator.eq,
+    operator.lt,
+    operator.le,
+    operator.gt,
+    operator.ge,
+    operator.ne,
+])
+def test_binops(df, gf, left, right, binop):
+    d = binop(left(df), right(df))
+    g = binop(left(gf), right(gf))
+    assert_eq(d, g)

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -1006,14 +1006,14 @@ def test_dataframe_shape_empty():
 
 
 @pytest.fixture
-def df():
+def pdf():
     return pd.DataFrame({'x': range(10),
                          'y': range(10)})
 
 
 @pytest.fixture
-def gf(df):
-    return gd.DataFrame.from_pandas(df)
+def gdf(pdf):
+    return gd.DataFrame.from_pandas(pdf)
 
 
 @pytest.mark.parametrize('func', [
@@ -1030,8 +1030,8 @@ def gf(df):
         reason="dataframe reductions not yet supported")),
     lambda df: df.x,
 ])
-def test_reductions(df, gf, accessor, func):
-    assert_eq(func(accessor(df)), func(accessor(gf)))
+def test_reductions(pdf, gdf, accessor, func):
+    assert_eq(func(accessor(pdf)), func(accessor(gdf)))
 
 
 @pytest.mark.parametrize('left', [
@@ -1058,7 +1058,7 @@ def test_reductions(df, gf, accessor, func):
     operator.ge,
     operator.ne,
 ])
-def test_binops(df, gf, left, right, binop):
-    d = binop(left(df), right(df))
-    g = binop(left(gf), right(gf))
+def test_binops(pdf, gdf, left, right, binop):
+    d = binop(left(pdf), right(pdf))
+    g = binop(left(gdf), right(gdf))
     assert_eq(d, g)

--- a/python/cudf/tests/utils.py
+++ b/python/cudf/tests/utils.py
@@ -1,6 +1,9 @@
 
 import numpy as np
+import pandas as pd
 from cudf.utils import utils
+
+import pandas.util.testing as tm
 
 
 def random_bitmask(size):
@@ -28,3 +31,32 @@ def expand_bits_to_bytes(arr):
 def count_zero(arr):
     arr = np.asarray(arr)
     return np.count_nonzero(arr == 0)
+
+
+def assert_eq(a, b, **kwargs):
+    """ Assert that two cudf-like things are equivalent
+
+    This equality test works for pandas/cudf dataframes/series/indexes/scalars
+    in the same way, and so makes it easier to perform parametrized testing
+    without switching between assert_frame_equal/assert_series_equal/...
+    functions.
+    """
+    if hasattr(a, 'to_pandas'):
+        a = a.to_pandas()
+    if hasattr(b, 'to_pandas'):
+        b = b.to_pandas()
+    if isinstance(a, pd.DataFrame):
+        tm.assert_frame_equal(a, b, **kwargs)
+    elif isinstance(a, pd.Series):
+        tm.assert_series_equal(a, b, **kwargs)
+    elif isinstance(a, pd.Index):
+        tm.assert_index_equal(a, b, **kwargs)
+    else:
+        if a == b:
+            return True
+        else:
+            if np.isnan(a):
+                assert np.isnan(b)
+            else:
+                assert np.allclose(a, b)
+    return True


### PR DESCRIPTION
This adds an `assert_eq` function for testing and then shows off the use of that function while testing reductions and binary operators.  This serves as a proof of concept for testing generally as described in 
https://github.com/rapidsai/cudf/issues/520

I think that this PR can stand on its own, but we should wait for a decision in #520 .  My apologies for pushing something before discussion.

Closes #520 