### PR TITLE
[REVIEW] Fix memory leak by preserving the boolean mask index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #821 Fix flake8 issues revealed by flake8 update
 - PR #808 Resolved renamed `d_columns_valids` variable name
 - PR #780 CSV Reader: Fix scientific notation parsing and null values for empty quotes
+- PR #861 Fix memory leak by preserving the boolean mask index
 
 
 # cuDF 0.5.0 (28 Jan 2019)

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -1485,7 +1485,7 @@ class DataFrame(object):
           import cudf
           import numpy as np
 
-          df = cudf.dataframe.DataFrame()
+          df = cudf.DataFrame()
           nelem = 3
           df['in1'] = np.arange(nelem)
           df['in2'] = np.arange(nelem)

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -46,7 +46,7 @@ class DataFrame(object):
 
     .. code-block:: python
 
-          from cudf.dataframe import DataFrame
+          from cudf import DataFrame
           df = DataFrame()
           df['key'] = [0, 1, 2, 3, 4]
           df['val'] = [float(i + 10) for i in range(5)]  # insert column
@@ -67,7 +67,7 @@ class DataFrame(object):
 
     .. code-block:: python
 
-          from cudf.dataframe import DataFrame
+          from cudf import DataFrame
           import numpy as np
           import datetime as dt
           ids = np.arange(5)
@@ -285,7 +285,7 @@ class DataFrame(object):
 
             import cudf
 
-            df = cudf.dataframe.DataFrame()
+            df = cudf.DataFrame()
             df = df.assign(a=[0,1,2], b=[3,4,5])
             print(df)
 
@@ -313,7 +313,7 @@ class DataFrame(object):
 
         .. code-block:: python
 
-            from cudf.dataframe import DataFrame
+            from cudf import DataFrame
 
             df = DataFrame()
             df['key'] = [0, 1, 2, 3, 4]
@@ -350,7 +350,7 @@ class DataFrame(object):
 
         .. code-block:: python
 
-            from cudf.dataframe import DataFrame()
+            from cudf import DataFrame
             df = DataFrame()
             df['key'] = [0, 1, 2]
             df['val'] = [float(i + 10) for i in range(3)]
@@ -421,17 +421,25 @@ class DataFrame(object):
 
         Examples
         --------
+        .. code-block:: python
 
-        >>> df = DataFrame([('a', list(range(20))),
-        ...                 ('b', list(range(20))),
-        ...                 ('c', list(range(20)))])
-        # get rows from index 2 to index 5 from 'a' and 'b' columns.
-        >>> df.loc[2:5, ['a', 'b']]
-             a    b
-        2    2    2
-        3    3    3
-        4    4    4
-        5    5    5
+           df = DataFrame([('a', list(range(20))),
+                           ('b', list(range(20))),
+                           ('c', list(range(20)))])
+
+           # get rows from index 2 to index 5 from 'a' and 'b' columns.
+           df.loc[2:5, ['a', 'b']]
+
+        Output:
+
+        .. code-block:: python
+
+               a    b
+          2    2    2
+          3    3    3
+          4    4    4
+          5    5    5
+
         """
         return Loc(self)
 
@@ -442,30 +450,41 @@ class DataFrame(object):
 
         Examples
         --------
-        >>> df = DataFrame([('a', list(range(20))),
-        ...                 ('b', list(range(20))),
-        ...                 ('c', list(range(20)))])
+        df = DataFrame([('a', list(range(20))),
+                        ('b', list(range(20))),
+                        ('c', list(range(20)))])
+
         #get the row from index 1st
-        >>> df.iloc[1]
-        a    1
-        b    1
-        c    1
+        df.iloc[1]
 
         # get the rows from indices 0,2,9 and 18.
-        >>> df.iloc[[0, 2, 9, 18]]
-             a    b    c
-        0    0    0    0
-        2    2    2    2
-        9    9    9    9
-        18   18   18   18
+        df.iloc[[0, 2, 9, 18]]
 
         # get the rows using slice indices
-        >>> df.iloc[3:10:2]
-             a    b    c
-        3    3    3    3
-        5    5    5    5
-        7    7    7    7
-        9    9    9    9
+        df.iloc[3:10:2]
+
+        Output:
+
+        .. code-block:: python
+
+          #get the row from index 1st
+          a    1
+          b    1
+          c    1
+
+          # get the rows from indices 0,2,9 and 18.
+               a    b    c
+          0    0    0    0
+          2    2    2    2
+          9    9    9    9
+          18   18   18   18
+
+          # get the rows using slice indices
+               a    b    c
+          3    3    3    3
+          5    5    5    5
+          7    7    7    7
+          9    9    9    9
         """
 
         return Iloc(self)
