### PR TITLE
[REVIEW] Stylesheet workaround for doc params [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@
 - PR #2066 exclude `IteratorTest.mean_var_output` test from debug build
 - PR #2069 Fix JNI code to use read_csv and read_parquet APIs
 - PR #2071 Fix bug with unfound transitive dependencies for GTests in Ubuntu 18.04
+- PR #2089 Configure Sphinx to render params correctly
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/docs/source/_static/params.css
+++ b/docs/source/_static/params.css
@@ -1,0 +1,9 @@
+/* Mirrors the change in:
+ *   https://github.com/sphinx-doc/sphinx/pull/5976
+ * which is not showing up in our theme.
+ */
+.classifier:before {
+    font-style: normal;
+    margin: 0.5em;
+    content: ":";
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
     'nbsphinx',
     'recommonmark'
 ]
+
 ipython_mplbackend = 'str'
 
 # Add any paths that contain templates here, relative to this directory.
@@ -190,3 +191,7 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 # Config numpydoc
 numpydoc_show_inherited_class_members = False
 numpydoc_class_members_toctree = False
+
+
+def setup(app):
+    app.add_stylesheet('params.css')


### PR DESCRIPTION
This fixes the param formatting for our python docs.