### PR TITLE
[REVIEW] Bump NVStrings to 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - PR #1395 Update CONTRIBUTING to use the environment variable CUDF_HOME
 - PR #1405 CSV Reader: Fix memory leaks on read_csv() failure
 - PR #1328 Fix CategoricalColumn to_arrow() null mask
+- PR #XXXX Update NVStrings to 0.7.* to coincide with 0.7 development
 
 
 # cuDF 0.6.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 - PR #1395 Update CONTRIBUTING to use the environment variable CUDF_HOME
 - PR #1405 CSV Reader: Fix memory leaks on read_csv() failure
 - PR #1328 Fix CategoricalColumn to_arrow() null mask
-- PR #XXXX Update NVStrings to 0.7.* to coincide with 0.7 development
+- PR #1432 Update NVStrings to 0.7.* to coincide with 0.7 development
 
 
 # cuDF 0.6.0 (Date TBD)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -18,6 +18,9 @@ export CUDA_REL=${CUDA_VERSION%.*}
 # Set home to the job's workspace
 export HOME=$WORKSPACE
 
+# Set versions of packages needed to be grabbed
+export NVSTRINGS_VERSION=0.7.*
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################
@@ -30,7 +33,7 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
-conda install -c rapidsai/label/cuda${CUDA_REL} -c rapidsai-nightly/label/cuda${CUDA_REL} nvstrings=0.7.*
+conda install -c rapidsai/label/cuda${CUDA_REL} -c rapidsai-nightly/label/cuda${CUDA_REL} nvstrings=${NVSTRINGS_VERSION}
 
 logger "Check versions..."
 python --version

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -30,7 +30,7 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
-conda install -c rapidsai/label/cuda${CUDA_REL} -c rapidsai-nightly/label/cuda${CUDA_REL} nvstrings=0.3*
+conda install -c rapidsai/label/cuda${CUDA_REL} -c rapidsai-nightly/label/cuda${CUDA_REL} nvstrings=0.7.*
 
 logger "Check versions..."
 python --version

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -1,7 +1,5 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
-# Usage:
-#   conda build -c nvidia -c rapidsai -c numba -c conda-forge -c defaults .
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 package:
@@ -18,13 +16,6 @@ build:
     - BUILD_ABI
 
 requirements:
-  # use channel:
-  #   - nvidia
-  #   - rapidsai
-  #   - rapidsai-nightly
-  #   - numba
-  #   - conda-forge
-  #   - defaults
   build:
     - python x.x
     - cython >=0.29,<0.30
@@ -32,7 +23,7 @@ requirements:
     - libcudf {{ version }}
     - libcudf_cffi {{ version }}
     - numba >=0.40
-    - nvstrings 0.3*
+    - nvstrings 0.7.*
   run:
     - python x.x
     - cython >=0.29,<0.30
@@ -41,7 +32,7 @@ requirements:
     - libcudf_cffi {{ version }}
     - pandas >=0.23.4
     - numba >=0.40
-    - nvstrings 0.3*
+    - nvstrings 0.7.*
 
 test:
   requires:

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -1,7 +1,5 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
-# Usage:
-#   conda build -c nvidia -c rapidsai -c conda-forge -c defaults .
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 {% set cuda_version='.'.join(environ.get('CUDA', 'unknown').split('.')[:2]) %}
@@ -10,7 +8,6 @@ package:
   version: {{ version }}
 
 source:
-  # git_url: ../../..
   path: ../../..
 
 build:
@@ -24,18 +21,12 @@ build:
     - BUILD_ABI
 
 requirements:
-  # use channel:
-  #   - nvidia
-  #   - rapidsai
-  #   - rapidsai-nightly
-  #   - conda-forge
-  #   - defaults
   build:
     - cmake >=3.12.4
-    - nvstrings 0.3*
+    - nvstrings 0.7.*
   run:
     - pyarrow 0.12.1
-    - nvstrings 0.3*
+    - nvstrings 0.7.*
 
 test:
   commands:

--- a/conda/recipes/libcudf_cffi/meta.yaml
+++ b/conda/recipes/libcudf_cffi/meta.yaml
@@ -1,7 +1,5 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
-# Usage:
-#   conda build -c nvidia -rapidsai -c conda-forge -c defaults .
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 {% set cuda_version='.'.join(environ.get('CUDA', 'unknown').split('.')[:2]) %}
@@ -11,7 +9,6 @@ package:
   version: {{ version }}
 
 source:
-  # git_url: ../../..
   path: ../../..
 
 build:
@@ -25,18 +22,12 @@ build:
     - BUILD_ABI
 
 requirements:
-  # use channel:
-  #   - nvidia
-  #   - rapidsai
-  #   - rapidsai-nightly
-  #   - conda-forge
-  #   - defaults
   build:
     - cmake >=3.12.4
     - python x.x
     - cffi
     - setuptools
-    - nvstrings 0.3*
+    - nvstrings 0.7.*
     - pycparser 2.19
     - pyarrow 0.12.1
   run:


### PR DESCRIPTION
Fixes #1414.

Bumping NVStrings to 0.7 to match development version of cuDF.