### PR TITLE
[REVIEW] cudf.sqrt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - PR #1091 Add `indicator=` and `suffixes=` keywords to merge
 - PR #1107 Add unsupported keywords to Series.fillna
 - PR #1136 Removed `gdf_concat` 
+- PR #1148 Add cudf.sqrt for dataframes and Series
 
 ## Improvements
 

--- a/python/cudf/__init__.py
+++ b/python/cudf/__init__.py
@@ -10,6 +10,7 @@ from cudf.io import (read_csv, read_parquet, read_feather, read_json,
                      read_hdf, read_orc)
 from cudf.settings import set_options
 from cudf.reshape import melt
+from cudf.ops import sqrt
 
 
 # Versioneer

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -416,7 +416,10 @@ class DataFrame(object):
     def _call_op(self, other, internal_fn, fn):
         result = DataFrame()
         result.set_index(self.index)
-        if isinstance(other, Sequence):
+        if other is self:
+            for col in self._cols:
+                result[col] = self._cols[col]._unaryop(fn)
+        elif isinstance(other, Sequence):
             for k, col in enumerate(self._cols):
                 result[col] = getattr(self._cols[col], internal_fn)(
                         other[k],

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -416,7 +416,7 @@ class DataFrame(object):
     def _call_op(self, other, internal_fn, fn):
         result = DataFrame()
         result.set_index(self.index)
-        if other is self:
+        if internal_fn == '_unaryop':
             for col in self._cols:
                 result[col] = self._cols[col]._unaryop(fn)
         elif isinstance(other, Sequence):

--- a/python/cudf/dataframe/numerical.py
+++ b/python/cudf/dataframe/numerical.py
@@ -50,6 +50,7 @@ _binary_impl = {
 _unary_impl = {
     'ceil': libgdf.gdf_ceil_generic,
     'floor': libgdf.gdf_floor_generic,
+    'sqrt': libgdf.gdf_sqrt_generic,
 }
 
 

--- a/python/cudf/ops.py
+++ b/python/cudf/ops.py
@@ -1,6 +1,10 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
 
 import numpy as np
 from numbers import Number
+
+""" Global __array_ufunc__ methods
+"""
 
 
 def sqrt(arbitrary):

--- a/python/cudf/ops.py
+++ b/python/cudf/ops.py
@@ -1,4 +1,10 @@
 
+import numpy as np
+from numbers import Number
+
 
 def sqrt(arbitrary):
-    return arbitrary._unaryop('sqrt')
+    if isinstance(arbitrary, Number):
+        return np.sqrt(arbitrary)
+    else:
+        return arbitrary._unaryop('sqrt')

--- a/python/cudf/ops.py
+++ b/python/cudf/ops.py
@@ -1,0 +1,4 @@
+
+
+def sqrt(arbitrary):
+    return arbitrary._unaryop('sqrt')

--- a/python/cudf/tests/test_ops.py
+++ b/python/cudf/tests/test_ops.py
@@ -1,0 +1,20 @@
+
+import pytest
+
+import cudf
+from cudf.tests.utils import assert_eq
+
+
+def test_sqrt_float():
+    assert cudf.sqrt(16.0) == 4.0
+    assert_eq(cudf.sqrt(cudf.Series([4.0, 9, 16])), cudf.Series([2.0, 3, 4]))
+    assert_eq(cudf.sqrt(cudf.DataFrame({'x': [4.0, 9, 16]})),
+              cudf.DataFrame({'x': [2.0, 3, 4]}))
+
+
+@pytest.mark.xfail(reason="integer sqrt results in GDF_UNSUPPORTED_DTYPE")
+def test_sqrt_integer():
+    assert cudf.sqrt(16) == 4
+    assert_eq(cudf.sqrt(cudf.Series([4, 9, 16])), cudf.Series([2, 3, 4]))
+    assert_eq(cudf.sqrt(cudf.DataFrame({'x': [4, 9, 16]})),
+              cudf.DataFrame({'x': [2, 3, 4]}))


### PR DESCRIPTION
Fixes #1055. Sets a simple template for improving all unaryops and extending them from libgdf. Cython has to be this simple.