### PR TITLE
[REVIEW] Fix bug in dask-cudf caused by inconsistency with Pandas empty groupby result

### DIFF
--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -162,7 +162,11 @@ class Groupby(object):
 
     def apply_multiindex_or_single_index(self, result):
         if len(result) == 0:
-            raise ValueError('Groupby result is empty!')
+            final_result = DataFrame()
+            for col in result.columns:
+                if col not in self._by:
+                    final_result[col] = result[col]
+            return final_result
         if len(self._by) == 1:
             from cudf.dataframe import index
             idx = index.as_index(result[self._by[0]])

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -383,9 +383,7 @@ def test_advanced_groupby_levels():
     gdh = gdg.groupby(level=1).sum()
     assert_eq(pdh, gdh)
     pdg = pdf.groupby(['x', 'y', 'z']).sum()
-    with pytest.raises(ValueError) as raises:
-        gdg = gdf.groupby(['x', 'y', 'z']).sum()
-    raises.match("Groupby result is empty!")
+    gdg = gdf.groupby(['x', 'y', 'z']).sum()
     pdg = pdf.groupby(['z']).sum()
     gdg = gdf.groupby(['z']).sum()
     assert_eq(pdg, gdg)


### PR DESCRIPTION
For some reason I decided to throw an exception when the groupby result was empty. This doesn't correspond with Pandas, which returns an empty DataFrame containing only the non `by` columns. This feature is important to `dask-cudf` in metadata relating to the groupbys. @ayushdg proposed the below solution which gives 100% test passes in dask-cudf and also cudf.

This should be considered a pre-release bugfix to MultiIndex and should go into branch-0.7 today if it checks out.