### PR TITLE
[REVIEW] Fix read_csv behavior with skiprows+header to match pandas version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 - PR #670 CMAKE: Fix env include path taking precedence over libcudf source headers
 - PR #674 Check for gdf supported column types
 - PR #677 Fix 'gdf_csv_test_Dates' gtest failure due to missing nrows parameter
-
+- PR #689 CSV Reader: Fix behavior with skiprows+header to match pandas implementation
 
 # cuDF 0.4.0 (05 Dec 2018)
 

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -162,8 +162,11 @@ __global__ void storeRecordStart(char *data, size_t chunk_offset,
 	const char terminator, const char quotechar, 
 	long num_bytes, long num_bits, cu_reccnt_t* num_records,
 	cu_recstart_t* recStart);
-__global__ void convertCsvToGdf(char *csv, const parsing_opts_t opts, gdf_size_type num_records, int num_columns, bool *parseCol, cu_recstart_t *recStart, gdf_dtype *dtype, void **gdf_data, gdf_valid_type **valid, string_pair **str_cols, long header_row, bool dayfirst, unsigned long long *num_valid);
-__global__ void dataTypeDetection(char *raw_csv, const parsing_opts_t opts, gdf_size_type num_records, int  num_columns, bool  *parseCol, cu_recstart_t *recStart, long header_row, column_data_t* d_columnData);
+__global__ void convertCsvToGdf(char *csv, const parsing_opts_t opts, gdf_size_type num_records, int num_columns, 
+	bool *parseCol, cu_recstart_t *recStart,gdf_dtype *dtype, void **gdf_data, gdf_valid_type **valid, 
+	string_pair **str_cols, bool dayfirst, unsigned long long *num_valid);
+__global__ void dataTypeDetection(char *raw_csv, const parsing_opts_t opts, gdf_size_type num_records, 
+	int  num_columns, bool  *parseCol, cu_recstart_t *recStart, column_data_t* d_columnData);
 
 //
 //---------------CUDA Valid (8 blocks of 8-bits) Bitmap Kernels ---------------------------------------------
@@ -394,74 +397,67 @@ gdf_error read_csv(csv_read_arg *args)
 		raw_csv->num_records = recCount;
 	}
 
-	uploadDataToDevice(h_uncomp_data, h_uncomp_size, raw_csv);
-
+	error = uploadDataToDevice(h_uncomp_data, h_uncomp_size, raw_csv);
+	if (error != GDF_SUCCESS) {
+		return error;
+	}
 
 	//-----------------------------------------------------------------------------
-	//-- Acquire header row of 
-
-	int h_num_cols=0, h_dup_cols_removed=0;
+	//-- Populate the header
 
 	// Check if the user gave us a list of column names
