### PR TITLE
[REVIEW] Add a CMake option to compile CUDA code with -lineinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #1376 Change series quantile default to linear
 - PR #1391 Tidy up bit-resolution-operation and bitmask class code
 - PR #1397 Add a utility function for producing an overflow-safe kernel launch grid configuratio.
+- PR #1439 Add cmake variable to enable compiling CUDA code with -lineinfo
 
 ## Bug Fixes
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -67,6 +67,12 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-
 # TODO: remove `no-maybe-unitialized` used to suppress warnings in rmm::exec_policy
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror")
 
+# Option to enable line info in CUDA device compilation to allow introspection when profiling / memchecking
+option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler" OFF)
+if (CMAKE_CUDA_LINEINFO)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo")
+endif(CMAKE_CUDA_LINEINFO)
+
 # Debug options
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     message(STATUS "Building with debugging flags")


### PR DESCRIPTION
The `-lineinfo` option to `nvcc` is useful to allow CUDA profilers and `cuda-memcheck` to display code or line numbers, even with a release build. 

This PR adds a cmake variable (`CMAKE_CUDA_LINEINFO`), which is `OFF` by default, which can be specified at cmake configuration time to enable passing `-lineinfo` to `nvcc` when compiling CUDA code.