### PR TITLE
[REVIEW] FIX Pin submodule to known working branches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "cpp/thirdparty/cub"]
 	path = cpp/thirdparty/cub
 	url = https://github.com/NVlabs/cub.git
+	branch = b165e1fb11eeea64ccf95053e40f2424312599cc
 [submodule "cpp/thirdparty/moderngpu"]
 	path = cpp/thirdparty/moderngpu
 	url = https://github.com/moderngpu/moderngpu.git
+	branch = c1fd31df008d79f727483e795b1ee1ce45b782ca
 [submodule "cpp/thirdparty/rmm"]
 	path = cpp/thirdparty/rmm
 	url = https://github.com/rapidsai/rmm
+	branch = branch-0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - PR #747 CSV Reader: fix an issue where CUDA allocations fail with some large input files
 - PR #750 Fix race condition for handling NVStrings in CMake
 - PR #719 Fix merge column ordering
+- PR #770 Fix issue where RMM submodule pointed to wrong branch and pin other to correct branches
 
 
 # cuDF 0.4.0 (05 Dec 2018)


### PR DESCRIPTION
After RMM merge, the git submodule points to the `rmm/master` branch which breaks testing for CI.

Example output seen:
```
CMake Error at thirdparty/rmm/CMakeLists.txt:60 (add_subdirectory):
  add_subdirectory not given a binary directory but the given source
  directory "/conda/envs/gdf/conda-bld/libcudf_1548310410120/work/cpp/tests"
  is not a subdirectory of
  "/conda/envs/gdf/conda-bld/libcudf_1548310410120/work/cpp/thirdparty/rmm".
  When specifying an out-of-tree source a binary directory must be explicitly
  specified.

CMake Error at CMakeLists.txt:245 (add_custom_target):
  add_custom_target cannot create target "python_cffi" because another target
  with the same name already exists.  The existing target is a custom target
  created in source directory
  "/conda/envs/gdf/conda-bld/libcudf_1548310410120/work/cpp/thirdparty/rmm".
  See documentation for policy CMP0002 for more details.

CMake Error at CMakeLists.txt:264 (add_custom_target):
  add_custom_target cannot create target "install_python" because another
  target with the same name already exists.  The existing target is a custom
  target created in source directory
  "/conda/envs/gdf/conda-bld/libcudf_1548310410120/work/cpp/thirdparty/rmm".
  See documentation for policy CMP0002 for more details.
```