### PR TITLE
[REVIEW] Update cython version to 0.29.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - PR #630 Fix deprecation warning for `pd.core.common.is_categorical_dtype`
 - PR #622 Fix Series.append() behaviour when appending values with different numeric dtype
 - PR #634 Fix create `DataFrame.from_pandas()` with numeric column names
+- PR #657 Update cython version to 0.29
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/conda/environments/dev_py35.yml
+++ b/conda/environments/dev_py35.yml
@@ -16,9 +16,9 @@ dependencies:
 - notebook>=0.5.0
 - boost
 - nvstrings
-- cffi>=1.10.0   
+- cffi>=1.10.0
 - distributed>=1.23.0
-- cython=0.28.*
+- cython=0.29.*
 - pytest
 - sphinx
 - sphinx_rtd_theme

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   #   - defaults
   build:
     - python
-    - cython=0.28.*
+    - cython=0.29.*
     - setuptools
     - libcudf 0.4.0.*
     - libcudf_cffi 0.4.0.*
@@ -33,7 +33,7 @@ requirements:
     - nvstrings
   run:
     - python
-    - cython=0.28.*
+    - cython=0.29.*
     - setuptools
     - libcudf 0.4.0.*
     - libcudf_cffi 0.4.0.*


### PR DESCRIPTION
Update cython to version `0.29.x`, to solve this integration issue between cuDF and cuML: 

https://github.com/rapidsai/cuml/issues/58

