### PR TITLE
[REVIEW] Fix two categorical tests that are failing due to weird implicit ndarray type conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@
 - PR #1185 Support left_on/right_on and also on=str in merge
 - PR #1200 Fix allocating bitmasks with numba instead of rmm in allocate_mask function
 - PR #1223 gpuCI: Fix label on rapidsai channel on gpu build scripts
+- PR #1246 Fix categorical tests that failed due to bad implicit type conversion
 
 
 # cuDF 0.5.1 (05 Feb 2019)

--- a/python/cudf/tests/test_categorical.py
+++ b/python/cudf/tests/test_categorical.py
@@ -68,12 +68,12 @@ def test_categorical_compare_unordered():
     out = sr == sr
     assert out.dtype == np.bool_
     assert type(out[0]) == np.bool_
-    assert np.all(out)
+    assert np.all(out.to_array())
     assert np.all(pdsr == pdsr)
 
     # test inequal
     out = sr != sr
-    assert not np.any(out)
+    assert not np.any(out.to_array())
     assert not np.any(pdsr != pdsr)
 
     assert not pdsr.cat.ordered
@@ -105,12 +105,12 @@ def test_categorical_compare_ordered():
     out = sr1 == sr1
     assert out.dtype == np.bool_
     assert type(out[0]) == np.bool_
-    assert np.all(out)
+    assert np.all(out.to_array())
     assert np.all(pdsr1 == pdsr1)
 
     # test inequal
     out = sr1 != sr1
-    assert not np.any(out)
+    assert not np.any(out.to_array())
     assert not np.any(pdsr1 != pdsr1)
 
     assert pdsr1.cat.ordered


### PR DESCRIPTION
These tests are using the `np.all` and `np.any` ufuncs on a `cudf.Series`. It isn't clear why this ever worked. The fix is to cast the `cudf.Series` `to_array` so that the ufuncs work explicitly. Implicit ufunc conversions shouldn't work on `cudf` objects because they can be extremely expensive.