### PR TITLE
[REVIEW] CSV Reader: Add index_col parameter to specify the column name or index to be used as row labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #906 Add binary and comparison ops to DataFrame
 - PR #958 Support unary and binary ops on indexes
 - PR #964 Add `rename` method to `DataFrame`, `Series`, and `Index`
+- PR #995 CSV Reader: Add index_col parameter to specify the column name or index to be used as row labels
 
 ## Improvements
 

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -122,7 +122,7 @@ def read_csv(filepath_or_buffer, lineterminator='\n',
     prefix : str, default None
         Prefix to add to column numbers when parsing without a header row
     index_col : int or string, default None
-        Column to use as the row labels 
+        Column to use as the row labels
 
     Returns
     -------

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -38,7 +38,7 @@ def read_csv(filepath_or_buffer, lineterminator='\n',
              thousands=None, decimal='.', true_values=None, false_values=None,
              nrows=None, byte_range=None, skip_blank_lines=True, comment=None,
              na_values=None, keep_default_na=True, na_filter=True,
-             prefix=None):
+             prefix=None, index_col=None):
 
     """
     Load and parse a CSV file into a DataFrame
@@ -121,6 +121,8 @@ def read_csv(filepath_or_buffer, lineterminator='\n',
         Passing False can improve performance.
     prefix : str, default None
         Prefix to add to column numbers when parsing without a header row
+    index_col : int or string, default None
+        Column to use as the row labels 
 
     Returns
     -------
@@ -367,6 +369,13 @@ def read_csv(filepath_or_buffer, lineterminator='\n',
     for k, v in zip(new_names, outcols):
         df[k] = v
 
+    # Set index if the index_col parameter is passed
+    if index_col is not None and index_col is not False:
+        if isinstance(index_col, (int)):
+            df = df.set_index(df.columns[index_col])
+        else:
+            df = df.set_index(index_col)
+
     nvtx_range_pop()
 
     return df
@@ -382,7 +391,7 @@ def read_csv_strings(filepath_or_buffer, lineterminator='\n',
                      true_values=None, false_values=None, nrows=None,
                      byte_range=None, skip_blank_lines=True, comment=None,
                      na_values=None, keep_default_na=True, na_filter=True,
-                     prefix=None):
+                     prefix=None, index_col=None):
 
     """
     **Experimental**: This function exists only as a beta way to use

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -862,7 +862,6 @@ def test_csv_reader_header_quotation():
 
 
 def test_csv_reader_oversized_byte_range():
-    # first and last columns are unnamed
     buffer = 'a,b,c,d,e\n4,5,6,7,8\n'
 
     cu_df = read_csv(StringIO(buffer), byte_range=(0, 1024))
@@ -870,3 +869,25 @@ def test_csv_reader_oversized_byte_range():
 
     assert(all(pd_df.columns == cu_df.columns))
     assert(pd_df.shape == cu_df.shape)
+
+def test_csv_reader_index_col():
+    buffer = '0,1,2\n3,4,5\n6,7,8\n'
+    names = ['int1', 'int2', 'int3']
+
+    # using a column name
+    cu_df = read_csv(StringIO(buffer), names=names, index_col='int1')
+    pd_df = pd.read_csv(StringIO(buffer), names=names, index_col='int1')
+    pd.util.testing.assert_frame_equal(pd_df, cu_df.to_pandas())
+
+    # using a column index
+    cu_df = read_csv(StringIO(buffer), header=None, index_col=0)
+    pd_df = pd.read_csv(StringIO(buffer), header=None, index_col=0)
+    for cu_idx, pd_idx in zip(cu_df.index, pd_df.index):
+        assert(str(cu_idx) == str(pd_idx))
+
+
+    # passing False to avoid using a column as index (no-op in cuDF)
+    cu_df = read_csv(StringIO(buffer), header=None, index_col=False)
+    pd_df = pd.read_csv(StringIO(buffer), header=None, index_col=False)
+    for cu_idx, pd_idx in zip(cu_df.index, pd_df.index):
+        assert(str(cu_idx) == str(pd_idx))

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -870,6 +870,7 @@ def test_csv_reader_oversized_byte_range():
     assert(all(pd_df.columns == cu_df.columns))
     assert(pd_df.shape == cu_df.shape)
 
+
 def test_csv_reader_index_col():
     buffer = '0,1,2\n3,4,5\n6,7,8\n'
     names = ['int1', 'int2', 'int3']
@@ -884,7 +885,6 @@ def test_csv_reader_index_col():
     pd_df = pd.read_csv(StringIO(buffer), header=None, index_col=0)
     for cu_idx, pd_idx in zip(cu_df.index, pd_df.index):
         assert(str(cu_idx) == str(pd_idx))
-
 
     # passing False to avoid using a column as index (no-op in cuDF)
     cu_df = read_csv(StringIO(buffer), header=None, index_col=False)


### PR DESCRIPTION
Fixes #922 
* Add the index_col parameter to read_csv() and read_csv_strings().
* Supports ints and strings to specify the index column.
* Add the test different index_col types.