### PR TITLE
[WIP] Make our df and Series string output identical to Pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Bug Fixes
 
+- PR #811 Improve output of DataFrame and Series to better match Pandas
+
 - ...
 
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -388,7 +388,7 @@ class DataFrame(object):
         # Format into a table
         return formatting.format(index=self._index, cols=cols,
                                  show_headers=True, more_cols=more_cols,
-                                 more_rows=more_rows)
+                                 more_rows=more_rows, min_width=2)
 
     def __str__(self):
         nrows = settings.formatting.get('nrows') or 10

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -299,8 +299,11 @@ class Series(object):
         # Prepare cells
         cols = OrderedDict([('', self.values_to_string(nrows=nrows))])
         # Format into a table
-        return formatting.format(index=self.index,
-                                 cols=cols, more_rows=more_rows)
+        output = formatting.format(index=self.index,
+                                   cols=cols, more_rows=more_rows,
+                                   series_spacing=True)
+        return output + "\nName: {}, dtype: {}".format(self.name, self.dtype)\
+            if self.name else output + "\ndtype: {}".format(self.dtype)
 
     def __str__(self):
         return self.to_string(nrows=10)

--- a/python/cudf/formatting.py
+++ b/python/cudf/formatting.py
@@ -7,7 +7,7 @@ import numbers
 
 
 def format(index, cols, show_headers=True, more_cols=0, more_rows=0,
-           min_width=4):
+           min_width=4, series_spacing=False):
     """
     Format columnar data.
 
@@ -47,21 +47,31 @@ def format(index, cols, show_headers=True, more_cols=0, more_rows=0,
     headers = tuple(cols.keys())
     lastcol = headers[-1] if more_cols > 0 else None
 
+    # offset because Series get more spaces than DFs
+    col0_offset = 3 if series_spacing else 1
+
     # compute column widths
     widths = {}
     for k, vs in cols.items():
-        if isinstance(k, numbers.Integral):
+        if k == 0 and not series_spacing:
+            widths[k] = 1
+        elif isinstance(k, numbers.Integral):
             widths[k] = min_width
         else:
-            widths[k] = max(len(k), max(map(len, vs), default=0), min_width)
-    # format table
+            widths[k] = max(len(k)+1, max(map(len, vs), default=0)+col0_offset,
+                            min_width)
+        for v in vs:
+            if len(v) == max(map(len, vs), default=0) and '-' in v and\
+                    len(v) > len(k):
+                widths[k] = widths[k]-2 if k == 0 else\
+                    max(min_width-1, widths[k]-1)
     out = []
-    widthkey = len(str(nrows))
+    widthkey = min(len(str(nrows)), len(headers[0]))
 
     cell_template = "{:>{}}"
     #   format headers
-    if show_headers:
-        header = [' ' * widthkey]
+    if show_headers and headers[0] != '':
+        header = [' ' * (widthkey)]
         header += [cell_template.format(k, widths[k]) for k in headers[:-1]]
         if lastcol is not None:
             header += ['...']
@@ -69,7 +79,7 @@ def format(index, cols, show_headers=True, more_cols=0, more_rows=0,
         out.append(' '.join(header))
     #   format rows
     for i in range(nrows):
-        row = [cell_template.format(str(index[i]), widthkey)]
+        row = [cell_template.format(str(index[i]), 0)]
         for k, vs in cols.items():
             if k == lastcol:
                 row.append('...')

--- a/python/cudf/tests/test_categorical.py
+++ b/python/cudf/tests/test_categorical.py
@@ -52,6 +52,7 @@ def test_categorical_integer():
 2
 3 c
 4 a
+dtype: category
 """
     assert string.split() == expect_str.split()
 

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -1448,9 +1448,10 @@ def test_many_string_outputs(length_variety, ncols, data_type):
     np.random.seed(0)
     pdf = pd.DataFrame()
     for i in range(ncols):
-        header_length = max(1, length_variety+(np.random.randint(-length_variety, length_variety)))
-        col = ''.join(np.random.choice(list(string.ascii_lowercase))\
-            for _ in range(header_length))
+        header_length = max(1, length_variety+(np.random.randint(
+                            -length_variety, length_variety)))
+        col = ''.join(np.random.choice(list(string.ascii_lowercase))
+                      for _ in range(header_length))
         pdf[col] = pd.Series(np.random.randint(0, 10**length_variety))\
             .astype(data_type)
     gdf = DataFrame.from_pandas(pdf)

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2,6 +2,7 @@
 
 import operator
 import pytest
+import string
 
 import numpy as np
 import pandas as pd
@@ -1435,3 +1436,29 @@ def test_arrow_pandas_compat(pdf, gdf, preserve_index):
     pdf2 = pdf_arrow_table.to_pandas()
 
     assert_eq(pdf2, gdf2)
+
+
+@pytest.mark.parametrize('length_variety', [1, 2, 8])
+@pytest.mark.parametrize('ncols', [1, 2, 4])
+@pytest.mark.parametrize(
+    'data_type',
+    ['int8', 'int16', 'int32', 'int64', 'float32', 'float64']
+)
+def test_many_string_outputs(length_variety, ncols, data_type):
+    np.random.seed(0)
+    pdf = pd.DataFrame()
+    for i in range(ncols):
+        header_length = max(1, length_variety+(np.random.randint(-length_variety, length_variety)))
+        col = ''.join(np.random.choice(list(string.ascii_lowercase))\
+            for _ in range(header_length))
+        pdf[col] = pd.Series(np.random.randint(0, 10**length_variety))\
+            .astype(data_type)
+    gdf = DataFrame.from_pandas(pdf)
+    print(pdf)
+    print(gdf)
+    assert pdf.to_string() == gdf.to_string()
+
+    for col in gdf.columns:
+        print(pdf[col])
+        print(gdf[col])
+        assert pdf[col].to_string() == gdf[col].to_string()


### PR DESCRIPTION
- Default `DataFrame` formatting `min_width` to 2
- Add Name/dtype line to end of `Series` output
- Prevent creation of an empty line when header is empty in
  formatting.py
  - Fix one test that is broken by this routine - perfect match for
    category
    - Create parametrized `Series` test
    - Create perfect match `DataFrame` test
    - Space column 0 differently
    - Space Df and Series differently
    - Space columns with `-` over by one
    - Space header to have minimum 2 spaces

Resolves #739 and #740