@@ -641,20 +660,22 @@ class DataFrame(object):
         A dataframe without dropped column(s)
 
         Examples
-        ----------
+        --------
 
         .. code-block:: python
 
-            from cudf.dataframe.dataframe import DataFrame
+            from cudf import DataFrame
+
             df = DataFrame()
             df['key'] = [0, 1, 2, 3, 4]
             df['val'] = [float(i + 10) for i in range(5)]
-
             df_new = df.drop('val')
+
             print(df)
             print(df_new)
 
         Output:
+
         .. code-block:: python
 
                 key  val
@@ -807,7 +828,7 @@ class DataFrame(object):
         .. code-block:: python
 
           import pandas as pd
-          from cudf.dataframe import DataFrame as gdf
+          from cudf import DataFrame as gdf
 
           pet_owner = [1, 2, 3, 4, 5]
           pet_type = ['fish', 'dog', 'fish', 'bird', 'fish']
@@ -918,7 +939,8 @@ class DataFrame(object):
 
         .. code-block:: python
 
-              from cudf.dataframe import DataFrame
+              from cudf import DataFrame
+
               a = ('a', [0, 1, 2])
               b = ('b', [-3, 2, 0])
               df = DataFrame([a, b])
@@ -1010,7 +1032,7 @@ class DataFrame(object):
 
         .. code-block:: python
 
-            from cudf.dataframe import DataFrame
+            from cudf import DataFrame
 
             df_a = DataFrame()
             df['key'] = [0, 1, 2, 3, 4]
@@ -1380,7 +1402,8 @@ class DataFrame(object):
 
         .. code-block:: python
 
-              from cudf.dataframe import DataFrame
+              from cudf import DataFrame
+
               a = ('a', [1, 2, 2])
               b = ('b', [3, 4, 5])
               df = DataFrame([a, b])
@@ -1399,7 +1422,7 @@ class DataFrame(object):
 
         .. code-block:: python
 
-           from cudf.dataframe import DataFrame
+           from cudf import DataFrame
            import numpy as np
 
            df = DataFrame()
@@ -1655,7 +1678,8 @@ class DataFrame(object):
 
         .. code-block:: python
 
-          from cudf.dataframe import DataFrame
+          from cudf import DataFrame
+
           a = ('a', [0, 1, 2])
           b = ('b', [-3, 2, 0])
           df = DataFrame([a, b])
@@ -1692,7 +1716,7 @@ class DataFrame(object):
 
             data = [[0,1], [1,2], [3,4]]
             pdf = pd.DataFrame(data, columns=['a', 'b'], dtype=int)
-            cudf.dataframe.DataFrame.from_pandas(pdf)
+            cudf.DataFrame.from_pandas(pdf)
 
         Output:
 
@@ -1720,7 +1744,7 @@ class DataFrame(object):
 
         .. code-block:: python
 
-            from cudf.dataframe import DataFrame
+            from cudf import DataFrame
 
             a = ('a', [0, 1, 2])
             b = ('b', [-3, 2, 0])
@@ -1787,7 +1811,7 @@ class DataFrame(object):
         .. code-block:: python
 
             import pyarrow as pa
