### PR TITLE
Utilities for making *typed* empty columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PR #1795 Add printing of git submodule info to `print_env.sh`
 - PR #1796 Removing old sort based group by code and gdf_filter
 - PR #1811 Added funtions for copying/allocating `cudf::table`s
+- PR #1838 Improve columnops.column_empty so that it returns typed columns instead of a generic Column
 
 ## Bug Fixes
 

--- a/python/cudf/dataframe/column.py
+++ b/python/cudf/dataframe/column.py
@@ -75,7 +75,9 @@ class Column(object):
                 # if all null, cast to appropriate dtype
                 if len(obj) == obj.null_count:
                     from cudf.dataframe.columnops import column_empty_like
-                    objs[i] = column_empty_like(head, dtype=head.dtype, masked=True,
+                    objs[i] = column_empty_like(head,
+                                                dtype=head.dtype,
+                                                masked=True,
                                                 newsize=len(obj))
 
         # Handle categories for categoricals

--- a/python/cudf/dataframe/column.py
+++ b/python/cudf/dataframe/column.py
@@ -74,8 +74,9 @@ class Column(object):
             if not objs[i].is_type_equivalent(head):
                 # if all null, cast to appropriate dtype
                 if len(obj) == obj.null_count:
-                    from cudf.dataframe.columnops import make_null_like
-                    objs[i] = make_null_like(head, size=len(obj))
+                    from cudf.dataframe.columnops import column_empty_like
+                    objs[i] = column_empty_like(head, dtype=head.dtype, masked=True,
+                                                newsize=len(obj))
 
         # Handle categories for categoricals
         if all(isinstance(o, CategoricalColumn) for o in objs):

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -98,7 +98,7 @@ def column_empty_like(column, dtype, masked, newsize=None):
     """
     row_count = len(column) if newsize is None else newsize
     categories = None
-    if hasattr(column, 'cat'):
+    if pd.api.types.is_categorical_dtype(dtype):
         categories = column.cat().categories
         dtype = column.data.dtype
     return column_empty(row_count, dtype, masked, categories=categories)

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -93,53 +93,52 @@ class TypedColumnBase(Column):
         raise NotImplementedError
 
 
-def make_null_like(other, size=None, dtype=None):
-    if size is None:
-        size = other.size
-    if dtype is None:
-        dtype = other.dtype
-    mask = cudautils.make_mask(size)
-    cudautils.fill_value(mask, 0)
+def column_empty_like(column, dtype, masked, newsize=None):
+    """Allocate a new column like the given *column*
+    """
+    row_count = len(column) if newsize is None else newsize
+    categories = None
+    if hasattr(column, 'cat'):
+        categories = column.cat().categories
+        dtype = column.data.dtype
+    return column_empty(row_count, dtype, masked, categories=categories)
 
-    if pd.api.types.is_categorical_dtype(dtype):
-        mem = rmm.device_array((size,), dtype=other.data.dtype)
+
+def column_empty(row_count, dtype, masked, categories=None):
+    """Allocate a new column like the given row_count and dtype.
+    """
+    dtype = np.dtype(dtype)
+
+    if masked:
+        mask = cudautils.make_mask(row_count)
+        cudautils.fill_value(mask, 0)
+    else:
+        mask = None
+
+    if (categories is not None
+        or pd.api.types.is_categorical_dtype(dtype)
+    ):
+        mem = rmm.device_array((row_count,), dtype=dtype)
         data = Buffer(mem)
+        dtype = 'category'
     elif dtype.kind in 'OU':
-        mem = rmm.device_array((size,), dtype='float64')
+        mem = rmm.device_array((row_count,), dtype='float64')
         data = nvstrings.dtos(mem,
                               len(mem),
                               nulls=mask,
                               bdevmem=True)
     else:
-        mem = rmm.device_array((size,), dtype=dtype)
+        mem = rmm.device_array((row_count,), dtype=dtype)
         data = Buffer(mem)
-    mask = Buffer(mask)
-    categories = None
-    if hasattr(other, 'cat'):
-        categories = other.cat().categories
+
+    if mask is not None:
+        mask = Buffer(mask)
+
     from cudf.dataframe.columnops import build_column
     return build_column(data,
                         dtype,
                         mask,
                         categories)
-
-
-def column_empty_like(column, dtype, masked):
-    """Allocate a new column like the given *column*
-    """
-    return column_empty(len(column), dtype, masked)
-
-
-def column_empty(row_count, dtype, masked):
-    """Allocate a new column like the given row_count and dtype.
-    """
-    data = rmm.device_array(shape=row_count, dtype=dtype)
-    params = dict(data=Buffer(data))
-    if masked:
-        mask = utils.make_mask(row_count)
-        cudautils.fill_value(mask, 0)
-        params.update(dict(mask=Buffer(mask), null_count=data.size))
-    return Column(**params)
 
 
 def column_empty_like_same_mask(column, dtype):

--- a/python/cudf/dataframe/columnops.py
+++ b/python/cudf/dataframe/columnops.py
@@ -115,7 +115,8 @@ def column_empty(row_count, dtype, masked, categories=None):
     else:
         mask = None
 
-    if (categories is not None
+    if (
+        categories is not None
         or pd.api.types.is_categorical_dtype(dtype)
     ):
         mem = rmm.device_array((row_count,), dtype=dtype)


### PR DESCRIPTION
`columnops.column_empty_like` and `columnops.column_empty` currently return a generic `Column` object. This PR improves it to return the appropriately typed column (numerical, string, datetime or categorical). For example:

```
In [1]: cudf.dataframe.columnops.column_empty(4, 'datetime64[ms]', False)                                                                                                               
Out[1]: <cudf.dataframe.datetime.DatetimeColumn at 0x7f6bd1b7fb38>
```

