### PR TITLE
[REVIEW] CSV Reader: fix an issue where the last data row is missing when using byte_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - PR #917 value_counts return int type on empty columns
 - PR #927 CSV Reader: Fix category GDF_CATEGORY hashes not being computed properly
 - PR #921 CSV Reader: Fix parsing errors with delim_whitespace, quotations in the header row, unnamed columns
+- PR #940 CSV Reader: fix an issue where the last data row is missing when using byte_range
 
 
 # cuDF 0.5.1 (05 Feb 2019)

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -426,9 +426,9 @@ gdf_error read_csv(csv_read_arg *args)
 
 		// Include the page padding in the mapped size
 		const size_t page_padding = args->byte_range_offset - map_offset;
-		const size_t padded_byte_range_size = args->byte_range_size + page_padding;
+		const size_t padded_byte_range_size = raw_csv->byte_range_size + page_padding;
 
-		if (args->byte_range_size != 0 && padded_byte_range_size < map_size) {
+		if (raw_csv->byte_range_size != 0 && padded_byte_range_size < map_size) {
 			// Need to make sure that w/ padding we don't overshoot the end of file
 			map_size = min(padded_byte_range_size + calculateMaxRowSize(args->num_cols), map_size);
 			// Ignore page padding for parsing purposes
@@ -445,6 +445,11 @@ gdf_error read_csv(csv_read_arg *args)
 		raw_csv->num_bytes = map_size = args->buffer_size;
 	}
 	else { checkError(GDF_C_ERROR, "invalid input type"); }
+
+	// Reset the byte range size if useless
+	if (raw_csv->byte_range_size >= raw_csv->num_bytes) {
+		raw_csv->byte_range_size = 0;
+	}
 
 	const char* h_uncomp_data;
 	size_t h_uncomp_size = 0;

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -860,6 +860,7 @@ def test_csv_reader_header_quotation():
     cu_df = read_csv(StringIO(buffer_pd_fail))
     assert(cu_df.shape == (1, 3))
 
+
 def test_csv_reader_oversized_byte_range():
     # first and last columns are unnamed
     buffer = 'a,b,c,d,e\n4,5,6,7,8\n'

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -842,7 +842,9 @@ def test_csv_reader_unnamed_cols():
 
     cu_df = read_csv(StringIO(buffer))
     pd_df = pd.read_csv(StringIO(buffer))
+
     assert(all(pd_df.columns == cu_df.columns))
+    assert(pd_df.shape == cu_df.shape)
 
 
 def test_csv_reader_header_quotation():
@@ -857,3 +859,13 @@ def test_csv_reader_header_quotation():
     buffer_pd_fail = '"1,one," , ",2,two" ,3\n4,5,6\n'
     cu_df = read_csv(StringIO(buffer_pd_fail))
     assert(cu_df.shape == (1, 3))
+
+def test_csv_reader_oversized_byte_range():
+    # first and last columns are unnamed
+    buffer = 'a,b,c,d,e\n4,5,6,7,8\n'
+
+    cu_df = read_csv(StringIO(buffer), byte_range=(0, 1024))
+    pd_df = pd.read_csv(StringIO(buffer))
+
+    assert(all(pd_df.columns == cu_df.columns))
+    assert(pd_df.shape == cu_df.shape)


### PR DESCRIPTION
Fixes #928 

* CSV reader now resets the byte_range_size to zero, if the size is larger than the input file. This prevents the byte_range from polluting the logic further down the line, and should not have unintended effects because that large byte range is functionally equivalent to zero.
* Added a test for the case where byte range is larger than the input file.
* Expanded one of the CSV tests to also check the dataframe shape.