### PR TITLE
[REVIEW] Fix transitive dependencies for `cudftestutil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@
 - PR #2066 exclude `IteratorTest.mean_var_output` test from debug build
 - PR #2069 Fix JNI code to use read_csv and read_parquet APIs
 - PR #2071 Fix bug with unfound transitive dependencies for GTests in Ubuntu 18.04
+- PR #XXXX Fix another bug with unfound transitive dependencies for `cudftestutils` in Ubuntu 18.04
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,7 @@
 - PR #2066 exclude `IteratorTest.mean_var_output` test from debug build
 - PR #2069 Fix JNI code to use read_csv and read_parquet APIs
 - PR #2071 Fix bug with unfound transitive dependencies for GTests in Ubuntu 18.04
-- PR #XXXX Fix another bug with unfound transitive dependencies for `cudftestutils` in Ubuntu 18.04
+- PR #2091 Fix another bug with unfound transitive dependencies for `cudftestutils` in Ubuntu 18.04
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -17,6 +17,10 @@ add_library(cudftestutil STATIC
 target_link_libraries(cudftestutil cudf rmm cudart cuda "${ARROW_LIB}" ${ZLIB_LIBRARIES} NVCategory
                       NVStrings nvrtc)
 
+if(USE_NVTX)
+    target_link_libraries(cudftestutil ${NVTX_LIBRARY})
+endif(USE_NVTX)
+
 ###################################################################################################
 # - compiler function -----------------------------------------------------------------------------
 
@@ -27,6 +31,9 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
     target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread cudf
                           cudftestutil rmm cudart cuda "${ARROW_LIB}" ${ZLIB_LIBRARIES} NVCategory
                           NVStrings nvrtc)
+    if(USE_NVTX)
+        target_link_libraries(${CMAKE_TEST_NAME} ${NVTX_LIBRARY})
+    endif(USE_NVTX)
     set_target_properties(${CMAKE_TEST_NAME} PROPERTIES
                             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/gtests")
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -14,7 +14,8 @@ add_library(cudftestutil STATIC
             "${CMAKE_CURRENT_SOURCE_DIR}/utilities/valid_vectors.cpp"
             "${CMAKE_CURRENT_SOURCE_DIR}/utilities/nvcategory_utils.cu")
 
-target_link_libraries(cudftestutil cudf)
+target_link_libraries(cudftestutil cudf rmm cudart cuda "${ARROW_LIB}" ${ZLIB_LIBRARIES} NVCategory
+                      NVStrings nvrtc)
 
 ###################################################################################################
 # - compiler function -----------------------------------------------------------------------------


### PR DESCRIPTION
Something in our Ubuntu 18.04 toolchain changed with regards to `RUNPATH` vs `RPATH` where transitive dependencies are no longer found properly so all of the linked libraries need to be defined until a better solution can be determined.