### PR TITLE
[REVIEW] Fix bug with unfound transitive dependencies for GTests in Ubuntu 18.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 - PR #2028 CSV Reader: Fix reading of uncompressed files without a recognized file extension
 - PR #2053 cudf::apply_boolean_mask return empty column for empty boolean mask
 - PR #2069 Fix JNI code to use read_csv and read_parquet APIs
+- PR #XXXX Fix bug with unfound transitive dependencies for GTests in Ubuntu 18.04
 
 # cudf 0.7.2 (16 May 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@
 - PR #2028 CSV Reader: Fix reading of uncompressed files without a recognized file extension
 - PR #2053 cudf::apply_boolean_mask return empty column for empty boolean mask
 - PR #2069 Fix JNI code to use read_csv and read_parquet APIs
-- PR #XXXX Fix bug with unfound transitive dependencies for GTests in Ubuntu 18.04
+- PR #2071 Fix bug with unfound transitive dependencies for GTests in Ubuntu 18.04
 
 # cudf 0.7.2 (16 May 2019)
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -23,7 +23,9 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
     add_executable(${CMAKE_TEST_NAME}
                    ${CMAKE_TEST_SRC})
     set_target_properties(${CMAKE_TEST_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
-    target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread cudf cudftestutil)
+    target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread cudf
+                          cudftestutil rmm cudart cuda "${ARROW_LIB}" ${ZLIB_LIBRARIES} NVCategory
+                          NVStrings nvrtc)
     set_target_properties(${CMAKE_TEST_NAME} PROPERTIES
                             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/gtests")
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})


### PR DESCRIPTION
Looks like something changed compiler wise in Ubuntu 18.04 where tests find libcudf.so but can't find the transitive dependencies of libcudf.so such as librmm.so and libNVCategory.so. This could likely be fixed in a better way with RPATH / RUNPATH settings, but didn't want to fight with those so close to release. Added the needed transitive dependencies to the link command of the tests.