### PR TITLE
[REVIEW] Rename namespace gdf to namespace cudf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - PR #1846 C++ type-erased gdf_equal_columns test util; fix gdf_equal_columns logic error
 - PR #1882 Add iloc functionality to MultiIndex dataframes
 - PR #1896 Improve performance of groupby with levels specified in dask-cudf
+- PR #1919 Rename libcudf namespace gdf to namespace cudf.
 
 ## Bug Fixes
 

--- a/cpp/src/bitmask/bit_mask.cuh
+++ b/cpp/src/bitmask/bit_mask.cuh
@@ -25,7 +25,7 @@
 #include <utilities/integer_utils.hpp>
 
 namespace bit_mask {
-enum { bits_per_element = gdf::util::size_in_bits<bit_mask_t>() };
+enum { bits_per_element = cudf::util::size_in_bits<bit_mask_t>() };
 
 /**
  * @brief determine the number of bit_mask_t elements required for @p size bits
@@ -166,7 +166,7 @@ CUDA_HOST_DEVICE_CALLABLE bool is_valid(bit_mask_t const * __restrict__ valid, T
   static_assert(std::is_integral<T>::value,
                 "Record index must be of an integral type");
 
-  return gdf::util::bit_is_set<bit_mask_t, T>(valid, record_idx);
+  return cudf::util::bit_is_set<bit_mask_t, T>(valid, record_idx);
 }
 
 /**
@@ -187,7 +187,7 @@ CUDA_HOST_DEVICE_CALLABLE void set_bit_unsafe(bit_mask_t *valid, T record_idx) {
   static_assert(std::is_integral<T>::value,
                 "Record index must be of an integral type");
 
-  gdf::util::turn_bit_on(valid, record_idx);
+  cudf::util::turn_bit_on(valid, record_idx);
 }
 
 /**
@@ -209,7 +209,7 @@ CUDA_HOST_DEVICE_CALLABLE void clear_bit_unsafe(bit_mask_t *valid,
   static_assert(std::is_integral<T>::value,
                 "Record index must be of an integral type");
 
-  return gdf::util::turn_bit_off(valid, record_idx);
+  return cudf::util::turn_bit_off(valid, record_idx);
 }
 
 /**
@@ -229,9 +229,9 @@ CUDA_DEVICE_CALLABLE void set_bit_safe(bit_mask_t *valid, T record_idx) {
                 "Record index must be of an integral type");
 
   const gdf_size_type rec{
-      gdf::util::detail::bit_container_index<bit_mask_t, T>(record_idx)};
+      cudf::util::detail::bit_container_index<bit_mask_t, T>(record_idx)};
   const gdf_size_type bit{
-      gdf::util::detail::intra_container_index<bit_mask_t, T>(record_idx)};
+      cudf::util::detail::intra_container_index<bit_mask_t, T>(record_idx)};
 
   atomicOr(&valid[rec], (bit_mask_t{1} << bit));
 }
@@ -253,9 +253,9 @@ CUDA_DEVICE_CALLABLE void clear_bit_safe(bit_mask_t *valid, T record_idx) {
                 "Record index must be of an integral type");
 
   const gdf_size_type rec{
-      gdf::util::detail::bit_container_index<bit_mask_t, T>(record_idx)};
+      cudf::util::detail::bit_container_index<bit_mask_t, T>(record_idx)};
   const gdf_size_type bit{
-      gdf::util::detail::intra_container_index<bit_mask_t, T>(record_idx)};
+      cudf::util::detail::intra_container_index<bit_mask_t, T>(record_idx)};
 
   atomicAnd(&valid[rec], ~(bit_mask_t{1} << bit));
 }

--- a/cpp/src/copying/slice.cu
+++ b/cpp/src/copying/slice.cu
@@ -80,8 +80,8 @@ void slice_bitmask_kernel(bit_mask_t*           output_bitmask,
   gdf_index_type input_index_begin = indices[indices_position * 2];
   gdf_index_type input_index_end = indices[indices_position * 2 + 1];
 
-  gdf_index_type input_offset = gdf::util::detail::bit_container_index<bit_mask_t, gdf_index_type>(input_index_begin);
-  gdf_index_type rotate_input = gdf::util::detail::intra_container_index<bit_mask_t, gdf_index_type>(input_index_begin);
+  gdf_index_type input_offset = cudf::util::detail::bit_container_index<bit_mask_t, gdf_index_type>(input_index_begin);
+  gdf_index_type rotate_input = cudf::util::detail::intra_container_index<bit_mask_t, gdf_index_type>(input_index_begin);
   bit_mask_t mask_last = (bit_mask_t{1} << ((input_index_end - input_index_begin) % bit_mask::bits_per_element)) - bit_mask_t{1};
 
   gdf_size_type input_block_length = bit_mask::num_elements(input_size);

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -154,7 +154,7 @@ void gpu_rolling(gdf_size_type nrows,
 
     // set the mask
     bit_mask_t const result_mask{__ballot_sync(active_threads, output_is_valid)};
-    gdf_index_type const out_mask_location = gdf::util::detail::bit_container_index<bit_mask_t, gdf_index_type>(i);
+    gdf_index_type const out_mask_location = cudf::util::detail::bit_container_index<bit_mask_t, gdf_index_type>(i);
 
     // only one thread writes the mask
     if (0 == threadIdx.x % warpSize)

--- a/cpp/src/utilities/bit_util.cuh
+++ b/cpp/src/utilities/bit_util.cuh
@@ -39,7 +39,7 @@
 #endif
 #endif
 
-namespace gdf {
+namespace cudf {
 namespace util {
 
 template <typename T>
@@ -117,4 +117,4 @@ inline constexpr gdf_size_type packed_bit_sequence_size_in_bytes (Size num_bits)
 
 
 } // namespace util
-} // namespace gdf
+} // namespace cudf

--- a/cpp/tests/binary/integration/binary-operation-operands-null-test.cpp
+++ b/cpp/tests/binary/integration/binary-operation-operands-null-test.cpp
@@ -151,4 +151,4 @@ TEST_F(BinaryOperationOperandsNullTest, Vector_Vector_FP64) {
 
 } // namespace binop
 } // namespace test
-} // namespace gdf
+} // namespace cudf

--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -78,7 +78,7 @@ struct ColumnConcatTest : public testing::Test
     std::vector<gdf_valid_type> ref_valid(gdf_valid_allocation_size(total_size));
     for (gdf_size_type index = 0, col = 0, row = 0; index < total_size; ++index)
     {
-      if (null_init(row, col)) gdf::util::turn_bit_on(ref_valid.data(), index);
+      if (null_init(row, col)) cudf::util::turn_bit_on(ref_valid.data(), index);
       else ref_null_count++;
       
       if (++row >= column_sizes[col]) { row = 0; col++; }

--- a/cpp/tests/utilities/column_wrapper.cuh
+++ b/cpp/tests/utilities/column_wrapper.cuh
@@ -225,7 +225,7 @@ struct column_wrapper {
     std::vector<gdf_valid_type> host_bitmask(num_masks, 0);
     for (gdf_index_type row = 0; row < num_rows; ++row) {
       if (true == bit_initializer(row)) {
-        gdf::util::turn_bit_on(host_bitmask.data(), row);
+        cudf::util::turn_bit_on(host_bitmask.data(), row);
       }
     }
     initialize_with_host_data(host_data, host_bitmask);
@@ -264,7 +264,7 @@ struct column_wrapper {
       host_data[row] = value_initalizer(row);
 
       if (true == bit_initializer(row)) {
-        gdf::util::turn_bit_on(host_bitmask.data(), row);
+        cudf::util::turn_bit_on(host_bitmask.data(), row);
       }
     }
     initialize_with_host_data(host_data, host_bitmask);

--- a/cpp/tests/utilities/cudf_test_utils.cuh
+++ b/cpp/tests/utilities/cudf_test_utils.cuh
@@ -268,7 +268,7 @@ gdf_col_pointer init_gdf_column(std::vector<T> data, size_t col_index, valid_ini
   for(size_t row = 0; row < num_rows; ++row){
     if(true == bit_initializer(row, col_index))
     {
-      gdf::util::turn_bit_on(valid_masks.data(), row);
+      cudf::util::turn_bit_on(valid_masks.data(), row);
     }
   }
 

--- a/cpp/tests/utilities/valid_vectors.cpp
+++ b/cpp/tests/utilities/valid_vectors.cpp
@@ -24,9 +24,9 @@ host_valid_pointer create_and_init_valid(size_t length, size_t null_count)
   auto valid_bits = new gdf_valid_type[n_bytes];
    for (size_t i = 0; i < length; ++i) {
     if ((float)std::rand()/(RAND_MAX + 1u) >= (float)null_count/(length-i)) {
-      gdf::util::turn_bit_on(valid_bits, i);
+      cudf::util::turn_bit_on(valid_bits, i);
     } else {
-      gdf::util::turn_bit_off(valid_bits, i);
+      cudf::util::turn_bit_off(valid_bits, i);
       --null_count;
     }
   }


### PR DESCRIPTION
Rename `namespace gdf` to `namespace cudf` to bring it up to date.