### PR TITLE
[HOTFIX] Overload for atomicAdd on int64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features
 
-- PR #1735 Added overload for atomicAdd on int64
+- PR #1735 Added overload for atomicAdd on int64. Streamlined implementation of custom atomic overloads.
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - PR #1718 Fix issue with SeriesGroupBy MultiIndex in dask-cudf
 
 
-
 # cudf 0.7.1 (11 May 2019)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # cudf 0.7.2 (Date TBD)
 
+## New Features
+
+- PR #1735 Added overload for atomicAdd on int64
+
 ## Bug Fixes
 
 - PR #1718 Fix issue with SeriesGroupBy MultiIndex in dask-cudf
+
 
 
 # cudf 0.7.1 (11 May 2019)

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -48,31 +48,6 @@ namespace detail {
         return *( reinterpret_cast<T_output*>(&value) );
     }
 
-    // call atomic function with type cast between same underlying type
-    template <typename T, typename Functor>
-    __forceinline__  __device__
-    T typesAtomicOperation32(T* addr, T val, Functor atomicFunc)
-    {
-        using T_int = int;
-        T_int ret = atomicFunc(reinterpret_cast<T_int*>(addr),
-            cudf::detail::type_reinterpret<T_int, T>(val));
-
-        return cudf::detail::type_reinterpret<T, T_int>(ret);
-    }
-
-    // call atomic function with type cast between same underlying type
-    template <typename T, typename Functor>
-    __forceinline__  __device__
-    T typesAtomicOperation64(T* addr, T val, Functor atomicFunc)
-    {
-        using T_int = long long int;
-        T_int ret = atomicFunc(reinterpret_cast<T_int*>(addr),
-            cudf::detail::type_reinterpret<T_int, T>(val));
-
-        return cudf::detail::type_reinterpret<T, T_int>(ret);
-    }
-
-
     // -----------------------------------------------------------------------
     // the implementation of `genericAtomicOperation`
     template <typename T, typename Op, size_t n>
@@ -253,9 +228,9 @@ namespace detail {
         __forceinline__  __device__
         T operator()(T* addr, T const & update_value, DeviceMin op)
         {
-            using T_out = long long int;
-            T ret = atomicMin(reinterpret_cast<T_out*>(addr),
-                type_reinterpret<T_out, T>(update_value) );
+            using T_int = long long int;
+            T ret = atomicMin(reinterpret_cast<T_int*>(addr),
+                type_reinterpret<T_int, T>(update_value) );
             return ret;
         }
     };
@@ -266,9 +241,9 @@ namespace detail {
         __forceinline__  __device__
         T operator()(T* addr, T const & update_value, DeviceMax op)
         {
-            using T_out = long long int;
-            T ret = atomicMax(reinterpret_cast<T_out*>(addr),
-                type_reinterpret<T_out, T>(update_value) );
+            using T_int = long long int;
+            T ret = atomicMax(reinterpret_cast<T_int*>(addr),
+                type_reinterpret<T_int, T>(update_value) );
             return ret;
         }
     };
@@ -288,8 +263,9 @@ namespace detail {
         T operator()(T* addr, T const & update_value, DeviceAnd op)
         {
             using T_int = long long int;
-            return cudf::detail::typesAtomicOperation64
-                (addr, update_value, [](T_int* a, T_int v){return atomicAnd(a, v);});
+            T ret = atomicAnd(reinterpret_cast<T_int*>(addr),
+                type_reinterpret<T_int, T>(update_value) );
+            return ret;
         }
     };
 
@@ -308,8 +284,9 @@ namespace detail {
         T operator()(T* addr, T const & update_value, DeviceOr op)
         {
             using T_int = long long int;
-            return cudf::detail::typesAtomicOperation64
-                (addr, update_value, [](T_int* a, T_int v){return atomicOr(a, v);});
+            T ret = atomicOr(reinterpret_cast<T_int*>(addr),
+                type_reinterpret<T_int, T>(update_value) );
+            return ret;
         }
     };
 
@@ -328,11 +305,12 @@ namespace detail {
         T operator()(T* addr, T const & update_value, DeviceXor op)
         {
             using T_int = long long int;
-            return cudf::detail::typesAtomicOperation64
-                (addr, update_value, [](T_int* a, T_int v){return atomicXor(a, v);});
+            T ret = atomicXor(reinterpret_cast<T_int*>(addr),
+                type_reinterpret<T_int, T>(update_value) );
+            return ret;
+
         }
     };
