### PR TITLE
fix/join_index_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 - PR #1896 Improve performance of groupby with levels specified in dask-cudf
 - PR #1859 Convert read_json into a C++ API
 - PR #1919 Rename libcudf namespace gdf to namespace cudf
-- PR #1850 Support left_on and right_on for DataFrame merge operator  
+- PR #1850 Support left_on and right_on for DataFrame merge operator
 - PR #1930 Specialize constructor for `cudf::bool8` to cast argument to `bool`
 - PR #1952 consolidate libcudf public API headers in include/cudf
 - PR #1949 Improved selection with boolmask using libcudf `apply_boolean_mask`
@@ -109,6 +109,7 @@
 - PR #1914 Zero initialize gdf_column local variables
 - PR #1966 Ignore index fix in series append
 - PR #1967 Compute index __sizeof__ only once for DataFrame __sizeof__
+- PR #1982 Fixes incorrect index name after join operation
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -1850,6 +1850,8 @@ class DataFrame(object):
                                                  ordered=False)
 
         df = df.set_index(idx_col_name)
+        # change random number index to None to better reflect pandas behavior
+        df.index.name = None
 
         if sort and len(df):
             return df.sort_index()

--- a/python/cudf/tests/test_joining.py
+++ b/python/cudf/tests/test_joining.py
@@ -102,8 +102,7 @@ def test_dataframe_join_how(aa, bb, how, method):
     expect.drop(['a'], axis=1)
     expect['a'] = expecta.astype(np.float64).fillna(np.nan)
 
-    # print(expect)
-    # print(got.to_string(nrows=None))
+    assert got.index.name is None
 
     assert list(expect.columns) == list(got.columns)
     # test disabled until libgdf sort join gets updated with new api


### PR DESCRIPTION
PR is a partial fix to https://github.com/rapidsai/cudf/issues/1945

I haven't gone through all the logic to get the index name the *exact* same as Pandas (it looks like it can be the LHS index name or None).  The quick solution in this PR is to set the name to `None` which is probably better than a random number