### PR TITLE
[REVIEW] Fix issue in CSV reader with empty dataframe

### DIFF
--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -618,7 +618,7 @@ gdf_error read_csv(csv_read_arg *args)
 
 	void **d_data,**h_data;
 	gdf_valid_type **d_valid,**h_valid;
-    unsigned long long	*d_valid_count,*h_valid_count;
+    unsigned long long	*d_valid_count;
 	gdf_dtype *d_dtypes,*h_dtypes;
 
 
@@ -626,7 +626,6 @@ gdf_error read_csv(csv_read_arg *args)
 
 
 	h_dtypes 		= (gdf_dtype*)malloc (	sizeof(gdf_dtype)* (raw_csv->num_active_cols));
-	h_valid_count	= (unsigned long long*)malloc (	sizeof(unsigned long long)* (raw_csv->num_active_cols));
 	h_data 			= (void**)malloc (	sizeof(void*)* (raw_csv->num_active_cols));
 	h_valid 		= (gdf_valid_type**)malloc (	sizeof(gdf_valid_type*)* (raw_csv->num_active_cols));
 
@@ -695,7 +694,8 @@ gdf_error read_csv(csv_read_arg *args)
 		if (error != GDF_SUCCESS) {
 			return error;
 		}
-		cudaDeviceSynchronize();
+		// Sync with the default stream, just in case create_from_index() is asynchronous 
+		cudaStreamSynchronize(0);
 
 		stringColCount=0;
 		for (int col = 0; col < raw_csv->num_active_cols; col++) {
@@ -709,8 +709,8 @@ gdf_error read_csv(csv_read_arg *args)
 			if ((raw_csv->quotechar != '\0') && (raw_csv->doublequote==true)) {
 				// In PANDAS, default of enabling doublequote for two consecutive
 				// quotechar in quote fields results in reduction to single
-				std::string quotechar = std::string(&raw_csv->quotechar);
-				std::string doublequotechar = quotechar + raw_csv->quotechar;
+				const string quotechar(1, raw_csv->quotechar);
+				const string doublequotechar(2, raw_csv->quotechar);
 				gdf->data = stringCol->replace(doublequotechar.c_str(), quotechar.c_str());
 				NVStrings::destroy(stringCol);
 			}
@@ -723,15 +723,13 @@ gdf_error read_csv(csv_read_arg *args)
 			stringColCount++;
 		}
 
-
-		CUDA_TRY( cudaMemcpy(h_valid_count,d_valid_count, sizeof(unsigned long long) * (raw_csv->num_active_cols), cudaMemcpyDeviceToHost));
+		vector<unsigned long long>	h_valid_count(raw_csv->num_active_cols);
+		CUDA_TRY( cudaMemcpy(h_valid_count.data(), d_valid_count, sizeof(unsigned long long) * h_valid_count.size(), cudaMemcpyDeviceToHost));
 
 		//--- set the null count
