### PR TITLE
[HOTFIX] Fix hash_partition exceptions on CentOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# cuDF 0.6.1 (Date TBD)
+
+## Bug Fixes
+
+- PR #1275 Fix CentOS exception in DataFrame.hash_partition from using value "returned" by a void function
+
+
 # cuDF 0.6.0 (Date TBD)
 
 ## New Features

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -527,9 +527,8 @@ gdf_error hash_partition_gdf_table(gdf_table<size_type> const & input_table,
   cudf::table destination_table{partitioned_output.get_columns(),
                                 input_table.get_num_columns()};
 
-  auto gdf_status = cudf::detail::scatter(&source_table, row_output_locations,
-                                          &destination_table);
-  GDF_REQUIRE(GDF_SUCCESS == gdf_status, gdf_status);
+  cudf::detail::scatter(&source_table, row_output_locations,
+                        &destination_table);
 
   CUDA_CHECK_LAST();
 


### PR DESCRIPTION
We were getting a value returned by a void function which is undefined in CentOS but somehow defined properly in Ubuntu...