-
     // -----------------------------------------------------------------------
     // the implementation of `typesAtomicCASImpl`
     template <typename T, size_t n>

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -447,6 +447,7 @@ T genericAtomicOperation(T* address, T const & update_value, BinaryOp op)
 
 // specialization for cudf::detail::wrapper types
 template <typename T, gdf_dtype dtype, typename BinaryOp, typename W = cudf::detail::wrapper<T, dtype> >
+__forceinline__  __device__
 W genericAtomicOperator( W* address, W const& update_value, BinaryOp op){
     // unwrap the input type to expect
     // that the native atomic API is used for the underlying type if possible

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -30,92 +30,13 @@
  * with the given binary operator.
  * ---------------------------------------------------------------------------**/
 
-#include "cudf.h"
-#include "utilities/cudf_utils.h"
-#include "utilities/wrapper_types.hpp"
-#include "utilities/error_utils.hpp"
+#include <cudf.h>
+#include <utilities/cudf_utils.h>
+#include <utilities/wrapper_types.hpp>
+#include <utilities/error_utils.hpp>
+#include <utilities/device_operators.cuh>
 
 namespace cudf {
-
-// ------------------------------------------------------------------------
-// Binary operators
-/* @brief binary `sum` operator */
-struct DeviceSum {
-    template<typename T>
-    __device__
-    T operator() (const T &lhs, const T &rhs) {
-        return lhs + rhs;
-    }
-
-    template<typename T>
-    static constexpr T identity() { return T{0}; }
-};
-
-/* @brief binary `min` operator */
-struct DeviceMin{
-    template<typename T>
-    __device__
-    T operator() (const T &lhs, const T &rhs) {
-        return lhs <= rhs? lhs: rhs;
-    }
-
-    template<typename T>
-    static constexpr T identity() { return std::numeric_limits<T>::max(); }
-};
-
-/* @brief binary `max` operator */
-struct DeviceMax{
-    template<typename T>
-    __device__
-    T operator() (const T &lhs, const T &rhs) {
-        return lhs >= rhs? lhs: rhs;
-    }
-
-    template<typename T>
-    static constexpr T identity() { return std::numeric_limits<T>::lowest(); }
-};
-
-/* @brief binary `product` operator */
-struct DeviceProduct {
-    template<typename T>
-    __device__
-    T operator() (const T &lhs, const T &rhs) {
-        return lhs * rhs;
-    }
-
-    template<typename T>
-    static constexpr T identity() { return T{1}; }
-};
-
-
-/* @brief binary `and` operator */
-struct DeviceAnd{
-    template<typename T>
-    __device__
-    T operator() (const T &lhs, const T &rhs) {
-        return (lhs & rhs );
-    }
-};
-
-/* @brief binary `or` operator */
-struct DeviceOr{
-    template<typename T>
-    __device__
-    T operator() (const T &lhs, const T &rhs) {
-        return (lhs | rhs );
-    }
-};
-
-/* @brief binary `xor` operator */
-struct DeviceXor{
-    template<typename T>
-    __device__
-    T operator() (const T &lhs, const T &rhs) {
-        return (lhs ^ rhs );
-    }
-};
-
-
 namespace detail {
 
     template <typename T_output, typename T_input>

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -28,7 +28,7 @@
  * where CUDA atomic operations are, `atomicAdd`, `atomicMin`, `atomicMax`,
  * `atomicCAS`.
  * `atomicAnd`, `atomicOr`, `atomicXor` are also supported for integer data types.
- * Also provides `cudf::genericAtomicOperation` which performs atomic operation 
+ * Also provides `cudf::genericAtomicOperation` which performs atomic operation
  * with the given binary operator.
  * ---------------------------------------------------------------------------**/
 
@@ -40,6 +40,9 @@
 
 namespace cudf {
 namespace detail {
+    // TODO: remove this if C++17 is supported.
+    // `static_assert` requires a string literal at C++14.
+#define errmsg_cast "`long long int` has different size to `int64_t`"
 
     template <typename T_output, typename T_input>
     __forceinline__  __device__
@@ -146,6 +149,7 @@ namespace detail {
         T operator()(T* addr, T const & update_value, Op op)
         {
             using T_int = unsigned long long int;
+            static_assert(sizeof(T) == sizeof(T_int), errmsg_cast);
 
             T old_value = *addr;
             T assumed {old_value};
@@ -231,6 +235,7 @@ namespace detail {
         T operator()(T* addr, T const & update_value, DeviceMin op)
         {
             using T_int = long long int;
+            static_assert(sizeof(T) == sizeof(T_int), errmsg_cast);
             T ret = atomicMin(reinterpret_cast<T_int*>(addr),
                 type_reinterpret<T_int, T>(update_value) );
             return ret;
@@ -244,6 +249,7 @@ namespace detail {
         T operator()(T* addr, T const & update_value, DeviceMax op)
         {
             using T_int = long long int;
+            static_assert(sizeof(T) == sizeof(T_int), errmsg_cast);
             T ret = atomicMax(reinterpret_cast<T_int*>(addr),
                 type_reinterpret<T_int, T>(update_value) );
             return ret;
@@ -265,6 +271,7 @@ namespace detail {
         T operator()(T* addr, T const & update_value, DeviceAnd op)
         {
             using T_int = long long int;
+            static_assert(sizeof(T) == sizeof(T_int), errmsg_cast);
             T ret = atomicAnd(reinterpret_cast<T_int*>(addr),
                 type_reinterpret<T_int, T>(update_value) );
             return ret;
@@ -286,6 +293,7 @@ namespace detail {
         T operator()(T* addr, T const & update_value, DeviceOr op)
         {
             using T_int = long long int;
+            static_assert(sizeof(T) == sizeof(T_int), errmsg_cast);
             T ret = atomicOr(reinterpret_cast<T_int*>(addr),
                 type_reinterpret<T_int, T>(update_value) );
             return ret;
@@ -307,6 +315,7 @@ namespace detail {
         T operator()(T* addr, T const & update_value, DeviceXor op)
         {
             using T_int = long long int;
+            static_assert(sizeof(T) == sizeof(T_int), errmsg_cast);
             T ret = atomicXor(reinterpret_cast<T_int*>(addr),
                 type_reinterpret<T_int, T>(update_value) );
             return ret;
@@ -406,6 +415,7 @@ namespace detail {
         T operator()(T* addr, T const & compare, T const & update_value)
         {
             using T_int = unsigned long long int;
+            static_assert(sizeof(T) == sizeof(T_int), errmsg_cast);
 
             T_int ret = atomicCAS(
                 reinterpret_cast<T_int*>(addr),

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -209,6 +209,20 @@ namespace detail {
     };
 
     template<>
+    struct genericAtomicOperationImpl<int64_t, DeviceSum, 8> {
+        using T = int64_t;
+        __forceinline__  __device__
+        T operator()(T* addr, T const & update_value, DeviceSum op)
+        {
+            using T_int = unsigned long long int;
+            static_assert(sizeof(T) == sizeof(T_int), errmsg_cast);
+            T ret = atomicAdd(reinterpret_cast<T_int*>(addr),
+                type_reinterpret<T_int, T>(update_value) );
+            return ret;
+        }
+    };
+
+    template<>
     struct genericAtomicOperationImpl<int32_t, DeviceMin, 4> {
         using T = int32_t;
         __forceinline__  __device__

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -612,59 +612,11 @@ T atomicCAS(T* address, T compare, T val)
  *
  * @returns The old value at `address`
  * -------------------------------------------------------------------------**/
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, T>* = nullptr>
 __forceinline__ __device__
-int8_t atomicAnd(int8_t* address, int8_t val)
+T atomicAnd(T* address, T val)
 {
     return cudf::genericAtomicOperation(address, val, cudf::DeviceAnd{});
-}
-
-/**
- * @overload uint8_t atomicAnd(uint8_t* address, uint8_t val)
- */
-__forceinline__ __device__
-uint8_t atomicAnd(uint8_t* address, uint8_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceAnd{});
-}
-
-/**
- * @overload int16_t atomicAnd(int16_t* address, int16_t val)
- */
-__forceinline__ __device__
-int16_t atomicAnd(int16_t* address, int16_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceAnd{});
-}
-
-/**
- * @overload uint16_t atomicAnd(uint16_t* address, uint16_t val)
- */
-__forceinline__ __device__
-uint16_t atomicAnd(uint16_t* address, uint16_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceAnd{});
-}
-
-/**
- * @overload int64_t atomicAnd(int64_t* address, int64_t val)
- */
-__forceinline__ __device__
-int64_t atomicAnd(int64_t* address, int64_t val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicAnd(a, v);});
-}
-
-/**
- * @overload uint64_t atomicAnd(uint64_t* address, uint64_t val)
- */
-__forceinline__ __device__
-uint64_t atomicAnd(uint64_t* address, uint64_t val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicAnd(a, v);});
 }
 
 /* Overloads for `atomicOr` */
@@ -682,61 +634,12 @@ uint64_t atomicAnd(uint64_t* address, uint64_t val)
  *
  * @returns The old value at `address`
  * -------------------------------------------------------------------------**/
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, T>* = nullptr>
 __forceinline__ __device__
-int8_t atomicOr(int8_t* address, int8_t val)
+T atomicOr(T* address, T val)
 {
     return cudf::genericAtomicOperation(address, val, cudf::DeviceOr{});
 }
-
-/**
- * @overload uint8_t atomicOr(uint8_t* address, uint8_t val)
- */
-__forceinline__ __device__
-uint8_t atomicOr(uint8_t* address, uint8_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceOr{});
-}
-
-/**
- * @overload int16_t atomicOr(int16_t* address, int16_t val)
- */
-__forceinline__ __device__
-int16_t atomicOr(int16_t* address, int16_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceOr{});
-}
-
-/**
- * @overload uint16_t atomicOr(uint16_t* address, uint16_t val)
- */
-__forceinline__ __device__
-uint16_t atomicOr(uint16_t* address, uint16_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceOr{});
-}
-
-/**
- * @overload int64_t atomicOr(int64_t* address, int64_t val)
- */
-__forceinline__ __device__
-int64_t atomicOr(int64_t* address, int64_t val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicOr(a, v);});
-}
-
-/**
- * @overload uint64_t atomicOr(uint64_t* address, uint64_t val)
- */
-__forceinline__ __device__
-uint64_t atomicOr(uint64_t* address, uint64_t val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicOr(a, v);});
-}
-
 
 /* Overloads for `atomicXor` */
 /** -------------------------------------------------------------------------*
@@ -753,60 +656,11 @@ uint64_t atomicOr(uint64_t* address, uint64_t val)
  *
  * @returns The old value at `address`
  * -------------------------------------------------------------------------**/
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, T>* = nullptr>
 __forceinline__ __device__
-int8_t atomicXor(int8_t* address, int8_t val)
+T atomicXor(T* address, T val)
 {
     return cudf::genericAtomicOperation(address, val, cudf::DeviceXor{});
 }
-
-/**
- * @overload uint8_t atomicXor(uint8_t* address, uint8_t val)
- */
-__forceinline__ __device__
-uint8_t atomicXor(uint8_t* address, uint8_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceXor{});
-}
-
-/**
- * @overload int16_t atomicXor(int16_t* address, int16_t val)
- */
-__forceinline__ __device__
-int16_t atomicXor(int16_t* address, int16_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceXor{});
-}
-
-/**
- * @overload uint16_t atomicXor(uint16_t* address, uint16_t val)
- */
-__forceinline__ __device__
-uint16_t atomicXor(uint16_t* address, uint16_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceXor{});
-}
-
-/**
- * @overload int64_t atomicXor(int64_t* address, int64_t val)
- */
-__forceinline__ __device__
-int64_t atomicXor(int64_t* address, int64_t val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicXor(a, v);});
-}
-
-/**
- * @overload uint64_t atomicXor(uint64_t* address, uint64_t val)
- */
-__forceinline__ __device__
-uint64_t atomicXor(uint64_t* address, uint64_t val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicXor(a, v);});
-}
-
 
 #endif

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -469,11 +469,23 @@ template <typename T, typename BinaryOp>
 __forceinline__  __device__
 T genericAtomicOperation(T* address, T const & update_value, BinaryOp op)
 {
+    // unwrap the input type to expect
+    // that the native atomic API is used for the underlying type
     auto ret = cudf::detail::genericAtomicOperationUnderlyingType(
          &cudf::detail::unwrap(*address),
          cudf::detail::unwrap(update_value),
          op);
     return T(ret);
+}
+
+template <typename BinaryOp>
+__forceinline__  __device__
+cudf::bool8 genericAtomicOperation(cudf::bool8* address, cudf::bool8 const & update_value, BinaryOp op)
+{
+    // don't use underlying type to apply operation for cudf::bool8
+    auto ret = cudf::detail::genericAtomicOperationUnderlyingType(
+         address, update_value, op);
+    return cudf::bool8(ret);
 }
 
 } // namespace cudf
