### PR TITLE
[REVIEW] Add column dtype checking for the all/any methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,8 @@
 - PR #1849 Allow DataFrame support methods to pass arguments to the methods
 - PR #1847 Fixed #1375 by moving the nvstring check into the wrapper function
 - PR #1864 Fixing cudf reduction for POWER platform
-- PR #1873 Add column dtype checking for the all/any methods
 - PR #1876 add dtype=bool for `any`, `all` to treat integer column correctly
+- PR #1873 Add column dtype checking for the all/any methods
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - PR #1849 Allow DataFrame support methods to pass arguments to the methods
 - PR #1847 Fixed #1375 by moving the nvstring check into the wrapper function
 - PR #1864 Fixing cudf reduction for POWER platform
+- PR #1873 Add column dtype checking for the all/any methods
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -776,7 +776,7 @@ class Series(object):
         assert axis in (None, 0) and skipna is True and level in (None,)
         if self.dtype.kind not in 'biuf':
             raise NotImplementedError(
-                "all does not currently support columns of {} dtype.".format(
+                "All does not currently support columns of {} dtype.".format(
                     self.dtype))
         return self._column.all()
 
@@ -786,7 +786,7 @@ class Series(object):
         assert axis in (None, 0) and skipna is True and level in (None,)
         if self.dtype.kind not in 'biuf':
             raise NotImplementedError(
-                "any does not currently support columns of {} dtype.".format(
+                "Any does not currently support columns of {} dtype.".format(
                     self.dtype))
         return self._column.any()
 

--- a/python/cudf/dataframe/series.py
+++ b/python/cudf/dataframe/series.py
@@ -774,12 +774,20 @@ class Series(object):
         """
         """
         assert axis in (None, 0) and skipna is True and level in (None,)
+        if self.dtype.kind not in 'biuf':
+            raise NotImplementedError(
+                "all does not currently support columns of {} dtype.".format(
+                    self.dtype))
         return self._column.all()
 
     def any(self, axis=0, skipna=True, level=None):
         """
         """
         assert axis in (None, 0) and skipna is True and level in (None,)
+        if self.dtype.kind not in 'biuf':
+            raise NotImplementedError(
+                "any does not currently support columns of {} dtype.".format(
+                    self.dtype))
         return self._column.any()
 
     def to_gpu_array(self, fillna=None):

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2538,7 +2538,7 @@ def test_round(decimal):
                                  ['b', False],
                                  ['c', False]
                              ], marks=[pytest.mark.xfail(
-                                 reason='NotImplementedError: any does not '
+                                 reason='NotImplementedError: all does not '
                                  'support columns of object dtype.')])
                          ])
 def test_all(data):

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2533,6 +2533,13 @@ def test_round(decimal):
                              [[1, True],
                               [2, False],
                               [3, False]],
+                             pytest.param([
+                                 ['a', True],
+                                 ['b', False],
+                                 ['c', False]
+                             ], marks=[pytest.mark.xfail(
+                                 reason='NotImplementedError: any does not '
+                                 'support columns of object dtype.')])
                          ])
 def test_all(data):
     if np.array(data).ndim <= 1:
@@ -2572,6 +2579,13 @@ def test_all(data):
                              [[1, True],
                               [2, False],
                               [3, False]],
+                             pytest.param([
+                                 ['a', True],
+                                 ['b', False],
+                                 ['c', False]
+                             ], marks=[pytest.mark.xfail(
+                                 reason='NotImplementedError: any does not '
+                                 'support columns of object dtype.')])
                          ])
 def test_any(data):
     if np.array(data).ndim <= 1:


### PR DESCRIPTION
Summary of Changes
- This PR adds a dtype check to the all/any methods to ensure they can currently only be used on NumericalColumns or dataframes of NumericalColumns
- If called on a non-NumericalColumn based Series or a DataFrame containing non-NumericalColumns, these methods will now raise a NotImplementedError
- Adds an xfailing test for future implementation that includes object columns

In the future, we can implement this for object and datetime columns.