### PR TITLE
[REVIEW] CSV Reader: Fix memory leaks on read_csv() failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #1289 Fix looping over each value instead of each category in concatenation
 - PR #1293 Fix Inaccurate error message in join.pyx
 - PR #1317 Fix catch polymorphic exception by reference in ipc.cu
+- PR #1338 CSV Reader: Fix memory leaks on read_csv() failure
 
 
 # cuDF 0.6.0 (Date TBD)

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -60,66 +60,11 @@
 #include "io/comp/io_uncomp.h"
 
 #include "io/utilities/parsing_utils.cuh"
+#include "io/utilities/memory_utils.hpp"
 
 using std::vector;
 using std::string;
 using std::unique_ptr;
-
-// DOXY
-template <class T>
-class rmm_unique_ptr {
-	T* ptr;
-
-public:
-	rmm_unique_ptr() {
-		//  if ((x) != RMM_SUCCESS) return GDF_MEMORYMANAGER_ERROR;
-		RMM_ALLOC(&ptr, sizeof(T), 0);
-	}
-	~rmm_unique_ptr() {
-		delete ptr;
-	}
-	T* get() {
-		return ptr;
-	}
-	rmm_unique_ptr& operator= (const rmm_unique_ptr &p) = delete;
-	rmm_unique_ptr& operator= (rmm_unique_ptr &&p) {
-		ptr = p.ptr;
-		p.ptr = nullptr;
-		return *this;
-	}
-};
-
-// DOXY
-template <class T>
-class rmm_unique_ptr<T[]> {
-	T* ptr = nullptr;
-
-public:
-	rmm_unique_ptr() = default;
-	explicit rmm_unique_ptr(size_t cnt) {
-		RMM_ALLOC(&ptr, sizeof(T)*cnt, 0);
-	}
-	~rmm_unique_ptr() {
-		RMM_FREE(ptr, 0);
-	}
-	T* get() {
-		return ptr;
-	}
-	void resize(size_t cnt) {
-		RMM_FREE(ptr, 0);
-		if (cnt != 0)
-			RMM_ALLOC(&ptr, sizeof(T)*cnt, 0);
-		else 
-			ptr = nullptr;
-	}
-	rmm_unique_ptr& operator= (const rmm_unique_ptr &p) = delete;
-	rmm_unique_ptr& operator= (rmm_unique_ptr &&p) {
-		ptr = p.ptr;
-		p.ptr = nullptr;
-		return *this;
-	}
-};
-
 
 /**---------------------------------------------------------------------------*
  * @brief Struct used for internal parsing state

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -65,12 +65,65 @@ using std::vector;
 using std::string;
 using std::unique_ptr;
 
+// DOXY
+template <class T>
+class rmm_unique_ptr {
+	T* ptr;
+
+public:
+	rmm_unique_ptr() {
+		//  if ((x) != RMM_SUCCESS) return GDF_MEMORYMANAGER_ERROR;
+		RMM_ALLOC(&ptr, sizeof(T), 0);
+	}
+	~rmm_unique_ptr() {
+		delete ptr;
+	}
+	T* get() {
+		return ptr;
+	}
+	rmm_unique_ptr& operator= (const rmm_unique_ptr &p) = delete;
+	rmm_unique_ptr& operator= (rmm_unique_ptr &&p) {
+		ptr = p.ptr;
+		p.ptr = nullptr;
+		return *this;
+	}
+};
+
+// DOXY
+template <class T>
+class rmm_unique_ptr<T[]> {
+	T* ptr = nullptr;
+
+public:
+	rmm_unique_ptr() = default;
+	explicit rmm_unique_ptr(size_t cnt) {
+		RMM_ALLOC(&ptr, sizeof(T)*cnt, 0);
+	}
+	~rmm_unique_ptr() {
+		RMM_FREE(ptr, 0);
+	}
+	T* get() {
+		return ptr;
+	}
+	void resize(size_t cnt) {
+		RMM_FREE(ptr, 0);
+		RMM_ALLOC(&ptr, sizeof(T)*cnt, 0);
+	}
+	rmm_unique_ptr& operator= (const rmm_unique_ptr &p) = delete;
+	rmm_unique_ptr& operator= (rmm_unique_ptr &&p) {
+		ptr = p.ptr;
+		p.ptr = nullptr;
+		return *this;
+	}
+};
+
+
 /**---------------------------------------------------------------------------*
  * @brief Struct used for internal parsing state
  *---------------------------------------------------------------------------**/
 typedef struct raw_csv_ {
-    char *				data;			// on-device: the raw unprocessed CSV data - loaded as a large char * array
-    uint64_t*		recStart;		// on-device: Starting position of the records.
+    rmm_unique_ptr<char[]>		data;		// on-device: the raw unprocessed CSV data - loaded as a large char * array
+    rmm_unique_ptr<uint64_t[]>	recStart;	// on-device: Starting position of the records.
 
     ParseOptions        opts;			// options to control parsing behavior
 
@@ -83,7 +136,7 @@ typedef struct raw_csv_ {
     vector<gdf_dtype>	dtypes;			// host: array of dtypes (since gdf_columns are not created until end)
     vector<string>		col_names;		// host: array of column names
     unique_ptr<bool[]>	h_parseCol;		// host: array of booleans stating if column should be parsed in reading process: parseCol[x]=false means that the column x needs to be filtered out.
-    bool* 				d_parseCol;		// device : array of booleans stating if column should be parsed in reading process: parseCol[x]=false means that the column x needs to be filtered out.
+    rmm_unique_ptr<bool[]> d_parseCol;	// device : array of booleans stating if column should be parsed in reading process: parseCol[x]=false means that the column x needs to be filtered out.
 
     long        byte_range_offset;  // offset into the data to start parsing
     long        byte_range_size;    // length of the data of interest to parse
@@ -222,14 +275,14 @@ gdf_error setColumnNamesFromCsv(raw_csv_t* raw_csv) {
 		uint64_t first_row_len{};
 		// If file only contains one row, raw_csv->recStart[1] is not valid
 		if (raw_csv->num_records > 1) {
-			CUDA_TRY(cudaMemcpy(&first_row_len, raw_csv->recStart + 1, sizeof(uint64_t), cudaMemcpyDefault));
+			CUDA_TRY(cudaMemcpy(&first_row_len, raw_csv->recStart.get() + 1, sizeof(uint64_t), cudaMemcpyDefault));
 		}
 		else {
 			// File has one row - use the file size for the row size
 			first_row_len = raw_csv->num_bytes / sizeof(char);
 		}
 		first_row.resize(first_row_len);
-		CUDA_TRY(cudaMemcpy(first_row.data(), raw_csv->data, first_row_len * sizeof(char), cudaMemcpyDefault));
+		CUDA_TRY(cudaMemcpy(first_row.data(), raw_csv->data.get(), first_row_len * sizeof(char), cudaMemcpyDefault));
 	}
 
 	int num_cols = 0;
@@ -328,12 +381,12 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 	const bool last_line_terminated = (h_data[h_size - 1] == raw_csv->opts.terminator);
 	// If the last line is not terminated, allocate space for the EOF entry (added later)
 	const gdf_size_type record_start_count = raw_csv->num_records + (last_line_terminated ? 0 : 1);
-	RMM_TRY( RMM_ALLOC(&raw_csv->recStart, sizeof(uint64_t) * record_start_count, 0) ); 
+	raw_csv->recStart = rmm_unique_ptr<uint64_t[]>(record_start_count);
 
-	auto* find_result_ptr = raw_csv->recStart;
+	auto* find_result_ptr = raw_csv->recStart.get();
 	if (raw_csv->byte_range_offset == 0) {
 		find_result_ptr++;
-		CUDA_TRY(cudaMemsetAsync(raw_csv->recStart, 0ull, sizeof(uint64_t)));
+		CUDA_TRY(cudaMemsetAsync(raw_csv->recStart.get(), 0ull, sizeof(uint64_t)));
 	}
 	vector<char> chars_to_find{raw_csv->opts.terminator};
 	if (raw_csv->opts.quotechar != '\0') {
@@ -345,7 +398,7 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 	// Previous kernel stores the record pinput_file.typeositions as encountered by all threads
 	// Sort the record positions as subsequent processing may require filtering
 	// certain rows or other processing on specific records
-	thrust::sort(rmm::exec_policy()->on(0), raw_csv->recStart, raw_csv->recStart + raw_csv->num_records);
+	thrust::sort(rmm::exec_policy()->on(0), raw_csv->recStart.get(), raw_csv->recStart.get() + raw_csv->num_records);
 
 	// Currently, ignoring lineterminations within quotes is handled by recording
 	// the records of both, and then filtering out the records that is a quotechar
@@ -354,7 +407,7 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 	if (raw_csv->opts.quotechar != '\0') {
 		vector<uint64_t> h_rec_starts(raw_csv->num_records);
 		const size_t rec_start_size = sizeof(uint64_t) * (h_rec_starts.size());
-		CUDA_TRY( cudaMemcpy(h_rec_starts.data(), raw_csv->recStart, rec_start_size, cudaMemcpyDeviceToHost) );
+		CUDA_TRY( cudaMemcpy(h_rec_starts.data(), raw_csv->recStart.get(), rec_start_size, cudaMemcpyDeviceToHost) );
 
 		auto recCount = raw_csv->num_records;
 
@@ -371,15 +424,15 @@ gdf_error setRecordStarts(const char *h_data, size_t h_size, raw_csv_t *raw_csv)
 			}
 		}
 
-		CUDA_TRY( cudaMemcpy(raw_csv->recStart, h_rec_starts.data(), rec_start_size, cudaMemcpyHostToDevice) );
-		thrust::sort(rmm::exec_policy()->on(0), raw_csv->recStart, raw_csv->recStart + raw_csv->num_records);
+		CUDA_TRY( cudaMemcpy(raw_csv->recStart.get(), h_rec_starts.data(), rec_start_size, cudaMemcpyHostToDevice) );
+		thrust::sort(rmm::exec_policy()->on(0), raw_csv->recStart.get(), raw_csv->recStart.get() + raw_csv->num_records);
 		raw_csv->num_records = recCount;
 	}
 
 	if (!last_line_terminated){
 		// Add the EOF as the last record when the terminator is missing in the last line
 		const uint64_t eof_offset = h_size;
-		CUDA_TRY(cudaMemcpy(raw_csv->recStart + raw_csv->num_records, &eof_offset, sizeof(uint64_t), cudaMemcpyDefault));
+		CUDA_TRY(cudaMemcpy(raw_csv->recStart.get() + raw_csv->num_records, &eof_offset, sizeof(uint64_t), cudaMemcpyDefault));
 		// Update the record count
 		++raw_csv->num_records;
 	}
@@ -599,7 +652,7 @@ gdf_error read_csv(csv_read_arg *args)
 
 		// Allocating a boolean array that will use to state if a column needs to read or filtered.
 		raw_csv.h_parseCol = std::make_unique<bool[]>(h_num_cols);
-		RMM_TRY( RMM_ALLOC((void**)&raw_csv.d_parseCol,(sizeof(bool) * (h_num_cols)),0 ) );
+		raw_csv.d_parseCol = rmm_unique_ptr<bool[]>(h_num_cols);
 		for (int i = 0; i<h_num_cols; i++)
 			raw_csv.h_parseCol[i]=true;		
 		// Rename empty column names to "Unnamed: col_index"
@@ -643,11 +696,11 @@ gdf_error read_csv(csv_read_arg *args)
 		raw_csv.num_actual_cols = h_num_cols;							// Actual number of columns in the CSV file
 		raw_csv.num_active_cols = h_num_cols-h_dup_cols_removed;		// Number of fields that need to be processed based on duplicatation fields
 
-		CUDA_TRY(cudaMemcpy(raw_csv.d_parseCol, raw_csv.h_parseCol.get(), sizeof(bool) * (h_num_cols), cudaMemcpyHostToDevice));
+		CUDA_TRY(cudaMemcpy(raw_csv.d_parseCol.get(), raw_csv.h_parseCol.get(), sizeof(bool) * (h_num_cols), cudaMemcpyHostToDevice));
 	}
 	else {
 		raw_csv.h_parseCol = std::make_unique<bool[]>(args->num_cols);
-		RMM_TRY( RMM_ALLOC((void**)&raw_csv.d_parseCol,(sizeof(bool) * (args->num_cols)),0 ) );
+		raw_csv.d_parseCol = rmm_unique_ptr<bool[]>(args->num_cols);
 
 		for (int i = 0; i<raw_csv.num_actual_cols; i++){
 			raw_csv.h_parseCol[i]=true;
@@ -655,7 +708,7 @@ gdf_error read_csv(csv_read_arg *args)
 			raw_csv.col_names.push_back(col_name);
 
 		}
-		CUDA_TRY(cudaMemcpy(raw_csv.d_parseCol, raw_csv.h_parseCol.get(), sizeof(bool) * (args->num_cols), cudaMemcpyHostToDevice));
+		CUDA_TRY(cudaMemcpy(raw_csv.d_parseCol.get(), raw_csv.h_parseCol.get(), sizeof(bool) * (args->num_cols), cudaMemcpyHostToDevice));
 	}
 
 	// User can give
