### PR TITLE
[REVIEW] JSON reader: add support for BytesIO and StringIO input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #1310 Implemented the slice/split functionality.
 - PR #1630 Add Python layer to the GPU-accelerated JSON reader
 - PR #1745 Add rounding of numeric columns via Numba
+- PR #1772 JSON reader: add support for BytesIO and StringIO input
 
 ## Improvements
 


### PR DESCRIPTION
Fixes #1769 

* Add support for BytesIO and StringIO input to read_json(), based on the CSV reader implementation;
* Expand the json_input test fixture to generate input of the newly added types;