### PR TITLE
[REVIEW] Refactor some of the CSV Reader kernels into generic utility functions

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -226,6 +226,7 @@ add_library(cudf SHARED
             src/unary/unary_ops.cu
             # src/windowed/windowed_ops.cu ... this is broken
             src/io/convert/csr/cudf_to_csr.cu
+            src/io/utilities/parsing_utils.cu
             src/io/convert/dlpack/cudf_dlpack.cpp
             src/io/csv/csv_reader.cu
             src/io/comp/uncomp.cpp

--- a/cpp/include/cudf/io_types.h
+++ b/cpp/include/cudf/io_types.h
@@ -22,9 +22,6 @@
  */
 #pragma once
 
-typedef unsigned long long int cu_reccnt_t;
-typedef unsigned long long int cu_recstart_t;
-
   /*
    * Enumerator for the supported forms of the input CSV file
    */

--- a/cpp/include/cudf/io_types.h
+++ b/cpp/include/cudf/io_types.h
@@ -22,6 +22,9 @@
  */
 #pragma once
 
+typedef unsigned long long int cu_reccnt_t;
+typedef unsigned long long int cu_recstart_t;
+
   /*
    * Enumerator for the supported forms of the input CSV file
    */

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -1162,7 +1162,7 @@ gdf_error launch_storeRecordStart(const char *h_data, size_t h_size,
                                   raw_csv_t *csvData) {
 
 	char* d_chunk = nullptr;
-	RMM_TRY(RMM_ALLOC (&d_chunk, max_chunk_bytes, 0)); 
+	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0)); 
 	
 	cu_reccnt_t*	d_num_records;
 	RMM_TRY(RMM_ALLOC((void**)&d_num_records, sizeof(cu_reccnt_t), 0) );

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -334,7 +334,7 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 	auto* find_result_ptr = raw_csv->recStart;
 	if (raw_csv->byte_range_offset == 0) {
 		find_result_ptr++;
-		CUDA_TRY(cudaMemsetAsync(raw_csv->recStart, 0ull, sizeof(ll_uint_t), (cudaStream_t)0));
+		CUDA_TRY(cudaMemsetAsync(raw_csv->recStart, 0ull, sizeof(ll_uint_t)));
 	}
 	vector<char> chars_to_find{raw_csv->opts.terminator};
 	if (raw_csv->opts.quotechar != '\0') {

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -68,7 +68,7 @@ using std::string;
  *---------------------------------------------------------------------------**/
 typedef struct raw_csv_ {
     char *				data;			// on-device: the raw unprocessed CSV data - loaded as a large char * array
-    ll_uint_t*		recStart;		// on-device: Starting position of the records.
+    uint64_t*		recStart;		// on-device: Starting position of the records.
 
     ParseOptions        opts;			// options to control parsing behavior
 
@@ -136,11 +136,11 @@ gdf_error launch_dataTypeDetection(raw_csv_t * raw_csv, column_data_t* d_columnD
 
 __global__ void convertCsvToGdf(char *csv, const ParseOptions opts,
 	gdf_size_type num_records, int num_columns, bool *parseCol,
-	ll_uint_t *recStart, gdf_dtype *dtype, void **gdf_data, gdf_valid_type **valid,
+	uint64_t *recStart, gdf_dtype *dtype, void **gdf_data, gdf_valid_type **valid,
 	string_pair **str_cols, unsigned long long *num_valid);
 __global__ void dataTypeDetection(char *raw_csv, const ParseOptions opts,
 	gdf_size_type num_records, int num_columns, bool *parseCol,
-	ll_uint_t *recStart, column_data_t* d_columnData);
+	uint64_t *recStart, column_data_t* d_columnData);
 
 //
 //---------------CUDA Valid (8 blocks of 8-bits) Bitmap Kernels ---------------------------------------------
@@ -217,10 +217,10 @@ gdf_error setColumnNamesFromCsv(raw_csv_t* raw_csv) {
 	vector<char> first_row = raw_csv->header;
 	// No header, read the first data row
 	if (first_row.empty()) {
-		ll_uint_t first_row_len{};
+		uint64_t first_row_len{};
 		// If file only contains one row, raw_csv->recStart[1] is not valid
 		if (raw_csv->num_records > 1) {
-			CUDA_TRY(cudaMemcpy(&first_row_len, raw_csv->recStart + 1, sizeof(ll_uint_t), cudaMemcpyDefault));
+			CUDA_TRY(cudaMemcpy(&first_row_len, raw_csv->recStart + 1, sizeof(uint64_t), cudaMemcpyDefault));
 		}
 		else {
 			// File has one row - use the file size for the row size
@@ -298,10 +298,7 @@ gdf_error countRecordsAndQuotes(const char *h_data, size_t h_size, raw_csv_t *ra
 		chars_to_count.push_back(raw_csv->opts.quotechar);
 	}
 
-	const auto error = countAllFromSet(h_data, h_size, chars_to_count, raw_csv->num_records);
-	if (error != GDF_SUCCESS) {
-		return error;
-	}
+	raw_csv->num_records = countAllFromSet(h_data, h_size, chars_to_count);
 
 	// If not starting at an offset, add an extra row to account for the first row in the file
 	if (raw_csv->byte_range_offset == 0) {
@@ -329,12 +326,12 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 	const bool last_line_terminated = (h_data[h_size - 1] == raw_csv->opts.terminator);
 	// If the last line is not terminated, allocate space for the EOF entry (added later)
 	const gdf_size_type record_start_count = raw_csv->num_records + (last_line_terminated ? 0 : 1);
-	RMM_TRY( RMM_ALLOC(&raw_csv->recStart, sizeof(ll_uint_t) * record_start_count, 0) ); 
+	RMM_TRY( RMM_ALLOC(&raw_csv->recStart, sizeof(uint64_t) * record_start_count, 0) ); 
 
 	auto* find_result_ptr = raw_csv->recStart;
 	if (raw_csv->byte_range_offset == 0) {
 		find_result_ptr++;
-		CUDA_TRY(cudaMemsetAsync(raw_csv->recStart, 0ull, sizeof(ll_uint_t)));
+		CUDA_TRY(cudaMemsetAsync(raw_csv->recStart, 0ull, sizeof(uint64_t)));
 	}
 	vector<char> chars_to_find{raw_csv->opts.terminator};
 	if (raw_csv->opts.quotechar != '\0') {
@@ -354,8 +351,8 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 	// or a linetermination within a quotechar pair. The future major refactoring
 	// of csv_reader and its kernels will probably use a different tactic.
 	if (raw_csv->opts.quotechar != '\0') {
-		vector<ll_uint_t> h_rec_starts(raw_csv->num_records);
-		const size_t rec_start_size = sizeof(ll_uint_t) * (h_rec_starts.size());
+		vector<uint64_t> h_rec_starts(raw_csv->num_records);
+		const size_t rec_start_size = sizeof(uint64_t) * (h_rec_starts.size());
 		CUDA_TRY( cudaMemcpy(h_rec_starts.data(), raw_csv->recStart, rec_start_size, cudaMemcpyDeviceToHost) );
 
 		auto recCount = raw_csv->num_records;
@@ -380,8 +377,8 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 
 	if (!last_line_terminated){
 		// Add the EOF as the last record when the terminator is missing in the last line
-		const ll_uint_t eof_offset = h_size;
-		CUDA_TRY(cudaMemcpy(raw_csv->recStart + raw_csv->num_records, &eof_offset, sizeof(ll_uint_t), cudaMemcpyDefault));
+		const uint64_t eof_offset = h_size;
+		CUDA_TRY(cudaMemcpy(raw_csv->recStart + raw_csv->num_records, &eof_offset, sizeof(uint64_t), cudaMemcpyDefault));
 		// Update the record count
 		++raw_csv->num_records;
 	}
@@ -1029,16 +1026,16 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
   const auto first_row = raw_csv->skiprows;
   raw_csv->num_records = raw_csv->num_records - first_row;
 
-  std::vector<ll_uint_t> h_rec_starts(raw_csv->num_records);
+  std::vector<uint64_t> h_rec_starts(raw_csv->num_records);
   CUDA_TRY(cudaMemcpy(h_rec_starts.data(), raw_csv->recStart + first_row,
-                      sizeof(ll_uint_t) * h_rec_starts.size(),
+                      sizeof(uint64_t) * h_rec_starts.size(),
                       cudaMemcpyDefault));
 
   // Trim lines that are outside range, but keep one greater for the end offset
   if (raw_csv->byte_range_size != 0) {
     auto it = h_rec_starts.end() - 1;
     while (it >= h_rec_starts.begin() &&
-           *it > ll_uint_t(raw_csv->byte_range_size)) {
+           *it > uint64_t(raw_csv->byte_range_size)) {
       --it;
     }
     if ((it + 2) < h_rec_starts.end()) {
@@ -1056,7 +1053,7 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
                                                       : match1;
     h_rec_starts.erase(
         std::remove_if(h_rec_starts.begin(), h_rec_starts.end(),
-                       [&](ll_uint_t i) {
+                       [&](uint64_t i) {
                          return (h_uncomp_data[i] == match1 ||
                                  h_uncomp_data[i] == match2);
                        }),
@@ -1099,9 +1096,9 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
 
   // Resize and upload the rows of interest
   RMM_TRY(RMM_REALLOC(&raw_csv->recStart,
-                      sizeof(ll_uint_t) * raw_csv->num_records, 0));
+                      sizeof(uint64_t) * raw_csv->num_records, 0));
   CUDA_TRY(cudaMemcpy(raw_csv->recStart, h_rec_starts.data(),
-                      sizeof(ll_uint_t) * raw_csv->num_records,
+                      sizeof(uint64_t) * raw_csv->num_records,
                       cudaMemcpyDefault));
 
   // Upload the raw data that is within the rows of interest
@@ -1113,7 +1110,7 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
   thrust::transform(rmm::exec_policy()->on(0), raw_csv->recStart,
                     raw_csv->recStart + raw_csv->num_records,
                     thrust::make_constant_iterator(start_offset),
-                    raw_csv->recStart, thrust::minus<ll_uint_t>());
+                    raw_csv->recStart, thrust::minus<uint64_t>());
 
   // The array of row offsets includes EOF
   // reduce the number of records by one to exclude it from the row count
@@ -1306,7 +1303,7 @@ void convertCsvToGdf(char *raw_csv,
                      gdf_size_type num_records,
                      int num_columns,
                      bool *parseCol,
-                     ll_uint_t *recStart,
+                     uint64_t *recStart,
                      gdf_dtype *dtype,
                      void **gdf_data,
                      gdf_valid_type **valid,
@@ -1475,7 +1472,7 @@ void dataTypeDetection(char *raw_csv,
                        gdf_size_type num_records,
                        int num_columns,
                        bool *parseCol,
-                       ll_uint_t *recStart,
+                       uint64_t *recStart,
                        column_data_t *d_columnData)
 {
 	// thread IDs range per block, so also need the block id

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -68,7 +68,7 @@ using std::string;
  *---------------------------------------------------------------------------**/
 typedef struct raw_csv_ {
     char *				data;			// on-device: the raw unprocessed CSV data - loaded as a large char * array
-    cu_recstart_t*		recStart;		// on-device: Starting position of the records.
+    ll_uint_t*		recStart;		// on-device: Starting position of the records.
 
     ParseOptions        opts;			// options to control parsing behavior
 
@@ -130,19 +130,17 @@ gdf_dtype convertStringToDtype(std::string &dtype);
 //---------------CUDA Kernel ---------------------------------------------
 //
 
-__device__ int findSetBit(int tid, long num_bits, uint64_t *f_bits, int x);
-
 gdf_error launch_dataConvertColumns(raw_csv_t * raw_csv, void** d_gdf,  gdf_valid_type** valid, gdf_dtype* d_dtypes, string_pair **str_cols, unsigned long long *);
 
 gdf_error launch_dataTypeDetection(raw_csv_t * raw_csv, column_data_t* d_columnData);
 
 __global__ void convertCsvToGdf(char *csv, const ParseOptions opts,
 	gdf_size_type num_records, int num_columns, bool *parseCol,
-	cu_recstart_t *recStart, gdf_dtype *dtype, void **gdf_data, gdf_valid_type **valid,
+	ll_uint_t *recStart, gdf_dtype *dtype, void **gdf_data, gdf_valid_type **valid,
 	string_pair **str_cols, unsigned long long *num_valid);
 __global__ void dataTypeDetection(char *raw_csv, const ParseOptions opts,
 	gdf_size_type num_records, int num_columns, bool *parseCol,
-	cu_recstart_t *recStart, column_data_t* d_columnData);
+	ll_uint_t *recStart, column_data_t* d_columnData);
 
 //
 //---------------CUDA Valid (8 blocks of 8-bits) Bitmap Kernels ---------------------------------------------
@@ -219,10 +217,10 @@ gdf_error setColumnNamesFromCsv(raw_csv_t* raw_csv) {
 	vector<char> first_row = raw_csv->header;
 	// No header, read the first data row
 	if (first_row.empty()) {
-		cu_recstart_t first_row_len{};
+		ll_uint_t first_row_len{};
 		// If file only contains one row, raw_csv->recStart[1] is not valid
 		if (raw_csv->num_records > 1) {
-			CUDA_TRY(cudaMemcpy(&first_row_len, raw_csv->recStart + 1, sizeof(cu_recstart_t), cudaMemcpyDefault));
+			CUDA_TRY(cudaMemcpy(&first_row_len, raw_csv->recStart + 1, sizeof(ll_uint_t), cudaMemcpyDefault));
 		}
 		else {
 			// File has one row - use the file size for the row size
@@ -331,12 +329,12 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 	const bool last_line_terminated = (h_data[h_size - 1] == raw_csv->opts.terminator);
 	// If the last line is not terminated, allocate space for the EOF entry (added later)
 	const gdf_size_type record_start_count = raw_csv->num_records + (last_line_terminated ? 0 : 1);
-	RMM_TRY( RMM_ALLOC(&raw_csv->recStart, sizeof(cu_recstart_t) * record_start_count, 0) ); 
+	RMM_TRY( RMM_ALLOC(&raw_csv->recStart, sizeof(ll_uint_t) * record_start_count, 0) ); 
 
 	auto* find_result_ptr = raw_csv->recStart;
 	if (raw_csv->byte_range_offset == 0) {
 		find_result_ptr++;
-		CUDA_TRY(cudaMemsetAsync(raw_csv->recStart, 0ull, sizeof(cu_recstart_t), (cudaStream_t)0));
+		CUDA_TRY(cudaMemsetAsync(raw_csv->recStart, 0ull, sizeof(ll_uint_t), (cudaStream_t)0));
 	}
 	vector<char> chars_to_find{raw_csv->opts.terminator};
 	if (raw_csv->opts.quotechar != '\0') {
@@ -356,8 +354,8 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 	// or a linetermination within a quotechar pair. The future major refactoring
 	// of csv_reader and its kernels will probably use a different tactic.
 	if (raw_csv->opts.quotechar != '\0') {
-		vector<cu_recstart_t> h_rec_starts(raw_csv->num_records);
-		const size_t rec_start_size = sizeof(cu_recstart_t) * (h_rec_starts.size());
+		vector<ll_uint_t> h_rec_starts(raw_csv->num_records);
+		const size_t rec_start_size = sizeof(ll_uint_t) * (h_rec_starts.size());
 		CUDA_TRY( cudaMemcpy(h_rec_starts.data(), raw_csv->recStart, rec_start_size, cudaMemcpyDeviceToHost) );
 
 		auto recCount = raw_csv->num_records;
@@ -382,8 +380,8 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 
 	if (!last_line_terminated){
 		// Add the EOF as the last record when the terminator is missing in the last line
-		const cu_recstart_t eof_offset = h_size;
-		CUDA_TRY(cudaMemcpy(raw_csv->recStart + raw_csv->num_records, &eof_offset, sizeof(cu_recstart_t), cudaMemcpyDefault));
+		const ll_uint_t eof_offset = h_size;
+		CUDA_TRY(cudaMemcpy(raw_csv->recStart + raw_csv->num_records, &eof_offset, sizeof(ll_uint_t), cudaMemcpyDefault));
 		// Update the record count
 		++raw_csv->num_records;
 	}
@@ -1031,16 +1029,16 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
   const auto first_row = raw_csv->skiprows;
   raw_csv->num_records = raw_csv->num_records - first_row;
 
-  std::vector<cu_recstart_t> h_rec_starts(raw_csv->num_records);
+  std::vector<ll_uint_t> h_rec_starts(raw_csv->num_records);
   CUDA_TRY(cudaMemcpy(h_rec_starts.data(), raw_csv->recStart + first_row,
-                      sizeof(cu_recstart_t) * h_rec_starts.size(),
+                      sizeof(ll_uint_t) * h_rec_starts.size(),
                       cudaMemcpyDefault));
 
   // Trim lines that are outside range, but keep one greater for the end offset
   if (raw_csv->byte_range_size != 0) {
     auto it = h_rec_starts.end() - 1;
     while (it >= h_rec_starts.begin() &&
-           *it > cu_recstart_t(raw_csv->byte_range_size)) {
+           *it > ll_uint_t(raw_csv->byte_range_size)) {
       --it;
     }
     if ((it + 2) < h_rec_starts.end()) {
@@ -1058,7 +1056,7 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
                                                       : match1;
     h_rec_starts.erase(
         std::remove_if(h_rec_starts.begin(), h_rec_starts.end(),
-                       [&](cu_recstart_t i) {
+                       [&](ll_uint_t i) {
                          return (h_uncomp_data[i] == match1 ||
                                  h_uncomp_data[i] == match2);
                        }),
@@ -1101,9 +1099,9 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
 
   // Resize and upload the rows of interest
   RMM_TRY(RMM_REALLOC(&raw_csv->recStart,
-                      sizeof(cu_recstart_t) * raw_csv->num_records, 0));
+                      sizeof(ll_uint_t) * raw_csv->num_records, 0));
   CUDA_TRY(cudaMemcpy(raw_csv->recStart, h_rec_starts.data(),
-                      sizeof(cu_recstart_t) * raw_csv->num_records,
+                      sizeof(ll_uint_t) * raw_csv->num_records,
                       cudaMemcpyDefault));
 
   // Upload the raw data that is within the rows of interest
@@ -1115,7 +1113,7 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
   thrust::transform(rmm::exec_policy()->on(0), raw_csv->recStart,
                     raw_csv->recStart + raw_csv->num_records,
                     thrust::make_constant_iterator(start_offset),
-                    raw_csv->recStart, thrust::minus<cu_recstart_t>());
+                    raw_csv->recStart, thrust::minus<ll_uint_t>());
 
   // The array of row offsets includes EOF
   // reduce the number of records by one to exclude it from the row count
@@ -1308,7 +1306,7 @@ void convertCsvToGdf(char *raw_csv,
                      gdf_size_type num_records,
                      int num_columns,
                      bool *parseCol,
-                     cu_recstart_t *recStart,
+                     ll_uint_t *recStart,
                      gdf_dtype *dtype,
                      void **gdf_data,
                      gdf_valid_type **valid,
@@ -1452,7 +1450,7 @@ void dataTypeDetection(char *raw_csv,
                        gdf_size_type num_records,
                        int num_columns,
                        bool *parseCol,
-                       cu_recstart_t *recStart,
+                       ll_uint_t *recStart,
                        column_data_t *d_columnData)
 {
 	// thread IDs range per block, so also need the block id

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -338,8 +338,7 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 		chars_to_find.push_back(raw_csv->opts.quotechar);
 	}
 	// Passing offset = 1 to return positions AFTER the found character
-	const auto error = findAllFromSet(h_data, h_size, chars_to_find, 1, find_result_ptr);
-	checkError(error, "call to record initial position store");
+	findAllFromSet(h_data, h_size, chars_to_find, 1, find_result_ptr);
 
 	// Previous kernel stores the record pinput_file.typeositions as encountered by all threads
 	// Sort the record positions as subsequent processing may require filtering

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -8,21 +8,23 @@
 #include "rmm/thrust_rmm_allocator.h"
 #include "utilities/error_utils.hpp"
 
+constexpr int bytes_per_find_thread = 64;
+
 /**---------------------------------------------------------------------------*
- * @brief Sums up the number of occurences of characters from a set
+ * @brief Searches the input character array for each of characters in a set
+ * and sums up the number of occurences.
  *
  * Does not load the entire buffer into the GPU memory at any time, so it can 
  * be used with buffers of any size.
  *
- * @param[in] h_data Pointer to the csv data in host memory
+ * @param[in] h_data Pointer to the data in host memory
  * @param[in] h_size Size of the input data, in bytes
  * @param[in] keys Vector containing the keys to count in the buffer
- * @param[in,out] raw_csv Structure containing the csv parsing parameters
- * and intermediate results
+ * @param[out] count Total number of occurences of all keys
  *
  * @return gdf_error
  *---------------------------------------------------------------------------**/
-gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, gdf_size_type &rec_cnt)
+gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, gdf_size_type &count)
 {
 	const size_t chunk_count = (h_size + max_chunk_bytes - 1) / max_chunk_bytes;
 
@@ -37,13 +39,104 @@ gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> k
 		CUDA_TRY(cudaMemcpyAsync(d_chunk, h_chunk, chunk_bytes, cudaMemcpyDefault, (cudaStream_t)0));
 
 		for (char key: keys) {
-			rec_cnt += thrust::count(rmm::exec_policy()->on(0), d_chunk, d_chunk + chunk_bytes, key);
+			count += thrust::count(rmm::exec_policy()->on(0), d_chunk, d_chunk + chunk_bytes, key);
 		}
 	}
 
 	RMM_TRY( RMM_FREE(d_chunk, 0) );
 
 	CUDA_TRY(cudaGetLastError());
+
+	return GDF_SUCCESS;
+}
+
+/**---------------------------------------------------------------------------*
+ * @brief CUDA kernel that finds all occurences of a character in the given 
+ * character array. The positions are stored in the output array.
+ * 
+ * @param[in] data Pointer to the input character array
+ * @param[in] size Number of bytes in the input array
+ * @param[in] offset Offset to add to the output positions
+ * @param[in] key Character to find in the array
+ * @param[in,out] count Pointer to the number of found occurences
+ * @param[out] positions Array containing the output positions
+ * 
+ * @return void
+ *---------------------------------------------------------------------------**/
+ __global__ void findAll(char *data, size_t size, size_t offset, const char key,
+	cu_reccnt_t* count, cu_recstart_t* positions) {
+
+	// thread IDs range per block, so also need the block id
+	const long tid = threadIdx.x + (blockDim.x * blockIdx.x);
+	const long did = tid * bytes_per_find_thread;
+	
+	const char *raw = (data + did);
+
+	const long byteToProcess = ((did + bytes_per_find_thread) < size) ?
+									bytes_per_find_thread :
+									(size - did);
+
+	// Process the data
+	for (long i = 0; i < byteToProcess; i++) {
+		if (raw[i] == key) {
+			const auto pos = atomicAdd(count, 1ull);
+			positions[pos] = did + offset + i;
+		}
+	}
+}
+
+/**---------------------------------------------------------------------------*
+ * @brief For each of the characters in the input set, find and saves all 
+ * cccurences in the input host array of characters.
+ * The positions are stored in the output device array.
+ * 
+ * Does not load the entire file into the GPU memory at any time, so it can 
+ * be used to parse large files. Output array needs to be preallocated.
+ * 
+ * @param[in] h_data Pointer to the input character array
+ * @param[in] h_size Number of bytes in the input array
+ * @param[in] keys Vector containing the keys to count in the buffer
+ * @param[in] result_offset Offset to add to the output positions
+ * @param[out] positions Array containing the output positions
+ * 
+ * @return gdf_error with error code on failure, otherwise GDF_SUCCESS
+ *---------------------------------------------------------------------------**/
+gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, cu_recstart_t result_offset,
+	cu_recstart_t *positions) {
+
+	char* d_chunk = nullptr;
+	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0)); 
+	
+	cu_reccnt_t*	d_count;
+	RMM_TRY(RMM_ALLOC((void**)&d_count, sizeof(cu_reccnt_t), 0) );
+	CUDA_TRY(cudaMemsetAsync(d_count, 0ull, sizeof(cu_reccnt_t)));
+
+	int blockSize;		// suggested thread count to use
+	int minGridSize;	// minimum block count required
+	CUDA_TRY(cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, findAll) );
+
+	const size_t chunk_count = (h_size + max_chunk_bytes - 1) / max_chunk_bytes;
+	for (size_t ci = 0; ci < chunk_count; ++ci) {	
+		const auto chunk_offset = ci * max_chunk_bytes;	
+		const auto h_chunk = h_data + chunk_offset;
+		const auto chunk_bytes = std::min((size_t)(h_size - ci * max_chunk_bytes), max_chunk_bytes);
+		const auto chunk_bits = (chunk_bytes + bytes_per_find_thread - 1) / bytes_per_find_thread;
+		const int gridSize = (chunk_bits + blockSize - 1) / blockSize;
+
+		// Copy chunk to device
+		CUDA_TRY(cudaMemcpyAsync(d_chunk, h_chunk, chunk_bytes, cudaMemcpyDefault));
+
+		for (char key: keys) {
+			findAll <<< gridSize, blockSize >>> (
+				d_chunk, chunk_bytes, chunk_offset + result_offset, key,
+				d_count, positions);
+		}
+	}
+
+	RMM_TRY( RMM_FREE( d_count, 0 ) ); 
+	RMM_TRY( RMM_FREE( d_chunk, 0 ) );
+
+	CUDA_TRY( cudaGetLastError() );
 
 	return GDF_SUCCESS;
 }

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -1,71 +1,85 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+	 * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file parsing_utils.cu Utility functions for parsing plain-text files
+ *
+ */
+
 #include "parsing_utils.cuh"
 
 #include <cuda_runtime.h>
 
 #include <vector>
+#include <memory>
 
 #include "rmm/rmm.h"
 #include "rmm/thrust_rmm_allocator.h"
 #include "utilities/error_utils.hpp"
 
+// When processing the input in chunks, this is the maximum size of each chunk.
+// Only one chunk is loaded on the GPU at a time, so this value is chosen to
+// be small enough to fit on the GPU in most cases.
 constexpr size_t max_chunk_bytes = 256*1024*1024; // 256MB
 constexpr int bytes_per_find_thread = 64;
 
-/**---------------------------------------------------------------------------*
- * @brief Searches the input character array for each of characters in a set
- * and sums up the number of occurences.
- *
- * Does not load the entire buffer into the GPU memory at any time, so it can 
- * be used with buffers of any size.
- *
- * @param[in] h_data Pointer to the data in host memory
- * @param[in] h_size Size of the input data, in bytes
- * @param[in] keys Vector containing the keys to count in the buffer
- * @param[out] count Total number of occurences of all keys
- *
- * @return gdf_error
- *---------------------------------------------------------------------------**/
-gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, gdf_size_type &count)
-{
-	const size_t chunk_count = (h_size + max_chunk_bytes - 1) / max_chunk_bytes;
+template <typename T>
+struct rmm_deleter {
+ void operator()(T *ptr) { RMM_FREE(ptr, 0); }
+};
+template <typename T>
+using device_ptr = std::unique_ptr<T, rmm_deleter<T>>;
 
-	char* d_chunk = nullptr;
-	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0)); 
+using position_key_pair = thrust::pair<uint64_t,char>;
 
-	for (size_t ci = 0; ci < chunk_count; ++ci) {
-		const auto h_chunk = h_data + ci * max_chunk_bytes;
-		const auto chunk_bytes = std::min((size_t)(h_size - ci * max_chunk_bytes), max_chunk_bytes);
+//doxy
+template<class P, class K>
+__device__ __forceinline__
+void updatePosition(P* positions, long idx, P position, K key){
+	positions[idx] = position;
+}
 
-		// Copy chunk to device
-		CUDA_TRY(cudaMemcpyAsync(d_chunk, h_chunk, chunk_bytes, cudaMemcpyDefault));
+template<class P, class K>
+__device__ __forceinline__
+void updatePosition(thrust::pair<P, K>* positions, long idx, P position, K key) {
+	positions[idx] = {position, key};
+}
 
-		for (char key: keys) {
-			count += thrust::count(rmm::exec_policy()->on(0), d_chunk, d_chunk + chunk_bytes, key);
-		}
-	}
-
-	RMM_TRY( RMM_FREE(d_chunk, 0) );
-
-	CUDA_TRY(cudaGetLastError());
-
-	return GDF_SUCCESS;
+template<class P, class K>
+__device__ __forceinline__
+void updatePosition(void* positions, long idx, P position, K key) {
 }
 
 /**---------------------------------------------------------------------------*
- * @brief CUDA kernel that finds all occurences of a character in the given 
+ * @brief CUDA kernel that finds all occurrences of a character in the given 
  * character array. The positions are stored in the output array.
  * 
  * @param[in] data Pointer to the input character array
  * @param[in] size Number of bytes in the input array
  * @param[in] offset Offset to add to the output positions
  * @param[in] key Character to find in the array
- * @param[in,out] count Pointer to the number of found occurences
+ * @param[in,out] count Pointer to the number of found occurrences
  * @param[out] positions Array containing the output positions
  * 
  * @return void
  *---------------------------------------------------------------------------**/
- __global__ void findAll(char *data, size_t size, size_t offset, const char key,
-	gdf_size_type* count, ll_uint_t* positions) {
+template<class T>
+ __global__ 
+ void countAndSetPositions(char *data, uint64_t size, uint64_t offset, const char key, gdf_size_type* count,
+	T* positions) {
 
 	// thread IDs range per block, so also need the block id
 	const long tid = threadIdx.x + (blockDim.x * blockIdx.x);
@@ -80,15 +94,69 @@ gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> k
 	// Process the data
 	for (long i = 0; i < byteToProcess; i++) {
 		if (raw[i] == key) {
-			const auto pos = atomicAdd(count, 1ull);
-			positions[pos] = did + offset + i;
+			const auto idx = atomicAdd(count, (gdf_size_type)1);
+			updatePosition(positions, idx, did + offset + i, key);
 		}
 	}
 }
 
 /**---------------------------------------------------------------------------*
+ * @brief Searches the input character array for each of characters in a set
+ * and sums up the number of occurrences.
+ *
+ * Does not load the entire buffer into the GPU memory at any time, so it can 
+ * be used with buffers of any size.
+ *
+ * @param[in] h_data Pointer to the data in host memory
+ * @param[in] h_size Size of the input data, in bytes
+ * @param[in] keys Vector containing the keys to count in the buffer
+ * @param[out] count Total number of occurrences of all keys
+ *
+ * @return gdf_error
+ *---------------------------------------------------------------------------**/
+gdf_size_type countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys)
+{
+	char* d_chunk = nullptr;
+	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0));
+	device_ptr<char> chunk_data(d_chunk);
+	
+	gdf_size_type*	d_count;
+	RMM_TRY(RMM_ALLOC((void**)&d_count, sizeof(gdf_size_type), 0) );
+	device_ptr<gdf_size_type> count_data(d_count);
+	CUDA_TRY(cudaMemsetAsync(d_count, 0ull, sizeof(gdf_size_type)));
+ 
+	int blockSize;		// suggested thread count to use
+	int minGridSize;	// minimum block count required
+	CUDA_TRY(cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, countAndSetPositions<void>) );
+ 
+	const size_t chunk_count = (h_size + max_chunk_bytes - 1) / max_chunk_bytes;
+	for (size_t ci = 0; ci < chunk_count; ++ci) {	
+		const auto chunk_offset = ci * max_chunk_bytes;	
+		const auto h_chunk = h_data + chunk_offset;
+		const auto chunk_bytes = std::min((size_t)(h_size - ci * max_chunk_bytes), max_chunk_bytes);
+		const auto chunk_bits = (chunk_bytes + bytes_per_find_thread - 1) / bytes_per_find_thread;
+		const int gridSize = (chunk_bits + blockSize - 1) / blockSize;
+ 
+		// Copy chunk to device
+		CUDA_TRY(cudaMemcpyAsync(d_chunk, h_chunk, chunk_bytes, cudaMemcpyDefault));
+ 
+		for (char key: keys) {
+		 countAndSetPositions<void> <<< gridSize, blockSize >>> (
+				d_chunk, chunk_bytes, 0, key,
+				d_count, nullptr);
+		}
+	}
+ 
+	gdf_size_type h_count = 0;
+	CUDA_TRY(cudaMemcpy(&h_count, d_count, sizeof(gdf_size_type), cudaMemcpyDefault));
+
+
+	return h_count;
+ }
+
+/**---------------------------------------------------------------------------*
  * @brief For each of the characters in the input set, find and saves all 
- * cccurences in the input host array of characters.
+ * occurrences in the input host array of characters.
  * The positions are stored in the output device array.
  * 
  * Does not load the entire file into the GPU memory at any time, so it can 
@@ -102,8 +170,9 @@ gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> k
  * 
  * @return gdf_error with error code on failure, otherwise GDF_SUCCESS
  *---------------------------------------------------------------------------**/
-gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, ll_uint_t result_offset,
-	ll_uint_t *positions) {
+template<class T>
+gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, uint64_t result_offset,
+	T *positions) {
 
 	char* d_chunk = nullptr;
 	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0)); 
@@ -114,7 +183,7 @@ gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> ke
 
 	int blockSize;		// suggested thread count to use
 	int minGridSize;	// minimum block count required
-	CUDA_TRY(cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, findAll) );
+	CUDA_TRY(cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, countAndSetPositions<T>) );
 
 	const size_t chunk_count = (h_size + max_chunk_bytes - 1) / max_chunk_bytes;
 	for (size_t ci = 0; ci < chunk_count; ++ci) {	
@@ -128,16 +197,26 @@ gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> ke
 		CUDA_TRY(cudaMemcpyAsync(d_chunk, h_chunk, chunk_bytes, cudaMemcpyDefault));
 
 		for (char key: keys) {
-			findAll <<< gridSize, blockSize >>> (
+			countAndSetPositions<T> <<< gridSize, blockSize >>> (
 				d_chunk, chunk_bytes, chunk_offset + result_offset, key,
 				d_count, positions);
 		}
 	}
 
-	RMM_TRY( RMM_FREE( d_count, 0 ) ); 
-	RMM_TRY( RMM_FREE( d_chunk, 0 ) );
+	gdf_size_type h_count = 0;
+	CUDA_TRY(cudaMemcpy(&h_count, d_count, sizeof(gdf_size_type), cudaMemcpyDefault));
+	thrust::sort(rmm::exec_policy()->on(0), positions, positions + h_count);
 
-	CUDA_TRY( cudaGetLastError() );
+	RMM_TRY(RMM_FREE(d_count, 0)); 
+	RMM_TRY(RMM_FREE(d_chunk, 0));
+
+	CUDA_TRY(cudaGetLastError());
 
 	return GDF_SUCCESS;
 }
+
+template gdf_error findAllFromSet<uint64_t>(const char *h_data, size_t h_size, std::vector<char> keys, uint64_t result_offset,
+	uint64_t *positions);
+
+template gdf_error findAllFromSet<thrust::pair<uint64_t,char>>(const char *h_data, size_t h_size, std::vector<char> keys, uint64_t result_offset,
+	thrust::pair<uint64_t,char> *positions);

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -64,7 +64,7 @@ gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> k
  * @return void
  *---------------------------------------------------------------------------**/
  __global__ void findAll(char *data, size_t size, size_t offset, const char key,
-	cu_reccnt_t* count, cu_recstart_t* positions) {
+	gdf_size_type* count, ll_uint_t* positions) {
 
 	// thread IDs range per block, so also need the block id
 	const long tid = threadIdx.x + (blockDim.x * blockIdx.x);
@@ -101,15 +101,15 @@ gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> k
  * 
  * @return gdf_error with error code on failure, otherwise GDF_SUCCESS
  *---------------------------------------------------------------------------**/
-gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, cu_recstart_t result_offset,
-	cu_recstart_t *positions) {
+gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, ll_uint_t result_offset,
+	ll_uint_t *positions) {
 
 	char* d_chunk = nullptr;
 	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0)); 
 	
-	cu_reccnt_t*	d_count;
-	RMM_TRY(RMM_ALLOC((void**)&d_count, sizeof(cu_reccnt_t), 0) );
-	CUDA_TRY(cudaMemsetAsync(d_count, 0ull, sizeof(cu_reccnt_t)));
+	gdf_size_type*	d_count;
+	RMM_TRY(RMM_ALLOC((void**)&d_count, sizeof(gdf_size_type), 0) );
+	CUDA_TRY(cudaMemsetAsync(d_count, 0ull, sizeof(gdf_size_type)));
 
 	int blockSize;		// suggested thread count to use
 	int minGridSize;	// minimum block count required

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -1,0 +1,49 @@
+#include "parsing_utils.cuh"
+
+#include <cuda_runtime.h>
+
+#include <vector>
+
+#include "rmm/rmm.h"
+#include "rmm/thrust_rmm_allocator.h"
+#include "utilities/error_utils.hpp"
+
+/**---------------------------------------------------------------------------*
+ * @brief Sums up the number of occurences of characters from a set
+ *
+ * Does not load the entire buffer into the GPU memory at any time, so it can 
+ * be used with buffers of any size.
+ *
+ * @param[in] h_data Pointer to the csv data in host memory
+ * @param[in] h_size Size of the input data, in bytes
+ * @param[in] keys Vector containing the keys to count in the buffer
+ * @param[in,out] raw_csv Structure containing the csv parsing parameters
+ * and intermediate results
+ *
+ * @return gdf_error
+ *---------------------------------------------------------------------------**/
+gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, gdf_size_type &rec_cnt)
+{
+	const size_t chunk_count = (h_size + max_chunk_bytes - 1) / max_chunk_bytes;
+
+	char* d_chunk = nullptr;
+	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0)); 
+
+	for (size_t ci = 0; ci < chunk_count; ++ci) {
+		const auto h_chunk = h_data + ci * max_chunk_bytes;
+		const auto chunk_bytes = std::min((size_t)(h_size - ci * max_chunk_bytes), max_chunk_bytes);
+
+		// Copy chunk to device
+		CUDA_TRY(cudaMemcpyAsync(d_chunk, h_chunk, chunk_bytes, cudaMemcpyDefault, (cudaStream_t)0));
+
+		for (char key: keys) {
+			rec_cnt += thrust::count(rmm::exec_policy()->on(0), d_chunk, d_chunk + chunk_bytes, key);
+		}
+	}
+
+	RMM_TRY( RMM_FREE(d_chunk, 0) );
+
+	CUDA_TRY(cudaGetLastError());
+
+	return GDF_SUCCESS;
+}

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -8,6 +8,7 @@
 #include "rmm/thrust_rmm_allocator.h"
 #include "utilities/error_utils.hpp"
 
