### PR TITLE
[REVIEW] Drop object columns automatically when running numeric groupby aggregations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@
 - PR #1648 ORC reader: fix non-deterministic output when skiprows is non-zero
 - PR #1676 Fix groupby `as_index` behaviour with `MultiIndex`
 - PR #1659 Fix bug caused by empty groupbys and multiindex slicing throwing exceptions
-
+- PR #1656 Correct Groupby failure in dask when un-aggregable columns are left in dataframe.
 
 
 # cuDF 0.6.1 (25 Mar 2019)

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -316,7 +316,9 @@ class DataFrame(object):
 
     def _get_numeric_data(self):
         """ Return a dataframe with only numeric data types """
-        columns = [c for c, dt in self.dtypes.items() if dt != object]
+        columns = [c for c, dt in self.dtypes.items()
+                   if dt != object and
+                   not pd.api.types.is_categorical_dtype(dt)]
         return self[columns]
 
     def assign(self, **kwargs):

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -228,7 +228,7 @@ class DataFrame(object):
         if isinstance(self.columns, cudf.dataframe.multiindex.MultiIndex) and\
            isinstance(arg, tuple):
             return self.columns._get_column_major(self, arg)
-        if isinstance(arg, str) or isinstance(arg, numbers.Integral) or \
+        if isinstance(arg, (str, numbers.Number)) or isinstance(arg, numbers.Integral) or \
            isinstance(arg, tuple):
             s = self._cols[arg]
             s.name = arg
@@ -317,9 +317,8 @@ class DataFrame(object):
 
     def _get_numeric_data(self):
         """ Return a dataframe with only numeric data types """
-        columns = [c for c, dt in self.dtypes.items()
-                   if dt != object and
-                   not pd.api.types.is_categorical_dtype(dt)]
+        columns = [c for c, dt in self.dtypes.items() if dt != object]  # and
+                   # not pd.api.types.is_categorical_dtype(dt)]
         return self[columns]
 
     def assign(self, **kwargs):
@@ -1806,7 +1805,6 @@ class DataFrame(object):
         - Since we don't support multiindex, the *by* columns are stored
           as regular columns.
         """
-
         if by is None and level is None:
             raise TypeError('groupby() requires either by or level to be'
                             'specified.')

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -242,7 +242,7 @@ class Groupby(object):
         for by in self._by:
             result._df[by] = self._df[by]
         result._val_columns = arg
-        if isinstance(arg, str):
+        if isinstance(arg, (str, Number)):
             result._df[arg] = self._df[arg]
         else:
             for a in arg:

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -90,7 +90,7 @@ class Groupby(object):
         self.level = None
         self._original_index_name = None
         self._val_columns = []
-        self._df = df.copy(deep=True)
+        self._df = df.copy(deep=False)
         self._as_index = as_index
         if isinstance(by, Series):
             if len(by) != len(self._df.index):
@@ -171,7 +171,7 @@ class Groupby(object):
         agg_type : str
             The aggregation function to run.
         """
-        agg_groupby = self.copy()
+        agg_groupby = self.copy(deep=False)
         if agg_type in ['mean', 'sum']:
             agg_groupby._df = agg_groupby._df._get_numeric_data()
             agg_groupby._val_columns = []
@@ -304,7 +304,7 @@ class Groupby(object):
             for val in arg:
                 if val not in self._val_columns:
                     raise KeyError("Column not found: " + str(val))
-        result = self.copy()
+        result = self.copy(deep=False)
         result._df = DataFrame()
         setattr(result, "_gotattr", True)
         if isinstance(self._by, (str, Number)):
@@ -393,5 +393,5 @@ class Groupby(object):
         Since multi-indexes aren't supported aggregation results are returned
         in columns using the naming scheme of `aggregation_columnname`.
         """
-        agg_groupby = self.copy()
+        agg_groupby = self.copy(deep=False)
         return cpp_agg(agg_groupby, args)

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -178,6 +178,12 @@ class Groupby(object):
             for val in self._val_columns:
                 if val in agg_groupby._df.columns:
                     agg_groupby._val_columns.append(val)
+            # _get_numeric_data might have removed the by column
+            if isinstance(self._by, (str, Number)):
+                agg_groupby._df[self._by] = self._df[self._by]
+            else:
+                for by in self._by:
+                    agg_groupby._df[by] = self._df[by]
         return _cpp_apply_basic_agg(agg_groupby, agg_type,
                                     sort_results=sort_results)
 

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -168,8 +168,6 @@ class Groupby(object):
                                     sort_results=sort_results)
 
     def apply_multiindex_or_single_index(self, result):
-        if len(result) == 0:
-            raise ValueError('Groupby result is empty!')
         if len(self._by) == 1:
             from cudf.dataframe import index
             idx = index.as_index(result[self._by[0]])

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -462,10 +462,19 @@ def test_empty_groupby(func):
 
 
 def test_groupby_unsupported_columns():
+    np.random.seed(12)
+    pd_cat = pd.Categorical(
+        pd.Series(
+            np.random.choice(['a', 'b', 1], 3),
+            dtype='category'
+            )
+        )
+
     pdf = pd.DataFrame({'x': [1, 2, 3],
                         'y': ['a', 'b', 'c'],
                         'z': ['d', 'e', 'f'],
                         'a': [3, 4, 5]})
+    pdf['b'] = pd_cat
     gdf = cudf.from_pandas(pdf)
     pdg = pdf.groupby('x').sum()
     gdg = gdf.groupby('x').sum()

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -432,3 +432,14 @@ def test_list_of_series():
     pdg = pdf.groupby([pdf.x, pdf.y]).y.sum()
     gdg = gdf.groupby([gdf.x, gdf.y]).y.sum()
     assert_eq(pdg, gdg)
+
+
+def test_groupby_unsupported_columns():
+    pdf = pd.DataFrame({'x': [1, 2, 3],
+                        'y': ['a', 'b', 'c'],
+                        'z': ['d', 'e', 'f'],
+                        'a': [3, 4, 5]})
+    gdf = cudf.from_pandas(pdf)
+    pdg = pdf.groupby('x').sum()
+    gdg = gdf.groupby('x').sum()
+    assert_eq(pdg, gdg)


### PR DESCRIPTION
Fixes https://github.com/rapidsai/dask-cudf/issues/234
Fixes https://github.com/rapidsai/cudf/issues/1064

This PR automatically drops unsupported dtypes (object) from numeric groupby aggregations. This is inline with Pandas behavior in this case.