### PR TITLE
[TEST] CI for RMM PR #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 - PR #719 Fix merge column ordering
 - PR #770 Fix issue where RMM submodule pointed to wrong branch and pin other to correct branches
 
+- PR TEST rename RMM headers (testing RMM PR, will delete this PR when CI passes)
 
 # cuDF 0.4.0 (05 Dec 2018)
 


### PR DESCRIPTION
This will be deleted once PR tests. This is a same-branch-name PR to cause CI to test rapidsai/rmm#9