### PR TITLE
[REVIEW] Fix csv-writer call to updated NVStrings method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@
 - PR #1490 Require Dask 1.1.0+ for `is_dataframe_like` test or skip otherwise.
 - PR #1497 Fix Thrust issue on CentOS caused by missing default constructor of host_vector elements
 - PR #1498 Add missing include guard to device_atomics.cuh and separated DEVICE_ATOMICS_TEST
-
+- PR #1506 Fix csv-write call to updated NVStrings method
 
 
 # cuDF 0.6.1 (25 Mar 2019)

--- a/cpp/src/io/csv/csv_writer.cu
+++ b/cpp/src/io/csv/csv_writer.cu
@@ -61,7 +61,7 @@ NVStrings* column_to_strings_csv( gdf_column* column, const char* delimiter, con
             rtn = NVStrings::dtos(static_cast<const double*>(column->data),rows,valid);
             break;
         case GDF_DATE64:
-            rtn = NVStrings::long2timestamp(static_cast<const uint64_t*>(column->data),rows,NVStrings::seconds,valid);
+            rtn = NVStrings::long2timestamp(static_cast<const uint64_t*>(column->data),rows,NVStrings::seconds,nullptr,valid);
             break;
         default:
             break;


### PR DESCRIPTION
This is to fix the call an NVStrings method the causes csv-writer compile failure.