### PR TITLE
[REVIEW] CSV Reader: fix issue with missing rows when using byte_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,11 @@
 - PR #927 CSV Reader: Fix category GDF_CATEGORY hashes not being computed properly
 - PR #921 CSV Reader: Fix parsing errors with delim_whitespace, quotations in the header row, unnamed columns
 - PR #933 Fix handling objects of all nulls in series creation
-- PR #940 CSV Reader: fix an issue where the last data row is missing when using byte_range
+- PR #940 CSV Reader: Fix an issue where the last data row is missing when using byte_range
 - PR #945 CSV Reader: Fix incorrect datetime64 when milliseconds or space separator are used
 - PR #959 Groupby: Problem with column name lookup
 - PR #950 Converting dataframe/recarry with non-contiguous arrays
+- PR #963 CSV Reader: Fix another issue with missing data rows when using byte_range
 
 # cuDF 0.5.1 (05 Feb 2019)
 

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -419,7 +419,10 @@ gdf_error read_csv(csv_read_arg *args)
 
 		// Have to align map offset to page size
 		map_offset = (args->byte_range_offset/page_size)*page_size;
-		if (map_offset >= (size_t)file_size) { close(fd); checkError(GDF_C_ERROR, "The offset is too high"); }
+		if (map_offset >= (size_t)file_size) { 
+			close(fd); 
+			checkError(GDF_INVALID_API_CALL, "The byte_range offset is larger than the file size");
+		}
 
 		// Set to rest-of-the-file size, will reduce based on the byte range size
 		raw_csv->num_bytes = map_size = file_size - map_offset;

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -446,11 +446,6 @@ gdf_error read_csv(csv_read_arg *args)
 	}
 	else { checkError(GDF_C_ERROR, "invalid input type"); }
 
-	// Reset the byte range size if useless
-	if (raw_csv->byte_range_size >= raw_csv->num_bytes) {
-		raw_csv->byte_range_size = 0;
-	}
-
 	const char* h_uncomp_data;
 	size_t h_uncomp_size = 0;
 	// Used when the input data is compressed, to ensure the allocated uncompressed data is freed
@@ -1049,14 +1044,9 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
                     thrust::make_constant_iterator(start_offset),
                     raw_csv->recStart, thrust::minus<cu_recstart_t>());
 
-  // We added extra for offset=0 position - remove for actual data row count
-  if (raw_csv->byte_range_offset == 0) {
-    raw_csv->num_records--;
-  }
-  // We kept extra for end offset - remove for actual data row count
-  if (raw_csv->byte_range_size != 0) {
-    raw_csv->num_records--;
-  }
+  // The array of row offsets includes EOF
+  // reduce the number of records by one to exclude it from the rwo count
+  raw_csv->num_records--;
 
   return GDF_SUCCESS;
 }

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -417,12 +417,13 @@ gdf_error read_csv(csv_read_arg *args)
 		const auto file_size = st.st_size;
 		const auto page_size = sysconf(_SC_PAGESIZE);
 
-		// Have to align map offset to page size
-		map_offset = (args->byte_range_offset/page_size)*page_size;
-		if (map_offset >= (size_t)file_size) { 
+		if (args->byte_range_offset >= (size_t)file_size) { 
 			close(fd); 
 			checkError(GDF_INVALID_API_CALL, "The byte_range offset is larger than the file size");
 		}
+
+		// Have to align map offset to page size
+		map_offset = (args->byte_range_offset/page_size)*page_size;
 
 		// Set to rest-of-the-file size, will reduce based on the byte range size
 		raw_csv->num_bytes = map_size = file_size - map_offset;

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -1049,7 +1049,7 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
                     raw_csv->recStart, thrust::minus<cu_recstart_t>());
 
   // The array of row offsets includes EOF
-  // reduce the number of records by one to exclude it from the rwo count
+  // reduce the number of records by one to exclude it from the row count
   raw_csv->num_records--;
 
   return GDF_SUCCESS;

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -754,16 +754,16 @@ def test_csv_reader_byte_range(tmpdir, segment_bytes):
             fp.write(str(i) + ', ' + str(2*i) + ' \n')
     file_size = os.stat(str(fname)).st_size
 
-    ref_df = read_csv(str(fname), names=names)
+    ref_df = read_csv(str(fname), names=names).to_pandas()
 
     dfs = []
     for segment in range((file_size + segment_bytes - 1)//segment_bytes):
         dfs.append(read_csv(str(fname), names=names,
                    byte_range=(segment*segment_bytes, segment_bytes)))
-    df = cudf.concat(dfs)
+    df = cudf.concat(dfs).to_pandas()
 
-    # comparing only the values here, concat does not update the index
-    np.array_equal(ref_df.to_pandas().values, df.to_pandas().values)
+    assert(list(df['int1']) == list(ref_df['int1']))
+    assert(list(df['int2']) == list(ref_df['int2']))
 
 
 @pytest.mark.parametrize('header_row, skip_rows, skip_blanks',


### PR DESCRIPTION
Fixes #946 

* Fixed the logic when removing extra record starts after uploading the data to the GPU; byte_range is excluded from this, as it does not actually affect the additional number of rows. The byte_range values are used such that only required rows are loaded in all cases (no need to remove extra rows). Now, only the OEF record start is excluded from the record count.
* Fixed the byte_range test, which did not check the dataframe content correctly.
* Updated the error message that's returned when the byte_range offset is larger than the input file.