### PR TITLE
[REVIEW] CSV Reader: Minor fixes and memory usage improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - PR #1058 Added support for `DataFrame.loc[scalar]`
 - PR #1060 Fix column creation with all valid nan values
 - PR #1073 CSV Reader: Fix an issue where a column name includes the return character
+- PR #1102 CSV Reader: Minor fixes and memory usage improvements
 
 
 # cuDF 0.5.1 (05 Feb 2019)

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -239,7 +239,7 @@ gdf_error setColumnNamesFromCsv(raw_csv_t* raw_csv) {
 			first_row_len = raw_csv->num_bytes / sizeof(char);
 		}
 		first_row.resize(first_row_len);
-		CUDA_TRY(cudaMemcpy(first_row.data(), raw_csv->data, raw_csv->num_bytes, cudaMemcpyDefault));
+		CUDA_TRY(cudaMemcpy(first_row.data(), raw_csv->data, first_row_len * sizeof(char), cudaMemcpyDefault));
 	}
 
 	int num_cols = 0;

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -782,6 +782,7 @@ gdf_error read_csv(csv_read_arg *args)
 	free(h_dtypes);
 	free(h_valid);
 	free(h_data);
+	free(raw_csv->h_parseCol);
 
 	if (raw_csv->num_records != 0) {
 		error = launch_dataConvertColumns(raw_csv, d_data, d_valid, d_dtypes, d_str_cols, d_valid_count);
@@ -790,7 +791,16 @@ gdf_error read_csv(csv_read_arg *args)
 		}
 		// Sync with the default stream, just in case create_from_index() is asynchronous 
 		CUDA_TRY(cudaStreamSynchronize(0));
+	}
 
+	// Free buffers that are not used from this point on
+	RMM_TRY( RMM_FREE( d_data, 0 ) );
+	RMM_TRY( RMM_FREE ( raw_csv->recStart, 0) );
+	RMM_TRY( RMM_FREE( raw_csv->d_parseCol, 0 ) );
+	RMM_TRY( RMM_FREE( d_dtypes, 0 ) );
+	RMM_TRY( RMM_FREE( d_valid, 0 ) );
+
+	if (raw_csv->num_records != 0) {
 		stringColCount=0;
 		for (int col = 0; col < raw_csv->num_active_cols; col++) {
 
@@ -800,6 +810,8 @@ gdf_error read_csv(csv_read_arg *args)
 				continue;
 
 			NVStrings* const stringCol = NVStrings::create_from_index(h_str_cols[stringColCount],size_t(raw_csv->num_records));
+			RMM_TRY( RMM_FREE( h_str_cols [stringColCount], 0 ) );
+
 			if ((raw_csv->opts.quotechar != '\0') && (raw_csv->opts.doublequote==true)) {
 				// In PANDAS, default of enabling doublequote for two consecutive
 				// quotechar in quote fields results in reduction to single
@@ -811,8 +823,6 @@ gdf_error read_csv(csv_read_arg *args)
 			else {
 				gdf->data = stringCol;
 			}
-
-			RMM_TRY( RMM_FREE( h_str_cols [stringColCount], 0 ) );
 
 			stringColCount++;
 		}
@@ -826,24 +836,10 @@ gdf_error read_csv(csv_read_arg *args)
 		}
 	}
 
-	// free up space that is no longer needed
-	if (h_str_cols != NULL)
-		free ( h_str_cols);
-
-	free(raw_csv->h_parseCol);
-
-	if (d_str_cols != NULL)
-		RMM_TRY( RMM_FREE( d_str_cols, 0 ) ); 
-
-	RMM_TRY( RMM_FREE( d_valid, 0 ) );
+	// Free up remaining internal buffers
 	RMM_TRY( RMM_FREE( d_valid_count, 0 ) );
-	RMM_TRY( RMM_FREE( d_dtypes, 0 ) );
-	RMM_TRY( RMM_FREE( d_data, 0 ) ); 
 
-	RMM_TRY( RMM_FREE( raw_csv->recStart, 0 ) ); 
-	RMM_TRY( RMM_FREE( raw_csv->d_parseCol, 0 ) ); 
 	RMM_TRY( RMM_FREE ( raw_csv->data, 0) );
-
 
 	args->data 			= cols;
 	args->num_cols_out	= raw_csv->num_active_cols;

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -581,7 +581,6 @@ def read_csv_strings(filepath_or_buffer, lineterminator='\n',
     csv_reader.skipinitialspace = skipinitialspace
     csv_reader.dayfirst = dayfirst
     csv_reader.header = header_infer
-    csv_reader.num_cols = len(names)
     csv_reader.skiprows = skiprows
     csv_reader.skipfooter = skipfooter
     csv_reader.compression = compression_bytes


### PR DESCRIPTION
Issue #1049 

* Free memory buffers immediately after last use to lower the peak memory consumption with NVString columns;
* Fix a heap corruption issue caused by incorrect copy size when header=None and names=None;
* Remove an outdated line of code in read_csv_strings(), that causes issues when using this function with names=None;