### PR TITLE
[REVIEW] Add a pandas-esque get_dummies wrapper around cudf.DataFrame.one_hot_encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PR #1796 Removing old sort based group by code and gdf_filter
 - PR #1811 Added funtions for copying/allocating `cudf::table`s
 - PR #1838 Improve columnops.column_empty so that it returns typed columns instead of a generic Column
+- PR #1890 Add utils.get_dummies- a pandas-like wrapper around one_hot-encoding
 - PR #1823 CSV Reader: default the column type to string for empty dataframes
 - PR #1827 Create bindings for scalar-vector binops, and update one_hot_encoding to use them
 - PR #1817 Operators now support different sized dataframes as long as they don't share different sized columns

--- a/python/cudf/tests/test_onehot.py
+++ b/python/cudf/tests/test_onehot.py
@@ -127,4 +127,3 @@ def test_onehot_get_dummies_multicol(n_cols):
 
 if __name__ == '__main__':
     test_onehot_random()
-

--- a/python/cudf/tests/test_onehot.py
+++ b/python/cudf/tests/test_onehot.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
 import numpy as np
+import pytest
 
 from cudf.dataframe import DataFrame, Series, GenericIndex
 from cudf.tests import utils
+from cudf.utils.utils import get_dummies
 
 
 def test_onehot_simple():
@@ -88,5 +90,41 @@ def test_onehot_generic_index():
     np.testing.assert_array_equal(values == 3, out.fo_3.to_array())
 
 
+def test_onehot_get_dummies_simple():
+    df = DataFrame({'x': np.arange(10)})
+    original = df.copy()
+    encoded = get_dummies(df, prefix='test')
+
+    assert df == original  # the original df should be unchanged
+    cols = list(encoded.columns)[1:]
+    actual = DataFrame(dict(zip(cols, np.eye(len(cols)))))
+    assert (encoded.loc[:, cols] == actual).all().all()
+
+
+@pytest.mark.parametrize('n_cols', [5, 10, 20])
+def test_onehot_get_dummies_multicol(n_cols):
+    from string import ascii_lowercase
+    n_categories = 5
+    df = DataFrame(
+        dict(zip(ascii_lowercase,
+                 (np.arange(n_categories) for _ in range(n_cols))))
+    )
+    original = df.copy()
+    encoded = get_dummies(df, prefix='test')
+
+    assert df == original
+
+    cols = list(encoded.columns)[n_cols:]
+    actual = DataFrame(
+        dict(
+            zip(cols,
+                np.concatenate(list(np.eye(n_categories)
+                                    for _ in range(n_cols))))
+        )
+    )
+    assert (encoded.loc[:, cols] == actual).all().all()
+
+
 if __name__ == '__main__':
     test_onehot_random()
+