-            from cudf.dataframe import DataFrame
+            from cudf import DataFrame
 
             data = [pa.array([1, 2, 3]), pa.array([4, 5, 6])
             batch = pa.RecordBatch.from_arrays(data, ['f0', 'f1'])
@@ -1809,7 +1833,7 @@ class DataFrame(object):
         if isinstance(table.schema.metadata, dict):
             if b'pandas' in table.schema.metadata:
                 index_col = json.loads(
-                    table.schema.metadata[b'pandas'].decode('utf-8')
+                    table.schema.metadata[b'pandas']
                 )['index_columns']
 
         df = cls()

--- a/python/cudf/dataframe/index.py
+++ b/python/cudf/dataframe/index.py
@@ -155,6 +155,10 @@ class RangeIndex(Index):
         start, stop: int
         name: string
         """
+        if isinstance(start, range):
+            therange = start
+            start = therange.start
+            stop = therange.stop
         if stop is None:
             start, stop = 0, start
         self._start = int(start)
@@ -200,6 +204,17 @@ class RangeIndex(Index):
     def dtype(self):
         return np.dtype(np.int64)
 
+    @property
+    def _values(self):
+        return Column(range(self._start, self._stop))
+
+    def is_contiguous(self):
+        return True
+
+    @property
+    def size(self):
+        return max(0, self._stop - self._start)
+
     def find_label_range(self, first, last):
         # clip first to range
         if first is None or first < self._start:
@@ -226,6 +241,9 @@ class RangeIndex(Index):
         else:
             vals = rmm.device_array(0, dtype=self.dtype)
         return NumericalColumn(data=Buffer(vals), dtype=vals.dtype)
+
+    def to_gpu_array(self):
+        return self.as_column().to_gpu_array()
 
     def to_pandas(self):
         return pd.RangeIndex(start=self._start, stop=self._stop,

--- a/python/cudf/dataframe/index.py
+++ b/python/cudf/dataframe/index.py
@@ -208,6 +208,7 @@ class RangeIndex(Index):
     def _values(self):
         return Column(range(self._start, self._stop))
 
+    @property
     def is_contiguous(self):
         return True
 

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -68,7 +68,7 @@ class Series(object):
             name = data.name
             index = as_index(data.index)
         if isinstance(data, Series):
-            index = data._index
+            index = data._index if index is None else index
             name = data.name
             data = data._column
         if data is None:
@@ -77,7 +77,9 @@ class Series(object):
         if not isinstance(data, columnops.TypedColumnBase):
             data = columnops.as_column(data, nan_as_null=nan_as_null)
 
-        if index is not None and not isinstance(index, Index):
+        if isinstance(index, range):
+            index = RangeIndex(index)
+        if index is not None and not isinstance(index, (RangeIndex, Index,)):
             raise TypeError('index not a Index type: got {!r}'.format(index))
 
         assert isinstance(data, columnops.TypedColumnBase)

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -1435,3 +1435,40 @@ def test_arrow_pandas_compat(pdf, gdf, preserve_index):
     pdf2 = pdf_arrow_table.to_pandas()
 
     assert_eq(pdf2, gdf2)
+
+
+def test_gpu_memory_usage_with_boolmask():
+    from numba import cuda
+    import cudf
+    ctx = cuda.current_context()
+
+    def query_GPU_memory(note=''):
+        memInfo = ctx.get_memory_info()
+        usedMemoryGB = (memInfo.total - memInfo.free)/1e9
+        return usedMemoryGB
+
+    cuda.current_context().deallocations.clear()
+    nRows = int(1e8)
+    nCols = 2
+    dataNumpy = np.asfortranarray(np.random.rand(nRows, nCols))
+    colNames = ['col'+str(iCol) for iCol in range(nCols)]
+    pandasDF = pd.DataFrame(data=dataNumpy, columns=colNames, dtype=np.float32)
+    cudaDF = cudf.dataframe.DataFrame.from_pandas(pandasDF)
+    boolmask = cudf.Series(np.random.randint(1, 2, len(cudaDF)).astype('bool'))
+
+    memory_used = query_GPU_memory()
+    cudaDF = cudaDF[boolmask]
+
+    assert cudaDF.index._values.data.mem.device_ctypes_pointer ==\
+        cudaDF['col0'].index._values.data.mem.device_ctypes_pointer
+    assert cudaDF.index._values.data.mem.device_ctypes_pointer ==\
+        cudaDF['col1'].index._values.data.mem.device_ctypes_pointer
+
+    assert memory_used == query_GPU_memory()
+
+
+def test_boolmask(pdf, gdf):
+    boolmask = np.random.randint(0, 2, len(pdf)) > 0
+    gdf = gdf[boolmask]
+    pdf = pdf[boolmask]
+    assert_eq(pdf, gdf)


### PR DESCRIPTION
- Correct leak by carefully assigning boolmask index to new df when
  masked
- Correct issue with Series not actually using an index specified in its
  constructor
- Add range initialization to `RangeIndex.__init__`
- Add range initialization to `Series.__init__`
- Fix issue with pyarrow serialization not recognizing binary string
- Add properties to RangeIndex:
 - _values
 - is_contiguous
 - size
 - to_gpu_array