### PR TITLE
[REVIEW] Fix groupby as_index behaviour with MultiIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@
 - PR #1631 Fix failure of TYPES_TEST on some gcc-7 based systems.
 - PR #1641 CSV Reader: Fix skip_blank_lines behavior with Windows line terminators (\r\n) 
 - PR #1648 ORC reader: fix non-deterministic output when skiprows is non-zero
+- PR #1676 Fix groupby `as_index` behaviour with `MultiIndex`
 
 
 # cuDF 0.6.1 (25 Mar 2019)

--- a/python/cudf/bindings/groupby.pyx
+++ b/python/cudf/bindings/groupby.pyx
@@ -336,7 +336,7 @@ def agg(groupby_class, args):
             add_col_values = False  # we only want to add them once
         if(groupby_class._as_index):
             result = groupby_class.apply_multiindex_or_single_index(result)
-        if use_prefix:
+        if use_prefix and groupby_class._as_index:
             result = groupby_class.apply_multicolumn(result, args)
     elif isinstance(args, collections.abc.Mapping):
         if (len(args.keys()) == 1):
@@ -377,7 +377,7 @@ def agg(groupby_class, args):
             add_col_values = False  # we only want to add them once
         if groupby_class._as_index:
             result = groupby_class.apply_multiindex_or_single_index(result)
-        if use_prefix:
+        if use_prefix and groupby_class._as_index:
             result = groupby_class.apply_multicolumn_mapped(result, args)
     else:
         result = groupby_class.agg([args])

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -58,7 +58,8 @@ def test_groupby_as_index_single_agg(pdf, gdf, as_index):
 
 @pytest.mark.parametrize('as_index', [True, False])
 def test_groupby_as_index_multiindex(pdf, gdf, as_index):
-    pdf = pd.DataFrame({'a': [1, 2, 1], 'b': [3, 3, 3], 'c': [2, 2, 3], 'd': [3, 1, 2]})
+    pdf = pd.DataFrame({'a': [1, 2, 1], 'b': [3, 3, 3],
+                        'c': [2, 2, 3], 'd': [3, 1, 2]})
     gdf = cudf.from_pandas(pdf)
 
     gdf = gdf.groupby(['a', 'b'], as_index=as_index).agg({'c': 'mean'})


### PR DESCRIPTION
Fix to ensure that passing `as_index=False` works properly with MultiIndex groupby