### PR TITLE
[REVIEW] Speed up unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #1713 Add documentation for Dask-XGBoost
 - PR #1666 CSV Reader: Improve performance for files with large number of columns
 - PR #1725 Enable the ability to use a single column groupby as its own index
+- PR #1767 Speed up unit tests
 
 ## Bug Fixes
 

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -1399,7 +1399,7 @@ def test_dataframe_shape_empty():
 
 
 @pytest.mark.parametrize('num_cols', [1, 2, 10])
-@pytest.mark.parametrize('num_rows', [1, 2, 1000])
+@pytest.mark.parametrize('num_rows', [1, 2, 20])
 @pytest.mark.parametrize(
     'dtype',
     ['int8', 'int16', 'int32', 'int64', 'float32', 'float64',

--- a/python/cudf/tests/test_sparse_df.py
+++ b/python/cudf/tests/test_sparse_df.py
@@ -80,8 +80,5 @@ def test_to_dense_array():
 def test_reading_arrow_sparse_data():
     pdf, schema, darr = read_data()
     gar = GpuArrowReader(schema, darr)
-
     gdf = DataFrame(gar.to_dict().items())
-
     assert_eq(pdf, gdf)
-

--- a/python/cudf/tests/test_sparse_df.py
+++ b/python/cudf/tests/test_sparse_df.py
@@ -16,6 +16,7 @@ from librmm_cffi import librmm as rmm
 
 from cudf.comm.gpuarrow import GpuArrowReader
 from cudf.dataframe import Series, DataFrame
+from cudf.tests.utils import assert_eq
 
 
 def read_data():
@@ -43,13 +44,13 @@ def read_data():
     data = np.ndarray(shape=len(data), dtype=np.byte,
                       buffer=bytearray(data))
     darr = rmm.to_device(data)
-    return schema, darr
+    return df, schema, darr
 
 
 @pytest.mark.skipif(arrow_version is None,
                     reason='need compatible pyarrow to generate test data')
 def test_fillna():
-    schema, darr = read_data()
+    _, schema, darr = read_data()
     gar = GpuArrowReader(schema, darr)
     masked_col = gar[8]
     assert masked_col.null_count
@@ -77,60 +78,10 @@ def test_to_dense_array():
 @pytest.mark.skipif(arrow_version is None,
                     reason='need compatible pyarrow to generate test data')
 def test_reading_arrow_sparse_data():
-    schema, darr = read_data()
+    pdf, schema, darr = read_data()
     gar = GpuArrowReader(schema, darr)
 
-    df = DataFrame(gar.to_dict().items())
+    gdf = DataFrame(gar.to_dict().items())
 
-    # preprocessing
-    num_cols = set()
-    cat_cols = set()
-    response_set = set(['INCEARN '])
-    feature_names = set(df.columns) - response_set
+    assert_eq(pdf, gdf)
 
-    # Determine cat and numeric columns
-    uniques = {}
-    for k in feature_names:
-        try:
-            uniquevals = df[k].unique()
-            uniques[k] = uniquevals
-        except ValueError:
-            num_cols.add(k)
-        else:
-            nunique = len(uniquevals)
-            if nunique < 2:
-                del df[k]
-            elif 1 < nunique < 1000:
-                cat_cols.add(k)
-            else:
-                num_cols.add(k)
-
-    # Fix numeric columns
-    for k in (num_cols - response_set):
-        df[k] = df[k].fillna(df[k].mean())
-        assert df[k].null_count == 0
-        std = df[k].std()
-        # drop near constant columns
-        if not np.isfinite(std) or std < 1e-4:
-            del df[k]
-            print('drop near constant', k)
-        else:
-            df[k] = df[k].scale()
-
-    # Expand categorical columns
-    for k in cat_cols:
-        cats = uniques[k][1:]  # drop first
-        df = df.one_hot_encoding(k, prefix=k, cats=cats)
-        del df[k]
-
-    # Print dtypes
-    assert {df[k].dtype for k in df.columns} == {np.dtype('float64')}
-
-    mat = df.as_matrix()
-
-    assert mat.max() == 1
-    assert mat.min() == 0
-
-
-if __name__ == '__main__':
-    test_reading_arrow_sparse_data()


### PR DESCRIPTION
* Reduce the size of the dataframe in `test_dataframe_transpose`
* Simplify `test_reading_arrow_sparse_data` to just compare the dataframe obtained from the `GpuArrowReader` with the original DF (I don't think that this is circular logic - as all we really want to test is whether the reader can construct the DF correctly given the schema and gpu_data).