+constexpr size_t max_chunk_bytes = 256*1024*1024; // 256MB
 constexpr int bytes_per_find_thread = 64;
 
 /**---------------------------------------------------------------------------*

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -45,8 +45,6 @@ struct rmm_deleter {
 template <typename T>
 using device_ptr = std::unique_ptr<T, rmm_deleter<T>>;
 
-using position_key_pair = thrust::pair<uint64_t,char>;
-
 /**---------------------------------------------------------------------------*
  * @brief Sets the specified element of the array to the passed value
  *---------------------------------------------------------------------------**/

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -36,7 +36,7 @@ gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> k
 		const auto chunk_bytes = std::min((size_t)(h_size - ci * max_chunk_bytes), max_chunk_bytes);
 
 		// Copy chunk to device
-		CUDA_TRY(cudaMemcpyAsync(d_chunk, h_chunk, chunk_bytes, cudaMemcpyDefault, (cudaStream_t)0));
+		CUDA_TRY(cudaMemcpyAsync(d_chunk, h_chunk, chunk_bytes, cudaMemcpyDefault));
 
 		for (char key: keys) {
 			count += thrust::count(rmm::exec_policy()->on(0), d_chunk, d_chunk + chunk_bytes, key);

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -19,6 +19,7 @@
  *
  */
 
+
 #include "parsing_utils.cuh"
 
 #include <cuda_runtime.h>
@@ -34,6 +35,7 @@
 // Only one chunk is loaded on the GPU at a time, so this value is chosen to
 // be small enough to fit on the GPU in most cases.
 constexpr size_t max_chunk_bytes = 256*1024*1024; // 256MB
+
 constexpr int bytes_per_find_thread = 64;
 
 template <typename T>
@@ -45,27 +47,38 @@ using device_ptr = std::unique_ptr<T, rmm_deleter<T>>;
 
 using position_key_pair = thrust::pair<uint64_t,char>;
 
-//doxy
-template<class P, class K>
+/**---------------------------------------------------------------------------*
+ * @brief Sets the specified element of the array to the passed value
+ *---------------------------------------------------------------------------**/
+template<class T, class V>
 __device__ __forceinline__
-void updatePosition(P* positions, long idx, P position, K key){
-	positions[idx] = position;
+void setElement(T* array, gdf_size_type idx, const T& t, const V& v){
+	array[idx] = t;
 }
 
-template<class P, class K>
+/**---------------------------------------------------------------------------*
+ * @brief Sets the specified element of the array of pairs using the two passed
+ * parameters.
+ *---------------------------------------------------------------------------**/
+template<class T, class V>
 __device__ __forceinline__
-void updatePosition(thrust::pair<P, K>* positions, long idx, P position, K key) {
-	positions[idx] = {position, key};
+void setElement(thrust::pair<T, V>* array, gdf_size_type idx, const T& t, const V& v) {
+	array[idx] = {t, v};
 }
 
-template<class P, class K>
+/**---------------------------------------------------------------------------*
+ * @brief Overloads the setElement() functions for void* arrays.
+ * Does not do anything, indexing is not allowed with void* arrays.
+ *---------------------------------------------------------------------------**/
+template<class T, class V>
 __device__ __forceinline__
-void updatePosition(void* positions, long idx, P position, K key) {
+void setElement(void* array, gdf_size_type idx, const T& t, const V& v) {
 }
 
 /**---------------------------------------------------------------------------*
  * @brief CUDA kernel that finds all occurrences of a character in the given 
- * character array. The positions are stored in the output array.
+ * character array. If the 'positions' parameter is not void*,
+ * positions of all occurrences are stored in the output array.
  * 
  * @param[in] data Pointer to the input character array
  * @param[in] size Number of bytes in the input array
@@ -82,8 +95,8 @@ template<class T>
 	T* positions) {
 
 	// thread IDs range per block, so also need the block id
-	const long tid = threadIdx.x + (blockDim.x * blockIdx.x);
-	const long did = tid * bytes_per_find_thread;
+	const uint64_t tid = threadIdx.x + (blockDim.x * blockIdx.x);
+	const uint64_t did = tid * bytes_per_find_thread;
 	
 	const char *raw = (data + did);
 
@@ -95,69 +108,15 @@ template<class T>
 	for (long i = 0; i < byteToProcess; i++) {
 		if (raw[i] == key) {
 			const auto idx = atomicAdd(count, (gdf_size_type)1);
-			updatePosition(positions, idx, did + offset + i, key);
+			setElement(positions, idx, did + offset + i, key);
 		}
 	}
 }
 
 /**---------------------------------------------------------------------------*
- * @brief Searches the input character array for each of characters in a set
- * and sums up the number of occurrences.
- *
- * Does not load the entire buffer into the GPU memory at any time, so it can 
- * be used with buffers of any size.
- *
- * @param[in] h_data Pointer to the data in host memory
- * @param[in] h_size Size of the input data, in bytes
- * @param[in] keys Vector containing the keys to count in the buffer
- * @param[out] count Total number of occurrences of all keys
- *
- * @return gdf_error
- *---------------------------------------------------------------------------**/
-gdf_size_type countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys)
-{
-	char* d_chunk = nullptr;
-	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0));
-	device_ptr<char> chunk_data(d_chunk);
-	
-	gdf_size_type*	d_count;
-	RMM_TRY(RMM_ALLOC((void**)&d_count, sizeof(gdf_size_type), 0) );
-	device_ptr<gdf_size_type> count_data(d_count);
-	CUDA_TRY(cudaMemsetAsync(d_count, 0ull, sizeof(gdf_size_type)));
- 
-	int blockSize;		// suggested thread count to use
-	int minGridSize;	// minimum block count required
-	CUDA_TRY(cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, countAndSetPositions<void>) );
- 
-	const size_t chunk_count = (h_size + max_chunk_bytes - 1) / max_chunk_bytes;
-	for (size_t ci = 0; ci < chunk_count; ++ci) {	
-		const auto chunk_offset = ci * max_chunk_bytes;	
-		const auto h_chunk = h_data + chunk_offset;
-		const auto chunk_bytes = std::min((size_t)(h_size - ci * max_chunk_bytes), max_chunk_bytes);
-		const auto chunk_bits = (chunk_bytes + bytes_per_find_thread - 1) / bytes_per_find_thread;
-		const int gridSize = (chunk_bits + blockSize - 1) / blockSize;
- 
-		// Copy chunk to device
-		CUDA_TRY(cudaMemcpyAsync(d_chunk, h_chunk, chunk_bytes, cudaMemcpyDefault));
- 
-		for (char key: keys) {
-		 countAndSetPositions<void> <<< gridSize, blockSize >>> (
-				d_chunk, chunk_bytes, 0, key,
-				d_count, nullptr);
-		}
-	}
- 
-	gdf_size_type h_count = 0;
-	CUDA_TRY(cudaMemcpy(&h_count, d_count, sizeof(gdf_size_type), cudaMemcpyDefault));
-
-
-	return h_count;
- }
-
-/**---------------------------------------------------------------------------*
- * @brief For each of the characters in the input set, find and saves all 
- * occurrences in the input host array of characters.
- * The positions are stored in the output device array.
+ * @brief Searches the input character array for each of characters in a set.
+ * Sums up the number of occurrences. If the 'positions' parameter is not void*,
+ * positions of all occurrences are stored in the output device array.
  * 
  * Does not load the entire file into the GPU memory at any time, so it can 
  * be used to parse large files. Output array needs to be preallocated.
@@ -168,17 +127,19 @@ gdf_size_type countAllFromSet(const char *h_data, size_t h_size, std::vector<cha
  * @param[in] result_offset Offset to add to the output positions
  * @param[out] positions Array containing the output positions
  * 
- * @return gdf_error with error code on failure, otherwise GDF_SUCCESS
+ * @return gdf_size_type total number of occurrences
  *---------------------------------------------------------------------------**/
 template<class T>
-gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, uint64_t result_offset,
+gdf_size_type findAllFromSet(const char *h_data, size_t h_size, const std::vector<char>& keys, uint64_t result_offset,
 	T *positions) {
 
 	char* d_chunk = nullptr;
-	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0)); 
-	
+	RMM_TRY(RMM_ALLOC (&d_chunk, min(max_chunk_bytes, h_size), 0));
+	device_ptr<char> chunk_deleter(d_chunk);
+
 	gdf_size_type*	d_count;
 	RMM_TRY(RMM_ALLOC((void**)&d_count, sizeof(gdf_size_type), 0) );
+	device_ptr<gdf_size_type> count_deleter(d_count);
 	CUDA_TRY(cudaMemsetAsync(d_count, 0ull, sizeof(gdf_size_type)));
 
 	int blockSize;		// suggested thread count to use
@@ -205,18 +166,28 @@ gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> ke
 
 	gdf_size_type h_count = 0;
 	CUDA_TRY(cudaMemcpy(&h_count, d_count, sizeof(gdf_size_type), cudaMemcpyDefault));
-	thrust::sort(rmm::exec_policy()->on(0), positions, positions + h_count);
-
-	RMM_TRY(RMM_FREE(d_count, 0)); 
-	RMM_TRY(RMM_FREE(d_chunk, 0));
-
-	CUDA_TRY(cudaGetLastError());
-
-	return GDF_SUCCESS;
+	return h_count;
 }
 
