### PR TITLE
[REVIEW] Matching get_dummies & select_dtypes behavior to pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #2186 Add `getitem` and `getattr` style access to Rolling objects
 - PR #2168 Use cudf.Column for CategoricalColumn's categories instead of a tuple
 - PR #2197 CSV Writer: Expose `chunksize` as a parameter for `to_csv`
+- PR #2209 Matching get_dummies & select_dtypes behavior to pandas
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - PR #2186 Add `getitem` and `getattr` style access to Rolling objects
 - PR #2168 Use cudf.Column for CategoricalColumn's categories instead of a tuple
 - PR #2197 CSV Writer: Expose `chunksize` as a parameter for `to_csv`
-- PR #2209 Matching get_dummies & select_dtypes behavior to pandas
+- PR #2209 Matching `get_dummies` & `select_dtypes` behavior to pandas
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/dataframe/dataframe.py
+++ b/python/cudf/cudf/dataframe/dataframe.py
@@ -3207,7 +3207,7 @@ class DataFrame(object):
         if not isinstance(exclude, (list, tuple)):
             exclude = (exclude,) if exclude is not None else ()
 
-        df = DataFrame()
+        df = DataFrame(index=self.index)
 
         # cudf_dtype_from_pydata_dtype can distinguish between
         # np.float and np.number
@@ -3251,12 +3251,14 @@ class DataFrame(object):
             [utils.cudf_dtype_from_pydata_dtype(d) for d in self.dtypes]
         )
 
+        if include:
+            inclusion = include_all & include_subtypes
+        elif exclude:
+            inclusion = include_all
+        else:
+            inclusion = set()
         # remove all exclude types
-        inclusion = include_all - exclude_subtypes
-
-        # keep only those included
-        if include_subtypes:
-            inclusion = inclusion & include_subtypes
+        inclusion = inclusion - exclude_subtypes
 
         for x in self._cols.values():
             infered_type = utils.cudf_dtype_from_pydata_dtype(x.dtype)

--- a/python/cudf/cudf/dataframe/dataframe.py
+++ b/python/cudf/cudf/dataframe/dataframe.py
@@ -3212,6 +3212,11 @@ class DataFrame(object):
         # cudf_dtype_from_pydata_dtype can distinguish between
         # np.float and np.number
         selection = tuple(map(frozenset, (include, exclude)))
