### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "thirdparty/rmm"]
 	path = thirdparty/rmm
 	url = https://github.com/rapidsai/rmm.git
-	branch = branch-0.6
+	branch = master
 [submodule "thirdparty/dlpack"]
 	path = thirdparty/dlpack
 	url = https://github.com/rapidsai/dlpack.git


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.