-template gdf_error findAllFromSet<uint64_t>(const char *h_data, size_t h_size, std::vector<char> keys, uint64_t result_offset,
+/**---------------------------------------------------------------------------*
+ * @brief Searches the input character array for each of characters in a set
+ * and sums up the number of occurrences.
+ *
+ * Does not load the entire buffer into the GPU memory at any time, so it can 
+ * be used with buffers of any size.
+ *
+ * @param[in] h_data Pointer to the data in host memory
+ * @param[in] h_size Size of the input data, in bytes
+ * @param[in] keys Vector containing the keys to count in the buffer
+ *
+ * @return gdf_size_type total number of occurrences
+ *---------------------------------------------------------------------------**/
+gdf_size_type countAllFromSet(const char *h_data, size_t h_size, const std::vector<char>& keys) {
+	return findAllFromSet<void>(h_data, h_size, keys, 0, nullptr);
+ }
+
+template gdf_size_type findAllFromSet<uint64_t>(const char *h_data, size_t h_size, const std::vector<char>& keys, uint64_t result_offset,
 	uint64_t *positions);
 
-template gdf_error findAllFromSet<thrust::pair<uint64_t,char>>(const char *h_data, size_t h_size, std::vector<char> keys, uint64_t result_offset,
+template gdf_size_type findAllFromSet<thrust::pair<uint64_t,char>>(const char *h_data, size_t h_size, const std::vector<char>& keys, uint64_t result_offset,
 	thrust::pair<uint64_t,char> *positions);

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -4,8 +4,6 @@
 
 #include "cudf.h"
 
-constexpr size_t max_chunk_bytes = 256*1024*1024; // 256MB
-
 using ll_uint_t = unsigned long long int;
 
 gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, 

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -1,13 +1,33 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+	 * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file parsing_utils.cuh Declarations of utility functions for parsing plain-text files
+ *
+ */
+
+
 #pragma once
 
 #include <vector>
 
 #include "cudf.h"
 
-using ll_uint_t = unsigned long long int;
+gdf_size_type countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys);
 
-gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, 
-	gdf_size_type &rec_cnt);
-
-gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, ll_uint_t result_offset,
-	ll_uint_t *recStart);
+template<class T>
+gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, uint64_t result_offset,
+	T *positions);

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -26,8 +26,8 @@
 
 #include "cudf.h"
 
