### PR TITLE
[REVIEW] Fix CMake race condition for NVStrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - PR #717 CSV reader: fix behavior when parsing a csv file with no data rows
 - PR #724 CSV Reader: fix build issue due to parameter type mismatch in a std::max call
 - PR #734 Prevents reading undefined memory in gpu_expand_mask_bits numba kernel
+- PR #750 Fix race condition for handling NVStrings in CMake
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -154,7 +154,8 @@ find_library(NVSTRINGS_LIBRARY "NVStrings"
 if(NVSTRINGS_INCLUDE AND NVSTRINGS_LIBRARY)
     execute_process(WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/include
-                    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/lib
+                    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/lib)
+    execute_process(WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                     COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} ln -snf ${NVSTRINGS_INCLUDE} ${CMAKE_BINARY_DIR}/include/NVStrings.h
                     COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} ln -snf ${NVSTRINGS_LIBRARY} ${CMAKE_BINARY_DIR}/lib/libNVStrings.so)
 endif(NVSTRINGS_INCLUDE AND NVSTRINGS_LIBRARY)


### PR DESCRIPTION
CMake `execute_process` executes commands in parallel, so we had a race condition between creating directories and creating a symlink into the directories. Split the directory creation and symlinking into two separate processes that execute sequentially.