### PR TITLE
[REVIEW] Add DataFrame.groupby(level=0) functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #871 CSV Reader: Add support for NA values, including user specified strings
 - PR #867 CSV Reader: Add support for ignoring blank lines and comment lines
 - PR #895 Add Series groupby
+- PR #898 Add DataFrame.groupby(level=0) support
 
 ## Improvements
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -1322,7 +1322,8 @@ class DataFrame(object):
 
         return df
 
-    def groupby(self, by, sort=False, as_index=True, method="hash"):
+    def groupby(self, by=None, sort=False, as_index=True, method="hash",
+                level=None):
         """Groupby
 
         Parameters
@@ -1357,6 +1358,10 @@ class DataFrame(object):
         - Since we don't support multiindex, the *by* columns are stored
           as regular columns.
         """
+
+        if by is None and level is None:
+            raise TypeError('groupby() requires either by or level to be'
+                            'specified.')
         if (method == "cudf"):
             from cudf.groupby.legacy_groupby import Groupby
             if as_index:
@@ -1373,7 +1378,8 @@ class DataFrame(object):
             _gdf.nvtx_range_push("PYGDF_GROUPBY", "purple")
             # The matching `pop` for this range is inside LibGdfGroupby
             # __apply_agg
-            result = Groupby(self, by=by, method=method, as_index=as_index)
+            result = Groupby(self, by=by, method=method, as_index=as_index,
+                             level=level)
             return result
 
     def query(self, expr):

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -78,12 +78,15 @@ class Groupby(object):
             group by. Valid values are "hash".
         """
 
+        self.level = None
         self._df = df
         if level == 0:
             self.level = level
             self._df[self._LEVEL_0_INDEX_NAME] = self._df.index
             self._original_index_name = self._df.index.name
             self._by = [self._LEVEL_0_INDEX_NAME]
+        elif level and level > 0:
+            raise NotImplementedError('MultiIndex not supported yet in cudf')
         else:
             self._by = [by] if isinstance(by, str) else list(by)
         self._val_columns = [idx for idx in self._df.columns

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -313,3 +313,14 @@ def test_series_groupby_agg(agg):
     sg = s.groupby(s // 2).agg(agg)
     gg = g.groupby(g // 2).agg(agg)
     assert_eq(sg, gg)
+
+
+@pytest.mark.parametrize('agg', ['min', 'max', 'count', 'sum', 'mean'])
+def test_groupby_level_zero(agg):
+    pdf = pd.DataFrame({'x': [1, 2, 3]}, index=[0, 1, 1])
+    gdf = DataFrame.from_pandas(pdf)
+    pdg = pdf.groupby(level=0)
+    gdg = gdf.groupby(level=0)
+    pdresult = getattr(pdg, agg)()
+    gdresult = getattr(gdg, agg)()
+    assert_eq(pdresult, gdresult)


### PR DESCRIPTION
- Add `level` argument, making it or `by` optional, but not both
- If level=0, convert the DF index into a column, groupby it, and
  convert it back to index.
- Add tests