@@ -525,103 +537,11 @@ T atomicAdd(T* address, T val)
  *
  * @returns The old value at `address`
  * -------------------------------------------------------------------------**/
+template <typename T>
 __forceinline__ __device__
-int8_t atomicMin(int8_t* address, int8_t val)
+T atomicMin(T* address, T val)
 {
     return cudf::genericAtomicOperation(address, val, cudf::DeviceMin{});
-}
-
-/**
- * @overload int16_t atomicMin(int16_t* address, int16_t val)
- */
-__forceinline__ __device__
-int16_t atomicMin(int16_t* address, int16_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceMin{});
-}
-
-/**
- * @overload int64_t atomicMin(int64_t* address, int64_t val)
- */
-__forceinline__ __device__
-int64_t atomicMin(int64_t* address, int64_t val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicMin(a, v);});
-}
-
-/**
- * @overload float atomicMin(float* address, float val)
- */
-__forceinline__ __device__
-float atomicMin(float* address, float val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceMin{});
-}
-
-/**
- * @overload double atomicMin(double* address, double val)
- */
-__forceinline__ __device__
-double atomicMin(double* address, double val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceMin{});
-}
-
-/**
- * @overload cudf::date32 atomicMin(cudf::date32* address, cudf::date32 val)
- */
-inline  __device__
-cudf::date32 atomicMin(cudf::date32* address, cudf::date32 val)
-{
-    using T = int;
-    return cudf::detail::typesAtomicOperation32
-        (address, val, [](T* a, T v){return atomicMin(a, v);});
-}
-
-/**
- * @overload cudf::category atomicMin(cudf::category* address, cudf::category val)
- */
-__forceinline__ __device__
-cudf::category atomicMin(cudf::category* address, cudf::category val)
-{
-    using T = int;
-    return cudf::detail::typesAtomicOperation32
-        (address, val, [](T* a, T v){return atomicMin(a, v);});
-}
-
-/**
- * @overload cudf::date64 atomicMin(cudf::date64* address, cudf::date64 val)
- */
-__forceinline__ __device__
-cudf::date64 atomicMin(cudf::date64* address, cudf::date64 val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicMin(a, v);});
-}
-
-/**
- * @overload cudf::timestamp atomicMin(cudf::timestamp* address, cudf::timestamp val)
- */
-__forceinline__ __device__
-cudf::timestamp atomicMin(cudf::timestamp* address, cudf::timestamp val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicMin(a, v);});
-}
-
-/**
- * @overload cudf::nvstring_category atomicMin(cudf::nvstring_category* address, cudf::nvstring_category val)
- */
-__forceinline__ __device__
-cudf::nvstring_category atomicMin(cudf::nvstring_category* address, cudf::nvstring_category val)
-{
-    using T = int;
-    return cudf::detail::typesAtomicOperation32
-        (address, val, [](T* a, T v){return atomicMin(a, v);});
 }
 
 /* Overloads for `atomicMax` */
