### PR TITLE
[REVIEW] API doc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - PR #943 Updated `count_nonzero_mask` to return `num_rows` when the mask is null
 - PR #942 Added increment/decrement operators for wrapper types
 - PR #966 Updated RMM submodule.
+- PR #998 Add IO reader/writer modules to API docs, fix for missing cudf.Series docs
 
 ## Bug Fixes
 

--- a/cpp/python/tests/test_hashing.py
+++ b/cpp/python/tests/test_hashing.py
@@ -92,7 +92,8 @@ def test_hashing():
         # Hash
         for init_vals in [ffi.NULL, init_hash_values]:
             hashed_column = _call_hash_multi(libgdf.gdf_hash, ncols,
-                                             col_input, magic, init_vals, nrows)
+                                             col_input, magic, init_vals,
+                                             nrows)
 
             # Check if first and last row are equal
             assert tuple([hashed_column[0]]) == tuple([hashed_column[-1]])

--- a/cpp/python/tests/test_sorting.py
+++ b/cpp/python/tests/test_sorting.py
@@ -82,16 +82,16 @@ def test_digitize(num_rows, num_bins, right, dtype):
     col_data = gen_rand(dtype, num_rows)
     d_col_data = rmm.to_device(col_data)
     col_in = new_column()
-    libgdf.gdf_column_view(col_in, unwrap_devary(d_col_data), ffi.NULL, num_rows,
-                           get_dtype(d_col_data.dtype))
+    libgdf.gdf_column_view(col_in, unwrap_devary(d_col_data), ffi.NULL,
+                           num_rows, get_dtype(d_col_data.dtype))
 
     bin_data = gen_rand(dtype, num_bins)
     bin_data.sort()
     bin_data = np.unique(bin_data)
     d_bin_data = rmm.to_device(bin_data)
     bins = new_column()
-    libgdf.gdf_column_view(bins, unwrap_devary(d_bin_data), ffi.NULL, len(bin_data),
-                           get_dtype(d_bin_data.dtype))
+    libgdf.gdf_column_view(bins, unwrap_devary(d_bin_data), ffi.NULL,
+                           len(bin_data), get_dtype(d_bin_data.dtype))
 
     out_ary = np.zeros(num_rows, dtype=np.int32)
     d_out = rmm.to_device(out_ary)
@@ -101,4 +101,3 @@ def test_digitize(num_rows, num_bins, right, dtype):
     result = d_out.copy_to_host()
     expected = np.digitize(col_data, bin_data, right)
     np.testing.assert_array_equal(expected, result)
-

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -n -v
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = cudf
 SOURCEDIR     = source

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -14,12 +14,15 @@ DataFrame
 .. automodule:: cudf.multi
     :members:
 
+..
+  For cudf.melt
+..
 .. automodule:: cudf.reshape.general
     :members:
 
 Series
 ------
-.. autoclass:: cudf.dataframe.series
+.. autoclass:: Series
     :members:
  
 Groupby
@@ -44,6 +47,16 @@ Groupby
 IO
 --
 .. automodule:: cudf.io.csv
+    :members:
+.. automodule:: cudf.io.parquet
+    :members:
+.. automodule:: cudf.io.orc
+    :members:
+.. automodule:: cudf.io.json
+    :members:
+.. automodule:: cudf.io.feather
+    :members:
+.. automodule:: cudf.io.hdf
     :members:
 
 GpuArrowReader

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ author = 'NVIDIA'
 # built documents.
 #
 # The short X.Y version.
-version = '0.6.0'
+version = '0.6'
 # The full version, including alpha/beta/rc tags.
 release = cudf.__version__
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -21,7 +21,7 @@ from librmm_cffi import librmm as rmm
 from libgdf_cffi import libgdf
 
 from cudf import formatting, _gdf
-from cudf.utils import cudautils, queryutils, applyutils, utils
+from cudf.utils import cudautils, queryutils, applyutils, utils, ioutils
 from cudf.dataframe.index import as_index, Index, RangeIndex
 from cudf.dataframe.series import Series
 from cudf.settings import NOTSET, settings
@@ -97,7 +97,8 @@ class DataFrame(object):
     .. code-block:: python
 
           import pandas as pd
-          from pygdf.dataframe import DataFrame
+          from cudf import DataFrame
+
           pdf = pd.DataFrame({'a': [0, 1, 2, 3],'b': [0.1, 0.2, None, 0.3]})
           df = DataFrame.from_pandas(pdf)
           print(df)
@@ -598,18 +599,20 @@ class DataFrame(object):
 
         Examples
         --------
-        df = DataFrame([('a', list(range(20))),
-                        ('b', list(range(20))),
-                        ('c', list(range(20)))])
+        .. code-block:: python
 
-        #get the row from index 1st
-        df.iloc[1]
+          df = DataFrame([('a', list(range(20))),
+                          ('b', list(range(20))),
+                          ('c', list(range(20)))])
 
-        # get the rows from indices 0,2,9 and 18.
-        df.iloc[[0, 2, 9, 18]]
+          #get the row from index 1st
+          df.iloc[1]
 
-        # get the rows using slice indices
-        df.iloc[3:10:2]
+          # get the rows from indices 0,2,9 and 18.
+          df.iloc[[0, 2, 9, 18]]
+
+          # get the rows using slice indices
+          df.iloc[3:10:2]
 
         Output:
 
@@ -887,6 +890,8 @@ class DataFrame(object):
         -------
         DataFrame
 
+        Notes
+        -----
         Difference from pandas:
           * Support axis='columns' only.
           * Not supporting: index, inplace, level
@@ -1124,6 +1129,8 @@ class DataFrame(object):
         -------
         sorted_obj : cuDF DataFrame
 
+        Notes
+        -----
         Difference from pandas:
           * Support axis='index' only.
           * Not supporting: inplace, kind
@@ -1159,6 +1166,8 @@ class DataFrame(object):
     def nlargest(self, n, columns, keep='first'):
         """Get the rows of the DataFrame sorted by the n largest value of *columns*
 
+        Notes
+        -----
         Difference from pandas:
         * Only a single column is supported in *columns*
         """
@@ -1199,8 +1208,9 @@ class DataFrame(object):
         -------
         a new (ncol x nrow) dataframe. self is (nrow x ncol)
 
