### PR TITLE
[REVIEW] Remove hard coded ABI off setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - PR #750 Fix race condition for handling NVStrings in CMake
 - PR #719 Fix merge column ordering
 - PR #770 Fix issue where RMM submodule pointed to wrong branch and pin other to correct branches
+- PR #778 Fix hard coded ABI off setting
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -69,7 +69,6 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Wn
 
 # set warnings as errors
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D_GLIBCXX_USE_CXX11_ABI=0")
 
 # Debug options
 if(CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
Fixes #777 

As @kkraus14 pointed out this line hard codes the ABI setting to `0` or off, ignoring the new flag `CMAKE_CXX11_ABI` introduced in #668. Removal should fix the issue, but will run tests to check.