### PR TITLE
[REVIEW] JSON Reader: add suport for bool8 columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #1745 Add rounding of numeric columns via Numba
 - PR #1772 JSON reader: add support for BytesIO and StringIO input
 - PR #1527 Support GDF_BOOL8 in readers and writers
+- PR #1828 JSON Reader: add suport for bool8 columns
 
 ## Improvements
 - PR #1538 Replacing LesserRTTI with inequality_comparator

--- a/cpp/src/io/json/json_reader.cu
+++ b/cpp/src/io/json/json_reader.cu
@@ -70,6 +70,12 @@ gdf_error read_json(json_read_arg *args) {
 JsonReader::JsonReader(json_read_arg *args) : args_(args) {
   // Check if the passed arguments are supported
   CUDF_EXPECTS(args_->lines, "Only Json Lines format is currently supported.\n");
+
+  d_true_trie_ = createSerializedTrie({"true"});
+  opts_.trueValuesTrie = d_true_trie_.data().get();
+
+  d_false_trie_ = createSerializedTrie({"false"});
+  opts_.falseValuesTrie = d_false_trie_.data().get();
 }
 
 /**---------------------------------------------------------------------------*
@@ -437,11 +443,37 @@ void JsonReader::setOutputArguments(json_read_arg *out_args) {
  *---------------------------------------------------------------------------**/
 struct ConvertFunctor {
   /**---------------------------------------------------------------------------*
-   * @brief Default template operator() dispatch
+   * @brief Template specialization for operator() for types whose values can be
+   * convertible to a 0 or 1 to represent false/true. The converting is done by
+   * checking against the default and user-specified true/false values list.
+   *
+   * It is handled here rather than within convertStrToValue() as that function
+   * is used by other types (ex. timestamp) that aren't 'booleable'.
    *---------------------------------------------------------------------------**/
-  template <typename T>
+  template <typename T, typename std::enable_if_t<std::is_integral<T>::value> * = nullptr>
   __host__ __device__ __forceinline__ void operator()(const char *data, void *gdf_columns, long row, long start,
-                                                      long end, const ParseOptions &opts) {
+    long end, const ParseOptions &opts) {
+    T &value{static_cast<T *>(gdf_columns)[row]};
+
+    // Check for user-specified true/false values first, where the output is
+    // replaced with 1/0 respectively
+    const size_t field_len = end - start + 1;
+    if (serializedTrieContains(opts.trueValuesTrie, data + start, field_len)) {
+      value = 1;
+    } else if (serializedTrieContains(opts.falseValuesTrie, data + start, field_len)) {
+      value = 0;
+    } else {
+      value = convertStrToValue<T>(data, start, end, opts);
+    }
+  }
+
+  /**---------------------------------------------------------------------------*
+   * @brief Default template operator() dispatch specialization all data types
+   * (including wrapper types) that is not covered by above.
+   *---------------------------------------------------------------------------**/
+  template <typename T, typename std::enable_if_t<!std::is_integral<T>::value> * = nullptr>
+  __host__ __device__ __forceinline__ void operator()(const char *data, void *gdf_columns, long row, long start,
+    long end, const ParseOptions &opts) {
     T &value{static_cast<T *>(gdf_columns)[row]};
     value = convertStrToValue<T>(data, start, end, opts);
   }
@@ -676,7 +708,10 @@ __global__ void detectJsonDataTypes(const char *data, size_t data_size, const Pa
     if (maybe_hex) {
       --int_req_number_cnt;
     }
-    if (digit_count == int_req_number_cnt) {
+    if (serializedTrieContains(opts.trueValuesTrie, data + start, field_len) ||
+        serializedTrieContains(opts.falseValuesTrie, data + start, field_len)) {
+      atomicAdd(&column_infos[col].bool_count, 1);
+    } else if (digit_count == int_req_number_cnt) {
       atomicAdd(&column_infos[col].int_count, 1);
     } else if (isLikeFloat(field_len, digit_count, decimal_count, dash_count, exponent_count)) {
       atomicAdd(&column_infos[col].float_count, 1);
@@ -766,6 +801,8 @@ void JsonReader::setDataTypes() {
         dtypes_.push_back(GDF_FLOAT64);
       } else if (cinfo.int_count > 0) {
         dtypes_.push_back(GDF_INT64);
+      } else if (cinfo.bool_count > 0) {
+        dtypes_.push_back(GDF_BOOL8);
       } else {
         CUDF_FAIL("Data type detection failed.\n");
       }

--- a/cpp/src/io/json/json_reader.hpp
+++ b/cpp/src/io/json/json_reader.hpp
@@ -36,6 +36,7 @@ public:
     gdf_size_type datetime_count;
     gdf_size_type string_count;
     gdf_size_type int_count;
+    gdf_size_type bool_count;
     gdf_size_type null_count;
   };
 
@@ -59,7 +60,9 @@ private:
 
   // parsing options
   const bool allow_newlines_in_strings_ = false;
-  const ParseOptions opts_{',', '\n', '\"', '.'};
+  ParseOptions opts_{',', '\n', '\"', '.'};
+  rmm::device_vector<SerialTrieNode>	d_true_trie_;
+  rmm::device_vector<SerialTrieNode>	d_false_trie_;
 
   /**---------------------------------------------------------------------------*
    * @brief Ingest input JSON file/buffer, without decompression

--- a/python/cudf/tests/test_json.py
+++ b/python/cudf/tests/test_json.py
@@ -249,3 +249,18 @@ def test_json_engine_selection():
     # should raise an exception
     with pytest.raises(ValueError):
         df = cudf.read_json(json, lines=False, engine='cudf')
+
+
+def test_json_bool_values():
+    buffer = '[true,1]\n[false,false]\n[true,true]'
+    cu_df = cudf.read_json(buffer, lines=True)
+    pd_df = pd.read_json(buffer, lines=True)
+
+    # types should be ['bool', 'int64']
+    np.testing.assert_array_equal(pd_df.dtypes, cu_df.dtypes)
+    np.testing.assert_array_equal(pd_df[0], cu_df['0'])
+    # boolean values should be converted to 0/1
+    np.testing.assert_array_equal(pd_df[1], cu_df['1'])
+
+    cu_df = cudf.read_json(buffer, lines=True, dtype=['bool','long'])
+    np.testing.assert_array_equal(pd_df.dtypes, cu_df.dtypes)

--- a/python/cudf/tests/test_json.py
+++ b/python/cudf/tests/test_json.py
@@ -262,5 +262,5 @@ def test_json_bool_values():
     # boolean values should be converted to 0/1
     np.testing.assert_array_equal(pd_df[1], cu_df['1'])
 
-    cu_df = cudf.read_json(buffer, lines=True, dtype=['bool','long'])
+    cu_df = cudf.read_json(buffer, lines=True, dtype=['bool', 'long'])
     np.testing.assert_array_equal(pd_df.dtypes, cu_df.dtypes)


### PR DESCRIPTION
Issue #1519

* Modify data type detection in JSON reader to include boolean values/columns;
* Include true and false tries when parsing integer values, to set the field values to 0/1;
* Add Python tests for boolean columns;