### PR TITLE
[REVIEW] Add Cython bindings for NVTX functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - PR #1363 Add a dataframe.mean(...) that raises NotImplementedError to satisfy `dask.dataframe.utils.is_dataframe_like`
 - PR #1319 CSV Reader: Use column wrapper for gdf_column output alloc/dealloc
 - PR #1376 Change series quantile default to linear
+- PR #1399 Replace CFFI bindings for NVTX functions with Cython bindings
 
 ## Bug Fixes
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -278,7 +278,7 @@ if(USE_NVTX)
     message(STATUS "Using Nvidia Tools Extension")
     find_library(NVTX_LIBRARY nvToolsExt PATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
     target_link_libraries(cudf ${NVTX_LIBRARY})
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --define-macro USE_NVTX")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_NVTX")
 endif(USE_NVTX)
 
 option(HT_LEGACY_ALLOCATOR "Use the legacy allocator for hash tables" ON)

--- a/python/cudf/_gdf.py
+++ b/python/cudf/_gdf.py
@@ -462,53 +462,6 @@ def count_nonzero_mask(mask, size):
     return nnz[0]
 
 
-_GDF_COLORS = {
-    'green':    libgdf.GDF_GREEN,
-    'blue':     libgdf.GDF_BLUE,
-    'yellow':   libgdf.GDF_YELLOW,
-    'purple':   libgdf.GDF_PURPLE,
-    'cyan':     libgdf.GDF_CYAN,
-    'red':      libgdf.GDF_RED,
-    'white':    libgdf.GDF_WHITE,
-    'darkgreen': libgdf.GDF_DARK_GREEN,
-    'orange':   libgdf.GDF_ORANGE,
-}
-
-
-def str_to_gdf_color(s):
-    """Util to convert str to gdf_color type.
-    """
-    return _GDF_COLORS[s.lower()]
-
-
-def nvtx_range_push(name, color='green'):
-    """
-    Demarcate the beginning of a user-defined NVTX range.
-
-    Parameters
-    ----------
-    name : str
-        The name of the NVTX range
-    color : str
-        The color to use for the range.
-        Can be named color or hex RGB string.
-    """
-    name_c = ffi.new("char[]", name.encode('ascii'))
-
-    try:
-        color = int(color, 16)  # only works if color is a hex string
-        libgdf.gdf_nvtx_range_push_hex(name_c, ffi.cast('unsigned int', color))
-    except ValueError:
-        color = str_to_gdf_color(color)
-        libgdf.gdf_nvtx_range_push(name_c, color)
-
-
-def nvtx_range_pop():
-    """ Demarcate the end of the inner-most range.
-    """
-    libgdf.gdf_nvtx_range_pop()
-
-
 def rmm_initialize():
     rmm.initialize()
     return True

--- a/python/cudf/bindings/cudf_cpp.pxd
+++ b/python/cudf/bindings/cudf_cpp.pxd
@@ -630,8 +630,8 @@ cdef extern from "cudf.h" nogil:
                                  const gdf_column ** columns,
                                  gdf_size_type num_columns) except +
 
-    cdef gdf_error gdf_nvtx_range_push(const char * const name, gdf_color color )
+    cdef gdf_error gdf_nvtx_range_push(const char * const name, gdf_color color ) except +
 
-    cdef gdf_error gdf_nvtx_range_push_hex(const char * const name, unsigned int color )
+    cdef gdf_error gdf_nvtx_range_push_hex(const char * const name, unsigned int color ) except +
 
-    cdef gdf_error gdf_nvtx_range_pop()
+    cdef gdf_error gdf_nvtx_range_pop() except +

--- a/python/cudf/bindings/cudf_cpp.pxd
+++ b/python/cudf/bindings/cudf_cpp.pxd
@@ -234,13 +234,6 @@ cdef extern from "cudf.h" nogil:
         void *data
         gdf_dtype dtype
 
-
-    cdef gdf_error gdf_nvtx_range_push(char  *  name, gdf_color color )
-
-    cdef gdf_error gdf_nvtx_range_push_hex(char * name, unsigned int color )
-
-    cdef gdf_error gdf_nvtx_range_pop()
-
     cdef gdf_error gdf_count_nonzero_mask(gdf_valid_type * masks, int num_rows, int * count)
 
     cdef gdf_size_type gdf_column_sizeof()

