### PR TITLE
[REVIEW] CSV Reader: Fix an issue where a column name includes the return character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - PR #1044 CSV Reader: Fix a segfault when byte range aligns with a page
 - PR #1058 Added support for `DataFrame.loc[scalar]`
 - PR #1060 Fix column creation with all valid nan values
+- PR #1073 CSV Reader: Fix an issue where a column name includes the return character
 
 
 # cuDF 0.5.1 (05 Feb 2019)

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -255,12 +255,20 @@ gdf_error setColumnNamesFromCsv(raw_csv_t* raw_csv) {
 				 first_row[pos] == raw_csv->opts.terminator)) {
 			// Got to the end of a column
 			if (raw_csv->header_row >= 0) {
-				// first_row is the header, add the column name
-				string new_col_name(first_row.data() + prev, pos - prev);
+				// First_row is the header, add the column name
+				int col_name_len = pos - prev;
+				// Exclude '\r' character at the end of the column name if it's part of the terminator
+				if (col_name_len > 0 &&
+					raw_csv->opts.terminator == '\n' &&
+					first_row[pos] == '\n' &&
+					first_row[pos - 1] == '\r') {
+						--col_name_len;
+					}
+				const string new_col_name(first_row.data() + prev, col_name_len);
 				raw_csv->col_names.push_back(removeQuotes(new_col_name, raw_csv->opts.quotechar));
 			}
 			else {
-				// first_row is the first data row, add the automatically generated name
+				// First_row is the first data row, add the automatically generated name
 				raw_csv->col_names.push_back(raw_csv->prefix + std::to_string(num_cols));
 			}
 			num_cols++;

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -685,21 +685,19 @@ def test_csv_reader_filenotfound(tmpdir):
 
 
 def test_csv_reader_carriage_return(tmpdir):
-
-    fname = tmpdir.mkdir("gdf_csv").join("tmp_csvreader_file16.csv")
-
     rows = 1000
+    names = ['int_row', 'int_double_row']
 
-    with open(str(fname), 'w') as fp:
-        for i in range(rows):
-            fp.write(str(i) + ', ' + str(2*i) + '\r\n')
+    buffer = ','.join(names) + '\r\n'
+    for row in range(rows):
+        buffer += str(row) + ', ' + str(2*row) + '\r\n'
 
-    df = read_csv(str(fname), names=["int1", "int2"])
+    df = read_csv(StringIO(buffer))
 
     assert(len(df) == rows)
     for row in range(0, rows):
-        assert(df['int1'][row] == row)
-        assert(df['int2'][row] == 2 * row)
+        assert(df[names[0]][row] == row)
+        assert(df[names[1]][row] == 2 * row)
 
 
 def test_csv_reader_bzip2_compression(tmpdir):


### PR DESCRIPTION
Fixes #1051 

* Exclude the last character in the column name when the terminator follows it, when using \r\n as the line terminating sequence.
* Modify a test to check the column names when \r\n is used as line terminator.