### PR TITLE
[REVIEW] Series.round via numba kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PR #1654 Add cudf::apply_boolean_mask: faster replacement for gdf_apply_stencil
 - PR #1487 cython gather/scatter
 - PR #1310 Implemented the slice/split functionality.
+- PR #1745 Add rounding of numeric columns via Numba
 
 ## Improvements
 

--- a/python/cudf/dataframe/numerical.py
+++ b/python/cudf/dataframe/numerical.py
@@ -260,6 +260,15 @@ class NumericalColumn(columnops.TypedColumnBase):
     def sum_of_squares(self, dtype=None):
         return cpp_reduce.apply_reduce('sum_of_squares', self, dtype=dtype)
 
+    def round(self, decimals=0):
+        mask = None
+        if self.has_null_mask:
+            mask = self.nullmask
+
+        rounded = cudautils.apply_round(self.data.mem, decimals)
+        return NumericalColumn(data=Buffer(rounded), mask=mask,
+                               dtype=self.dtype)
+
     def applymap(self, udf, out_dtype=None):
         """Apply a elemenwise function to transform the values in the Column.
 

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -1225,7 +1225,7 @@ class Series(object):
         return self._column.sum_of_squares(dtype=dtype)
 
     def round(self, decimals=0):
-        """
+        """Round a Series to a configurable number of decimal places.
         """
         return Series(self._column.round(decimals=decimals), name=self.name,
                       index=self.index)

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -1227,11 +1227,8 @@ class Series(object):
     def round(self, decimals=0):
         """
         """
-        if self.empty:
-            return self
-
-        rounded = cudautils.apply_round(self.data.to_gpu_array(), decimals)
-        return Series(rounded, name=self.name, index=self.index)
+        return Series(self._column.round(decimals=decimals), name=self.name,
+                      index=self.index)
 
     def unique_k(self, k):
         warnings.warn("Use .unique() instead", DeprecationWarning)

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -1224,6 +1224,15 @@ class Series(object):
     def sum_of_squares(self, dtype=None):
         return self._column.sum_of_squares(dtype=dtype)
 
+    def round(self, decimals=0):
+        """
+        """
+        if self.empty:
+            return self
+
+        rounded = cudautils.apply_round(self.data.to_gpu_array(), decimals)
+        return Series(rounded, name=self.name, index=self.index)
+
     def unique_k(self, k):
         warnings.warn("Use .unique() instead", DeprecationWarning)
         return self.unique()

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2403,9 +2403,21 @@ def test_ndim():
 @pytest.mark.parametrize('decimal', range(-8, 8))
 def test_round(decimal):
     arr = np.random.normal(0, 100, 10000)
+    pser = pd.Series(arr)
     ser = Series(arr)
     result = ser.round(decimal)
