### PR TITLE
[WIP] compare label codes against the category indices instead of the category values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - PR #1254 CSV Reader: fix data type detection for floating-point numbers in scientific notation
 - PR #1289 Fix looping over each value instead of each category in concatenation
 - PR #1293 Fix Inaccurate error message in join.pyx
-
+- PR #1331 Fix Series label_encode to compare codes against category indices instead of values
 
 # cuDF 0.6.0 (Date TBD)
 

--- a/python/cudf/utils/cudautils.py
+++ b/python/cudf/utils/cudautils.py
@@ -511,7 +511,7 @@ def compute_scale(arr, vmin, vmax):
 
 
 @cuda.jit
-def gpu_label(arr, cats, enc, na_sentinel, out):
+def gpu_label(arr, enc, cats, na_sentinel, out):
     i = cuda.grid(1)
     if i < out.size:
         val = arr[i]


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/1330

I intentionally kept this PR minimal so it'd be obvious where the bug is. I'd be happy to rename the arguments or variables in both `gpu_label` and `cudautils.apply_label` to be clearer as a follow-up commit.

In the implementation of `cudautils.apply_label`, it seems the category values are being compared against the label indices, rather than the category indices:

* The values from the source Series are the codes, aka the indices in the categories list: https://github.com/rapidsai/cudf/blob/9c49d49fef6341aeebbc1e9333fa8fef88ff8de9/python/cudf/dataframe/series.py#L993-L1005
* The first argument to `arr` is the codes, and `encs` is the list of category indices, 0 through n-1: https://github.com/rapidsai/cudf/blob/9c49d49fef6341aeebbc1e9333fa8fef88ff8de9/python/cudf/utils/cudautils.py#L542-L548
* But in the `gpu_label` numba function, it's comparing `arr[i] == cats[j]`, i.e. comparing the code to the category value, instead of to the index of that value in the categories list:
https://github.com/rapidsai/cudf/blob/9c49d49fef6341aeebbc1e9333fa8fef88ff8de9/python/cudf/utils/cudautils.py#L517-L523

```python
# Ints:
codes = Series([0, 1, 2, 3,  4,  5]).astype(np.int32)
cats = Series([2, 1, 0, -1, -2, -3]).astype(np.int32)
vals = codes.label_encoding(cats)
print(vals)
# 0     2
# 1     1
# 2     0
# 3    -1
# 4    -2
# 5    -3
# dtype: int32

# Strings
codes = Series([0, 1, 2, 3,  4,  5]).astype(np.int32)
cats = pd.Series(['2', '1', '0', '-1', '-2', '-3'])
cats = Series.from_categorical(pd.Categorical(cats))
vals = codes.label_encoding(cats)
print('cats.codes:\n', cats.cat.codes)
print('cats.categories:\n', cats.cat.categories)
print(vals)

print('as strings:', Series(CategoricalColumn(
    ordered=False,
    dtype='categorical',
    data=vals.data,
    categories=cats.cat.categories)))

# cats.codes:
# 0    5
# 1    4
# 2    3
# 3    0
# 4    1
# 5    2
# dtype: int8
# 
# cats.categories:
#  ('-1', '-2', '-3', '0', '1', '2')

# 0    5
# 1    4
# 2    3
# 3    0
# 4    1
# 5    2
# dtype: int32

# as strings:
# 0     2
# 1     1
# 2     0
# 3    -1
# 4    -2
# 5    -3
# dtype: category
```
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
