### PR TITLE
[REVIEW] type-erased gdf_equal_columns, and fix for gdf_equal_columns logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #1796 Removing old sort based group by code and gdf_filter
 - PR #1811 Added funtions for copying/allocating `cudf::table`s
 - PR #1823 CSV Reader: default the column type to string for empty dataframes
+- PR #1846 C++ type-erased gdf_equal_columns util; fix gdf_equal_columns logic error
 
 ## Bug Fixes
 

--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -87,7 +87,7 @@ struct ColumnConcatTest : public testing::Test
 
     EXPECT_EQ(ref_null_count, ref_gdf_col->null_count);
 
-    EXPECT_TRUE(gdf_equal_columns<ColumnType>(ref_gdf_col.get(), output_gdf_col.get()));
+    EXPECT_TRUE(gdf_equal_columns(*ref_gdf_col.get(), *output_gdf_col.get()));
 
   }
 

--- a/cpp/tests/transpose/transpose_test.cu
+++ b/cpp/tests/transpose/transpose_test.cu
@@ -199,7 +199,7 @@ protected:
         for(size_t i = 0; i < _nrows; i++)
         {
             ASSERT_TRUE(
-                gdf_equal_columns<T>(ref_gdf_columns[i].get(), out_gdf_columns[i].get())
+                gdf_equal_columns(*ref_gdf_columns[i].get(), *out_gdf_columns[i].get())
             );
         }
     }

