### PR TITLE
[REVIEW] Add cudf-java-codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,9 @@ python/    @rapidsai/cudf-python-codeowners
 **/CMakeLists.txt  @rapidsai/cudf-cmake-codeowners
 **/cmake/          @rapidsai/cudf-cmake-codeowners
 
+#java code owners
+java/              @rapidsai/cudf-java-codeowners
+
 #build/ops code owners
 .github/           @rapidsai/cudf-ops-codeowners 
 ci/                @rapidsai/cudf-ops-codeowners


### PR DESCRIPTION
Adding the java code owners as specified in https://github.com/rapidsai/cudf/pull/1995