### PR TITLE
[REVIEW] Add nullability template argument to device_table row operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #1713 Add documentation for Dask-XGBoost
 - PR #1666 CSV Reader: Improve performance for files with large number of columns
 - PR #1725 Enable the ability to use a single column groupby as its own index
+- PR #1748 Add `bool` nullability flag to `device_table` row operators
 
 ## Bug Fixes
 

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -54,7 +54,7 @@ struct row_hasher_initial_values {
       : the_table{table_to_hash}, initial_hash_values(initial_hash_values) {}
 
   __device__ hash_value_type operator()(gdf_size_type row_index) const {
-    return hash_row<hash_function>(the_table, row_index, initial_hash_values);
+    return hash_row<true,hash_function>(the_table, row_index, initial_hash_values);
   }
 
   device_table the_table;
@@ -69,7 +69,7 @@ struct row_hasher {
   row_hasher(device_table const& table_to_hash) : the_table{table_to_hash} {}
 
   __device__ hash_value_type operator()(gdf_size_type row_index) const {
-    return hash_row<hash_function>(the_table, row_index);
+    return hash_row<true,hash_function>(the_table, row_index);
   }
 
   device_table the_table;
@@ -305,7 +305,7 @@ void compute_row_partition_numbers(device_table the_table,
   while( row_number < num_rows)
   {
     const hash_value_type row_hash_value =
-        hash_row<hash_function>(the_table, row_number);
+        hash_row<true, hash_function>(the_table, row_number);
 
     const gdf_size_type partition_number = the_partitioner(row_hash_value);
 

--- a/cpp/src/table/device_table.cuh
+++ b/cpp/src/table/device_table.cuh
@@ -199,6 +199,7 @@ struct elements_are_equal {
 };
 }  // namespace
 
+
 /**
  * @brief  Checks for equality between two rows between two tables.
  *
@@ -228,6 +229,27 @@ __device__ inline bool rows_equal(device_table const& lhs,
   return thrust::equal(thrust::seq, lhs.begin(), lhs.end(), rhs.begin(),
                        equal_elements);
 }
+
+/**---------------------------------------------------------------------------*
+ * @brief Functor to compute if two rows are equal.
+ * 
+ * @tparam nullable Flag indicating the possibility of null values 
+*---------------------------------------------------------------------------**/
+template <bool nullable = true>
+struct row_equality_comparator {
+  device_table lhs;
+  device_table rhs;
+  bool nulls_are_equal;
+  row_equality_comparator(device_table const& l, device_table const& r,
+                          bool nulls_equal = false)
+      : lhs{l}, rhs{r}, nulls_are_equal{nulls_equal} {}
+
+  __device__ bool operator()(gdf_size_type lhs_index,
+                             gdf_size_type rhs_index) const {
+    return rows_equal<nullable>(lhs, lhs_index, rhs, rhs_index,
+                                nulls_are_equal);
+  }
+};
 
 namespace {
 template <template <typename> typename hash_function, bool nullable>

--- a/cpp/src/table/device_table.cuh
+++ b/cpp/src/table/device_table.cuh
@@ -228,9 +228,12 @@ struct copy_element {
                                     gdf_size_type target_index,
                                     gdf_column const& source,
                                     gdf_size_type source_index) {
+    // FIXME: This will copy garbage data if the source element is null
     static_cast<T*>(target.data)[target_index] =
         static_cast<T const*>(source.data)[source_index];
 
+    // This is very inefficient, setting the target bitmask should be done
+    // separately when possible
     if (update_target_bitmask) {
       using namespace bit_mask;
 
@@ -239,8 +242,6 @@ struct copy_element {
       bit_mask_t* const target_mask{
           reinterpret_cast<bit_mask_t*>(target.valid)};
 
-      // This is very inefficient, setting the target bitmask should be done
-      // separately when possible
       if (nullptr != target_mask) {
         bool const target_is_valid{is_valid(target_mask, target_index)};
         if (nullptr != source_mask) {

--- a/cpp/src/table/device_table.cuh
+++ b/cpp/src/table/device_table.cuh
@@ -208,11 +208,12 @@ struct elements_are_equal {
  * @param rhs_index The index of the row within rhs table to compare
  * @param nulls_are_equal Flag indicating whether two null values are considered
  * equal
+ * @tparam nullable Flag indicating the possibility of null values
  *
  * @returns true If the two rows are element-wise equal
  * @returns false If any element differs between the two rows
  */
-template <bool nullable = false>
+template <bool nullable = true>
 __device__ inline bool rows_equal(device_table const& lhs,
                                   const gdf_size_type lhs_index,
                                   device_table const& rhs,
@@ -267,11 +268,12 @@ struct hash_element {
  * column
  * @tparam hash_function The hash function that is used for each element in
  * the row, as well as combine hash values
+ * @tparam nullable Flag indicating the possibility of null values
  *
  * @return The hash value of the row
  * ----------------------------------------------------------------------------**/
-template <template <typename> class hash_function = default_hash,
-          bool nullable = false>
+template <bool nullable = true,
+          template <typename> class hash_function = default_hash>
 __device__ inline hash_value_type hash_row(
     device_table const& t, gdf_size_type row_index,
     hash_value_type const* __restrict__ initial_hash_values) {
@@ -312,11 +314,12 @@ __device__ inline hash_value_type hash_row(
  * @param[in] row_index The row of the table to compute the hash value for
  * @tparam hash_function The hash function that is used for each element in
  * the row, as well as combine hash values
+ * @tparam nullable Flag indicating the possibility of null values
  *
  * @return The hash value of the row
  * ----------------------------------------------------------------------------**/
-template <template <typename> class hash_function = default_hash,
-          bool nullable = false>
+template <bool nullable = true,
+          template <typename> class hash_function = default_hash>
 __device__ inline hash_value_type hash_row(device_table const& t,
                                            gdf_size_type row_index) {
   auto hash_combiner = [](hash_value_type lhs, hash_value_type rhs) {

--- a/cpp/src/table/device_table.cuh
+++ b/cpp/src/table/device_table.cuh
@@ -20,6 +20,7 @@
 #include <cudf.h>
 #include <rmm/thrust_rmm_allocator.h>
 #include <utilities/cudf_utils.h>
+#include <bitmask/bit_mask.cuh>
 #include <bitmask/legacy_bitmask.hpp>
 #include <hash/hash_functions.cuh>
 #include <hash/managed.cuh>
@@ -220,6 +221,7 @@ struct hash_element {
   }
 };
 
+template <bool update_target_bitmask>
 struct copy_element {
   template <typename T>
   __device__ inline void operator()(gdf_column const& target,
@@ -228,6 +230,35 @@ struct copy_element {
                                     gdf_size_type source_index) {
     static_cast<T*>(target.data)[target_index] =
         static_cast<T const*>(source.data)[source_index];
+
+    if (update_target_bitmask) {
+      using namespace bit_mask;
+
+      bit_mask_t const* const source_mask{
+          reinterpret_cast<bit_mask_t const*>(source.valid)};
+      bit_mask_t* const target_mask{
+          reinterpret_cast<bit_mask_t*>(target.valid)};
+
+      // This is very inefficient, setting the target bitmask should be done
+      // separately when possible
+      if (nullptr != target_mask) {
+        bool const target_is_valid{is_valid(target_mask, target_index)};
+        if (nullptr != source_mask) {
+          bool const source_is_valid{is_valid(source_mask, source_index)};
+          if (source_is_valid and not target_is_valid) {
+            set_bit_safe(target_mask, target_index);
+          } else if (not source_is_valid and target_is_valid) {
+            clear_bit_safe(target_mask, target_index);
+          }
+        } else {
+          // If the source mask doesn't exist, it's assumed the source element
+          // is valid
+          if (not target_is_valid) {
+            set_bit_safe(target_mask, target_index);
+          }
+        }
+      }
+    }
   }
 };
 }  // namespace
@@ -376,19 +407,27 @@ __device__ inline hash_value_type hash_row(device_table const& t,
  * This device function should be called by a single thread and the thread
  * will copy all of the elements in the row from one table to the other.
  *
- * FIXME: Does NOT set null bitmask for the target row.
+ * @note If the `update_target_bitmask` template argument is `true`, then this
+ * function will update the target bitmask (if it exists) to match the bitmask
+ * for the source element. A non-existant source bitmask is assumed to mean the
+ * source element is non-null. However, this operation is very inefficient and
+ * should be done outside of this function when possible.
  *
  * @param[in,out] The table whose row will be updated
  * @param[in] The index of the row to update in the target table
  * @param[in] source The table whose row will be copied
  * @param source_row_index The index of the row to copy in the source table
+ * @tparam update_target_bitmask Flag indicating if the target bitmask should be
+ * updated
  */
+template <bool update_target_bitmask = true>
 __device__ inline void copy_row(device_table const& target,
                                 gdf_size_type target_index,
                                 device_table const& source,
                                 gdf_size_type source_index) {
   for (gdf_size_type i = 0; i < target.num_columns(); ++i) {
-    cudf::type_dispatcher(target.get_column(i)->dtype, copy_element{},
+    cudf::type_dispatcher(target.get_column(i)->dtype,
+                          copy_element<update_target_bitmask>{},
                           *target.get_column(i), target_index,
                           *source.get_column(i), source_index);
   }

--- a/cpp/tests/device_table/device_table_tests.cu
+++ b/cpp/tests/device_table/device_table_tests.cu
@@ -270,6 +270,7 @@ TEST_F(DeviceTableTest, TwoTablesAllRowsEqual) {
                      row_comparison<true>{*left_table, *right_table, false}));
 }
 
+template <bool update_target_bitmask>
 struct row_copier {
   device_table target;
   device_table source;
@@ -280,7 +281,8 @@ struct row_copier {
       : target{_target}, source{_source} {}
 
   __device__ void operator()(index_pair const& indices) {
-    copy_row(target, thrust::get<0>(indices), source, thrust::get<1>(indices));
+    copy_row<update_target_bitmask>(target, thrust::get<0>(indices), source,
+                                    thrust::get<1>(indices));
   }
 };
 
@@ -326,7 +328,7 @@ TEST_F(DeviceTableTest, CopyRowsNoNulls) {
           thrust::make_tuple(target_indices.begin(), source_indices.begin())),
       thrust::make_zip_iterator(
           thrust::make_tuple(target_indices.end(), source_indices.end())),
-      row_copier{*target_table, *source_table}));
+      row_copier<false>{*target_table, *source_table}));
 
   // ensure source_table row @ source_indices[i] == target_table row @
   // target_indices[i]

--- a/cpp/tests/device_table/device_table_tests.cu
+++ b/cpp/tests/device_table/device_table_tests.cu
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <bitmask/bit_mask.cuh>
+#include <bitmask/bitmask_ops.hpp>
 #include <table/device_table.cuh>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -30,7 +32,7 @@
 #include <random>
 
 struct DeviceTableTest : GdfTest {
-  gdf_size_type const size{1000};
+  gdf_size_type const size{2000};
 };
 
 /**---------------------------------------------------------------------------*
@@ -339,4 +341,226 @@ TEST_F(DeviceTableTest, CopyRowsNoNulls) {
       thrust::make_zip_iterator(
           thrust::make_tuple(source_indices.end(), target_indices.end())),
       row_comparison<false>{*source_table, *target_table}));
+}
+
+struct verify_bitmask {
+  bit_mask::bit_mask_t* bitmask;
+
+  verify_bitmask(bit_mask::bit_mask_t* _bitmask) : bitmask{_bitmask} {}
+
+  __device__ bool operator()(gdf_size_type i) {
+    return bit_mask::is_valid(bitmask, i);
+  }
+};
+
+TEST_F(DeviceTableTest, CopyRowsSourceNullTargetValid) {
+  int const val{42};
+  auto init_values = [val](auto index) { return index; };
+  auto all_valid = [](auto index) { return true; };
+  auto all_null = [](auto index) { return false; };
+
+  cudf::test::column_wrapper<int32_t> source_col0(size, init_values, all_null);
+  cudf::test::column_wrapper<float> source_col1(size, init_values, all_null);
+  cudf::test::column_wrapper<double> source_col2(size, init_values, all_null);
+  cudf::test::column_wrapper<int8_t> source_col3(size, init_values, all_null);
+  std::vector<gdf_column*> source_cols{source_col0, source_col1, source_col2,
+                                       source_col3};
+  auto source_table =
+      device_table::create(source_cols.size(), source_cols.data());
+
+  cudf::test::column_wrapper<int32_t> target_col0(size, init_values, all_valid);
+  cudf::test::column_wrapper<float> target_col1(size, init_values, all_valid);
+  cudf::test::column_wrapper<double> target_col2(size, init_values, all_valid);
+  cudf::test::column_wrapper<int8_t> target_col3(size, init_values, all_valid);
+  std::vector<gdf_column*> target_cols{target_col0, target_col1, target_col2,
+                                       target_col3};
+  auto target_table =
+      device_table::create(target_cols.size(), target_cols.data());
+
+  // Copy a random row from the source table to a random row in the target table
+  // Thrust doesn't have a `shuffle` algorithm, so we've got to do it on the
+  // host
+  std::vector<gdf_size_type> indices(source_table->num_rows());
+  std::iota(indices.begin(), indices.end(), 0);
+  std::shuffle(indices.begin(), indices.end(), std::default_random_engine{});
+  thrust::device_vector<gdf_size_type> target_indices(indices);
+
+  std::shuffle(indices.begin(), indices.end(), std::default_random_engine{});
+  thrust::device_vector<gdf_size_type> source_indices(indices);
+
+  // Copy source_table row @ source_indices[i] to target_table @
+  // target_indices[i]
+  EXPECT_NO_THROW(thrust::for_each(
+      rmm::exec_policy()->on(0),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(target_indices.begin(), source_indices.begin())),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(target_indices.end(), source_indices.end())),
+      row_copier<true>{*target_table, *source_table}));
+
+  // Every source and target row should be all nulls
+
+  // Rows should be equal if NULL == NULL
+  EXPECT_TRUE(thrust::all_of(
+      rmm::exec_policy()->on(0),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.begin(), target_indices.begin())),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.end(), target_indices.end())),
+      row_comparison<true>{*source_table, *target_table, true}));
+
+  // No row should be equal if NULL != NULL
+  EXPECT_TRUE(thrust::none_of(
+      rmm::exec_policy()->on(0),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.begin(), target_indices.begin())),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.end(), target_indices.end())),
+      row_comparison<true>{*source_table, *target_table, false}));
+}
+
+TEST_F(DeviceTableTest, CopyRowsSourceValidTargetNull) {
+  int const val{42};
+  auto init_values = [val](auto index) { return index; };
+  auto all_valid = [](auto index) { return true; };
+
+  cudf::test::column_wrapper<int32_t> source_col0(size, init_values, all_valid);
+  cudf::test::column_wrapper<float> source_col1(size, init_values, all_valid);
+  cudf::test::column_wrapper<double> source_col2(size, init_values, all_valid);
+  cudf::test::column_wrapper<int8_t> source_col3(size, init_values, all_valid);
+  std::vector<gdf_column*> source_cols{source_col0, source_col1, source_col2,
+                                       source_col3};
+  auto source_table =
+      device_table::create(source_cols.size(), source_cols.data());
+
+  cudf::test::column_wrapper<int32_t> target_col0(size, true);
+  cudf::test::column_wrapper<float> target_col1(size, true);
+  cudf::test::column_wrapper<double> target_col2(size, true);
+  cudf::test::column_wrapper<int8_t> target_col3(size, true);
+  std::vector<gdf_column*> target_cols{target_col0, target_col1, target_col2,
+                                       target_col3};
+
+  auto target_table =
+      device_table::create(target_cols.size(), target_cols.data());
+
+  // Copy a random row from the source table to a random row in the target table
+  // Thrust doesn't have a `shuffle` algorithm, so we've got to do it on the
+  // host
+  std::vector<gdf_size_type> indices(source_table->num_rows());
+  std::iota(indices.begin(), indices.end(), 0);
+  std::shuffle(indices.begin(), indices.end(), std::default_random_engine{});
+  thrust::device_vector<gdf_size_type> target_indices(indices);
+
+  std::shuffle(indices.begin(), indices.end(), std::default_random_engine{});
+  thrust::device_vector<gdf_size_type> source_indices(indices);
+
+  // Copy source_table row @ source_indices[i] to target_table @
+  // target_indices[i]
+  EXPECT_NO_THROW(thrust::for_each(
+      rmm::exec_policy()->on(0),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(target_indices.begin(), source_indices.begin())),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(target_indices.end(), source_indices.end())),
+      row_copier<true>{*target_table, *source_table}));
+
+  // ensure source_table row @ source_indices[i] == target_table row @
+  // target_indices[i] regardless of NULL ?= NULL
+  EXPECT_TRUE(thrust::all_of(
+      rmm::exec_policy()->on(0),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.begin(), target_indices.begin())),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.end(), target_indices.end())),
+      row_comparison<true>{*source_table, *target_table, true}));
+
+  EXPECT_TRUE(thrust::all_of(
+      rmm::exec_policy()->on(0),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.begin(), target_indices.begin())),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.end(), target_indices.end())),
+      row_comparison<true>{*source_table, *target_table, false}));
+
+  // No row should contain a null value
+  cudf::table target_host_table{target_cols.data(),
+                                static_cast<gdf_size_type>(target_cols.size())};
+  auto row_bitmask = cudf::row_bitmask(target_host_table);
+
+  EXPECT_TRUE(thrust::all_of(
+      rmm::exec_policy()->on(0), thrust::make_counting_iterator(0),
+      thrust::make_counting_iterator(target_host_table.num_rows()),
+      verify_bitmask{row_bitmask.data().get()}));
+}
+
+TEST_F(DeviceTableTest, CopyRowsSourceNoBitmaskTargetNull) {
+  auto init_values = [](auto index) { return index; };
+
+  cudf::test::column_wrapper<int32_t> source_col0(size, init_values);
+  cudf::test::column_wrapper<float> source_col1(size, init_values);
+  cudf::test::column_wrapper<double> source_col2(size, init_values);
+  cudf::test::column_wrapper<int8_t> source_col3(size, init_values);
+  std::vector<gdf_column*> source_cols{source_col0, source_col1, source_col2,
+                                       source_col3};
+  auto source_table =
+      device_table::create(source_cols.size(), source_cols.data());
+
+  cudf::test::column_wrapper<int32_t> target_col0(size, true);
+  cudf::test::column_wrapper<float> target_col1(size, true);
+  cudf::test::column_wrapper<double> target_col2(size, true);
+  cudf::test::column_wrapper<int8_t> target_col3(size, true);
+  std::vector<gdf_column*> target_cols{target_col0, target_col1, target_col2,
+                                       target_col3};
+
+  auto target_table =
+      device_table::create(target_cols.size(), target_cols.data());
+
+  // Copy a random row from the source table to a random row in the target table
+  // Thrust doesn't have a `shuffle` algorithm, so we've got to do it on the
+  // host
+  std::vector<gdf_size_type> indices(source_table->num_rows());
+  std::iota(indices.begin(), indices.end(), 0);
+  std::shuffle(indices.begin(), indices.end(), std::default_random_engine{});
+  thrust::device_vector<gdf_size_type> target_indices(indices);
+
+  std::shuffle(indices.begin(), indices.end(), std::default_random_engine{});
+  thrust::device_vector<gdf_size_type> source_indices(indices);
+
+  // Copy source_table row @ source_indices[i] to target_table @
+  // target_indices[i]
+  EXPECT_NO_THROW(thrust::for_each(
+      rmm::exec_policy()->on(0),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(target_indices.begin(), source_indices.begin())),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(target_indices.end(), source_indices.end())),
+      row_copier<true>{*target_table, *source_table}));
+
+  // ensure source_table row @ source_indices[i] == target_table row @
+  // target_indices[i] regardless of NULL ?= NULL
+  EXPECT_TRUE(thrust::all_of(
+      rmm::exec_policy()->on(0),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.begin(), target_indices.begin())),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.end(), target_indices.end())),
+      row_comparison<true>{*source_table, *target_table, true}));
+
+  EXPECT_TRUE(thrust::all_of(
+      rmm::exec_policy()->on(0),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.begin(), target_indices.begin())),
+      thrust::make_zip_iterator(
+          thrust::make_tuple(source_indices.end(), target_indices.end())),
+      row_comparison<true>{*source_table, *target_table, false}));
+
+  // No row should contain a null value
+  cudf::table target_host_table{target_cols.data(),
+                                static_cast<gdf_size_type>(target_cols.size())};
+  auto row_bitmask = cudf::row_bitmask(target_host_table);
+
+  EXPECT_TRUE(thrust::all_of(
+      rmm::exec_policy()->on(0), thrust::make_counting_iterator(0),
+      thrust::make_counting_iterator(target_host_table.num_rows()),
+      verify_bitmask{row_bitmask.data().get()}));
 }

--- a/cpp/tests/device_table/device_table_tests.cu
+++ b/cpp/tests/device_table/device_table_tests.cu
@@ -37,6 +37,7 @@ struct DeviceTableTest : GdfTest {
  * @brief Compares if a row in one table is equal to all rows in another table.
  *
  *---------------------------------------------------------------------------**/
+template <bool nullable>
 struct all_rows_equal {
   device_table lhs;
   device_table rhs;
@@ -53,7 +54,7 @@ struct all_rows_equal {
    *---------------------------------------------------------------------------**/
   __device__ bool operator()(int lhs_index) {
     auto row_equality = [this, lhs_index](gdf_size_type rhs_index) {
-      return rows_equal(lhs, lhs_index, rhs, rhs_index, nulls_are_equal);
+      return rows_equal<nullable>(lhs, lhs_index, rhs, rhs_index, nulls_are_equal);
     };
     return thrust::all_of(thrust::seq, thrust::make_counting_iterator(0),
                           thrust::make_counting_iterator(rhs.num_rows()),
@@ -61,6 +62,7 @@ struct all_rows_equal {
   }
 };
 
+template <bool nullable>
 struct row_comparison {
   device_table lhs;
   device_table rhs;
@@ -73,16 +75,17 @@ struct row_comparison {
       : lhs{_lhs}, rhs{_rhs}, nulls_are_equal{_nulls_are_equal} {}
 
   __device__ bool operator()(index_pair const& indices) {
-    return rows_equal(lhs, thrust::get<0>(indices), rhs,
+    return rows_equal<nullable>(lhs, thrust::get<0>(indices), rhs,
                       thrust::get<1>(indices), nulls_are_equal);
   }
 };
 
+template <bool nullable>
 struct row_hasher {
   device_table t;
   row_hasher(device_table _t) : t{_t} {}
   __device__ hash_value_type operator()(gdf_size_type row_index) {
-    return hash_row(t, row_index);
+    return hash_row<nullable>(t, row_index);
   }
 };
 
@@ -105,15 +108,15 @@ TEST_F(DeviceTableTest, AllRowsEqualNoNulls) {
   EXPECT_TRUE(thrust::all_of(rmm::exec_policy()->on(0),
                              thrust::make_counting_iterator(0),
                              thrust::make_counting_iterator(size),
-                             all_rows_equal(*table, *table, true)));
+                             all_rows_equal<false>(*table, *table, true)));
   EXPECT_TRUE(thrust::all_of(rmm::exec_policy()->on(0),
                              thrust::make_counting_iterator(0),
                              thrust::make_counting_iterator(size),
-                             all_rows_equal(*table, *table, false)));
+                             all_rows_equal<false>(*table, *table, false)));
 
   // Compute hash value of every row
   thrust::device_vector<hash_value_type> row_hashes(table->num_rows());
-  thrust::tabulate(row_hashes.begin(), row_hashes.end(), row_hasher{*table});
+  thrust::tabulate(row_hashes.begin(), row_hashes.end(), row_hasher<false>{*table});
 
   // All hash values should be equal
   EXPECT_TRUE(thrust::equal(row_hashes.begin() + 1, row_hashes.end(),
@@ -140,17 +143,17 @@ TEST_F(DeviceTableTest, AllRowsEqualWithNulls) {
   EXPECT_FALSE(thrust::all_of(rmm::exec_policy()->on(0),
                               thrust::make_counting_iterator(0),
                               thrust::make_counting_iterator(size),
-                              all_rows_equal(*table, *table, false)));
+                              all_rows_equal<true>(*table, *table, false)));
 
   // If NULL == NULL, all rows should be equal
   EXPECT_TRUE(thrust::all_of(rmm::exec_policy()->on(0),
                              thrust::make_counting_iterator(0),
                              thrust::make_counting_iterator(size),
-                             all_rows_equal(*table, *table, true)));
+                             all_rows_equal<true>(*table, *table, true)));
 
   // Compute hash value of every row
   thrust::device_vector<hash_value_type> row_hashes(table->num_rows());
-  thrust::tabulate(row_hashes.begin(), row_hashes.end(), row_hasher{*table});
+  thrust::tabulate(row_hashes.begin(), row_hashes.end(), row_hasher<true>{*table});
 
   // All hash values should be equal because hash_row should ignore nulls
   EXPECT_TRUE(thrust::equal(row_hashes.begin() + 1, row_hashes.end(),
@@ -181,7 +184,7 @@ TEST_F(DeviceTableTest, AllRowsDifferentWithNulls) {
                                  indices.begin(), indices.begin())),
                              thrust::make_zip_iterator(thrust::make_tuple(
                                  indices.end(), indices.end())),
-                             row_comparison{*table, *table, true}));
+                             row_comparison<true>{*table, *table, true}));
 
   // If NULL!=NULL, every row should *not* be equal to itself
   EXPECT_FALSE(thrust::all_of(rmm::exec_policy()->on(0),
@@ -189,11 +192,11 @@ TEST_F(DeviceTableTest, AllRowsDifferentWithNulls) {
                                   indices.begin(), indices.begin())),
                               thrust::make_zip_iterator(thrust::make_tuple(
                                   indices.end(), indices.end())),
-                              row_comparison{*table, *table, false}));
+                              row_comparison<true>{*table, *table, false}));
 
   // Compute hash value of every row
   thrust::device_vector<hash_value_type> row_hashes(table->num_rows());
-  thrust::tabulate(row_hashes.begin(), row_hashes.end(), row_hasher{*table});
+  thrust::tabulate(row_hashes.begin(), row_hashes.end(), row_hasher<true>{*table});
 
   // All hash values should be NOT be equal
   EXPECT_FALSE(thrust::equal(row_hashes.begin() + 1, row_hashes.end(),
@@ -216,7 +219,7 @@ TEST_F(DeviceTableTest, AllRowsDifferentWithNulls) {
             thrust::make_tuple(left_indices.begin(), right_indices.begin())),
         thrust::make_zip_iterator(
             thrust::make_tuple(left_indices.end(), right_indices.end())),
-        row_comparison{*table, *table, true}));
+        row_comparison<true>{*table, *table, true}));
   }
 }
 
@@ -253,7 +256,7 @@ TEST_F(DeviceTableTest, TwoTablesAllRowsEqual) {
                                  indices.begin(), indices.begin())),
                              thrust::make_zip_iterator(thrust::make_tuple(
                                  indices.end(), indices.end())),
-                             row_comparison{*left_table, *right_table, true}));
+                             row_comparison<true>{*left_table, *right_table, true}));
 
   // If NULL!=NULL, left_table row @ i should NOT equal right_table row @ i
   EXPECT_FALSE(
@@ -262,7 +265,7 @@ TEST_F(DeviceTableTest, TwoTablesAllRowsEqual) {
                          thrust::make_tuple(indices.begin(), indices.begin())),
                      thrust::make_zip_iterator(
                          thrust::make_tuple(indices.end(), indices.end())),
-                     row_comparison{*left_table, *right_table, false}));
+                     row_comparison<true>{*left_table, *right_table, false}));
 }
 
 struct row_copier {
@@ -331,5 +334,5 @@ TEST_F(DeviceTableTest, CopyRowsNoNulls) {
           thrust::make_tuple(source_indices.begin(), target_indices.begin())),
       thrust::make_zip_iterator(
           thrust::make_tuple(source_indices.end(), target_indices.end())),
-      row_comparison{*source_table, *target_table}));
+      row_comparison<false>{*source_table, *target_table}));
 }

--- a/cpp/tests/hashing/hash_partition_test.cu
+++ b/cpp/tests/hashing/hash_partition_test.cu
@@ -51,7 +51,7 @@ struct row_partition_mapper
   __device__
   hash_value_type operator()(gdf_size_type row_index) const
   {
-    return hash_row<hash_function>(the_table, row_index) % num_partitions;
+    return hash_row<true, hash_function>(the_table, row_index) % num_partitions;
   }
 
   device_table the_table;


### PR DESCRIPTION
This was split off from https://github.com/rapidsai/cudf/pull/1478

In order to provide more efficient row-level operators for `device_table` when the columns are non-nullable, this PR adds a `nullable` boolean template parameter to the `rows_equal` and `hash_row` functions.

Because these flags are template arguments, their value is known at compile time. As such, the compiler will optimize away the code path that checks for null values when the flag equals `false`. This is a convenient way to provide optimal performance row operators without the need for code duplication in creating two sets of operators. 

This PR also adds a `row_equality_comparator` functor for use where a functor is necessary to compare equality of two rows. 

Finally, updates `copy_row` to optionally update the target bitmask. This is pretty inefficient, so it's better to do it outside of this function. 