### PR TITLE
[REVIEW] Add DataFrame.pop()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - PR #1335 Added local_dict arg in `DataFrame.query()`.
 - PR #1381 Add DataFrame._get_numeric_data
 - PR #1396 Add DataFrame.drop method
+- PR #1412 Add DataFrame.pop()
 
 ## Improvements
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -920,6 +920,13 @@ class DataFrame(object):
             raise NameError('column {!r} does not exist'.format(name))
         del self._cols[name]
 
+    def pop(self, item):
+        """Return a column and drop it from the DataFrame.
+        """
+        popped = self[item]
+        del self[item]
+        return popped
+
     def rename(self, mapper=None, columns=None, copy=True, inplace=False):
         """
         Alter column labels.

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -331,7 +331,7 @@ def test_dataframe_pop():
     empty_gdf = DataFrame.from_pandas(empty_pdf)
     pb = empty_pdf.pop('b')
     gb = empty_gdf.pop('b')
-    assert assert len(pb) == len(gb)
+    assert len(pb) == len(gb)
     assert empty_pdf.empty and empty_gdf.empty
 
 

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -297,6 +297,44 @@ def test_dataframe_column_add_drop():
     assert tuple(df.columns) == ('b', 'c', 'a')
 
 
+def test_dataframe_pop():
+    pdf = pd.DataFrame(
+        {'a': [1, 2, 3], 'b': ['x', 'y', 'z'], 'c': [7., 8., 9.]}
+    )
+    gdf = DataFrame.from_pandas(pdf)
+
+    # Test non-existing column error
+    with pytest.raises(KeyError) as raises:
+        gdf.pop('fake_colname')
+    raises.match("fake_colname")
+
+    # check pop numeric column
+    pdf_pop = pdf.pop('a')
+    gdf_pop = gdf.pop('a')
+    assert_eq(pdf_pop, gdf_pop)
+    assert_eq(pdf, gdf)
+
+    # check string column
+    pdf_pop = pdf.pop('b')
+    gdf_pop = gdf.pop('b')
+    assert_eq(pdf_pop, gdf_pop)
+    assert_eq(pdf, gdf)
+
+    # check float column and empty dataframe
+    pdf_pop = pdf.pop('c')
+    gdf_pop = gdf.pop('c')
+    assert_eq(pdf_pop, gdf_pop)
+    assert_eq(pdf, gdf)
+
+    # check empty dataframe edge case
+    empty_pdf = pd.DataFrame(columns=['a', 'b'])
+    empty_gdf = DataFrame.from_pandas(empty_pdf)
+    pb = empty_pdf.pop('b')
+    gb = empty_gdf.pop('b')
+    assert empty_pdf.index.size == empty_gdf.index.size
+    assert empty_pdf.empty and empty_gdf.empty
+
+
 @pytest.mark.parametrize('nelem', [0, 3, 100, 1000])
 def test_dataframe_astype(nelem):
     df = DataFrame()

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -331,7 +331,7 @@ def test_dataframe_pop():
     empty_gdf = DataFrame.from_pandas(empty_pdf)
     pb = empty_pdf.pop('b')
     gb = empty_gdf.pop('b')
-    assert empty_pdf.index.size == empty_gdf.index.size
+    assert assert len(pb) == len(gb)
     assert empty_pdf.empty and empty_gdf.empty
 
 


### PR DESCRIPTION
This PR adds the pop method to the DataFrame object, analogous to pandas's [pop method](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.pop.html).

**Summary of Changes**
- Adds a DataFrame level `pop` method and associated unit tests

This closes #1410 