### PR TITLE
[REVIEW] Added missing type_traits include.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PR #815 CSV Reader: Fix data parsing when tabs are present in the input CSV file
 - PR #850 Fix bug where left joins where the left df has 0 rows causes a crash
 - PR #861 Fix memory leak by preserving the boolean mask index
+- PR #876 Added missing `<type_traits>` include
 
 
 # cuDF 0.5.0 (28 Jan 2019)

--- a/cpp/src/utilities/wrapper_types.hpp
+++ b/cpp/src/utilities/wrapper_types.hpp
@@ -4,6 +4,7 @@
 #include "cudf/types.h"
 #include "cudf_utils.h"
 #include <iostream>
+#include <type_traits>
 
 /* --------------------------------------------------------------------------*/
 /** 


### PR DESCRIPTION
`wrappers.hpp` was missing an include for `<type_traits>`.

This causes a failure to build on CentOS systems.

My guess is on Ubuntu systems that it was being included somewhere up the include chain, but not on CentOS.