### PR TITLE
[REVIEW] Allow DataFrame support methods to pass arguments to the methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - PR #1831 build.sh: Assuming python is in PATH instead of using PYTHON env var
 - PR #1825 cuDF: Multiaggregation Groupby Failures
 - PR #1789 CSV Reader: Fix missing support for specifying `int8` and `int16` dtypes
+- PR #1849 Allow DataFrame support methods to pass arguments to the methods
 
 # cudf 0.7.2 (16 May 2019)
 

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -2624,35 +2624,34 @@ class DataFrame(object):
     #
     # Stats
     #
-    def count(self):
-        return self._apply_support_method('count')
+    def count(self, **kwargs):
+        return self._apply_support_method('count', **kwargs)
 
-    def min(self):
-        return self._apply_support_method('min')
+    def min(self, **kwargs):
+        return self._apply_support_method('min', **kwargs)
 
-    def max(self):
-        return self._apply_support_method('max')
+    def max(self, **kwargs):
+        return self._apply_support_method('max', **kwargs)
 
-    def sum(self):
-        return self._apply_support_method('sum')
+    def sum(self, **kwargs):
+        return self._apply_support_method('sum', **kwargs)
 
-    def product(self):
-        return self._apply_support_method('product')
+    def product(self, **kwargs):
+        return self._apply_support_method('product', **kwargs)
 
-    def cummin(self):
-        return self._apply_support_method('cummin')
+    def cummin(self, **kwargs):
+        return self._apply_support_method('cummin', **kwargs)
 
-    def cummax(self):
-        return self._apply_support_method('cummax')
+    def cummax(self, **kwargs):
+        return self._apply_support_method('cummax', **kwargs)
 
-    def cumsum(self):
-        return self._apply_support_method('cumsum')
+    def cumsum(self, **kwargs):
+        return self._apply_support_method('cumsum', **kwargs)
 
-    def cumprod(self):
-        return self._apply_support_method('cumprod')
+    def cumprod(self, **kwargs):
+        return self._apply_support_method('cumprod', **kwargs)
 
-    def mean(self, axis=None, skipna=None, level=None, numeric_only=None,
-             **kwargs):
+    def mean(self, numeric_only=None, **kwargs):
         """Return the mean of the values for the requested axis.
 
         Parameters
@@ -2679,13 +2678,13 @@ class DataFrame(object):
         -------
         mean : Series or DataFrame (if level specified)
         """
-        return self._apply_support_method('mean')
+        return self._apply_support_method('mean', **kwargs)
 
-    def std(self, ddof=1):
-        return self._apply_support_method('std', ddof=ddof)
+    def std(self, **kwargs):
+        return self._apply_support_method('std', **kwargs)
 
-    def var(self, ddof=1):
-        return self._apply_support_method('var', ddof=ddof)
+    def var(self, **kwargs):
+        return self._apply_support_method('var', **kwargs)
 
     def _apply_support_method(self, method, **kwargs):
         result = [getattr(self[col], method)(**kwargs)

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -2682,14 +2682,13 @@ class DataFrame(object):
         return self._apply_support_method('mean')
 
     def std(self, ddof=1):
-        return self._apply_support_method('std', ddof)
+        return self._apply_support_method('std', ddof=ddof)
 
     def var(self, ddof=1):
-        return self._apply_support_method('var', ddof)
+        return self._apply_support_method('var', ddof=ddof)
 
-    def _apply_support_method(self, *args, **kwargs):
-        method = args[0]
-        result = [getattr(self[col], method)(*kwargs)
+    def _apply_support_method(self, method, **kwargs):
+        result = [getattr(self[col], method)(**kwargs)
                   for col in self._cols.keys()]
         if isinstance(result[0], Series):
             support_result = result

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -1593,6 +1593,8 @@ def gdf(pdf):
     lambda df: df.max(),
     lambda df: df.std(ddof=1),
     lambda df: df.var(ddof=1),
+    lambda df: df.std(ddof=2),
+    lambda df: df.var(ddof=2),
     ])
 def test_dataframe_reductions(func):
     pdf = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})


### PR DESCRIPTION
**Summary of Changes**
- This PR updates `_apply_support_method` to pass keyword arguments to the grabbed method.
    - There are several ways to accomplish this, but I think the simplest is to simply remove `*args` in favor of an explicit method argument (since this private method is designed to apply a single method), and unpack the keyword arguments twice.
- This PR also updates the DataFrame statistical methods to leverage `**kwargs`, allowing them to pass through arguments to the Series methods. I think this is a good choice, as it simplifies the code by only explicitly enumerating keyword arguments used in DataFrame-specific logic (such as `numeric_only`, if we decide to implement this down the road) and will help alleviate dask-related API issues that pop up from missing keyword arguments.

**Context**
These bugs come from two places:
- The fact that `*args` supersedes `**kwargs` for all non-keyward named arguments in the function call (thus the created keyword arguments dictionary is actually empty inside `DataFrame.var` and `std` (and any other support-based method)).
- The need to unpack a keyword arguments dictionary when passed to the method via the `getattr` call

Our unit tests for dataframe reductions only tested the base case for var and std (ddof=1), so this didn't show itself.

This closes #1848 and closes #1843 and closes rapidsai/dask-cudf#261 .