### PR TITLE
[REVIEW] Return a Series (not a Column) in Series.cat.set_categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - PR #1092 Fix select_dtype docstring
 - PR #1111 Added cudf::table
 - PR #1108 Sorting for datetime columns
+- PR #1120 Return a `Series` (not a `Column`) from `Series.cat.set_categories()`
 
 ## Bug Fixes
 

--- a/cpp/tests/table/table_tests.cu
+++ b/cpp/tests/table/table_tests.cu
@@ -21,6 +21,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <random>
+
 template <typename T>
 struct TableTest : public GdfTest {
   std::default_random_engine generator;

--- a/python/cudf/dataframe/column.py
+++ b/python/cudf/dataframe/column.py
@@ -55,7 +55,7 @@ class Column(object):
         # Handle categories for categoricals
         if all(isinstance(o, CategoricalColumn) for o in objs):
             new_cats = tuple(set([val for o in objs for val in o]))
-            objs = [o.cat().set_categories(new_cats) for o in objs]
+            objs = [o.cat()._set_categories(new_cats) for o in objs]
 
         head = objs[0]
         for o in objs:

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -1379,16 +1379,16 @@ class DataFrame(object):
                 rcats = rhs[name].cat.categories
                 if how == 'rhs':
                     cats = rcats
-                    lhs[name] = (lhs[name].cat.set_categories(cats)
+                    lhs[name] = (lhs[name].cat._set_categories(cats)
                                  .fillna(-1))
                 elif how in ['inner', 'outer']:
                     # Do the join using the union of categories from both side.
                     # Adjust for inner joins afterwards
                     cats = sorted(set(lcats) | set(rcats))
-                    lhs[name] = (lhs[name].cat.set_categories(cats)
+                    lhs[name] = (lhs[name].cat._set_categories(cats)
                                  .fillna(-1))
                     lhs[name] = lhs[name]._column.as_numerical
-                    rhs[name] = (rhs[name].cat.set_categories(cats)
+                    rhs[name] = (rhs[name].cat._set_categories(cats)
                                  .fillna(-1))
                     rhs[name] = rhs[name]._column.as_numerical
                 col_cats[name] = cats
@@ -1398,16 +1398,16 @@ class DataFrame(object):
                 rcats = rhs[name].cat.categories
                 if how == 'left':
                     cats = lcats
-                    rhs[name] = (rhs[name].cat.set_categories(cats)
+                    rhs[name] = (rhs[name].cat._set_categories(cats)
                                  .fillna(-1))
                 elif how in ['inner', 'outer']:
                     # Do the join using the union of categories from both side.
                     # Adjust for inner joins afterwards
                     cats = sorted(set(lcats) | set(rcats))
-                    lhs[name] = (lhs[name].cat.set_categories(cats)
+                    lhs[name] = (lhs[name].cat._set_categories(cats)
                                  .fillna(-1))
                     lhs[name] = lhs[name]._column.as_numerical
-                    rhs[name] = (rhs[name].cat.set_categories(cats)
+                    rhs[name] = (rhs[name].cat._set_categories(cats)
                                  .fillna(-1))
                     rhs[name] = rhs[name]._column.as_numerical
                 col_cats[name] = cats
@@ -1598,23 +1598,23 @@ class DataFrame(object):
             if how == 'left':
                 cats = lcats
                 rhs[idx_col_name] = (rhs[idx_col_name].cat
-                                                      .set_categories(cats)
+                                                      ._set_categories(cats)
                                                       .fillna(-1))
             elif how == 'right':
                 cats = rcats
                 lhs[idx_col_name] = (lhs[idx_col_name].cat
-                                                      .set_categories(cats)
+                                                      ._set_categories(cats)
                                                       .fillna(-1))
             elif how in ['inner', 'outer']:
                 cats = sorted(set(lcats) | set(rcats))
 
                 lhs[idx_col_name] = (lhs[idx_col_name].cat
-                                                      .set_categories(cats)
+                                                      ._set_categories(cats)
                                                       .fillna(-1))
                 lhs[idx_col_name] = lhs[idx_col_name]._column.as_numerical
 
                 rhs[idx_col_name] = (rhs[idx_col_name].cat
-                                                      .set_categories(cats)
+                                                      ._set_categories(cats)
                                                       .fillna(-1))
                 rhs[idx_col_name] = rhs[idx_col_name]._column.as_numerical
 

--- a/python/cudf/tests/test_categorical.py
+++ b/python/cudf/tests/test_categorical.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 from cudf.dataframe import Series, DataFrame
+from cudf.tests.utils import assert_eq
 
 
 def test_categorical_basic():
@@ -342,3 +343,19 @@ def test_categorical_empty():
     np.testing.assert_array_equal(pdsr.cat.codes.values,
                                   sr.cat.codes.to_array())
     np.testing.assert_array_equal(pdsr.cat.codes.dtype, sr.cat.codes.dtype)
+
+
+def test_categorical_set_categories():
+    cat = pd.Categorical(['a', 'a', 'b', 'c', 'a'], categories=['a', 'b', 'c'])
+    psr = pd.Series(cat)
+    sr = Series.from_categorical(cat)
+
+    # adding category
+    expect = psr.cat.set_categories(['a', 'b', 'c', 'd'])
+    got = sr.cat.set_categories(['a', 'b', 'c', 'd'])
+    assert_eq(expect, got)
+
+    # removing category
+    expect = psr.cat.set_categories(['a', 'b'])
+    got = sr.cat.set_categories(['a', 'b'])
+    assert_eq(expect, got)


### PR DESCRIPTION
This PR introduces the following changes:

* `set_categories()` now returns a `Series` (the appropriate return type since it is part of the public API).
*  The old `set_categories()` is renamed to `_set_categories()` which can be used internally when a `Column` is needed.