### PR TITLE
Add specialization for bool8 constructor to cast argument to bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - PR #1859 Convert read_json into a C++ API
 - PR #1919 Rename libcudf namespace gdf to namespace cudf
 - PR #1850 Support left_on and right_on for DataFrame merge operator  
+- PR #1930 Specialize constructor for `cudf::bol8` to cast argument to `bool`
 
 
 ## Bug Fixes

--- a/cpp/src/utilities/wrapper_types.hpp
+++ b/cpp/src/utilities/wrapper_types.hpp
@@ -77,11 +77,19 @@ struct wrapper
   using value_type = T;                                          ///< The underlying fundamental type of the wrapper
   value_type value;                                              ///< The wrapped value
 
+  template <gdf_dtype dtype = type_id,
+            std::enable_if_t<(dtype != GDF_BOOL8)> * = nullptr>
   CUDA_HOST_DEVICE_CALLABLE
   constexpr explicit wrapper(T v) : value{v} {}
 
-  CUDA_HOST_DEVICE_CALLABLE
-  explicit operator value_type() const { return this->value; }
+  template <gdf_dtype dtype = type_id,
+            std::enable_if_t<(dtype == GDF_BOOL8)> * = nullptr>
+  CUDA_HOST_DEVICE_CALLABLE constexpr explicit wrapper(T v)
+      : value{static_cast<bool>(v)} {}
+
+  CUDA_HOST_DEVICE_CALLABLE explicit operator value_type() const {
+    return this->value;
+  }
 
   // enable conversion to arithmetic types *only* for the cudf::bool8 wrapper
   // (defined later in this file as wrapper<gdf_bool8, GDF_BOOL8>)
@@ -220,7 +228,6 @@ wrapper<T,type_id> operator/(wrapper<T,type_id> const& lhs, wrapper<T,type_id> c
      * 
      * @returns A reference to the underlying wrapped value  
      */
-/* ----------------------------------------------------------------------------*/
 template <typename T, gdf_dtype type_id>
 CUDA_HOST_DEVICE_CALLABLE
 typename wrapper<T, type_id>::value_type &
@@ -349,10 +356,8 @@ using bool8 = detail::wrapper<gdf_bool8, GDF_BOOL8>;
 // We can't rely on --expt-relaxed-constexpr here because `bool8` is not a
 // scalar type. See CUDA Programming guide
 // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#constexpr-variables
-#define HOST_DEVICE_CONSTANT
 #ifdef __CUDA_ARCH__
 __device__ __constant__ static bool8 true_v{gdf_bool8{1}};
-
 __device__ __constant__ static bool8 false_v{gdf_bool8{0}};
 #else
 static constexpr bool8 true_v{gdf_bool8{1}};

--- a/cpp/tests/types/types_test.cpp
+++ b/cpp/tests/types/types_test.cpp
@@ -211,7 +211,6 @@ TYPED_TEST(WrappersNoBoolTest, BooleanOperators)
 // Ensure bool8 constructor is correctly casting the input type to a bool
 TEST_F(WrappersTestBool8, BooleanConstructor) {
   using UnderlyingType = cudf::bool8::value_type;
-  cudf::bool8 const w{t};
   for (int i = 0; i < NUM_TRIALS; ++i) {
     UnderlyingType t{this->rand()};
     cudf::bool8 const w{t};

--- a/cpp/tests/types/types_test.cpp
+++ b/cpp/tests/types/types_test.cpp
@@ -208,6 +208,17 @@ TYPED_TEST(WrappersNoBoolTest, BooleanOperators)
     EXPECT_TRUE(w2 <= w3);
 }
 
+// Ensure bool8 constructor is correctly casting the input type to a bool
+TEST_F(WrappersTestBool8, BooleanConstructor) {
+  using UnderlyingType = cudf::bool8::value_type;
+  cudf::bool8 const w{t};
+  for (int i = 0; i < NUM_TRIALS; ++i) {
+    UnderlyingType t{this->rand()};
+    cudf::bool8 const w{t};
+    EXPECT_EQ(unwrap(w), static_cast<bool>(t));
+  }
+}
+
 // Just for booleans
 TEST_F(WrappersTestBool8, BooleanOperatorsBool8)
 {


### PR DESCRIPTION
Constructing a `cudf::bool8` with any value should be the same as first casting that value to `bool` and then constructing the `bool8`.

This PR adds a specialization for `wrapper` constructor for `GDF_BOOL8` that ensures the above is true. 

Also removed an errant `HOST_DEVICE_CONSTANT` definition that was not used. 