### PR TITLE
[REVIEW] CSV reader: automatically set compression type to None with buffer input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - PR #500 Improved the concurrent hash map class to support partitioned (multi-pass) hash table building
 - PR #617 Added .dockerignore file. Prevents adding stale cmake cache files to the docker container
 - PR #658 Reduced `JOIN_TEST` time by isolating overflow test of hash table size computation
+- PR #671 CSV Reader: uncompressed buffer input can be parsed without explicitly specifying compression as None
 
 ## Bug Fixes
 
@@ -60,7 +61,6 @@
 - PR #648 Enforce one-to-one copy required when using `numba>=0.42.0`
 - PR #645 Fix cmake build type handling not setting debug options when CMAKE_BUILD_TYPE=="Debug"
 - PR #665 Reworked the hash map to add a way to report the destination partition for a key
-
 
 # cuDF 0.4.0 (05 Dec 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - PR #665 Reworked the hash map to add a way to report the destination partition for a key
 - PR #670 CMAKE: Fix env include path taking precedence over libcudf source headers
 
+
 # cuDF 0.4.0 (05 Dec 2018)
 
 ## New Features

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -158,7 +158,7 @@ def read_csv(filepath_or_buffer, lineterminator='\n',
     # Populate csv_reader struct
     if is_file_like(filepath_or_buffer):
         if compression == 'infer':
-            raise ValueError("Cannot infer compression type from a buffer")
+            compression = None
         buffer = filepath_or_buffer.read()
         # check if StringIO is used
         if hasattr(buffer, 'encode'):

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -340,16 +340,14 @@ def test_csv_reader_buffer(tmpdir):
     int32_ref = [1234567, 12345]
 
     df_str = read_csv(StringIO(buffer),
-                      names=names, dtype=dtypes, skiprows=1,
-                      compression=None)
+                      names=names, dtype=dtypes, skiprows=1)
     np.testing.assert_allclose(f32_ref, df_str['float32'])
     np.testing.assert_allclose(int32_ref, df_str['int32'])
     assert("1995-11-22T00:00:00.000" == str(df_str['date'][0]))
     assert("2002-01-02T00:00:00.000" == str(df_str['date'][1]))
 
     df_bytes = read_csv(BytesIO(str.encode(buffer)),
-                        names=names, dtype=dtypes, skiprows=1,
-                        compression=None)
+                        names=names, dtype=dtypes, skiprows=1)
     np.testing.assert_allclose(f32_ref, df_bytes['float32'])
     np.testing.assert_allclose(int32_ref, df_bytes['int32'])
     assert("1995-11-22T00:00:00.000" == str(df_bytes['date'][0]))


### PR DESCRIPTION
Simple change to allow users to use the default compression value for buffer input. 
Previously compression=None was required as the default value, 'infer' would lead to failure. 
This change addresses the issue and sets the compression type to None if the input is a buffer, instead of a file.
Modifications in the test demonstrate the purpose of the change.