### PR TITLE
[REVIEW] Prevent cudf upload overwrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@
 - PR #1184 Fix iloc performance regression
 - PR #1185 Support left_on/right_on and also on=str in merge
 - PR #1200 Fix allocating bitmasks with numba instead of rmm in allocate_mask function
+- PR #1255 Fix overwriting conda package main label uploads
 
 
 # cuDF 0.5.1 (05 Feb 2019)

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
 export BUILD_ABI=1
-export BUILD_CUDF=1
 export BUILD_CFFI=1
 
+#Build cudf once per PYTHON
+if [[ "$CUDA" == "9.2" ]]; then
+    export BUILD_CUDF=1
+else
+    export BUILD_CUDF=0
+fi
+
+#Build libcudf once per CUDA
 if [[ "$PYTHON" == "3.6" ]]; then
     export BUILD_LIBCUDF=1
 else


### PR DESCRIPTION
Sometimes cudf packages weren't being labeled as `main`. This was because cudf was build 4 times and upload each time, but `LABEL_MAIN` is true for only 2 of those builds. So often the main cudf would be overwritten.

This PR fixes that by only building cudf twice.