-		for ( int col = 0; col < raw_csv->num_active_cols; col++) {
+		for (size_t col = 0; col < h_valid_count.size(); col++) {
 			cols[col]->null_count = raw_csv->num_records - h_valid_count[col];
 		}
-
-		free(h_valid_count); 
 	}
 
 	// free up space that is no longer needed

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -553,6 +553,9 @@ gdf_error read_csv(csv_read_arg *args)
 	//--- Auto detect types of the vectors
 
 	if(args->dtype==NULL){
+		if (raw_csv->num_records == 0) {
+			checkError(GDF_INVALID_API_CALL, "read_csv: no data available for data type inference");
+		}
 
 		column_data_t *d_ColumnData,*h_ColumnData;
 
@@ -686,45 +689,50 @@ gdf_error read_csv(csv_read_arg *args)
 	free(h_dtypes); 
 	free(h_valid); 
 	free(h_data); 
-	
-	launch_dataConvertColumns(raw_csv, d_data, d_valid, d_dtypes, d_str_cols, d_valid_count);
-	cudaDeviceSynchronize();
 
-	stringColCount=0;
-	for (int col = 0; col < raw_csv->num_active_cols; col++) {
-
-		gdf_column *gdf = cols[col];
-
-		if (gdf->dtype != gdf_dtype::GDF_STRING)
-			continue;
-
-		NVStrings* const stringCol = NVStrings::create_from_index(h_str_cols[stringColCount],size_t(raw_csv->num_records));
-		if ((raw_csv->quotechar != '\0') && (raw_csv->doublequote==true)) {
-			// In PANDAS, default of enabling doublequote for two consecutive
-			// quotechar in quote fields results in reduction to single
-			std::string quotechar = std::string(&raw_csv->quotechar);
-			std::string doublequotechar = quotechar + raw_csv->quotechar;
-			gdf->data = stringCol->replace(doublequotechar.c_str(), quotechar.c_str());
-			NVStrings::destroy(stringCol);
+	if (raw_csv->num_records != 0) {
+		error = launch_dataConvertColumns(raw_csv, d_data, d_valid, d_dtypes, d_str_cols, d_valid_count);
+		if (error != GDF_SUCCESS) {
+			return error;
 		}
-		else {
-			gdf->data = stringCol;
+		cudaDeviceSynchronize();
+
+		stringColCount=0;
+		for (int col = 0; col < raw_csv->num_active_cols; col++) {
+
+			gdf_column *gdf = cols[col];
+
+			if (gdf->dtype != gdf_dtype::GDF_STRING)
+				continue;
+
+			NVStrings* const stringCol = NVStrings::create_from_index(h_str_cols[stringColCount],size_t(raw_csv->num_records));
+			if ((raw_csv->quotechar != '\0') && (raw_csv->doublequote==true)) {
+				// In PANDAS, default of enabling doublequote for two consecutive
+				// quotechar in quote fields results in reduction to single
+				std::string quotechar = std::string(&raw_csv->quotechar);
+				std::string doublequotechar = quotechar + raw_csv->quotechar;
+				gdf->data = stringCol->replace(doublequotechar.c_str(), quotechar.c_str());
+				NVStrings::destroy(stringCol);
+			}
+			else {
+				gdf->data = stringCol;
+			}
+
+			RMM_TRY( RMM_FREE( h_str_cols [stringColCount], 0 ) );
+
+			stringColCount++;
 		}
 
-		RMM_TRY( RMM_FREE( h_str_cols [stringColCount], 0 ) );
 
-		stringColCount++;
+		CUDA_TRY( cudaMemcpy(h_valid_count,d_valid_count, sizeof(unsigned long long) * (raw_csv->num_active_cols), cudaMemcpyDeviceToHost));
+
+		//--- set the null count
+		for ( int col = 0; col < raw_csv->num_active_cols; col++) {
+			cols[col]->null_count = raw_csv->num_records - h_valid_count[col];
+		}
+
+		free(h_valid_count); 
 	}
-
-
-	CUDA_TRY( cudaMemcpy(h_valid_count,d_valid_count, sizeof(unsigned long long) * (raw_csv->num_active_cols), cudaMemcpyDeviceToHost));
-
-	//--- set the null count
-	for ( int col = 0; col < raw_csv->num_active_cols; col++) {
-		cols[col]->null_count = raw_csv->num_records - h_valid_count[col];
-	}
-
-	free(h_valid_count); 
 
 	// free up space that is no longer needed
 	if (h_str_cols != NULL)

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -17,6 +17,7 @@ from .utils import assert_eq
 import gzip
 import shutil
 
+from libgdf_cffi import GDFError
 
 def make_numeric_dataframe(nrows, dtype):
     df = pd.DataFrame()
@@ -581,3 +582,17 @@ def test_csv_reader_skiprows_header(skip_rows, header_row):
 
     assert(cu_df.shape == pd_df.shape)
     assert(list(cu_df.columns.values) == list(pd_df.columns.values))
+
+
+def test_csv_reader_empty_dataframe():
+
+    dtypes = ['float64', 'int64']
+    buffer = 'float_point, integer\n'
+
+    #should work fine with dtypes
+    df = read_csv(StringIO(buffer), dtype=dtypes)
+    assert(df.shape == (0, 2))
+
+	# should raise an error without dtypes
+    with pytest.raises(GDFError):
+        read_csv(StringIO(buffer))


### PR DESCRIPTION
Changes to read_csv back end:
* Skip data conversion when number of records is zero.
* Raise an error when there are no data rows and data type inference is used.

Fixes #707 