### PR TITLE
[REVIEW] CSV Reader: default the column type to string for empty dataframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #1770 Added build.sh script, updated CI scripts and documentation
 - PR #1739 ORC Reader: Add more pytest coverage
 - PR #1796 Removing old sort based group by code and gdf_filter
+- PR #1823 CSV Reader: default the column type to string for empty dataframes
 
 ## Bug Fixes
 

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -686,45 +686,45 @@ gdf_error read_csv(csv_read_arg *args)
 
   if(args->dtype == NULL){
     if (raw_csv.num_records == 0) {
-      checkError(GDF_INVALID_API_CALL, "read_csv: no data available for data type inference");
-    }
+      raw_csv.dtypes = vector<gdf_dtype>(raw_csv.num_active_cols, GDF_STRING);
+    } else {
+      vector<column_data_t> h_ColumnData(raw_csv.num_active_cols);
+      device_buffer<column_data_t> d_ColumnData(raw_csv.num_active_cols);
+      CUDA_TRY(cudaMemset(d_ColumnData.data(), 0, sizeof(column_data_t) * raw_csv.num_active_cols));
 
-    vector<column_data_t> h_ColumnData(raw_csv.num_active_cols);
-    device_buffer<column_data_t> d_ColumnData(raw_csv.num_active_cols);
-    CUDA_TRY(cudaMemset(d_ColumnData.data(), 0, sizeof(column_data_t) * raw_csv.num_active_cols));
+      launch_dataTypeDetection(&raw_csv, d_ColumnData.data());
+      CUDA_TRY(cudaMemcpy(h_ColumnData.data(), d_ColumnData.data(), sizeof(column_data_t) * raw_csv.num_active_cols, cudaMemcpyDeviceToHost));
 
-    launch_dataTypeDetection(&raw_csv, d_ColumnData.data());
-    CUDA_TRY(cudaMemcpy(h_ColumnData.data(), d_ColumnData.data(), sizeof(column_data_t) * raw_csv.num_active_cols, cudaMemcpyDeviceToHost));
+      // host: array of dtypes (since gdf_columns are not created until end)
+      vector<gdf_dtype> d_detectedTypes;
 
-    // host: array of dtypes (since gdf_columns are not created until end)
-    vector<gdf_dtype> d_detectedTypes;
+      for(int col = 0; col < raw_csv.num_active_cols; col++){
+        unsigned long long countInt = h_ColumnData[col].countInt8 + h_ColumnData[col].countInt16 +
+                                      h_ColumnData[col].countInt32 + h_ColumnData[col].countInt64;
 
-    for(int col = 0; col < raw_csv.num_active_cols; col++){
-      unsigned long long countInt = h_ColumnData[col].countInt8 + h_ColumnData[col].countInt16 +
-                                    h_ColumnData[col].countInt32 + h_ColumnData[col].countInt64;
-
-      if (h_ColumnData[col].countNULL == raw_csv.num_records){
-        // Entire column is NULL; allocate the smallest amount of memory
-        d_detectedTypes.push_back(GDF_INT8);
-      } else if(h_ColumnData[col].countString > 0L){
-        d_detectedTypes.push_back(GDF_STRING);
-      } else if(h_ColumnData[col].countDateAndTime > 0L){
-        d_detectedTypes.push_back(GDF_DATE64);
-      } else if(h_ColumnData[col].countBool > 0L) {
-        d_detectedTypes.push_back(GDF_BOOL8);
-      } else if(h_ColumnData[col].countFloat > 0L ||
-        (h_ColumnData[col].countFloat == 0L &&
-         countInt > 0L && h_ColumnData[col].countNULL > 0L)) {
-        // The second condition has been added to conform to
-        // PANDAS which states that a column of integers with
-        // a single NULL record need to be treated as floats.
-        d_detectedTypes.push_back(GDF_FLOAT64);
-      } else {
-        // All other integers are stored as 64-bit to conform to PANDAS
-        d_detectedTypes.push_back(GDF_INT64);
+        if (h_ColumnData[col].countNULL == raw_csv.num_records){
+          // Entire column is NULL; allocate the smallest amount of memory
+          d_detectedTypes.push_back(GDF_INT8);
+        } else if(h_ColumnData[col].countString > 0L){
+          d_detectedTypes.push_back(GDF_STRING);
+        } else if(h_ColumnData[col].countDateAndTime > 0L){
+          d_detectedTypes.push_back(GDF_DATE64);
+        } else if(h_ColumnData[col].countBool > 0L) {
+          d_detectedTypes.push_back(GDF_BOOL8);
+        } else if(h_ColumnData[col].countFloat > 0L ||
+          (h_ColumnData[col].countFloat == 0L &&
+           countInt > 0L && h_ColumnData[col].countNULL > 0L)) {
+          // The second condition has been added to conform to
+          // PANDAS which states that a column of integers with
+          // a single NULL record need to be treated as floats.
+          d_detectedTypes.push_back(GDF_FLOAT64);
+        } else {
+          // All other integers are stored as 64-bit to conform to PANDAS
+          d_detectedTypes.push_back(GDF_INT64);
+        }
       }
+      raw_csv.dtypes = d_detectedTypes;
     }
-    raw_csv.dtypes = d_detectedTypes;
   }
   else {
     const bool is_dict = std::all_of(args->dtype, args->dtype + args->num_dtype,

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -672,10 +672,12 @@ def test_csv_reader_empty_dataframe():
     # should work fine with dtypes
     df = read_csv(StringIO(buffer), dtype=dtypes)
     assert(df.shape == (0, 2))
+    assert(all(df.dtypes == ['float64', 'int64']))
 
-    # should raise an error without dtypes
-    with pytest.raises(GDFError):
-        read_csv(StringIO(buffer))
+    # should default to string columns without dtypes
+    df = read_csv(StringIO(buffer))
+    assert(df.shape == (0, 2))
+    assert(all(df.dtypes == ['object', 'object']))
 
 
 def test_csv_reader_filenotfound(tmpdir):

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -16,8 +16,6 @@ import gzip
 import shutil
 import os
 
-from cudf.bindings.GDFError import GDFError
-
 
 def make_numeric_dataframe(nrows, dtype):
     df = pd.DataFrame()


### PR DESCRIPTION
Fixes #1598 

* Default the column type to string when no data is available for inference, instead of throwing;
* Modified the Python test to match the new POR;