### PR TITLE
[REVIEW] Fix null_count bug in cudf::copy_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Bug Fixes
 
+- PR #2151 Fixes bug in cudf::copy_range where null_count was invalid
 
 # cuDF 0.8.0 (27 June 2019)
 

--- a/cpp/src/copying/copy_range.cuh
+++ b/cpp/src/copying/copy_range.cuh
@@ -132,8 +132,10 @@ struct copy_range_dispatch {
 
     if (cudf::is_nullable(*column)) {
       RMM_ALLOC(&null_count, sizeof(gdf_size_type), stream);
-      CUDA_TRY(cudaMemsetAsync(null_count, column->null_count, 
-                               sizeof(gdf_size_type), stream));
+      CUDA_TRY(cudaMemcpyAsync(null_count, &column->null_count, 
+                               sizeof(gdf_size_type), 
+                               cudaMemcpyHostToDevice,
+                               stream));
       kernel = copy_range_kernel<T, decltype(input), true>;
     }
 

--- a/cpp/tests/filling/filling_tests.cu
+++ b/cpp/tests/filling/filling_tests.cu
@@ -112,7 +112,7 @@ TYPED_TEST(FillingTest, SetRangeNullCount)
   TypeParam val = TypeParam{1};
 
   auto some_valid = [](gdf_index_type row) { 
-    return row % 2 == 0 ? false : true;
+    return row % 2 != 0;
   };
 
   auto all_invalid = [](gdf_index_type row) { 


### PR DESCRIPTION
This is a small fix for `cudf::copy_range`, re: https://github.com/rapidsai/cudf/issues/2142, and adds a test.

The original code was doing a `cudaMemsetAsync` to fill the `null_count` on to the device with the source's `null_count`. `cudaMemsetAsync` operates per byte of the destination, and `gdf_size_type` is 4 bytes, so this doesn't have the intended effect. 

One way to fix is to use `cudaMemcpyAsync`, which this PR does. Another would be to `cudaMemsetAsync` to 0, and then add up to the original `null_count` host-side after kernel is done. One issue with the second approach is that you could get a negative `null_count` from the kernel, so if the gdf_size_type ever became unsigned, we could have underflow issues.