### PR TITLE
apply_boolean_mask: return empty column for empty mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@
 - PR #1965 Parquet Reader: Fix duplicate index column when it's already in `use_cols`
 - PR #2033 Add pip to conda environment files to fix warning
 - PR #2028 CSV Reader: Fix reading of uncompressed files without a recognized file extension
+- PR #2053 cudf::apply_boolean_mask return empty column for empty boolean mask
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/cpp/src/stream_compaction/stream_compaction.cu
+++ b/cpp/src/stream_compaction/stream_compaction.cu
@@ -88,9 +88,14 @@ namespace cudf {
  */
 gdf_column apply_boolean_mask(gdf_column const &input,
                               gdf_column const &boolean_mask) {
-  CUDF_EXPECTS(boolean_mask.dtype == GDF_BOOL8, "Mask must be Boolean type");
+  if (boolean_mask.size == 0 || input.size == 0)
+      return cudf::empty_like(input);
+
+  // for non-zero-length masks we expect one of the pointers to be non-null    
   CUDF_EXPECTS(boolean_mask.data != nullptr ||
                boolean_mask.valid != nullptr, "Null boolean_mask");
+  CUDF_EXPECTS(boolean_mask.dtype == GDF_BOOL8, "Mask must be Boolean type");
+  
   // zero-size inputs are OK, but otherwise input size must match mask size
   CUDF_EXPECTS(input.size == 0 || input.size == boolean_mask.size, 
                "Column size mismatch");

--- a/python/cudf/tests/test_dataframe.py
+++ b/python/cudf/tests/test_dataframe.py
@@ -1748,6 +1748,27 @@ def test_dataframe_boolean_mask_with_None():
 
 
 @pytest.mark.parametrize(
+    'dtype',
+    [
+        int,
+        float,
+        str
+    ]
+)
+def test_empty_boolean_mask(dtype):
+    gdf = gd.datasets.randomdata(nrows=0, dtypes={'a': dtype})
+    pdf = gdf.to_pandas()
+
+    expected = pdf[pdf.a == 1]
+    got = gdf[gdf.a == 1]
+    assert_eq(expected, got)
+
+    expected = pdf.a[pdf.a == 1]
+    got = gdf.a[gdf.a == 1]
+    assert_eq(expected, got)
+
+
+@pytest.mark.parametrize(
     'data',
     [
         [1, 2, 3, 4],


### PR DESCRIPTION
Fixes #2046 from the C++ side. Return `cudf::empty_like(input)` when the input column *or* the input mask are zero-length.