### PR TITLE
[REVIEW] Fix deprecation warning for is_categorical_dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - PR #545 Temporarily disable csv reader thousands test to prevent segfault (test re-enabled in PR #501)
 - PR #559 Fix Assertion error while using `applymap` to change the output dtype
 - PR #575 Update `print_env.sh` script to better handle missing commands
+- PR #630 Fix deprecation warning for `pd.core.common.is_categorical_dtype`
 
 # cuDF 0.4.0 (05 Dec 2018)
 

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -274,7 +274,7 @@ def as_column(arbitrary, nan_as_null=True):
             )
 
     elif isinstance(arbitrary, (pd.Series, pd.Categorical)):
-        if pd.core.common.is_categorical_dtype(arbitrary):
+        if pd.api.types.is_categorical_dtype(arbitrary):
             data = as_column(pa.array(arbitrary, from_pandas=True))
         else:
             data = as_column(pa.array(arbitrary, from_pandas=nan_as_null))


### PR DESCRIPTION
Addresses the following test warnings:

```python
/home/jenkins/workspace/cudf-prb/python/cudf/dataframe/series.py:75: DeprecationWarning: 
pandas.core.common.is_categorical_dtype is deprecated. import from the public API: pandas.api.types.is_categorical_dtype instead
```