### PR TITLE
Add `bool8(bool)` constructor

### DIFF
--- a/cpp/src/utilities/wrapper_types.hpp
+++ b/cpp/src/utilities/wrapper_types.hpp
@@ -80,7 +80,7 @@ struct wrapper
   template <gdf_dtype dtype = type_id,
             std::enable_if_t<(dtype != GDF_BOOL8)> * = nullptr>
   CUDA_HOST_DEVICE_CALLABLE
-  constexpr explicit wrapper(T v) : value{v} {}
+  constexpr explicit wrapper(value_type v) : value{v} {}
 
   // Constructing a bool8 from any value should be the same as first casting the
   // value to a `bool`


### PR DESCRIPTION
Depends on https://github.com/rapidsai/cudf/pull/1930

It would be nice to be able to construct a `bool8` from a `bool`. This PR adds that functionality.

However, in order to provide this functionality, I also had to update the `bool8` arithmetic operator overloads. The reasons for this are a bit nuanced. For example:

```
cudf::bool8 operator+(cudf::bool8 const &lhs, cudf::bool8 const &rhs){
   return cudf::bool8{static_cast<bool>(bool(lhs) + bool(rhs))};
}
```

In C++, when performing an arithmetic operation on any type smaller than an `int`, the operands are automatically up-casted to an `int`. (see https://github.com/rapidsai/cudf/pull/817#issuecomment-459168159 for previous discussion).

Therefore, when doing:

```
auto result = bool(lhs) + bool(rhs);
```

The type of `result` is `int`.

If we were to attempt to construct `cudf::bool8` from an `int`, it would fail, because there is no `bool8(int)` constructor defined.

Therefore, we need to cast `result` back to a `bool` before we can construct a `bool8` from `result`. 

After these fixes, I uncovered another issue: https://github.com/rapidsai/cudf/issues/1931 

Any place where previously one was trying to construct a `bool8` from an `int` (e.g., `cudf::bool8 b{42}) will now be ambiguous because there are two possible constructors:

1. `bool8::bool8(gdf_bool8)` (`gdf_bool8` is a `char`)
2. `bool8::bool8(bool)`

`int` is implicitly convertible to both `char` and `bool`, so therefore,  the choice between 1. and 2.  is ambiguous. 

- [ ] Update any previous attempts to construct `bool8` from an `int` to be more explicit about the type being constructed from. 