### PR TITLE
[REVIEW] Support for different exception types with CUDF_EXPECT and CUDF_FAIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Improvements
 
 - PR #1713 Add documentation for Dask-XGBoost
+- PR #1719 `CUDF_EXPECT()` and `CUDF_FAIL()` can now be used with exceptions other than `cudf::logic_error`
 
 ## Bug Fixes
 

--- a/cpp/tests/utilities/cudf_test_utils.cuh
+++ b/cpp/tests/utilities/cudf_test_utils.cuh
@@ -58,23 +58,22 @@ do {                                                                          \
 
 // Utility for testing the expectation that an expression x throws the specified
 // exception whose what() message ends with the msg
-#define EXPECT_THROW_MESSAGE(x, exception, startswith, endswith)     \
+#define EXPECT_THROW_MESSAGE(x, exception, endswith)     \
 do { \
   EXPECT_THROW({                                                     \
     try { x; }                                                       \
     catch (const exception &e) {                                     \
     ASSERT_NE(nullptr, e.what());                                    \
-    EXPECT_THAT(e.what(), testing::StartsWith((startswith)));        \
     EXPECT_THAT(e.what(), testing::EndsWith((endswith)));            \
     throw;                                                           \
   }}, exception);                                                    \
 } while (0)
 
 #define CUDF_EXPECT_THROW_MESSAGE(x, msg) \
-EXPECT_THROW_MESSAGE(x, cudf::logic_error, "cuDF failure at:", msg)
+EXPECT_THROW_MESSAGE(x, cudf::logic_error, msg)
 
 #define CUDA_EXPECT_THROW_MESSAGE(x, msg) \
-EXPECT_THROW_MESSAGE(x, cudf::cuda_error, "CUDA error encountered at:", msg)
+EXPECT_THROW_MESSAGE(x, cudf::cuda_error, msg)
 
 /**---------------------------------------------------------------------------*
  * @brief test macro to be expected as no exception.


### PR DESCRIPTION
This fixes #1682 by overloading the `CUDF_EXPECTS()` and `CUDF_FAIL()` macros, so that the existing usage still works, but you can also, instead, specify a different exception type.

Also, I've removed the check for the prefix of an exception's "what" from the relevant unit tests; the prefix has no particular significance, as opposed to other elements of the "what" string. Also, while I could have updated the test with my changed message, it really isn't a "failure" if you get a different what string prefix but it's the appropriate exception type with the relevant details.