@@ -643,102 +563,11 @@ cudf::nvstring_category atomicMin(cudf::nvstring_category* address, cudf::nvstri
  *
  * @returns The old value at `address`
  * -------------------------------------------------------------------------**/
+template <typename T>
 __forceinline__ __device__
-int8_t atomicMax(int8_t* address, int8_t val)
+T atomicMax(T* address, T val)
 {
     return cudf::genericAtomicOperation(address, val, cudf::DeviceMax{});
-}
-
-/**
- * @overload int16_t atomicMax(int16_t* address, int16_t val)
- */
-__forceinline__ __device__
-int16_t atomicMax(int16_t* address, int16_t val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceMax{});
-}
-
-/**
- * @overload int64_t atomicMax(int64_t* address, int64_t val)
- */
-__forceinline__ __device__
-int64_t atomicMax(int64_t* address, int64_t val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicMax(a, v);});
-}
-
-/**
- * @overload float atomicMax(float* address, float val)
- */
-__forceinline__ __device__
-float atomicMax(float* address, float val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceMax{});
-}
-
-/**
- * @overload double atomicMax(double* address, double val)
- */
-__forceinline__ __device__
-double atomicMax(double* address, double val)
-{
-    return cudf::genericAtomicOperation(address, val, cudf::DeviceMax{});
-}
-
-/**
- * @overload cudf::date32 atomicMax(cudf::date32* address, cudf::date32 val)
- */inline  __device__
-cudf::date32 atomicMax(cudf::date32* address, cudf::date32 val)
-{
-    using T = int;
-    return cudf::detail::typesAtomicOperation32
-        (address, val, [](T* a, T v){return atomicMax(a, v);});
-}
-
-/**
- * @overload cudf::category atomicMax(cudf::category* address, cudf::category val)
- */
-__forceinline__ __device__
-cudf::category atomicMax(cudf::category* address, cudf::category val)
-{
-    using T = int;
-    return cudf::detail::typesAtomicOperation32
-        (address, val, [](T* a, T v){return atomicMax(a, v);});
-}
-
-/**
- * @overload cudf::date64 atomicMax(cudf::date64* address, cudf::date64 val)
- */
-__forceinline__ __device__
-cudf::date64 atomicMax(cudf::date64* address, cudf::date64 val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicMax(a, v);});
-}
-
-/**
- * @overload cudf::timestamp atomicMax(cudf::timestamp* address, cudf::timestamp val)
- */
-__forceinline__ __device__
-cudf::timestamp atomicMax(cudf::timestamp* address, cudf::timestamp val)
-{
-    using T = long long int;
-    return cudf::detail::typesAtomicOperation64
-        (address, val, [](T* a, T v){return atomicMax(a, v);});
-}
-
-/**
- * @overload cudf::nvstring_category atomicMax(cudf::nvstring_category* address, cudf::nvstring_category val)
- */
-__forceinline__ __device__
-cudf::nvstring_category atomicMax(cudf::nvstring_category* address, cudf::nvstring_category val)
-{
-    using T = int;
-    return cudf::detail::typesAtomicOperation32
-        (address, val, [](T* a, T v){return atomicMax(a, v);});
 }
 
 /* Overloads for `atomicCAS` */

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -208,6 +208,13 @@ namespace detail {
         }
     };
 
