### PR TITLE
Update usage of `std::tuple` to `std::pair` in external libcudf APIs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - PR #1952 consolidate libcudf public API headers in include/cudf
 - PR #1949 Improved selection with boolmask using libcudf `apply_boolean_mask`
 - PR #1956 Add support for nulls in `query()`
+- PR #1973 Update `std::tuple` to `std::pair` in top-most libcudf APIs and C++ transition guide
 
 
 ## Bug Fixes

--- a/cpp/docs/TRANSITIONGUIDE.md
+++ b/cpp/docs/TRANSITIONGUIDE.md
@@ -108,24 +108,26 @@ column output = cudf::some_function(input, &in_out, size);
 
 ### Multiple Return Values
 
-Sometimes it is necessary for functions to have multiple outputs. There are a few ways this can be done in C++ (including creating a `struct` for the output). One convenient way to do this is using `std::tie` and `std::make_tuple`.
+Sometimes it is necessary for functions to have multiple outputs. There are a few ways this can be done in C++ (including creating a `struct` for the output). One convenient way to do this is using `std::tie` and `std::make_pair`.
 
 ```
-auto return_multiple_outputs(void){
+auto return_two_outputs(void){
   cudf::table out0;
   cudf::table out1;
   ...
   // Do stuff with out0, out1
   
-  // Return a tuple of all the outputs
-  return std::make_tuple(out0, out1);
+  // Return a std::pair of the two outputs
+  return std::make_pair(out0, out1);
 }
 
 
 cudf::table out0;
 cudf::table out1;
-std::tie(out0, out1) = cudf::return_multiple_outputs();
+std::tie(out0, out1) = cudf::return_two_outputs();
 ```
+
+Note: `std::tuple` *could* be used if not for the fact that Cython does not support `std::tuple`. Therefore, libcudf APIs must use `std::pair`, and are therefore limited to return only two objects of different types. Multiple objects of the same type may be returned via a `std::vector<T>`.
 
 
 ## Error Checking

--- a/cpp/include/cudf/groupby.hpp
+++ b/cpp/include/cudf/groupby.hpp
@@ -56,7 +56,7 @@ gdf_unique_indices(cudf::table const& input_table,
  *          - A cudf::table containing a set of columns sorted by the key columns.
  *          - A device vector containing the first index of every unique row
  */
-std::tuple<cudf::table, rmm::device_vector<gdf_index_type>> 
+std::pair<cudf::table, rmm::device_vector<gdf_index_type>> 
 gdf_group_by_without_aggregations(cudf::table const& input_table,
                                   gdf_size_type num_key_cols,
                                   gdf_index_type const * key_col_indices,

--- a/cpp/src/groupby/new_groupby.cu
+++ b/cpp/src/groupby/new_groupby.cu
@@ -269,7 +269,7 @@ gdf_unique_indices(cudf::table const& input_table, gdf_context const& context)
   return unique_indices;
 }
 
-std::tuple<cudf::table, rmm::device_vector<gdf_index_type>> 
+std::pair<cudf::table, rmm::device_vector<gdf_index_type>> 
 gdf_group_by_without_aggregations(cudf::table const& input_table,
                                   gdf_size_type num_key_cols,
                                   gdf_index_type const * key_col_indices,
@@ -279,7 +279,7 @@ gdf_group_by_without_aggregations(cudf::table const& input_table,
   CUDF_EXPECTS(0 < num_key_cols, "number of key colums should be greater than zero");
 
   if (0 == input_table.num_rows()) {
-    return std::make_tuple(cudf::table(), rmm::device_vector<gdf_index_type>());
+    return std::make_pair(cudf::table(), rmm::device_vector<gdf_index_type>());
   }
 
   gdf_size_type nrows = input_table.num_rows();
@@ -351,5 +351,5 @@ gdf_group_by_without_aggregations(cudf::table const& input_table,
                   [&destination_table] (gdf_index_type const index) { return destination_table.get_column(index); });
   cudf::table key_col_sorted_table(key_cols_vect_out.data(), key_cols_vect_out.size());
   
-  return std::make_tuple(destination_table, gdf_unique_indices(key_col_sorted_table, *context));
+  return std::make_pair(destination_table, gdf_unique_indices(key_col_sorted_table, *context));
 }


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/1970 