### PR TITLE
Update Java bindings for reduction rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #2209 Matching `get_dummies` & `select_dtypes` behavior to pandas
 - PR #2214 DOC: Update doc instructions to build/install `cudf` and `dask-cudf`
 - PR #1993 Add iterator driven reduction for mean, var, std
+- PR #2220 Update Java bindings for reduction rename
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -997,7 +997,7 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * of the specified type.
    */
   public Scalar sum(DType outType) {
-    return reduction(ReductionOp.SUM, outType);
+    return reduce(ReductionOp.SUM, outType);
   }
 
   /**
@@ -1013,7 +1013,7 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * of the specified type.
    */
   public Scalar min(DType outType) {
-    return reduction(ReductionOp.MIN, outType);
+    return reduce(ReductionOp.MIN, outType);
   }
 
   /**
@@ -1029,7 +1029,7 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * of the specified type.
    */
   public Scalar max(DType outType) {
-    return reduction(ReductionOp.MAX, outType);
+    return reduce(ReductionOp.MAX, outType);
   }
 
   /**
@@ -1045,7 +1045,7 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * of the specified type.
    */
   public Scalar product(DType outType) {
-    return reduction(ReductionOp.PRODUCT, outType);
+    return reduce(ReductionOp.PRODUCT, outType);
   }
 
   /**
@@ -1061,7 +1061,7 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * scalar of the specified type.
    */
   public Scalar sumOfSquares(DType outType) {
-    return reduction(ReductionOp.SUMOFSQUARES, outType);
+    return reduce(ReductionOp.SUMOFSQUARES, outType);
   }
 
   /**
@@ -1074,8 +1074,8 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * empty or the reduction operation fails then the
    * {@link Scalar#isValid()} method of the result will return false.
    */
-  public Scalar reduction(ReductionOp op) {
-    return reduction(op, type);
+  public Scalar reduce(ReductionOp op) {
+    return reduce(op, type);
   }
 
   /**
@@ -1090,8 +1090,8 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * empty or the reduction operation fails then the
    * {@link Scalar#isValid()} method of the result will return false.
    */
-  public Scalar reduction(ReductionOp op, DType outType) {
-    return Cudf.reduction(this, op, outType);
+  public Scalar reduce(ReductionOp op, DType outType) {
+    return Cudf.reduce(this, op, outType);
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/java/src/main/java/ai/rapids/cudf/Cudf.java
+++ b/java/src/main/java/ai/rapids/cudf/Cudf.java
@@ -117,11 +117,11 @@ class Cudf {
   private static native void fill(long input, long sIntValues, float sFValue,
                                   double sDValue, boolean sIsValid, int sDtype);
 
-  static Scalar reduction(ColumnVector v, ReductionOp op, DType outType) {
-    return reduction(v.getNativeCudfColumnAddress(), op.nativeId, outType.nativeId);
+  static Scalar reduce(ColumnVector v, ReductionOp op, DType outType) {
+    return reduce(v.getNativeCudfColumnAddress(), op.nativeId, outType.nativeId);
   }
 
-  private static native Scalar reduction(long v, int op, int dtype);
+  private static native Scalar reduce(long v, int op, int dtype);
 
   /* datetime extract*/
 

--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -511,14 +511,14 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cudf_fill(JNIEnv *env, jclass, jlong 
   CATCH_STD(env, );
 }
 
-JNIEXPORT jobject JNICALL Java_ai_rapids_cudf_Cudf_reduction(JNIEnv *env, jclass, jlong jcol,
-                                                             jint jop, jint jdtype) {
+JNIEXPORT jobject JNICALL Java_ai_rapids_cudf_Cudf_reduce(JNIEnv *env, jclass, jlong jcol,
+                                                          jint jop, jint jdtype) {
   JNI_NULL_CHECK(env, jcol, "input column is null", 0);
   try {
     gdf_column *col = reinterpret_cast<gdf_column *>(jcol);
-    gdf_reduction_op op = static_cast<gdf_reduction_op>(jop);
+    cudf::reduction::operators op = static_cast<cudf::reduction::operators>(jop);
     gdf_dtype dtype = static_cast<gdf_dtype>(jdtype);
-    gdf_scalar scalar = cudf::reduction(col, op, dtype);
+    gdf_scalar scalar = cudf::reduce(col, op, dtype);
     return cudf::jni::jscalar_from_scalar(env, scalar, col->dtype_info.time_unit);
   }
   CATCH_STD(env, 0);

--- a/java/src/test/java/ai/rapids/cudf/ReductionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ReductionTest.java
@@ -161,7 +161,7 @@ class ReductionTest {
   @MethodSource("createBooleanParams")
   void testBoolean(ReductionOp op, Boolean[] values, Scalar expected) {
     try (ColumnVector v = ColumnVector.fromBoxedBooleans(values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }
@@ -170,7 +170,7 @@ class ReductionTest {
   @MethodSource("createByteParams")
   void testByte(ReductionOp op, Byte[] values, Scalar expected) {
     try (ColumnVector v = ColumnVector.fromBoxedBytes(values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }
@@ -179,7 +179,7 @@ class ReductionTest {
   @MethodSource("createShortParams")
   void testShort(ReductionOp op, Short[] values, Scalar expected) {
     try (ColumnVector v = ColumnVector.fromBoxedShorts(values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }
@@ -188,7 +188,7 @@ class ReductionTest {
   @MethodSource("createIntParams")
   void testInt(ReductionOp op, Integer[] values, Scalar expected) {
     try (ColumnVector v = ColumnVector.fromBoxedInts(values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }
@@ -197,7 +197,7 @@ class ReductionTest {
   @MethodSource("createLongParams")
   void testLong(ReductionOp op, Long[] values, Scalar expected) {
     try (ColumnVector v = ColumnVector.fromBoxedLongs(values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }
@@ -206,7 +206,7 @@ class ReductionTest {
   @MethodSource("createFloatParams")
   void testFloat(ReductionOp op, Float[] values, Scalar expected) {
     try (ColumnVector v = ColumnVector.fromBoxedFloats(values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }
@@ -215,7 +215,7 @@ class ReductionTest {
   @MethodSource("createDoubleParams")
   void testByte(ReductionOp op, Double[] values, Scalar expected) {
     try (ColumnVector v = ColumnVector.fromBoxedDoubles(values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }
@@ -224,7 +224,7 @@ class ReductionTest {
   @MethodSource("createDate32Params")
   void testDate32(ReductionOp op, Integer[] values, Scalar expected) {
     try (ColumnVector v = ColumnVector.datesFromBoxedInts(values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }
@@ -233,7 +233,7 @@ class ReductionTest {
   @MethodSource("createDate64Params")
   void testDate64(ReductionOp op, Long[] values, Scalar expected) {
     try (ColumnVector v = ColumnVector.datesFromBoxedLongs(values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }
@@ -242,7 +242,7 @@ class ReductionTest {
   @MethodSource("createTimestampParams")
   void testTimestamp(ReductionOp op, Long[] values, TimeUnit timeUnit, Scalar expected) {
     try (ColumnVector v = ColumnVector.timestampsFromBoxedLongs(timeUnit, values)) {
-      Scalar result = v.reduction(op);
+      Scalar result = v.reduce(op);
       assertEquals(expected, result);
     }
   }


### PR DESCRIPTION
This updates the Java bindings to adapt to the renaming of gdf_reduction_op to cudf::reduction::operators and cudf::reduction to cudf::reduce.