-        Difference from pandas
-        ----------------------
+        Notes
+        -----
+        Difference from pandas:
         Not supporting *copy* because default and only behaviour is copy=True
         """
         if len(self.columns) == 0:
@@ -1473,7 +1483,6 @@ class DataFrame(object):
 
         Notes
         -----
-
         Difference from pandas:
 
         - *other* must be a single DataFrame for now.
@@ -2217,99 +2226,21 @@ class DataFrame(object):
                                          quant_index=False)
         return result
 
+    @ioutils.doc_to_parquet()
     def to_parquet(self, path, *args, **kwargs):
-        """
-        Write a DataFrame to the parquet format.
-        Parameters
-        ----------
-        path : str
-            File path or Root Directory path. Will be used as Root Directory
-            path while writing a partitioned dataset.
-        compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
-            Name of the compression to use. Use ``None`` for no compression.
-        index : bool, default None
-            If ``True``, include the dataframe's index(es) in the file output.
-            If ``False``, they will not be written to the file. If ``None``,
-            the engine's default behavior will be used.
-        partition_cols : list, optional, default None
-            Column names by which to partition the dataset
-            Columns are partitioned in the order they are given
-        """
+        """{docstring}"""
         import cudf.io.parquet as pq
         pq.to_parquet(self, path, *args, **kwargs)
 
+    @ioutils.doc_to_feather()
     def to_feather(self, path, *args, **kwargs):
-        """
-        Write a DataFrame to the feather format.
-        Parameters
-        ----------
-        path : str
-            File path
-        """
+        """{docstring}"""
         import cudf.io.feather as feather
         feather.to_feather(self, path, *args, **kwargs)
 
+    @ioutils.doc_to_json()
     def to_json(self, path_or_buf=None, *args, **kwargs):
-        """
-        Convert the cuDF object to a JSON string.
-        Note nulls and NaNs will be converted to null and datetime objects
-        will be converted to UNIX timestamps.
-        Parameters
-        ----------
-        path_or_buf : string or file handle, optional
-            File path or object. If not specified, the result is returned as
-            a string.
-        orient : string
-            Indication of expected JSON string format.
-            * Series
-                - default is 'index'
-                - allowed values are: {'split','records','index','table'}
-            * DataFrame
-                - default is 'columns'
-                - allowed values are:
-                {'split','records','index','columns','values','table'}
-            * The format of the JSON string
-                - 'split' : dict like {'index' -> [index],
-                'columns' -> [columns], 'data' -> [values]}
-                - 'records' : list like
-                [{column -> value}, ... , {column -> value}]
-                - 'index' : dict like {index -> {column -> value}}
-                - 'columns' : dict like {column -> {index -> value}}
-                - 'values' : just the values array
-                - 'table' : dict like {'schema': {schema}, 'data': {data}}
-                describing the data, and the data component is
-                like ``orient='records'``.
-        date_format : {None, 'epoch', 'iso'}
-            Type of date conversion. 'epoch' = epoch milliseconds,
-            'iso' = ISO8601. The default depends on the `orient`. For
-            ``orient='table'``, the default is 'iso'. For all other orients,
-            the default is 'epoch'.
-        double_precision : int, default 10
-            The number of decimal places to use when encoding
-            floating point values.
-        force_ascii : bool, default True
-            Force encoded string to be ASCII.
-        date_unit : string, default 'ms' (milliseconds)
-            The time unit to encode to, governs timestamp and ISO8601
-            precision.  One of 's', 'ms', 'us', 'ns' for second, millisecond,
-            microsecond, and nanosecond respectively.
-        default_handler : callable, default None
-            Handler to call if object cannot otherwise be converted to a
-            suitable format for JSON. Should receive a single argument which is
-            the object to convert and return a serialisable object.
-        lines : bool, default False
-            If 'orient' is 'records' write out line delimited json format. Will
-            throw ValueError if incorrect 'orient' since others are not list
-            like.
-        compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}
-            A string representing the compression to use in the output file,
-            only used when the first argument is a filename. By default, the
-            compression is inferred from the filename.
-        index : bool, default True
-            Whether to include the index values in the JSON string. Not
-            including the index (``index=False``) is only supported when
-            orient is 'split' or 'table'.
-        """
+        """{docstring}"""
         import cudf.io.json as json
         json.to_json(
             self,
@@ -2318,66 +2249,9 @@ class DataFrame(object):
             **kwargs
         )
 
+    @ioutils.doc_to_hdf()
     def to_hdf(self, path_or_buf, key, *args, **kwargs):
-        """
-        Write the contained data to an HDF5 file using HDFStore.
-
-        Hierarchical Data Format (HDF) is self-describing, allowing an
-        application to interpret the structure and contents of a file with
-        no outside information. One HDF file can hold a mix of related objects
-        which can be accessed as a group or as individual objects.
-
-        In order to add another DataFrame or Series to an existing HDF file
-        please use append mode and a different a key.
-
-        For more information see the :ref:`user guide <io.hdf5>`.
-        Parameters
-        ----------
-        path_or_buf : str or pandas.HDFStore
-            File path or HDFStore object.
-        key : str
-            Identifier for the group in the store.
-        mode : {'a', 'w', 'r+'}, default 'a'
-            Mode to open file:
-            - 'w': write, a new file is created (an existing file with
-                the same name would be deleted).
-            - 'a': append, an existing file is opened for reading and
-                writing, and if the file does not exist it is created.
-            - 'r+': similar to 'a', but the file must already exist.
-        format : {'fixed', 'table'}, default 'fixed'
-            Possible values:
-            - 'fixed': Fixed format. Fast writing/reading. Not-appendable,
-                nor searchable.
-            - 'table': Table format. Write as a PyTables Table structure
-                which may perform worse but allow more flexible operations
-                like searching / selecting subsets of the data.
-        append : bool, default False
-            For Table formats, append the input data to the existing.
-        data_columns :  list of columns or True, optional
-            List of columns to create as indexed data columns for on-disk
-            queries, or True to use all columns. By default only the axes
-            of the object are indexed. See :ref:`io.hdf5-query-data-columns`.
-            Applicable only to format='table'.
-        complevel : {0-9}, optional
-            Specifies a compression level for data.
-            A value of 0 disables compression.
-        complib : {'zlib', 'lzo', 'bzip2', 'blosc'}, default 'zlib'
-            Specifies the compression library to be used.
-            As of v0.20.2 these additional compressors for Blosc are supported
-            (default if no compressor specified: 'blosc:blosclz'):
-            {'blosc:blosclz', 'blosc:lz4', 'blosc:lz4hc', 'blosc:snappy',
-            'blosc:zlib', 'blosc:zstd'}.
-            Specifying a compression library which is not available issues
-            a ValueError.
-        fletcher32 : bool, default False
-            If applying compression use the fletcher32 checksum.
-        dropna : bool, default False
-            If true, ALL nan rows will not be written to store.
-        errors : str, default 'strict'
-            Specifies how encoding and decoding errors are to be handled.
-            See the errors argument for :func:`open` for a full list
-            of options.
-        """
+        """{docstring}"""
         import cudf.io.hdf as hdf
         hdf.to_hdf(path_or_buf, key, self, *args, **kwargs)
 

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -592,27 +592,39 @@ class Series(object):
 
         Examples
         --------
+        .. code-block:: python
 
-        >>> sr = Series(list(range(20)))
-        # get the value from 1st index
-        >>> sr.iloc[1]
-        1
+          from cudf import Series
 
-        # get the values from 0,2,9 and 18th index
-        >>> sr.iloc[0,2,9,18]
-        0    0
-        2    2
-        9    9
-        18   18
+          sr = Series(list(range(20)))
 
-        # get the values using slice indices
-        >>> sr.iloc[3:10:2]
-        3    3
-        5    5
-        7    7
-        9    9
+          # get the value from 1st index
+          sr.iloc[1]
 
-        :return:
+          # get the values from 0,2,9 and 18th index
+          sr.iloc[0,2,9,18]
+
+          # get the values using slice indices
+          sr.iloc[3:10:2]
+
+        Output:
+
+        .. code-block:: python
+
+          1
+
+          0    0
+          2    2
+          9    9
+          18   18
+
+          3    3
+          5    5
+          7    7
+          9    9
+
+        Returns
+        -------
         Series containing the elements corresponding to the indices
         """
         return Iloc(self)
