### PR TITLE
[REVIEW] ORC Reader: fix long strings of NULLs corrupting decoded values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - PR #1709 Fix handling of `datetime64[ms]` in `dataframe.select_dtypes`
 - PR #1704 CSV Reader: Add support for the plus sign in number fields
 - PR #1687 CSV reader: return an empty dataframe for zero size input
+- PR #1749 ORC reader: fix long strings of NULL values resulting in incorrect data
 
 
 # cuDF 0.7.1 (11 May 2019)


### PR DESCRIPTION
Long strings of NULLs can cause out-of bounds writes in the row position array, overwriting data values in shared mem.
Also fix decoding of boolean runs longer than 128 (ORC byte RLE can go up to 130).