### PR TITLE
[REVIEW] Fix query function on empty dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# cuDF 0.8.0 (Date TBD)
+
+## New Features
+
+- PR #1524 Add GPU-accelerated JSON Lines parser with limited feature set
+- PR #1569 Add support for Json objects to the JSON Lines reader
+
+## Improvements
+
+...
+
+## Bug Fixes
+
+- PR #1583 Fix underlying issue in `as_index()` that was causing `Series.quantile()` to fail
+- PR #1651 Fix `query` function on empty dataframe
+
+
 # cuDF 0.7.0 (Date TBD)
 
 ## New Features

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -1889,6 +1889,9 @@ class DataFrame(object):
                         datetimes
         1 2018-10-08T00:00:00.000
         """
+        if self.empty:
+            return self.copy()
+
         if not isinstance(local_dict, dict):
             raise TypeError("local_dict type: expected dict but found {!r}"
                             .format(type(local_dict)))

--- a/python/cudf/tests/test_query.py
+++ b/python/cudf/tests/test_query.py
@@ -140,3 +140,15 @@ def test_query_splitted_combine():
     # Should equal to just querying the original GDF
     expect = gdf.query(expr).to_pandas()
     assert_frame_equal(got, expect)
+
+
+def test_query_empty_frames():
+    empty_pdf = pd.DataFrame({'a': [], 'b': []})
+    empty_gdf = DataFrame.from_pandas(empty_pdf)
+    # Do the query
+    expr = 'a > 2'
+    got = empty_gdf.query(expr).to_pandas()
+    expect = empty_pdf.query(expr)
+
+    # assert euqal results
+    assert_frame_equal(got, expect)


### PR DESCRIPTION
Fixes issues caused by calling query on empty dataframe by adding a check on the `query` function . 

Fixes https://github.com/rapidsai/cudf/issues/1646
Fixes https://github.com/rapidsai/dask-cudf/issues/199

- [x] Check if we want to create a deep copy instead
- [x] Add test
- [x] Edit Change Log