@@ -1246,7 +1258,9 @@ class Series(object):
         In order to add another DataFrame or Series to an existing HDF file
         please use append mode and a different a key.
 
-        For more information see the :ref:`user guide <io.hdf5>`.
+        For more information see the :ref:`user guide
+        <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#hdf5-pytables>`_.
+
         Parameters
         ----------
         path_or_buf : str or pandas.HDFStore
@@ -1272,7 +1286,8 @@ class Series(object):
         data_columns :  list of columns or True, optional
             List of columns to create as indexed data columns for on-disk
             queries, or True to use all columns. By default only the axes
-            of the object are indexed. See :ref:`io.hdf5-query-data-columns`.
+            of the object are indexed. `See Query via Data Columns
+            <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#hdf5-pytables>`_.
             Applicable only to format='table'.
         complevel : {0-9}, optional
             Specifies a compression level for data.

--- a/python/cudf/io/feather.py
+++ b/python/cudf/io/feather.py
@@ -1,52 +1,15 @@
 # Copyright (c) 2019, NVIDIA CORPORATION.
 
 from cudf.dataframe.dataframe import DataFrame
+from cudf.utils import ioutils
 
 from pyarrow import feather
 import warnings
 
 
+@ioutils.doc_read_feather()
 def read_feather(path, *args, **kwargs):
-    """
-    Load an feather object from the file path, returning a DataFrame.
-
-    Parameters
-    ----------
-    path : string
-        File path
-    columns : list, default=None
-        If not None, only these columns will be read from the file.
-
-    Returns
-    -------
-    DataFrame
-
-    Examples
-    --------
-
-
-    .. code-block:: python
-
-      import cudf
-
-      df = cudf.read_feather(filename)
-
-      # Display results
-      print(df)
-
-    Output:
-
-    .. code-block:: python
-
-          num1                datetime text
-        0  123 2018-11-13T12:00:00.000 5451
-        1  456 2018-11-14T12:35:01.000 5784
-        2  789 2018-11-15T18:02:59.000 6117
-
-    See Also
-    --------
-    .to_feather
-    """
+    """{docstring}"""
 
     warnings.warn("Using CPU via PyArrow to read feather dataset, this may "
                   "be GPU accelerated in the future")
@@ -54,18 +17,9 @@ def read_feather(path, *args, **kwargs):
     return DataFrame.from_arrow(pa_table)
 
 
+@ioutils.doc_to_feather()
 def to_feather(df, path, *args, **kwargs):
-    """
-    Write a DataFrame to the feather format.
-    Parameters
-    ----------
-    path : str
-        File path
-
-    See Also
-    --------
-    .read_feather
-    """
+    """{docstring}"""
     warnings.warn("Using CPU via PyArrow to write Feather dataset, this may "
                   "be GPU accelerated in the future")
     # Feather doesn't support using an index

--- a/python/cudf/io/hdf.py
+++ b/python/cudf/io/hdf.py
@@ -4,125 +4,21 @@ import cudf
 
 import pandas as pd
 import warnings
+from cudf.utils import ioutils
 
 
+@ioutils.doc_read_hdf()
 def read_hdf(path_or_buf, *args, **kwargs):
