### PR TITLE
[REVIEW] Better Concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - PR #998 Add IO reader/writer modules to API docs, fix for missing cudf.Series docs
 - PR #1017 concatenate along columns for Series and DataFrames
 - PR #1002 Support indexing a dataframe with another boolean dataframe
+- PR #1018 Better concatenation for Series and Dataframes
 
 ## Bug Fixes
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -955,13 +955,6 @@ class DataFrame(object):
     @classmethod
     def _concat(cls, objs, axis=0, ignore_index=False):
         nvtx_range_push("CUDF_CONCAT", "orange")
-        if axis == 1:
-            df = DataFrame()
-            for o in objs:
-                for col in o.columns:
-                    df[col] = o[col]
-            return df
-
         if len(set(frozenset(o.columns) for o in objs)) != 1:
             what = set(frozenset(o.columns) for o in objs)
             raise ValueError('columns mismatch: {}'.format(what))

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -495,13 +495,6 @@ class Series(object):
     @classmethod
     def _concat(cls, objs, axis=0, index=True):
         # Concatenate index if not provided
-        if axis == 1:
-            from cudf import DataFrame
-            df = DataFrame()
-            for o in objs:
-                df[o.name] = o
-            return df
-
         if index is True:
             index = Index._concat([o.index for o in objs])
 

--- a/python/cudf/multi.py
+++ b/python/cudf/multi.py
@@ -26,6 +26,23 @@ def concat(objs, axis=0, ignore_index=False):
         return objs[0]
 
     typs = set(type(o) for o in objs)
+    allowed_typs = {Series, DataFrame}
+    # when axis is 1 (column) we can concat with Series and Dataframes
+    if axis == 1:
+        assert typs.issubset(allowed_typs)
+        df = DataFrame()
+        for idx, o in enumerate(objs):
+            if isinstance(o, Series):
+                name = o.name
+                if o.name is None:
+                    # pandas uses 0-offset
+                    name = idx - 1
+                df[name] = o
+            else:
+                for col in o.columns:
+                    df[col] = o[col]
+        return df
+
     if len(typs) > 1:
         raise ValueError("`concat` expects all objects to be of the same "
                          "type. Got mix of %r." % [t.__name__ for t in typs])

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -973,15 +973,25 @@ def test_concat_with_axis():
     cdf1 = gd.from_pandas(df1)
     cdf2 = gd.from_pandas(df2)
 
+    # concat only dataframes
     concat_cdf = gd.concat([cdf1, cdf2], axis=1)
     assert_eq(concat_cdf, concat_df)
 
+    # concat only series
     concat_s = pd.concat([df1.x, df1.y], axis=1)
-    s1 = gd.Series.from_pandas(df1.x)
-    s2 = gd.Series.from_pandas(df1.y)
-    concat_cdf_s = gd.concat([s1, s2], axis=1)
+    cs1 = gd.Series.from_pandas(df1.x)
+    cs2 = gd.Series.from_pandas(df1.y)
+    concat_cdf_s = gd.concat([cs1, cs2], axis=1)
 
     assert_eq(concat_cdf_s, concat_s)
+
+    # concat series and dataframes
+    s3 = pd.Series(np.random.random(5))
+    cs3 = gd.Series.from_pandas(s3)
+
+    concat_cdf_all = gd.concat([cdf1, cs3, cdf2], axis=1)
+    concat_df_all = pd.concat([df1, s3, df2], axis=1)
+    assert_eq(concat_cdf_all, concat_df_all)
 
 
 @pytest.mark.parametrize('nrows', [0, 3, 10, 100, 1000])


### PR DESCRIPTION
This PR improves the naive approach of concatenation for Series and Dataframes.  Code is now in one files (multi.py) and handle concatenation of `Series` and `Dataframes` together.


cc @mrocklin @kkraus14 