### PR TITLE
[REVIEW] Add arbitrary list of Series as a valid argument to Groupby function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - PR #1588 Add Index `astype` typecasting
 - PR #1301 MultiIndex support
 - PR #1599 Level keyword supported in groupby
+- PR #1609 Groupby accept list of Series
 
 ## Improvements
 

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -80,8 +80,7 @@ class Groupby(object):
         self._val_columns = []
         self._df = df.copy(deep=True)
         self._as_index = as_index
-        if isinstance(by, (Sequence, Series)):
-            by = list(by)
+        if isinstance(by, Series):
             if len(by) != len(self._df.index):
                 raise NotImplementedError("CUDF doesn't support series groupby"
                                           "with indices of arbitrary length")
@@ -132,8 +131,21 @@ class Groupby(object):
                     self._by.append(self._df.index.names[which_level])
         else:
             self._by = [by] if isinstance(by, (str, Number)) else list(by)
-        self._val_columns = [idx for idx in self._df.columns
-                             if idx not in self._by]
+        if isinstance(self._by[0], (str, Number)):
+            # by is a list of column names or numerals
+            # The base case!
+            # Everything else in __init__ handles more complicated
+            # configurations of "by"
+            self._val_columns = [idx for idx in self._df.columns
+                                 if idx not in self._by]
+        else:
+            # by is a list of objects - lists, or Series
+            self._val_columns = self._df.columns
+            by = self._by
+            self._by = []
+            for idx, each_by in enumerate(by):
+                self._df[each_by.name] = each_by
+                self._by.append(each_by.name)
         if (method == "hash"):
             self._method = method
         else:

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+from collections.abc import Sequence
 from numbers import Number
 
 from cudf.dataframe.dataframe import DataFrame
@@ -79,7 +80,8 @@ class Groupby(object):
         self._val_columns = []
         self._df = df.copy(deep=True)
         self._as_index = as_index
-        if isinstance(by, Series):
+        if isinstance(by, (Sequence, Series)):
+            by = list(by)
             if len(by) != len(self._df.index):
                 raise NotImplementedError("CUDF doesn't support series groupby"
                                           "with indices of arbitrary length")

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-from collections.abc import Sequence
 from numbers import Number
 
 from cudf.dataframe.dataframe import DataFrame

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -429,6 +429,6 @@ def test_list_of_series():
     pdg = pdf.groupby([pdf.x]).y.sum()
     gdg = gdf.groupby([gdf.x]).y.sum()
     assert_eq(pdg, gdg)
-    pdg = pdf.groupby([pdf.x], [0, 1, 0]).y.sum()
-    gdg = gdf.groupby([gdf.x], [0, 1, 0]).y.sum()
+    pdg = pdf.groupby([pdf.x, pdf.y]).y.sum()
+    gdg = gdf.groupby([gdf.x, gdf.y]).y.sum()
     assert_eq(pdg, gdg)

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -421,3 +421,14 @@ def test_advanced_groupby_levels():
         gdh = gdg.groupby(level=2).sum()
     raises.match("Too many levels")
     assert_eq(pdh, gdh)
+
+
+def test_list_of_series():
+    pdf = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 1]})
+    gdf = cudf.from_pandas(pdf)
+    pdg = pdf.groupby([pdf.x]).y.sum()
+    gdg = gdf.groupby([gdf.x]).y.sum()
+    assert_eq(pdg, gdg)
+    pdg = pdf.groupby([pdf.x], [0, 1, 0]).y.sum()
+    gdg = gdf.groupby([gdf.x], [0, 1, 0]).y.sum()
+    assert_eq(pdg, gdg)


### PR DESCRIPTION
Pandas does this. It may be tricky particularly because pandas doesn't require they be named. Cudf doesn't work great with unnamed columns atm.

This fixes #1096 