### PR TITLE
[REVIEW] Set `*count` to 0 when there are 0 rows to count valid bits for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PR #1354 Fix `fillna()` behaviour when replacing values with different dtypes
 - PR #1347 Fixed core dump issue while passing dict_dtypes without column names in `cudf.read_csv()`
 - PR #1379 Fixed build failure caused due to error: 'col_dtype' may be used uninitialized
+- PR #1393 Fixed a bug in `gdf_count_nonzero_mask()` for the case of 0 bits to count
 
 
 # cuDF 0.6.0 (Date TBD)

--- a/cpp/include/cudf/functions.h
+++ b/cpp/include/cudf/functions.h
@@ -41,16 +41,18 @@ gdf_error gdf_nvtx_range_push_hex(char const * const name, unsigned int color );
  */
 gdf_error gdf_nvtx_range_pop();
 
-/** 
- * @brief  Counts the number of valid bits in the mask that corresponds to
- * the specified number of rows.
- * 
- * @param[in] masks Array of gdf_valid_types with enough bits to represent
- * num_rows number of rows
- * @param[in] num_rows The number of rows represented in the bit-validity mask.
- * @param[out] count The number of valid rows in the mask
- * 
- * @returns  GDF_SUCCESS upon successful completion. 
+/**
+ * @brief  Counts the number of valid bits for the specified number of rows
+ * in a validity bitmask.
+ *
+ * If the bitmask is null, returns a count equal to the number of rows.
+ *
+ * @param[in] masks The validity bitmask buffer in device memory
+ * @param[in] num_rows The number of bits to count
+ * @param[out] count The number of valid bits in the buffer from [0, num_rows)
+ *
+ * @returns  GDF_SUCCESS upon successful completion
+ *
  */
 gdf_error gdf_count_nonzero_mask(gdf_valid_type const *masks,
                                  gdf_size_type num_rows, gdf_size_type *count);

--- a/cpp/src/bitmask/valid_ops.cu
+++ b/cpp/src/bitmask/valid_ops.cu
@@ -132,7 +132,10 @@ gdf_error gdf_count_nonzero_mask(gdf_valid_type const *masks,
 
   if((nullptr == count)){return GDF_DATASET_EMPTY;}
 
-  if(0 == num_rows) {return GDF_SUCCESS;}
+  if(0 == num_rows){
+    *count = 0;
+    return GDF_SUCCESS;
+  }
 
   if(nullptr == masks){
       *count = num_rows;


### PR DESCRIPTION
... and updated the doxygen for `gdf_count_nonzero_mask()` in `cudf/functions.h`.

Fixes #1370.