--- a/python/cudf/utils/utils.py
+++ b/python/cudf/utils/utils.py
@@ -245,8 +245,8 @@ def get_dummies(df, prefix='', prefix_sep='_', cats={}, columns=None,
         df.one_hot_encoding(
             name,
             prefix=name
-                    + (prefix_sep if prefix else '')
-                    + prefix_map.get(name, prefix),
+            + (prefix_sep if prefix else '')
+            + prefix_map.get(name, prefix),
             cats=cats.get(name, df[name].unique()),
             prefix_sep=prefix_sep,
             dtype=dtype)

--- a/python/cudf/utils/utils.py
+++ b/python/cudf/utils/utils.py
@@ -226,7 +226,7 @@ def get_dummies(df, prefix, prefix_sep='_', cats={}, columns=None,
         columns. Note this is different from pandas default behavior, which
         encodes all columns with dtype object or categorical
     dtype : str, optional
-        output dtyle, default 'float64'
+        output dtype, default 'float64'
     """
     from cudf.multi import concat
 

--- a/python/cudf/utils/utils.py
+++ b/python/cudf/utils/utils.py
@@ -211,9 +211,10 @@ def get_dummies(df, prefix, prefix_sep='_', cats={}, columns=None,
     ----------
     df : cudf.DataFrame
         dataframe to encode
-    prefix : str or dict
-        prefix to append. Either a str (to apply a constant prefix) or a
-        mapping of column names to prefixes
+    prefix : str, dict, or sequence
+        prefix to append. Either a str (to apply a constant prefix), dict
+        mapping column names to prefixes, or sequence of prefixes to apply with
+        the same length as the number of columns
     prefix_sep : str, optional
         separator to use when appending prefixes
     cats : dict, optional
@@ -229,13 +230,15 @@ def get_dummies(df, prefix, prefix_sep='_', cats={}, columns=None,
     """
     from cudf.multi import concat
 
-    if isinstance(prefix, str):
-        prefix_map = {}
-    else:
-        prefix_map = prefix
-
     if columns is None:
         columns = df.columns
+
+    if isinstance(prefix, str):
+        prefix_map = {}
+    elif isinstance(prefix, dict):
+        prefix_map = prefix
+    else:
+        prefix_map = dict(zip(columns, prefix))
 
     return concat([
         df.one_hot_encoding(

--- a/python/cudf/utils/utils.py
+++ b/python/cudf/utils/utils.py
@@ -243,7 +243,7 @@ def get_dummies(df, prefix, prefix_sep='_', cats={}, columns=None,
     return concat([
         df.one_hot_encoding(
             name,
-            prefix=prefix_map.get(name, prefix),
+            prefix=name + prefix_sep + prefix_map.get(name, prefix),
             cats=cats.get(name, df[name].unique()),
             prefix_sep=prefix_sep,
             dtype=dtype)

--- a/python/cudf/utils/utils.py
+++ b/python/cudf/utils/utils.py
@@ -200,3 +200,38 @@ def cudf_dtype_from_pydata_dtype(dtype):
         dtype = np.datetime64
 
     return infer_dtype_from_object(dtype)
+
+
+def get_dummies(df, prefix, prefix_sep='_', cats=None, dtype='float64'):
+    """ Returns a dataframe whose columns are the one hot encodings of all
+    columns in `df`
+
+    Parameters
+    ----------
+    df : cudf.DataFrame
+        dataframe to encode
+    prefix : str
+        prefix to append
+    prefix_sep : str, optional
+        separator to use when appending prefixes
+    cats : dict, optional
+        dictionary mapping column names to sequences of integers representing
+        that column's category. See `cudf.DataFrame.one_hot_encoding` for more
+        information. if None, it will be computed
+    dtype : str, optional
+        output dtyle, default 'float64'
+
+    """
+    from cudf.multi import concat
+    dummies= []
+    for name, col in df.iteritems():
+        if cats is None or name not in cats:
+            col_uniques = col.unique()
+        else:
+            col_uniques = cats[name]
+        dummies.append(df.one_hot_encoding(name,
+                                           prefix=prefix,
+                                           cats=col_uniques,
+                                           prefix_sep=prefix_sep,
+                                           dtype=dtype)
+    return concat(dummies)

--- a/python/cudf/utils/utils.py
+++ b/python/cudf/utils/utils.py
@@ -202,7 +202,7 @@ def cudf_dtype_from_pydata_dtype(dtype):
     return infer_dtype_from_object(dtype)
 
 
-def get_dummies(df, prefix, prefix_sep='_', cats={}, columns=None,
+def get_dummies(df, prefix='', prefix_sep='_', cats={}, columns=None,
                 dtype='float64'):
     """ Returns a dataframe whose columns are the one hot encodings of all
     columns in `df`
@@ -211,10 +211,11 @@ def get_dummies(df, prefix, prefix_sep='_', cats={}, columns=None,
     ----------
     df : cudf.DataFrame
         dataframe to encode
-    prefix : str, dict, or sequence
+    prefix : str, dict, or sequence, optional
         prefix to append. Either a str (to apply a constant prefix), dict
         mapping column names to prefixes, or sequence of prefixes to apply with
-        the same length as the number of columns
+        the same length as the number of columns. If not supplied, defaults
+        to the empty string
     prefix_sep : str, optional
         separator to use when appending prefixes
     cats : dict, optional

--- a/python/cudf/utils/utils.py
+++ b/python/cudf/utils/utils.py
@@ -244,7 +244,9 @@ def get_dummies(df, prefix='', prefix_sep='_', cats={}, columns=None,
     return concat([
         df.one_hot_encoding(
             name,
-            prefix=name + prefix_sep + prefix_map.get(name, prefix),
+            prefix=name
+                    + (prefix_sep if prefix else '')
+                    + prefix_map.get(name, prefix),
             cats=cats.get(name, df[name].unique()),
             prefix_sep=prefix_sep,
             dtype=dtype)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
Unlike cudf, pandas doesn't directly expose a one hot encoding method in its dataframes. One hot encoding is done though a global utility [`pandas.get_dummies`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.get_dummies.html). More context can be found in issue #1063 

This PR implements a cudf approximation of that, to the extent that's currently possible. More specifically:

```python
# pandas
def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False, columns=None, 
                sparse=False, drop_first=False, dtype=None)

# cudf 
def get_dummies(df, prefix, prefix_sep='_', cats={}, columns=None, dtype='float64')
```
- `data` maps directly to `df`
- `prefix`  and `prefix_sep` share the same functionality
- `dummy_na` is not supported. Instead, this implementation follows the default pandas behavior of ignoring `NaN`s
- `columns`, like in pandas, specifies which columns to encode. Unlike pandas however, the default behavior when `columns` is not provided is to encode all columns, (rather than only those with categorical or object dtype as in pandas)
- `sparse` is not supported by cudf
- `drop_first` is not supported by cudf
- `dtype` shares the same behavior as pandas, save that the default dtype is `float64` to fit with `cudf.DataFrame.one_hot_encoding`
- `cats`, an optional argument not present in pandas, allows optionally passing in precomputed categories to reduce overhead