### PR TITLE
[HOTFIX] Added missing include for <random>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
  
 ## Bug Fixes
 
- - PR #473 Added missing <random> include
+ - PR #566 Added missing <random> include
  - PR #444 Fix csv_test CUDA too many resources requested fail. 
  - PR #396 added missing output buffer in validity tests for groupbys.
  - PR #408 Dockerfile updates for source reorganization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# cuDF 0.4.1 (21 Dec 2018)
+
+## New Features
+
+## Improvements
+
+## Bug Fix
+
+- PR #566 Added missing <random> include that prevents building of unit tests on some systems
+
+
 # cuDF 0.4.0 (05 Dec 2018)
 
 ## New Features
@@ -19,7 +30,6 @@
  
 ## Bug Fixes
 
- - PR #566 Added missing <random> include
  - PR #444 Fix csv_test CUDA too many resources requested fail. 
  - PR #396 added missing output buffer in validity tests for groupbys.
  - PR #408 Dockerfile updates for source reorganization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
  
 ## Bug Fixes
 
+ - PR #473 Added missing <random> include
  - PR #444 Fix csv_test CUDA too many resources requested fail. 
  - PR #396 added missing output buffer in validity tests for groupbys.
  - PR #408 Dockerfile updates for source reorganization

--- a/cpp/tests/types/types_test.cpp
+++ b/cpp/tests/types/types_test.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <random>
 #include "gtest/gtest.h"
 
 #include <utilities/wrapper_types.hpp>


### PR DESCRIPTION
This PR accomplishes the same thing as https://github.com/rapidsai/cudf/pull/473 that was already merged into `branch-0.5`, however, in order to fix the broken build on master, this PR against master has been created per request from @mt-jones. 