### PR TITLE
[HOTFIX] Fix memory leak in groupby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@
 - PR #2071 Fix bug with unfound transitive dependencies for GTests in Ubuntu 18.04
 - PR #2089 Configure Sphinx to render params correctly
 - PR #2091 Fix another bug with unfound transitive dependencies for `cudftestutils` in Ubuntu 18.04
+- PR #2102 Fix memory leak in groupby
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/cpp/include/cudf/table.hpp
+++ b/cpp/include/cudf/table.hpp
@@ -143,6 +143,14 @@ struct table {
     return 0;
   }
 
+  /**---------------------------------------------------------------------------*
+   * @brief Destroys the `gdf_column`s in the table.
+   *
+   * Free's each column's device memory and destroys the `gdf_column` object.
+   *
+   *---------------------------------------------------------------------------**/
+  void destroy(void);
+
  private:
   std::vector<gdf_column*> _columns;  ///< Pointers to the wrapped columns
 };

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -198,7 +198,6 @@ auto build_aggregation_map(table const& input_keys, table const& input_values,
   // an upper bound
   gdf_size_type const output_size_estimate{input_keys.num_rows()};
 
-
   cudf::table sparse_output_values{
       output_size_estimate, target_dtypes(column_dtypes(input_values), ops),
       values_have_nulls, false, stream};
@@ -352,8 +351,8 @@ auto compute_hash_groupby(cudf::table const& keys, cudf::table const& values,
                  });
 
   // Some aggregations are "compound", meaning they need be satisfied via the
-  // composition of 1 or more "simple" aggregation requests. For example, MEAN is
-  // satisfied via the division of the SUM by the COUNT aggregation. We
+  // composition of 1 or more "simple" aggregation requests. For example, MEAN
+  // is satisfied via the division of the SUM by the COUNT aggregation. We
   // translate these compound requests into simple requests, and compute the
   // groupby operation for these simple requests. Later, we translate the simple
   // requests back to compound request results.
@@ -374,12 +373,11 @@ auto compute_hash_groupby(cudf::table const& keys, cudf::table const& values,
 
   // Step 1: Build hash map
   auto result = build_aggregation_map<keys_have_nulls, values_have_nulls>(
-      keys, simple_values_table, *d_input_keys, *d_input_values, simple_operators, options,
-      stream);
+      keys, simple_values_table, *d_input_keys, *d_input_values,
+      simple_operators, options, stream);
 
   auto const map{std::move(result.first)};
-  cudf::table const sparse_output_values{result.second};
-
+  cudf::table sparse_output_values{result.second};
 
   // Step 2: Extract non-empty entries
   cudf::table output_keys;
@@ -387,6 +385,9 @@ auto compute_hash_groupby(cudf::table const& keys, cudf::table const& values,
   std::tie(output_keys, simple_output_values) =
       extract_results<keys_have_nulls, values_have_nulls>(
           keys, values, *d_input_keys, sparse_output_values, map.get(), stream);
+
+  // Delete intermediate results storage
+  sparse_output_values.destroy();
 
   // If any of the original requests were compound, compute them from the
   // results of simple aggregation requests

--- a/cpp/src/table/table.cpp
+++ b/cpp/src/table/table.cpp
@@ -19,8 +19,8 @@
 #include <cassert>
 #include <cudf/copying.hpp>
 #include <cudf/table.hpp>
-#include <utilities/error_utils.hpp>
 #include <utilities/column_utils.hpp>
+#include <utilities/error_utils.hpp>
 
 #include <algorithm>
 
@@ -80,6 +80,13 @@ table::table(gdf_size_type num_rows, std::vector<gdf_dtype> const& dtypes,
         }
         return col;
       });
+}
+
+void table::destroy(void) {
+  for (auto& col : _columns) {
+    gdf_column_free(col);
+    delete col;
+  }
 }
 
 std::vector<gdf_dtype> column_dtypes(cudf::table const& table) {


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/2101

Previously, the intermediate result table in groupby was not being freed, causing a sizable memory leak.


- [x] Adds `table::destroy`