### PR TITLE
BLD Update RMM paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 - PR #719 Fix merge column ordering
 - PR #770 Fix issue where RMM submodule pointed to wrong branch and pin other to correct branches
 - PR #778 Fix hard coded ABI off setting
+- PR #784 Update RMM submodule commit-ish and pip paths
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/setup_pip.py
+++ b/setup_pip.py
@@ -25,7 +25,7 @@ import zipfile
 from hashlib import sha256
 from base64 import urlsafe_b64encode
 
-os.environ['RMM_HEADER'] = 'cpp/src/rmm/memory.h'
+os.environ['RMM_HEADER'] = 'cpp/thirdparty/rmm/include/rmm/rmm_api.h'
 os.environ['CUDF_INCLUDE_DIR'] = 'cpp/include/cudf'
 
 CMAKE_EXE = os.environ.get('CMAKE_EXE', shutil.which('cmake'))
@@ -166,7 +166,7 @@ setup(name=name,
       package_dir={
           'cudf': 'python/cudf',
           'libgdf_cffi': 'cpp/python/libgdf_cffi',
-          'librmm_cffi': 'cpp/python/librmm_cffi'
+          'librmm_cffi': 'cpp/thirdparty/rmm/python/librmm_cffi'
       },
       package_data={
           'cudf.tests': ['data/*'],
@@ -176,7 +176,7 @@ setup(name=name,
       python_requires='>=3.6,<3.8',
       cffi_modules=[
           'cpp/python/libgdf_cffi/libgdf_build.py:ffibuilder',
-          'cpp/python/librmm_cffi/librmm_build.py:ffibuilder'
+          'cpp/thirdparty/rmm/python/librmm_cffi/librmm_build.py.in:ffibuilder'
       ],
       ext_modules=cythonize(extensions),
       cmdclass={


### PR DESCRIPTION
Updates the commit-ish of RMM submodule to tip of `branch-0.5` and updates rmm paths for pip package builds.