### PR TITLE
[REVIEW] Fix signed/unsigned type mismatch causing incorrect NULLs bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 - PR #1967 Compute index __sizeof__ only once for DataFrame __sizeof__
 - PR #1982 Fixes incorrect index name after join operation
 - PR #1985 Implement `GDF_PYMOD`, a special modulo that follows python's sign rules
+- PR #1991 Parquet reader: fix decoding of NULLs
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -259,7 +259,8 @@ __device__ void gpuDecodeLevels(page_state_s *s, int32_t target_count, int t)
     int32_t coded_count = s->nz_count;      // Count of non-null values
     while (coded_count < target_count && value_count < num_values)
     {
-        int batch_len, is_valid, valid_mask;
+        int batch_len, is_valid;
+        uint32_t valid_mask;
         if (def_run <= 1)
         {
             // Get a new run symbol from the byte stream

--- a/python/cudf/tests/test_parquet.py
+++ b/python/cudf/tests/test_parquet.py
@@ -9,6 +9,7 @@ import pandas as pd
 import numpy as np
 import pyarrow as pa
 from string import ascii_letters
+import random
 
 
 @pytest.fixture(scope='module')
@@ -61,6 +62,24 @@ def parquet_file(request, tmp_path_factory, pdf):
     fname = tmp_path_factory.mktemp("parquet") / "test.parquet"
     pdf.to_parquet(fname, engine='pyarrow', compression=request.param)
     return fname
+
+
+def make_pdf(nrows, ncolumns=1, nvalids=0, dtype=np.int64):
+    test_pdf = pd.util.testing.makeCustomDataframe(
+        nrows=nrows,
+        ncols=1,
+        data_gen_f=lambda r, c: r,
+        dtype=dtype,
+        r_idx_type='i'
+    )
+    del(test_pdf.columns.name)
+
+    # Randomly but reproducibly mark subset of rows as invalid
+    random.seed(1337)
+    mask = random.sample(range(nrows), nvalids)
+    test_pdf[test_pdf.index.isin(mask)] = np.NaN
+
+    return test_pdf
 
 
 @pytest.mark.filterwarnings("ignore:Using CPU")
@@ -206,6 +225,18 @@ def test_parquet_reader_spark_timestamps(datadir):
 
 def test_parquet_reader_microsecond_timestamps(datadir):
     fname = datadir / 'usec_timestamp.parquet'
+
+    expect = pd.read_parquet(fname)
+    got = cudf.read_parquet(fname)
+
+    assert_eq(expect, got)
+
+
+def test_parquet_reader_invalids(tmpdir):
+    test_pdf = make_pdf(nrows=1000, nvalids=1000 // 4, dtype=np.int64)
+
+    fname = tmpdir.join("invalids.parquet")
+    test_pdf.to_parquet(fname, engine='pyarrow')
 
     expect = pd.read_parquet(fname)
     got = cudf.read_parquet(fname)


### PR DESCRIPTION
Fix incorrect type definition causing signed right-shift instead of unsigned right-shift.
Resolves #1986 