### PR TITLE
Fix catch polymorphic exception by reference in ipc.cu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #1254 CSV Reader: fix data type detection for floating-point numbers in scientific notation
 - PR #1289 Fix looping over each value instead of each category in concatenation
 - PR #1293 Fix Inaccurate error message in join.pyx
+- PR #1317 Fix catch polymorphic exception by reference in ipc.cu
 
 
 # cuDF 0.6.0 (Date TBD)

--- a/cpp/src/comms/ipc/ipc.cu
+++ b/cpp/src/comms/ipc/ipc.cu
@@ -128,7 +128,7 @@ public:
     void open(const uint8_t *schema, size_t length) {
         try {
             read_schema(schema, length);
-        } catch ( ParseError e ) {
+        } catch ( ParseError const &e ) {
             std::ostringstream oss;
             oss << "ParseError: " << e.what();
             _error_message = oss.str();
@@ -139,7 +139,7 @@ public:
     void open_recordbatches(const uint8_t *recordbatches, size_t length) {
         try {
             read_record_batch(recordbatches, length);
-        } catch ( ParseError e ) {
+        } catch ( ParseError const &e ) {
             std::ostringstream oss;
             oss << "ParseError: " << e.what();
             _error_message = oss.str();


### PR DESCRIPTION
Issue #1307 pointed out that on some platforms the compiler warns (therefore error) that a `catch` block in `ipc.cu` is catching a polymorphic exception by value. This PR changes it to a const reference.