### PR TITLE
[REVIEW] Fix merge column ordering.

### DIFF
--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -1104,7 +1104,6 @@ class DataFrame(object):
         df = DataFrame()
 
         # Columns are returned in order left - on - right from libgdf
-        # Creating dataframe with ordering as pandas:
 
         gap = len(self.columns) - len(on)
         for idx in range(len(on)):
@@ -1162,9 +1161,25 @@ class DataFrame(object):
                                               mask=Buffer(valids[idx]))
                 idx = idx + 1
 
+        # Creating dataframe with ordering as pandas:
+        # Pandas always orders the output first according to the input
+        # column order.
+
+        final_df = DataFrame()
+        for col in lhs.columns:
+            fcol = col
+            if col not in df.columns:
+                fcol = fix_name(col, lsuffix)
+            if fcol not in df.columns:
+                fcol = fix_name(col, rsuffix)
+            final_df[fcol] = df[fcol]
+        for col in df.columns:
+            if col not in final_df.columns:
+                final_df[col] = df[col]
+
         _gdf.nvtx_range_pop()
 
-        return df
+        return final_df
 
     def join(self, other, on=None, how='left', lsuffix='', rsuffix='',
              sort=False, type="", method='hash'):

--- a/python/cudf/tests/test_joining.py
+++ b/python/cudf/tests/test_joining.py
@@ -335,3 +335,29 @@ def test_dataframe_empty_merge():
     got = gdf1.merge(gdf2, how='left', on=['a'])
 
     assert_eq(expect, got)
+
+
+def test_dataframe_merge_order():
+    gdf1 = DataFrame()
+    gdf2 = DataFrame()
+    gdf1['id'] = [10, 11]
+    gdf1['timestamp'] = [1, 2]
+    gdf1['a'] = [3, 4]
+
+    gdf2['id'] = [4, 5]
+    gdf2['a'] = [7, 8]
+
+    gdf = gdf1.merge(gdf2, how='left', on=['id', 'a'], method='hash')
+
+    df1 = pd.DataFrame()
+    df2 = pd.DataFrame()
+    df1['id'] = [10, 11]
+    df1['timestamp'] = [1, 2]
+    df1['a'] = [3, 4]
+
+    df2['id'] = [4, 5]
+    df2['a'] = [7, 8]
+
+    df = df1.merge(df2, how='left', on=['id', 'a'])
+
+    assert_eq(gdf, df)


### PR DESCRIPTION
This PR reorders the final dataframe to mirror the original lhs of a given `.merge`, substituting left and right suffixes when appropriate. I only include a single unit test based on the original error report as the set of possible merges is infinite. If you'd like to see additional tests included please provide further examples.