+    // Cuda natively supports `unsigned long long int` for `atomicAdd`,
+    // but doesn't supports `signed long long int`.
+    // However, since the signed integer is represented as Two's complement,
+    // the fundamental arithmetic operations of addition are identical to
+    // those for unsigned binary numbers.
+    // Then, this computes as `unsigned long long int` with `atomicAdd`
+    // @sa https://en.wikipedia.org/wiki/Two%27s_complement
     template<>
     struct genericAtomicOperationImpl<int64_t, DeviceSum, 8> {
         using T = int64_t;

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -324,7 +324,7 @@ namespace detail {
     };
     // -----------------------------------------------------------------------
     // the implementation of `typesAtomicCASImpl`
-    template <typename T, size_t n>
+    template <typename T, size_t N= sizeof(T)>
     struct typesAtomicCASImpl;
 
     template<typename T>
@@ -584,7 +584,7 @@ template <typename T>
 __forceinline__ __device__
 T atomicCAS(T* address, T compare, T val)
 {
-    return cudf::detail::typesAtomicCASImpl<T, sizeof(T)>()(address, compare, val);
+    return cudf::detail::typesAtomicCASImpl<T>()(address, compare, val);
 }
 
 /** -------------------------------------------------------------------------*

--- a/cpp/src/utilities/device_atomics.cuh
+++ b/cpp/src/utilities/device_atomics.cuh
@@ -53,7 +53,7 @@ namespace detail {
 
     // -----------------------------------------------------------------------
     // the implementation of `genericAtomicOperation`
-    template <typename T, typename Op, size_t n>
+    template <typename T, typename Op, size_t N = sizeof(T)>
     struct genericAtomicOperationImpl;
 
     // single byte atomic operation
@@ -450,7 +450,7 @@ template <typename T, typename BinaryOp>
 __forceinline__  __device__
 T genericAtomicOperation(T* address, T const & update_value, BinaryOp op)
 {
-    auto ret=  cudf::detail::genericAtomicOperationImpl<T, BinaryOp, sizeof(T)>{}
+    auto ret=  cudf::detail::genericAtomicOperationImpl<T, BinaryOp>{}
             (address, update_value, op);
     return T(ret);
 }
@@ -461,7 +461,7 @@ __forceinline__  __device__
 W genericAtomicOperator( W* address, W const& update_value, BinaryOp op){
     // unwrap the input type to expect
     // that the native atomic API is used for the underlying type if possible
-    auto ret=  cudf::detail::genericAtomicOperationImpl<T, BinaryOp, sizeof(T)>{}
+    auto ret=  cudf::detail::genericAtomicOperationImpl<T, BinaryOp>{}
             (static_cast<T*>(address), cudf::detail::unwrap(update_value), op);
     return W(ret);
 }
@@ -473,7 +473,7 @@ cudf::bool8 genericAtomicOperation(cudf::bool8* address, cudf::bool8 const & upd
 {
     using T = cudf::bool8;
     // don't use underlying type to apply operation for cudf::bool8
-    auto ret = cudf::detail::genericAtomicOperationImpl<T, BinaryOp, sizeof(T)>()
+    auto ret = cudf::detail::genericAtomicOperationImpl<T, BinaryOp>()
             (address, update_value, op);
 
     return T(ret);

--- a/cpp/src/utilities/device_operators.cuh
+++ b/cpp/src/utilities/device_operators.cuh
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DEVICE_OPERATORS_CUH
+#define DEVICE_OPERATORS_CUH
+
+/** ---------------------------------------------------------------------------*
+ * @brief definition of the device operators
+ * @file device_operators.cuh
+ *
+ * ---------------------------------------------------------------------------**/
+
+#include <cudf.h>
+#include <utilities/cudf_utils.h>
+#include <utilities/wrapper_types.hpp>
+#include <utilities/error_utils.hpp>
+
+namespace cudf {
+
+// ------------------------------------------------------------------------
+// Binary operators
+/* @brief binary `sum` operator */
+struct DeviceSum {
+    template<typename T>
+    __device__
+    T operator() (const T &lhs, const T &rhs) {
+        return lhs + rhs;
+    }
+
+    template<typename T>
+    static constexpr T identity() { return T{0}; }
+};
+
+/* @brief binary `min` operator */
+struct DeviceMin{
+    template<typename T>
+    __device__
+    T operator() (const T &lhs, const T &rhs) {
+        return lhs <= rhs? lhs: rhs;
+    }
+
+    template<typename T>
+    static constexpr T identity() { return std::numeric_limits<T>::max(); }
+};
+
+/* @brief binary `max` operator */
+struct DeviceMax{
+    template<typename T>
+    __device__
+    T operator() (const T &lhs, const T &rhs) {
+        return lhs >= rhs? lhs: rhs;
+    }
+
+    template<typename T>
+    static constexpr T identity() { return std::numeric_limits<T>::lowest(); }
+};
+
+/* @brief binary `product` operator */
+struct DeviceProduct {
+    template<typename T>
+    __device__
+    T operator() (const T &lhs, const T &rhs) {
+        return lhs * rhs;
+    }
+
+    template<typename T>
+    static constexpr T identity() { return T{1}; }
+};
+
+
+/* @brief binary `and` operator */
+struct DeviceAnd{
+    template<typename T>
+    __device__
+    T operator() (const T &lhs, const T &rhs) {
+        return (lhs & rhs );
+    }
+};
+
+/* @brief binary `or` operator */
+struct DeviceOr{
+    template<typename T>
+    __device__
+    T operator() (const T &lhs, const T &rhs) {
+        return (lhs | rhs );
+    }
+};
+
+/* @brief binary `xor` operator */
+struct DeviceXor{
+    template<typename T>
+    __device__
+    T operator() (const T &lhs, const T &rhs) {
+        return (lhs ^ rhs );
+    }
+};
+
+} // namespace cudf
+
+
+#endif

--- a/cpp/tests/device_atomics/device_atomics_test.cu
+++ b/cpp/tests/device_atomics/device_atomics_test.cu
@@ -42,6 +42,8 @@ void gpu_atomic_test(T *result, T *data, size_t size)
         atomicMin(&result[1], data[id]);
         atomicMax(&result[2], data[id]);
         cudf::genericAtomicOperation(&result[3], data[id], cudf::DeviceSum{});
+        cudf::genericAtomicOperation(&result[4], data[id], cudf::DeviceMin{});
+        cudf::genericAtomicOperation(&result[5], data[id], cudf::DeviceMax{});
     }
 }
 
