### PR TITLE
[REVIEW] Require Dask 1.1.0+ for testing `is_dataframe_like`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - PR #1447 Fix legacy groupby apply docstring
 - PR #1451 Fix hash join estimated result size is not correct
 - PR #1454 Fix local build script improperly change directory permissions
+- PR #1490 Require Dask 1.1.0+ for `is_dataframe_like` test or skip otherwise.
 
 
 # cuDF 0.6.1 (25 Mar 2019)

--- a/python/cudf/tests/test_dask.py
+++ b/python/cudf/tests/test_dask.py
@@ -3,7 +3,7 @@
 import pytest
 import cudf
 
-dask = pytest.importorskip('dask')
+dask = pytest.importorskip('dask', minversion='1.1.0')
 
 from dask.dataframe.utils import (
     is_dataframe_like, is_series_like, is_index_like

--- a/python/cudf/tests/test_dask.py
+++ b/python/cudf/tests/test_dask.py
@@ -3,7 +3,10 @@
 import pytest
 import cudf
 
-dask = pytest.importorskip('dask', minversion='1.1.0')
+dask = pytest.importorskip(
+    'dask', minversion='1.1.0',
+    reason='Needs Dask 1.1.0+ to use `is_dataframe_like`'
+)
 
 from dask.dataframe.utils import (
     is_dataframe_like, is_series_like, is_index_like


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/1488

This is a follow up to PR ( https://github.com/rapidsai/cudf/pull/1363 ). Adds a minimum version requirement to Dask for this test to ensure upstream PR ( https://github.com/dask/dask/pull/4359 ) is included. If that minimum version is not met, the test is skipped. A reason is added to explain why this test is skipped in that case.

cc @harrism @kkraus14