### PR TITLE
[REVIEW] Series and Dataframe methods for all and any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #1813 ORC Reader: Add support for stripe selection
 - PR #1828 JSON Reader: add suport for bool8 columns
 - PR #1665 Add the point-in-polygon GIS function
+- PR #1863 Series and Dataframe methods for all and any
 
 ## Improvements
 - PR #1538 Replacing LesserRTTI with inequality_comparator

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -2691,6 +2691,18 @@ class DataFrame(object):
     def var(self, **kwargs):
         return self._apply_support_method('var', **kwargs)
 
+    def all(self, bool_only=None, **kwargs):
+        if bool_only:
+            return self.select_dtypes(include='bool')._apply_support_method(
+                'all', **kwargs)
+        return self._apply_support_method('all', **kwargs)
+
+    def any(self, bool_only=None, **kwargs):
+        if bool_only:
+            return self.select_dtypes(include='bool')._apply_support_method(
+                'any', **kwargs)
+        return self._apply_support_method('any', **kwargs)
+
     def _apply_support_method(self, method, **kwargs):
         result = [getattr(self[col], method)(**kwargs)
                   for col in self._cols.keys()]

--- a/python/cudf/dataframe/numerical.py
+++ b/python/cudf/dataframe/numerical.py
@@ -234,6 +234,11 @@ class NumericalColumn(columnops.TypedColumnBase):
     def all(self):
         return bool(self.min())
 
+    def any(self):
+        if self.valid_count == 0:
+            return False
+        return bool(self.max())
+
     def min(self, dtype=None):
         return cpp_reduce.apply_reduce('min', self, dtype=dtype)
 

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -775,6 +775,18 @@ class Series(object):
         mask = cudautils.notna_mask(self.data, self.nullmask.to_gpu_array())
         return Series(mask, name=self.name, index=self.index)
 
