### PR TITLE
[REVIEW] Change series quantile default to linear interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #1349 Replace modernGPU sort join with thrust.
 - PR #1363 Add a dataframe.mean(...) that raises NotImplementedError to satisfy `dask.dataframe.utils.is_dataframe_like`
 - PR #1319 CSV Reader: Use column wrapper for gdf_column output alloc/dealloc
+- PR #1376 Change series quantile default to linear
 
 ## Bug Fixes
 

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -1299,7 +1299,7 @@ class Series(object):
         mod_vals = cudautils.modulo(hashed_values.data.to_gpu_array(), stop)
         return Series(mod_vals)
 
-    def quantile(self, q, interpolation='midpoint', exact=True,
+    def quantile(self, q, interpolation='linear', exact=True,
                  quant_index=True):
         """
         Return values at the given quantile.


### PR DESCRIPTION
**Summary of Changes**
- Update Series.quantile to use linear interpolation by default, to [match pandas](https://github.com/pandas-dev/pandas/blob/v0.24.2/pandas/core/series.py#L2004)

Since `describe` does not expose the quantile interpolation keyword argument, we should be mimicking pandas and using linear interpolation by default.