### PR TITLE
[REVIEW] Fix issue by handling same-column-as-index rules for the first time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #1701 Added `unique` method for stringColumns
 - PR #1713 Add documentation for Dask-XGBoost
 - PR #1666 CSV Reader: Improve performance for files with large number of columns
+- PR #1725 Enable the ability to use a single column groupby as its own index
 
 ## Bug Fixes
 

--- a/python/cudf/bindings/groupby.pyx
+++ b/python/cudf/bindings/groupby.pyx
@@ -255,6 +255,12 @@ cdef _apply_agg(groupby_class, agg_type, result, add_col_values,
         if isinstance(val_columns_out, (str, Number)):
             result[val_columns_out] = out_col_agg_series[:num_row_results]
         else:
+            if len(val_columns_out) == 0:
+                if groupby_class._as_index:
+                    val_columns_out = ['cudfvalcol_'+by for by in groupby_class._by]
+                else:
+                    raise ValueError('cannot insert %s, already exists' % (
+                            groupby_class._by[0]))
             result[val_columns_out[col_count]
                     ] = out_col_agg_series[:num_row_results]
 

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -214,6 +214,12 @@ class Groupby(object):
             if idx.name == self._LEVEL_0_INDEX_NAME:
                 idx.name = self._original_index_name
             result = result.set_index(idx)
+            for col in result.columns:
+                if isinstance(col, str):
+                    colnames = col.split('_')
+                    if colnames[0] == 'cudfvalcol':
+                        result[colnames[1]] = result[col]
+                        result = result.drop(col)
             return result
         else:
             multi_index = MultiIndex(source_data=result[self._by])

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -490,3 +490,13 @@ def test_list_of_series():
     gdg = gdf.groupby([gdf.x, gdf.y]).y.sum()
     pytest.skip()
     assert_eq(pdg, gdg)
+
+
+def test_groupby_use_agg_column_as_index():
+    pdf = pd.DataFrame()
+    pdf['a'] = [1, 1, 1, 3, 5]
+    gdf = cudf.DataFrame()
+    gdf['a'] = [1, 1, 1, 3, 5]
+    pdg = pdf.groupby('a').agg({'a': 'count'})
+    gdg = gdf.groupby('a').agg({'a': 'count'})
+    assert_eq(pdg, gdg)


### PR DESCRIPTION
Fixes #1509 

This functionality can only be supported by `as_index=True`, which was not possible with the original implementation of Groupby. I enabled a special case when a single column is grouped as its own index.