### PR TITLE
[REVIEW] Update CONTRIBUTING to use the environment variable CUDF_HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PR #1379 Fixed build failure caused due to error: 'col_dtype' may be used uninitialized
 - PR #1395 Update CONTRIBUTING to use the environment variable CUDF_HOME
 
+
 # cuDF 0.6.0 (Date TBD)
 
 ## New Features
@@ -195,6 +196,7 @@
 - PR #1246 Fix categorical tests that failed due to bad implicit type conversion
 - PR #1255 Fix overwriting conda package main label uploads
 - PR #1259 Add dlpack includes to pip build
+
 
 # cuDF 0.5.1 (05 Feb 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - PR #1354 Fix `fillna()` behaviour when replacing values with different dtypes
 - PR #1347 Fixed core dump issue while passing dict_dtypes without column names in `cudf.read_csv()`
 - PR #1379 Fixed build failure caused due to error: 'col_dtype' may be used uninitialized
-
+- PR #1395 Update CONTRIBUTING to use the environment variable CUDF_HOME
 
 # cuDF 0.6.0 (Date TBD)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ To install cuDF from source, ensure the dependencies are met and follow the step
 ```bash
 CUDF_HOME=$(pwd)/cudf
 git clone https://github.com/rapidsai/cudf.git $CUDF_HOME
-cd CUDF_HOME
+cd $CUDF_HOME
 git submodule update --init --remote --recursive
 ```
 - Create the conda development environment `cudf_dev`:


### PR DESCRIPTION
**Summary of Changes**
- Updates the process of cloning cudf to use `CUDF_HOME` the environment variable. Currently, this step errors as written.

This PR closes #1290.