### PR TITLE
[REVIEW] Add better indexing to groupby.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ dist/
 cudf.egg-info/
 python/build
 python/cudf/bindings/*.cpp
+python/cudf/bindings/.nfs*
+python/*.ipynb
 
 ## Patching
 *.diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #836 Add ingest support for arrow chunked arrays in Column, Series, DataFrame creation
 - PR #763 Format doxygen comments for csv_read_arg struct
 - PR #532 CSV Reader: Use type dispatcher instead of switch block
+- PR #878 Add better indexing to Groupby
 
 ## Bug Fixes
 

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -68,7 +68,7 @@ class Series(object):
             name = data.name
             index = as_index(data.index)
         if isinstance(data, Series):
-            index = data._index
+            index = data._index if index is None else index
             name = data.name
             data = data._column
         if data is None:

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -68,7 +68,7 @@ class Series(object):
             name = data.name
             index = as_index(data.index)
         if isinstance(data, Series):
-            index = data._index if index is None else index
+            index = data._index
             name = data.name
             data = data._column
         if data is None:
@@ -77,9 +77,7 @@ class Series(object):
         if not isinstance(data, columnops.TypedColumnBase):
             data = columnops.as_column(data, nan_as_null=nan_as_null)
 
-        if isinstance(index, range):
-            index = RangeIndex(index)
-        if index is not None and not isinstance(index, (RangeIndex, Index,)):
+        if index is not None and not isinstance(index, Index):
             raise TypeError('index not a Index type: got {!r}'.format(index))
 
         assert isinstance(data, columnops.TypedColumnBase)
@@ -301,8 +299,11 @@ class Series(object):
         # Prepare cells
         cols = OrderedDict([('', self.values_to_string(nrows=nrows))])
         # Format into a table
-        return formatting.format(index=self.index,
-                                 cols=cols, more_rows=more_rows)
+        output = formatting.format(index=self.index,
+                                   cols=cols, more_rows=more_rows,
+                                   series_spacing=True)
+        return output + "\nName: {}, dtype: {}".format(self.name, self.dtype)\
+            if self.name else output + "\ndtype: {}".format(self.dtype)
 
     def __str__(self):
         return self.to_string(nrows=10)

--- a/python/cudf/formatting.py
+++ b/python/cudf/formatting.py
@@ -7,7 +7,7 @@ import numbers
 
 
 def format(index, cols, show_headers=True, more_cols=0, more_rows=0,
-           min_width=4):
+           min_width=4, series_spacing=False):
     """
     Format columnar data.
 
@@ -47,20 +47,30 @@ def format(index, cols, show_headers=True, more_cols=0, more_rows=0,
     headers = tuple(cols.keys())
     lastcol = headers[-1] if more_cols > 0 else None
 
+    # offset because Series get more spaces than DFs
+    col0_offset = 3 if series_spacing else 1
+
     # compute column widths
     widths = {}
     for k, vs in cols.items():
-        if isinstance(k, numbers.Integral):
+        if k == 0 and not series_spacing:
+            widths[k] = 1
+        elif isinstance(k, numbers.Integral):
             widths[k] = min_width
         else:
-            widths[k] = max(len(k), max(map(len, vs), default=0), min_width)
-    # format table
+            widths[k] = max(len(k)+1, max(map(len, vs), default=0)+col0_offset,
+                            min_width)
+        for v in vs:
+            if len(v) == max(map(len, vs), default=0) and '-' in v and\
+                    len(v) > len(k):
+                widths[k] = widths[k]-2 if k == 0 else\
+                    max(min_width-1, widths[k]-1)
     out = []
-    widthkey = len(str(nrows))
+    widthkey = min(len(str(nrows)), len(headers[0]))
 
     cell_template = "{:>{}}"
     #   format headers
-    if show_headers:
+    if show_headers and headers[0] != '':
         header = [' ' * widthkey]
         header += [cell_template.format(k, widths[k]) for k in headers[:-1]]
         if lastcol is not None:
@@ -68,8 +78,10 @@ def format(index, cols, show_headers=True, more_cols=0, more_rows=0,
         header += [cell_template.format(k, widths[k]) for k in headers[-1:]]
         out.append(' '.join(header))
     #   format rows
+    if index.name:
+        out.append(cell_template.format(str(index.name), 0))
     for i in range(nrows):
-        row = [cell_template.format(str(index[i]), widthkey)]
+        row = [cell_template.format(str(index[i]), 0)]
         for k, vs in cols.items():
             if k == lastcol:
                 row.append('...')

--- a/python/cudf/tests/test_categorical.py
+++ b/python/cudf/tests/test_categorical.py
@@ -52,6 +52,7 @@ def test_categorical_integer():
 2
 3 c
 4 a
+dtype: category
 """
     assert string.split() == expect_str.split()
 

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -48,7 +48,7 @@ def pdf(gdf):
 
 
 @pytest.mark.parametrize('as_index', [True, False])
-def test_groupby_no_index(pdf, gdf, as_index):
+def test_groupby_as_index_single_agg(pdf, gdf, as_index):
     gdf = gdf.groupby('y', as_index=as_index).agg({'x': 'mean'})
     pdf = pdf.groupby('y', as_index=as_index).agg({'x': 'mean'})
     assert_eq(pdf, gdf)
@@ -60,7 +60,7 @@ def test_groupby_default(pdf, gdf):
     assert_eq(pdf, gdf)
 
 
-def test_groupby_indexing():
+def test_groupby_getitem_styles():
     pdf = pd.DataFrame({'x': [1, 3, 1], 'y': [1, 2, 3]})
     gdf = cudf.from_pandas(pdf)
     assert_eq(gdf.groupby('x')['y'].mean(),

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -2,10 +2,12 @@
 
 import pytest
 
+import cudf
 import numpy as np
 import pandas as pd
 
 from cudf.dataframe import DataFrame
+from .utils import assert_eq
 
 
 def make_frame(dataframe_class, nelem, seed=0, extra_levels=(), extra_vals=()):
@@ -35,16 +37,52 @@ def get_nelem():
         yield elem
 
 
+@pytest.fixture
+def gdf():
+    return DataFrame({'x': [1, 2], 'y': [1, 2]})
+
+
+@pytest.fixture
+def pdf(gdf):
+    return gdf.to_pandas()
+
+
+def test_groupby_no_index(pdf, gdf):
+    gdf = gdf.groupby('y', as_index=False).agg({'x': 'mean'})
+    pdf = pdf.groupby('y', as_index=False).agg({'x': 'mean'})
+    assert_eq(pdf, gdf)
+
+
+def test_groupby_index(pdf, gdf):
+    gdf = gdf.groupby('y', as_index=True).agg({'x': 'mean'})
+    pdf = pdf.groupby('y', as_index=True).agg({'x': 'mean'})
+    assert_eq(pdf, gdf)
+
+
+def test_groupby_default(pdf, gdf):
+    gdf = gdf.groupby('y').agg({'x': 'mean'})
+    pdf = pdf.groupby('y').agg({'x': 'mean'})
+    assert_eq(pdf, gdf)
+
+
+def test_groupby_indexing():
+    pdf = pd.DataFrame({'x': [1, 3, 1], 'y': [1, 2, 3]})
+    gdf = cudf.from_pandas(pdf)
+    assert_eq(gdf.groupby('x')['y'].mean(),
+              pdf.groupby('x')['y'].mean())
+    assert_eq(pdf.groupby('x').y.sum(),
+              gdf.groupby('x').y.sum())
+    assert_eq(pdf.groupby('x')[['y']].sum(),
+              gdf.groupby('x')[['y']].sum())
+
+
 @pytest.mark.parametrize('nelem', get_nelem())
 @pytest.mark.parametrize('method', get_methods())
 def test_groupby_mean(nelem, method):
     # gdf
     got_df = make_frame(DataFrame, nelem=nelem).groupby(
         ['x', 'y'], method=method).mean()
-    if method == 'cudf':
-        got = np.sort(got_df['val'].to_array())
-    else:
-        got = np.sort(got_df['mean_val'].to_array())
+    got = np.sort(got_df['val'].to_array())
     # pandas
     expect_df = make_frame(pd.DataFrame,
                            nelem=nelem).groupby(['x', 'y']).mean()
@@ -61,10 +99,7 @@ def test_groupby_mean_3level(nelem, method):
     # gdf
     got_df = make_frame(DataFrame, nelem=nelem,
                         extra_levels=lvls).groupby(bys, method=method).mean()
-    if method == "cudf":
-        got = np.sort(got_df['val'].to_array())
-    else:
-        got = np.sort(got_df['mean_val'].to_array())
+    got = np.sort(got_df['val'].to_array())
     # pandas
     expect_df = make_frame(pd.DataFrame, nelem=nelem,
                            extra_levels=lvls).groupby(bys).mean()
@@ -126,12 +161,10 @@ def test_groupby_cats(method):
     cats = np.asarray(list(df['cats']))
     vals = df['vals'].to_array()
 
-    grouped = df.groupby(['cats'], method=method).mean()
+    grouped = df.groupby(['cats'], method=method, as_index=False).mean()
 
-    if method == 'cudf':
-        got_vals = grouped['vals']
-    else:
-        got_vals = grouped['mean_vals']
+    print(grouped)
+    got_vals = grouped['vals']
 
     got_cats = grouped['cats']
 
@@ -256,10 +289,7 @@ def test_groupby_cudf_2keys_agg(nelem, func, method):
     got_df = make_frame(DataFrame, nelem=nelem)\
         .groupby(['x', 'y'], method=method).agg(func)
 
-    if method == "cudf":
-        got_agg = np.sort(got_df['val'].to_array())
-    else:
-        got_agg = np.sort(got_df[func + '_val'].to_array())
+    got_agg = np.sort(got_df['val'].to_array())
     # pandas
     expect_df = make_frame(pd.DataFrame, nelem=nelem)\
         .groupby(['x', 'y']).agg(func)

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -47,15 +47,10 @@ def pdf(gdf):
     return gdf.to_pandas()
 
 
-def test_groupby_no_index(pdf, gdf):
-    gdf = gdf.groupby('y', as_index=False).agg({'x': 'mean'})
-    pdf = pdf.groupby('y', as_index=False).agg({'x': 'mean'})
-    assert_eq(pdf, gdf)
-
-
-def test_groupby_index(pdf, gdf):
-    gdf = gdf.groupby('y', as_index=True).agg({'x': 'mean'})
-    pdf = pdf.groupby('y', as_index=True).agg({'x': 'mean'})
+@pytest.mark.parametrize('as_index', [True, False])
+def test_groupby_no_index(pdf, gdf, as_index):
+    gdf = gdf.groupby('y', as_index=as_index).agg({'x': 'mean'})
+    pdf = pdf.groupby('y', as_index=as_index).agg({'x': 'mean'})
     assert_eq(pdf, gdf)
 
 
@@ -163,7 +158,6 @@ def test_groupby_cats(method):
 
     grouped = df.groupby(['cats'], method=method, as_index=False).mean()
 
-    print(grouped)
     got_vals = grouped['vals']
 
     got_cats = grouped['cats']

--- a/python/cudf/tests/test_libgdf_groupby.py
+++ b/python/cudf/tests/test_libgdf_groupby.py
@@ -30,7 +30,7 @@ def test_groupby_mean(nelem):
     # gdf
     got_df = make_frame(DataFrame, nelem=nelem).groupby(
         ['x', 'y'], method="hash").mean()
-    got = np.sort(got_df['mean_val'].to_array())
+    got = np.sort(got_df['val'].to_array())
     # pandas
     expect_df = make_frame(pd.DataFrame,
                            nelem=nelem).groupby(['x', 'y']).mean()
@@ -46,7 +46,7 @@ def test_groupby_mean_3level(nelem):
     # gdf
     got_df = make_frame(DataFrame, nelem=nelem, extra_levels=lvls)\
         .groupby(bys, method="hash").mean()
-    got = np.sort(got_df['mean_val'].to_array())
+    got = np.sort(got_df['val'].to_array())
     # pandas
     expect_df = make_frame(pd.DataFrame, nelem=nelem,
                            extra_levels=lvls).groupby(bys).mean()
@@ -120,7 +120,7 @@ def test_groupby_2keys_agg(nelem, func):
     got_df = make_frame(DataFrame, nelem=nelem)\
         .groupby(['x', 'y'], method="hash").agg(func)
 
-    got_agg = np.sort(got_df[func + '_val'].to_array())
+    got_agg = np.sort(got_df['val'].to_array())
     # pandas
     expect_df = make_frame(pd.DataFrame, nelem=nelem)\
         .groupby(['x', 'y']).agg(func)


### PR DESCRIPTION
This fixes #828 (also #739 and #740).

Add better indexing to Groupby objects (`['y']`, `.y`, and `[['y']]`). This also adds support for as_index=True when a single index and a single aggregation is specified, with results that perfectly match pandas. If multi-index is specified, the index columns will be returned as normal columns as `MultiIndex` is not yet supported. If multi-aggregation is specified, the prefix aggregation types are still appended to column names, until `MultiColumn` is supported.

- Change default to as_index=True to match pandas
- Change `cudf` as_index NotImplementedError to a warning, so I don't have to modify _every_ test.
- Remove the multi-aggregation column prefix when multi-aggregation is not used
- Implement __getitem__ and __getattr__
- Implement UnaryIndex - that is, if as_index is set and `by` is length 1, convert that column into the df or Series index
- Return a Series when as_index, `by` is length 1, and 1 other column exists
- Create indexing tests as requested by @mrocklin
- Pass all tests

Formatting:
- Default dataframe to 2 column tabs
- Add name and dtype to Series output
- Format Dataframe and Series nicely