### PR TITLE
[REVIEW] Fixed count_nonzero_mask for null masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #554 Add `empty` method and `is_monotonic` attribute to `Index`
 - PR #909 CSV Reader: Avoid host->device->host copy for header row data
 - PR #916 Improved unit testing and error checking for `gdf_column_concat`
+- PR #943 Updated `count_nonzero_mask` to return `num_rows` when the mask is null
 
 ## Bug Fixes
 

--- a/cpp/src/utilities/cudf_utils.h
+++ b/cpp/src/utilities/cudf_utils.h
@@ -16,6 +16,17 @@
 #define CUDA_LAUNCHABLE
 #endif
 
+inline gdf_error set_null_count(gdf_column* col) {
+  gdf_size_type valid_count{};
+  gdf_error result =
+      gdf_count_nonzero_mask(col->valid, col->size, &valid_count);
+
+  GDF_REQUIRE(GDF_SUCCESS == result, result);
+
+  col->null_count = col->size - valid_count;
+
+  return GDF_SUCCESS;
+}
 
 CUDA_HOST_DEVICE_CALLABLE 
 bool gdf_is_valid(const gdf_valid_type *valid, gdf_index_type pos) {

--- a/cpp/tests/bitmask/valid_ops_test.cu
+++ b/cpp/tests/bitmask/valid_ops_test.cu
@@ -49,9 +49,11 @@ TEST_F(ValidsTest, NoValids)
 TEST_F(ValidsTest, NullValids)
 {
   int count{-1};
-  gdf_error error_code = gdf_count_nonzero_mask(nullptr, 1, &count);
+  const gdf_size_type size{100};
+  gdf_error error_code = gdf_count_nonzero_mask(nullptr, size, &count);
 
-  ASSERT_EQ(GDF_DATASET_EMPTY,error_code) << "Expected failure for null input.";
+  ASSERT_EQ(GDF_SUCCESS,error_code) << "GDF Operation did not complete successfully.";
+  EXPECT_EQ(size, count);
 }
 
 TEST_F(ValidsTest, NullCount)


### PR DESCRIPTION
Previously, `count_nonzero_mask` would return `GDF_DATASET_EMPTY` if the passed in bitmask was null.

Since the bitmask in a column is optional, `count_nonzero_mask` should instead simply return `num_rows` when the bitmask is null.

Just for fun, also added a utility function `set_null_count` to update the null count for a `gdf_column`.