### PR TITLE
[WIP] CUDF Interchange Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PR #947 Prefixsum to handle nulls and float types
 - PR #1029 Remove rest of relative path imports
 - PR #1021 Add filtered selection with assignment for Dataframes
+- PR #1065 Add CUDF Interchange Format to simplify data exchange to/from XGBoost
 
 ## Improvements
 

--- a/cpp/include/cudf/io_functions.h
+++ b/cpp/include/cudf/io_functions.h
@@ -21,3 +21,5 @@
 gdf_error read_csv(csv_read_arg *args);
 
 gdf_error gdf_to_csr(gdf_column **gdfData, int num_cols, csr_gdf *csrReturn);
+
+gdf_error gdf_to_interchange(gdf_column ** cols, int * n_cols, gdf_interchange_column ** intc_cols);

--- a/cpp/src/io/convert/interchange/interchange.cpp
+++ b/cpp/src/io/convert/interchange/interchange.cpp
@@ -1,0 +1,7 @@
+#include "interchange.h"
+
+gdf_error gdf_to_interchange(gdf_column ** cols,
+                             int * n_cols,
+                             gdf_interchange_column ** intc_cols) {
+
+}

--- a/cpp/src/io/convert/interchange/interchange.h
+++ b/cpp/src/io/convert/interchange/interchange.h
@@ -1,0 +1,44 @@
+#include "cudf.h"
+#include "utilities/error_utils.h"
+#include "rmm/rmm.h"
+#include "rmm/thrust_rmm_allocator.h"
+
+#include <thrust/scan.h>
+#include <thrust/execution_policy.h>
+
+typedef unsigned char gdf_interchange_valid_type;
+typedef int32_t
+    gdf_interchange_size_type;  // Limits the maximum size of a
+                                 // gdf_interchange_column to 2^31-1
+typedef enum {
+  invalid = 0,
+  INT8,
+  INT16,
+  INT32,
+  INT64,
+  FLOAT32,
+  FLOAT64,
+} gdf_interchange_dtype;
+
+// We define a simple interchange format loosely based on the internal column
+// structure of gdf (cuda data frame). gdf is responsible for passing this
+// exact structure to the xgboost C API for DMatrix construction. The decoupled
+// interchange format means xgboost does not depend on the specific internal
+// structure of gdf which may change.
+
+typedef struct gdf_interchange_column_ {
+  void* data;  // Pointer to the columns data
+  gdf_interchange_valid_type*
+      valid;  // Pointer to the columns validity bit mask where the
+              // 'i'th bit indicates if the 'i'th row is NULL
+  gdf_interchange_size_type size;  // Number of data elements in the columns
+                                    // data buffer. Limited to 2^31 - 1.
+  gdf_interchange_dtype dtype;     // The datatype of the column's data
+  int32_t null_count;  // The number of NULL values in the column's data
+  char* col_name;      // host-side: null terminated string
+  gdf_interchange_column_() {
+    static_assert(sizeof(gdf_interchange_column_) == 40,
+                  "If this static assert fails, the compiler is not supported "
+                  "- please file an issue");
+  }
+} gdf_interchange_column;


### PR DESCRIPTION
This PR adds initial support for data exchange between `cudf` and `xgboost`. It is matched by the [XGB CUDF Integration PR](https://github.com/dmlc/xgboost/pull/3997).

- [x] Add minimalist columnar data structure for numeric types, called `gdf_interchange_column`
- [ ] Add function to `export` a `gdf_column` type to `gdf_interchange_column` type
- [ ] Add C API for `interchange`
- [ ] Add C++ API for Google Tests for the above
- [ ] Add Python cuDF `Dataframe.to_interchange(...)` and `Dataframe.from_interchange(...)`
- [ ] Add `pytest`s for the above