### PR TITLE
[REVIEW] Add Python coverage test to gpu build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #1420 Add script to build and test on a local gpuCI image
 - PR #1440 Add DatetimeColumn.min(), DatetimeColumn.max()
 - PR #1441 Add Series level cumulative ops (cumsum, cummin, cummax, cumprod)
+- PR #1461 Add Python coverage test to gpu build
 
 ## Improvements
 
@@ -71,6 +72,7 @@
 - PR #1447 Fix legacy groupby apply docstring
 - PR #1451 Fix hash join estimated result size is not correct
 - PR #1454 Fix local build script improperly change directory permissions
+
 
 # cuDF 0.6.1 (25 Mar 2019)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -92,10 +92,6 @@ pip install cupy-cuda92
 logger "conda install feather-format"
 conda install -c conda-forge -y feather-format
 
-# Temporarily install tzdata otherwise pyarrow core dumps
-logger "apt-get update && apt-get install -y tzdata"
-apt-get update && apt-get install -y tzdata
-
 logger "Python py.test for cuDF..."
 cd $WORKSPACE/python
-py.test --cache-clear --junitxml=${WORKSPACE}/junit-cudf.xml -v
+py.test --cache-clear --junitxml=${WORKSPACE}/junit-cudf.xml -v --cov-config=.coveragerc --cov=cudf --cov-report=xml:${WORKSPACE}/cudf-coverage.xml --cov-report term

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,0 +1,3 @@
+# Configuration file for Python coverage tests
+[run]
+omit = cudf/tests/*


### PR DESCRIPTION
Currently outputs test percentage coverage of the `cudf` module in the output of gpuCI.

Will be adding it to the status update for gpuCI as well.

Also removed unnecessary install from the build script since the package is installed in our base image.