### PR TITLE
Drop unused `libgdf_cffi` import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ## Improvements
 
+- PR #1589 Drop unused `libgdf_cffi` import
 - PR #1531 Refactor closures as private functions in gpuarrow
 - PR #1404 Parquet reader page data decoding speedup
 - PR #1076 Use `type_dispatcher` in join, quantiles, filter, segmented sort, radix sort and hash_groupby

--- a/python/cudf/bindings/sort.pyx
+++ b/python/cudf/bindings/sort.pyx
@@ -17,7 +17,6 @@ import pandas as pd
 import pyarrow as pa
 import itertools
 
-from libgdf_cffi import ffi, libgdf
 from librmm_cffi import librmm as rmm
 
 


### PR DESCRIPTION
Appears this import is a leftover that is no longer need. So go ahead and drop it.