-    """
-    Read from the store, close it if we opened it.
-
-    Retrieve pandas object stored in file, optionally based on where
-    criteria
-
-    Parameters
-    ----------
-    path_or_buf : string, buffer or path object
-        Path to the file to open, or an open :class:`pandas.HDFStore` object.
-        Supports any object implementing the ``__fspath__`` protocol.
-        This includes :class:`pathlib.Path` and py._path.local.LocalPath
-        objects.
-    key : object, optional
-        The group identifier in the store. Can be omitted if the HDF file
-        contains a single pandas object.
-    mode : {'r', 'r+', 'a'}, optional
-        Mode to use when opening the file. Ignored if path_or_buf is a
-        :class:`pandas.HDFStore`. Default is 'r'.
-    where : list, optional
-        A list of Term (or convertible) objects.
-    start : int, optional
-        Row number to start selection.
-    stop  : int, optional
-        Row number to stop selection.
-    columns : list, optional
-        A list of columns names to return.
-    iterator : bool, optional
-        Return an iterator object.
-    chunksize : int, optional
-        Number of rows to include in an iteration when using an iterator.
-    errors : str, default 'strict'
-        Specifies how encoding and decoding errors are to be handled.
-        See the errors argument for :func:`open` for a full list
-        of options.
-    **kwargs
-        Additional keyword arguments passed to HDFStore.
-    Returns
-    -------
-    item : object
-        The selected object. Return type depends on the object stored.
-    See Also
-    --------
-    .to_hdf : Write a HDF file from a DataFrame.
-    """
-
+    """{docstring}"""
     warnings.warn("Using CPU via Pandas to read HDF dataset, this may "
                   "be GPU accelerated in the future")
     pd_value = pd.read_hdf(path_or_buf, *args, **kwargs)
     return cudf.from_pandas(pd_value)
 
 
+@ioutils.doc_to_hdf()
 def to_hdf(path_or_buf, key, value, *args, **kwargs):
-    """
-    Write the contained data to an HDF5 file using HDFStore.
-
-    Hierarchical Data Format (HDF) is self-describing, allowing an
-    application to interpret the structure and contents of a file with
-    no outside information. One HDF file can hold a mix of related objects
-    which can be accessed as a group or as individual objects.
-
-    In order to add another DataFrame or Series to an existing HDF file
-    please use append mode and a different a key.
-
-    For more information see the :ref:`user guide <io.hdf5>`.
-    Parameters
-    ----------
-    path_or_buf : str or pandas.HDFStore
-        File path or HDFStore object.
-    key : str
-        Identifier for the group in the store.
-    mode : {'a', 'w', 'r+'}, default 'a'
-        Mode to open file:
-        - 'w': write, a new file is created (an existing file with
-            the same name would be deleted).
-        - 'a': append, an existing file is opened for reading and
-            writing, and if the file does not exist it is created.
-        - 'r+': similar to 'a', but the file must already exist.
-    format : {'fixed', 'table'}, default 'fixed'
-        Possible values:
-        - 'fixed': Fixed format. Fast writing/reading. Not-appendable,
-            nor searchable.
-        - 'table': Table format. Write as a PyTables Table structure
-            which may perform worse but allow more flexible operations
-            like searching / selecting subsets of the data.
-    append : bool, default False
-        For Table formats, append the input data to the existing.
-    data_columns :  list of columns or True, optional
-        List of columns to create as indexed data columns for on-disk
-        queries, or True to use all columns. By default only the axes
-        of the object are indexed. See :ref:`io.hdf5-query-data-columns`.
-        Applicable only to format='table'.
-    complevel : {0-9}, optional
-        Specifies a compression level for data.
-        A value of 0 disables compression.
-    complib : {'zlib', 'lzo', 'bzip2', 'blosc'}, default 'zlib'
-        Specifies the compression library to be used.
-        As of v0.20.2 these additional compressors for Blosc are supported
-        (default if no compressor specified: 'blosc:blosclz'):
-        {'blosc:blosclz', 'blosc:lz4', 'blosc:lz4hc', 'blosc:snappy',
-        'blosc:zlib', 'blosc:zstd'}.
-        Specifying a compression library which is not available issues
-        a ValueError.
-    fletcher32 : bool, default False
-        If applying compression use the fletcher32 checksum.
-    dropna : bool, default False
-        If true, ALL nan rows will not be written to store.
-    errors : str, default 'strict'
-        Specifies how encoding and decoding errors are to be handled.
-        See the errors argument for :func:`open` for a full list
-        of options.
-
-    See Also
-    --------
-    .read_hdf : Read from HDF file.
-    """
+    """{docstring}"""
     warnings.warn("Using CPU via Pandas to write HDF dataset, this may "
                   "be GPU accelerated in the future")
     pd_value = value.to_pandas()

--- a/python/cudf/io/json.py
+++ b/python/cudf/io/json.py
@@ -1,102 +1,15 @@
 # Copyright (c) 2019, NVIDIA CORPORATION.
 
 import cudf
+from cudf.utils import ioutils
 
 import pandas as pd
 import warnings
 
 
+@ioutils.doc_read_json()
 def read_json(path_or_buf, *args, **kwargs):
