### PR TITLE
[REVIEW] CSV Reader: Set the column type to float64 when all fields are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #1783 Update conda dependencies
 - PR #1786 Maintain the original series name in series.unique output
 - PR #1760 CSV Reader: fix segfault when dtype list only includes columns from usecols list
+- PR #1826 CSV Reader: Set the column type to float64 when all fields are empty
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/cpp/src/io/csv/csv_reader.cu
+++ b/cpp/src/io/csv/csv_reader.cu
@@ -703,21 +703,18 @@ gdf_error read_csv(csv_read_arg *args)
       unsigned long long countInt = h_ColumnData[col].countInt8 + h_ColumnData[col].countInt16 +
                                     h_ColumnData[col].countInt32 + h_ColumnData[col].countInt64;
 
-      if (h_ColumnData[col].countNULL == raw_csv.num_records){
-        // Entire column is NULL; allocate the smallest amount of memory
-        d_detectedTypes.push_back(GDF_INT8);
-      } else if(h_ColumnData[col].countString > 0L){
+      if(h_ColumnData[col].countString > 0L){
         d_detectedTypes.push_back(GDF_STRING);
       } else if(h_ColumnData[col].countDateAndTime > 0L){
         d_detectedTypes.push_back(GDF_DATE64);
       } else if(h_ColumnData[col].countBool > 0L) {
         d_detectedTypes.push_back(GDF_BOOL8);
       } else if(h_ColumnData[col].countFloat > 0L ||
-        (h_ColumnData[col].countFloat == 0L &&
-         countInt > 0L && h_ColumnData[col].countNULL > 0L)) {
-        // The second condition has been added to conform to
-        // PANDAS which states that a column of integers with
-        // a single NULL record need to be treated as floats.
+        (countInt > 0L && h_ColumnData[col].countNULL > 0L) ||
+        h_ColumnData[col].countNULL == raw_csv.num_records) {
+        // Additional conditions have been added to conform to PANDAS:
+        //   1. Columns of integers with one or more NULL records are treated as floats;
+        //   2. Columns containing only NULL records are treated as floats;
         d_detectedTypes.push_back(GDF_FLOAT64);
       } else {
         // All other integers are stored as 64-bit to conform to PANDAS

--- a/python/cudf/tests/test_csvreader.py
+++ b/python/cudf/tests/test_csvreader.py
@@ -1038,3 +1038,13 @@ def test_csv_reader_partial_dtype(dtype):
 
     assert(names_df == header_df)
     assert(all(names_df.dtypes == ['int16', 'int32']))
+
+
+def test_csv_reader_null_column():
+    # first column consists of empty fields, should be float64
+    # second column is a mix of numbers and empty fields, should be float64
+    buffer = ',1\n,2\n,'
+
+    cu_df = read_csv(StringIO(buffer), header=None)
+    pd_df = pd.read_csv(StringIO(buffer), header=None)
+    assert(list(cu_df.dtypes) == list(pd_df.dtypes))


### PR DESCRIPTION
Fixes #1765 

* Modify data type inference to set the column type to float64 when all fields of the column are empty;
* Add a Python test for this case;