### PR TITLE
[REVIEW] Allow concatenating columns with null columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #1709 Fix handling of `datetime64[ms]` in `dataframe.select_dtypes`
 - PR #1704 CSV Reader: Add support for the plus sign in number fields
 - PR #1687 CSV reader: return an empty dataframe for zero size input
+- PR #1757 Concatenating columns with null columns
 
 
 # cuDF 0.7.1 (11 May 2019)

--- a/python/cudf/dataframe/column.py
+++ b/python/cudf/dataframe/column.py
@@ -62,11 +62,6 @@ class Column(object):
                 dtype = np.dtype(dtype)
                 return Column(Buffer.null(dtype))
 
-        # Handle strings separately
-        if all(isinstance(o, StringColumn) for o in objs):
-            objs = [o._data for o in objs]
-            return StringColumn(data=nvstrings.from_strings(*objs))
-
         # Handle categories for categoricals
         if all(isinstance(o, CategoricalColumn) for o in objs):
             new_cats = tuple(set(
@@ -74,10 +69,28 @@ class Column(object):
             ))
             objs = [o.cat()._set_categories(new_cats) for o in objs]
 
+        # Find the first non-null column:
         head = objs[0]
-        for o in objs:
-            if not o.is_type_equivalent(head):
-                raise ValueError("All series must be of same type")
+        for i, obj in enumerate(objs):
+            if len(obj) != obj.null_count:
+                head = obj
+                break
+
+        for i, obj in enumerate(objs):
+            # Check that all columns are the same type:
+            if not objs[i].is_type_equivalent(head):
+                # if all null, cast to appropriate dtype
+                if len(obj) == obj.null_count:
+                    from cudf.dataframe.columnops import make_null_like
+                    objs[i] = make_null_like(head, size=len(obj))
+                else:
+                    raise ValueError("All series must be of same type")
+
+        # Handle strings separately
+        if all(isinstance(o, StringColumn) for o in objs):
+            objs = [o._data for o in objs]
+            return StringColumn(data=nvstrings.from_strings(*objs))
+
         # Filter out inputs that have 0 length
         objs = [o for o in objs if len(o) > 0]
         nulls = sum(o.null_count for o in objs)

--- a/python/cudf/dataframe/column.py
+++ b/python/cudf/dataframe/column.py
@@ -86,6 +86,8 @@ class Column(object):
             ))
             objs = [o.cat()._set_categories(new_cats) for o in objs]
 
+        head = objs[0]
+
         # Handle strings separately
         if all(isinstance(o, StringColumn) for o in objs):
             objs = [o._data for o in objs]

--- a/python/cudf/dataframe/column.py
+++ b/python/cudf/dataframe/column.py
@@ -62,13 +62,6 @@ class Column(object):
                 dtype = np.dtype(dtype)
                 return Column(Buffer.null(dtype))
 
-        # Handle categories for categoricals
-        if all(isinstance(o, CategoricalColumn) for o in objs):
-            new_cats = tuple(set(
-                [val for o in objs for val in o.cat().categories]
-            ))
-            objs = [o.cat()._set_categories(new_cats) for o in objs]
-
         # Find the first non-null column:
         head = objs[0]
         for i, obj in enumerate(objs):
@@ -85,6 +78,13 @@ class Column(object):
                     objs[i] = make_null_like(head, size=len(obj))
                 else:
                     raise ValueError("All series must be of same type")
+
+        # Handle categories for categoricals
+        if all(isinstance(o, CategoricalColumn) for o in objs):
+            new_cats = tuple(set(
+                [val for o in objs for val in o.cat().categories]
+            ))
+            objs = [o.cat()._set_categories(new_cats) for o in objs]
 
         # Handle strings separately
         if all(isinstance(o, StringColumn) for o in objs):

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -93,6 +93,30 @@ class TypedColumnBase(Column):
         raise NotImplementedError
 
 
+def make_null_like(other, size=None, dtype=None):
+    if size is None:
+        size = other.size
+    if dtype is None:
+        dtype = other.dtype
+    mask = utils.make_mask(size)
+    if dtype.kind in 'OU':
+        mem = rmm.device_array((size,), dtype='float64')
+        mem = nvstrings.dtos(mem,
+                             len(mem),
+                             nulls=mask,
+                             bdevmem=True)
+    else:
+        mem = rmm.device_array((size,), dtype=dtype)
+    categories = None
+    if hasattr(other, 'cat'):
+        categories = other.cat().categories
+    from cudf.dataframe.columnops import build_column
+    return build_column(mem,
+                        dtype,
+                        mask,
+                        categories)
+
+
 def column_empty_like(column, dtype, masked):
     """Allocate a new column like the given *column*
     """
@@ -162,16 +186,16 @@ def column_select_by_position(column, positions):
 
 def build_column(buffer, dtype, mask=None, categories=None):
     from cudf.dataframe import numerical, categorical, datetime, string
-    if np.dtype(dtype).type == np.datetime64:
-        return datetime.DatetimeColumn(data=buffer,
-                                       dtype=np.dtype(dtype),
-                                       mask=mask)
-    elif pd.api.types.is_categorical_dtype(dtype):
+    if pd.api.types.is_categorical_dtype(dtype):
         return categorical.CategoricalColumn(data=buffer,
                                              dtype='categorical',
                                              categories=categories,
                                              ordered=False,
                                              mask=mask)
+    elif np.dtype(dtype).type == np.datetime64:
+        return datetime.DatetimeColumn(data=buffer,
+                                       dtype=np.dtype(dtype),
+                                       mask=mask)
     elif np.dtype(dtype).type in (np.object_, np.str_):
         if not isinstance(buffer, nvstrings.nvstrings):
             raise TypeError

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -106,9 +106,9 @@ def make_null_like(other, size=None, dtype=None):
     elif dtype.kind in 'OU':
         mem = rmm.device_array((size,), dtype='float64')
         data = nvstrings.dtos(mem,
-                             len(mem),
-                             nulls=mask,
-                             bdevmem=True)
+                              len(mem),
+                              nulls=mask,
+                              bdevmem=True)
     else:
         mem = rmm.device_array((size,), dtype=dtype)
         data = Buffer(mem)

--- a/python/cudf/dataframe/string.py
+++ b/python/cudf/dataframe/string.py
@@ -519,6 +519,7 @@ class StringColumn(columnops.TypedColumnBase):
     def _replace_defaults(self):
         params = {
             'data': self.data,
+            'mask': self.mask,
             'null_count': self.null_count,
         }
         return params


### PR DESCRIPTION
Concatenating nulls to a column currently fails because a column of nulls in cuDF can have any dtype. This PR enables the concatenation of nulls of any dtype to a column.

Fixes #1723 