### PR TITLE
[REVIEW] Fix issue 560: numba>=0.42 requires one-to-one copying.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - PR #630 Fix deprecation warning for `pd.core.common.is_categorical_dtype`
 - PR #622 Fix Series.append() behaviour when appending values with different numeric dtype
 - PR #634 Fix create `DataFrame.from_pandas()` with numeric column names
-
+- PR #560 Enforce one-to-one copy required when using numba>=0.42.0.
 
 # cuDF 0.4.0 (05 Dec 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - PR #630 Fix deprecation warning for `pd.core.common.is_categorical_dtype`
 - PR #622 Fix Series.append() behaviour when appending values with different numeric dtype
 - PR #634 Fix create `DataFrame.from_pandas()` with numeric column names
-- PR #560 Enforce one-to-one copy required when using numba>=0.42.0.
+- PR #560 Enforce one-to-one copy required when using `numba>=0.42.0`
 
 # cuDF 0.4.0 (05 Dec 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - PR #630 Fix deprecation warning for `pd.core.common.is_categorical_dtype`
 - PR #622 Fix Series.append() behaviour when appending values with different numeric dtype
 - PR #634 Fix create `DataFrame.from_pandas()` with numeric column names
-- PR #560 Enforce one-to-one copy required when using `numba>=0.42.0`
+- PR #648 Enforce one-to-one copy required when using `numba>=0.42.0`
 
 # cuDF 0.4.0 (05 Dec 2018)
 

--- a/python/cudf/dataframe/buffer.py
+++ b/python/cudf/dataframe/buffer.py
@@ -158,7 +158,7 @@ class Buffer(object):
         needed = array.size
         self._sentry_capacity(needed)
         array = cudautils.astype(array, dtype=self.dtype)
-        self.mem[self.size:].copy_to_device(array)
+        self.mem[self.size:self.size+needed].copy_to_device(array)
         self.size += needed
 
     def astype(self, dtype):


### PR DESCRIPTION
Fixes cudf issue [#560](https://github.com/rapidsai/cudf/issues/560). 