### PR TITLE
[REVIEW] Handle datetime64[ms] in `select_dtypes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuDF 0.7.0 (Date TBD)
+# cuDF 0.7.0 (10 May 2019)
 
 ## New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-- PR #XXXX Fix handling of `datetime64[ms]` in `dataframe.select_dtypes`
+- PR #1708 Fix handling of `datetime64[ms]` in `dataframe.select_dtypes`
 
 # cuDF 0.7.0 (10 May 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - PR #1708 Fix handling of `datetime64[ms]` in `dataframe.select_dtypes`
 
+
 # cuDF 0.7.0 (10 May 2019)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# cuDF 0.7.1 (TBD)
+
+## Bug Fixes
+
+- PR #XXXX Fix handling of `datetime64[ms]` in `dataframe.select_dtypes`
+
 # cuDF 0.7.0 (10 May 2019)
 
 ## New Features

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -16,15 +16,6 @@ import pandas as pd
 import pyarrow as pa
 from pandas.api.types import is_dict_like
 
-try:
-    # pd 0.24.X
-    from pandas.core.dtypes.common import infer_dtype_from_object
-except ImportError:
-    # pd 0.23.X
-    from pandas.core.dtypes.common import \
-            _get_dtype_from_object as infer_dtype_from_object
-
-
 from types import GeneratorType
 
 from librmm_cffi import librmm as rmm
@@ -2699,6 +2690,8 @@ class DataFrame(object):
         # code modified from:
         # https://github.com/pandas-dev/pandas/blob/master/pandas/core/frame.py#L3196
 
+        from utils import cudf_dtype_from_pydata_dtype
+
         if not isinstance(include, (list, tuple)):
             include = (include,) if include is not None else ()
         if not isinstance(exclude, (list, tuple)):
@@ -2706,12 +2699,12 @@ class DataFrame(object):
 
         df = DataFrame()
 
-        # infer_dtype_from_object can distinguish between
+        # cudf_dtype_from_pydata_dtype can distinguish between
         # np.float and np.number
         selection = tuple(map(frozenset, (include, exclude)))
         include, exclude = map(
             lambda x: frozenset(
-                map(infer_dtype_from_object, x)),
+                map(cudf_dtype_from_pydata_dtype, x)),
             selection,
         )
 
@@ -2744,7 +2737,7 @@ class DataFrame(object):
                 if issubclass(dtype.type, e_dtype):
                     exclude_subtypes.add(dtype.type)
 
-        include_all = set([infer_dtype_from_object(d)
+        include_all = set([cudf_dtype_from_pydata_dtype(d)
                            for d in self.dtypes])
 
         # remove all exclude types
@@ -2755,7 +2748,7 @@ class DataFrame(object):
             inclusion = inclusion & include_subtypes
 
         for x in self._cols.values():
-            infered_type = infer_dtype_from_object(x.dtype)
+            infered_type = cudf_dtype_from_pydata_dtype(x.dtype)
             if infered_type in inclusion:
                 df.add_column(x.name, x)
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -2690,8 +2690,6 @@ class DataFrame(object):
         # code modified from:
         # https://github.com/pandas-dev/pandas/blob/master/pandas/core/frame.py#L3196
 
-        from utils import cudf_dtype_from_pydata_dtype
-
         if not isinstance(include, (list, tuple)):
             include = (include,) if include is not None else ()
         if not isinstance(exclude, (list, tuple)):
@@ -2704,7 +2702,7 @@ class DataFrame(object):
         selection = tuple(map(frozenset, (include, exclude)))
         include, exclude = map(
             lambda x: frozenset(
-                map(cudf_dtype_from_pydata_dtype, x)),
+                map(utils.cudf_dtype_from_pydata_dtype, x)),
             selection,
         )
 
@@ -2737,7 +2735,7 @@ class DataFrame(object):
                 if issubclass(dtype.type, e_dtype):
                     exclude_subtypes.add(dtype.type)
 
-        include_all = set([cudf_dtype_from_pydata_dtype(d)
+        include_all = set([utils.cudf_dtype_from_pydata_dtype(d)
                            for d in self.dtypes])
 
         # remove all exclude types
@@ -2748,7 +2746,7 @@ class DataFrame(object):
             inclusion = inclusion & include_subtypes
 
         for x in self._cols.values():
-            infered_type = cudf_dtype_from_pydata_dtype(x.dtype)
+            infered_type = utils.cudf_dtype_from_pydata_dtype(x.dtype)
             if infered_type in inclusion:
                 df.add_column(x.name, x)
 

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2093,6 +2093,24 @@ def test_select_dtype():
         gdf.select_dtypes(exclude=np.number, include=np.number)
 
 
+def test_select_dtype_datetime():
+    gdf = gd.datasets.timeseries(
+        start='2000-01-01',
+        end='2000-01-02',
+        freq='3600s',
+        dtypes={'x': int}
+    )
+    gdf = gdf.reset_index()
+
+    assert_eq(gdf[['timestamp']], gdf.select_dtypes('datetime64'))
+    assert_eq(gdf[['timestamp']], gdf.select_dtypes(np.dtype('datetime64')))
+    assert_eq(gdf[['timestamp']], gdf.select_dtypes(include='datetime64'))
+    assert_eq(gdf[['timestamp']], gdf.select_dtypes('datetime64[ms]'))
+    assert_eq(gdf[['timestamp']],
+              gdf.select_dtypes(np.dtype('datetime64[ms]')))
+    assert_eq(gdf[['timestamp']], gdf.select_dtypes(include='datetime64[ms]'))
+
+
 def test_array_ufunc():
     gdf = gd.DataFrame({'x': [2, 3, 4.0], 'y': [9.0, 2.5, 1.1]})
     pdf = gdf.to_pandas()

--- a/python/cudf/utils/utils.py
+++ b/python/cudf/utils/utils.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 from math import isnan, isinf, ceil
 
@@ -193,7 +194,9 @@ def cudf_dtype_from_pydata_dtype(dtype):
         from pandas.core.dtypes.common import \
             _get_dtype_from_object as infer_dtype_from_object
 
-    if np.issubdtype(dtype, np.datetime64):
+    if pd.api.types.is_categorical_dtype(dtype):
+        pass
+    elif np.issubdtype(dtype, np.datetime64):
         dtype = np.datetime64
 
     return infer_dtype_from_object(dtype)

--- a/python/cudf/utils/utils.py
+++ b/python/cudf/utils/utils.py
@@ -178,3 +178,22 @@ def buffers_from_pyarrow(pa_arr, dtype=None):
             np.empty(0, dtype=new_dtype)
         )
     return (pamask, padata)
+
+
+def cudf_dtype_from_pydata_dtype(dtype):
+    """ Given a numpy or pandas dtype, converts it into the equivalent cuDF
+        Python dtype.
+    """
+    try:
+        # pd 0.24.X
+        from pandas.core.dtypes.common import \
+            infer_dtype_from_object
+    except ImportError:
+        # pd 0.23.X
+        from pandas.core.dtypes.common import \
+            _get_dtype_from_object as infer_dtype_from_object
+
+    if np.issubdtype(dtype, np.datetime64):
+        dtype = np.datetime64
+
+    return infer_dtype_from_object(dtype)


### PR DESCRIPTION
Fixes a bug in dask-cudf with read_csv and datetime64[ms] columns