### PR TITLE
[REVIEW] Fix undefined variable in `gdf_table`

### DIFF
--- a/cpp/src/dataframe/cudf_table.cuh
+++ b/cpp/src/dataframe/cudf_table.cuh
@@ -319,7 +319,7 @@ public:
     thrust::tabulate(rmm::exec_policy()->on(0),
                      device_row_valid.begin(),
                      device_row_valid.end(),
-                     row_masker<size_type>(d_columns_valids, num_cols));
+                     row_masker<size_type>(d_columns_valids_ptr, num_cols));
 
     d_row_valid = device_row_valid.data().get();
   }


### PR DESCRIPTION
A erroneous merge conflict resolution rolled back a change to a variable name in `gdf_table`.

This PR resolves that error.