### PR TITLE
[REVIEW] Fix potentially uninitialized tail rows when skiprows!=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 - PR #1618 ORC reader: fix assert & data output when nrows/skiprows isn't aligned to stripe boundaries
 - PR #1631 Fix failure of TYPES_TEST on some gcc-7 based systems.
 - PR #1641 CSV Reader: Fix skip_blank_lines behavior with Windows line terminators (\r\n) 
+- PR #1648 ORC reader: fix non-deterministic output when skiprows is non-zero
 
 
 # cuDF 0.6.1 (25 Mar 2019)

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -1584,7 +1584,7 @@ gpuDecodeOrcColumnData(ColumnDesc *chunks, DictionaryEntry *global_dictionary, i
     __syncthreads();
     if (t == 0)
     {
-        s->top.data.cur_row = min(s->chunk.start_row, max((int32_t)(first_row - s->chunk.skip_count), 0));
+        s->top.data.cur_row = max(s->chunk.start_row, max((int32_t)(first_row - s->chunk.skip_count), 0));
         s->top.data.end_row = s->chunk.start_row + s->chunk.num_rows;
         s->top.data.buffered_count = 0;
         if (s->top.data.end_row > first_row + max_num_rows)

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -1376,8 +1376,16 @@ static __device__ void DecodeRowPositions(orcdec_state_s *s, size_t first_row, i
 {
     if (t == 0)
     {
-        s->u.rowdec.nz_count = min(min(s->chunk.skip_count, s->top.data.max_vals), NTHREADS);
-        s->chunk.skip_count -= s->u.rowdec.nz_count;
+        if (s->chunk.skip_count != 0)
+        {
+            s->u.rowdec.nz_count = min(min(s->chunk.skip_count, s->top.data.max_vals), NTHREADS);
+            s->chunk.skip_count -= s->u.rowdec.nz_count;
+            s->top.data.nrows = s->u.rowdec.nz_count;
+        }
+        else
+        {
+            s->u.rowdec.nz_count = 0;
+        }
     }
     __syncthreads();
     if (t < s->u.rowdec.nz_count)
@@ -1576,7 +1584,7 @@ gpuDecodeOrcColumnData(ColumnDesc *chunks, DictionaryEntry *global_dictionary, i
     __syncthreads();
     if (t == 0)
     {
-        s->top.data.cur_row = s->chunk.start_row;
+        s->top.data.cur_row = min(s->chunk.start_row, max((int32_t)(first_row - s->chunk.skip_count), 0));
         s->top.data.end_row = s->chunk.start_row + s->chunk.num_rows;
         s->top.data.buffered_count = 0;
         if (s->top.data.end_row > first_row + max_num_rows)


### PR DESCRIPTION
Fix incorrect starting row position when skiprows!=0, which could lead to last <skiprow> rows being uninitialized.

Resolves #1640 