-gdf_size_type countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys);
+gdf_size_type countAllFromSet(const char *h_data, size_t h_size, const std::vector<char>& keys);
 
 template<class T>
-gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, uint64_t result_offset,
+gdf_size_type findAllFromSet(const char *h_data, size_t h_size, const std::vector<char>& keys, uint64_t result_offset,
 	T *positions);

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -6,4 +6,8 @@
 
 constexpr size_t max_chunk_bytes = 256*1024*1024; // 256MB
 
-gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, gdf_size_type &rec_cnt);
+gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, 
+	gdf_size_type &rec_cnt);
+
+gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, cu_recstart_t result_offset,
+	cu_recstart_t *recStart);

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -6,8 +6,10 @@
 
 constexpr size_t max_chunk_bytes = 256*1024*1024; // 256MB
 
+using ll_uint_t = unsigned long long int;
+
 gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, 
 	gdf_size_type &rec_cnt);
 
-gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, cu_recstart_t result_offset,
-	cu_recstart_t *recStart);
+gdf_error findAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, ll_uint_t result_offset,
+	ll_uint_t *recStart);

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <vector>
+
+#include "cudf.h"
+
+constexpr size_t max_chunk_bytes = 256*1024*1024; // 256MB
+
+gdf_error countAllFromSet(const char *h_data, size_t h_size, std::vector<char> keys, gdf_size_type &rec_cnt);


### PR DESCRIPTION
Set up utility functions for file parsing:
* Replace the countRecords kernel with thrust library calls;
* Make the launch_countRecords into a generic utility function;
* Make the storerecordStart kernel and launch_storerecordStart generic;
* move all of the above into a separate file, making the code reusable;
Other:
* Use Async CUDA calls for memory copies and sets;
* fix chunk allocation for small files - no longer allocates full chunk size when the file is smaller than chunk size;
* Refactor the code that set the record starts into a separate function;
* Rename the CSV specific typedefs to be more generic. usable in the utility functions;