### PR TITLE
[REVIEW] Improve performance of the CUDA trie used in the CSV reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - PR #1202 Simplify README.md
 - PR #1149 CSV Reader: Change convertStrToValue() functions to `__device__` only
+- PR #1238 Improve performance of the CUDA trie used in the CSV reader
 
 ## Bug Fixes
 


### PR DESCRIPTION
Issue #716 

* Each array of child nodes in a trie is sorted in the ascending order. Once the current node is larger than the key character we are looking for, we can terminate the search and return false.
* This PR modifies serializedTrieContains() to make use of this property to improve trie performance.
* The performance improvement should be the largest for number fields, where the search will terminate after a single comparison.