### PR TITLE
[REVIEW] Fix type inference failures caused by whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 - PR #686 Fix converting nulls to NaT values when converting Series to Pandas/Numpy
 - PR #689 CSV Reader: Fix behavior with skiprows+header to match pandas implementation
 - PR #691 Fixes Join on empty input DFs
-- PR #700 CSV Reader: Fix broken dtype inference when whitespace is in data
+- PR #706 CSV Reader: Fix broken dtype inference when whitespace is in data
 
 # cuDF 0.4.0 (05 Dec 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - PR #677 Fix 'gdf_csv_test_Dates' gtest failure due to missing nrows parameter
 - PR #686 Fix converting nulls to NaT values when converting Series to Pandas/Numpy
 - PR #689 CSV Reader: Fix behavior with skiprows+header to match pandas implementation
+- PR #700 CSV Reader: Fix broken dtype inference when whitespace is in data
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -1333,7 +1333,7 @@ __global__ void convertCsvToGdf(
 
 			// Modify start & end to ignore whitespace and quotechars
 			if(dtype[actual_col] != gdf_dtype::GDF_CATEGORY && dtype[actual_col] != gdf_dtype::GDF_STRING){
-				adjustForWhitespaceAndQuotes(raw_csv, start, tempPos, opts.quotechar);
+				adjustForWhitespaceAndQuotes(raw_csv, &start, &tempPos, opts.quotechar);
 			}
 
 			if(start<=(tempPos)) { // Empty strings are not legal values
@@ -1519,7 +1519,6 @@ __global__ void dataTypeDetection(
 		column_data_t* d_columnData
 		)
 {
-
 	// thread IDs range per block, so also need the block id
 	long	rec_id  = threadIdx.x + (blockDim.x * blockIdx.x);		// this is entry into the field array - tid is an elements within the num_entries array
 
@@ -1589,11 +1588,11 @@ __global__ void dataTypeDetection(
 			long countColon=0;
 			long countString=0;
 
-			long strLen=pos-start;
-
 			// Modify start & end to ignore whitespace and quotechars
 			// This could possibly result in additional empty fields
-			adjustForWhitespaceAndQuotes(raw_csv, start, tempPos);
+			adjustForWhitespaceAndQuotes(raw_csv, &start, &tempPos);
+
+			long strLen=tempPos-start+1;
 
 			for(long startPos=start; startPos<=tempPos; startPos++){
 				if(raw_csv[startPos]>= '0' && raw_csv[startPos] <= '9'){

--- a/cpp/src/io/csv/type_conversion.cuh
+++ b/cpp/src/io/csv/type_conversion.cuh
@@ -20,6 +20,7 @@ bool isDigit(char data) {
 }
 
 
+/*
 __host__ __device__
 void adjustForWhitespaceAndQuotes(const char *data, long& start_idx, long& end_idx, char quotechar='\0') {
 
@@ -30,7 +31,17 @@ void adjustForWhitespaceAndQuotes(const char *data, long& start_idx, long& end_i
 		--end_idx;
 	}
 }
+*/
 
+__host__ __device__
+void adjustForWhitespaceAndQuotes(const char *data, long* start_idx, long* end_idx, char quotechar='\0') {
+  while ((*start_idx < *end_idx) && (data[*start_idx] == ' ' || data[*start_idx] == quotechar)) {
+    (*start_idx)++;
+  }
+  while ((*start_idx < *end_idx) && (data[*end_idx] == ' ' || data[*end_idx] == quotechar)) {
+    (*end_idx)--;
+  }
+}
 
 template<typename T>
 __host__ __device__

--- a/cpp/src/io/csv/type_conversion.cuh
+++ b/cpp/src/io/csv/type_conversion.cuh
@@ -20,19 +20,6 @@ bool isDigit(char data) {
 }
 
 
-/*
-__host__ __device__
-void adjustForWhitespaceAndQuotes(const char *data, long& start_idx, long& end_idx, char quotechar='\0') {
-
-	while ((start_idx < end_idx) && (data[start_idx] == ' ' || data[start_idx] == quotechar)) {
-		++start_idx;
-	}
-	while ((start_idx < end_idx) && (data[end_idx] == ' ' || data[end_idx] == quotechar)) {
-		--end_idx;
-	}
-}
-*/
-
 __host__ __device__
 void adjustForWhitespaceAndQuotes(const char *data, long* start_idx, long* end_idx, char quotechar='\0') {
   while ((*start_idx < *end_idx) && (data[*start_idx] == ' ' || data[*start_idx] == quotechar)) {

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -537,3 +537,37 @@ def test_csv_reader_skiprows_header(skip_rows, header_row):
 
     assert(cu_df.shape == pd_df.shape)
     assert(list(cu_df.columns.values) == list(pd_df.columns.values))
+
+
+def test_csv_reader_dtype_inference():
+    names = ['float_point', 'integer']
+    lines = [','.join(names),
+             '1.2,1',
+             '2.3,2',
+             '3.4,3',
+             '4.5,4',
+             '5.6,5',
+             '6.7,6']
+    buffer = '\n'.join(lines) + '\n'
+    cu_df = read_csv(StringIO(buffer))
+    pd_df = pd.read_csv(StringIO(buffer))
+
+    assert(cu_df.shape == pd_df.shape)
+    assert(list(cu_df.columns.values) == list(pd_df.columns.values))
+
+
+def test_csv_reader_dtype_inference_whitespace():
+    names = ['float_point', 'integer']
+    lines = [','.join(names),
+             '  1.2,    1',
+             '2.3,2    ',
+             '  3.4,   3',
+             ' 4.5,4',
+             '5.6,  5',
+             ' 6.7,6 ']
+    buffer = '\n'.join(lines) + '\n'
+    cu_df = read_csv(StringIO(buffer))
+    pd_df = pd.read_csv(StringIO(buffer))
+
+    assert(cu_df.shape == pd_df.shape)
+    assert(list(cu_df.columns.values) == list(pd_df.columns.values))


### PR DESCRIPTION
This fixes issue #700 wherein type inference fails when there's whitespace among the entries. This can make it into 0.5.