### PR TITLE
Fix the bug in JitCache tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@
 - PR #2091 Fix another bug with unfound transitive dependencies for `cudftestutils` in Ubuntu 18.04
 - PR #2115 Just apply `--disable-new-dtags` instead of trying to define all the transitive dependencies
 - PR #2106 Fix errors in JitCache tests caused by sharing of device memory between processes
+- PR #2120 Fix errors in JitCache tests caused by running multiple threads on the same data
 - PR #2102 Fix memory leak in groupby
 
 

--- a/cpp/tests/binaryop/unit/jit-cache-multiprocess-test.cpp
+++ b/cpp/tests/binaryop/unit/jit-cache-multiprocess-test.cpp
@@ -37,12 +37,12 @@ TEST_F(JitCacheMultiProcessTest, MultiProcessTest) {
         output[idx] = 1;
 
         // make program
-        auto program = cache.getProgram("MemoryCacheTestProg", program3_source);
+        auto program = cache.getProgram("FileCacheTestProg3", program3_source);
         // make kernel
         auto kernel = cache.getKernelInstantiation("my_kernel",
                                                     program,
                                                     {"3", "int"});
-        (*std::get<1>(kernel)).configure_1d_max_occupancy()
+        (*std::get<1>(kernel)).configure(grid, block)
             .launch(input, &output[idx]);
         cudaDeviceSynchronize();
 

--- a/cpp/tests/binaryop/unit/jit-cache-multiprocess-test.cpp
+++ b/cpp/tests/binaryop/unit/jit-cache-multiprocess-test.cpp
@@ -20,6 +20,23 @@
 
 
 #if defined(JITIFY_USE_CACHE)
+/**---------------------------------------------------------------------------*
+ * @brief This test runs two processes that try to access the same kernel
+ * 
+ * This is a stress test.
+ * 
+ * A single test process is forked before invocation of CUDA and then both the 
+ * parent and child processes try to get and run a kernel. The child process
+ * clears the cache before each iteration of the test so that the cache has to
+ * be re-written by it. The parent process runs on a changing time offset so 
+ * that it sometimes gets the kernel from cache and sometimes it doesn't.
+ * 
+ * The aim of this test is to check that the file cache doesn't get corrupted
+ * when multiple processes are reading/writing to it at the same time. Since 
+ * the public API of JitCache doesn't return the serialized string of the
+ * cached kernel, the way to test its validity is to run it on test data.
+ * 
+ *---------------------------------------------------------------------------**/
 TEST_F(JitCacheMultiProcessTest, MultiProcessTest) {
 
     int num_tests = 20;

--- a/cpp/tests/binaryop/unit/jit-cache-test.cu
+++ b/cpp/tests/binaryop/unit/jit-cache-test.cu
@@ -49,7 +49,7 @@ TEST_F(JitCacheTest, MemoryCacheKernelTest) {
                                          program,
                                          {"3", "int"});
 
-    (*std::get<1>(kernel)).configure_1d_max_occupancy()
+    (*std::get<1>(kernel)).configure(grid, block)
                 .launch(column.get()->data);
 
     ASSERT_TRUE(expect == column) << "Expected col: " << expect.to_str()
@@ -73,7 +73,7 @@ TEST_F(JitCacheTest, MemoryCacheProgramTest) {
                                          program,
                                          {"4", "int"});
 
-    (*std::get<1>(kernel)).configure_1d_max_occupancy()
+    (*std::get<1>(kernel)).configure(grid, block)
                 .launch(column.get()->data);
 
     ASSERT_TRUE(expect == column) << "Expected col: " << expect.to_str()
@@ -91,12 +91,12 @@ TEST_F(JitCacheTest, FileCacheProgramTest) {
     auto expect = cudf::test::column_wrapper<int>{{625,0}};
 
     // make program
-    auto program = cache.getProgram("MemoryCacheTestProg", program_source);
+    auto program = cache.getProgram("FileCacheTestProg", program_source);
     // make kernel that HAS to be compiled
     auto kernel = cache.getKernelInstantiation("my_kernel",
                                                 program,
                                                 {"4", "int"});
-    (*std::get<1>(kernel)).configure_1d_max_occupancy()
+    (*std::get<1>(kernel)).configure(grid, block)
                 .launch(column.get()->data);
 
     ASSERT_EQ(expect, column) << "Expected col: " << expect.to_str()
@@ -112,12 +112,12 @@ TEST_F(JitCacheTest, FileCacheKernelTest) {
     auto expect = cudf::test::column_wrapper<int>{{125,0}};
 
     // make program
-    auto program = cache.getProgram("MemoryCacheTestProg", program_source);
+    auto program = cache.getProgram("FileCacheTestProg", program_source);
     // make kernel that should NOT need to be compiled
     auto kernel = cache.getKernelInstantiation("my_kernel",
                                                 program,
                                                 {"3", "int"});
-    (*std::get<1>(kernel)).configure_1d_max_occupancy()
+    (*std::get<1>(kernel)).configure(grid, block)
                 .launch(column.get()->data);
 
     ASSERT_EQ(expect, column) << "Expected col: " << expect.to_str()

--- a/cpp/tests/binaryop/unit/jit-cache-test.hpp
+++ b/cpp/tests/binaryop/unit/jit-cache-test.hpp
@@ -24,7 +24,7 @@
 
 struct JitCacheTest : public ::testing::Test
                     , public cudf::jit::cudfJitCache {
-    JitCacheTest() {
+    JitCacheTest() : grid(1), block(1) {
     }
 
     virtual ~JitCacheTest() {
@@ -63,7 +63,7 @@ struct JitCacheTest : public ::testing::Test
         auto kernel = getKernelInstantiation("my_kernel",
                                                     program,
                                                     {"3", "int"});
-        (*std::get<1>(kernel)).configure_1d_max_occupancy()
+        (*std::get<1>(kernel)).configure(grid, block)
                  .launch(column.get()->data);
 
         ASSERT_TRUE(expect == column) << "Expected col: " << expect.to_str()
@@ -103,6 +103,8 @@ struct JitCacheTest : public ::testing::Test
         "    }\n"
         "}\n";
 
+    dim3 grid;
+    dim3 block;
 };
 
 /**---------------------------------------------------------------------------*


### PR DESCRIPTION
Changed the kernel launch to single block, single thread. 
Earlier the kernel launch was using maximum occupancy. The operation happening in the kernel is this:
```c++
// out[0] = 1, data0 = 4, N=3
for( int i=0; i<N; ++i )
    out[0] *= data0;

// Now out[0] = 1*4*4*4 = 64
```
This is wrong, the threads shouldn't be writing to the same location. But the bug didn't appear in single process tests because all the threads ran concurrently. When using multiple processes, some kernel launches would've been delayed for either process because a similar kernel launch was taking place from the other process. When the rest of the kernel launches came to run, they'd see the output already populated and then they'd multiply 64 to it again.
```c++
// out[0] = 64, data0 = 4, N=3
for( int i=0; i<N; ++i )
    out[0] *= data0;

// Now out[0] = 64*4*4*4 = 4096
```

I'll rerun tests for this PR a bunch of times to ensure that it doesn't ever break.
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
