### PR TITLE
[REVIEW] Fix the test errors in JitCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@
 - PR #2071 Fix bug with unfound transitive dependencies for GTests in Ubuntu 18.04
 - PR #2089 Configure Sphinx to render params correctly
 - PR #2091 Fix another bug with unfound transitive dependencies for `cudftestutils` in Ubuntu 18.04
+- PR #2106 Fix errors in JitCache tests caused by sharing of device memory between processes
 
 
 # cudf 0.7.2 (16 May 2019)

--- a/cpp/tests/binaryop/unit/jit-cache-test.cu
+++ b/cpp/tests/binaryop/unit/jit-cache-test.cu
@@ -91,7 +91,7 @@ TEST_F(JitCacheTest, FileCacheProgramTest) {
     auto expect = cudf::test::column_wrapper<int>{{625,0}};
 
     // make program
-    auto program = cache.getProgram("MemoryCacheTestProg");
+    auto program = cache.getProgram("MemoryCacheTestProg", program_source);
     // make kernel that HAS to be compiled
     auto kernel = cache.getKernelInstantiation("my_kernel",
                                                 program,
@@ -112,10 +112,8 @@ TEST_F(JitCacheTest, FileCacheKernelTest) {
     auto expect = cudf::test::column_wrapper<int>{{125,0}};
 
     // make program
-    auto program = cache.getProgram("MemoryCacheTestProg1", program2_source);
+    auto program = cache.getProgram("MemoryCacheTestProg", program_source);
     // make kernel that should NOT need to be compiled
-    // TODO (dm): convert this pair to a class, so the name can be edited
-    std::get<0>(program) = "MemoryCacheTestProg";
     auto kernel = cache.getKernelInstantiation("my_kernel",
                                                 program,
                                                 {"3", "int"});

--- a/cpp/tests/binaryop/unit/jit-cache-test.hpp
+++ b/cpp/tests/binaryop/unit/jit-cache-test.hpp
@@ -92,6 +92,17 @@ struct JitCacheTest : public ::testing::Test
         "    }\n"
         "}\n";
 
+    const char* program3_source =
+        "my_program\n"
+        "template<int N, typename T>\n"
+        "__global__\n"
+        "void my_kernel(T* data, T* out) {\n"
+        "    T data0 = data[0];\n"
+        "    for( int i=0; i<N; ++i ) {\n"
+        "        out[0] *= data0;\n"
+        "    }\n"
+        "}\n";
+
 };
 
 /**---------------------------------------------------------------------------*


### PR DESCRIPTION
This will hopefully fix the breaks in tests that were reported [here](https://gpuci.gpuopenanalytics.com/view/rapids-branch-gpu-matrix/job/gpuCI/job/cudf/job/branches/job/cudf-gpu-matrix-branch-0.8/CC_VERSION=5,CUDA=9.2,LINUX_VERSION=ubuntu16.04,PYTHON=3.7/36/console) and [here](https://gpuci.gpuopenanalytics.com/view/rapids-branch-gpu-matrix/job/gpuCI/job/cudf/job/branches/job/cudf-gpu-matrix-branch-0.8/CC_VERSION=7,CUDA=9.2,LINUX_VERSION=centos7,PYTHON=3.6/36/console)

For the single process test, the problem was that the cache is not guaranteed to exist and could've been deleted. JitCache handles that case by recompiling but the test would've only passed if it came from file cache.

For the Multi process test, the issue was that both the parent and child process pointed to the same GPU memory of output so if the kernels launched at the same time, the output would be `func(func(input))` instead of just `func(input)`. This was fixed by using managed memory.
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