-    """
-    Convert a JSON string to a cuDF object.
-    Parameters
-    ----------
-    path_or_buf : a valid JSON string or file-like, default: None
-        The string could be a URL. Valid URL schemes include http, ftp, s3,
-        gcs, and file. For file URLs, a host is expected. For instance, a local
-        file could be ``file://localhost/path/to/table.json``
-    orient : string,
-        Indication of expected JSON string format.
-        Compatible JSON strings can be produced by ``to_json()`` with a
-        corresponding orient value.
-        The set of possible orients is:
-        - ``'split'`` : dict like
-          ``{index -> [index], columns -> [columns], data -> [values]}``
-        - ``'records'`` : list like
-          ``[{column -> value}, ... , {column -> value}]``
-        - ``'index'`` : dict like ``{index -> {column -> value}}``
-        - ``'columns'`` : dict like ``{column -> {index -> value}}``
-        - ``'values'`` : just the values array
-        The allowed and default values depend on the value
-        of the `typ` parameter.
-        * when ``typ == 'series'``,
-          - allowed orients are ``{'split','records','index'}``
-          - default is ``'index'``
-          - The Series index must be unique for orient ``'index'``.
-        * when ``typ == 'frame'``,
-          - allowed orients are ``{'split','records','index',
-            'columns','values', 'table'}``
-          - default is ``'columns'``
-          - The DataFrame index must be unique for orients ``'index'`` and
-            ``'columns'``.
-          - The DataFrame columns must be unique for orients ``'index'``,
-            ``'columns'``, and ``'records'``.
-           'table' as an allowed value for the ``orient`` argument
-    typ : type of object to recover (series or frame), default 'frame'
-    dtype : boolean or dict, default True
-        If True, infer dtypes, if a dict of column to dtype, then use those,
-        if False, then don't infer dtypes at all, applies only to the data.
-    convert_axes : boolean, default True
-        Try to convert the axes to the proper dtypes.
-    convert_dates : boolean, default True
-        List of columns to parse for dates; If True, then try to parse
-        datelike columns default is True; a column label is datelike if
-        * it ends with ``'_at'``,
-        * it ends with ``'_time'``,
-        * it begins with ``'timestamp'``,
-        * it is ``'modified'``, or
-        * it is ``'date'``
-    keep_default_dates : boolean, default True
-        If parsing dates, then parse the default datelike columns
-    numpy : boolean, default False
-        Direct decoding to numpy arrays. Supports numeric data only, but
-        non-numeric column and index labels are supported. Note also that the
-        JSON ordering MUST be the same for each term if numpy=True.
-    precise_float : boolean, default False
-        Set to enable usage of higher precision (strtod) function when
-        decoding string to double values. Default (False) is to use fast but
-        less precise builtin functionality
-    date_unit : string, default None
-        The timestamp unit to detect if converting dates. The default behaviour
-        is to try and detect the correct precision, but if this is not desired
-        then pass one of 's', 'ms', 'us' or 'ns' to force parsing only seconds,
-        milliseconds, microseconds or nanoseconds respectively.
-    encoding : str, default is 'utf-8'
-        The encoding to use to decode py3 bytes.
-    lines : boolean, default False
-        Read the file as a json object per line.
-    chunksize : integer, default None
-        Return JsonReader object for iteration.
-        See the `line-delimted json docs
-        <http://pandas.pydata.org/pandas-docs/stable/io.html#io-jsonl>`_
-        for more information on ``chunksize``.
-        This can only be passed if `lines=True`.
-        If this is None, the file will be read into memory all at once.
-    compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default 'infer'
-        For on-the-fly decompression of on-disk data. If 'infer', then use
-        gzip, bz2, zip or xz if path_or_buf is a string ending in
-        '.gz', '.bz2', '.zip', or 'xz', respectively, and no decompression
-        otherwise. If using 'zip', the ZIP file must contain only one data
-        file to be read in. Set to None for no decompression.
-
-    Returns
-    -------
-    result : Series or DataFrame, depending on the value of `typ`.
-
-    See Also
-    --------
-    .to_json
-    """
+    """{docstring}"""
 
     warnings.warn("Using CPU via Pandas to read JSON dataset, this may "
                   "be GPU accelerated in the future")
@@ -104,70 +17,9 @@ def read_json(path_or_buf, *args, **kwargs):
     return cudf.from_pandas(pd_value)
 
 
+@ioutils.doc_to_json()
 def to_json(cudf_val, path_or_buf=None, *args, **kwargs):
-    """
-    Convert the cuDF object to a JSON string.
-    Note nulls and NaNs will be converted to null and datetime objects
-    will be converted to UNIX timestamps.
-    Parameters
-    ----------
-    path_or_buf : string or file handle, optional
-        File path or object. If not specified, the result is returned as
-        a string.
-    orient : string
-        Indication of expected JSON string format.
-        * Series
-            - default is 'index'
-            - allowed values are: {'split','records','index','table'}
-        * DataFrame
-            - default is 'columns'
-            - allowed values are:
-            {'split','records','index','columns','values','table'}
-        * The format of the JSON string
-            - 'split' : dict like {'index' -> [index],
-            'columns' -> [columns], 'data' -> [values]}
-            - 'records' : list like
-            [{column -> value}, ... , {column -> value}]
-            - 'index' : dict like {index -> {column -> value}}
-            - 'columns' : dict like {column -> {index -> value}}
-            - 'values' : just the values array
-            - 'table' : dict like {'schema': {schema}, 'data': {data}}
-            describing the data, and the data component is
-            like ``orient='records'``.
-    date_format : {None, 'epoch', 'iso'}
-        Type of date conversion. 'epoch' = epoch milliseconds,
-        'iso' = ISO8601. The default depends on the `orient`. For
-        ``orient='table'``, the default is 'iso'. For all other orients,
-        the default is 'epoch'.
-    double_precision : int, default 10
-        The number of decimal places to use when encoding
-        floating point values.
-    force_ascii : bool, default True
-        Force encoded string to be ASCII.
-    date_unit : string, default 'ms' (milliseconds)
-        The time unit to encode to, governs timestamp and ISO8601
-        precision.  One of 's', 'ms', 'us', 'ns' for second, millisecond,
-        microsecond, and nanosecond respectively.
-    default_handler : callable, default None
-        Handler to call if object cannot otherwise be converted to a
-        suitable format for JSON. Should receive a single argument which is
-        the object to convert and return a serialisable object.
-    lines : bool, default False
-        If 'orient' is 'records' write out line delimited json format. Will
-        throw ValueError if incorrect 'orient' since others are not list
-        like.
-    compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}
-        A string representing the compression to use in the output file,
-        only used when the first argument is a filename. By default, the
-        compression is inferred from the filename.
-    index : bool, default True
-        Whether to include the index values in the JSON string. Not
-        including the index (``index=False``) is only supported when
-        orient is 'split' or 'table'.
-    See Also
-    --------
-    .read_json
-    """
+    """{docstring}"""
 
     warnings.warn("Using CPU via Pandas to write JSON dataset, this may "
                   "be GPU accelerated in the future")

--- a/python/cudf/io/orc.py
+++ b/python/cudf/io/orc.py
@@ -1,55 +1,15 @@
 # Copyright (c) 2019, NVIDIA CORPORATION.
 
 from cudf.dataframe.dataframe import DataFrame
+from cudf.utils import ioutils
 
 import pyarrow.orc as orc
 import warnings
 
 
+@ioutils.doc_read_orc()
 def read_orc(path, columns=None, **kwargs):
-    """
-    Load an orc object from the file path, returning a DataFrame.
-
-    Parameters
-    ----------
-    path : string
-        File path
-    columns : list, default=None
-        If not None, only these columns will be read from the file.
-    kwargs are passed to the engine
-
-    Returns
-    -------
-    DataFrame
-
-    Examples
-    --------
-
-
-    .. code-block:: python
-
-      import cudf
-
-      df = cudf.read_orc(filename)
-
-      # Display results
-      print(df)
-
-    Output:
-
-    .. code-block:: python
-
-          num1                datetime text
-        0  123 2018-11-13T12:00:00.000 5451
-        1  456 2018-11-14T12:35:01.000 5784
-        2  789 2018-11-15T18:02:59.000 6117
-
-    See Also
-    --------
-    cudf.io.parquet.read_parquet
-    cudf.io.parquet.to_parquet
-    """
-
+    """{docstring}"""
     warnings.warn("Using CPU via PyArrow to read ORC dataset, this will "
                   "be GPU accelerated in the future")
     orc_file = orc.ORCFile(path)

