### PR TITLE
[REVIEW] Add include guards _around_ inclusions of `NVStrings.h`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PR #1354 Fix `fillna()` behaviour when replacing values with different dtypes
 - PR #1347 Fixed core dump issue while passing dict_dtypes without column names in `cudf.read_csv()`
 - PR #1379 Fixed build failure caused due to error: 'col_dtype' may be used uninitialized
+- PR #1403 Compensated for lack of include guards in `NVStrings.h`
 
 
 # cuDF 0.6.0 (Date TBD)

--- a/cpp/src/io/parquet/parquet_reader.cu
+++ b/cpp/src/io/parquet/parquet_reader.cu
@@ -24,7 +24,10 @@
 #include "utilities/error_utils.hpp"
 
 #include <cuda_runtime.h>
+#ifndef INCLUDED_NVGSTRINGS_H_
+#define INCLUDED_NVGSTRINGS_H_
 #include <nvstrings/NVStrings.h>
+#endif // INCLUDED_NVGSTRINGS_H_
 #include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
 

--- a/cpp/src/string/nvcategory_util.cpp
+++ b/cpp/src/string/nvcategory_util.cpp
@@ -3,7 +3,10 @@
 
 
 #include <nvstrings/NVCategory.h>
+#ifndef INCLUDED_NVGSTRINGS_H_
+#define INCLUDED_NVGSTRINGS_H_
 #include <nvstrings/NVStrings.h>
+#endif // INCLUDED_NVGSTRINGS_H_
 #include "rmm/rmm.h"
 
 #include "utilities/error_utils.hpp"

--- a/cpp/src/utilities/type_dispatcher.hpp
+++ b/cpp/src/utilities/type_dispatcher.hpp
@@ -21,7 +21,10 @@
 
 #include <cudf/types.h>
 
+#ifndef INCLUDED_NVGSTRINGS_H_
+#define INCLUDED_NVGSTRINGS_H_
 #include <nvstrings/NVStrings.h>
+#endif // INCLUDED_NVGSTRINGS_H_
 
 #include <cassert>
 #include <utility>

--- a/cpp/tests/io/csv/csv_test.cu
+++ b/cpp/tests/io/csv/csv_test.cu
@@ -16,7 +16,10 @@
 
 #include <cudf.h>
 
+#ifndef INCLUDED_NVGSTRINGS_H_
+#define INCLUDED_NVGSTRINGS_H_
 #include <nvstrings/NVStrings.h>
+#endif // INCLUDED_NVGSTRINGS_H_
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>


### PR DESCRIPTION
This fixes bug #1402.