--- a/cpp/tests/unary/unary_ops_test.cu
+++ b/cpp/tests/unary/unary_ops_test.cu
@@ -112,7 +112,7 @@ TEST_F(gdf_cast_test, usage_example) {
 	// example for gdf_cast generic to f32
 	{
 		// Output column
-		auto outputFloat32Col = cudf::test::column_wrapper<float>(colSize, true);
+		auto outputFloat32Col = cudf::test::column_wrapper<float>(colSize);
 		auto results = cudf::test::column_wrapper<float>(std::vector<float>{
 			-1528.0,
 			1.0,
@@ -127,7 +127,7 @@ TEST_F(gdf_cast_test, usage_example) {
 	// example for gdf_cast generic to i32
 	{
 		// Output column
-		auto outputInt32Col = cudf::test::column_wrapper<int32_t>(colSize, true);
+		auto outputInt32Col = cudf::test::column_wrapper<int32_t>(colSize);
 		auto results = cudf::test::column_wrapper<int32_t>(std::vector<int32_t>{
 			-1528,
 			1,
@@ -142,7 +142,7 @@ TEST_F(gdf_cast_test, usage_example) {
 	// example for gdf_cast generic to i64 - upcast
 	{
 		// Output column
-		auto outputInt64Col = cudf::test::column_wrapper<int64_t>(colSize, true);
+		auto outputInt64Col = cudf::test::column_wrapper<int64_t>(colSize);
 		auto results = cudf::test::column_wrapper<int64_t>(std::vector<int64_t>{
 			-1528,
 			1,
@@ -158,7 +158,7 @@ TEST_F(gdf_cast_test, usage_example) {
 	// example for gdf_cast generic to i32 - downcast
 	{
 		// Output column
-		auto outputInt32Col = cudf::test::column_wrapper<int32_t>(colSize, true);
+		auto outputInt32Col = cudf::test::column_wrapper<int32_t>(colSize);
 		auto results = cudf::test::column_wrapper<int32_t>(std::vector<int32_t>{
 			-1528,
 			1,
@@ -174,7 +174,7 @@ TEST_F(gdf_cast_test, usage_example) {
 	// example for gdf_cast generic to i32
 	{
 		// Output column
-		auto outputInt32Col = cudf::test::column_wrapper<int32_t>(colSize, true);
+		auto outputInt32Col = cudf::test::column_wrapper<int32_t>(colSize);
 		auto results = cudf::test::column_wrapper<int32_t>(std::vector<int32_t>{
 			-1528,
 			17716,
@@ -190,7 +190,7 @@ TEST_F(gdf_cast_test, usage_example) {
 	// example for gdf_cast generic to date32
 	{
 		// Output column
-		auto outputDate32Col = cudf::test::column_wrapper<cudf::date32>(colSize, true);
+		auto outputDate32Col = cudf::test::column_wrapper<cudf::date32>(colSize);
 		auto results = cudf::test::column_wrapper<cudf::date32>(std::vector<cudf::date32>{
 			cudf::date32{-1528},
 			cudf::date32{1},
@@ -206,7 +206,7 @@ TEST_F(gdf_cast_test, usage_example) {
 	// example for gdf_cast generic to timestamp
 	{
 		// Output column
-		auto outputTimestampMicroCol = cudf::test::column_wrapper<cudf::timestamp>(colSize, true);
+		auto outputTimestampMicroCol = cudf::test::column_wrapper<cudf::timestamp>(colSize);
 		auto results = cudf::test::column_wrapper<cudf::timestamp>(std::vector<cudf::timestamp>{
 			cudf::timestamp{1528935590000000}, // '2018-06-14 00:19:50.000000'
 			cudf::timestamp{1528935599999000}, // '2018-06-14 00:19:59.999000'
@@ -224,7 +224,7 @@ TEST_F(gdf_cast_test, usage_example) {
 	// example for gdf_cast generic to date32
 	{
 		// Output column
-		auto outputDate32Col = cudf::test::column_wrapper<cudf::date32>(colSize, true);
+		auto outputDate32Col = cudf::test::column_wrapper<cudf::date32>(colSize);
 		auto results = cudf::test::column_wrapper<cudf::date32>(std::vector<cudf::date32>{
 			cudf::date32{17696}, // '2018-06-14'
 			cudf::date32{17696}, // '2018-06-14'

--- a/cpp/tests/utilities/column_wrapper.cuh
+++ b/cpp/tests/utilities/column_wrapper.cuh
@@ -28,9 +28,6 @@
 #include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
 
-#include <thrust/equal.h>
-#include <thrust/logical.h>
-
 #include <string>
 
 #ifndef CUDA_RT_CALL
@@ -331,46 +328,6 @@ struct column_wrapper {
   }
 
   /**---------------------------------------------------------------------------*
-   * @brief Functor for comparing if two elements between two gdf_columns are
-   * equal.
-   *
-   *---------------------------------------------------------------------------**/
-  struct elements_equal {
-    gdf_column lhs_col;
-    gdf_column rhs_col;
-    bool nulls_are_equivalent;
-
-    /**---------------------------------------------------------------------------*
-     * @brief Constructs functor for comparing elements between two gdf_column's
-     *
-     * @param lhs The left column for comparison
-     * @param rhs The right column for comparison
-     * @param nulls_are_equal Desired behavior for whether or not nulls are
-     * treated as equal to other nulls. Defaults to true.
-     *---------------------------------------------------------------------------**/
-    __host__ __device__ elements_equal(gdf_column lhs, gdf_column rhs,
-                                       bool nulls_are_equal = true)
-        : lhs_col{lhs}, rhs_col{rhs}, nulls_are_equivalent{nulls_are_equal} {}
-
-    __device__ bool operator()(gdf_index_type row) {
-      bool const lhs_is_valid{gdf_is_valid(lhs_col.valid, row)};
-      bool const rhs_is_valid{gdf_is_valid(rhs_col.valid, row)};
-
-      if (lhs_is_valid and rhs_is_valid) {
-        return static_cast<ColumnType const*>(lhs_col.data)[row] ==
-               static_cast<ColumnType const*>(rhs_col.data)[row];
-      }
-
-      // If one value is valid but the other is not
-      if (lhs_is_valid != rhs_is_valid) {
-        return false;
-      }
-
-      return nulls_are_equivalent;
-    }
-  };
-
-  /**---------------------------------------------------------------------------*
    * @brief Compares this wrapper to a gdf_column for equality.
    *
    * Treats NULL == NULL
@@ -380,28 +337,7 @@ struct column_wrapper {
    * @return false The two columns are not equal
    *---------------------------------------------------------------------------**/
   bool operator==(gdf_column const& rhs) const {
-    if (the_column.size != rhs.size) return false;
-    if (the_column.dtype != rhs.dtype) return false;
-    if (the_column.null_count != rhs.null_count) return false;
-    if (the_column.dtype_info.time_unit != rhs.dtype_info.time_unit)
-      return false;
-
-    if ((the_column.data == nullptr) != (rhs.data == nullptr))
-      return false;  // if one is null but not both
-    else if (rhs.data == nullptr)
-      return true;  // logically, both are null
-    // both are non-null...
-
-    if (not thrust::all_of(rmm::exec_policy()->on(0),
-                           thrust::make_counting_iterator(0),
-                           thrust::make_counting_iterator(the_column.size),
-                           elements_equal{the_column, rhs})) {
-      return false;
-    }
-
-    CUDA_RT_CALL(cudaPeekAtLastError());
-
-    return true;
+    return gdf_equal_columns(the_column, rhs);
   }
 
   /**---------------------------------------------------------------------------*

--- a/cpp/tests/utilities/cudf_test_utils.cu
+++ b/cpp/tests/utilities/cudf_test_utils.cu
@@ -97,7 +97,22 @@ struct column_printer {
         }
     }
 };
+
+struct columns_equal
+{
+  template <typename T>
+  bool operator()(gdf_column *left, gdf_column *right) {
+    return gdf_equal_columns<T>(left, right);
+  }
+};
+
 } // namespace
+
+bool gdf_equal_columns(gdf_column* left, gdf_column* right)
+{
+  return (left != nullptr) && (right != nullptr) &&
+    cudf::type_dispatcher(left->dtype, columns_equal{}, left, right);
+}
 
 void print_gdf_column(gdf_column const * the_column, unsigned min_printing_width)
 {

--- a/cpp/tests/utilities/cudf_test_utils.cu
+++ b/cpp/tests/utilities/cudf_test_utils.cu
@@ -20,6 +20,7 @@
 #include "cudf_test_utils.cuh"
 #include <nvstrings/NVCategory.h>
 #include <nvstrings/NVStrings.h>
+#include <utilities/type_dispatcher.hpp>
 
 namespace {
 
@@ -98,25 +99,118 @@ struct column_printer {
     }
 };
 
+/**---------------------------------------------------------------------------*
+ * @brief Functor for comparing if two elements between two gdf_columns are
+ * equal.
+ *
+ *---------------------------------------------------------------------------**/
+template <typename T, bool has_nulls>
+struct elements_equal {
+  gdf_column lhs_col;
+  gdf_column rhs_col;
+  bool nulls_are_equivalent;
+
+  using bit_mask_t = bit_mask::bit_mask_t;
+
+  /**---------------------------------------------------------------------------*
+   * @brief Constructs functor for comparing elements between two gdf_column's
+   *
+   * @param lhs The left column for comparison
+   * @param rhs The right column for comparison
+   * @param nulls_are_equal Desired behavior for whether or not nulls are
+   * treated as equal to other nulls. Defaults to true.
+   *---------------------------------------------------------------------------**/
+  __host__ __device__ elements_equal(gdf_column lhs, gdf_column rhs,
+                                     bool nulls_are_equal = true)
+      : lhs_col{lhs}, rhs_col{rhs}, nulls_are_equivalent{nulls_are_equal} {}
+
+  __device__ bool operator()(gdf_index_type row) {    
+    bool const lhs_is_valid{gdf_is_valid(lhs_col.valid, row)};
+    bool const rhs_is_valid{gdf_is_valid(rhs_col.valid, row)};
+
+    if (lhs_is_valid and rhs_is_valid) {
+      return static_cast<T const*>(lhs_col.data)[row] ==
+             static_cast<T const*>(rhs_col.data)[row];
+    }
+
+    // If one value is valid but the other is not
+    if (lhs_is_valid != rhs_is_valid) {
+      return false;
+    }
+
+    return nulls_are_equivalent;
+  }
+};
+
+} // namespace anonymous
+
+/**
+ * ---------------------------------------------------------------------------*
+ * @brief Compare two gdf_columns on all fields, including pairwise comparison
+ * of data and valid arrays
+ *
+ * @tparam T The type of columns to compare
+ * @param left The left column
+ * @param right The right column
+ * @return bool Whether or not the columns are equal
+ * ---------------------------------------------------------------------------**/
+template <typename T>
+bool gdf_equal_columns(gdf_column const& left, gdf_column const& right)
+{
+  if (left.size != right.size) return false;
+  if (left.dtype != right.dtype) return false;
+  if (left.null_count != right.null_count) return false;
+  if (left.dtype_info.time_unit != right.dtype_info.time_unit) return false;
+
+  if ((left.data == nullptr) != (right.data == nullptr))
+    return false;  // if one is null but not both
+  
+  if ((left.valid == nullptr) != (right.valid == nullptr))
+    return false;  // if one is null but not both
+
+  if (left.data == nullptr)
+      return true;  // logically, both are null
+
+  // both are non-null...
+  bool const has_nulls {(left.valid != nullptr) && (left.null_count > 0)};
+
+  bool equal_data = (has_nulls) ?
+    thrust::all_of(rmm::exec_policy()->on(0),
+                   thrust::make_counting_iterator(0),
+                   thrust::make_counting_iterator(left.size),
+                   elements_equal<T, true>{left, right}) :
+    thrust::all_of(rmm::exec_policy()->on(0),
+                   thrust::make_counting_iterator(0),
+                   thrust::make_counting_iterator(left.size),
+                   elements_equal<T, false>{left, right});
+  
+  CHECK_STREAM(0);
+
+  return equal_data;
+}
+
+namespace {
+
 struct columns_equal
 {
   template <typename T>
-  bool operator()(gdf_column *left, gdf_column *right) {
+  bool operator()(gdf_column const& left, gdf_column const& right) {
     return gdf_equal_columns<T>(left, right);
   }
 };
 
-} // namespace
+}; // namespace anonymous
 
-bool gdf_equal_columns(gdf_column* left, gdf_column* right)
+// Type-erased version of gdf_equal_columns
+bool gdf_equal_columns(gdf_column const& left, gdf_column const& right)
 {
-  return (left != nullptr) && (right != nullptr) &&
-    cudf::type_dispatcher(left->dtype, columns_equal{}, left, right);
+  return cudf::type_dispatcher(left.dtype, columns_equal{}, left, right);
 }
 
 void print_gdf_column(gdf_column const * the_column, unsigned min_printing_width)
 {
-    cudf::type_dispatcher(the_column->dtype, column_printer{}, the_column, min_printing_width);
+  cudf::type_dispatcher(the_column->dtype, column_printer{}, 
+                        the_column, min_printing_width);
 }
 
 void print_valid_data(const gdf_valid_type *validity_mask,
@@ -129,7 +223,8 @@ void print_valid_data(const gdf_valid_type *validity_mask,
 
   std::vector<gdf_valid_type> h_mask(gdf_valid_allocation_size(num_rows));
   if (error != cudaErrorInvalidValue && isDeviceType(attrib))
-    cudaMemcpy(h_mask.data(), validity_mask, gdf_valid_allocation_size(num_rows), cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_mask.data(), validity_mask, gdf_valid_allocation_size(num_rows),
+               cudaMemcpyDeviceToHost);
   else
     memcpy(h_mask.data(), validity_mask, gdf_valid_allocation_size(num_rows));
 

--- a/cpp/tests/utilities/cudf_test_utils.cuh
+++ b/cpp/tests/utilities/cudf_test_utils.cuh
@@ -28,7 +28,7 @@
 
 #include <rmm/rmm.h>
 
-#include <thrust/equal.h>
+#include <thrust/logical.h>
 
 #include <bitset>
 #include <numeric> // for std::accumulate
@@ -347,44 +347,6 @@ std::vector<gdf_col_pointer> initialize_gdf_columns(
   return initialize_gdf_columns(columns,
                                 [](size_t row, size_t col) { return true; });
 }
-/**
- * ---------------------------------------------------------------------------*
- * @brief Compare two gdf_columns on all fields, including pairwise comparison
- * of data and valid arrays
- *
- * @tparam T The type of columns to compare
- * @param left The left column
- * @param right The right column
- * @return bool Whether or not the columns are equal
- * ---------------------------------------------------------------------------**/
-template <typename T>
-bool gdf_equal_columns(gdf_column* left, gdf_column* right)
-{
-  if (left->size != right->size) return false;
-  if (left->dtype != right->dtype) return false;
-  if (left->null_count != right->null_count) return false;
-  if (left->dtype_info.time_unit != right->dtype_info.time_unit) return false;
-
-  if ((left->data == nullptr) != (right->data == nullptr))
-    return false;  // if one is null but not both
-
-  if ((left->data != nullptr) && 
-      !thrust::equal(thrust::cuda::par, reinterpret_cast<T*>(left->data),
-                     reinterpret_cast<T*>(left->data) + left->size,
-                     reinterpret_cast<T*>(right->data)))
-    return false;
-
-  if ((left->valid == nullptr) != (right->valid == nullptr))
-    return false;  // if one is null but not both
-
-  if ((left->valid != nullptr) && 
-      !thrust::equal(thrust::cuda::par, left->valid,
-                     left->valid + gdf_num_bitmask_elements(left->size),
-                     right->valid))
-    return false;
-  
-  return true;
-}
 
 /**
  * ---------------------------------------------------------------------------*
@@ -397,6 +359,6 @@ bool gdf_equal_columns(gdf_column* left, gdf_column* right)
  * @param right The right column
  * @return bool Whether or not the columns are equal
  * ---------------------------------------------------------------------------**/
-bool gdf_equal_columns(gdf_column *left, gdf_column *right);
+bool gdf_equal_columns(gdf_column const& left, gdf_column const &right);
 
 #endif // CUDF_TEST_UTILS_CUH_

--- a/cpp/tests/utilities/cudf_test_utils.cuh
+++ b/cpp/tests/utilities/cudf_test_utils.cuh
@@ -365,18 +365,20 @@ bool gdf_equal_columns(gdf_column* left, gdf_column* right)
   if (left->null_count != right->null_count) return false;
   if (left->dtype_info.time_unit != right->dtype_info.time_unit) return false;
 
-  if (!(left->data && right->data))
+  if ((left->data == nullptr) != (right->data == nullptr))
     return false;  // if one is null but not both
 
-  if (!thrust::equal(thrust::cuda::par, reinterpret_cast<T*>(left->data),
+  if ((left->data != nullptr) && 
+      !thrust::equal(thrust::cuda::par, reinterpret_cast<T*>(left->data),
                      reinterpret_cast<T*>(left->data) + left->size,
                      reinterpret_cast<T*>(right->data)))
     return false;
 
-  if (!(left->valid && right->valid))
+  if ((left->valid == nullptr) != (right->valid == nullptr))
     return false;  // if one is null but not both
 
-  if (!thrust::equal(thrust::cuda::par, left->valid,
+  if ((left->valid != nullptr) && 
+      !thrust::equal(thrust::cuda::par, left->valid,
                      left->valid + gdf_num_bitmask_elements(left->size),
                      right->valid))
     return false;
@@ -384,5 +386,17 @@ bool gdf_equal_columns(gdf_column* left, gdf_column* right)
   return true;
 }
 
+/**
+ * ---------------------------------------------------------------------------*
+ * @brief Compare two gdf_columns on all fields, including pairwise comparison
+ * of data and valid arrays. 
+ * 
+ * Uses type_dispatcher to dispatch the data comparison
+ *
+ * @param left The left column
+ * @param right The right column
+ * @return bool Whether or not the columns are equal
+ * ---------------------------------------------------------------------------**/
+bool gdf_equal_columns(gdf_column *left, gdf_column *right);
 
-#endif
+#endif // CUDF_TEST_UTILS_CUH_


### PR DESCRIPTION
New type-erased version of the utility `gdf_equal_columns`. Uses type dispatcher on the type of the first column to call the typed version.

- [x] `gdf_equal_columns` now type-erased and takes const reference parameters. Template version is an implementation detail. 
- [x] Use implementation / logic from `column_wrapper::operator==` as new gdf_equal_columns implementation
- [x] refactor `column_wrapper::operator==` to just call gdf_equal_columns
- [x] Fix latent bug in unary_ops_test.cu which compared column with null mask to column without null mask. Previous gdf_equal_columns incorrectly found them to be equal...

Closes #1844 