### PR TITLE
Fix nvstrings version in cudf_dev.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@
 - PR #1185 Support left_on/right_on and also on=str in merge
 - PR #1200 Fix allocating bitmasks with numba instead of rmm in allocate_mask function
 - PR #1223 gpuCI: Fix label on rapidsai channel on gpu build scripts
+- PR #1240 Fix nvstrings version in cudf_dev.yml
 
 
 # cuDF 0.5.1 (05 Feb 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@
 - PR #1185 Support left_on/right_on and also on=str in merge
 - PR #1200 Fix allocating bitmasks with numba instead of rmm in allocate_mask function
 - PR #1223 gpuCI: Fix label on rapidsai channel on gpu build scripts
+- PR #1246 Fix categorical tests that failed due to bad implicit type conversion
 - PR #1240 Fix nvstrings version in cudf_dev.yml
 
 

--- a/conda/environments/cudf_dev.yml
+++ b/conda/environments/cudf_dev.yml
@@ -13,7 +13,7 @@ dependencies:
 - pyarrow=0.12.1
 - notebook>=0.5.0
 - boost
-- nvstrings
+- nvstrings>=0.3.0
 - cffi>=1.10.0   
 - distributed>=1.23.0
 - cython>=0.29,<0.30

--- a/python/cudf/tests/test_categorical.py
+++ b/python/cudf/tests/test_categorical.py
@@ -68,12 +68,12 @@ def test_categorical_compare_unordered():
     out = sr == sr
     assert out.dtype == np.bool_
     assert type(out[0]) == np.bool_
-    assert np.all(out)
+    assert np.all(out.to_array())
     assert np.all(pdsr == pdsr)
 
     # test inequal
     out = sr != sr
-    assert not np.any(out)
+    assert not np.any(out.to_array())
     assert not np.any(pdsr != pdsr)
 
     assert not pdsr.cat.ordered
@@ -105,12 +105,12 @@ def test_categorical_compare_ordered():
     out = sr1 == sr1
     assert out.dtype == np.bool_
     assert type(out[0]) == np.bool_
-    assert np.all(out)
+    assert np.all(out.to_array())
     assert np.all(pdsr1 == pdsr1)
 
     # test inequal
     out = sr1 != sr1
-    assert not np.any(out)
+    assert not np.any(out.to_array())
     assert not np.any(pdsr1 != pdsr1)
 
     assert pdsr1.cat.ordered


### PR DESCRIPTION
NVStrings loads 0.2.0 by default, which hasn't been fixed in `cudf_dev` yet. This is a critical hotfix because people trying to build from source will run into this problem.