### PR TITLE
[REVIEW] CSV Reader: Fix data type detection for floating-point numbers in scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Bug Fixes
 
-...
+- PR #1254 CSV Reader: fix data type detection for floating-point numbers in scientific notation
 
 
 # cuDF 0.6.0 (Date TBD)

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -1724,12 +1724,12 @@ void dataTypeDetection(char *raw_csv,
 						countDash++; break;
 					case '/':
 						countSlash++;break;
-						case ':':
-							countColon++;break;
-						case 'e':
-						case 'E':
-							if (!maybe_hex && startPos > start && startPos < tempPos) 
-								countExponent++;break;
+					case ':':
+						countColon++;break;
+					case 'e':
+					case 'E':
+						if (!maybe_hex && startPos > start && startPos < tempPos) 
+							countExponent++;break;
 					default:
 						countString++;
 						break;	

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -1608,7 +1608,7 @@ bool isDigit(char c, bool is_hex){
 }
 
 /**
-* @brief Returns true if the counters indicate a ponentially valid float.
+* @brief Returns true if the counters indicate a potentially valid float.
 * False positives are possible because positions are not taken into account.
 * For example, field "e.123-" would match the pattern.
 */

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -1617,18 +1617,17 @@ bool isLikeFloat(long len, long digit_cnt, long decimal_cnt, long dash_cnt, long
 	// Can't have more than one exponent and one decimal point
 	if (decimal_cnt > 1) return false;
 	if (exponent_cnt > 1) return false;
-	// Without the exponent, or a decimal point, this is an integer, not a float
+	// Without the exponent or a decimal point, this is an integer, not a float
 	if (decimal_cnt == 0 && exponent_cnt == 0) return false;
 
 	// Can only have one '-' per component
 	if (dash_cnt > 1 + exponent_cnt) return false;
 
-	// If anything other than these characters are present, it's not a float
+	// If anything other than these characters is present, it's not a float
 	if (digit_cnt + decimal_cnt + dash_cnt + exponent_cnt != len) return false;
 
-	// Needs at least 1-3 digits, depending on the format
-	const int digit_req = 1 + exponent_cnt + decimal_cnt;
-	if (digit_cnt < digit_req) return false;
+	// Needs at least 1 digit, 2 if exponent is present
+	if (digit_cnt < 1 + exponent_cnt) return false;
 
 	return true;
 }
@@ -1701,6 +1700,7 @@ void dataTypeDetection(char *raw_csv,
 			long countDash=0;
 			long countColon=0;
 			long countString=0;
+			long countExponent=0;
 
 			// Modify start & end to ignore whitespace and quotechars
 			// This could possibly result in additional empty fields
@@ -1724,8 +1724,12 @@ void dataTypeDetection(char *raw_csv,
 						countDash++; break;
 					case '/':
 						countSlash++;break;
-					case ':':
-						countColon++;break;
+						case ':':
+							countColon++;break;
+						case 'e':
+						case 'E':
+							if (!maybe_hex && startPos > start && startPos < tempPos) 
+								countExponent++;break;
 					default:
 						countString++;
 						break;	

--- a/cpp/src/utilities/trie.cuh
+++ b/cpp/src/utilities/trie.cuh
@@ -43,12 +43,12 @@ struct SerialTrieNode {
 
 /**---------------------------------------------------------------------------*
  * @brief Create a serialized trie for cache-friendly string search
- *
+ * 
  * The resulting trie is a compact array - children array size is equal to the
  * actual number of children nodes, not the size of the alphabet
- *
+ * 
  * @param[in] keys Array of strings to insert into the trie
- *
+ * 
  * @return A host vector of nodes representing the serialized trie
  *---------------------------------------------------------------------------**/
 inline thrust::host_vector<SerialTrieNode> createSerializedTrie(const std::vector<std::string> &keys) {
@@ -70,10 +70,10 @@ inline thrust::host_vector<SerialTrieNode> createSerializedTrie(const std::vecto
 		for (const char character : key) {
 			if (current_node->children[character] == nullptr)
 				current_node->children[character] = std::make_unique<TreeTrieNode>();
-
+		
 			current_node = current_node->children[character].get();
 		}
-
+		
 		current_node->is_end_of_word = true;
 	}
 
@@ -121,14 +121,14 @@ inline thrust::host_vector<SerialTrieNode> createSerializedTrie(const std::vecto
 
 /**---------------------------------------------------------------------------*
  * @brief Searches for a string in a serialized trie
- *
+ * 
  * Can be executed on host or device, as long as the data is available
- *
+ * 
  * @param[in] trie Pointer to the array of nodes that make up the trie
  * @param[in] key Pointer to the start of the string to find
  * @param[in] key_len Length of the string to find
- *
- * @return Boolean value, true if string is found, false otherwise
+ * 
+ * @return Boolean value, true if string is found, false otherwise 
  *---------------------------------------------------------------------------**/
 __host__ __device__
 inline bool serializedTrieContains(const SerialTrieNode* trie, const char* key, size_t key_len) {
@@ -140,13 +140,12 @@ inline bool serializedTrieContains(const SerialTrieNode* trie, const char* key, 
 			curr_node += trie[curr_node].children_offset;
 		}
 		// Search for the next character in the array of children nodes
-		// Nodes are sorted - terminate search if the node is larger or equal
-		while (trie[curr_node].character != trie_terminating_character &&
-			trie[curr_node].character < key[i]) {
+		while (trie[curr_node].character != trie_terminating_character && 
+			trie[curr_node].character != key[i]) {
 			++curr_node;
 		}
 		// Could not find the next character, done with the search
-		if (trie[curr_node].character != key[i]) {
+		if (trie[curr_node].character == trie_terminating_character) {
 			return false;
 		}
 	}

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -950,8 +950,8 @@ def test_csv_reader_pd_consistent_quotes(quoting):
 
 
 def test_csv_reader_scientific_type_detection():
-    buffer = '1.1, -1.1, 1E1, 1e1, -1e1, -1e-1, 1e-1, 1.1e1, 1.1e-1, -1.1e-1, -1.1e1'
-    expected = [1.1, -1.1, 10., 10., -10, -0.1, 0.1, 11, 0.11, -0.11, -11]
+    buffer = '1., 1.1, -1.1, 1E1, 1e1, -1e1, -1e-1, 1e-1, 1.1e1, 1.1e-1, -1.1e-1, -1.1e1'
+    expected = [1., 1.1, -1.1, 10., 10., -10, -0.1, 0.1, 11, 0.11, -0.11, -11]
 
     df = read_csv(StringIO(buffer),
                   header=None)

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -947,3 +947,16 @@ def test_csv_reader_pd_consistent_quotes(quoting):
                         names=names, quoting=quoting)
 
     assert_eq(pd_df, gd_df)
+
+
+def test_csv_reader_scientific_type_detection():
+    buffer = '1.1, -1.1, 1E1, 1e1, -1e1, -1e-1, 1e-1, 1.1e1, 1.1e-1, -1.1e-1, -1.1e1'
+    expected = [1.1, -1.1, 10., 10., -10, -0.1, 0.1, 11, 0.11, -0.11, -11]
+
+    df = read_csv(StringIO(buffer),
+                  header=None)
+
+    for dt in df.dtypes:
+        assert(dt == 'float64')
+    for col in df:
+        assert(np.isclose(df[col][0], expected[int(col)]))

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -950,7 +950,7 @@ def test_csv_reader_pd_consistent_quotes(quoting):
 
 
 def test_csv_reader_scientific_type_detection():
-    buffer = '1., 1.1, -1.1, 1E1, 1e1, -1e1, -1e-1, 1e-1, 1.1e1, 1.1e-1, -1.1e-1, -1.1e1'
+    buffer = '1.,1.1,-1.1,1E1,1e1,-1e1,-1e-1,1e-1,1.1e1,1.1e-1,-1.1e-1,-1.1e1'
     expected = [1., 1.1, -1.1, 10., 10., -10, -0.1, 0.1, 11, 0.11, -0.11, -11]
 
     df = read_csv(StringIO(buffer),


### PR DESCRIPTION
Fixes #1117 

* Expand the data type detection to cover scientific notation of floating-point numbers.
* Add a test to cover different cases of numbers in this format.