### PR TITLE
Removed few redundant unit-tests from test_string.py::test_string_cat 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 - PR #1973 Update `std::tuple` to `std::pair` in top-most libcudf APIs and C++ transition guide
 - PR #1868 ORC Reader: Support row index for speed up on small/medium datasets
 - PR #1964 Added support for list-like types in Series.str.cat
-- PR #2003 Removed few redundant unit-tests
+- PR #2003 Removed few redundant unit-tests from test_string.py::test_string_cat 
 
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - PR #1973 Update `std::tuple` to `std::pair` in top-most libcudf APIs and C++ transition guide
 - PR #1868 ORC Reader: Support row index for speed up on small/medium datasets
 - PR #1964 Added support for list-like types in Series.str.cat
+- PR #2003 Removed few redundant unit-tests
 
 
 ## Bug Fixes

--- a/python/cudf/tests/test_string.py
+++ b/python/cudf/tests/test_string.py
@@ -316,30 +316,25 @@ def test_string_len(ps_gs):
     pd.Index(['f', 'g', 'h', 'i', 'j']),
     (['f', 'g', 'h', 'i', 'j'], ['f', 'g', 'h', 'i', 'j']),
     [['f', 'g', 'h', 'i', 'j'], ['f', 'g', 'h', 'i', 'j']],
-    (pd.Series(['f', 'g', 'h', 'i', 'j']),
-     pd.Series(['f', 'g', 'h', 'i', 'j'])),
-    (pd.Index(['f', 'g', 'h', 'i', 'j']),
-     pd.Index(['1', '2', '3', '4', '5'])),
-    [pd.Series(['f', 'g', 'h', 'i', 'j']), pd.Series(
-        ['f', 'g', 'h', 'i', 'j'])] * 20,
     (
         pd.Series(['f', 'g', 'h', 'i', 'j']),
+        ['f', 'a', 'b', 'f', 'a'],
         pd.Series(['f', 'g', 'h', 'i', 'j']),
-        pd.Series(['f', 'g', 'h', 'i', 'j']),
-        pd.Series(['f', 'g', 'h', 'i', 'j']),
-        ['f', 'a', 'b', 'f', 'a']
+        ['f', 'a', 'b', 'f', 'a'],
+        ['f', 'a', 'b', 'f', 'a'],
+        pd.Index(['1', '2', '3', '4', '5']),
+        ['f', 'a', 'b', 'f', 'a'],
+        pd.Index(['f', 'g', 'h', 'i', 'j'])
     ),
     [
-        ['f', 'a', 'b', 'f', 'a'], pd.Series(['f', 'g', 'h', 'i', 'j']),
-        pd.Series(['f', 'g', 'h', 'i', 'j']),
-        pd.Series(['f', 'g', 'h', 'i', 'j']),
-        pd.Series(['f', 'g', 'h', 'i', 'j'])
-    ],
-    [
-        ['f', 'a', 'b', 'f', 'a'], pd.Index(['f', 'g', 'h', 'i', 'j']),
-        pd.Series(['f', 'g', 'h', 'i', 'j']),
         pd.Index(['f', 'g', 'h', 'i', 'j']),
-        pd.Series(['f', 'g', 'h', 'i', 'j'])
+        ['f', 'a', 'b', 'f', 'a'],
+        pd.Series(['f', 'g', 'h', 'i', 'j']),
+        ['f', 'a', 'b', 'f', 'a'],
+        ['f', 'a', 'b', 'f', 'a'],
+        pd.Index(['f', 'g', 'h', 'i', 'j']),
+        ['f', 'a', 'b', 'f', 'a'],
+        pd.Index(['f', 'g', 'h', 'i', 'j'])
     ]
 ])
 @pytest.mark.parametrize('sep', [None, '', ' ', '|', ',', '|||'])
@@ -349,12 +344,7 @@ def test_string_len(ps_gs):
     pd.Series(['1', '2', '3', '4', '5']),
     pd.Index(['1', '2', '3', '4', '5'])
 ])
-@pytest.mark.parametrize('misc_with_index', [
-    ['1', '2', '3', '4', '5'],
-    pd.Series(['1', '2', '3', '4', '5']),
-    pd.Index(['1', '2', '3', '4', '5'])
-])
-def test_string_cat(ps_gs, others, sep, na_rep, index, misc_with_index):
+def test_string_cat(ps_gs, others, sep, na_rep, index):
     ps, gs = ps_gs
 
     pd_others = others
@@ -373,16 +363,16 @@ def test_string_cat(ps_gs, others, sep, na_rep, index, misc_with_index):
 
     assert_eq(expect, got)
 
-    expect = ps.str.cat(others=[ps.index] + [misc_with_index],
+    expect = ps.str.cat(others=[ps.index] + [ps.index],
                         sep=sep, na_rep=na_rep)
-    got = gs.str.cat(others=[gs.index] + [misc_with_index],
+    got = gs.str.cat(others=[gs.index] + [gs.index],
                      sep=sep, na_rep=na_rep)
 
     assert_eq(expect, got)
 
-    expect = ps.str.cat(others=(ps.index, misc_with_index),
+    expect = ps.str.cat(others=(ps.index, ps.index),
                         sep=sep, na_rep=na_rep)
-    got = gs.str.cat(others=(gs.index, misc_with_index),
+    got = gs.str.cat(others=(gs.index, gs.index),
                      sep=sep, na_rep=na_rep)
 
     assert_eq(expect, got)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

Added 8400 unit-tests for `test_string_cat` as part of PR: #1964 
Reduced them down to 1944 by removing redundant parameters.


cc: @thomcom , @kkraus14 