+    def all(self, axis=0, skipna=True, level=None):
+        """
+        """
+        assert axis in (None, 0) and skipna is True and level in (None,)
+        return self._column.all()
+
+    def any(self, axis=0, skipna=True, level=None):
+        """
+        """
+        assert axis in (None, 0) and skipna is True and level in (None,)
+        return self._column.any()
+
     def to_gpu_array(self, fillna=None):
         """Get a dense numba device array for the data.
 

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2512,3 +2512,62 @@ def test_round(decimal):
     np.testing.assert_array_almost_equal(result.to_pandas(), expected,
                                          decimal=10)
     np.array_equal(ser.nullmask.to_array(), result.nullmask.to_array())
+
+
+@pytest.mark.parametrize('data',
+                         [
+                             np.array([0, 1, 2, 3]),
+                             np.array([-2, -1, 2, 3, 5]),
+                             np.array([True, False, False]),
+                             np.array([True]),
+                             np.array([False]),
+                             np.array([]),
+                             np.array([True, None, False]),
+                             np.array([True, True, None]),
+                             np.array([None, None]),
+                             np.array([range(5), range(5, 10)]),
+                             np.array([[1, 2, 3], [True, False, False]]),
+                         ])
+def test_all(data):
+    if data.ndim <= 1:
+        pdata = pd.Series(data)
+        gdata = Series.from_pandas(pdata)
+    else:
+        ncols = data.shape[1]
+        cols = np.random.choice(['a', 'bb', 'ccc', 'dddd', 'eeee'], ncols,
+                                replace=False).tolist()
+        pdata = pd.DataFrame(data, columns=cols)
+        gdata = DataFrame.from_pandas(pdata)
+    got = gdata.all()
+    expected = pdata.all()
+    assert_eq(got, expected)
+
+
+@pytest.mark.parametrize('data',
+                         [
+                             np.array([0, 1, 2, 3]),
+                             np.array([-2, -1, 2, 3, 5]),
+                             np.array([True, False, False]),
+                             np.array([True]),
+                             np.array([False]),
+                             np.array([]),
+                             np.array([True, None, False]),
+                             np.array([True, True, None]),
+                             np.array([None, None]),
+                             np.array([range(5), range(5, 10)]),
+                             np.array([[1, 2, 3], [True, False, False]]),
+                         ])
+def test_any(data):
+    if data.ndim <= 1:
+        pdata = pd.Series(data)
+        gdata = Series.from_pandas(pdata)
+    else:
+        ncols = data.shape[1]
+        cols = np.random.choice(['a', 'bb', 'ccc', 'dddd', 'eeee'], ncols,
+                                replace=False).tolist()
+        pdata = pd.DataFrame(data, columns=cols)
+        gdata = DataFrame.from_pandas(pdata)
+
+    got = gdata.any()
+    expected = pdata.any()
+    assert_eq(got, expected)

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2516,58 +2516,77 @@ def test_round(decimal):
 
 @pytest.mark.parametrize('data',
                          [
-                             np.array([0, 1, 2, 3]),
-                             np.array([-2, -1, 2, 3, 5]),
-                             np.array([True, False, False]),
-                             np.array([True]),
-                             np.array([False]),
-                             np.array([]),
-                             np.array([True, None, False]),
-                             np.array([True, True, None]),
-                             np.array([None, None]),
-                             np.array([range(5), range(5, 10)]),
-                             np.array([[1, 2, 3], [True, False, False]]),
+                             [0, 1, 2, 3],
+                             [-2, -1, 2, 3, 5],
+                             [True, False, False],
+                             [True],
+                             [False],
+                             [],
+                             [True, None, False],
+                             [True, True, None],
+                             [None, None],
+                             [[0, 5],
+                              [1, 6],
+                              [2, 7],
+                              [3, 8],
+                              [4, 9]],
+                             [[1, True],
+                              [2, False],
+                              [3, False]],
                          ])
 def test_all(data):
-    if data.ndim <= 1:
+    if np.array(data).ndim <= 1:
         pdata = pd.Series(data)
         gdata = Series.from_pandas(pdata)
     else:
-        ncols = data.shape[1]
-        cols = np.random.choice(['a', 'bb', 'ccc', 'dddd', 'eeee'], ncols,
-                                replace=False).tolist()
-        pdata = pd.DataFrame(data, columns=cols)
+        pdata = pd.DataFrame(data, columns=['a', 'b'])
         gdata = DataFrame.from_pandas(pdata)
+
     got = gdata.all()
     expected = pdata.all()
     assert_eq(got, expected)
 
+    # test bool_only
+    if pdata['b'].dtype == 'bool':
+        got = gdata.all(bool_only=True)
+        expected = pdata.all(bool_only=True)
+        assert_eq(got, expected)
+
 
 @pytest.mark.parametrize('data',
                          [
-                             np.array([0, 1, 2, 3]),
-                             np.array([-2, -1, 2, 3, 5]),
-                             np.array([True, False, False]),
-                             np.array([True]),
-                             np.array([False]),
-                             np.array([]),
-                             np.array([True, None, False]),
-                             np.array([True, True, None]),
-                             np.array([None, None]),
-                             np.array([range(5), range(5, 10)]),
-                             np.array([[1, 2, 3], [True, False, False]]),
+                             [0, 1, 2, 3],
+                             [-2, -1, 2, 3, 5],
+                             [True, False, False],
+                             [True],
+                             [False],
+                             [],
+                             [True, None, False],
+                             [True, True, None],
+                             [None, None],
+                             [[0, 5],
+                              [1, 6],
+                              [2, 7],
+                              [3, 8],
+                              [4, 9]],
+                             [[1, True],
+                              [2, False],
+                              [3, False]],
                          ])
 def test_any(data):
-    if data.ndim <= 1:
+    if np.array(data).ndim <= 1:
         pdata = pd.Series(data)
         gdata = Series.from_pandas(pdata)
     else:
-        ncols = data.shape[1]
-        cols = np.random.choice(['a', 'bb', 'ccc', 'dddd', 'eeee'], ncols,
-                                replace=False).tolist()
-        pdata = pd.DataFrame(data, columns=cols)
+        pdata = pd.DataFrame(data, columns=['a', 'b'])
         gdata = DataFrame.from_pandas(pdata)
 
     got = gdata.any()
     expected = pdata.any()
     assert_eq(got, expected)
+
+    # test bool_only
+    if pdata['b'].dtype == 'bool':
+        got = gdata.all(bool_only=True)
+        expected = pdata.all(bool_only=True)
+        assert_eq(got, expected)

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2542,15 +2542,15 @@ def test_all(data):
         pdata = pd.DataFrame(data, columns=['a', 'b'])
         gdata = DataFrame.from_pandas(pdata)
 
+        # test bool_only
+        if pdata['b'].dtype == 'bool':
+            got = gdata.all(bool_only=True)
+            expected = pdata.all(bool_only=True)
+            assert_eq(got, expected)
+
     got = gdata.all()
     expected = pdata.all()
     assert_eq(got, expected)
-
-    # test bool_only
-    if pdata['b'].dtype == 'bool':
-        got = gdata.all(bool_only=True)
-        expected = pdata.all(bool_only=True)
-        assert_eq(got, expected)
 
 
 @pytest.mark.parametrize('data',
@@ -2581,12 +2581,12 @@ def test_any(data):
         pdata = pd.DataFrame(data, columns=['a', 'b'])
         gdata = DataFrame.from_pandas(pdata)
 
+        # test bool_only
+        if pdata['b'].dtype == 'bool':
+            got = gdata.all(bool_only=True)
+            expected = pdata.all(bool_only=True)
+            assert_eq(got, expected)
+
     got = gdata.any()
     expected = pdata.any()
     assert_eq(got, expected)
-
-    # test bool_only
-    if pdata['b'].dtype == 'bool':
-        got = gdata.all(bool_only=True)
-        expected = pdata.all(bool_only=True)
-        assert_eq(got, expected)


### PR DESCRIPTION
**Summary of Changes**
- This PR adds the `all` and `any` methods to Series and DataFrames (and the `any` method to NumericalColumns), analogous to pandas.

Note that the behavior of `pandas.all([None])` does not match Python's built in `all`'s behavior. This PR matches pandas. Additionally, pandas does not appear to restrict the values of `bool_only`. For example:

```python
import pandas as pd
pdf = pd.DataFrame([[1, True],
                    [2, False],
                    [3, False]])
print(pdf.all(bool_only='example'))
print(pdf.all())
1    False
dtype: bool
0     True
1    False
dtype: bool
```