### PR TITLE
[WIP] test dask.dataframe.utils.is_dataframe_like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,13 @@
 - PR #1254 CSV Reader: fix data type detection for floating-point numbers in scientific notation
 - PR #1289 Fix looping over each value instead of each category in concatenation
 - PR #1293 Fix Inaccurate error message in join.pyx
-- PR #1308 Add atomicCAS overload for `int8_t`, `int16_t` 
+- PR #1308 Add atomicCAS overload for `int8_t`, `int16_t`
 - PR #1317 Fix catch polymorphic exception by reference in ipc.cu
 - PR #1325 Fix dtype of null bitmasks to int8
 - PR #1326 Update build documentation to use -DCMAKE_CXX11_ABI=ON
 - PR #1334 Add "na_position" argument to CategoricalColumn sort_by_values
 - PR #1321 Fix out of bounds warning when checking Bzip2 header
+- PR #1345 Add a test for dask.dataframe.utils.is_dataframe_like
 
 # cuDF 0.6.0 (Date TBD)
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -304,6 +304,9 @@ class DataFrame(object):
     def empty(self):
         return not len(self)
 
+    def mean(self, *args, **kwargs):
+        raise NotImplementedError()
+
     def assign(self, **kwargs):
         """
         Assign columns to DataFrame from keyword arguments.

--- a/python/cudf/tests/test_dask.py
+++ b/python/cudf/tests/test_dask.py
@@ -1,0 +1,17 @@
+import pytest
+import cudf
+
+dask = pytest.importorskip('dask')
+
+from dask.dataframe.utils import (is_dataframe_like, is_series_like,
+        is_index_like)  # noqa: E402
+
+
+def test_is_dataframe_like():
+    df = cudf.DataFrame({'x': [1, 2, 3]})
+    assert is_dataframe_like(df)
+    assert is_series_like(df.x)
+    assert is_index_like(df.index)
+    assert not is_dataframe_like(df.x)
+    assert not is_series_like(df)
+    assert not is_index_like(df)


### PR DESCRIPTION
Add a test for `dask.dataframe.utils.is_dataframe_like`

Short term this requires that we add a mean function to DataFrame.  
Currently this doesn't do anything, but it's useful to pass the `is_dataframe_like` check defined in Dask 1.1.5