### PR TITLE
[REVIEW] Fixed #1375 by moving the nvstring check into the wrapper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - PR #1786 Maintain the original series name in series.unique output
 - PR #1760 CSV Reader: fix segfault when dtype list only includes columns from usecols list
 - PR #1831 build.sh: Assuming python is in PATH instead of using PYTHON env var
+- PR #1847 Fixed #1375 by moving the nvstring check into the wrapper function
 
 # cudf 0.7.2 (16 May 2019)
 

--- a/python/cudf/dataframe/string.py
+++ b/python/cudf/dataframe/string.py
@@ -32,12 +32,13 @@ class StringMethods(object):
             passed_attr = getattr(self._parent._data, attr)
             if callable(passed_attr):
                 def wrapper(*args, **kwargs):
-                    return getattr(self._parent._data, attr)(*args, **kwargs)
-                if isinstance(wrapper, nvstrings.nvstrings):
-                    wrapper = Series(
-                        columnops.as_column(wrapper),
-                        index=self._index
-                    )
+                    ret = getattr(self._parent._data, attr)(*args, **kwargs)
+                    if isinstance(ret, nvstrings.nvstrings):
+                        ret = Series(
+                            columnops.as_column(ret),
+                            index=self._index
+                        )
+                    return ret
                 return wrapper
             else:
                 return passed_attr

--- a/python/cudf/tests/test_string.py
+++ b/python/cudf/tests/test_string.py
@@ -815,3 +815,9 @@ def test_string_unique(item):
     pres = pres.sort_values(na_position='first').reset_index(drop=True)
     gres = gs.unique()
     assert_eq(pres, gres)
+
+
+def test_string_slice():
+    df = DataFrame({'a': ['hello', 'world']})
+    a_slice = df.a.str.slice(0, 2)
+    assert isinstance(a_slice, Series)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
