### PR TITLE
[REVIEW]Fix dtypes issue #1172 while adding a col to empty object dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Bug Fixes
 
-...
+- PR #1233 Fix dtypes issue while adding the column to `str` dataframe.
 
 
 # cuDF 0.6.0 (Date TBD)

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -736,7 +736,10 @@ class DataFrame(object):
         series = Series(col)
         if len(self) == 0 and len(self.columns) > 0 and len(series) > 0:
             ind = series.index
-            arr = rmm.device_array(shape=len(ind), dtype=np.float64)
+            dtype = np.float64
+            if self[next(iter(self._cols))].dtype == np.dtype("object"):
+                dtype = np.dtype("object")
+            arr = rmm.device_array(shape=len(ind), dtype=dtype)
             size = utils.calc_chunk_size(arr.size, utils.mask_bitsize)
             mask = cudautils.zeros(size, dtype=utils.mask_dtype)
             val = Series.from_masked_array(arr, mask, null_count=len(ind))

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -695,6 +695,25 @@ def test_dataframe_dtypes():
     assert df.dtypes.equals(dtypes)
 
 
+def test_dataframe_add_col_to_object_dataframe():
+    # Test for adding column to an empty object dataframe
+    cols = ['a', 'b', 'c']
+    df = pd.DataFrame(columns=cols, dtype='str')
+
+    data = {k: v for (k, v) in zip(cols, [['a'] for _ in cols])}
+
+    gdf = DataFrame(data)
+    gdf = gdf[:0]
+
+    assert gdf.dtypes.equals(df.dtypes)
+    gdf['a'] = [1]
+    df['a'] = [10]
+    assert gdf.dtypes.equals(df.dtypes)
+    gdf['b'] = [1.0]
+    df['b'] = [10.0]
+    assert gdf.dtypes.equals(df.dtypes)
+
+
 def test_dataframe_dir_and_getattr():
     df = DataFrame([('a', np.ones(10)),
                     ('b', np.ones(10)),


### PR DESCRIPTION
This PR fixes the issue #1172 . There is very minor change in `dataframe._sanitize_columns()` in order to handle this.