### PR TITLE
[HOTFIX] Fix dtype for groupby-count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Bug Fixes
 
 - PR #1718 Fix issue with SeriesGroupBy MultiIndex in dask-cudf
-- PR #1730 Python: fix performance regression for groupby count() aggregations
+- PR #1734 Python: fix performance regression for groupby count() aggregations
 
 
 # cudf 0.7.1 (11 May 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 - PR #1718 Fix issue with SeriesGroupBy MultiIndex in dask-cudf
+- PR #1730 Python: fix performance regression for groupby count() aggregations
 
 
 # cudf 0.7.1 (11 May 2019)

--- a/python/cudf/bindings/groupby.pyx
+++ b/python/cudf/bindings/groupby.pyx
@@ -125,7 +125,7 @@ cdef _apply_agg(groupby_class, agg_type, result, add_col_values,
                 Buffer(
                     rmm.device_array(
                         col_agg.size,
-                        dtype=np.int64
+                        dtype=np.int32
                     )
                 )
             )

--- a/python/cudf/bindings/groupby.pyx
+++ b/python/cudf/bindings/groupby.pyx
@@ -121,6 +121,8 @@ cdef _apply_agg(groupby_class, agg_type, result, add_col_values,
             vector_out_col_values.push_back(column_view_from_column(out_col_values_series[i]._column))
 
         if agg_type == "count":
+            # To ensure that we update this code if gdf_size_type changes
+            assert np.dtype(np.int32).itemsize == sizeof(gdf_size_type)
             out_col_agg_series = Series(
                 Buffer(
                     rmm.device_array(

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -310,7 +310,8 @@ def test_groupby_cudf_2keys_agg(nelem, func, method):
         # verify
         np.testing.assert_array_almost_equal(expect_agg, got_agg)
     else:
-        assert_eq(got_df, expect_df)
+        check_dtype = False if func == 'count' else True
+        assert_eq(got_df, expect_df, check_dtype=check_dtype)
 
 
 @pytest.mark.parametrize('agg', ['min', 'max', 'count', 'sum', 'mean'])
@@ -321,7 +322,8 @@ def test_series_groupby(agg):
     gg = g.groupby(g // 2)
     sa = getattr(sg, agg)()
     ga = getattr(gg, agg)()
-    assert_eq(sa, ga)
+    check_dtype = False if agg == 'count' else True
+    assert_eq(sa, ga, check_dtype=check_dtype)
 
 
 @pytest.mark.xfail(reason="Prefixed column names are not removed yet")
@@ -331,7 +333,8 @@ def test_series_groupby_agg(agg):
     g = Series([1, 2, 3])
     sg = s.groupby(s // 2).agg(agg)
     gg = g.groupby(g // 2).agg(agg)
-    assert_eq(sg, gg)
+    check_dtype = False if agg == 'count' else True
+    assert_eq(sg, gg, check_dtype=check_dtype)
 
 
 @pytest.mark.parametrize('agg', ['min', 'max', 'count', 'sum', 'mean'])
@@ -342,7 +345,8 @@ def test_groupby_level_zero(agg):
     gdg = gdf.groupby(level=0)
     pdresult = getattr(pdg, agg)()
     gdresult = getattr(gdg, agg)()
-    assert_eq(pdresult, gdresult)
+    check_dtype = False if agg == 'count' else True
+    assert_eq(pdresult, gdresult, check_dtype=check_dtype)
 
 
 @pytest.mark.parametrize('agg', ['min', 'max', 'count', 'sum', 'mean'])
@@ -353,7 +357,8 @@ def test_groupby_series_level_zero(agg):
     gdg = gdf.groupby(level=0)
     pdresult = getattr(pdg, agg)()
     gdresult = getattr(gdg, agg)()
-    assert_eq(pdresult, gdresult)
+    check_dtype = False if agg == 'count' else True
+    assert_eq(pdresult, gdresult, check_dtype=check_dtype)
 
 
 def test_groupby_column_name():

--- a/python/cudf/tests/test_libgdf_groupby.py
+++ b/python/cudf/tests/test_libgdf_groupby.py
@@ -82,4 +82,5 @@ def test_groupby_2keys_agg(nelem, func):
         .groupby(['x', 'y']).agg(func)
     got_df = make_frame(DataFrame, nelem=nelem)\
         .groupby(['x', 'y'], method="hash").agg(func)
-    assert_eq(got_df, expect_df)
+    check_dtype = False if func == 'count' else True
+    assert_eq(got_df, expect_df, check_dtype=check_dtype)

--- a/python/cudf/tests/test_string.py
+++ b/python/cudf/tests/test_string.py
@@ -683,7 +683,7 @@ def test_string_groupby_key(str_data, str_data_raise, num_keys):
         expect = expect.sort_values([0]).reset_index(drop=True)
         got = got.sort_values([0]).reset_index(drop=True)
 
-        assert_eq(expect, got)
+        assert_eq(expect, got, check_dtype=False)
 
 
 @pytest.mark.parametrize('str_data,str_data_raise', [
@@ -715,7 +715,7 @@ def test_string_groupby_non_key(str_data, str_data_raise, num_cols):
         expect = expect.sort_values(['a']).reset_index(drop=True)
         got = got.sort_values(['a']).reset_index(drop=True)
 
-        assert_eq(expect, got)
+        assert_eq(expect, got, check_dtype=False)
 
         expect = pdf.groupby('a', as_index=False).max()
         got = gdf.groupby('a', as_index=False).max()
@@ -756,7 +756,7 @@ def test_string_groupby_key_index():
     expect = pdf.groupby('a').count()
     got = gdf.groupby('a').count()
 
-    assert_eq(expect, got)
+    assert_eq(expect, got, check_dtype=False)
 
 
 @pytest.mark.parametrize('scalar', [


### PR DESCRIPTION
This PR extends #1730 and fixes pytests so that they don't compare dtypes when doing groupby-count.