### PR TITLE
[REVIEW] Update `rmm::exec_policy` usage 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 - PR #770 Fix issue where RMM submodule pointed to wrong branch and pin other to correct branches
 - PR #778 Fix hard coded ABI off setting
 - PR #784 Update RMM submodule commit-ish and pip paths
+- PR #794 Update `rmm::exec_policy` usage to fix segmentation faults when used as temprory allocator.
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -69,7 +69,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Wn
 
 # set warnings as errors
 # TODO: remove `no-maybe-unitialized` used to suppress warnings in rmm::exec_policy
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-maybe-uninitialized")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror")
 
 # Debug options
 if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -68,7 +68,8 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Wno-deprecated-declarations -Xptxas --disable-warnings")
 
 # set warnings as errors
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror")
+# TODO: remove `no-maybe-unitialized` used to suppress warnings in rmm::exec_policy
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-maybe-uninitialized")
 
 # Debug options
 if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/cpp/src/bitmask/bitmask_ops.cu
+++ b/cpp/src/bitmask/bitmask_ops.cu
@@ -53,7 +53,7 @@ gdf_error all_bitmask_on(gdf_valid_type * valid_out, gdf_size_type & out_null_co
 
 	thrust::device_ptr<gdf_valid_type> valid_out_ptr = thrust::device_pointer_cast(valid_out);
 	gdf_valid_type max_char = 255;
-	thrust::fill(rmm::exec_policy(stream),thrust::detail::make_normal_iterator(valid_out_ptr),thrust::detail::make_normal_iterator(valid_out_ptr + num_chars_bitmask),max_char);
+	thrust::fill(rmm::exec_policy(stream)->on(stream),thrust::detail::make_normal_iterator(valid_out_ptr),thrust::detail::make_normal_iterator(valid_out_ptr + num_chars_bitmask),max_char);
 	//we have no nulls so set all the bits in gdf_valid_type to 1
 	out_null_count = 0;
 	return GDF_SUCCESS;
@@ -70,7 +70,7 @@ gdf_error apply_bitmask_to_bitmask(gdf_size_type & out_null_count, gdf_valid_typ
 	thrust::device_ptr<gdf_valid_type> valid_right_ptr = thrust::device_pointer_cast(valid_right);
 
 
-	thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(valid_left_ptr),
+	thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(valid_left_ptr),
 			thrust::detail::make_normal_iterator(valid_left_end_ptr), thrust::detail::make_normal_iterator(valid_right_ptr),
 			thrust::detail::make_normal_iterator(valid_out_ptr), thrust::bit_and<gdf_valid_type>());
 
@@ -87,7 +87,7 @@ gdf_error apply_bitmask_to_bitmask(gdf_size_type & out_null_count, gdf_valid_typ
 	null_counts_iter( bit_mask_null_counts_device.begin(),thrust::detail::make_normal_iterator(valid_out_ptr));
 
 	//you will notice that we subtract the number of zeros we found in the last character
-	out_null_count = thrust::reduce(rmm::exec_policy(stream),null_counts_iter, null_counts_iter + num_chars_bitmask) - gdf_num_bits_zero_after_pos(*last_char,num_values % GDF_VALID_BITSIZE );
+	out_null_count = thrust::reduce(rmm::exec_policy(stream)->on(stream),null_counts_iter, null_counts_iter + num_chars_bitmask) - gdf_num_bits_zero_after_pos(*last_char,num_values % GDF_VALID_BITSIZE );
 
 	delete[] last_char;
 	return GDF_SUCCESS;

--- a/cpp/src/bitmask/valid_ops.cu
+++ b/cpp/src/bitmask/valid_ops.cu
@@ -277,7 +277,7 @@ gdf_error gdf_mask_concat(gdf_valid_type *output_mask,
 
     // This is like thrust::for_each where the lambda gets the current index into the output array
     // as input
-    thrust::tabulate(rmm::exec_policy(cudaStream_t{0}),
+    thrust::tabulate(rmm::exec_policy()->on(0),
                      output_mask,
                      output_mask + gdf_get_num_chars_bitmask(output_column_length),
                      mask_concatenator);

--- a/cpp/src/compaction/stream_compaction_ops.cu
+++ b/cpp/src/compaction/stream_compaction_ops.cu
@@ -245,7 +245,7 @@ gdf_error gpu_apply_stencil(gdf_column *lhs, gdf_column * stencil, gdf_column * 
 		thrust::detail::normal_iterator<thrust::device_ptr<int8_t> > output_start =
 				thrust::detail::make_normal_iterator(thrust::device_pointer_cast((int8_t *) output->data));
 		thrust::detail::normal_iterator<thrust::device_ptr<int8_t> > output_end =
-				thrust::copy_if(rmm::exec_policy(stream),input_start,input_start + lhs->size,zipped_stencil_iter,output_start,is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
+				thrust::copy_if(rmm::exec_policy(stream)->on(stream),input_start,input_start + lhs->size,zipped_stencil_iter,output_start,is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
 		output->size = output_end - output_start;
 	}else if(width == 2){
 		thrust::detail::normal_iterator<thrust::device_ptr<int16_t> > input_start =
@@ -253,7 +253,7 @@ gdf_error gpu_apply_stencil(gdf_column *lhs, gdf_column * stencil, gdf_column * 
 		thrust::detail::normal_iterator<thrust::device_ptr<int16_t> > output_start =
 				thrust::detail::make_normal_iterator(thrust::device_pointer_cast((int16_t *) output->data));
 		thrust::detail::normal_iterator<thrust::device_ptr<int16_t> > output_end =
-				thrust::copy_if(rmm::exec_policy(stream),input_start,input_start + lhs->size,zipped_stencil_iter,output_start,is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
+				thrust::copy_if(rmm::exec_policy(stream)->on(stream),input_start,input_start + lhs->size,zipped_stencil_iter,output_start,is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
 		output->size = output_end - output_start;
 	}else if(width == 4){
 		thrust::detail::normal_iterator<thrust::device_ptr<int32_t> > input_start =
@@ -261,7 +261,7 @@ gdf_error gpu_apply_stencil(gdf_column *lhs, gdf_column * stencil, gdf_column * 
 		thrust::detail::normal_iterator<thrust::device_ptr<int32_t> > output_start =
 				thrust::detail::make_normal_iterator(thrust::device_pointer_cast((int32_t *) output->data));
 		thrust::detail::normal_iterator<thrust::device_ptr<int32_t> > output_end =
-				thrust::copy_if(rmm::exec_policy(stream),input_start,input_start + lhs->size,zipped_stencil_iter,output_start,is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
+				thrust::copy_if(rmm::exec_policy(stream)->on(stream),input_start,input_start + lhs->size,zipped_stencil_iter,output_start,is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
 		output->size = output_end - output_start;
 	}else if(width == 8){
 		thrust::detail::normal_iterator<thrust::device_ptr<int64_t> > input_start =
@@ -269,7 +269,7 @@ gdf_error gpu_apply_stencil(gdf_column *lhs, gdf_column * stencil, gdf_column * 
 		thrust::detail::normal_iterator<thrust::device_ptr<int64_t> > output_start =
 				thrust::detail::make_normal_iterator(thrust::device_pointer_cast((int64_t *) output->data));
 		thrust::detail::normal_iterator<thrust::device_ptr<int64_t> > output_end =
-				thrust::copy_if(rmm::exec_policy(stream),input_start,input_start + lhs->size,zipped_stencil_iter,output_start,is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
+				thrust::copy_if(rmm::exec_policy(stream)->on(stream),input_start,input_start + lhs->size,zipped_stencil_iter,output_start,is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
 		output->size = output_end - output_start;
 	}
 
@@ -306,10 +306,10 @@ gdf_error gpu_apply_stencil(gdf_column *lhs, gdf_column * stencil, gdf_column * 
 	);
 
 	//copy the bitmask to device_vector of int8
-	thrust::copy(rmm::exec_policy(stream), bit_set_iter, bit_set_iter + num_values, valid_bit_mask.begin());
+	thrust::copy(rmm::exec_policy(stream)->on(stream), bit_set_iter, bit_set_iter + num_values, valid_bit_mask.begin());
 
 	//remove the values that don't pass the stencil
-	thrust::remove_if(rmm::exec_policy(stream),valid_bit_mask.begin(), valid_bit_mask.begin() + num_values,zipped_stencil_iter, is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
+	thrust::remove_if(rmm::exec_policy(stream)->on(stream),valid_bit_mask.begin(), valid_bit_mask.begin() + num_values,zipped_stencil_iter, is_stencil_true<thrust::detail::normal_iterator<thrust::device_ptr<int8_t> >::value_type >());
 
 	//recompact the values and store them in the output bitmask
 	//we can group them into pieces of 8 because we aligned this earlier on when we made the device_vector
@@ -319,7 +319,7 @@ gdf_error gpu_apply_stencil(gdf_column *lhs, gdf_column * stencil, gdf_column * 
 
 	//you may notice that we can write out more bytes than our valid_num_bytes, this only happens when we are not aligned to  GDF_VALID_BITSIZE bytes, becasue the
 	//arrow standard requires 64 byte alignment, this is a safe assumption to make
-	thrust::transform(rmm::exec_policy(stream), valid_bit_mask_group_8_iter, valid_bit_mask_group_8_iter + ((num_values + GDF_VALID_BITSIZE - 1) / GDF_VALID_BITSIZE),
+	thrust::transform(rmm::exec_policy(stream)->on(stream), valid_bit_mask_group_8_iter, valid_bit_mask_group_8_iter + ((num_values + GDF_VALID_BITSIZE - 1) / GDF_VALID_BITSIZE),
 			thrust::detail::make_normal_iterator(thrust::device_pointer_cast(output->valid)),bit_mask_pack_op());
 
 	cudaStreamSynchronize(stream);

--- a/cpp/src/dataframe/cudf_table.cuh
+++ b/cpp/src/dataframe/cudf_table.cuh
@@ -309,7 +309,7 @@ public:
     // If a row contains a single NULL value, then the entire row is considered
     // to be NULL, therefore initialize the row-validity mask with the 
     // bit-wise AND of the validity mask of all the columns
-    thrust::tabulate(rmm::exec_policy(cudaStream_t{0}),
+    thrust::tabulate(rmm::exec_policy()->on(0),
                      device_row_valid.begin(),
                      device_row_valid.end(),
                      row_masker<size_type>(d_columns_valids, num_cols));
@@ -974,7 +974,7 @@ private:
     // Gathering from one table to another
     if (i_data != o_data) {
         if (range_check) {
-            thrust::gather_if(rmm::exec_policy(stream),
+            thrust::gather_if(rmm::exec_policy(stream)->on(stream),
                     row_gather_map,
                     row_gather_map + num_rows,
                     row_gather_map,
@@ -983,7 +983,7 @@ private:
                     ValidRange<index_type>(0, input_column->size));
 
         } else {
-            thrust::gather(rmm::exec_policy(stream),
+            thrust::gather(rmm::exec_policy(stream)->on(stream),
                     row_gather_map,
                     row_gather_map + num_rows,
                     i_data,
@@ -994,7 +994,7 @@ private:
     else {
         rmm::device_vector<column_type> remapped_copy(num_rows);
         if (range_check) {
-            thrust::gather_if(rmm::exec_policy(stream),
+            thrust::gather_if(rmm::exec_policy(stream)->on(stream),
                            row_gather_map,
                            row_gather_map + num_rows,
                            row_gather_map,
@@ -1002,13 +1002,13 @@ private:
                            remapped_copy.begin(),
                            ValidRange<index_type>(0, input_column->size));
         } else {
-            thrust::gather(rmm::exec_policy(stream),
+            thrust::gather(rmm::exec_policy(stream)->on(stream),
                            row_gather_map,
                            row_gather_map + num_rows,
                            i_data,
                            remapped_copy.begin());
         }
-        thrust::copy(rmm::exec_policy(stream),
+        thrust::copy(rmm::exec_policy(stream)->on(stream),
                 remapped_copy.begin(),
                 remapped_copy.end(),
                 o_data);
@@ -1022,7 +1022,7 @@ private:
                 remapped_valid_copy.data().get(),
                 row_gather_map, 
                 num_rows, input_column->size, stream);
-        thrust::copy(rmm::exec_policy(stream),
+        thrust::copy(rmm::exec_policy(stream)->on(stream),
                 remapped_valid_copy.begin(),
                 remapped_valid_copy.end(), output_column->valid);
     }
@@ -1069,7 +1069,7 @@ gdf_error scatter_column(column_type const * const __restrict__ input_column,
   gdf_error gdf_status{GDF_SUCCESS};
 
 
-  thrust::scatter(rmm::exec_policy(stream),
+  thrust::scatter(rmm::exec_policy(stream)->on(stream),
                   input_column,
                   input_column + num_rows,
                   row_scatter_map,

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -319,28 +319,28 @@ gdf_error gdf_extract_datetime_year(gdf_column *input, gdf_column *output) {
 
     if (input->valid){
       gdf_size_type num_chars_bitmask = ( ( input->size +( GDF_VALID_BITSIZE - 1)) / GDF_VALID_BITSIZE );
-      thrust::copy(rmm::exec_policy(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
+      thrust::copy(rmm::exec_policy(stream)->on(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
     }
 
 	if ( input->dtype == GDF_DATE64 ) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_year_from_unixtime_op op(TIME_UNIT_ms);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	}else if (input->dtype == GDF_DATE32) {
 		thrust::device_ptr<int32_t> input_ptr((int32_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_year_from_date32_op op;
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	}else if (input->dtype == GDF_TIMESTAMP) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_year_from_unixtime_op op(input->dtype_info.time_unit);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	} else {
@@ -364,28 +364,28 @@ gdf_error gdf_extract_datetime_month(gdf_column *input, gdf_column *output) {
 
     if (input->valid){
       gdf_size_type num_chars_bitmask = ( ( input->size +( GDF_VALID_BITSIZE - 1)) / GDF_VALID_BITSIZE );
-      thrust::copy(rmm::exec_policy(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
+      thrust::copy(rmm::exec_policy(stream)->on(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
     }
 
 	if ( input->dtype == GDF_DATE64 ) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_month_from_unixtime_op op(TIME_UNIT_ms);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	}else if (input->dtype == GDF_DATE32) {
 		thrust::device_ptr<int32_t> input_ptr((int32_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_month_from_date32_op op;
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	}else if (input->dtype == GDF_TIMESTAMP) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_month_from_unixtime_op op(input->dtype_info.time_unit);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	} else {
@@ -409,27 +409,27 @@ gdf_error gdf_extract_datetime_day(gdf_column *input, gdf_column *output) {
 
     if (input->valid){
       gdf_size_type num_chars_bitmask = ( ( input->size +( GDF_VALID_BITSIZE - 1)) / GDF_VALID_BITSIZE );
-      thrust::copy(rmm::exec_policy(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
+      thrust::copy(rmm::exec_policy(stream)->on(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
     }
 	if ( input->dtype == GDF_DATE64 ) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_day_from_unixtime_op op(TIME_UNIT_ms);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	}else if (input->dtype == GDF_DATE32) {
 		thrust::device_ptr<int32_t> input_ptr((int32_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_day_from_date32_op op;
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	}else if (input->dtype == GDF_TIMESTAMP) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_day_from_unixtime_op op(input->dtype_info.time_unit);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	} else {
@@ -454,21 +454,21 @@ gdf_error gdf_extract_datetime_hour(gdf_column *input, gdf_column *output) {
 
     if (input->valid){
       gdf_size_type num_chars_bitmask = ( ( input->size +( GDF_VALID_BITSIZE - 1)) / GDF_VALID_BITSIZE );
-      thrust::copy(rmm::exec_policy(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
+      thrust::copy(rmm::exec_policy(stream)->on(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
     }
 
 	if ( input->dtype == GDF_DATE64 ) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_hour_from_unixtime_op op(TIME_UNIT_ms);;
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	}else if (input->dtype == GDF_TIMESTAMP) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_hour_from_unixtime_op op(input->dtype_info.time_unit);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	} else {
@@ -493,20 +493,20 @@ gdf_error gdf_extract_datetime_minute(gdf_column *input, gdf_column *output) {
 
     if (input->valid){
       gdf_size_type num_chars_bitmask = ( ( input->size +( GDF_VALID_BITSIZE - 1)) / GDF_VALID_BITSIZE );
-      thrust::copy(rmm::exec_policy(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
+      thrust::copy(rmm::exec_policy(stream)->on(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
     }
 	if ( input->dtype == GDF_DATE64 ) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_minute_from_unixtime_op op(TIME_UNIT_ms);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	}else if (input->dtype == GDF_TIMESTAMP) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_minute_from_unixtime_op op(input->dtype_info.time_unit);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	} else {
@@ -531,20 +531,20 @@ gdf_error gdf_extract_datetime_second(gdf_column *input, gdf_column *output) {
 
     if (input->valid){
       gdf_size_type num_chars_bitmask = ( ( input->size +( GDF_VALID_BITSIZE - 1)) / GDF_VALID_BITSIZE );
-      thrust::copy(rmm::exec_policy(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
+      thrust::copy(rmm::exec_policy(stream)->on(stream), input->valid, input->valid + num_chars_bitmask, output->valid); // copy over valid bitmask
     }
 	if ( input->dtype == GDF_DATE64 ) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_second_from_unixtime_op op(TIME_UNIT_ms);;
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	}else if (input->dtype == GDF_TIMESTAMP) {
 		thrust::device_ptr<int64_t> input_ptr((int64_t *) input->data);
 		thrust::device_ptr<int16_t> output_ptr((int16_t *) output->data);
 		gdf_extract_second_from_unixtime_op op(input->dtype_info.time_unit);
-		thrust::transform(rmm::exec_policy(stream), thrust::detail::make_normal_iterator(input_ptr),
+		thrust::transform(rmm::exec_policy(stream)->on(stream), thrust::detail::make_normal_iterator(input_ptr),
 				thrust::detail::make_normal_iterator(input_ptr) + input->size, thrust::detail::make_normal_iterator(output_ptr), op);
 
 	} else {

--- a/cpp/src/filter/filter_ops.cu
+++ b/cpp/src/filter/filter_ops.cu
@@ -108,27 +108,27 @@ void gpu_filter_op(IteratorTypeLeft begin_left, IteratorTypeRight begin_right, I
 	if (operation == GDF_EQUALS) {
 
 		gdf_equals_op<LeftType, RightType, ResultType> op;
-		thrust::transform(rmm::exec_policy(stream), begin_left, end_left, begin_right, result, op);
+		thrust::transform(rmm::exec_policy(stream)->on(stream), begin_left, end_left, begin_right, result, op);
 
 	} else if (operation == GDF_NOT_EQUALS) {
 		gdf_not_equals_op<LeftType, RightType, ResultType> op;
-		thrust::transform(rmm::exec_policy(stream), begin_left, end_left, begin_right, result, op);
+		thrust::transform(rmm::exec_policy(stream)->on(stream), begin_left, end_left, begin_right, result, op);
 
 	} else if (operation == GDF_GREATER_THAN_OR_EQUALS) {
 		gdf_greater_than_or_equals_op<LeftType, RightType, ResultType> op;
-		thrust::transform(rmm::exec_policy(stream), begin_left, end_left, begin_right, result, op);
+		thrust::transform(rmm::exec_policy(stream)->on(stream), begin_left, end_left, begin_right, result, op);
 
 	} else if (operation == GDF_GREATER_THAN) {
 		gdf_greater_than_op<LeftType, RightType, ResultType> op;
-		thrust::transform(rmm::exec_policy(stream), begin_left, end_left, begin_right, result, op);
+		thrust::transform(rmm::exec_policy(stream)->on(stream), begin_left, end_left, begin_right, result, op);
 
 	} else if (operation == GDF_LESS_THAN) {
 		gdf_less_than_op<LeftType, RightType, ResultType> op;
-		thrust::transform(rmm::exec_policy(stream), begin_left, end_left, begin_right, result, op);
+		thrust::transform(rmm::exec_policy(stream)->on(stream), begin_left, end_left, begin_right, result, op);
 
 	} else if (operation == GDF_LESS_THAN_OR_EQUALS) {
 		gdf_less_than_or_equals_op<LeftType, RightType, ResultType> op;
-		thrust::transform(rmm::exec_policy(stream),begin_left, end_left, begin_right, result, op);
+		thrust::transform(rmm::exec_policy(stream)->on(stream),begin_left, end_left, begin_right, result, op);
 
 	}
 

--- a/cpp/src/groupby/groupby_compute_api.h
+++ b/cpp/src/groupby/groupby_compute_api.h
@@ -209,7 +209,7 @@ gdf_error GroupbyHash(gdf_table<size_type> const & groupby_input_table,
   if(true == sort_result) {
 
       rmm::device_vector<int32_t> sorted_indices(*out_size);
-      thrust::sequence(rmm::exec_policy(cudaStream_t{0}), sorted_indices.begin(), sorted_indices.end());
+      thrust::sequence(rmm::exec_policy()->on(0), sorted_indices.begin(), sorted_indices.end());
 
       gdf_column sorted_indices_col;
       gdf_error status = gdf_column_view(&sorted_indices_col, (void*)thrust::raw_pointer_cast(sorted_indices.data()), 
@@ -228,11 +228,11 @@ gdf_error GroupbyHash(gdf_table<size_type> const & groupby_input_table,
       groupby_output_table.gather(sorted_indices);
 
       rmm::device_vector<aggregation_type> agg(*out_size);
-      thrust::gather(rmm::exec_policy(cudaStream_t{0}),
+      thrust::gather(rmm::exec_policy()->on(0),
                sorted_indices.begin(), sorted_indices.end(),
                out_aggregation_column,
                agg.begin());
-      thrust::copy(rmm::exec_policy(cudaStream_t{0}), agg.begin(), agg.end(), out_aggregation_column);
+      thrust::copy(rmm::exec_policy()->on(0), agg.begin(), agg.end(), out_aggregation_column);
   }
 
   return GDF_SUCCESS;

--- a/cpp/src/groupby/hash_groupby.cuh
+++ b/cpp/src/groupby/hash_groupby.cuh
@@ -322,7 +322,7 @@ void compute_average(gdf_column * avg_column, gdf_column const & count_column, g
   auto average_op =  [] __device__ (sum_type sum, size_t count)->avg_type { return (sum / static_cast<avg_type>(count)); };
 
   // Computes the average into the passed in output buffer for the average column
-  thrust::transform(rmm::exec_policy(cudaStream_t{0}), d_sums, d_sums + output_size, d_counts, d_avg, average_op);
+  thrust::transform(rmm::exec_policy()->on(0), d_sums, d_sums + output_size, d_counts, d_avg, average_op);
 
   // Update the size of the average column
   avg_column->size = output_size;

--- a/cpp/src/hash/hash_ops.cu
+++ b/cpp/src/hash/hash_ops.cu
@@ -113,7 +113,7 @@ gdf_error gpu_hash_columns(gdf_column ** columns_to_hash, int num_columns, gdf_c
 	auto begin = thrust::make_counting_iterator<gdf_size_type>(0);
 	auto end = thrust::make_counting_iterator<gdf_size_type>(0) + columns_to_hash[0]->size;
 	auto pointer_wrapper = thrust::device_pointer_cast((unsigned long long *) output_column->data);
-	thrust::transform(rmm::exec_policy(*stream),
+	thrust::transform(rmm::exec_policy(*stream)->on(*stream),
 			begin,
 			end,
 			thrust::detail::make_normal_iterator(pointer_wrapper),

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -127,7 +127,7 @@ gdf_error gdf_hash(int num_cols, gdf_column **input, gdf_hash_func hash, gdf_col
   {
     case GDF_HASH_MURMUR3:
       {
-        thrust::tabulate(rmm::exec_policy(cudaStream_t{0}),
+        thrust::tabulate(rmm::exec_policy()->on(0),
                         row_hash_values, 
                          row_hash_values + num_rows, 
                          row_hasher<MurmurHash3_32,size_type>(*input_table));
@@ -135,7 +135,7 @@ gdf_error gdf_hash(int num_cols, gdf_column **input, gdf_hash_func hash, gdf_col
       }
     case GDF_HASH_IDENTITY:
       {
-        thrust::tabulate(rmm::exec_policy(cudaStream_t{0}),
+        thrust::tabulate(rmm::exec_policy()->on(0),
                          row_hash_values, 
                          row_hash_values + num_rows, 
                          row_hasher<IdentityHash,size_type>(*input_table));
@@ -471,7 +471,7 @@ gdf_error hash_partition_gdf_table(gdf_table<size_type> const & input_table,
   // Compute exclusive scan of all blocks' partition sizes in-place to determine 
   // the starting point for each blocks portion of each partition in the output
   size_type * scanned_block_partition_sizes{block_partition_sizes};
-  thrust::exclusive_scan(rmm::exec_policy(cudaStream_t{0}),
+  thrust::exclusive_scan(rmm::exec_policy()->on(0),
                          block_partition_sizes, 
                          block_partition_sizes + (grid_size * num_partitions), 
                          scanned_block_partition_sizes);
@@ -483,7 +483,7 @@ gdf_error hash_partition_gdf_table(gdf_table<size_type> const & input_table,
   cudaStream_t s1{};
   cudaStreamCreate(&s1);
   size_type * scanned_global_partition_sizes{global_partition_sizes};
-  thrust::exclusive_scan(rmm::exec_policy(s1),
+  thrust::exclusive_scan(rmm::exec_policy(s1)->on(s1),
                          global_partition_sizes, 
                          global_partition_sizes + num_partitions,
                          scanned_global_partition_sizes);

--- a/cpp/src/io/convert/csr/cudf_to_csr.cu
+++ b/cpp/src/io/convert/csr/cudf_to_csr.cu
@@ -118,7 +118,7 @@ gdf_error gdf_to_csr(gdf_column **gdfData, int numCol, csr_gdf *csrReturn) {
 
 	//--------------------------------------------------------------------------------------
 	// Now do an exclusive scan to compute the offsets for where to write data
-    thrust::exclusive_scan(rmm::exec_policy(cudaStream_t{0}), offsets, (offsets + numRows + 1), offsets);
+    thrust::exclusive_scan(rmm::exec_policy()->on(0), offsets, (offsets + numRows + 1), offsets);
 
 	//--------------------------------------------------------------------------------------
     // get the number of elements - NNZ, this is the last item in the array

--- a/cpp/src/quantiles/quantiles.h
+++ b/cpp/src/quantiles/quantiles.h
@@ -34,7 +34,7 @@ template<typename T>
 size_t quantile_index(T* dv, size_t n, double q, double& fract_pos, cudaStream_t stream, bool flag_sorted)
 {
   if( !flag_sorted )
-    thrust::sort(rmm::exec_policy(stream), dv, dv+n);
+    thrust::sort(rmm::exec_policy(stream)->on(stream), dv, dv+n);
 
   double pos = q*static_cast<double>(n);//(n-1);
   size_t k = static_cast<size_t>(pos);
@@ -52,7 +52,7 @@ T quantile_approx(T* dv, size_t n, double q, cudaStream_t stream = NULL, bool fl
   std::vector<T> hv(2);
   if( q >= 1.0 )
     {
-      T* d_res = thrust::max_element(rmm::exec_policy(stream), dv, dv+n);
+      T* d_res = thrust::max_element(rmm::exec_policy(stream)->on(stream), dv, dv+n);
       cudaMemcpy(&hv[0], d_res, sizeof(T), cudaMemcpyDeviceToHost);//TODO: async with streams?
       return hv[0];
     }
@@ -77,7 +77,7 @@ RetT quantile_exact(T* dv, size_t n, double q, std::function<RetT(T, T, double)>
   std::vector<T> hv(2);
   if( q >= 1.0 )
     {
-      T* d_res = thrust::max_element(rmm::exec_policy(stream), dv, dv+n);
+      T* d_res = thrust::max_element(rmm::exec_policy(stream)->on(stream), dv, dv+n);
       cudaMemcpy(&hv[0], d_res, sizeof(T), cudaMemcpyDeviceToHost);//TODO: async with streams?
       return hv[0];
     }

--- a/cpp/src/sqls/sqls_rtti_comp.h
+++ b/cpp/src/sqls/sqls_rtti_comp.h
@@ -463,7 +463,7 @@ size_t multi_col_filter(size_t nrows,
   //actual filtering happens here:
   //
   auto ret_iter_last =
-    thrust::copy_if(rmm::exec_policy(stream),
+    thrust::copy_if(rmm::exec_policy(stream)->on(stream),
                     thrust::make_counting_iterator<size_t>(0), 
                     thrust::make_counting_iterator<size_t>(nrows),
                     ptr_d_flt_indx,
@@ -522,7 +522,7 @@ multi_col_group_by_count_sort(size_t         nrows,
 
 
   thrust::pair<IndexT*, CountT*> ret =
-    thrust::reduce_by_key(rmm::exec_policy(stream),
+    thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream),
                           ptr_d_indx, ptr_d_indx+nrows,
                           thrust::make_constant_iterator<CountT>(1),
                           ptr_d_kout,
@@ -591,7 +591,7 @@ size_t multi_col_group_by_sort(size_t         nrows,
     multi_col_sort(d_cols, nullptr, d_gdf_t, nullptr, ncols, nrows, false, ptr_d_indx, false, stream);
 
   
-  thrust::gather(rmm::exec_policy(stream),
+  thrust::gather(rmm::exec_policy(stream)->on(stream),
                  ptr_d_indx, ptr_d_indx + nrows,  //map[i]
   		 ptr_d_agg,                    //source[i]
   		 ptr_d_agg_p);                 //source[map[i]]
@@ -599,7 +599,7 @@ size_t multi_col_group_by_sort(size_t         nrows,
   LesserRTTI<IndexT> f(d_cols, d_gdf_t, ncols);
   
   thrust::pair<IndexT*, ValsT*> ret =
-    thrust::reduce_by_key(rmm::exec_policy(stream),
+    thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream),
                           ptr_d_indx, ptr_d_indx + nrows,
                           ptr_d_agg_p,
                           ptr_d_kout,
@@ -754,7 +754,7 @@ size_t multi_col_group_by_avg_sort(size_t         nrows,
                                                stream);
 
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy(stream)->on(stream),
                     ptr_d_cout, ptr_d_cout + nrows,
                     ptr_d_vout,
                     ptr_d_vout,
@@ -800,18 +800,18 @@ void multi_col_sort(void* const *           d_cols,
   //cannot use counting_iterator 2 reasons:
   //(1.) need to return a container result;
   //(2.) that container must be mutable;
-  thrust::sequence(rmm::exec_policy(stream), d_indx, d_indx+nrows, 0);
+  thrust::sequence(rmm::exec_policy(stream)->on(stream), d_indx, d_indx+nrows, 0);
   
   LesserRTTI<IndexT> comp(d_cols, d_valids, d_col_types, d_asc_desc, ncols, nulls_are_smallest);
   if (d_valids != nullptr && have_nulls) {
-		thrust::sort(rmm::exec_policy(stream),
+		thrust::sort(rmm::exec_policy(stream)->on(stream),
 				         d_indx, d_indx+nrows,
 				         [comp] __device__ (IndexT i1, IndexT i2){
                     return comp.asc_desc_comparison_with_nulls(i1, i2);
                  });
   }
   else {
-    thrust::sort(rmm::exec_policy(stream),
+    thrust::sort(rmm::exec_policy(stream)->on(stream),
                 d_indx, d_indx+nrows,
                 [comp] __device__ (IndexT i1, IndexT i2) {
                   return comp.asc_desc_comparison(i1, i2);

--- a/cpp/src/unary/unary_ops.cu
+++ b/cpp/src/unary/unary_ops.cu
@@ -376,7 +376,7 @@ gdf_error gdf_cast_##VFROM##_to_##VTO(gdf_column *input, gdf_column *output) {  
     output->dtype = LTO;                                                                                        \
     if (input->valid && output->valid) {                                                                        \
         gdf_size_type num_chars_bitmask = gdf_get_num_chars_bitmask(input->size);                               \
-        thrust::copy(rmm::exec_policy(cudaStream_t{0}), input->valid, input->valid + num_chars_bitmask, output->valid);            \
+        thrust::copy(rmm::exec_policy()->on(0), input->valid, input->valid + num_chars_bitmask, output->valid);            \
     }                                                                                                           \
                                                                                                                 \
     /* Handling datetime logical castings */                                                                    \
@@ -412,7 +412,7 @@ gdf_error gdf_cast_##VFROM##_to_##VTO(gdf_column *input, gdf_column *output, gdf
     output->dtype_info.time_unit = time_unit;                                                           \
     if (input->valid && output->valid) {                                                                \
         gdf_size_type num_chars_bitmask = gdf_get_num_chars_bitmask(input->size);                       \
-        thrust::copy(rmm::exec_policy(cudaStream_t{0}), input->valid, input->valid + num_chars_bitmask, output->valid);    \
+        thrust::copy(rmm::exec_policy()->on(0), input->valid, input->valid + num_chars_bitmask, output->valid);    \
     }                                                                                                   \
                                                                                                         \
     /* Handling datetime logical castings */                                                            \


### PR DESCRIPTION
fixes https://github.com/rapidsai/cudf/issues/792

Previously, `rmm::exec_policy(stream)` returned a Thrust execution policy that would use RMM for temporary Thrust allocations in addition to running on the desired stream.

Due to a bug in `rmm::exec_policy`, the returned Thrust execution policy would be returned with a reference to a local variable that is not valid after the function returns. This would cause errors when using Thrust algorithms with the `rmm::exec_policy`. 

To fix this, `rmm::exec_policy` was updated to return a `std::unique_ptr` that points to the Thrust execution policy that uses RMM for temporary allocation. Furthermore, it no longer specifies that the execution policy should run on the specified stream, requiring the usage to be updated from:

```
thrust::sort(rmm::exec_policy(stream), ...);
```

to 

```
thrust::sort(rmm::exec_policy(stream)->on(stream), ...);
```

This PR updates all previous usages of `rmm::exec_policy` to reflect the new usage.