--- a/python/cudf/io/parquet.py
+++ b/python/cudf/io/parquet.py
@@ -1,53 +1,15 @@
 # Copyright (c) 2019, NVIDIA CORPORATION.
 
 from cudf.dataframe.dataframe import DataFrame
+from cudf.utils import ioutils
 
 import pyarrow.parquet as pq
 import warnings
 
 
+@ioutils.doc_read_parquet()
 def read_parquet(path, *args, **kwargs):
-    """
-    Load a parquet object from the file path, returning a DataFrame.
-
-    Parameters
-    ----------
-    path : string
-        File path
-    columns : list, default=None
-        If not None, only these columns will be read from the file.
-
-    Returns
-    -------
-    DataFrame
-
-    Examples
-    --------
-
-
-    .. code-block:: python
-
-      import cudf
-
-      df = cudf.read_parquet(filename)
-
-      # Display results
-      print(df)
-
-    Output:
-
-    .. code-block:: python
-
-          num1                datetime text
-        0  123 2018-11-13T12:00:00.000 5451
-        1  456 2018-11-14T12:35:01.000 5784
-        2  789 2018-11-15T18:02:59.000 6117
-
-    See Also
-    --------
-    cudf.io.parquet.to_parquet
-    cudf.io.orc.read_orc
-    """
+    """{docstring}"""
 
     warnings.warn("Using CPU via PyArrow to read Parquet dataset, this will "
                   "be GPU accelerated in the future")
@@ -55,29 +17,9 @@ def read_parquet(path, *args, **kwargs):
     return DataFrame.from_arrow(pa_table)
 
 
+@ioutils.doc_to_parquet()
 def to_parquet(df, path, *args, **kwargs):
-    """
-    Write a DataFrame to the parquet format.
-    Parameters
-    ----------
-    path : str
-        File path or Root Directory path. Will be used as Root Directory path
-        while writing a partitioned dataset.
-    compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
-        Name of the compression to use. Use ``None`` for no compression.
-    index : bool, default None
-        If ``True``, include the dataframe's index(es) in the file output. If
-        ``False``, they will not be written to the file. If ``None``, the
-        engine's default behavior will be used.
-    partition_cols : list, optional, default None
-        Column names by which to partition the dataset
-        Columns are partitioned in the order they are given
-
-    See Also
-    --------
-    cudf.io.parquet.read_parquet
-    cudf.io.orc.read_orc
-    """
+    """{docstring}"""
     warnings.warn("Using CPU via PyArrow to write Parquet dataset, this will "
                   "be GPU accelerated in the future")
     pa_table = df.to_arrow()

