### PR TITLE
[REVIEW] Added increment and decrement operators for the wrapper types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #554 Add `empty` method and `is_monotonic` attribute to `Index`
 - PR #909 CSV Reader: Avoid host->device->host copy for header row data
 - PR #916 Improved unit testing and error checking for `gdf_column_concat`
+- PR #942 Added increment/decrement operators for wrapper types
 
 ## Bug Fixes
 

--- a/cpp/src/utilities/wrapper_types.hpp
+++ b/cpp/src/utilities/wrapper_types.hpp
@@ -177,6 +177,42 @@ wrapper<T,type_id> operator/(wrapper<T,type_id> const& lhs, wrapper<T,type_id> c
   return wrapper<T, type_id>{lhs.value / rhs.value};
 }
 
+// prefix increment operator
+template <typename T, gdf_dtype type_id>
+CUDA_HOST_DEVICE_CALLABLE
+wrapper<T,type_id>& operator++(wrapper<T,type_id> & w)
+{
+  w.value++;
+  return w;
+}
+
+// postfix increment operator
+template <typename T, gdf_dtype type_id>
+CUDA_HOST_DEVICE_CALLABLE
+wrapper<T,type_id> operator++(wrapper<T,type_id> & w, int)
+{
+  return wrapper<T,type_id>{w.value++};
+}
+
+// prefix decrement operator
+template <typename T, gdf_dtype type_id>
+CUDA_HOST_DEVICE_CALLABLE
+wrapper<T,type_id>& operator--(wrapper<T,type_id> & w)
+{
+  w.value--;
+  return w;
+}
+
+// postfix decrement operator
+template <typename T, gdf_dtype type_id>
+CUDA_HOST_DEVICE_CALLABLE
+wrapper<T,type_id> operator--(wrapper<T,type_id> & w, int)
+{
+  return wrapper<T,type_id>{w.value--};
+}
+
+
+
 /* --------------------------------------------------------------------------*/
 /** 
      * @brief  Returns a reference to the underlying "value" member of a wrapper struct

--- a/cpp/tests/types/types_test.cpp
+++ b/cpp/tests/types/types_test.cpp
@@ -147,8 +147,8 @@ TYPED_TEST(WrappersTest, IncrementOperators){
     for(int i = 0; i < NUM_TRIALS; ++i){
         UnderlyingType t{this->rand()};
         TypeParam w{t};
-        EXPECT_EQ(t++, w++.value);
-        EXPECT_EQ(++t, ++w.value);
+        EXPECT_EQ(t++, (w++).value);
+        EXPECT_EQ(++t, (++w).value);
     }
 }
 
@@ -158,8 +158,8 @@ TYPED_TEST(WrappersTest, DecrementOperators){
     for(int i = 0; i < NUM_TRIALS; ++i){
         UnderlyingType t{this->rand()};
         TypeParam w{t};
-        EXPECT_EQ(t--, w--.value);
-        EXPECT_EQ(--t, --w.value);
+        EXPECT_EQ(t--, (w--).value);
+        EXPECT_EQ(--t, (--w).value);
     }
 }
 

--- a/cpp/tests/types/types_test.cpp
+++ b/cpp/tests/types/types_test.cpp
@@ -140,6 +140,29 @@ TYPED_TEST(WrappersTest, ArithmeticOperators)
     }
 }
 
+
+TYPED_TEST(WrappersTest, IncrementOperators){
+    using UnderlyingType = typename TypeParam::value_type;
+
+    for(int i = 0; i < NUM_TRIALS; ++i){
+        UnderlyingType t{this->rand()};
+        TypeParam w{t};
+        EXPECT_EQ(t++, w++.value);
+        EXPECT_EQ(++t, ++w.value);
+    }
+}
+
+TYPED_TEST(WrappersTest, DecrementOperators){
+    using UnderlyingType = typename TypeParam::value_type;
+
+    for(int i = 0; i < NUM_TRIALS; ++i){
+        UnderlyingType t{this->rand()};
+        TypeParam w{t};
+        EXPECT_EQ(t--, w--.value);
+        EXPECT_EQ(--t, --w.value);
+    }
+}
+
 TYPED_TEST(WrappersTest, BooleanOperators)
 {
     using UnderlyingType = typename TypeParam::value_type;


### PR DESCRIPTION
The wrapper types were missing post and prefix increment/decrement operators. 

This PR adds them along with associated unit tests.