-	if(args->names==NULL){
-
+	if(args->names == nullptr) {
+		int h_num_cols = 0;
 		// Getting the first row of data from the file. We will parse the data to find lineterminator as
 		// well as the column delimiter.
+		cu_recstart_t second_rec_start;
+		CUDA_TRY(cudaMemcpy(&second_rec_start, raw_csv->recStart + 1, sizeof(cu_recstart_t), cudaMemcpyDefault));
+		vector<char> first_row(second_rec_start);
+		CUDA_TRY(cudaMemcpy(first_row.data(), raw_csv->data, sizeof(char) * first_row.size(), cudaMemcpyDefault));
 
-		if(raw_csv->header_row >= (long)raw_csv->num_records){
-			checkError(GDF_FILE_ERROR, "Number of records is smaller than the id of the specified header row");
-		}
-
-		cu_recstart_t headerPositions[2];
-		CUDA_TRY( cudaMemcpy(headerPositions, raw_csv->recStart + raw_csv->header_row, sizeof(cu_recstart_t)*2, cudaMemcpyDeviceToHost));
-		vector<char> cmap_data(headerPositions[1] - headerPositions[0]);
-		CUDA_TRY( cudaMemcpy(cmap_data.data(), raw_csv->data + headerPositions[0], sizeof(char) * cmap_data.size(), cudaMemcpyDefault));
-
-		size_t c=0;
-		while(c < cmap_data.size()){
-			if (cmap_data[c]==args->lineterminator){
-				h_num_cols++;
-				break;
-			}
-			else if(cmap_data[c] == '\r' && (c+1L)<cmap_data.size() && cmap_data[c+1] == '\n'){
-				h_num_cols++;
-				break;
-			}else if (cmap_data[c]==args->delimiter)
-				h_num_cols++;
-			c++;
-		}
-
-		size_t prev=0;
-		c=0;
-
+		// datect the number of rows and assign the column name
 		raw_csv->col_names.clear();
-
-		if(raw_csv->header_row>=0){
-			h_num_cols=0;
+		if(raw_csv->header_row >= 0) {
+			size_t prev = 0;
+			size_t c = 0;
 			// Storing the names of the columns into a vector of strings
-			while(c < cmap_data.size()){
-				if (cmap_data[c]==args->delimiter || cmap_data[c]==args->lineterminator){
-					std::string colName(cmap_data.data() + prev, c - prev );
-					prev=c+1;
+			while(c < first_row.size()) {
+				if (first_row[c] == args->delimiter || first_row[c] == args->lineterminator){
+					std::string colName(first_row.data() + prev, c - prev );
+					prev = c + 1;
 					raw_csv->col_names.push_back(colName);
 					h_num_cols++;
 				}
 				c++;
 			}
-		}else{
-			for (int i = 0; i<h_num_cols; i++){
+		}
+		else {
+			size_t c = 0;
+			while(c < first_row.size()) {
+				if (first_row[c] == args->lineterminator) {
+					h_num_cols++;
+					break;
+				}
+				else if(first_row[c] == '\r' && (c+1L) < first_row.size() && first_row[c+1] == '\n'){
+					h_num_cols++;
+					break;
+				}else if (first_row[c] == args->delimiter)
+					h_num_cols++;
+				c++;
+			}
+			// assign column indexes as names if the header column is not present
+			for (int i = 0; i<h_num_cols; i++) {
 				std::string newColName = std::to_string(i);
 				raw_csv->col_names.push_back(newColName);
 			}
 		}
 		// Allocating a boolean array that will use to state if a column needs to read or filtered.
-
-
 		raw_csv->h_parseCol = (bool*)malloc(sizeof(bool) * (h_num_cols));
 		RMM_TRY( RMM_ALLOC((void**)&raw_csv->d_parseCol,(sizeof(bool) * (h_num_cols)),0 ) );
 		for (int i = 0; i<h_num_cols; i++)
 			raw_csv->h_parseCol[i]=true;
 
+		int h_dup_cols_removed = 0;
 		// Looking for duplicates
 		for (auto it = raw_csv->col_names.begin(); it != raw_csv->col_names.end(); it++){
 			bool found_dupe = false;
@@ -492,7 +488,7 @@ gdf_error read_csv(csv_read_arg *args)
 			}
 		}
 
-		raw_csv->num_actual_cols = h_num_cols;							// Actuaul number of columns in the CSV file
+		raw_csv->num_actual_cols = h_num_cols;							// Actual number of columns in the CSV file
 		raw_csv->num_active_cols = h_num_cols-h_dup_cols_removed;		// Number of fields that need to be processed based on duplicatation fields
 
 		CUDA_TRY(cudaMemcpy(raw_csv->d_parseCol, raw_csv->h_parseCol, sizeof(bool) * (h_num_cols), cudaMemcpyHostToDevice));
@@ -878,7 +874,7 @@ gdf_error uploadDataToDevice(const char* h_uncomp_data, size_t h_uncomp_size, ra
 		raw_csv->num_records = raw_csv->num_records - (long)first_row;
 	}
 	else {
-		raw_csv->num_records = 0;
+		checkError(GDF_FILE_ERROR, "Number of records is too small for the specified skiprows and header parameters");
 	}
 
 	// Restrict the rows to nrows if nrows is smaller than the remaining number of rows
@@ -1241,18 +1237,23 @@ gdf_error launch_dataConvertColumns(raw_csv_t *raw_csv, void **gdf, gdf_valid_ty
 	opts.falseValues		= thrust::raw_pointer_cast(raw_csv->d_falseValues.data());
 	opts.falseValuesCount		= raw_csv->d_falseValues.size();
 
+	auto first_data_rec_start = raw_csv->recStart;
+	if (raw_csv->header_row >= 0) {
+		// skip the header row if present
+		++first_data_rec_start;
+	}
+
 	convertCsvToGdf <<< gridSize, blockSize >>>(
 		raw_csv->data,
 		opts,
 		raw_csv->num_records,
 		raw_csv->num_actual_cols,
 		raw_csv->d_parseCol,
-		raw_csv->recStart,
+		first_data_rec_start,
 		d_dtypes,
 		gdf,
 		valid,
 		str_cols,
-		raw_csv->header_row,
 		raw_csv->dayfirst,
 		num_valid
 	);
@@ -1277,7 +1278,6 @@ __global__ void convertCsvToGdf(
 		void			**gdf_data,
 		gdf_valid_type 	**valid,
 		string_pair		**str_cols,
-		long 			header_row,
 		bool			dayfirst,
 		unsigned long long			*num_valid
 		)
@@ -1289,12 +1289,8 @@ __global__ void convertCsvToGdf(
 	if ( rec_id >= num_records)
 		return;
 
-	long extraOff=0;
-	if(rec_id>=header_row && header_row>=0)
-		extraOff=1;
-
-	long start 		= recStart[rec_id + extraOff];
-	long stop 		= recStart[rec_id + 1 + extraOff];
+	long start 		= recStart[rec_id];
+	long stop 		= recStart[rec_id + 1];
 
 	long pos 		= start;
 	int  col 		= 0;
@@ -1491,14 +1487,19 @@ gdf_error launch_dataTypeDetection(
 	opts.falseValues		= thrust::raw_pointer_cast(raw_csv->d_falseValues.data());
 	opts.falseValuesCount		= raw_csv->d_falseValues.size();
 
+	auto first_data_rec_start = raw_csv->recStart;
+	if (raw_csv->header_row >= 0) {
+		// skip the header row if present
+		++first_data_rec_start;
+	}
+
 	dataTypeDetection <<< gridSize, blockSize >>>(
 		raw_csv->data,
 		opts,
 		raw_csv->num_records,
 		raw_csv->num_actual_cols,
 		raw_csv->d_parseCol,
-		raw_csv->recStart,
-		raw_csv->header_row,
+		first_data_rec_start,
 		d_columnData
 	);
 
@@ -1515,7 +1516,6 @@ __global__ void dataTypeDetection(
 		int  			num_columns,
 		bool  			*parseCol,
 		cu_recstart_t 			*recStart,
-		long 			header_row,
 		column_data_t* d_columnData
 		)
 {
@@ -1527,12 +1527,8 @@ __global__ void dataTypeDetection(
 	if ( rec_id >= num_records)
 		return;
 
-	long extraOff=0;
-	if(rec_id>=header_row && header_row>=0)
-		extraOff=1;
-
-	long start 		= recStart[rec_id + extraOff];
-	long stop 		= recStart[rec_id + 1 + extraOff];
+	long start 		= recStart[rec_id];
+	long stop 		= recStart[rec_id + 1];
 
 	long pos 		= start;
 	int  col 		= 0;

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -327,7 +327,7 @@ def test_csv_reader_thousands(tmpdir):
     np.testing.assert_allclose(int64_ref, df['int64'])
 
 
-def test_csv_reader_buffer(tmpdir):
+def test_csv_reader_buffer():
 
     names = dtypes = ["float32", "int32", "date"]
     lines = [','.join(names),
@@ -354,7 +354,7 @@ def test_csv_reader_buffer(tmpdir):
     assert("2002-01-02T00:00:00.000" == str(df_bytes['date'][1]))
 
 
-def test_csv_reader_buffer_strings(tmpdir):
+def test_csv_reader_buffer_strings():
 
     names = ['text', 'int']
     dtypes = ['str', 'int']
@@ -513,3 +513,27 @@ def test_csv_reader_nrows(tmpdir):
     with pytest.raises(ValueError):
         read_csv(str(fname),
                  nrows=read_rows, skipfooter=1)
+
+
+@pytest.mark.parametrize('skip_rows', [0, 2, 4])
+@pytest.mark.parametrize('header_row', [0, 2])
+def test_csv_reader_skiprows_header(skip_rows, header_row):
+
+    names = ['float_point', 'integer']
+    dtypes = ['float64', 'int64']
+    lines = [','.join(names),
+	         '1.2, 1',
+	         '2.3, 2',
+	         '3.4, 3',
+	         '4.5, 4',
+	         '5.6, 5',
+	         '6.7, 6']
+    buffer = '\n'.join(lines) + '\n'
+
+    cu_df = read_csv(StringIO(buffer), dtype=dtypes,
+	              skiprows=skip_rows, header=header_row)
+    pd_df = pd.read_csv(StringIO(buffer),
+	              skiprows=skip_rows, header=header_row)
+
+    assert(cu_df.shape == pd_df.shape)
+    assert(list(cu_df.columns.values) == list(pd_df.columns.values))

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -272,7 +272,7 @@ def test_csv_reader_mangle_dupe_cols_header(tmpdir):
     out = read_csv(str(fname), dayfirst=True, header=2)
     assert len(out.columns) == len(df_out.columns)
     # assert len(out) == len(df_out)
-    # Compare column names
+    # Compare column names    
     assert list(df_out.columns.values) == list(out.columns.values)
 
 
@@ -496,6 +496,11 @@ def test_csv_reader_nrows(tmpdir):
         assert(df['int1'][row] == row)
         assert(df['int2'][row] == 2 * row)
     assert(df['int2'][rows - 1] == 2 * (rows - 1))
+
+    # nrows + skiprows larger than the file
+    df = read_csv(str(fname),
+                  dtype=dtypes, nrows=read_rows, skiprows=read_rows)
+    assert(df.shape == (rows - read_rows, 2))
 
     # nrows equal to zero
     df = read_csv(str(fname),

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -272,7 +272,7 @@ def test_csv_reader_mangle_dupe_cols_header(tmpdir):
     out = read_csv(str(fname), dayfirst=True, header=2)
     assert len(out.columns) == len(df_out.columns)
     # assert len(out) == len(df_out)
-    # Compare column names    
+    # Compare column names
     assert list(df_out.columns.values) == list(out.columns.values)
 
 
@@ -522,18 +522,18 @@ def test_csv_reader_skiprows_header(skip_rows, header_row):
     names = ['float_point', 'integer']
     dtypes = ['float64', 'int64']
     lines = [','.join(names),
-	         '1.2, 1',
-	         '2.3, 2',
-	         '3.4, 3',
-	         '4.5, 4',
-	         '5.6, 5',
-	         '6.7, 6']
+             '1.2, 1',
+             '2.3, 2',
+             '3.4, 3',
+             '4.5, 4',
+             '5.6, 5',
+             '6.7, 6']
     buffer = '\n'.join(lines) + '\n'
 
     cu_df = read_csv(StringIO(buffer), dtype=dtypes,
-	              skiprows=skip_rows, header=header_row)
+                     skiprows=skip_rows, header=header_row)
     pd_df = pd.read_csv(StringIO(buffer),
-	              skiprows=skip_rows, header=header_row)
+                        skiprows=skip_rows, header=header_row)
 
     assert(cu_df.shape == pd_df.shape)
     assert(list(cu_df.columns.values) == list(pd_df.columns.values))


### PR DESCRIPTION
* Modified the internal logic to treat the header parameter effectively as additional row offset - total number of skipped rows is skiprows+header. This means that the header row is always the first one to be read.
* As part of the logic change, fixed a bug where having skiprows+nrows larger that the actual number of rows would cause a crash. 
* Added error checking to the uploadDataToDevice() call.
Fixes #656 