@@ -685,7 +738,7 @@ gdf_error read_csv(csv_read_arg *args)
 			}
 			raw_csv.num_active_cols = countFound;
 		}
-		CUDA_TRY(cudaMemcpy(raw_csv.d_parseCol, raw_csv.h_parseCol.get(), sizeof(bool) * (raw_csv.num_actual_cols), cudaMemcpyHostToDevice));
+		CUDA_TRY(cudaMemcpy(raw_csv.d_parseCol.get(), raw_csv.h_parseCol.get(), sizeof(bool) * (raw_csv.num_actual_cols), cudaMemcpyHostToDevice));
 	}
 
 
@@ -852,8 +905,6 @@ gdf_error read_csv(csv_read_arg *args)
 
 	// Free buffers that are not used from this point on
 	RMM_TRY( RMM_FREE( d_data, 0 ) );
-	RMM_TRY( RMM_FREE ( raw_csv.recStart, 0) );
-	RMM_TRY( RMM_FREE( raw_csv.d_parseCol, 0 ) );
 	RMM_TRY( RMM_FREE( d_dtypes, 0 ) );
 	RMM_TRY( RMM_FREE( d_valid, 0 ) );
 
@@ -895,7 +946,6 @@ gdf_error read_csv(csv_read_arg *args)
 
 	// Free up remaining internal buffers
 	RMM_TRY( RMM_FREE( d_valid_count, 0 ) );
