### PR TITLE
[REVIEW] Add condition check for truediv of integers to prevent GDF error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - PR #545 Temporarily disable csv reader thousands test to prevent segfault (test re-enabled in PR #501)
 - PR #559 Fix Assertion error while using `applymap` to change the output dtype
 - PR #575 Update `print_env.sh` script to better handle missing commands
+- PR #612 Prevent an exception from occuring with true division on integer series.
 
 # cuDF 0.4.0 (05 Dec 2018)
 

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -357,14 +357,18 @@ class Series(object):
         return self._rbinaryop(other, 'floordiv')
 
     def __truediv__(self, other):
-        if self.dtype in ('int64', 'int32',):
-            return self._binaryop(other, 'floordiv')
-        return self._binaryop(other, 'truediv')
+        if self.dtype in list(truediv_int_dtype_corrections.keys()):
+            truediv_type = truediv_int_dtype_corrections[str(self.dtype)]
+            return self.astype(truediv_type)._binaryop(other, 'truediv')
+        else:
+            return self._binaryop(other, 'truediv')
 
     def __rtruediv__(self, other):
-        if self.dtype in ('int64', 'int32',):
-            return self._rbinaryop(other, 'floordiv')
-        return self._rbinaryop(other, 'truediv')
+        if self.dtype in list(truediv_int_dtype_corrections.keys()):
+            truediv_type = truediv_int_dtype_corrections[str(self.dtype)]
+            return self.astype(truediv_type)._rbinaryop(other, 'truediv')
+        else:
+            return self._rbinaryop(other, 'truediv')
 
     __div__ = __truediv__
 
@@ -951,6 +955,13 @@ class Series(object):
 
 
 register_distributed_serializer(Series)
+
+
+truediv_int_dtype_corrections = {
+        'int64': 'float64',
+        'int32': 'float32',
+        'int': 'float',
+}
 
 
 class DatetimeProperties(object):

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -357,9 +357,13 @@ class Series(object):
         return self._rbinaryop(other, 'floordiv')
 
     def __truediv__(self, other):
+        if self.dtype in ('int64', 'int32',):
+            return self._binaryop(other, 'floordiv')
         return self._binaryop(other, 'truediv')
 
     def __rtruediv__(self, other):
+        if self.dtype in ('int64', 'int32',):
+            return self._rbinaryop(other, 'floordiv')
         return self._rbinaryop(other, 'truediv')
 
     __div__ = __truediv__

--- a/python/cudf/tests/test_binops.py
+++ b/python/cudf/tests/test_binops.py
@@ -167,14 +167,14 @@ def test_reflected_ops_scalar(func, dtype):
     np.testing.assert_allclose(ps_result, gs_result)
 
 
-@pytest.mark.parametrize('int_dtypes', ['int64', 'int32'])
+@pytest.mark.parametrize('int_dtypes', ['int64', 'int32', 'int'])
 def test_integer_true_division(int_dtypes):
     s = Series([-3, -2, -1, -0, 1, 2, 3]).astype(int_dtypes)
     assert np.array_equal((s/2), (s//2))
     assert np.array_equal((s/3), (s//3))
 
 
-@pytest.mark.parametrize('float_dtypes', ['float64', 'float32'])
+@pytest.mark.parametrize('float_dtypes', ['float64', 'float32', 'float'])
 def test_float_true_division(float_dtypes):
     s = Series([-3, -2, -1, -0, 1, 2, 3]).astype(float_dtypes)
     assert not np.array_equal((s/2), (s//2))

--- a/python/cudf/tests/test_binops.py
+++ b/python/cudf/tests/test_binops.py
@@ -161,6 +161,10 @@ _reflected_ops = [
     lambda x: -3 - x,
     lambda x: -3 // x,
     lambda x: -3 / x,
+    lambda x: 0 + x,
+    lambda x: 0 * x,
+    lambda x: 0 - x,
+    lambda x: 0 // x,
     lambda x: 0 / x,
 ]
 

--- a/python/cudf/tests/test_binops.py
+++ b/python/cudf/tests/test_binops.py
@@ -145,6 +145,23 @@ _reflected_ops = [
     lambda x: 2 * x,
     lambda x: 2 - x,
     lambda x: 2 // x,
+    lambda x: 2 / x,
+    lambda x: 3 + x,
+    lambda x: 3 * x,
+    lambda x: 3 - x,
+    lambda x: 3 // x,
+    lambda x: 3 / x,
+    lambda x: -1 + x,
+    lambda x: -2 * x,
+    lambda x: -2 - x,
+    lambda x: -2 // x,
+    lambda x: -2 / x,
+    lambda x: -3 + x,
+    lambda x: -3 * x,
+    lambda x: -3 - x,
+    lambda x: -3 // x,
+    lambda x: -3 / x,
+    lambda x: 0 / x,
 ]
 
 
@@ -165,17 +182,3 @@ def test_reflected_ops_scalar(func, dtype):
 
     # verify
     np.testing.assert_allclose(ps_result, gs_result)
-
-
-@pytest.mark.parametrize('int_dtypes', ['int64', 'int32', 'int'])
-def test_integer_true_division(int_dtypes):
-    s = Series([-3, -2, -1, -0, 1, 2, 3]).astype(int_dtypes)
-    assert np.array_equal((s/2), (s//2))
-    assert np.array_equal((s/3), (s//3))
-
-
-@pytest.mark.parametrize('float_dtypes', ['float64', 'float32', 'float'])
-def test_float_true_division(float_dtypes):
-    s = Series([-3, -2, -1, -0, 1, 2, 3]).astype(float_dtypes)
-    assert not np.array_equal((s/2), (s//2))
-    assert not np.array_equal((s/3), (s//3))

--- a/python/cudf/tests/test_binops.py
+++ b/python/cudf/tests/test_binops.py
@@ -165,3 +165,17 @@ def test_reflected_ops_scalar(func, dtype):
 
     # verify
     np.testing.assert_allclose(ps_result, gs_result)
+
+
+@pytest.mark.parametrize('int_dtypes', ['int64', 'int32'])
+def test_integer_true_division(int_dtypes):
+    s = Series([-3, -2, -1, -0, 1, 2, 3]).astype(int_dtypes)
+    assert np.array_equal((s/2), (s//2))
+    assert np.array_equal((s/3), (s//3))
+
+
+@pytest.mark.parametrize('float_dtypes', ['float64', 'float32'])
+def test_float_true_division(float_dtypes):
+    s = Series([-3, -2, -1, -0, 1, 2, 3]).astype(float_dtypes)
+    assert not np.array_equal((s/2), (s//2))
+    assert not np.array_equal((s/3), (s//3))


### PR DESCRIPTION
If GDF doesn't like true integer division, we should just call floor division for integers. Deal?