### PR TITLE
[REVIEW] Fix uncaught string initialization when `object` dtype is in from_pandas and column creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - PR #612 Prevent an exception from occuring with true division on integer series.
 - PR #630 Fix deprecation warning for `pd.core.common.is_categorical_dtype`
 - PR #622 Fix Series.append() behaviour when appending values with different numeric dtype
+- PR #673 Fix array of strings not being caught in from_pandas
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -174,7 +174,7 @@ def as_column(arbitrary, nan_as_null=True):
     elif isinstance(arbitrary, np.ndarray):
         if arbitrary.dtype.kind == 'M':
             data = datetime.DatetimeColumn.from_numpy(arbitrary)
-        elif arbitrary.dtype.kind == 'O':
+        elif arbitrary.dtype.kind in ('O', 'U'):
             raise NotImplementedError("Strings are not yet supported")
         else:
             data = as_column(rmm.to_device(arbitrary), nan_as_null=nan_as_null)

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -174,6 +174,8 @@ def as_column(arbitrary, nan_as_null=True):
     elif isinstance(arbitrary, np.ndarray):
         if arbitrary.dtype.kind == 'M':
             data = datetime.DatetimeColumn.from_numpy(arbitrary)
+        elif arbitrary.dtype.kind == 'O':
+            raise NotImplementedError("Strings are not yet supported")
         else:
             data = as_column(rmm.to_device(arbitrary), nan_as_null=nan_as_null)
 

--- a/python/cudf/tests/test_joining.py
+++ b/python/cudf/tests/test_joining.py
@@ -318,13 +318,9 @@ def test_dataframe_merge_no_common_column():
     raises.match('No common columns to perform merge on')
 
 
-def test_dataframe_merge_issue626():
+def test_dataframe_merge_strings_not_supported():
     pleft = pd.DataFrame({'x': [0, 1, 2, 3],
                           'name': ['Alice', 'Bob', 'Charlie', 'Dan']})
-    gleft = DataFrame.from_pandas(pleft)
-    pright = pd.DataFrame({'x': [i % 4 for i in range(10)],
-                           'y': range(10)})
-    gright = DataFrame.from_pandas(pright)
-    with pytest.raises(TypeError) as raises:
-        gleft.merge(gright)
-    raises.match('column type `object` not supported in gdf')
+    with pytest.raises(NotImplementedError) as raises:
+        gleft = DataFrame.from_pandas(pleft)  # noqa:F841
+    raises.match('Strings are not yet supported')


### PR DESCRIPTION
Fixes the specific issue presented in #626.