### PR TITLE
[REVIEW] Added default constructor for SerialTrieNode to solve Thrust bug on CentOS7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - PR #1002 Support indexing a dataframe with another boolean dataframe
 - PR #1018 Better concatenation for Series and Dataframes
 - PR #1047 Adding gdf_dtype_extra_info to gdf_column_view_augmented
+- PR #1054 Added default ctor to SerialTrieNode to overcome Thrust issue in CentOS7 + CUDA10
 
 
 ## Bug Fixes

--- a/cpp/src/utilities/trie.cuh
+++ b/cpp/src/utilities/trie.cuh
@@ -33,6 +33,7 @@ struct SerialTrieNode {
 	int16_t children_offset = -1;
 	char character;
 	bool is_leaf;
+    SerialTrieNode() = default; // FIXME This is necessary for a Thrust bug on CentOS7 + CUDA10
 	explicit SerialTrieNode(char c, bool leaf = false) noexcept
 		: character(c), is_leaf(leaf) {}
 };

--- a/cpp/src/utilities/trie.cuh
+++ b/cpp/src/utilities/trie.cuh
@@ -29,16 +29,16 @@
 #include <cuda_runtime.h>
 #include <thrust/host_vector.h>
 
+static constexpr char trie_terminating_character = '\n';
+
 struct SerialTrieNode {
-	int16_t children_offset = -1;
-	char character;
-	bool is_leaf;
+	int16_t children_offset{-1};
+	char character{trie_terminating_character};
+	bool is_leaf{false};
     SerialTrieNode() = default; // FIXME This is necessary for a Thrust bug on CentOS7 + CUDA10
 	explicit SerialTrieNode(char c, bool leaf = false) noexcept
 		: character(c), is_leaf(leaf) {}
 };
-
-static constexpr char trie_terminating_character = '\n';
 
 
 /**---------------------------------------------------------------------------*


### PR DESCRIPTION
@mike-wendt reported an error in building libcudf on CentOS7 + CUDA10.

I triaged the issue, and it appears to be some failure in the combination of CUDA10 Thrust + CentOS7 libc++. 

I isolated to a more minimal reproducer:

```
// compile with nvcc --std=c++11 ./test.cu
#include <thrust/device_vector.h>
#include <thrust/host_vector.h>

struct foo {
  //foo() = default; // This code will fail to compile on CentOS7 + CUDA10 without a default ctor
  foo(int n) : value{n} { }
  int value;
};

thrust::host_vector<foo> return_vector(){
  thrust::host_vector<foo> h_vec;
  h_vec.push_back(foo{0});
  return h_vec;
}

int main(void){
  thrust::device_vector<foo> d_vec = return_vector();
}
```

It appears that adding a default constructor for `SerialTrieNode` solved the problem. 