### PR TITLE
Operators on different sized dataframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PR #1795 Add printing of git submodule info to `print_env.sh`
 - PR #1796 Removing old sort based group by code and gdf_filter
 - PR #1811 Added funtions for copying/allocating `cudf::table`s
+- PR #1736 Operators now support different sized dataframes as long as they don't share different sized columns
 
 ## Bug Fixes
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -459,17 +459,18 @@ class DataFrame(object):
             for k, col in enumerate(self._cols):
                 result[col] = getattr(self._cols[col], fn)(other[k])
         elif isinstance(other, DataFrame):
+            max_num_rows = max(self.shape[0], other.shape[0])
             for col in other._cols:
                 if col in self._cols:
                     result[col] = getattr(self._cols[col], fn)(
                                           other._cols[col])
                 else:
-                    result[col] = Series(cudautils.full(self.shape[0],
+                    result[col] = Series(cudautils.full(max_num_rows,
                                          np.dtype('float64').type(np.nan),
                                          'float64'), nan_as_null=False)
             for col in self._cols:
                 if col not in other._cols:
-                    result[col] = Series(cudautils.full(self.shape[0],
+                    result[col] = Series(cudautils.full(max_num_rows,
                                          np.dtype('float64').type(np.nan),
                                          'float64'), nan_as_null=False)
         elif isinstance(other, Series):

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -462,6 +462,10 @@ class DataFrame(object):
             max_num_rows = max(self.shape[0], other.shape[0])
             for col in other._cols:
                 if col in self._cols:
+                    if self.shape[0] != other.shape[0]:
+                        raise NotImplementedError(
+                                "%s on columns with different "
+                                "length is not supported", fn)
                     result[col] = getattr(self._cols[col], fn)(
                                           other._cols[col])
                 else:

--- a/python/cudf/tests/test_binops.py
+++ b/python/cudf/tests/test_binops.py
@@ -324,3 +324,41 @@ def test_reflected_ops_scalar(func, dtype, obj_class):
 
     # verify
     np.testing.assert_allclose(ps_result, gs_result)
+
+
+@pytest.mark.parametrize('binop', _binops)
+def test_different_shapes_and_columns(binop):
+    import cudf
+    import pandas as pd
+
+    # TODO: support `pow()` on NaN values. Particularly, the cases:
+    #       `pow(1, NaN) == 1` and `pow(NaN, 0) == 1`
+    if binop is operator.pow:
+        return
+
+    # Empty frame on the right side
+    pd_frame = binop(pd.DataFrame({'x': [1, 2]}), pd.DataFrame({}))
+    cd_frame = binop(cudf.DataFrame({'x': [1, 2]}), cudf.DataFrame({}))
+    pd.testing.assert_frame_equal(cd_frame.to_pandas(), pd_frame)
+
+    # Empty frame on the left side
+    pd_frame = pd.DataFrame({}) + pd.DataFrame({'x': [1, 2]})
+    cd_frame = cudf.DataFrame({}) + cudf.DataFrame({'x': [1, 2]})
+    pd.testing.assert_frame_equal(cd_frame.to_pandas(), pd_frame)
+
+    # More rows on the left side
+    pd_frame = pd.DataFrame({'y': [1, 2, 3]}) + pd.DataFrame({'x': [1, 2]})
+    cd_frame = cudf.DataFrame({'y': [1, 2, 3]}) + cudf.DataFrame({'x': [1, 2]})
+    pd.testing.assert_frame_equal(cd_frame.to_pandas(), pd_frame)
+
+    # More rows on the right side
+    pd_frame = pd.DataFrame({'y': [1, 2]}) + pd.DataFrame({'x': [1, 2, 3]})
+    cd_frame = cudf.DataFrame({'y': [1, 2]}) + cudf.DataFrame({'x': [1, 2, 3]})
+    pd.testing.assert_frame_equal(cd_frame.to_pandas(), pd_frame)
+
+
+@pytest.mark.parametrize('binop', _binops)
+def test_different_shapes_and_same_columns(binop):
+    import cudf
+    with pytest.raises(NotImplementedError):
+        binop(cudf.DataFrame({'x': [1, 2]}), cudf.DataFrame({'x': [1, 2, 3]}))


### PR DESCRIPTION
This PR fixes #1736 by inserting new NaN columns with the length of the largest operand.

However, this does **not** work when operands share columns with different length. 
E.g. `cudf.DataFrame({'x': [1, 2]}) + cudf.DataFrame({'x': [1, 2, 3]}` will raise `NotImplementedError`.

To support this case, we need to insert NaN rows until the length of the operands matches -- similar to how [`.reindex()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.reindex.html#pandas.DataFrame.reindex) works in Pandas. Thus, we might consider implementing #1779 before handling this case.

I have added testing of both cases.

Finally, there is still an issue with NaN and pow(). The problem is the following cases where the result is not NaN:
```python
pow(1, NaN) == 1
pow(NaN, 0) == 1
```
which we cannot handle by inserting new NaN columns. 