### PR TITLE
[REVIEW] Correct performance regression with 0.7 groupby.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@
 - PR #1648 ORC reader: fix non-deterministic output when skiprows is non-zero
 - PR #1676 Fix groupby `as_index` behaviour with `MultiIndex`
 - PR #1659 Fix bug caused by empty groupbys and multiindex slicing throwing exceptions
-
+- PR #1689 Fix groupby performance regression
 
 
 # cuDF 0.6.1 (25 Mar 2019)

--- a/python/cudf/dataframe/multiindex.py
+++ b/python/cudf/dataframe/multiindex.py
@@ -7,6 +7,7 @@ import warnings
 from collections.abc import Sequence
 
 from cudf.dataframe import columnops
+from cudf.dataframe.series import Series
 from cudf.comm.serialize import register_distributed_serializer
 from cudf.dataframe.index import Index, StringIndex
 from cudf.utils import utils
@@ -63,7 +64,7 @@ class MultiIndex(Index):
 
         # converting levels to numpy array will produce a Float64Index
         # (on empty levels)for levels mimicking the behavior of Pandas
-        self.levels = np.array(levels)
+        self.levels = np.array([Series(level).to_array() for level in levels])
         self._validate_levels_and_codes(self.levels, self.codes)
         self.name = None
         self.names = names

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -206,12 +206,9 @@ class Groupby(object):
             # time the groupby is calculated.
             for by in self._by:
                 level = result[by].unique()
-                code = result[by]
-                for idx, value in enumerate(level):
-                    level_mask = code == value
-                    code = code.masked_assign(idx, level_mask)
+                replaced = result[by].replace(level, range(len(level)))
                 levels.append(level)
-                codes[by] = code
+                codes[by] = Series(replaced, dtype="int32")
                 names.append(by)
             multi_index = MultiIndex(levels=levels,
                                      codes=codes,


### PR DESCRIPTION
An O(N^2) replacement operation was easily replicated with a cpp level replace. Thanks @shwina for your help!

Fixes https://github.com/rapidsai/cudf/issues/1685