-	RMM_TRY( RMM_FREE ( raw_csv.data, 0) );
 	cols_owner.release();
 	
 	args->data 			= cols;
@@ -1025,7 +1075,7 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
   raw_csv->num_records = raw_csv->num_records - first_row;
 
   std::vector<uint64_t> h_rec_starts(raw_csv->num_records);
-  CUDA_TRY(cudaMemcpy(h_rec_starts.data(), raw_csv->recStart + first_row,
+  CUDA_TRY(cudaMemcpy(h_rec_starts.data(), raw_csv->recStart.get() + first_row,
                       sizeof(uint64_t) * h_rec_starts.size(),
                       cudaMemcpyDefault));
 
@@ -1093,22 +1143,21 @@ gdf_error uploadDataToDevice(const char *h_uncomp_data, size_t h_uncomp_size,
   raw_csv->num_bits = (raw_csv->num_bytes + 63) / 64;
 
   // Resize and upload the rows of interest
-  RMM_TRY(RMM_REALLOC(&raw_csv->recStart,
-                      sizeof(uint64_t) * raw_csv->num_records, 0));
-  CUDA_TRY(cudaMemcpy(raw_csv->recStart, h_rec_starts.data(),
+  raw_csv->recStart.resize(raw_csv->num_records);
+  CUDA_TRY(cudaMemcpy(raw_csv->recStart.get(), h_rec_starts.data(),
                       sizeof(uint64_t) * raw_csv->num_records,
                       cudaMemcpyDefault));
 
   // Upload the raw data that is within the rows of interest
-  RMM_TRY(RMM_ALLOC(&raw_csv->data, raw_csv->num_bytes, 0));
-  CUDA_TRY(cudaMemcpy(raw_csv->data, h_uncomp_data + start_offset,
+  raw_csv->data = rmm_unique_ptr<char[]>(raw_csv->num_bytes);
+  CUDA_TRY(cudaMemcpy(raw_csv->data.get(), h_uncomp_data + start_offset,
                       raw_csv->num_bytes, cudaMemcpyHostToDevice));
 
   // Adjust row start positions to account for the data subcopy
-  thrust::transform(rmm::exec_policy()->on(0), raw_csv->recStart,
-                    raw_csv->recStart + raw_csv->num_records,
+  thrust::transform(rmm::exec_policy()->on(0), raw_csv->recStart.get(),
+                    raw_csv->recStart.get() + raw_csv->num_records,
                     thrust::make_constant_iterator(start_offset),
-                    raw_csv->recStart, thrust::minus<uint64_t>());
+                    raw_csv->recStart.get(), thrust::minus<uint64_t>());
 
   // The array of row offsets includes EOF
   // reduce the number of records by one to exclude it from the row count
@@ -1175,8 +1224,8 @@ gdf_error launch_dataConvertColumns(raw_csv_t *raw_csv, void **gdf,
   int gridSize = (raw_csv->num_records + blockSize - 1) / blockSize;
 
   convertCsvToGdf <<< gridSize, blockSize >>> (
-      raw_csv->data, raw_csv->opts, raw_csv->num_records,
-      raw_csv->num_actual_cols, raw_csv->d_parseCol, raw_csv->recStart,
+      raw_csv->data.get(), raw_csv->opts, raw_csv->num_records,
+      raw_csv->num_actual_cols, raw_csv->d_parseCol.get(), raw_csv->recStart.get(),
       d_dtypes, gdf,
       valid, str_cols, num_valid);
 
@@ -1401,8 +1450,8 @@ gdf_error launch_dataTypeDetection(raw_csv_t *raw_csv,
   int gridSize = (raw_csv->num_records + blockSize - 1) / blockSize;
 
   dataTypeDetection <<< gridSize, blockSize >>> (
-      raw_csv->data, raw_csv->opts, raw_csv->num_records,
-      raw_csv->num_actual_cols, raw_csv->d_parseCol, raw_csv->recStart,
+      raw_csv->data.get(), raw_csv->opts, raw_csv->num_records,
+      raw_csv->num_actual_cols, raw_csv->d_parseCol.get(), raw_csv->recStart.get(),
       d_columnData);
 
   CUDA_TRY(cudaGetLastError());

--- a/cpp/src/io/utilities/memory_utils.hpp
+++ b/cpp/src/io/utilities/memory_utils.hpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+	 * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file memory_utils.hpp  code to provide RAII abstractions for RMM managed device memory
+ *
+ */
+
+#pragma once
+
+#include "rmm/rmm.h"
+#include "rmm/thrust_rmm_allocator.h"
+
+#include "utilities/error_utils.hpp"
+
+/**---------------------------------------------------------------------------*
+ * @brief Base class for pointers owning RMM allocated memory
+ *---------------------------------------------------------------------------**/
+template <class T>
+class rmm_unique_ptr_base {
+protected:
+	/**
+	 * @brief Pointer to the owned memory
+	 */
+	T* ptr = nullptr;
+
+	/**
+	 * @brief Create an empty object - does not allocate any memory
+	 */
+	rmm_unique_ptr_base() noexcept = default;
+
+public:
+	/**
+	 * @brief Frees the owned memory on destruction
+	 */
+	~rmm_unique_ptr_base() {
+		RMM_FREE(ptr, 0);
+	}
+
+	/**
+	 * @brief Delete the copy assignment operator to prevent object copying
+	 */
+	rmm_unique_ptr_base& operator= (const rmm_unique_ptr_base &p) = delete;
+
+	/**
+	 * @brief Takes over the ownership of the memory. Leaves the passed
+	 * object in an empty state
+	 */
+	rmm_unique_ptr_base& operator= (rmm_unique_ptr_base &&p) noexcept {
+		ptr = p.ptr;
+		p.ptr = nullptr;
+		return *this;
+	}
+
+	/**
+	 * @brief Delete the copy constructor to prevent object copying
+	 */
+	rmm_unique_ptr_base(rmm_unique_ptr_base &p) = delete;
+
+	/**
+	 * @brief Takes over the ownership of the memory. Leaves the passed
+	 * object in an empty state
+	 */
+	rmm_unique_ptr_base(rmm_unique_ptr_base &&p) noexcept {
+		ptr = p.ptr;
+		p.ptr = nullptr;
+	}
+
+	/**
+	 * @brief Getter method for the internal pointer
+	 */
+	T* get() noexcept {
+		return ptr;
+	}
+};
+
+/**---------------------------------------------------------------------------*
+ * @brief Smart pointer class for a single element RMM allocation
+ *---------------------------------------------------------------------------**/
+template <class T>
+class rmm_unique_ptr: public rmm_unique_ptr_base<T> {
+public:
+	/**
+	 * @brief Allocates a single element of the given type.
+	 * 
+	 * Throws if allocation fails.
+	 */
+	rmm_unique_ptr() {
+		const auto error = RMM_ALLOC(&this->ptr, sizeof(T), 0);
+		if(error != RMM_SUCCESS) {
+			cudf::detail::throw_cuda_error(cudaErrorMemoryAllocation, __FILE__, __LINE__);
+		}
+	}
+};
+
+/**---------------------------------------------------------------------------*
+ * @brief Smart pointer class for an RMM allocated device array
+ *---------------------------------------------------------------------------**/
+template <class T>
+class rmm_unique_ptr<T[]>: public rmm_unique_ptr_base<T> {
+public:
+	/**
+	 * @brief Create an empty object - does not allocate any memory
+	 */
+	rmm_unique_ptr() = default;
+
+	/**
+	 * @brief Allocates an array of cnt elements
+	 * 
+	 * Throws if allocation fails.
+	 */
+	explicit rmm_unique_ptr(size_t cnt) {
+		resize(cnt);
+	}
+	
+	/**
+	 * @brief Resize the owned array
+	 * 
+	 * Does not retain the values in the owner memory.
+	 * Throws if allocation fails.
+	 */
+	void resize(size_t cnt) {
+		RMM_FREE(this->ptr, 0);
+
+		if (cnt != 0) {
+			const auto error = RMM_ALLOC(&this->ptr, sizeof(T)*cnt, 0);
+			if(error != RMM_SUCCESS) {
+				cudf::detail::throw_cuda_error(cudaErrorMemoryAllocation, __FILE__, __LINE__);
+			}
+		}
+		else {
+			this->ptr = nullptr;
+		}
+	}
+};


### PR DESCRIPTION
Fixes #1256 

* Move the local raw_csv_t object to stack (no longer a pointer).
* Use RAII to own memory allocated within the read_csv call.
* Add smart pointer classes for RMM allocated device memory.
* Add a unique pointer with a custom deleter to own the output gdf columns until the end of the function execution.