@@ -74,6 +76,8 @@ void gpu_atomicCAS_test(T *result, T *data, size_t size)
         atomic_op(&result[1], data[id], cudf::DeviceMin{});
         atomic_op(&result[2], data[id], cudf::DeviceMax{});
         atomic_op(&result[3], data[id], cudf::DeviceSum{});
+        atomic_op(&result[4], data[id], cudf::DeviceMin{});
+        atomic_op(&result[5], data[id], cudf::DeviceMax{});
     }
 }
 
@@ -89,6 +93,8 @@ void gpu_atomic_bitwiseOp_test(T *result, T *data, size_t size)
         atomicOr(&result[1], data[id]);
         atomicXor(&result[2], data[id]);
         cudf::genericAtomicOperation(&result[3], data[id], cudf::DeviceAnd{});
+        cudf::genericAtomicOperation(&result[4], data[id], cudf::DeviceOr{});
+        cudf::genericAtomicOperation(&result[5], data[id], cudf::DeviceXor{});
     }
 }
 
@@ -110,11 +116,13 @@ struct AtomicsTest : public GdfTest
         exact[1] = *( std::min_element(v.begin(), v.end()) );
         exact[2] = *( std::max_element(v.begin(), v.end()) );
 
-        std::vector<T> result_init(4);
+        std::vector<T> result_init(6);
         result_init[0] = T{0};
         result_init[1] = std::numeric_limits<T>::max();
         result_init[2] = std::numeric_limits<T>::min();