-    expected = np.round(arr, decimal)
-    np.testing.assert_array_almost_equal(result.to_array(),
-                                         expected,
+    expected = pser.round(decimal)
+    np.testing.assert_array_almost_equal(result.to_pandas(), expected,
                                          decimal=10)
+
+    # with nulls, maintaining existing null mask
+    mask = np.random.randint(0, 2, 10000)
+    arr[mask == 1] = np.nan
+
+    pser = pd.Series(arr)
+    ser = Series(arr)
+    result = ser.round(decimal)
+    expected = pser.round(decimal)
+    np.testing.assert_array_almost_equal(result.to_pandas(), expected,
+                                         decimal=10)
+    np.array_equal(ser.nullmask.to_array(), result.nullmask.to_array())

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2400,10 +2400,12 @@ def test_ndim():
     assert s.ndim == gs.ndim
 
 
-@pytest.mark.parametrize('decimal', range(-8,8))
+@pytest.mark.parametrize('decimal', range(-8, 8))
 def test_round(decimal):
     arr = np.random.normal(0, 100, 10000)
     ser = Series(arr)
     result = ser.round(decimal)
     expected = np.round(arr, decimal)
-    np.testing.assert_array_almost_equal(result.to_array(), expected, decimal=10)
+    np.testing.assert_array_almost_equal(result.to_array(),
+                                         expected,
+                                         decimal=10)

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2398,3 +2398,12 @@ def test_ndim():
     s = pd.Series()
     gs = Series()
     assert s.ndim == gs.ndim
+
+
+@pytest.mark.parametrize('decimal', range(-8,8))
+def test_round(decimal):
+    arr = np.random.normal(0, 100, 10000)
+    ser = Series(arr)
+    result = ser.round(decimal)
+    expected = np.round(arr, decimal)
+    np.testing.assert_array_almost_equal(result.to_array(), expected, decimal=10)

--- a/python/cudf/utils/cudautils.py
+++ b/python/cudf/utils/cudautils.py
@@ -616,14 +616,19 @@ def gpu_round(in_col, out_col, decimal):
     round_val = 10 ** (-1.0 * decimal)
 
     if i < in_col.size:
+        if not in_col[i]:
+            out_col[i] = np.nan
+            return
+
         newval = in_col[i] // round_val * round_val
         remainder = fmod(in_col[i], round_val)
 
-        if remainder > (.5 * round_val) and in_col[i] > 0:
+        if remainder != 0 and remainder > (.5 * round_val) and in_col[i] > 0:
             newval = newval + round_val
             out_col[i] = newval
 
-        elif abs(remainder) < (.5 * round_val) and in_col[i] < 0:
+        elif remainder != 0 and abs(remainder) < (.5 * round_val) and \
+                in_col[i] < 0:
             newval = newval + round_val
             out_col[i] = newval
 
@@ -633,7 +638,8 @@ def gpu_round(in_col, out_col, decimal):
 
 def apply_round(data, decimal):
     output_dary = rmm.device_array_like(data)
-    gpu_round.forall(output_dary.size)(data, output_dary, decimal)
+    if data.size > 0:
+        gpu_round.forall(output_dary.size)(data, output_dary, decimal)
     return output_dary
 
 

--- a/python/cudf/utils/cudautils.py
+++ b/python/cudf/utils/cudautils.py
@@ -610,6 +610,27 @@ def gpu_diff(in_col, out_col, N):
             out_col[i] = -1
 
 
+@cuda.jit
+def gpu_round(in_col, out_col, decimal):
+    i = cuda.grid(1)
+    round_val = 10 ** (-1.0 * decimal)
+
+    if i < in_col.size:
+        newval = in_col[i] // round_val * round_val
+        remainder = fmod(in_col[i], round_val)
+
+        if remainder > (.5 * round_val) and in_col[i] > 0:
+            newval = newval + round_val
+            out_col[i] = newval
+
+        elif abs(remainder) < (.5 * round_val) and in_col[i] < 0:
+            newval = newval + round_val
+            out_col[i] = newval
+
+        else:
+            out_col[i] = newval
+
+
 MAX_FAST_UNIQUE_K = 2 * 1024
 
 

--- a/python/cudf/utils/cudautils.py
+++ b/python/cudf/utils/cudautils.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from numba import cuda, int32, numpy_support
-from math import isnan
+from math import fmod, isnan
 
 from librmm_cffi import librmm as rmm
 

--- a/python/cudf/utils/cudautils.py
+++ b/python/cudf/utils/cudautils.py
@@ -631,6 +631,12 @@ def gpu_round(in_col, out_col, decimal):
             out_col[i] = newval
 
 
+def apply_round(data, decimal):
+    output_dary = rmm.device_array_like(data)
+    gpu_round.forall(output_dary.size)(data, output_dary, decimal)
+    return output_dary
+
+
 MAX_FAST_UNIQUE_K = 2 * 1024
 
 

--- a/python/cudf/utils/cudautils.py
+++ b/python/cudf/utils/cudautils.py
@@ -638,7 +638,7 @@ def gpu_round(in_col, out_col, decimal):
 
 def apply_round(data, decimal):
     output_dary = rmm.device_array_like(data)
-    if data.size > 0:
+    if output_dary.size > 0:
         gpu_round.forall(output_dary.size)(data, output_dary, decimal)
     return output_dary
 


### PR DESCRIPTION
While we will eventually implement `round` in libcudf (#1270), in the meantime some users want to be able to round numeric Series. This PR implements `round` functionality via Numba using floor division and the modulo operator to determine whether to round up or down.

@robocopnixon, you can use this PR.