### PR TITLE
[REVIEW] Add col_level keyword argument to melt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #1709 Fix handling of `datetime64[ms]` in `dataframe.select_dtypes`
 - PR #1704 CSV Reader: Add support for the plus sign in number fields
 - PR #1687 CSV reader: return an empty dataframe for zero size input
+- PR #1755 Add col_level keyword argument to melt
 
 
 # cuDF 0.7.1 (11 May 2019)

--- a/python/cudf/reshape/general.py
+++ b/python/cudf/reshape/general.py
@@ -11,7 +11,7 @@ from cudf.dataframe.categorical import CategoricalColumn
 
 
 def melt(frame, id_vars=None, value_vars=None, var_name=None,
-         value_name='value'):
+         value_name='value', col_level=None):
     """Unpivots a DataFrame from wide format to long format,
     optionally leaving identifier variables set.
 
@@ -56,6 +56,8 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
     4    1    3        D   5.0
     5    5    6        D   6.0
     """
+    assert col_level in (None,)
+
     # Arg cleaning
     import collections
     # id_vars


### PR DESCRIPTION
**Summary of Changes**
- Adds a `col_level` keyword argument to `melt`, that defaults to `None` and is required to be None. Used the tuple in case we eventually implement multi-level melt in stages.


This closes #1721 and will also close rapidsai/dask-cudf#209