### PR TITLE
[HOTFIX] Point git submodule to branches of forks instead of exact commits

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = cudf-moderngpu
 [submodule "thirdparty/rmm"]
 	path = thirdparty/rmm
-	url = https://github.com/rapidsai/rmm
+	url = https://github.com/rapidsai/rmm.git
 	branch = branch-0.5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "thirdparty/cub"]
 	path = thirdparty/cub
-	url = https://github.com/NVlabs/cub.git
-	branch = b165e1fb11eeea64ccf95053e40f2424312599cc
+	url = https://github.com/rapidsai/thirdparty-cub.git
+	branch = cudf-cub
 [submodule "thirdparty/moderngpu"]
 	path = thirdparty/moderngpu
-	url = https://github.com/moderngpu/moderngpu.git
-	branch = c1fd31df008d79f727483e795b1ee1ce45b782ca
+	url = https://github.com/rapidsai/thirdparty-moderngpu.git
+	branch = cudf-moderngpu
 [submodule "thirdparty/rmm"]
 	path = thirdparty/rmm
 	url = https://github.com/rapidsai/rmm

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 [submodule "thirdparty/rmm"]
 	path = thirdparty/rmm
 	url = https://github.com/rapidsai/rmm
-	branch = branch-0.5
+	branch = .

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 [submodule "thirdparty/rmm"]
 	path = thirdparty/rmm
 	url = https://github.com/rapidsai/rmm
-	branch = .
+	branch = branch-0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 - PR #778 Fix hard coded ABI off setting
 - PR #784 Update RMM submodule commit-ish and pip paths
 - PR #794 Update `rmm::exec_policy` usage to fix segmentation faults when used as temprory allocator.
+- PR #800 Point git submodules to branches of forks instead of exact commits
 
 
 # cuDF 0.4.0 (05 Dec 2018)

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ To install cuDF from source, ensure the dependencies are met and follow the step
 - Clone the repository and submodules
 ```bash
 CUDF_HOME=$(pwd)/cudf
-git clone --recurse-submodules --remote https://github.com/rapidsai/cudf.git $CUDF_HOME
+git clone https://github.com/rapidsai/cudf.git $CUDF_HOME
 cd CUDF_HOME
+git submodule update --init --remote --recursive
 ```
 - Create the conda development environment `cudf_dev`
 ```bash

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To install cuDF from source, ensure the dependencies are met and follow the step
 - Clone the repository and submodules
 ```bash
 CUDF_HOME=$(pwd)/cudf
-git clone --recurse-submodules https://github.com/rapidsai/cudf.git $CUDF_HOME
+git clone --recurse-submodules --remote https://github.com/rapidsai/cudf.git $CUDF_HOME
 cd CUDF_HOME
 ```
 - Create the conda development environment `cudf_dev`


### PR DESCRIPTION
- [x] Update docs
- [X] Update git modules
- [x] Update CI to sync git submodules

Needed to fork (cub and moderngpu) and update to tip of the branch to resolve situation where RMM `branch-0.5` was not being updated, leading to errors. Commits are not supported in `.gitmodules` so by forking the repos above we can create a branch that is at our desired commit.

This is to fix an issue where after merging #794 all builds fail because `branch-0.5` for the RMM submodule points to an old commit.