### PR TITLE
[REVIEW] Improve .column element of MultiColumn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 - PR #1991 Parquet reader: fix decoding of NULLs
 - PR #1990 Fixes a rendering bug in the `apply_grouped` documentation
 - PR #1978 Fix for values being filled in an empty dataframe 
+- PR #2001 Correctly create MultiColumn from Pandas MultiColumn
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -1138,6 +1138,8 @@ class DataFrame(object):
         Difference from pandas:
           * Support axis='columns' only.
           * Not supporting: index, level
+        Rename will not overwite column names. If a list with duplicates it
+        passed, column names will be postfixed.
         """
         # Pandas defaults to using columns over mapper
         if columns:
@@ -1145,11 +1147,16 @@ class DataFrame(object):
 
         out = DataFrame()
         out = out.set_index(self.index)
-
         if isinstance(mapper, Mapping):
+            postfix = 1
             for column in self.columns:
                 if column in mapper:
-                    out[mapper[column]] = self[column]
+                    if mapper[column] in out.columns:
+                        out_column = str(mapper[column]) + '_' + str(postfix)
+                        postfix += 1
+                    else:
+                        out_column = mapper[column]
+                    out[out_column] = self[column]
                 else:
                     out[column] = self[column]
         elif callable(mapper):
@@ -1444,10 +1451,13 @@ class DataFrame(object):
         Difference from pandas:
         Not supporting *copy* because default and only behaviour is copy=True
         """
-        from cudf.bindings.transpose import transpose as cpp_tranpose
-        result = cpp_tranpose(self)
+        from cudf.bindings.transpose import transpose as cpp_transpose
+        result = cpp_transpose(self)
         result = result.rename(dict(zip(result.columns, self.index)))
+        index = self.index
         result = result.set_index(self.columns)
+        if isinstance(index, cudf.dataframe.multiindex.MultiIndex):
+            result.columns = index
         return result
 
     @property
@@ -2398,7 +2408,7 @@ class DataFrame(object):
         for c, x in self._cols.items():
             out[c] = x.to_pandas(index=index)
         if isinstance(self.columns, Index):
-            out.columns = self.columns
+            out.columns = self.columns.to_pandas()
             if isinstance(self.columns, cudf.dataframe.multiindex.MultiIndex):
                 if self.columns.names is not None:
                     out.columns.names = self.columns.names
@@ -2431,14 +2441,31 @@ class DataFrame(object):
         # Set columns
         for colk in dataframe.columns:
             vals = dataframe[colk].values
-            df[colk] = Series(vals, nan_as_null=nan_as_null)
+            # necessary because multi-index can return multiple
+            # columns for a single key
+            if isinstance(colk, tuple):
+                colk = str(colk)
+            if len(vals.shape) == 1:
+                df[colk] = Series(vals, nan_as_null=nan_as_null)
+            else:
+                vals = vals.T
+                if vals.shape[0] == 1:
+                    df[colk] = Series(vals.flatten(), nan_as_null=nan_as_null)
+                else:
+                    for idx in range(len(vals.shape)):
+                        df[colk+str(idx)] = Series(vals[idx],
+                                                   nan_as_null=nan_as_null)
         # Set index
         if isinstance(dataframe.index, pd.MultiIndex):
             import cudf
             index = cudf.from_pandas(dataframe.index)
         else:
             index = dataframe.index
-        return df.set_index(index)
+        result = df.set_index(index)
+        if isinstance(dataframe.columns, pd.MultiIndex):
+            import cudf
+            result.columns = cudf.from_pandas(dataframe.columns)
+        return result
 
     def to_arrow(self, preserve_index=True):
         """

--- a/python/cudf/dataframe/multiindex.py
+++ b/python/cudf/dataframe/multiindex.py
@@ -249,6 +249,14 @@ class MultiIndex(Index):
                 # directly
                 result = result.T
                 result = result[result.columns[0]]
+                # convert to Series
+                series_name = []
+                for idx, code in enumerate(result.columns.codes):
+                    series_name.append(result.columns.levels[idx][
+                            result.columns.codes[code][0]])
+                result = Series(list(result._cols.values())[0],
+                                name=series_name)
+                result.name = tuple(series_name)
             elif(len(out_index.columns)) > 0:
                 # Otherwise pop the leftmost levels, names, and codes from the
                 # source index until it has the correct number of columns (n-k)

--- a/python/cudf/tests/test_multiindex.py
+++ b/python/cudf/tests/test_multiindex.py
@@ -478,3 +478,26 @@ def test_multiindex_iloc(pdf, gdf, pdfIndex):
     assert_eq(pdf.iloc[0:2], gdf.iloc[0:2])
     assert_eq(pdf.iloc[0:], gdf.iloc[0:])
     assert_eq(pdf.iloc[1:], gdf.iloc[1:])
+
+
+def test_multiindex_columns_from_pandas(pdf, pdfIndex):
+    pdf.index = pdfIndex
+    pdfT = pdf.T
+    gdfT = cudf.from_pandas(pdfT)
+    assert(isinstance(gdfT.columns, cudf.dataframe.multiindex.MultiIndex))
+
+
+def test_groupby_multiindex_columns_from_pandas(pdf, gdf, pdfIndex):
+    gdfIndex = cudf.from_pandas(pdfIndex)
+    pdf.index = pdfIndex
+    gdf.index = gdfIndex
+    assert_eq(gdf, pdf)
+    assert_eq(gdf.T, pdf.T)
+    gdf = cudf.DataFrame({'x': [1, 5, 3, 4, 1],
+                          'y': [1, 1, 2, 2, 5],
+                          'z': [0, 1, 0, 1, 0]})
+    pdf = gdf.to_pandas()
+    gdg = gdf.groupby(['x', 'y']).sum()
+    pdg = pdf.groupby(['x', 'y']).sum()
+    assert_eq(gdg, pdg)
+    assert_eq(gdg.T, pdg.T)


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/1561

The primary contribution of this PR is that `cudf.from_pandas(pdf)` will correctly return a cudf MultiColumn object if `pdf` has a MultiColumn.

This also fixes our transpose function with multiindex/multicolumn.