--- a/python/cudf/bindings/cudf_cpp.pxd
+++ b/python/cudf/bindings/cudf_cpp.pxd
@@ -629,4 +629,9 @@ cdef extern from "cudf.h" nogil:
     cdef gdf_error gdf_to_dlpack(DLManagedTensor *tensor,
                                  const gdf_column ** columns,
                                  gdf_size_type num_columns) except +
-    
+
+    cdef gdf_error gdf_nvtx_range_push(const char * const name, gdf_color color )
+
+    cdef gdf_error gdf_nvtx_range_push_hex(const char * const name, unsigned int color )
+
+    cdef gdf_error gdf_nvtx_range_pop()

--- a/python/cudf/bindings/nvtx.pyx
+++ b/python/cudf/bindings/nvtx.pyx
@@ -10,19 +10,6 @@
 from cudf.bindings.cudf_cpp cimport *
 from cudf.bindings.cudf_cpp import *
 
-import numpy as np
-import pandas as pd
-import pyarrow as pa
-
-from librmm_cffi import librmm as rmm
-import nvcategory
-import nvstrings
-
-from libc.stdint cimport uintptr_t
-from libc.stdlib cimport calloc, malloc, free
-
-cimport cython
-
 
 _GDF_COLORS = {
     'green':    GDF_GREEN,

--- a/python/cudf/bindings/nvtx.pyx
+++ b/python/cudf/bindings/nvtx.pyx
@@ -1,0 +1,73 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+# Copyright (c) 2018, NVIDIA CORPORATION.
+
+from cudf.bindings.cudf_cpp cimport *
+from cudf.bindings.cudf_cpp import *
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+
+from librmm_cffi import librmm as rmm
+import nvcategory
+import nvstrings
+
+from libc.stdint cimport uintptr_t
+from libc.stdlib cimport calloc, malloc, free
+
+cimport cython
+
+
+_GDF_COLORS = {
+    'green':    GDF_GREEN,
+    'blue':     GDF_BLUE,
+    'yellow':   GDF_YELLOW,
+    'purple':   GDF_PURPLE,
+    'cyan':     GDF_CYAN,
+    'red':      GDF_RED,
+    'white':    GDF_WHITE,
+    'darkgreen': GDF_DARK_GREEN,
+    'orange':   GDF_ORANGE,
+}
+
+
+def str_to_gdf_color(s):
+    """Util to convert str to gdf_color type.
+    """
+    return _GDF_COLORS[s.lower()]
+
+
+def nvtx_range_push(name, color='green'):
+    """
+    Demarcate the beginning of a user-defined NVTX range.
+
+    Parameters
+    ----------
+    name : str
+        The name of the NVTX range
+    color : str
+        The color to use for the range.
+        Can be named color or hex RGB string.
+    """
+    name = name.encode('ascii')
+    try:
+        color = int(color, 16)
+        result = gdf_nvtx_range_push_hex(name, color)
+    except ValueError:
+        color = _GDF_COLORS[color]
+        result = gdf_nvtx_range_push(name, color)
+    check_gdf_error(result)
+
+
+def nvtx_range_pop():
+    """
+    Denarcate the end of a user-defined NVTX range.
+    """
+    result = gdf_nvtx_range_pop()
+    check_gdf_error(result)

--- a/python/cudf/bindings/nvtx.pyx
+++ b/python/cudf/bindings/nvtx.pyx
@@ -54,7 +54,7 @@ def nvtx_range_push(name, color='green'):
 
 def nvtx_range_pop():
     """
-    Denarcate the end of a user-defined NVTX range.
+    Demarcate the end of a user-defined NVTX range.
     """
     result = gdf_nvtx_range_pop()
     check_gdf_error(result)

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -38,7 +38,7 @@ from cudf.settings import NOTSET, settings
 from cudf.comm.serialize import register_distributed_serializer
 from cudf.dataframe.categorical import CategoricalColumn
 from cudf.dataframe.buffer import Buffer
-from cudf._gdf import nvtx_range_push, nvtx_range_pop
+from cudf.bindings.nvtx import nvtx_range_push, nvtx_range_pop
 from cudf._sort import get_sorted_inds
 from cudf.dataframe import columnops
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -1361,7 +1361,7 @@ class DataFrame(object):
         2    4    14.0    12.0
         """
         import nvstrings
-        _gdf.nvtx_range_push("CUDF_JOIN", "blue")
+        nvtx_range_push("CUDF_JOIN", "blue")
         if indicator:
             raise NotImplementedError(
                 "Only indicator=False is currently supported"
@@ -1593,7 +1593,7 @@ class DataFrame(object):
             new_index = new_index[indexed-1]
             df.index = new_index
 
-        _gdf.nvtx_range_pop()
+        nvtx_range_pop()
 
         return df
 
@@ -1624,7 +1624,7 @@ class DataFrame(object):
         - *on* is not supported yet due to lack of multi-index support.
         """
 
-        _gdf.nvtx_range_push("CUDF_JOIN", "blue")
+        nvtx_range_push("CUDF_JOIN", "blue")
 
         # Outer joins still use the old implementation
         if type != "":
@@ -1774,7 +1774,7 @@ class DataFrame(object):
         else:
             from cudf.groupby.groupby import Groupby
 
-            _gdf.nvtx_range_push("CUDF_GROUPBY", "purple")
+            nvtx_range_push("CUDF_GROUPBY", "purple")
             # The matching `pop` for this range is inside LibGdfGroupby
             # __apply_agg
             result = Groupby(self, by=by, method=method, as_index=as_index,
@@ -1844,7 +1844,7 @@ class DataFrame(object):
             raise TypeError("local_dict type: expected dict but found {!r}"
                             .format(type(local_dict)))
 
-        _gdf.nvtx_range_push("CUDF_QUERY", "purple")
+        nvtx_range_push("CUDF_QUERY", "purple")
         # Get calling environment
         callframe = inspect.currentframe().f_back
         callenv = {
@@ -1861,7 +1861,7 @@ class DataFrame(object):
             newseries = self[col][selected]
             newdf[col] = newseries
         result = newdf
-        _gdf.nvtx_range_pop()
+        nvtx_range_pop()
         return result
 
     @applyutils.doc_apply()

--- a/python/cudf/dataframe/datetime.py
+++ b/python/cudf/dataframe/datetime.py
@@ -10,7 +10,7 @@ from cudf.utils import utils, cudautils
 from cudf.dataframe.buffer import Buffer
 from libgdf_cffi import libgdf
 from cudf.comm.serialize import register_distributed_serializer
-from cudf._gdf import nvtx_range_push, nvtx_range_pop
+from cudf.bindings.nvtx import nvtx_range_push, nvtx_range_pop
 from cudf._sort import get_sorted_inds
 
 import cudf.bindings.replace as cpp_replace

--- a/python/cudf/dataframe/numerical.py
+++ b/python/cudf/dataframe/numerical.py
@@ -16,7 +16,7 @@ from cudf.utils import cudautils, utils
 from cudf import _gdf
 from cudf.dataframe.buffer import Buffer
 from cudf.comm.serialize import register_distributed_serializer
-from cudf._gdf import nvtx_range_push, nvtx_range_pop
+from cudf.bindings.nvtx import nvtx_range_push, nvtx_range_pop
 from cudf._sort import get_sorted_inds
 
 import cudf.bindings.reduce as cpp_reduce

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -19,7 +19,7 @@ from cudf.dataframe.column import Column
 from cudf.dataframe.datetime import DatetimeColumn
 from cudf.dataframe import columnops
 from cudf.comm.serialize import register_distributed_serializer
-from cudf._gdf import nvtx_range_push, nvtx_range_pop
+from cudf.bindings.nvtx import nvtx_range_push, nvtx_range_pop
 
 
 class Series(object):

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -11,7 +11,7 @@ from cudf.dataframe.series import Series
 from cudf.dataframe.buffer import Buffer
 from cudf.dataframe.categorical import CategoricalColumn
 from cudf.utils.cudautils import zeros
-from cudf._gdf import nvtx_range_pop
+from cudf.bindings.nvtx import nvtx_range_pop
 import cudf.dataframe.index as index
 
 from libgdf_cffi import ffi, libgdf

--- a/python/cudf/io/csv.py
+++ b/python/cudf/io/csv.py
@@ -7,7 +7,7 @@ from cudf.dataframe.column import Column
 from cudf.dataframe.numerical import NumericalColumn
 from cudf.dataframe.dataframe import DataFrame
 from cudf.dataframe.datetime import DatetimeColumn
-from cudf._gdf import nvtx_range_push, nvtx_range_pop
+from cudf.bindings.nvtx import nvtx_range_push, nvtx_range_pop
 
 import numpy as np
 import collections.abc


### PR DESCRIPTION
This PR adds Cython bindings for the `gdf_nvtx_range_push` and `gdf_nvtx_range_pop` functions, while removing the old CFFI bindings.

It also fixes a bug in `CMakeLists.txt` relating to the `USE_NVTX` option.