### PR TITLE
[REVIEW] NVStrings doesn't install correctly in branch-0.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@
 - PR #1185 Support left_on/right_on and also on=str in merge
 - PR #1200 Fix allocating bitmasks with numba instead of rmm in allocate_mask function
 - PR #1223 gpuCI: Fix label on rapidsai channel on gpu build scripts
+- PR #1246 Fix categorical tests that failed due to bad implicit type conversion
 
 
 # cuDF 0.5.1 (05 Feb 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 - PR #1128 CSV Reader: The last data row does not need to be line terminated
 - PR #1183 Bump Arrow version to 0.12.1
 - PR #1208 Default to CXX11_ABI=ON
+- PR #1247 Handle issues with NVStrings versions by creating conda_prepare.sh
 
 ## Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,12 @@ git submodule update --init --remote --recursive
 - Create the conda development environment `cudf_dev`
 ```bash
 # create the conda environment (assuming in base `cudf` directory)
-conda env create --name cudf_dev --file conda/environments/cudf_dev.yml
-# activate the environment
-source activate cudf_dev
+# ./conda_prepare.sh depends on the `nvcc` executable being on your path.
+./conda_prepare.sh
+
+# Rerun ./conda_prepare.sh any time to update/clean your environment
+# for cudf dependencies. Beware, any additional pip or conda installs you
+# may have made will be removed by the above command.
 ```
 
 - Build and install `libcudf`. CMake depends on the `nvcc` executable being on your path or defined in `$CUDACXX`.

--- a/conda/environments/cudf_dev.yml
+++ b/conda/environments/cudf_dev.yml
@@ -13,7 +13,6 @@ dependencies:
 - pyarrow=0.12.1
 - notebook>=0.5.0
 - boost
-- nvstrings
 - cffi>=1.10.0   
 - distributed>=1.23.0
 - cython>=0.29,<0.30

--- a/conda_prepare.sh
+++ b/conda_prepare.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+# COPYRIGHT 2019 NVIDIA
+# conda_prepare.sh creates and activates the correct conda environment for cudf
+# or updates it based on the latest .yml file.
+
+if ! type nvcc 2>/dev/null; then
+  echo 'Please put nvcc on your path before executing this script'
+  exit
+fi
+
+# If CUDF is installed then we need to update, otherwise we need to create
+CUDF=`conda list | grep cudf`
+if [[ $CUDF == *"cudf"* ]]; then
+  conda env update -f conda/environments/cudf_dev.yml
+else
+  conda env create --name cudf_dev --file conda/environments/cudf_dev.yml
+  source activate cudf_dev
+fi
+
+# NVStrings has CUDF dependency that can only be installed post environment
+# creation
+NVCC_VER=`nvcc --version`
+PY_VER=`python --version`
+if [[ $PY_VER == *"3.7"* ]]; then
+  PY_VER='3.7'
+else
+  PY_VER='3.6'
+fi
+if [[ $NVCC_VER == *"9.2"* ]]; then
+  conda install -c nvidia -c rapidsai -c numba -c conda-forge -c defaults \
+      nvstrings=0.3 python=$PY_VER
+else
+  conda install -c nvidia/label/cuda10.0 -c rapidsai/label/cuda10.0 -c numba \
+        -c conda-forge -c defaults nvstrings=0.3 python=$PY_VER
+fi

--- a/python/cudf/tests/test_categorical.py
+++ b/python/cudf/tests/test_categorical.py
@@ -68,12 +68,12 @@ def test_categorical_compare_unordered():
     out = sr == sr
     assert out.dtype == np.bool_
     assert type(out[0]) == np.bool_
-    assert np.all(out)
+    assert np.all(out.to_array())
     assert np.all(pdsr == pdsr)
 
     # test inequal
     out = sr != sr
-    assert not np.any(out)
+    assert not np.any(out.to_array())
     assert not np.any(pdsr != pdsr)
 
     assert not pdsr.cat.ordered
@@ -105,12 +105,12 @@ def test_categorical_compare_ordered():
     out = sr1 == sr1
     assert out.dtype == np.bool_
     assert type(out[0]) == np.bool_
-    assert np.all(out)
+    assert np.all(out.to_array())
     assert np.all(pdsr1 == pdsr1)
 
     # test inequal
     out = sr1 != sr1
-    assert not np.any(out)
+    assert not np.any(out.to_array())
     assert not np.any(pdsr1 != pdsr1)
 
     assert pdsr1.cat.ordered


### PR DESCRIPTION
The NVStrings dependency installation currently in branch-0.6 is insufficient. Either it installs version 0.2.0 by default, or it installs NVStrings for CUDA 9.2 by default (which is fine for people running CUDA 9.2, but bad for those on CUDA 10).

This PR adds a new `prepare_conda.sh` script that will create and activate the `cudf_dev` environment if it is not active, then install the correct version of `nvstrings` for the user. If `cudf_dev` is already active (based on the presence of the `cudf` package), the environment will be updated, then the correct version of `nvstrings` installed.