### PR TITLE
[REVIEW] Improve Numerical column: `mean_var` and `mean`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #1713 Add documentation for Dask-XGBoost
 - PR #1666 CSV Reader: Improve performance for files with large number of columns
 - PR #1725 Enable the ability to use a single column groupby as its own index
+- PR #1764 Improve Numerical column: `mean_var` and `mean`
 
 ## Bug Fixes
 

--- a/python/cudf/dataframe/numerical.py
+++ b/python/cudf/dataframe/numerical.py
@@ -245,14 +245,13 @@ class NumericalColumn(columnops.TypedColumnBase):
     def product(self, dtype=None):
         return cpp_reduce.apply_reduce('product', self, dtype=dtype)
 
-    def mean(self, dtype=None):
-        return np.float64(self.sum(dtype=dtype)) / self.valid_count
+    def mean(self, dtype=np.float64):
+        return self.sum(dtype=dtype) / self.valid_count
 
-    def mean_var(self, ddof=1, dtype=None):
-        x = self.astype('f8')
-        mu = x.mean(dtype=dtype)
-        n = x.valid_count
-        asum = x.sum_of_squares(dtype=dtype)
+    def mean_var(self, ddof=1, dtype=np.float64):
+        mu = self.mean(dtype=dtype)
+        n = self.valid_count
+        asum = self.sum_of_squares(dtype=dtype)
         div = n - ddof
         var = asum / div - (mu ** 2) * n / div
         return mu, var

--- a/python/cudf/dataframe/numerical.py
+++ b/python/cudf/dataframe/numerical.py
@@ -246,12 +246,12 @@ class NumericalColumn(columnops.TypedColumnBase):
         return cpp_reduce.apply_reduce('product', self, dtype=dtype)
 
     def mean(self, dtype=np.float64):
-        return self.sum(dtype=dtype) / self.valid_count
+        return np.float64(self.sum(dtype=dtype)) / self.valid_count
 
     def mean_var(self, ddof=1, dtype=np.float64):
         mu = self.mean(dtype=dtype)
         n = self.valid_count
-        asum = self.sum_of_squares(dtype=dtype)
+        asum = np.float64(self.sum_of_squares(dtype=dtype))
         div = n - ddof
         var = asum / div - (mu ** 2) * n / div
         return mu, var


### PR DESCRIPTION
Remove unnecessary type cast for Numerical column `mean_var` and `mean` and use dtype=np.float64 for reduction instead.