### PR TITLE
[REVIEW] Add iloc and tests for MultiIndex dataframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PR #1827 Create bindings for scalar-vector binops, and update one_hot_encoding to use them
 - PR #1817 Operators now support different sized dataframes as long as they don't share different sized columns
 - PR #1846 C++ type-erased gdf_equal_columns test util; fix gdf_equal_columns logic error
+- PR #1882 Add iloc functionality to MultiIndex dataframes
 
 ## Bug Fixes
 

--- a/python/cudf/dataframe/multiindex.py
+++ b/python/cudf/dataframe/multiindex.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2019, NVIDIA CORPORATION.
 
+import numbers
+
 import pandas as pd
 import numpy as np
 import warnings
@@ -8,6 +10,7 @@ from collections.abc import Sequence
 
 from cudf.dataframe import columnops
 from cudf.dataframe.series import Series
+from cudf.dataframe.index import as_index
 from cudf.comm.serialize import register_distributed_serializer
 from cudf.dataframe.index import Index, StringIndex
 from cudf.utils import utils
@@ -199,7 +202,22 @@ class MultiIndex(Index):
         return validity_mask
 
     def _get_row_major(self, df, row_tuple):
-        valid_indices = self._compute_validity_mask(df, row_tuple)
+        print(row_tuple)
+        slice_access = False
+        if isinstance(row_tuple[0], numbers.Number):
+            valid_indices = row_tuple[0]
+        elif isinstance(row_tuple[0], slice):
+            # 1. empty slice compute
+            if row_tuple[0].stop == 0:
+                valid_indices = []
+            else:
+                slice_access = True
+                start = row_tuple[0].start or 0
+                stop = row_tuple[0].stop or len(df)
+                step = row_tuple[0].step or 1
+                valid_indices = np.array(range(start, stop, step))
+        else:
+            valid_indices = self._compute_validity_mask(df, row_tuple)
         from cudf import Series
         result = df.take(Series(valid_indices))
         # Build new index - INDEX based MultiIndex
@@ -208,29 +226,34 @@ class MultiIndex(Index):
         out_index = DataFrame()
         # Select the last n-k columns where n is the number of source
         # levels and k is the length of the indexing tuple
-        for k in range(len(row_tuple), len(df.index.levels)):
+        size = 0
+        if not isinstance(row_tuple[0], (numbers.Number, slice)):
+            size = len(row_tuple)
+        for k in range(size, len(df.index.levels)):
             out_index.add_column(df.index.names[k],
                                  df.index.codes[df.index.codes.columns[k]])
         # If there's only one column remaining in the output index, convert
-        # it into a StringIndex and name the final index values according
+        # it into an Index and name the final index values according
         # to the proper codes.
         if len(out_index.columns) == 1:
             out_index = []
             for val in result.index.codes[result.index.codes.columns[len(result.index.codes.columns)-1]]:  # noqa: E501
                 out_index.append(result.index.levels[
                         len(result.index.codes.columns)-1][val])
-            # TODO: Warning! The final index column could be arbitrarily
-            # ordered integers, not Strings, so we need to check for that
-            # dtype and produce a GenericIndex instead of a StringIndex
-            out_index = StringIndex(out_index)
+            out_index = as_index(out_index)
             out_index.name = result.index.names[len(result.index.names)-1]
             result.index = out_index
         else:
-            # Otherwise pop the leftmost levels, names, and codes from the
-            # source index until it has the correct number of columns (n-k)
-            if(len(out_index.columns)) > 0:
+            if len(result) == 1 and size == 0 and slice_access == False:
+                # If the final result is one row and it was not mapped into
+                # directly
+                result = result.T
+                result = result[result.columns[0]]
+            elif(len(out_index.columns)) > 0:
+                # Otherwise pop the leftmost levels, names, and codes from the
+                # source index until it has the correct number of columns (n-k)
                 result.reset_index(drop=True)
-                result.index = result.index._popn(len(row_tuple))
+                result.index = result.index._popn(size)
         return result
 
     def _get_column_major(self, df, row_tuple):

--- a/python/cudf/dataframe/multiindex.py
+++ b/python/cudf/dataframe/multiindex.py
@@ -13,7 +13,7 @@ from cudf.dataframe.series import Series
 from cudf.dataframe.index import as_index
 from cudf.comm.serialize import register_distributed_serializer
 from cudf.dataframe.index import Index, StringIndex
-from cudf.utils import utils
+from cudf.utils import cudautils, utils
 
 
 class MultiIndex(Index):
