### PR TITLE
[REVIEW] added nvstrings fill_na function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 - PR #1506 Fix csv-write call to updated NVStrings method
 - PR #1510 Added nvstrings `fillna()` function
 
+
 # cuDF 0.6.1 (25 Mar 2019)
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@
 - PR #1497 Fix Thrust issue on CentOS caused by missing default constructor of host_vector elements
 - PR #1498 Add missing include guard to device_atomics.cuh and separated DEVICE_ATOMICS_TEST
 - PR #1506 Fix csv-write call to updated NVStrings method
-
+- PR #1510 Added nvstrings `fillna()` function
 
 # cuDF 0.6.1 (25 Mar 2019)
 

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -88,7 +88,7 @@ class TypedColumnBase(Column):
     def find_and_replace(self, to_replace, values):
         raise NotImplementedError
 
-    def fillna(self, fill_value):
+    def fillna(self, fill_value, inplace):
         raise NotImplementedError
 
 

--- a/python/cudf/dataframe/string.py
+++ b/python/cudf/dataframe/string.py
@@ -8,7 +8,7 @@ from numbers import Number
 from numba.cuda.cudadrv.devicearray import DeviceNDArray
 import warnings
 
-from cudf.dataframe import columnops, numerical
+from cudf.dataframe import columnops, numerical, series
 from cudf.dataframe.buffer import Buffer
 from cudf.utils import utils, cudautils
 
@@ -521,3 +521,29 @@ class StringColumn(columnops.TypedColumnBase):
     def copy(self, deep=True):
         params = self._replace_defaults()
         return type(self)(**params)
+
+    def fillna(self, fill_value, inplace=False):
+        """
+        Fill null values with * fill_value *
+        """
+        result = self.copy()
+        if not isinstance(fill_value, str) and \
+            not(
+                isinstance(fill_value, series.Series) and
+                isinstance(fill_value._column, StringColumn)
+                ):
+            raise TypeError("fill_value must be a string or a string series")
+
+        # replace fill_value with nvstrings
+        # if it is a column
+
+        if isinstance(fill_value, series.Series):
+            if len(fill_value) < len(result):
+                raise ValueError("fill value series must be of same or "
+                                 "greater length than the series to be filled")
+
+            fill_value = fill_value[: len(self)]._column._data
+
+        result._data = result._data.fillna(fill_value)
+        result = result.replace(mask=None)
+        return self._mimic_inplace(result, inplace)

--- a/python/cudf/dataframe/string.py
+++ b/python/cudf/dataframe/string.py
@@ -526,7 +526,7 @@ class StringColumn(columnops.TypedColumnBase):
         """
         Fill null values with * fill_value *
         """
-        result = self.copy()
+
         if not isinstance(fill_value, str) and \
             not(
                 isinstance(fill_value, series.Series) and
@@ -538,12 +538,13 @@ class StringColumn(columnops.TypedColumnBase):
         # if it is a column
 
         if isinstance(fill_value, series.Series):
-            if len(fill_value) < len(result):
+            if len(fill_value) < len(self):
                 raise ValueError("fill value series must be of same or "
                                  "greater length than the series to be filled")
 
             fill_value = fill_value[: len(self)]._column._data
 
-        result._data = result._data.fillna(fill_value)
+        filled_data = self._data.fillna(fill_value)
+        result = StringColumn(filled_data)
         result = result.replace(mask=None)
         return self._mimic_inplace(result, inplace)

--- a/python/cudf/tests/test_replace.py
+++ b/python/cudf/tests/test_replace.py
@@ -198,7 +198,7 @@ def test_fillna_dataframe(fill_type, inplace):
 
     assert_eq(expect, got)
 
-    
+
 @pytest.mark.parametrize(
     'fill_type',
     ['scalar', 'series'])
@@ -206,12 +206,12 @@ def test_fillna_dataframe(fill_type, inplace):
     'inplace',
     [True, False])
 def test_fillna_string(fill_type, inplace):
-    psr = pd.Series(['z',None,'z',None])
+    psr = pd.Series(['z', None, 'z', None])
 
     if fill_type == 'scalar':
         fill_value = 'a'
     elif fill_type == 'series':
-        fill_value = Series(['a','b','c','d'])
+        fill_value = Series(['a', 'b', 'c', 'd'])
 
     sr = Series.from_pandas(psr)
 
@@ -223,7 +223,7 @@ def test_fillna_string(fill_type, inplace):
 
     assert_eq(expect, got)
 
-    
+
 @pytest.mark.parametrize(
     'data_dtype',
     ['int8', 'int16', 'int32', 'int64'])

--- a/python/cudf/tests/test_replace.py
+++ b/python/cudf/tests/test_replace.py
@@ -198,7 +198,32 @@ def test_fillna_dataframe(fill_type, inplace):
 
     assert_eq(expect, got)
 
+    
+@pytest.mark.parametrize(
+    'fill_type',
+    ['scalar', 'series'])
+@pytest.mark.parametrize(
+    'inplace',
+    [True, False])
+def test_fillna_string(fill_type, inplace):
+    psr = pd.Series(['z',None,'z',None])
 
+    if fill_type == 'scalar':
+        fill_value = 'a'
+    elif fill_type == 'series':
+        fill_value = Series(['a','b','c','d'])
+
+    sr = Series.from_pandas(psr)
+
+    expect = psr.fillna(fill_value)
+    got = sr.fillna(fill_value, inplace=inplace)
+
+    if inplace:
+        got = sr
+
+    assert_eq(expect, got)
+
+    
 @pytest.mark.parametrize(
     'data_dtype',
     ['int8', 'int16', 'int32', 'int64'])


### PR DESCRIPTION
This pr fixes the bug `fillna` fails for cudf string series [issue](https://github.com/rapidsai/cudf/issues/1448)

- [x] Change abstract function to match `fillna` to match `series.fillna`:
- [x] Implement `fillna` for strings
- [x] Add test for `fillna_strings`

