### PR TITLE
[REVIEW] Use prefix removal instead of multiindex for when two aggs are called on a SeriesGroupby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 - PR #1909 Support of `to_pandas()` of boolean series with null values
 - PR #1923 Use prefix removal when two aggs are called on a SeriesGroupBy
 
+
 # cudf 0.7.2 (16 May 2019)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@
 - PR #1887 Fix for initialization issue in pq_read_arg,orc_read_arg
 - PR #1867 JSON reader: add support for null/empty fields, including the 'null' literal
 - PR #1909 Support of `to_pandas()` of boolean series with null values
-
+- PR #1923 Use prefix removal when two aggs are called on a SeriesGroupBy
 
 # cudf 0.7.2 (16 May 2019)
 

--- a/python/cudf/groupby/groupby.py
+++ b/python/cudf/groupby/groupby.py
@@ -70,7 +70,7 @@ class SeriesGroupBy(object):
             df['y'] = self.group_series
         groupby = df.groupby('y').agg(agg_types)
         idx = groupby.index
-        idx.name = None
+        idx.name = self.group_name
         groupby.set_index(idx)
         return groupby
 
@@ -236,29 +236,32 @@ class Groupby(object):
             return final_result.set_index(multi_index)
 
     def apply_multicolumn(self, result, aggs):
-        levels = []
-        codes = []
-        levels.append(self._val_columns)
-        levels.append(aggs)
-
-        # if the values columns have length == 1, codes is a nested list of
-        # zeros equal to the size of aggs (sum, min, mean, etc.)
-        # if the values columns are length>1, codes will monotonically
-        # increase by 1 for every n values where n is the number of aggs
-        # [['x,', 'z'], ['sum', 'min']]
-        # codes == [[0, 1], [0, 1]]
-        code_size = max(len(aggs), len(self._val_columns))
-        codes.append(list(np.zeros(code_size, dtype='int64')))
-        codes.append(list(range(code_size)))
-
-        if len(aggs) == 1:
+        # multicolumn only applies with multiple aggs and multiple groupby keys
+        if len(aggs) == 1 or len(self._by) == 1:
             # unprefix columns
             new_cols = []
             for c in result.columns:
-                new_col = c.split('_')[1]  # sum_z-> (sum, z)
+                if len(self._by) == 1 and len(result) != 0:
+                    new_col = c.split('_')[0]  # sum_z-> (sum, z)
+                else:
+                    new_col = c.split('_')[1]  # sum_z-> (sum, z)
                 new_cols.append(new_col)
             result.columns = new_cols
         else:
+            levels = []
+            codes = []
+            levels.append(self._val_columns)
+            levels.append(aggs)
+
+            # if the values columns have length == 1, codes is a nested list of
+            # zeros equal to the size of aggs (sum, min, mean, etc.)
+            # if the values columns are length>1, codes will monotonically
+            # increase by 1 for every n values where n is the number of aggs
+            # [['x,', 'z'], ['sum', 'min']]
+            # codes == [[0, 1], [0, 1]]
+            code_size = max(len(aggs), len(self._val_columns))
+            codes.append(list(np.zeros(code_size, dtype='int64')))
+            codes.append(list(range(code_size)))
             result.columns = MultiIndex(levels, codes)
         return result
 

--- a/python/cudf/tests/test_groupby.py
+++ b/python/cudf/tests/test_groupby.py
@@ -554,3 +554,12 @@ def test_groupby_apply_basic_agg_single_column():
     gdg = gdf.groupby(['key', 'val']).mult.sum()
     pdg = pdf.groupby(['key', 'val']).mult.sum()
     assert_eq(pdg, gdg)
+
+
+def test_groupby_multi_agg_single_groupby_series():
+    pdf = pd.DataFrame({"x": np.random.randint(0, 5, size=10000),
+                        "y": np.random.normal(size=10000)})
+    gdf = cudf.from_pandas(pdf)
+    pdg = pdf.groupby("x").y.agg(["sum", "max"])
+    gdg = gdf.groupby("x").y.agg(["sum", "max"])
+    assert_eq(pdg, gdg)


### PR DESCRIPTION
This fixes https://github.com/rapidsai/cudf/issues/1920 and https://github.com/rapidsai/dask-cudf/issues/93