### PR TITLE
[REVIEW] Bug fix: add dtype for any, all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 - PR #1849 Allow DataFrame support methods to pass arguments to the methods
 - PR #1847 Fixed #1375 by moving the nvstring check into the wrapper function
 - PR #1864 Fixing cudf reduction for POWER platform
-
+- PR #1876 add dtype=bool for `any`, `all` to treat integer column correctly
 
 # cudf 0.7.2 (16 May 2019)
 

--- a/python/cudf/dataframe/numerical.py
+++ b/python/cudf/dataframe/numerical.py
@@ -245,12 +245,12 @@ class NumericalColumn(columnops.TypedColumnBase):
         return out_vals, out_counts
 
     def all(self):
-        return bool(self.min())
+        return bool(self.min(dtype=np.bool_))
 
     def any(self):
         if self.valid_count == 0:
             return False
-        return bool(self.max())
+        return bool(self.max(dtype=np.bool_))
 
     def min(self, dtype=None):
         return cpp_reduce.apply_reduce('min', self, dtype=dtype)

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -2518,6 +2518,7 @@ def test_round(decimal):
                          [
                              [0, 1, 2, 3],
                              [-2, -1, 2, 3, 5],
+                             [-2, -1, 0, 3, 5],
                              [True, False, False],
                              [True],
                              [False],
@@ -2557,6 +2558,7 @@ def test_all(data):
                          [
                              [0, 1, 2, 3],
                              [-2, -1, 2, 3, 5],
+                             [-2, -1, 0, 3, 5],
                              [True, False, False],
                              [True],
                              [False],


### PR DESCRIPTION
If an integer column has minus and 0 value, the any, all result got wrong
 e.g.  [-2, -1, 0, 3, 5]  the expected result is True for `any`, False for `all`
   However, the old implementation do 'min' or 'max' of integer column, then cast it to boolean, the result got wrong.

This PR corrects it using `dtype=np.bool_` reduction option for `any` and `all`.

Related PR #1863 Issue #1874

