### PR TITLE
[REVIEW] Add check for GDF_TIMESTAMP resolution to Join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - PR #630 Fix deprecation warning for `pd.core.common.is_categorical_dtype`
 - PR #622 Fix Series.append() behaviour when appending values with different numeric dtype
 - PR #634 Fix create `DataFrame.from_pandas()` with numeric column names
+- PR #654 Add resolution check for GDF_TIMESTAMP in Join
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/cpp/include/cudf/types.h
+++ b/cpp/include/cudf/types.h
@@ -39,28 +39,29 @@ typedef enum {
 /* ----------------------------------------------------------------------------*/
 typedef enum {
     GDF_SUCCESS=0,                
-    GDF_CUDA_ERROR,                   /**< Error occured in a CUDA call */ 
-    GDF_UNSUPPORTED_DTYPE,            /**< The datatype of the gdf_column is unsupported */ 
-    GDF_COLUMN_SIZE_MISMATCH,         /**< Two columns that should be the same size aren't the same size*/        
-    GDF_COLUMN_SIZE_TOO_BIG,          /**< Size of column is larger than the max supported size */      
-    GDF_DATASET_EMPTY,                /**< Input dataset is either null or has size 0 when it shouldn't */   
-    GDF_VALIDITY_MISSING,             /**< gdf_column's validity bitmask is null */  
-    GDF_VALIDITY_UNSUPPORTED,         /**< The requested gdf operation does not support validity bitmask handling, and one of the input columns has the valid bits enabled */
-    GDF_INVALID_API_CALL,             /**< The arguments passed into the function were invalid */   
-    GDF_JOIN_DTYPE_MISMATCH,          /**< Datatype mismatch between corresponding columns in  left/right tables in the Join function */   
-    GDF_JOIN_TOO_MANY_COLUMNS,        /**< Too many columns were passed in for the requested join operation*/       
-    GDF_DTYPE_MISMATCH,               /**< Type mismatch between columns that should be the same type */
-    GDF_UNSUPPORTED_METHOD,           /**< The method requested to perform an operation was invalid or unsupported (e.g., hash vs. sort)*/ 
-    GDF_INVALID_AGGREGATOR,           /**< Invalid aggregator was specified for a groupby*/
-    GDF_INVALID_HASH_FUNCTION,        /**< Invalid hash function was selected */
-    GDF_PARTITION_DTYPE_MISMATCH,     /**< Datatype mismatch between columns of input/output in the hash partition function */
-    GDF_HASH_TABLE_INSERT_FAILURE,    /**< Failed to insert to hash table, likely because its full */
-    GDF_UNSUPPORTED_JOIN_TYPE,        /**< The type of join requested is unsupported */
-    GDF_C_ERROR,                      /**< C error not related to CUDA */
-    GDF_FILE_ERROR,                   /**< error processing sepcified file */      
-    GDF_MEMORYMANAGER_ERROR,          /**< Memory manager error (see memory.h) */
-    GDF_UNDEFINED_NVTX_COLOR,         /**< The requested color used to define an NVTX range is not defined */
-    GDF_NULL_NVTX_NAME,               /**< The requested name for an NVTX range cannot be nullptr */
+    GDF_CUDA_ERROR,                    /**< Error occured in a CUDA call */ 
+    GDF_UNSUPPORTED_DTYPE,             /**< The datatype of the gdf_column is unsupported */ 
+    GDF_COLUMN_SIZE_MISMATCH,          /**< Two columns that should be the same size aren't the same size*/        
+    GDF_COLUMN_SIZE_TOO_BIG,           /**< Size of column is larger than the max supported size */      
+    GDF_DATASET_EMPTY,                 /**< Input dataset is either null or has size 0 when it shouldn't */   
+    GDF_VALIDITY_MISSING,              /**< gdf_column's validity bitmask is null */  
+    GDF_VALIDITY_UNSUPPORTED,          /**< The requested gdf operation does not support validity bitmask handling, and one of the input columns has the valid bits enabled */
+    GDF_INVALID_API_CALL,              /**< The arguments passed into the function were invalid */   
+    GDF_JOIN_DTYPE_MISMATCH,           /**< Datatype mismatch between corresponding columns in  left/right tables in the Join function */   
+    GDF_JOIN_TOO_MANY_COLUMNS,         /**< Too many columns were passed in for the requested join operation*/       
+    GDF_DTYPE_MISMATCH,                /**< Type mismatch between columns that should be the same type */
+    GDF_UNSUPPORTED_METHOD,            /**< The method requested to perform an operation was invalid or unsupported (e.g., hash vs. sort)*/ 
+    GDF_INVALID_AGGREGATOR,            /**< Invalid aggregator was specified for a groupby*/
+    GDF_INVALID_HASH_FUNCTION,         /**< Invalid hash function was selected */
+    GDF_PARTITION_DTYPE_MISMATCH,      /**< Datatype mismatch between columns of input/output in the hash partition function */
+    GDF_HASH_TABLE_INSERT_FAILURE,     /**< Failed to insert to hash table, likely because its full */
+    GDF_UNSUPPORTED_JOIN_TYPE,         /**< The type of join requested is unsupported */
+    GDF_C_ERROR,                       /**< C error not related to CUDA */
+    GDF_FILE_ERROR,                    /**< error processing sepcified file */      
+    GDF_MEMORYMANAGER_ERROR,           /**< Memory manager error (see memory.h) */
+    GDF_UNDEFINED_NVTX_COLOR,          /**< The requested color used to define an NVTX range is not defined */
+    GDF_NULL_NVTX_NAME,                /**< The requested name for an NVTX range cannot be nullptr */
+    GDF_TIMESTAMP_RESOLUTION_MISMATCH, /**< Resolution mismatch between two columns of GDF_TIMESTAMP */
     N_GDF_ERRORS
 } gdf_error;
 

--- a/cpp/src/join/joining.cu
+++ b/cpp/src/join/joining.cu
@@ -331,9 +331,16 @@ gdf_error join_call( int num_cols, gdf_column **leftcol, gdf_column **rightcol,
     if((left_col_size > 0) && (nullptr == leftcol[i]->data)){
      return GDF_DATASET_EMPTY;
     } 
-    if(rightcol[i]->dtype != leftcol[i]->dtype) return GDF_JOIN_DTYPE_MISMATCH;
+    if(rightcol[i]->dtype != leftcol[i]->dtype) return GDF_DTYPE_MISMATCH;
     if(left_col_size != leftcol[i]->size) return GDF_COLUMN_SIZE_MISMATCH;
     if(right_col_size != rightcol[i]->size) return GDF_COLUMN_SIZE_MISMATCH;
+
+    // Ensure GDF_TIMESTAMP columns have the same resolution
+    if (GDF_TIMESTAMP == rightcol[i]->dtype) {
+      GDF_REQUIRE(
+          rightcol[i]->dtype_info.time_unit == leftcol[i]->dtype_info.time_unit,
+          GDF_TIMESTAMP_RESOLUTION_MISMATCH);
+    }
   }
 
   gdf_method join_method = join_context->flag_method; 

--- a/cpp/src/utilities/error_utils.cpp
+++ b/cpp/src/utilities/error_utils.cpp
@@ -28,6 +28,7 @@ const char * gdf_error_get_name(gdf_error errcode) {
     GETNAME(GDF_MEMORYMANAGER_ERROR)
     GETNAME(GDF_UNDEFINED_NVTX_COLOR)
     GETNAME(GDF_NULL_NVTX_NAME)
+    GETNAME(GDF_TIMESTAMP_RESOLUTION_MISMATCH)
     default:
         // This means we are missing an entry above for a gdf_error value.
         return "Internal error. Unknown error code.";


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/395

I believe this is the only offending code for https://github.com/rapidsai/cudf/issues/395 

Added a check to ensure that two columns of `GDF_TIMESTAMP` must have the same resolution in order to be joined on.