--- a/python/cudf/utils/ioutils.py
+++ b/python/cudf/utils/ioutils.py
@@ -1,0 +1,444 @@
+from cudf.utils.docutils import docfmt_partial
+
+_docstring_read_parquet = """
+Load a parquet object from the file path, returning a DataFrame.
+
+Parameters
+----------
+path : string
+    File path
+columns : list, default=None
+    If not None, only these columns will be read from the file.
+
+Returns
+-------
+DataFrame
+
+Examples
+--------
+.. code-block:: python
+
+  import cudf
+
+  df = cudf.read_parquet(filename)
+
+  # Display results
+  print(df)
+
+Output:
+
+.. code-block:: python
+
+      num1                datetime text
+    0  123 2018-11-13T12:00:00.000 5451
+    1  456 2018-11-14T12:35:01.000 5784
+    2  789 2018-11-15T18:02:59.000 6117
+
+See Also
+--------
+cudf.io.parquet.to_parquet
+cudf.io.orc.read_orc
+"""
+doc_read_parquet = docfmt_partial(docstring=_docstring_read_parquet)
+
+_docstring_to_parquet = """
+Write a DataFrame to the parquet format.
+
+Parameters
+----------
+path : str
+    File path or Root Directory path. Will be used as Root Directory path
+    while writing a partitioned dataset.
+compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
+    Name of the compression to use. Use ``None`` for no compression.
+index : bool, default None
+    If ``True``, include the dataframe's index(es) in the file output. If
+    ``False``, they will not be written to the file. If ``None``, the
+    engine's default behavior will be used.
+partition_cols : list, optional, default None
+    Column names by which to partition the dataset
+    Columns are partitioned in the order they are given
+
+See Also
+--------
+cudf.io.parquet.read_parquet
+cudf.io.orc.read_orc
+"""
+doc_to_parquet = docfmt_partial(docstring=_docstring_to_parquet)
+
+_docstring_read_orc = """
+Load an orc object from the file path, returning a DataFrame.
+
+Parameters
+----------
+path : string
+    File path
+columns : list, default=None
+    If not None, only these columns will be read from the file.
+kwargs are passed to the engine
+
+Returns
+-------
+DataFrame
+
+Examples
+--------
+.. code-block:: python
+
+  import cudf
+
+  df = cudf.read_orc(filename)
+
+  # Display results
+  print(df)
+
+Output:
+
+.. code-block:: python
+
+    num1                datetime text
+  0  123 2018-11-13T12:00:00.000 5451
+  1  456 2018-11-14T12:35:01.000 5784
+  2  789 2018-11-15T18:02:59.000 6117
+
+See Also
+--------
+cudf.io.parquet.read_parquet
+cudf.io.parquet.to_parquet
+"""
+doc_read_orc = docfmt_partial(docstring=_docstring_read_orc)
+
+_docstring_read_json = """
+Convert a JSON string to a cuDF object.
+
+Parameters
+----------
+path_or_buf : a valid JSON string or file-like, default: None
+    The string could be a URL. Valid URL schemes include http, ftp, s3,
+    gcs, and file. For file URLs, a host is expected. For instance, a local
+    file could be ``file://localhost/path/to/table.json``
+orient : string,
+    Indication of expected JSON string format.
+    Compatible JSON strings can be produced by ``to_json()`` with a
+    corresponding orient value.
+    The set of possible orients is:
+    - ``'split'`` : dict like
+      ``{index -> [index], columns -> [columns], data -> [values]}``
+    - ``'records'`` : list like
+      ``[{column -> value}, ... , {column -> value}]``
+    - ``'index'`` : dict like ``{index -> {column -> value}}``
+    - ``'columns'`` : dict like ``{column -> {index -> value}}``
+    - ``'values'`` : just the values array
+    The allowed and default values depend on the value
+    of the `typ` parameter.
+    * when ``typ == 'series'``,
+      - allowed orients are ``{'split','records','index'}``
+      - default is ``'index'``
+      - The Series index must be unique for orient ``'index'``.
+    * when ``typ == 'frame'``,
+      - allowed orients are ``{'split','records','index',
+        'columns','values', 'table'}``
+      - default is ``'columns'``
+      - The DataFrame index must be unique for orients ``'index'`` and
+        ``'columns'``.
+      - The DataFrame columns must be unique for orients ``'index'``,
+        ``'columns'``, and ``'records'``.
+       'table' as an allowed value for the ``orient`` argument
+typ : type of object to recover (series or frame), default 'frame'
+dtype : boolean or dict, default True
+    If True, infer dtypes, if a dict of column to dtype, then use those,
+    if False, then don't infer dtypes at all, applies only to the data.
+convert_axes : boolean, default True
+    Try to convert the axes to the proper dtypes.
+convert_dates : boolean, default True
+    List of columns to parse for dates; If True, then try to parse
+    datelike columns default is True; a column label is datelike if
+    * it ends with ``'_at'``,
+    * it ends with ``'_time'``,
+    * it begins with ``'timestamp'``,
+    * it is ``'modified'``, or
+    * it is ``'date'``
+keep_default_dates : boolean, default True
+    If parsing dates, then parse the default datelike columns
+numpy : boolean, default False
+    Direct decoding to numpy arrays. Supports numeric data only, but
+    non-numeric column and index labels are supported. Note also that the
+    JSON ordering MUST be the same for each term if numpy=True.
+precise_float : boolean, default False
+    Set to enable usage of higher precision (strtod) function when
+    decoding string to double values. Default (False) is to use fast but
+    less precise builtin functionality
+date_unit : string, default None
+    The timestamp unit to detect if converting dates. The default behaviour
+    is to try and detect the correct precision, but if this is not desired
+    then pass one of 's', 'ms', 'us' or 'ns' to force parsing only seconds,
+    milliseconds, microseconds or nanoseconds respectively.
+encoding : str, default is 'utf-8'
+    The encoding to use to decode py3 bytes.
+lines : boolean, default False
+    Read the file as a json object per line.
+chunksize : integer, default None
+    Return JsonReader object for iteration.
+    See the `line-delimted json docs
+    <http://pandas.pydata.org/pandas-docs/stable/io.html#io-jsonl>`_
+    for more information on ``chunksize``.
+    This can only be passed if `lines=True`.
+    If this is None, the file will be read into memory all at once.
+compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default 'infer'
+    For on-the-fly decompression of on-disk data. If 'infer', then use
+    gzip, bz2, zip or xz if path_or_buf is a string ending in
+    '.gz', '.bz2', '.zip', or 'xz', respectively, and no decompression
+    otherwise. If using 'zip', the ZIP file must contain only one data
+    file to be read in. Set to None for no decompression.
+
+Returns
+-------
+result : Series or DataFrame, depending on the value of `typ`.
+
+See Also
+--------
+.cudf.io.json.to_json
+"""
+doc_read_json = docfmt_partial(docstring=_docstring_read_json)
+
+_docstring_to_json = """
+Convert the cuDF object to a JSON string.
+Note nulls and NaNs will be converted to null and datetime objects
+will be converted to UNIX timestamps.
+
+Parameters
+----------
+path_or_buf : string or file handle, optional
+    File path or object. If not specified, the result is returned as a string.
+orient : string
+    Indication of expected JSON string format.
+    * Series
+        - default is 'index'
+        - allowed values are: {'split','records','index','table'}
+    * DataFrame
+        - default is 'columns'
+        - allowed values are:
+        {'split','records','index','columns','values','table'}
+    * The format of the JSON string
+        - 'split' : dict like {'index' -> [index],
+        'columns' -> [columns], 'data' -> [values]}
+        - 'records' : list like
+        [{column -> value}, ... , {column -> value}]
+        - 'index' : dict like {index -> {column -> value}}
+        - 'columns' : dict like {column -> {index -> value}}
+        - 'values' : just the values array
+        - 'table' : dict like {'schema': {schema}, 'data': {data}}
+        describing the data, and the data component is
+        like ``orient='records'``.
+date_format : {None, 'epoch', 'iso'}
+    Type of date conversion. 'epoch' = epoch milliseconds,
+    'iso' = ISO8601. The default depends on the `orient`. For
+    ``orient='table'``, the default is 'iso'. For all other orients,
+    the default is 'epoch'.
+double_precision : int, default 10
+    The number of decimal places to use when encoding
+    floating point values.
+force_ascii : bool, default True
+    Force encoded string to be ASCII.
+date_unit : string, default 'ms' (milliseconds)
+    The time unit to encode to, governs timestamp and ISO8601
+    precision.  One of 's', 'ms', 'us', 'ns' for second, millisecond,
+    microsecond, and nanosecond respectively.
+default_handler : callable, default None
+    Handler to call if object cannot otherwise be converted to a
+    suitable format for JSON. Should receive a single argument which is
+    the object to convert and return a serialisable object.
+lines : bool, default False
+    If 'orient' is 'records' write out line delimited json format. Will
+    throw ValueError if incorrect 'orient' since others are not list
+    like.
+compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}
+    A string representing the compression to use in the output file,
+    only used when the first argument is a filename. By default, the
+    compression is inferred from the filename.
+index : bool, default True
+    Whether to include the index values in the JSON string. Not
+    including the index (``index=False``) is only supported when
+    orient is 'split' or 'table'.
+See Also
+--------
+.cudf.io.json.read_json
+"""
+doc_to_json = docfmt_partial(docstring=_docstring_to_json)
+
+_docstring_read_hdf = """
+Read from the store, close it if we opened it.
+
+Retrieve pandas object stored in file, optionally based on where
+criteria
+
+Parameters
+----------
+path_or_buf : string, buffer or path object
+    Path to the file to open, or an open `HDFStore
+    <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#hdf5-pytables>`_.
+    object.
+    Supports any object implementing the ``__fspath__`` protocol.
+    This includes :class:`pathlib.Path` and py._path.local.LocalPath
+    objects.
+key : object, optional
+    The group identifier in the store. Can be omitted if the HDF file
+    contains a single pandas object.
+mode : {'r', 'r+', 'a'}, optional
+    Mode to use when opening the file. Ignored if path_or_buf is a
+    `Pandas HDFS
+    <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#hdf5-pytables>`_.
+    Default is 'r'.
+where : list, optional
+    A list of Term (or convertible) objects.
+start : int, optional
+    Row number to start selection.
+stop  : int, optional
+    Row number to stop selection.
+columns : list, optional
+    A list of columns names to return.
+iterator : bool, optional
+    Return an iterator object.
+chunksize : int, optional
+    Number of rows to include in an iteration when using an iterator.
+errors : str, default 'strict'
+    Specifies how encoding and decoding errors are to be handled.
+    See the errors argument for :func:`open` for a full list
+    of options.
+**kwargs
+    Additional keyword arguments passed to HDFStore.
+
+Returns
+-------
+item : object
+    The selected object. Return type depends on the object stored.
+See Also
+--------
+cudf.io.hdf.to_hdf : Write a HDF file from a DataFrame.
+"""
+doc_read_hdf = docfmt_partial(docstring=_docstring_read_hdf)
+
+_docstring_to_hdf = """
+Write the contained data to an HDF5 file using HDFStore.
+
+Hierarchical Data Format (HDF) is self-describing, allowing an
+application to interpret the structure and contents of a file with
+no outside information. One HDF file can hold a mix of related objects
+which can be accessed as a group or as individual objects.
+
+In order to add another DataFrame or Series to an existing HDF file
+please use append mode and a different a key.
+
+For more information see the `user guide
+<https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#hdf5-pytables>`_.
+
+Parameters
+----------
+path_or_buf : str or pandas.HDFStore
+    File path or HDFStore object.
+key : str
+    Identifier for the group in the store.
+mode : {'a', 'w', 'r+'}, default 'a'
+    Mode to open file:
+
+    - 'w': write, a new file is created (an existing file with the same name
+      would be deleted).
+    - 'a': append, an existing file is opened for reading and writing, and if
+      the file does not exist it is created.
+    - 'r+': similar to 'a', but the file must already exist.
+format : {'fixed', 'table'}, default 'fixed'
+    Possible values:
+
+    - 'fixed': Fixed format. Fast writing/reading. Not-appendable,
+    nor searchable.
+    - 'table': Table format. Write as a PyTables Table structure
+    which may perform worse but allow more flexible operations
+    like searching / selecting subsets of the data.
+append : bool, default False
+    For Table formats, append the input data to the existing.
+data_columns :  list of columns or True, optional
+    List of columns to create as indexed data columns for on-disk
+    queries, or True to use all columns. By default only the axes
+    of the object are indexed. See `Query via Data Columns
+    <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-hdf5-query-data-columns>`_.
+    Applicable only to format='table'.
+complevel : {0-9}, optional
+    Specifies a compression level for data.
+    A value of 0 disables compression.
+complib : {'zlib', 'lzo', 'bzip2', 'blosc'}, default 'zlib'
+    Specifies the compression library to be used.
+    As of v0.20.2 these additional compressors for Blosc are supported
+    (default if no compressor specified: 'blosc:blosclz'):
+    {'blosc:blosclz', 'blosc:lz4', 'blosc:lz4hc', 'blosc:snappy',
+    'blosc:zlib', 'blosc:zstd'}.
+    Specifying a compression library which is not available issues
+    a ValueError.
+fletcher32 : bool, default False
+    If applying compression use the fletcher32 checksum.
+dropna : bool, default False
+    If true, ALL nan rows will not be written to store.
+errors : str, default 'strict'
+    Specifies how encoding and decoding errors are to be handled.
+    See the errors argument for :func:`open` for a full list
+    of options.
+
+See Also
+--------
+cudf.io.hdf.read_hdf : Read from HDF file.
+cudf.io.parquet.to_parquet : Write a DataFrame to the binary parquet format.
+cudf.io.feather..to_feather : Write out feather-format for DataFrames.
+"""
+doc_to_hdf = docfmt_partial(docstring=_docstring_to_hdf)
+
+_docstring_read_feather = """
+Load an feather object from the file path, returning a DataFrame.
+
+Parameters
+----------
+path : string
+    File path
+columns : list, default=None
+    If not None, only these columns will be read from the file.
+
+Returns
+-------
+DataFrame
+
+Examples
+--------
+.. code-block:: python
+
+  import cudf
+
+  df = cudf.read_feather(filename)
+
+  print(df)
+
+Output:
+
+.. code-block:: python
+
+      num1                datetime text
+    0  123 2018-11-13T12:00:00.000 5451
+    1  456 2018-11-14T12:35:01.000 5784
+    2  789 2018-11-15T18:02:59.000 6117
+
+See Also
+--------
+cudf.io.feather.to_feather
+"""
+doc_read_feather = docfmt_partial(docstring=_docstring_read_feather)
+
+_docstring_to_feather = """
+Write a DataFrame to the feather format.
+
+Parameters
+----------
+path : str
+    File path
+
+See Also
+--------
+cudf.io.feather.read_feather
+"""
+doc_to_feather = docfmt_partial(docstring=_docstring_to_feather)


### PR DESCRIPTION
1. Fixing broken Series API docs
2. Adding Parquet, ORC, JSON, Feather, HDF file reader/writers to API docs
3. Moving the above io module docstrings to cudf/python/utils/ioutils.py:

These docstrings are currently repeated in cudf/python/dataframe/dataframe.py and cudf/io/${type}.py, moving to ioutils eliminates the duplicated content

4. Fixing flake8 issues with a couple of cpp/python tests
5. Fixing docstring formatting for DataFrame/Series methods