### PR TITLE
[REVIEW] Copy null_count from result in mimic_inplace()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@
 - PR #1118 Enhanced the `DataFrame.from_records()` feature
 - PR #1129 Fix join performance with index parameter from using numpy array
 - PR #1145 Issue with .agg call on multi-column dataframes
+- PR #1167 Fix issue with null_count not being set after inplace fillna()
 
 
 # cuDF 0.5.1 (05 Feb 2019)

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -74,6 +74,7 @@ class TypedColumnBase(Column):
         if inplace:
             self._data = result._data
             self._mask = result._mask
+            self._null_count = result._null_count
         else:
             return result
 

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -65,11 +65,10 @@ class TypedColumnBase(Column):
 
     def _mimic_inplace(self, result, inplace=False):
         """
-        Used to mimic an inplace operation by copying data from the
-        result of an out-of-place operation.
+        If `inplace=True`, used to mimic an inplace operation
+        by replacing data in ``self`` with data in ``result``.
 
-        If ``inplace`` is ``True``, copy data from ``result`` to ``self``.
-        Otherwise, return ``result`` unchanged.
+        Otherwise, returns ``result`` unchanged.
         """
         if inplace:
             self._data = result._data


### PR DESCRIPTION
Quick fix to `_mimic_inplace()` that ensures that the `null_count` is properly set after an inplace operation.