### PR TITLE
[REVIEW] Testing code cleanup & some utility code include reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@
 - PR #1118 Enhanced the `DataFrame.from_records()` feature
 - PR #1129 Fix join performance with index parameter from using numpy array
 - PR #1145 Issue with .agg call on multi-column dataframes
+- PR #908 Some testing code cleanup
 
 
 # cuDF 0.5.1 (05 Feb 2019)

--- a/cpp/include/cudf/types.h
+++ b/cpp/include/cudf/types.h
@@ -99,10 +99,10 @@ typedef struct {
  */
 // TODO: #1119 Use traits to set `gdf_data` elements
 typedef union {
-  int8_t        si08;  /**< GDF_INT8      */
-  int16_t       si16;  /**< GDF_INT16     */
-  int32_t       si32;  /**< GDF_INT32     */
-  int64_t       si64;  /**< GDF_INT64     */
+  char          si08;  /**< GDF_INT8      */
+  short         si16;  /**< GDF_INT16     */
+  int           si32;  /**< GDF_INT32     */
+  long          si64;  /**< GDF_INT64     */
   float         fp32;  /**< GDF_FLOAT32   */
   double        fp64;  /**< GDF_FLOAT64   */
   gdf_date32    dt32;  /**< GDF_DATE32    */

--- a/cpp/src/utilities/bit_util.cuh
+++ b/cpp/src/utilities/bit_util.cuh
@@ -17,6 +17,23 @@
  */
 #pragma once
 
+#include <cudf/types.h>
+
+#include <stdint.h>
+#include <string>
+
+#ifndef CUDA_HOST_DEVICE_CALLABLE
+#ifdef __CUDACC__
+#define CUDA_HOST_DEVICE_CALLABLE __host__ __device__ inline
+#define CUDA_DEVICE_CALLABLE __device__ inline
+#define CUDA_LAUNCHABLE __global__
+#else
+#define CUDA_HOST_DEVICE_CALLABLE inline
+#define CUDA_DEVICE_CALLABLE inline
+#define CUDA_LAUNCHABLE
+#endif
+#endif
+
 namespace gdf {
 namespace util {
 
@@ -25,7 +42,7 @@ using ValidType = uint32_t;
 
 
 // Instead of this function, use gdf_valid_allocation_size from legacy_bitmask.hpp
-//__host__ __device__ __forceinline__
+//CUDA_HOST_DEVICE_CALLABLE
 //  size_t
 //  valid_size(size_t column_length)
 //{
@@ -34,12 +51,12 @@ using ValidType = uint32_t;
 //}
 
 // Instead of this function, use gdf_is_valid from gdf/utils.h
-///__host__ __device__ __forceinline__ bool get_bit(const gdf_valid_type* const bits, size_t i)
+///CUDA_HOST_DEVICE_CALLABLE bool get_bit(const gdf_valid_type* const bits, size_t i)
 ///{
 ///  return  bits == nullptr? true :  bits[i >> size_t(3)] & (1 << (i & size_t(7)));
 ///}
 
-__host__ __device__ __forceinline__
+CUDA_HOST_DEVICE_CALLABLE
   uint8_t
   byte_bitmask(size_t i)
 {
@@ -47,7 +64,7 @@ __host__ __device__ __forceinline__
   return kBitmask[i];
 }
 
-__host__ __device__ __forceinline__
+CUDA_HOST_DEVICE_CALLABLE
   uint8_t
   flipped_bitmask(size_t i)
 {
@@ -55,17 +72,17 @@ __host__ __device__ __forceinline__
   return kFlippedBitmask[i];
 }
 
-__host__ __device__ __forceinline__ void turn_bit_on(uint8_t* const bits, size_t i)
+CUDA_HOST_DEVICE_CALLABLE void turn_bit_on(uint8_t* const bits, size_t i)
 {
   bits[i / 8] |= byte_bitmask(i % 8);
 }
 
-__host__ __device__ __forceinline__ void turn_bit_off(uint8_t* const bits, size_t i)
+CUDA_HOST_DEVICE_CALLABLE void turn_bit_off(uint8_t* const bits, size_t i)
 {
   bits[i / 8] &= flipped_bitmask(i % 8);
 }
 
-__host__ __device__ __forceinline__ size_t last_byte_index(size_t column_size)
+CUDA_HOST_DEVICE_CALLABLE size_t last_byte_index(size_t column_size)
 {
   return (column_size + 8 - 1) / 8;
 }

--- a/cpp/src/utilities/cudf_utils.h
+++ b/cpp/src/utilities/cudf_utils.h
@@ -1,10 +1,12 @@
 #ifndef GDF_UTILS_H
 #define GDF_UTILS_H
 
+#include <utilities/error_utils.hpp>
+#include <cudf.h>
+
 #include <cuda_runtime_api.h>
+
 #include <vector>
-#include "cudf.h"
-#include "error_utils.hpp"
 
 #ifdef __CUDACC__
 #define CUDA_HOST_DEVICE_CALLABLE __host__ __device__ inline

--- a/cpp/src/utilities/type_dispatcher.hpp
+++ b/cpp/src/utilities/type_dispatcher.hpp
@@ -16,10 +16,13 @@
 #ifndef TYPE_DISPATCHER_HPP
 #define TYPE_DISPATCHER_HPP
 
-#include "NVStrings.h"
-#include "cudf/types.h"
 #include "wrapper_types.hpp"
 #include "release_assert.cuh"
+
+#include <cudf/types.h>
+
+#include <NVStrings.h>
+
 #include <cassert>
 #include <utility>
 

--- a/cpp/src/utilities/wrapper_types.hpp
+++ b/cpp/src/utilities/wrapper_types.hpp
@@ -1,9 +1,10 @@
 #ifndef GDF_CPPTYPES_H
 #define GDF_CPPTYPES_H
 
-#include "cudf/types.h"
+#include <cudf/types.h>
 #include "cudf_utils.h"
-#include <iostream>
+
+#include <iosfwd>
 #include <type_traits>
 
 /* --------------------------------------------------------------------------*/

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ ConfigureTest(ERROR_TEST "${ERROR_TEST_SRC}")
 # - filter tests ----------------------------------------------------------------------------------
 
 set(FILTER_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/utilities/cudf_test_utils.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/filter/helper/utils.cuh"
     "${CMAKE_CURRENT_SOURCE_DIR}/filter/helper/utils.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/filter/test_example.cu"
@@ -83,6 +84,7 @@ ConfigureTest(GROUPBY_TEST "${GROUPBY_TEST_SRC}")
 # - join tests ------------------------------------------------------------------------------------
 
 set(JOIN_TEST_SRC 
+    "${CMAKE_CURRENT_SOURCE_DIR}/utilities/valid_vectors.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/join/join_tests.cu")
 
 ConfigureTest(JOIN_TEST "${JOIN_TEST_SRC}")
@@ -91,6 +93,7 @@ ConfigureTest(JOIN_TEST "${JOIN_TEST_SRC}")
 # - orderby tests ---------------------------------------------------------------------------------
 
 set(ORDERBY_TEST_SRC 
+    "${CMAKE_CURRENT_SOURCE_DIR}/utilities/valid_vectors.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/orderby/orderby_tests.cu")
 
 ConfigureTest(ORDERBY_TEST "${ORDERBY_TEST_SRC}")

--- a/cpp/tests/bitmask/bit_mask_test.cu
+++ b/cpp/tests/bitmask/bit_mask_test.cu
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
+#include <tests/utilities/cudf_test_utils.cuh>
+#include <tests/utilities/cudf_test_fixtures.h>
+#include <bitmask/bit_mask.cuh>
 
-#include "cuda_profiler_api.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
-#include "tests/utilities/cudf_test_utils.cuh"
-#include "tests/utilities/cudf_test_fixtures.h"
-#include "bitmask/bit_mask.cuh"
+#include <cuda_profiler_api.h>
+
+#include <gtest/gtest.h>
 
 #include <chrono>
+
 
 struct BitMaskTest : public GdfTest {};
 

--- a/cpp/tests/bitmask/valid_ops_test.cu
+++ b/cpp/tests/bitmask/valid_ops_test.cu
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
+#include <tests/utilities/cudf_test_utils.cuh>
+#include <tests/utilities/cudf_test_fixtures.h>
 
 #include <cudf.h>
-#include <cudf/functions.h>
 
-#include "cuda_profiler_api.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
-#include "tests/utilities/cudf_test_utils.cuh"
-#include "tests/utilities/cudf_test_fixtures.h"
+#include <cuda_profiler_api.h>
 
 #include <chrono>
 

--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -1,4 +1,13 @@
-#include "gtest/gtest.h"
+#include <tests/utilities/cudf_test_utils.cuh>
+
+#include <utilities/cudf_utils.h>
+#include <cudf.h>
+
+#include <thrust/device_vector.h>
+
+#include <gtest/gtest.h>
+
+#include <gtest/gtest.h>
 
 #include <cstdlib>
 #include <iostream>
@@ -6,15 +15,6 @@
 #include <chrono>
 #include <map>
 
-#include <thrust/device_vector.h>
-
-#include "gtest/gtest.h"
-
-#include <cudf.h>
-#include <utilities/cudf_utils.h>
-#include <cudf/functions.h>
-
-#include "tests/utilities/cudf_test_utils.cuh"
 
 // uncomment to enable benchmarking gdf_column_concat
 //#define ENABLE_CONCAT_BENCHMARK 

--- a/cpp/tests/datetime/datetime_ops_test.cu
+++ b/cpp/tests/datetime/datetime_ops_test.cu
@@ -16,16 +16,19 @@
  * limitations under the License.
  */
 
-#include <cstdlib>
-#include <iostream>
-#include <vector>
-#include <thrust/device_vector.h>
+#include <tests/utilities/cudf_test_fixtures.h>
 
 #include <cudf.h>
 #include <cudf/functions.h>
+
 #include <rmm/thrust_rmm_allocator.h>
 
-#include "tests/utilities/cudf_test_fixtures.h"
+#include <thrust/device_vector.h>
+
+#include <iostream>
+#include <vector>
+
+#include <cstdlib>
 
 
 struct gdf_extract_from_datetime_example_test : public GdfTest {};

--- a/cpp/tests/error/error_handling_test.cu
+++ b/cpp/tests/error/error_handling_test.cu
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cudf.h"
-#include "gtest/gtest.h"
-#include "utilities/error_utils.hpp"
+#include <utilities/error_utils.hpp>
+#include <cudf.h>
 
-#include <cuda_runtime_api.h>
 #include <rmm/rmm.h>
+
+#include <gtest/gtest.h>
+
 #include <cstring>
 
 // If this test fails, it means an error code was added without

--- a/cpp/tests/filter/helper/utils.cu
+++ b/cpp/tests/filter/helper/utils.cu
@@ -1,11 +1,7 @@
 
-#include <iostream>
-#include <cudf.h>
-#include <cudf/functions.h>
-#include <cuda_runtime.h>
-#include <limits.h>
-#include <gtest/gtest.h>
 #include "utils.cuh"
+
+#include <climits>
 
 
 gdf_valid_type * get_gdf_valid_from_device(gdf_column* column) {

--- a/cpp/tests/filter/helper/utils.cuh
+++ b/cpp/tests/filter/helper/utils.cuh
@@ -2,19 +2,22 @@
 #ifndef GDF_TEST_UTILS
 #define GDF_TEST_UTILS
 
-#include <iostream>
 #include <cudf.h>
-#include <cudf/functions.h>
+
 #include <thrust/functional.h>
 #include <thrust/device_ptr.h>
 #include <thrust/iterator/counting_iterator.h>
-#include "utilities/type_dispatcher.hpp"
+#include <utilities/type_dispatcher.hpp>
 
+#include <rmm/rmm.h>
+
+#include <gtest/gtest.h>
+
+#include <iostream>
 #include <string>
 #include <functional>
 #include <vector>
 #include <tuple>
-#include <rmm/rmm.h>
 
 inline auto get_number_of_bytes_for_valid (size_t column_size) -> size_t {
     return sizeof(gdf_valid_type) * (column_size + GDF_VALID_BITSIZE - 1) / GDF_VALID_BITSIZE;

--- a/cpp/tests/filter/test_example.cu
+++ b/cpp/tests/filter/test_example.cu
@@ -15,20 +15,22 @@
  * limitations under the License.
  */
 
-#include "gtest/gtest.h"
-
-#include <iostream>
-#include <thrust/functional.h>
-#include <thrust/device_ptr.h>
-
-#include <thrust/execution_policy.h>
-#include <cuda_runtime.h>
 #include "helper/utils.cuh"
 
-#include <cudf.h>
-#include <cudf/functions.h>
+#include <tests/utilities/cudf_test_fixtures.h>
 
-#include "tests/utilities/cudf_test_fixtures.h"
+#include <cudf.h>
+
+#include <thrust/functional.h>
+#include <thrust/device_ptr.h>
+#include <thrust/execution_policy.h>
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+
+#include <iostream>
+
 struct Example : public GdfTest {};
 
 /*

--- a/cpp/tests/filter/test_filter_ops.cu
+++ b/cpp/tests/filter/test_filter_ops.cu
@@ -16,17 +16,22 @@
  * limitations under the License.
  */
 
-#include "gtest/gtest.h"
-#include <iostream>
+#include "helper/utils.cuh"
+
+#include <tests/utilities/cudf_test_fixtures.h>
+
 #include <cudf.h>
-#include <cudf/functions.h>
+
 #include <thrust/functional.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
+
+#include <gtest/gtest.h>
+
 #include <cuda_runtime.h>
+
+#include <iostream>
 #include <tuple>
-#include "helper/utils.cuh"
-#include "tests/utilities/cudf_test_fixtures.h"
 
 /*
  ============================================================================

--- a/cpp/tests/groupby/groupby_test.cu
+++ b/cpp/tests/groupby/groupby_test.cu
@@ -13,29 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cstdlib>
-#include <iostream>
-#include <vector>
-#include <map>
-#include <utility>
-#include <type_traits>
-#include <typeinfo>
-#include <memory>
-
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-
-#include <cudf.h>
-#include <cudf/functions.h>
-
-#include "utilities/cudf_utils.h"
-
-#include <tests/utilities/cudf_test_fixtures.h>
 
 // See this header for all of the recursive handling of tuples of vectors
 #include "test_parameters.cuh"
 #include "groupby_test_helpers.cuh"
-#include <bitmask/legacy_bitmask.hpp>
+
+#include <tests/utilities/cudf_test_fixtures.h>
+
+#include <utilities/cudf_utils.h>
+
+#include <cudf.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <iostream>
+#include <vector>
+#include <utility>
+#include <type_traits>
+#include <typeinfo>
+#include <memory>
+#include <cstdlib>
+
 
 // A new instance of this class will be created for each *TEST(GroupTest, ...)
 // Put all repeated setup and validation stuff here

--- a/cpp/tests/groupby/test_parameters.cuh
+++ b/cpp/tests/groupby/test_parameters.cuh
@@ -1,11 +1,16 @@
 #pragma once
+
+#include <tests/utilities/cudf_test_fixtures.h>
+
+#include <cudf/types.h>
+
 #include <tuple>
 #include <algorithm>
 #include <random>
 #include <type_traits>
 #include <vector>
+#include <map>
 
-#include <cudf/types.h>
 
 // Selects the kind of join operation that is performed
 enum struct agg_op

--- a/cpp/tests/hash_map/map_test.cu
+++ b/cpp/tests/hash_map/map_test.cu
@@ -14,23 +14,26 @@
  * limitations under the License.
  */
 
-#include <cstdlib>
+#include <tests/utilities/cudf_test_fixtures.h>
+
+#include <hash/concurrent_unordered_map.cuh>
+#include <groupby/aggregation_operations.hpp>
+
+#include <cudf.h>
+
+#include <thrust/device_vector.h>
+
+#include <rmm/thrust_rmm_allocator.h>
+
+#include <gtest/gtest.h>
+
+
 #include <iostream>
 #include <vector>
 #include <unordered_map>
 #include <random>
 
-#include <thrust/device_vector.h>
-
-#include "gtest/gtest.h"
-
-#include <cudf.h>
-#include <cudf/functions.h>
-#include <rmm/thrust_rmm_allocator.h>
-#include <hash/concurrent_unordered_map.cuh>
-#include <groupby/aggregation_operations.hpp>
-
-#include "tests/utilities/cudf_test_fixtures.h"
+#include <cstdlib>
 
 
 // This is necessary to do a parametrized typed-test over multiple template arguments

--- a/cpp/tests/hash_map/multimap_test.cu
+++ b/cpp/tests/hash_map/multimap_test.cu
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-#include <cstdlib>
+#include <tests/utilities/cudf_test_fixtures.h>
+
+#include <thrust/device_vector.h>
+
+#include <cudf.h>
+#include <hash/concurrent_unordered_multimap.cuh>
+
+#include <gtest/gtest.h>
+
 #include <iostream>
 #include <vector>
 #include <limits>
 
-#include <thrust/device_vector.h>
-
-#include "gtest/gtest.h"
-
-#include <cudf.h>
-#include <cudf/functions.h>
-#include <hash/concurrent_unordered_multimap.cuh>
-
-#include "tests/utilities/cudf_test_fixtures.h"
+#include <cstdlib>
 
 // This is necessary to do a parametrized typed-test over multiple template arguments
 template <typename Key, typename Value>

--- a/cpp/tests/hashing/hash_partition_test.cu
+++ b/cpp/tests/hashing/hash_partition_test.cu
@@ -13,31 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cstdlib>
+
+#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/cudf_test_utils.cuh>
+
+#include <utilities/int_fastdiv.h>
+#include <dataframe/cudf_table.cuh>
+#include <hash/hash_functions.cuh>
+
+#include <cudf.h>
+
+#include <thrust/device_vector.h>
+#include <thrust/sort.h>
+#include <thrust/gather.h>
+
+#include <rmm/thrust_rmm_allocator.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
 #include <iostream>
 #include <vector>
 #include <map>
 #include <type_traits>
 #include <memory>
 
-#include <thrust/device_vector.h>
-#include <thrust/sort.h>
-#include <thrust/gather.h>
-
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-
-#include <cudf.h>
-#include <cudf/functions.h>
-#include <dataframe/cudf_table.cuh>
-#include <hash/hash_functions.cuh>
-#include <utilities/int_fastdiv.h>
-#include <rmm/thrust_rmm_allocator.h>
-
-#include "tests/utilities/cudf_test_utils.cuh"
-#include "tests/utilities/cudf_test_fixtures.h"
-
-
+#include <cstdlib>
 
 template <template <typename> class hash_function,
          typename size_type>

--- a/cpp/tests/hashing/hash_test.cu
+++ b/cpp/tests/hashing/hash_test.cu
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
- #include <cstdlib>
- #include <iostream>
- #include <vector>
- 
- #include <thrust/device_vector.h>
- 
- #include "gtest/gtest.h"
- #include "tests/utilities/cudf_test_fixtures.h"
+#include <tests/utilities/cudf_test_fixtures.h>
 
 #include <cudf.h>
-#include <cudf/functions.h>
+#include <thrust/device_vector.h>
+
+
 #include <rmm/thrust_rmm_allocator.h>
 
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <vector>
+
+#include <cstdlib>
 
 struct gdf_hashing_test : public GdfTest {};
 

--- a/cpp/tests/io/csv/csv_test.cu
+++ b/cpp/tests/io/csv/csv_test.cu
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-#include <cstdlib>
+#include <cudf.h>
+
+#include <NVStrings.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <sys/stat.h>
+
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <sys/stat.h>
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
+#include <cstdlib>
 
-#include <cudf.h>
-#include <NVStrings.h>
 
 MATCHER_P(FloatNearPointwise, tolerance, "Out of range")
 {

--- a/cpp/tests/join/join_tests.cu
+++ b/cpp/tests/join/join_tests.cu
@@ -14,30 +14,31 @@
  * limitations under the License.
  */
 
-#include <cstdlib>
+// See this header for all of the recursive handling of tuples of vectors
+#include <tests/utilities/tuple_vectors.h>
+
+// See this header for all of the handling of valids' vectors
+#include <tests/utilities/valid_vectors.h>
+#include <tests/utilities/cudf_test_fixtures.h>
+
+#include <join/joining.h>
+#include <join/join_compute_api.h>
+#include <utilities/bit_util.cuh>
+
+#include <cudf.h>
+
+#include <rmm/rmm.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
 #include <iostream>
 #include <vector>
 #include <map>
 #include <type_traits>
 #include <memory>
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-
-#include <cudf.h>
-#include <rmm/rmm.h>
-#include <cudf/functions.h>
-#include <join/joining.h>
-#include <join/join_compute_api.h>
-#include <utilities/bit_util.cuh>
-
-#include "tests/utilities/cudf_test_fixtures.h"
-
-// See this header for all of the recursive handling of tuples of vectors
-#include "tests/utilities/tuple_vectors.h"
-
-// See this header for all of the handling of valids' vectors 
-#include "tests/utilities/valid_vectors.h"
+#include <cstdlib>
 
 // Selects the kind of join operation that is performed
 enum struct join_op

--- a/cpp/tests/orderby/order_by_type_vectors.h
+++ b/cpp/tests/orderby/order_by_type_vectors.h
@@ -17,10 +17,15 @@
 #ifndef ORDER_BY_TYPE_VECTORS_H
 #define ORDER_BY_TYPE_VECTORS_H
 
+#include <tests/utilities/tuple_vectors.h>
+#include <tests/utilities/valid_vectors.h>
+
+#include <utilities/cudf_utils.h>
+
 #include <memory>
 #include <vector>
 #include <string>
-#include <utilities/cudf_utils.h>
+#include <numeric>
 
 // Initialize valids
 void initialize_order_by_types(std::vector<int8_t>& order_by_types, size_t length, bool random_values = true)

--- a/cpp/tests/orderby/orderby_tests.cu
+++ b/cpp/tests/orderby/orderby_tests.cu
@@ -13,31 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "order_by_type_vectors.h"
+
+#include <tests/utilities/cudf_test_fixtures.h>
+
+// See this header for all of the handling of valids' vectors
+#include <tests/utilities/valid_vectors.h>
+
+// See this header for all of the recursive handling of tuples of vectors
+#include <tests/utilities/tuple_vectors.h>
+
+#include <utilities/bit_util.cuh>
+#include <bitmask/legacy_bitmask.hpp>
+#include <cudf.h>
+
+#include <rmm/rmm.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
 #include <cstdlib>
 #include <iostream>
 #include <vector>
 #include <type_traits>
 #include <memory>
 #include <numeric>
-
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-
-#include <cudf.h>
-#include <rmm/rmm.h>
-#include <cudf/functions.h>
-#include <utilities/bit_util.cuh>
-#include <bitmask/legacy_bitmask.hpp>
-
-#include "tests/utilities/cudf_test_fixtures.h"
-
-// See this header for all of the recursive handling of tuples of vectors
-#include "tests/utilities/tuple_vectors.h"
-
-// See this header for all of the handling of valids' vectors 
-#include "tests/utilities/valid_vectors.h"
-
-#include "order_by_type_vectors.h"
 
 // A new instance of this class will be created for each *TEST(OrderbyTest, ...)
 // Put all repeated setup and validation stuff here

--- a/cpp/tests/quantiles/quantiles_test.cu
+++ b/cpp/tests/quantiles/quantiles_test.cu
@@ -17,8 +17,19 @@
 //Quantile (percentile) testing
 
 
+#include <tests/utilities/cudf_test_fixtures.h>
+
+#include <utilities/cudf_utils.h>
+#include <utilities/error_utils.hpp>
+#include <quantiles/quantiles.h>
+#include <cudf.h>
+
+#include <rmm/thrust_rmm_allocator.h>
+
 #include <thrust/device_vector.h>
 #include <thrust/copy.h>
+
+#include <gtest/gtest.h>
 
 #include <iostream>
 #include <vector>
@@ -27,17 +38,6 @@
 #include <cassert>
 #include <cmath>
 
-#include "gtest/gtest.h"
-
-#include <cudf.h>
-#include <cudf/functions.h>
-#include <utilities/cudf_utils.h>
-#include <rmm/thrust_rmm_allocator.h>
-#include <utilities/error_utils.hpp>
-#include <quantiles/quantiles.h>
-#include <bitmask/legacy_bitmask.hpp>
-
-#include "tests/utilities/cudf_test_fixtures.h"
 
 
 

--- a/cpp/tests/replace/replace-nulls_tests.cu
+++ b/cpp/tests/replace/replace-nulls_tests.cu
@@ -15,19 +15,18 @@
  * limitations under the License.
  */
 
-#include <cstdlib>
-#include <iostream>
-#include <vector>
-
-#include "gtest/gtest.h"
+#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/cudf_test_utils.cuh>
 
 #include <cudf.h>
-#include <cudf/functions.h>
 
 #include <thrust/device_vector.h>
 
-#include "tests/utilities/cudf_test_fixtures.h"
-#include "tests/utilities/cudf_test_utils.cuh"
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
 
 // This is the main test feature
 template <class T>

--- a/cpp/tests/replace/replace_tests.cu
+++ b/cpp/tests/replace/replace_tests.cu
@@ -15,19 +15,18 @@
  * limitations under the License.
  */
 
-#include <cstdlib>
-#include <iostream>
-#include <vector>
-
-#include "gtest/gtest.h"
+#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/cudf_test_utils.cuh>
 
 #include <cudf.h>
-#include <cudf/functions.h>
 
 #include <thrust/device_vector.h>
 
-#include "tests/utilities/cudf_test_fixtures.h"
-#include "tests/utilities/cudf_test_utils.cuh"
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
 
 // This is the main test feature
 template <class T>

--- a/cpp/tests/sort/digitize_test.cu
+++ b/cpp/tests/sort/digitize_test.cu
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-#include <thrust/device_vector.h>
 
-#include "gtest/gtest.h"
-
+#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/cudf_test_utils.cuh>
 #include <cudf.h>
-#include <cudf/functions.h>
 
-#include "tests/utilities/cudf_test_fixtures.h"
-#include "tests/utilities/cudf_test_utils.cuh"
 
 #include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
+#include <thrust/device_vector.h>
 
+#include <gtest/gtest.h>
 
 template <class ColumnType>
 struct DigitizeTest : public GdfTest {

--- a/cpp/tests/sqls/sqls_test.cu
+++ b/cpp/tests/sqls/sqls_test.cu
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+#include <tests/utilities/cudf_test_fixtures.h>
+
+#include <sqls/sqls_rtti_comp.h>
+#include <utilities/cudf_utils.h>
+#include <utilities/error_utils.h>
+#include <cudf.h>
+
+#include <rmm/thrust_rmm_allocator.h>
 
 #include <thrust/device_vector.h>
 #include <thrust/tuple.h>
@@ -28,6 +36,8 @@
 #include <thrust/reduce.h>
 #include <thrust/functional.h>
 
+#include <gtest/gtest.h>
+
 #include <iostream>
 #include <vector>
 #include <tuple>
@@ -35,22 +45,9 @@
 #include <type_traits>
 #include <numeric>
 #include <unordered_map>
-//
 
 #include <cassert>
 #include <cmath>
-
-//
-
-#include <cudf.h>
-#include <utilities/cudf_utils.h>
-#include <utilities/error_utils.hpp>
-#include <cudf/functions.h>
-#include <rmm/thrust_rmm_allocator.h>
-#include <sqls/sqls_rtti_comp.h>
-
-#include "gtest/gtest.h"
-#include "tests/utilities/cudf_test_fixtures.h"
 
 
 ///using IndexT = int;//okay...

--- a/cpp/tests/table/table_tests.cu
+++ b/cpp/tests/table/table_tests.cu
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "tests/utilities/column_wrapper.cuh"
-#include "tests/utilities/cudf_test_fixtures.h"
-#include "types.hpp"
+#include <tests/utilities/column_wrapper.cuh>
+#include <tests/utilities/cudf_test_fixtures.h>
+#include <types.hpp>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <random>
 

--- a/cpp/tests/transpose/transpose_test.cu
+++ b/cpp/tests/transpose/transpose_test.cu
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-// #include "test_utils.h"
-#include "gtest/gtest.h"
 #include <tests/utilities/cudf_test_fixtures.h>
-#include "tests/utilities/cudf_test_utils.cuh"
+#include <tests/utilities/cudf_test_utils.cuh>
 
 #include <cudf.h>
-#include <cudf/functions.h>
 #include <utilities/error_utils.hpp>
 #include <utilities/cudf_utils.h>
+
+#include <gtest/gtest.h>
 
 #include <vector>
 #include <random>

--- a/cpp/tests/types/dispatcher_test.cu
+++ b/cpp/tests/types/dispatcher_test.cu
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-
-#include <cudf.h>
+#include <tests/utilities/cudf_test_fixtures.h>
 
 #include <utilities/type_dispatcher.hpp>
-#include "gtest/gtest.h"
-#include "tests/utilities/cudf_test_fixtures.h"
+#include <cudf.h>
 
 #include <thrust/device_vector.h>
-#include <cstdint>
 
+#include <gtest/gtest.h>
+
+#include <cstdint>
 
 /**
  * @file dispatcher_test.cu

--- a/cpp/tests/types/types_test.cpp
+++ b/cpp/tests/types/types_test.cpp
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <random>
-#include "gtest/gtest.h"
 
 #include <utilities/wrapper_types.hpp>
-
 #include <cudf.h>
 
+#include <gtest/gtest.h>
+
+#include <random>
 
 
 /**

--- a/cpp/tests/unary/unary_ops_test.cu
+++ b/cpp/tests/unary/unary_ops_test.cu
@@ -15,28 +15,26 @@
  * limitations under the License.
  */
 
-#include <cstdlib>
-#include <iostream>
-#include <vector>
-#include <numeric>
-#include <limits>
-#include <random>
-#include <algorithm>
+#include <tests/utilities/cudf_test_fixtures.h>
+#include <utilities/cudf_utils.h>
+#include <cudf.h>
 
 #include <thrust/device_vector.h>
 #include <thrust/random.h>
 #include <thrust/transform.h>
 #include <thrust/iterator/counting_iterator.h>
 
-#include "gtest/gtest.h"
-#include "tests/utilities/cudf_test_fixtures.h"
-#include <bitmask/legacy_bitmask.hpp>
-
-#include <cudf.h>
-#include <cudf/functions.h>
-#include <utilities/cudf_utils.h>
 #include <rmm/thrust_rmm_allocator.h>
 
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <vector>
+#include <numeric>
+#include <limits>
+#include <random>
+#include <algorithm>
+#include <cstdlib>
 
 struct gdf_cast_test : public GdfTest {};
 

--- a/cpp/tests/utilities/column_wrapper.cuh
+++ b/cpp/tests/utilities/column_wrapper.cuh
@@ -17,15 +17,17 @@
 #ifndef COLUMN_WRAPPER_H
 #define COLUMN_WRAPPER_H
 
-#include "cudf.h"
-#include "cudf_test_utils.cuh"
-#include "rmm/rmm.h"
-#include "rmm/thrust_rmm_allocator.h"
-#include "utilities/bit_util.cuh"
-#include "utilities/type_dispatcher.hpp"
+#include <utilities/bit_util.cuh>
+#include <utilities/type_dispatcher.hpp>
+#include <tests/utilities/cudf_test_utils.cuh>
+#include <cudf.h>
+
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
 
 #include <thrust/equal.h>
 #include <thrust/logical.h>
+
 #include <string>
 
 #ifndef CUDA_RT_CALL

--- a/cpp/tests/utilities/cudf_test_fixtures.h
+++ b/cpp/tests/utilities/cudf_test_fixtures.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <rmm/rmm.h>
 

--- a/cpp/tests/utilities/cudf_test_utils.cu
+++ b/cpp/tests/utilities/cudf_test_utils.cu
@@ -1,6 +1,9 @@
 /*
  * Copyright (c) 2018, NVIDIA CORPORATION.
  *
+ * Copyright 2019 BlazingDB, Inc.
+ *     Copyright 2019 Eyal Rozenberg <eyalroz@blazingdb.com>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,47 +21,62 @@
 
 namespace {
 
+namespace detail {
+
+// When streaming char-like types, the standard library streams tend to treat
+// them as characters rather than numbers, e.g. you would get an 'a' instead of 97.
+// The following function(s) ensure we "promote" such values to integers before
+// they're streamed
+
+template <typename T>
+const T& promote_for_streaming(const T& x) { return x; }
+
+
+//int promote_for_streaming(const char& x)          { return x; }
+//int promote_for_streaming(const unsigned char& x) { return x; }
+int promote_for_streaming(const signed char& x)   { return x; }
+
+} // namespace detail
+
+
 struct column_printer {
-  template <typename ColumnType>
-  void operator()(gdf_column const* the_column) {
+    template<typename Element>
+    void operator()(gdf_column const* the_column, unsigned min_printing_width)
+    {
+        gdf_size_type num_rows { the_column->size };
 
-    gdf_size_type const num_rows{the_column->size};
+        Element const* column_data { static_cast<Element const*>(the_column->data) };
 
-    ColumnType const* col_data{
-        static_cast<ColumnType const*>(the_column->data)};
+        std::vector<Element> host_side_data(num_rows);
+        cudaMemcpy(host_side_data.data(), column_data, num_rows * sizeof(Element), cudaMemcpyDeviceToHost);
 
-    std::vector<ColumnType> h_data(num_rows);
-    cudaMemcpy(h_data.data(), col_data, num_rows * sizeof(ColumnType),
-               cudaMemcpyDeviceToHost);
+        gdf_size_type const num_masks { gdf_valid_allocation_size(num_rows) };
+        std::vector<gdf_valid_type> h_mask(num_masks, ~gdf_valid_type { 0 });
+        if (nullptr != the_column->valid) {
+            cudaMemcpy(h_mask.data(), the_column->valid, num_masks * sizeof(gdf_valid_type), cudaMemcpyDeviceToHost);
+        }
 
-    std::vector<gdf_valid_type> h_mask(gdf_valid_allocation_size(num_rows), ~gdf_valid_type{0});
-    if (nullptr != the_column->valid) {
-      cudaMemcpy(h_mask.data(), the_column->valid,
-                 gdf_num_bitmask_elements(num_rows) * sizeof(gdf_valid_type), cudaMemcpyDeviceToHost);
+        for (gdf_size_type i = 0; i < num_rows; ++i) {
+            std::cout << std::setw(min_printing_width);
+            if (gdf_is_valid(h_mask.data(), i)) {
+                std::cout << detail::promote_for_streaming(host_side_data[i]);
+            }
+            else {
+                std::cout << null_representative;
+            }
+            std::cout << ' ';
+        }
+        std::cout << std::endl;
     }
-
-    for (gdf_size_type i = 0; i < num_rows; ++i) {
-      // If the element is valid, print it's value
-      if (true == gdf_is_valid(h_mask.data(), i)) {
-        std::cout << h_data[i] << " ";
-      }
-      // Otherwise, print an @ to represent a null value
-      else {
-        std::cout << "@"
-                  << " ";
-      }
-    }
-    std::cout << std::endl;
-  }
 };
-}
+} // namespace
 
-void print_gdf_column(gdf_column const * the_column)
+void print_gdf_column(gdf_column const * the_column, unsigned min_printing_width)
 {
-    cudf::type_dispatcher(the_column->dtype, column_printer{}, the_column);
+    cudf::type_dispatcher(the_column->dtype, column_printer{}, the_column, min_printing_width);
 }
 
-void print_valid_data(const gdf_valid_type *validity_mask, 
+void print_valid_data(const gdf_valid_type *validity_mask,
                       const size_t num_rows)
 {
   cudaError_t error;
@@ -81,3 +99,39 @@ void print_valid_data(const gdf_valid_type *validity_mask,
   std::cout << std::endl;
 }
 
+gdf_size_type count_valid_bits_host(
+    std::vector<gdf_valid_type> const& masks, gdf_size_type const num_rows)
+{
+  if ((0 == num_rows) || (0 == masks.size())) {
+    return 0;
+  }
+
+  gdf_size_type count{0};
+
+  // Count the valid bits for all masks except the last one
+  for (gdf_size_type i = 0; i < (gdf_num_bitmask_elements(num_rows) - 1); ++i) {
+    gdf_valid_type current_mask = masks[i];
+
+    while (current_mask > 0) {
+      current_mask &= (current_mask - 1);
+      count++;
+    }
+  }
+
+  // Only count the bits in the last mask that correspond to rows
+  int num_rows_last_mask = num_rows % GDF_VALID_BITSIZE;
+  if (num_rows_last_mask == 0) {
+    num_rows_last_mask = GDF_VALID_BITSIZE;
+  }
+
+  // Mask off only the bits that correspond to rows
+  gdf_valid_type const rows_mask = ( gdf_valid_type{1} << num_rows_last_mask ) - 1;
+  gdf_valid_type last_mask = masks[gdf_num_bitmask_elements(num_rows) - 1] & rows_mask;
+
+  while (last_mask > 0) {
+    last_mask &= (last_mask - 1);
+    count++;
+  }
+
+  return count;
+}

--- a/cpp/tests/utilities/tuple_vectors.h
+++ b/cpp/tests/utilities/tuple_vectors.h
@@ -16,10 +16,15 @@
 #ifndef TUPLE_VECTORS_H
 #define TUPLE_VECTORS_H
 
+// See this header for all of the handling of valids' vectors
+// #include <tests/utilities/valid_vectors.h>
+
 #include <vector>
 #include <type_traits>
 #include <iostream>
 #include <cstdlib>
+#include <algorithm>
+#include <ostream>
 #include <iterator>
 
 template <typename... T>

--- a/cpp/tests/utilities/valid_vectors.cpp
+++ b/cpp/tests/utilities/valid_vectors.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 BlazingDB, Inc.
+ *     Copyright 2019 Eyal Rozenberg <eyalroz@blazingdb.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "valid_vectors.h"
+
+host_valid_pointer create_and_init_valid(size_t length, size_t null_count)
+{
+  auto deleter = [](gdf_valid_type* valid) { delete[] valid; };
+  auto n_bytes = gdf_valid_allocation_size(length);
+  auto valid_bits = new gdf_valid_type[n_bytes];
+   for (size_t i = 0; i < length; ++i) {
+    if ((float)std::rand()/(RAND_MAX + 1u) >= (float)null_count/(length-i)) {
+      gdf::util::turn_bit_on(valid_bits, i);
+    } else {
+      gdf::util::turn_bit_off(valid_bits, i);
+      --null_count;
+    }
+  }
+  return host_valid_pointer{ valid_bits, deleter };
+}
+
+void initialize_valids(std::vector<host_valid_pointer>& valids, size_t size, size_t length, size_t null_count)
+{
+  valids.clear();
+  for (size_t i = 0; i < size; ++i) {
+    valids.push_back(create_and_init_valid(length, null_count));
+  }
+}

--- a/cpp/tests/utilities/valid_vectors.h
+++ b/cpp/tests/utilities/valid_vectors.h
@@ -20,43 +20,27 @@
 
 #include <functional>
 #include <memory>
+#include <numeric>
+#include <algorithm>
+#include <iterator>
 #include <string>
 
 #include <utilities/cudf_utils.h>
 #include <utilities/bit_util.cuh>
+#include <bitmask/legacy_bitmask.hpp>
 
 // host_valid_pointer is a wrapper for gdf_valid_type* with custom deleter
 using host_valid_pointer = typename std::unique_ptr<gdf_valid_type, std::function<void(gdf_valid_type*)>>;
 
 
 // Create a valid pointer and init it with null_count invalids
-host_valid_pointer create_and_init_valid(size_t length, size_t null_count)
-{
-  auto deleter = [](gdf_valid_type* valid) { delete[] valid; };
-  auto n_bytes = gdf_valid_allocation_size(length);
-  auto valid_bits = new gdf_valid_type[n_bytes];
-   for (size_t i = 0; i < length; ++i) {
-    if ((float)std::rand()/(RAND_MAX + 1u) >= (float)null_count/(length-i)) {
-      gdf::util::turn_bit_on(valid_bits, i);
-    } else {
-      gdf::util::turn_bit_off(valid_bits, i);
-      --null_count;
-    }
-  }
-  return host_valid_pointer{ valid_bits, deleter };
-}
+host_valid_pointer create_and_init_valid(size_t length, size_t null_count);
 
-void initialize_valids(std::vector<host_valid_pointer>& valids, size_t size, size_t length, size_t null_count)
-{
-  valids.clear();
-  for (size_t i = 0; i < size; ++i) {
-    valids.push_back(create_and_init_valid(length, null_count));
-  }
-}
+void initialize_valids(std::vector<host_valid_pointer>& valids, size_t size, size_t length, size_t null_count);
 
 // Prints a vector and valids
 template <typename T>
-void print_vector_and_valid(std::vector<T>& v, gdf_valid_type* valid)
+void print_vector_and_valid(std::vector<T>& v, const gdf_valid_type* valid)
 {
   auto functor = [&valid, &v](int index) -> std::string {
     if (gdf_is_valid(valid, index))

--- a/cpp/tests/utilities_tests/column_wrapper_tests.cu
+++ b/cpp/tests/utilities_tests/column_wrapper_tests.cu
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include "tests/utilities/column_wrapper.cuh"
-#include "tests/utilities/cudf_test_fixtures.h"
-#include "utilities/type_dispatcher.hpp"
-#include "utilities/wrapper_types.hpp"
+#include <tests/utilities/column_wrapper.cuh>
+#include <tests/utilities/cudf_test_fixtures.h>
+#include <utilities/type_dispatcher.hpp>
+#include <utilities/wrapper_types.hpp>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <bitset>
 #include <cstdint>


### PR DESCRIPTION
Some housekeeping/cleanup of the code under `cpp/tests` (which also splits off some of the changes in PR #902 ):

* Reversed include orders - see issue #681; this exposed some missing includes, so:
* Added missing includes, especially for standard library headers, to some test programs
* Moved some non-inlined, non-template test utility code from headers into actual source files (so that it doesn't get defined twice)
* Minor changes to the column printing code: Promoting int8_t's to int's for printing; supporting a minimum width parameter when printing out columns.

No changes to cudf functionality (nor to which tests are run).