### PR TITLE
[REVIEW] Fix issues with multiple aggregation and groupby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #1783 Update conda dependencies
 - PR #1786 Maintain the original series name in series.unique output
 - PR #1760 CSV Reader: fix segfault when dtype list only includes columns from usecols list
+- PR #1825 cuDF: Multiaggregation Groupby Failures
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -273,8 +273,7 @@ class Groupby(object):
         # if there are no repeated keys in the mapping set,
         # and all of the actual aggregations in the mapping set are only
         # length 1, we can assign the columns directly as keys.
-        if len(set(aggs.keys())) == len(aggs.keys()) and\
-                (np.array(list(map(lambda x: len([x] if isinstance(
+        if (np.array(list(map(lambda x: len([x] if isinstance(
                     x, str) else list(x)), aggs.values()))) == 1).all():
             result.columns = aggs.keys()
         else:

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -270,11 +270,15 @@ class Groupby(object):
         return result
 
     def apply_multicolumn_mapped(self, result, aggs):
-        # if there are no repeated keys in the mapping set,
-        # and all of the actual aggregations in the mapping set are only
+        # if all of the aggregations in the mapping set are only
         # length 1, we can assign the columns directly as keys.
-        if (np.array(list(map(lambda x: len([x] if isinstance(
-                    x, str) else list(x)), aggs.values()))) == 1).all():
+        can_map_directly = True
+        for values in aggs.values():
+            value = [values] if isinstance(values, str) else list(values)
+            if len(value) != 1:
+                can_map_directly = False
+                break
+        if can_map_directly:
             result.columns = aggs.keys()
         else:
             tuples = []

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -276,7 +276,9 @@ class Groupby(object):
         else:
             tuples = []
             for k in aggs.keys():
-                for v in aggs[k]:
+                value = [aggs[k]] if isinstance(aggs[k], str) else list(
+                        aggs[k])
+                for v in value:
                     tuples.append((k, v))
             multiindex = MultiIndex.from_tuples(tuples)
             result.columns = multiindex

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -167,6 +167,7 @@ class Groupby(object):
             self._method = method
         else:
             msg = "Method {!r} is not a supported group by method"
+            raise NotImplementedError(msg.format(method))
 
     def _apply_basic_agg(self, agg_type, sort_results=False):
         """
@@ -273,7 +274,8 @@ class Groupby(object):
         # and all of the actual aggregations in the mapping set are only
         # length 1, we can assign the columns directly as keys.
         if len(set(aggs.keys())) == len(aggs.keys()) and\
-                (np.array(list(map(lambda x: len([x] if isinstance(x, str) else list(x)), aggs.values())))==1).all():
+                (np.array(list(map(lambda x: len([x] if isinstance(
+                    x, str) else list(x)), aggs.values()))) == 1).all():
             result.columns = aggs.keys()
         else:
             tuples = []

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -167,7 +167,6 @@ class Groupby(object):
             self._method = method
         else:
             msg = "Method {!r} is not a supported group by method"
-            raise NotImplementedError(msg.format(method))
 
     def _apply_basic_agg(self, agg_type, sort_results=False):
         """
@@ -270,8 +269,11 @@ class Groupby(object):
         return result
 
     def apply_multicolumn_mapped(self, result, aggs):
+        # if there are no repeated keys in the mapping set,
+        # and all of the actual aggregations in the mapping set are only
+        # length 1, we can assign the columns directly as keys.
         if len(set(aggs.keys())) == len(aggs.keys()) and\
-                isinstance(aggs[list(aggs.keys())[0]], (str, Number)):
+                (np.array(list(map(lambda x: len([x] if isinstance(x, str) else list(x)), aggs.values())))==1).all():
             result.columns = aggs.keys()
         else:
             tuples = []

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -505,3 +505,16 @@ def test_groupby_use_agg_column_as_index():
     pdg = pdf.groupby('a').agg({'a': 'count'})
     gdg = gdf.groupby('a').agg({'a': 'count'})
     assert_eq(pdg, gdg, check_dtype=False)
+
+
+def test_groupby_list_then_string():
+    gdf = cudf.DataFrame()
+    gdf['a'] = [0, 1, 0, 1, 2]
+    gdf['b'] = [11, 2, 15, 12, 2]
+    gdf['c'] = [6, 7, 6, 7, 6]
+    pdf = gdf.to_pandas()
+    gdg = gdf.groupby('a', as_index=True).agg({'b': [
+        'min', 'max'], 'c': 'max'})
+    pdg = pdf.groupby('a', as_index=True).agg({'b': [
+        'min', 'max'], 'c': 'max'})
+    assert_eq(gdg, pdg)

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -518,3 +518,27 @@ def test_groupby_list_then_string():
     pdg = pdf.groupby('a', as_index=True).agg({'b': [
         'min', 'max'], 'c': 'max'})
     assert_eq(gdg, pdg)
+
+
+def test_groupby_different_unequal_length_column_aggregations():
+    gdf = cudf.DataFrame()
+    gdf['a'] = [0, 1, 0, 1, 2]
+    gdf['b'] = [11, 2, 15, 12, 2]
+    gdf['c'] = [11, 2, 15, 12, 2]
+    pdf = gdf.to_pandas()
+    gdg = gdf.groupby('a', as_index=True).agg(
+            {'b': 'min', 'c': ['max', 'min']})
+    pdg = pdf.groupby('a', as_index=True).agg(
+            {'b': 'min', 'c': ['max', 'min']})
+    assert_eq(pdg, gdg)
+
+
+def test_groupby_single_var_two_aggs():
+    gdf = cudf.DataFrame()
+    gdf['a'] = [0, 1, 0, 1, 2]
+    gdf['b'] = [11, 2, 15, 12, 2]
+    gdf['c'] = [11, 2, 15, 12, 2]
+    pdf = gdf.to_pandas()
+    gdg = gdf.groupby('a', as_index=True).agg({'b': ['min', 'max']})
+    pdg = pdf.groupby('a', as_index=True).agg({'b': ['min', 'max']})
+    assert_eq(pdg, gdg)


### PR DESCRIPTION
```
import cudf
df = cudf.DataFrame()
df['a'] = [0,1,0,1,2]
df['b'] = [11,2,15,12,2]
df['c'] = [11,2,15,12,2]
df.groupby('a',as_index=True).agg({'b':['min','max'],'c':'max'}).to_pandas()
```
Done.

```
df = cudf.DataFrame()
df['a'] = [0,1,0,1,2]
df['b'] = [11,2,15,12,2]
df['c'] = [11,2,15,12,2]
df.groupby('a',as_index=True).agg({'b':'min','c':['max','min']}).to_pandas()
```
Done

```
import cudf
df = cudf.DataFrame()
df['a'] = [0,1,0,1,2]
df['b'] = [11,2,15,12,2]
df.groupby('a',as_index=True).agg({'b':['min','max']}).to_pandas()
```
Done

Fixes #1814 