### PR TITLE
[gpuCI] Auto-merge branch-0.8 to branch-0.9 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuDF 0.8.0 (Date TBD)
+# cuDF 0.8.0 (27 June 2019)
 
 ## New Features
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <div align="left"><img src="img/rapids_logo.png" width="90px"/>&nbsp;cuDF - GPU DataFrames</div>
 
-[![Build Status](http://gpuci.gpuopenanalytics.com/buildStatus/icon?job=gpuCI/cudf/branches/cudf-cpu-branch-0.8)](http://gpuci.gpuopenanalytics.com/buildStatus/icon?job=gpuCI/cudf/branches/cudf-cpu-branch-0.8)
+[![Build Status](https://gpuci.gpuopenanalytics.com/buildStatus/icon?job=gpuCI%2Fcudf%2Fbranches%2Fcudf-gpu-branch-0.8)](https://gpuci.gpuopenanalytics.com/job/gpuCI/job/cudf/job/branches/job/cudf-gpu-branch-0.8/)
 
 **NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cudf/blob/master/README.md) ensure you are on the `master` branch.
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.8` that creates a PR to keep `branch-0.9` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.