@@ -214,7 +214,7 @@ class MultiIndex(Index):
                 start = row_tuple[0].start or 0
                 stop = row_tuple[0].stop or len(df)
                 step = row_tuple[0].step or 1
-                valid_indices = np.array(range(start, stop, step))
+                valid_indices = cudautils.arange(start, stop, step)
         else:
             valid_indices = self._compute_validity_mask(df, row_tuple)
         from cudf import Series
@@ -327,7 +327,7 @@ class MultiIndex(Index):
         elif isinstance(indices, slice):
             start, stop, step, sln = utils.standard_python_slice(len(self),
                                                                  indices)
-            indices = np.arange(start, stop, step)
+            indices = cudautils.arange(start, stop, step)
         if hasattr(self, '_source_data'):
             result = MultiIndex(source_data=self._source_data.take(indices))
         else:

--- a/python/cudf/dataframe/multiindex.py
+++ b/python/cudf/dataframe/multiindex.py
@@ -202,7 +202,6 @@ class MultiIndex(Index):
         return validity_mask
 
     def _get_row_major(self, df, row_tuple):
-        print(row_tuple)
         slice_access = False
         if isinstance(row_tuple[0], numbers.Number):
             valid_indices = row_tuple[0]

--- a/python/cudf/dataframe/multiindex.py
+++ b/python/cudf/dataframe/multiindex.py
@@ -244,7 +244,7 @@ class MultiIndex(Index):
             out_index.name = result.index.names[len(result.index.names)-1]
             result.index = out_index
         else:
-            if len(result) == 1 and size == 0 and slice_access == False:
+            if len(result) == 1 and size == 0 and slice_access is False:
                 # If the final result is one row and it was not mapped into
                 # directly
                 result = result.T

--- a/python/cudf/indexing.py
+++ b/python/cudf/indexing.py
@@ -68,7 +68,6 @@ class _SeriesIlocIndexer(object):
 class _DataFrameIndexer(object):
 
     def __getitem__(self, arg):
-
         if type(arg) is not tuple:
             arg = (arg, slice(None, None))
 
@@ -237,6 +236,12 @@ class _DataFrameIlocIndexer(_DataFrameIndexer):
     def _getitem_scalar(self, arg):
         col = self._df.columns[arg[1]]
         return self._df[col].iloc[arg[0]]
+
+    def _getitem_multiindex_arg(self, arg):
+        # Explicitly ONLY support tuple indexes into MultiIndex.
+        # Pandas allows non tuple indices and warns "results may be
+        # undefined."
+        return self._df._index._get_row_major(self._df, arg)
 
     def _get_column_selection(self, arg):
         cols = self._df.columns

--- a/python/cudf/tests/test_multiindex.py
+++ b/python/cudf/tests/test_multiindex.py
@@ -462,3 +462,18 @@ def test_multiindex_copy():
 
     mi2 = mi1.copy(deep=True)
     assert_eq(mi1, mi2)
+
+def test_multiindex_iloc(pdf, gdf, pdfIndex):
+    gdfIndex = cudf.from_pandas(pdfIndex)
+    assert_eq(pdfIndex, gdfIndex)
+    pdf.index = pdfIndex
+    gdf.index = gdfIndex
+    assert_eq(pdf.iloc[0], gdf.iloc[0])
+    assert_eq(pdf.iloc[1], gdf.iloc[1])
+    assert_eq(pdf.iloc[:0], gdf.iloc[:0])
+    assert_eq(pdf.iloc[:1], gdf.iloc[:1])
+    assert_eq(pdf.iloc[0:1], gdf.iloc[0:1])
+    assert_eq(pdf.iloc[1:2], gdf.iloc[1:2])
+    assert_eq(pdf.iloc[0:2], gdf.iloc[0:2])
+    assert_eq(pdf.iloc[0:], gdf.iloc[0:])
+    assert_eq(pdf.iloc[1:], gdf.iloc[1:])

--- a/python/cudf/tests/test_multiindex.py
+++ b/python/cudf/tests/test_multiindex.py
@@ -463,6 +463,7 @@ def test_multiindex_copy():
     mi2 = mi1.copy(deep=True)
     assert_eq(mi1, mi2)
 
+
 def test_multiindex_iloc(pdf, gdf, pdfIndex):
     gdfIndex = cudf.from_pandas(pdfIndex)
     assert_eq(pdfIndex, gdfIndex)


### PR DESCRIPTION
This fixes https://github.com/rapidsai/dask-cudf/issues/125, which depended on MultiIndex supporting `iloc` indexing. This PR adds iloc indexing to dataframes with multiindexes.