### PR TITLE
[REVIEW] Update `print_env.sh` to better handle missing commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PR #537 Fix CMAKE_CUDA_STANDARD_REQURIED typo in CMakeLists.txt
 - PR #545 Temporarily disable csv reader thousands test to prevent segfault (test re-enabled in PR #501)
 - PR #559 Fix Assertion error while using `applymap` to change the output dtype
+- PR #575 Update `print_env.sh` script to better handle missing commands
 
 # cuDF 0.4.0 (05 Dec 2018)
 

--- a/print_env.sh
+++ b/print_env.sh
@@ -6,7 +6,11 @@
 # "./print_env.sh > env.txt" - prints to file "env.txt"
 
 echo "**git***"
+if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]; then
 git log --decorate -n 1
+else
+echo "Not inside a git repository"
+fi
 echo 
 
 echo "***OS Information***"
@@ -54,14 +58,19 @@ printf '%-32s: %s\n' PYTHON_PATH $PYTHON_PATH
 
 echo
 
+
 # Print conda packages if conda exists
-if type "conda" > /dev/null; then
+if type "conda" &> /dev/null; then
 echo '***conda packages***'
 which conda && conda list 
 echo
 # Print pip packages if pip exists
-elif type "pip" > /dev/null; then
+elif type "pip" &> /dev/null; then
+echo "conda not found"
 echo "***pip packages***"
 which pip && pip list
 echo
+else
+echo "conda not found"
+echo "pip not found"
 fi


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/574

- Adds a check such that `git` information will only be displayed if the script is invoked within a git repository.

- Corrects what is displayed if `conda` and `pip` are not found