-        result_init[3] = T{0};
+        result_init[3] = result_init[0];
+        result_init[4] = result_init[1];
+        result_init[5] = result_init[2];
 
         thrust::device_vector<T> dev_data(v);
         thrust::device_vector<T> dev_result(result_init);
@@ -137,6 +145,8 @@ struct AtomicsTest : public GdfTest
         EXPECT_EQ(host_result[1], exact[1]) << "atomicMin test failed";
         EXPECT_EQ(host_result[2], exact[2]) << "atomicMax test failed";
         EXPECT_EQ(host_result[3], exact[0]) << "atomicAdd test(2) failed";
+        EXPECT_EQ(host_result[4], exact[1]) << "atomicMin test(2) failed";
+        EXPECT_EQ(host_result[5], exact[2]) << "atomicMax test(2) failed";
     }
 };
 
@@ -235,30 +245,25 @@ TYPED_TEST(AtomicsTest, atomicCASRandom)
 template <typename T>
 struct AtomicsBitwiseOpTest : public GdfTest
 {
-    void atomic_test(std::vector<uint64_t> const & v,
+    void atomic_test(std::vector<uint64_t> const & v_input,
         int block_size=0, int grid_size=1)
     {
-        std::vector<T> identity = {T(~0ull), T(0), T(0), T(~0ull)};
-        T exact[4];
+        size_t vec_size = v_input.size();
+        std::vector<T> v(vec_size);
+        std::transform(v_input.begin(), v_input.end(), v.begin(),
+            [](int x) { T t(x) ; return t; } );
+
+        std::vector<T> identity = {T(~0ull), T(0), T(0), T(~0ull), T(0), T(0)};
+        T exact[3];
         exact[0] = std::accumulate(v.begin(), v.end(), identity[0],
             [](T acc, uint64_t i) { return acc & T(i); });
         exact[1] = std::accumulate(v.begin(), v.end(), identity[1],
             [](T acc, uint64_t i) { return acc | T(i); });
         exact[2] = std::accumulate(v.begin(), v.end(), identity[2],
             [](T acc, uint64_t i) { return acc ^ T(i); });
-        exact[3] = exact[0];
 
-        size_t vec_size = v.size();
-
-        std::vector<T> v_type(vec_size);
-        std::transform(v.begin(), v.end(), v_type.begin(),
-            [](uint64_t x) { T t(x) ; return t; } );
-
-        std::vector<T> result_init(identity);
-
-
-        thrust::device_vector<T> dev_result(result_init);
-        thrust::device_vector<T> dev_data(v_type);
+        thrust::device_vector<T> dev_result(identity);
+        thrust::device_vector<T> dev_data(v);
 
         if( block_size == 0) block_size = vec_size;
 
@@ -276,9 +281,11 @@ struct AtomicsBitwiseOpTest : public GdfTest
 
 
         EXPECT_EQ(host_result[0], exact[0]) << "atomicAnd test failed";
-        EXPECT_EQ(host_result[1], exact[1]) << "atomicOr test failed";
+        EXPECT_EQ(host_result[1], exact[1]) << "atomicOr  test failed";
         EXPECT_EQ(host_result[2], exact[2]) << "atomicXor test failed";
         EXPECT_EQ(host_result[3], exact[0]) << "atomicAnd test(2) failed";
+        EXPECT_EQ(host_result[4], exact[1]) << "atomicOr  test(2) failed";
+        EXPECT_EQ(host_result[5], exact[2]) << "atomicXor test(2) failed";
     }
 
     void print_exact(const T *v, const char* msg){


### PR DESCRIPTION
Supersedes https://github.com/rapidsai/cudf/pull/1691

Because https://github.com/rapidsai/cudf/pull/1691 was based off of branch-0.8, I had to cherry-pick it's commits onto a new branch based off of release-0.7.2.

In order to hotfix the abysmal performance of groupby when summing int64, provides an overload for atomicAdd `int64` that simply casts to `uint64`. Because 2s complement is used, this is safe. 

> Compared to other systems for representing signed numbers (e.g., ones' complement), two's complement has the advantage that the fundamental arithmetic operations of addition, subtraction, and multiplication are identical to those for unsigned binary numbers (as long as the inputs are represented in the same number of bits - as the output, and any overflow beyond those bits is discarded from the result). This property makes the system simpler to implement, especially for higher-precision arithmetic.

https://en.wikipedia.org/wiki/Two%27s_complement