+
+        if not any(selection):
+            raise ValueError('at least one of include or exclude must be \
+                             nonempty')
+
         include, exclude = map(
             lambda x: frozenset(map(utils.cudf_dtype_from_pydata_dtype, x)),
             selection,

--- a/python/cudf/cudf/dataframe/dataframe.py
+++ b/python/cudf/cudf/dataframe/dataframe.py
@@ -1733,43 +1733,6 @@ class DataFrame(object):
 
         return melt(self, **kwargs)
 
-    def get_dummies(self, **kwargs):
-        """ Returns a dataframe whose columns are the one hot encodings of all
-        columns in `df`
-
-        Parameters
-        ----------
-        df : cudf.DataFrame
-            dataframe to encode
-        prefix : str, dict, or sequence, optional
-            prefix to append. Either a str (to apply a constant prefix), dict
-            mapping column names to prefixes, or sequence of prefixes to apply
-            with the same length as the number of columns. If not supplied,
-            defaults to the empty string
-        prefix_sep : str, optional
-            separator to use when appending prefixes
-        dummy_na : boolean, optional
-            Right now this is NON-FUNCTIONAL argument in rapids.
-        cats : dict, optional
-            dictionary mapping column names to sequences of integers
-            representing that column's category.
-            See `cudf.DataFrame.one_hot_encoding` for more information.
-            if not supplied, it will be computed
-        sparse : boolean, optional
-            Right now this is NON-FUNCTIONAL argument in rapids.
-        drop_first : boolean, optional
-            Right now this is NON-FUNCTIONAL argument in rapids.
-        columns : sequence of str, optional
-            Names of columns to encode. If not provided, will attempt to encode
-            all columns. Note this is different from pandas default behavior,
-            which encodes all columns with dtype object or categorical
-        dtype : str, optional
-            output dtype, default 'float64'
-        """
-        from cudf.reshape import get_dummies
-
-        return get_dummies(self, **kwargs)
-
     def merge(
         self,
         right,

--- a/python/cudf/cudf/dataframe/dataframe.py
+++ b/python/cudf/cudf/dataframe/dataframe.py
@@ -3271,8 +3271,7 @@ class DataFrame(object):
                 # category handling
                 if i_dtype is cat_type:
                     include_subtypes.add(i_dtype)
-                    break
-                if issubclass(dtype.type, i_dtype):
+                elif issubclass(dtype.type, i_dtype):
                     include_subtypes.add(dtype.type)
 
         # exclude all subtypes
@@ -3282,8 +3281,7 @@ class DataFrame(object):
                 # category handling
                 if e_dtype is cat_type:
                     exclude_subtypes.add(e_dtype)
-                    break
-                if issubclass(dtype.type, e_dtype):
+                elif issubclass(dtype.type, e_dtype):
                     exclude_subtypes.add(dtype.type)
 
         include_all = set(

--- a/python/cudf/cudf/dataframe/series.py
+++ b/python/cudf/cudf/dataframe/series.py
@@ -1516,8 +1516,6 @@ class Series(object):
         A sequence of new series for each category.  Its length is determined
         by the length of ``cats``.
         """
-        if self.dtype.kind not in "iuf":
-            raise TypeError("expecting integer or float dtype")
 
         dtype = np.dtype(dtype)
         return ((self == cat).fillna(False).astype(dtype) for cat in cats)

--- a/python/cudf/cudf/reshape/general.py
+++ b/python/cudf/cudf/reshape/general.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from cudf.dataframe import Buffer, DataFrame, Series
 from cudf.dataframe.categorical import CategoricalColumn
-from cudf.utils import cudautils
+from cudf.utils import cudautils, utils
 
 
 def melt(
@@ -171,7 +171,7 @@ def get_dummies(
     cats={},
     sparse=False,
     drop_first=False,
-    dtype="float64",
+    dtype="uint8",
 ):
     """ Returns a dataframe whose columns are the one hot encodings of all
     columns in `df`
@@ -202,7 +202,7 @@ def get_dummies(
         columns. Note this is different from pandas default behavior, which
         encodes all columns with dtype object or categorical
     dtype : str, optional
-        output dtype, default 'float64'
+        output dtype, default 'int64'
     """
     if dummy_na:
         raise NotImplementedError("dummy_na is not supported yet")
@@ -215,31 +215,55 @@ def get_dummies(
 
     from cudf.multi import concat
 
+    encode_fallback_dtypes = ['object', 'category']
+
     if columns is None or len(columns) == 0:
-        columns = df.columns
+        columns = df.select_dtypes(include=encode_fallback_dtypes).columns
+
+    def length_check(obj, name):
+        err_msg = ("Length of '{name}' ({len_obj}) did not match the "
+                   "length of the columns being encoded ({len_required}).")
+
+        if utils.is_list_like(obj):
+            if len(obj) != len(columns):
+                err_msg = err_msg.format(name=name, len_obj=len(obj),
+                                         len_required=len(columns))
+                raise ValueError(err_msg)
+
+    length_check(prefix, 'prefix')
+    length_check(prefix_sep, 'prefix_sep')
 
     if prefix is None:
-        prefix_map = {}
-        prefix = ""
-    elif isinstance(prefix, str):
+        prefix = columns
+
+    if isinstance(prefix, str):
         prefix_map = {}
     elif isinstance(prefix, dict):
         prefix_map = prefix
     else:
         prefix_map = dict(zip(columns, prefix))
 
-    return concat(
-        [
-            df.one_hot_encoding(
+    if isinstance(prefix_sep, str):
+        prefix_sep_map = {}
+    elif isinstance(prefix_sep, dict):
+        prefix_sep_map = prefix_sep
+    else:
+        prefix_sep_map = dict(zip(columns, prefix_sep))
+
+    # If we have no columns to encode, we need to drop fallback columns(if any)
+    if len(columns) == 0:
+        return df.select_dtypes(exclude=encode_fallback_dtypes)
+    else:
+        df_list = []
+
+        for name in columns:
+            col_enc_df = df.one_hot_encoding(
                 name,
-                prefix=name
-                + (prefix_sep if prefix else "")
-                + prefix_map.get(name, prefix),
+                prefix=prefix_map.get(name, prefix),
                 cats=cats.get(name, df[name].unique()),
-                prefix_sep=prefix_sep,
+                prefix_sep=prefix_sep_map.get(name, prefix_sep),
                 dtype=dtype,
             )
-            for name in columns
-        ],
-        axis=1,
-    )
+            df_list.append(col_enc_df)
+
+        return concat(df_list, axis=1).drop(labels=columns)

--- a/python/cudf/cudf/reshape/general.py
+++ b/python/cudf/cudf/reshape/general.py
@@ -185,7 +185,7 @@ def get_dummies(
         mapping column names to prefixes, or sequence of prefixes to apply with
         the same length as the number of columns. If not supplied, defaults
         to the empty string
-    prefix_sep : str, optional
+    prefix_sep : str, dict, or sequence, optional, default '_'
         separator to use when appending prefixes
     dummy_na : boolean, optional
         Right now this is NON-FUNCTIONAL argument in rapids.
@@ -202,7 +202,7 @@ def get_dummies(
         columns. Note this is different from pandas default behavior, which
         encodes all columns with dtype object or categorical
     dtype : str, optional
-        output dtype, default 'int64'
+        output dtype, default 'uint8'
     """
     if dummy_na:
         raise NotImplementedError("dummy_na is not supported yet")

--- a/python/cudf/cudf/reshape/general.py
+++ b/python/cudf/cudf/reshape/general.py
@@ -202,7 +202,7 @@ def get_dummies(
         columns. Note this is different from pandas default behavior, which
         encodes all columns with dtype object or categorical
     dtype : str, optional
-        output dtype, default 'uint8'
+        output dtype, default 'int8'
     """
     if dummy_na:
         raise NotImplementedError("dummy_na is not supported yet")

--- a/python/cudf/cudf/reshape/general.py
+++ b/python/cudf/cudf/reshape/general.py
@@ -171,7 +171,7 @@ def get_dummies(
     cats={},
     sparse=False,
     drop_first=False,
-    dtype="uint8",
+    dtype="int8",
 ):
     """ Returns a dataframe whose columns are the one hot encodings of all
     columns in `df`

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2666,12 +2666,14 @@ def test_column_assignment():
 
 def test_select_dtype():
     gdf = gd.datasets.randomdata(
-        nrows=20, dtypes={"a": "category", "b": int, "c": float}
+        nrows=20, dtypes={"a": "category", "b": int, "c": float, "d": str}
     )
 
     assert_eq(gdf[["c"]], gdf.select_dtypes("float64"))
     assert_eq(gdf[["c"]], gdf.select_dtypes(np.float64))
     assert_eq(gdf[["c"]], gdf.select_dtypes(include=["float64"]))
+    assert_eq(gdf[["a", "b", "d"]],
+              gdf.select_dtypes(include=['object', 'int', 'category']))
 
     assert_eq(gdf[["b", "c"]], gdf.select_dtypes(include=["int64", "float64"]))
     assert_eq(gdf[["b", "c"]], gdf.select_dtypes(include=np.number))
@@ -2680,13 +2682,19 @@ def test_select_dtype():
     )
 
     assert_eq(gdf[["a"]], gdf.select_dtypes(include=["category"]))
-    assert_eq(gdf[["a"]], gdf.select_dtypes(exclude=np.number))
+    assert_eq(gdf[["a", "d"]], gdf.select_dtypes(exclude=np.number))
 
     with pytest.raises(TypeError):
         assert_eq(gdf[["a"]], gdf.select_dtypes(include=["Foo"]))
 
     with pytest.raises(ValueError):
         gdf.select_dtypes(exclude=np.number, include=np.number)
+
+    gdf = DataFrame({'A': [3, 4, 5],
+                     'C': [1, 2, 3],
+                     'D': ['a', 'b', 'c']})
+    assert_eq(gdf[["A", "C", "D"]],
+              gdf.select_dtypes(include=['object', 'int', 'category']))
 
 
 def test_select_dtype_datetime():

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2725,6 +2725,18 @@ def test_select_dtype():
               gdf.select_dtypes(exclude=['object']))
     assert_eq(pdf.select_dtypes(include=['int'], exclude=['object']),
               gdf.select_dtypes(include=['int'], exclude=['object']))
+    with pytest.raises(ValueError):
+        pdf.select_dtypes()
+    with pytest.raises(ValueError):
+        gdf.select_dtypes()
+
+    gdf = gd.DataFrame({'a': gd.Series([], dtype='int'),
+                        'b': gd.Series([], dtype='str')})
+    pdf = gdf.to_pandas()
+    assert_eq(pdf.select_dtypes(exclude=['object']),
+              gdf.select_dtypes(exclude=['object']))
+    assert_eq(pdf.select_dtypes(include=['int'], exclude=['object']),
+              gdf.select_dtypes(include=['int'], exclude=['object']))
 
 
 def test_select_dtype_datetime():

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2668,33 +2668,63 @@ def test_select_dtype():
     gdf = gd.datasets.randomdata(
         nrows=20, dtypes={"a": "category", "b": int, "c": float, "d": str}
     )
+    pdf = gdf.to_pandas()
 
-    assert_eq(gdf[["c"]], gdf.select_dtypes("float64"))
-    assert_eq(gdf[["c"]], gdf.select_dtypes(np.float64))
-    assert_eq(gdf[["c"]], gdf.select_dtypes(include=["float64"]))
-    assert_eq(gdf[["a", "b", "d"]],
+    assert_eq(pdf.select_dtypes("float64"), gdf.select_dtypes("float64"))
+    assert_eq(pdf.select_dtypes(np.float64), gdf.select_dtypes(np.float64))
+    assert_eq(pdf.select_dtypes(include=["float64"]),
+              gdf.select_dtypes(include=["float64"]))
+    assert_eq(pdf.select_dtypes(include=['object', 'int', 'category']),
               gdf.select_dtypes(include=['object', 'int', 'category']))
 
-    assert_eq(gdf[["b", "c"]], gdf.select_dtypes(include=["int64", "float64"]))
-    assert_eq(gdf[["b", "c"]], gdf.select_dtypes(include=np.number))
+    assert_eq(pdf.select_dtypes(include=["int64", "float64"]),
+              gdf.select_dtypes(include=["int64", "float64"]))
+    assert_eq(pdf.select_dtypes(include=np.number),
+              gdf.select_dtypes(include=np.number))
     assert_eq(
-        gdf[["b", "c"]], gdf.select_dtypes(include=[np.int64, np.float64])
+        pdf.select_dtypes(include=[np.int64, np.float64]),
+        gdf.select_dtypes(include=[np.int64, np.float64])
     )
 
-    assert_eq(gdf[["a"]], gdf.select_dtypes(include=["category"]))
-    assert_eq(gdf[["a", "d"]], gdf.select_dtypes(exclude=np.number))
+    assert_eq(pdf.select_dtypes(include=["category"]),
+              gdf.select_dtypes(include=["category"]))
+    assert_eq(pdf.select_dtypes(exclude=np.number),
+              gdf.select_dtypes(exclude=np.number))
 
     with pytest.raises(TypeError):
-        assert_eq(gdf[["a"]], gdf.select_dtypes(include=["Foo"]))
+        assert_eq(pdf.select_dtypes(include=["Foo"]),
+                  gdf.select_dtypes(include=["Foo"]))
 
     with pytest.raises(ValueError):
         gdf.select_dtypes(exclude=np.number, include=np.number)
+    with pytest.raises(ValueError):
+        pdf.select_dtypes(exclude=np.number, include=np.number)
 
     gdf = DataFrame({'A': [3, 4, 5],
                      'C': [1, 2, 3],
                      'D': ['a', 'b', 'c']})
-    assert_eq(gdf[["A", "C", "D"]],
+    pdf = gdf.to_pandas()
+    assert_eq(pdf.select_dtypes(include=['object', 'int', 'category']),
               gdf.select_dtypes(include=['object', 'int', 'category']))
+    assert_eq(pdf.select_dtypes(include=['object'], exclude=['category']),
+              gdf.select_dtypes(include=['object'], exclude=['category']))
+
+    gdf = gd.DataFrame({'a': range(10), 'b': range(10, 20)})
+    pdf = gdf.to_pandas()
+    assert_eq(pdf.select_dtypes(include=['category']),
+              gdf.select_dtypes(include=['category']))
+    assert_eq(pdf.select_dtypes(include=['float']),
+              gdf.select_dtypes(include=['float']))
+    assert_eq(pdf.select_dtypes(include=['object']),
+              gdf.select_dtypes(include=['object']))
+    assert_eq(pdf.select_dtypes(include=['int']),
+              gdf.select_dtypes(include=['int']))
+    assert_eq(pdf.select_dtypes(exclude=['float']),
+              gdf.select_dtypes(exclude=['float']))
+    assert_eq(pdf.select_dtypes(exclude=['object']),
+              gdf.select_dtypes(exclude=['object']))
+    assert_eq(pdf.select_dtypes(include=['int'], exclude=['object']),
+              gdf.select_dtypes(include=['int'], exclude=['object']))
 
 
 def test_select_dtype_datetime():

--- a/python/cudf/cudf/tests/test_onehot.py
+++ b/python/cudf/cudf/tests/test_onehot.py
@@ -4,8 +4,10 @@ import numpy as np
 import pytest
 
 from cudf.dataframe import DataFrame, GenericIndex, Series
-from cudf.reshape import get_dummies
 from cudf.tests import utils
+from string import ascii_lowercase
+import pandas as pd
+import cudf
 
 
 def test_onehot_simple():
@@ -94,47 +96,68 @@ def test_onehot_generic_index():
     np.testing.assert_array_equal(values == 3, out.fo_3.to_array())
 
 
-def test_onehot_get_dummies_simple():
-    df = DataFrame({"x": np.arange(10)})
-    original = df.copy()
-    encoded = get_dummies(df, prefix="test")
+@pytest.mark.parametrize("data", [
+    np.arange(10),
+    ['abc', 'zyx', 'pppp'],
+    [],
+    pd.Series(['cudf', 'hello', 'pandas'] * 10, dtype='category')
+])
+def test_get_dummies(data):
+    gdf = DataFrame({"x": data})
+    pdf = pd.DataFrame({"x": data})
 
-    assert df == original  # the original df should be unchanged
-    cols = list(encoded.columns)[1:]
-    actual = DataFrame(dict(zip(cols, np.eye(len(cols)))))
-    assert (encoded.loc[:, cols] == actual).all().all()
+    encoded_expected = pd.get_dummies(pdf, prefix="test")
+    encoded_actual = cudf.get_dummies(gdf, prefix="test")
+
+    utils.assert_eq(encoded_expected, encoded_actual)
 
 
 @pytest.mark.parametrize("n_cols", [5, 10, 20])
 def test_onehot_get_dummies_multicol(n_cols):
-    from string import ascii_lowercase
-
     n_categories = 5
-    df = DataFrame(
-        dict(
-            zip(
-                ascii_lowercase,
-                (np.arange(n_categories) for _ in range(n_cols)),
-            )
-        )
-    )
-    original = df.copy()
-    encoded = get_dummies(df, prefix="test")
+    data = dict(zip(ascii_lowercase,
+                    (np.arange(n_categories) for _ in range(n_cols))
+                    )
+                )
 
-    assert df == original
+    gdf = cudf.DataFrame(data)
+    pdf = pd.DataFrame(data)
 
-    cols = list(encoded.columns)[n_cols:]
-    actual = DataFrame(
-        dict(
-            zip(
-                cols,
-                np.concatenate(
-                    list(np.eye(n_categories) for _ in range(n_cols))
-                ),
-            )
-        )
-    )
-    assert (encoded.loc[:, cols] == actual).all().all()
+    encoded_expected = pd.get_dummies(pdf, prefix="test")
+    encoded_actual = cudf.get_dummies(gdf, prefix="test")
+
+    utils.assert_eq(encoded_expected, encoded_actual)
+
+
+@pytest.mark.parametrize("prefix", [
+    ["a" , "b", "c"],
+    "",
+    None,
+    {'first': 'one', 'second': 'two', 'third': 'three'},
+    "--"
+])
+@pytest.mark.parametrize("prefix_sep", [
+    ["a" , "b", "c"],
+    "",
+    "++",
+    {'first': '*******', 'second': '__________', 'third': '#########'}
+])
+def test_get_dummies_prefix_sep(prefix, prefix_sep):
+    data = {'first': ['1', '2', '3'],
+            'second': ['abc', 'def', 'ghi'],
+            'third': ['ji', 'ji', 'ji']}
+
+    gdf = DataFrame(data)
+    pdf = pd.DataFrame(data)
+
+    encoded_expected = pd.get_dummies(pdf,
+                                      prefix=prefix,
+                                      prefix_sep=prefix_sep)
+    encoded_actual = cudf.get_dummies(gdf,
+                                      prefix=prefix,
+                                      prefix_sep=prefix_sep)
+
+    utils.assert_eq(encoded_expected, encoded_actual)
 
 
 if __name__ == "__main__":

--- a/python/cudf/cudf/tests/test_onehot.py
+++ b/python/cudf/cudf/tests/test_onehot.py
@@ -109,7 +109,7 @@ def test_get_dummies(data):
     encoded_expected = pd.get_dummies(pdf, prefix="test")
     encoded_actual = cudf.get_dummies(gdf, prefix="test")
 
-    utils.assert_eq(encoded_expected, encoded_actual)
+    utils.assert_eq(encoded_expected, encoded_actual, check_dtype=False)
 
 
 @pytest.mark.parametrize("n_cols", [5, 10, 20])
@@ -126,7 +126,7 @@ def test_onehot_get_dummies_multicol(n_cols):
     encoded_expected = pd.get_dummies(pdf, prefix="test")
     encoded_actual = cudf.get_dummies(gdf, prefix="test")
 
-    utils.assert_eq(encoded_expected, encoded_actual)
+    utils.assert_eq(encoded_expected, encoded_actual, check_dtype=False)
 
 
 @pytest.mark.parametrize("prefix", [
@@ -157,7 +157,7 @@ def test_get_dummies_prefix_sep(prefix, prefix_sep):
                                       prefix=prefix,
                                       prefix_sep=prefix_sep)
 
-    utils.assert_eq(encoded_expected, encoded_actual)
+    utils.assert_eq(encoded_expected, encoded_actual, check_dtype=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This fixes: #2203 , #1853 

Changes made in this PR:

- [x] Remove `cudf.DataFrame.get_dummies` as we have `cudf.get_dummies` and dask has changes merged which will work with `cudf.get_dummies`
- [x] fix issues in `select_dtypes`
- [x] fix index not being set in `select_dtypes` (inconsistency with pandas)
- [x] changle default type of get_dummies from float64 to uint8
- [x] allow lists & dicts for `prefix_sep`
- [x] add support for fallback dtypes to be encoded if none are given for encoding
- [x] add & revamp tests for `get_dummies`
- [x] add tests for `select_dtypes`

cc: @randerzander , @beckernick @kkraus14 