### PR TITLE
[REVIEW] Move CodeCov upload from build script to Jenkins

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -101,7 +101,4 @@ else
     cd $WORKSPACE/python/dask_cudf
     logger "Python py.test for dask-cudf..."
     py.test --cache-clear --junitxml=${WORKSPACE}/junit-dask-cudf.xml -v --cov-config=.coveragerc --cov=dask_cudf --cov-report=xml:${WORKSPACE}/python/dask_cudf/dask-cudf-coverage.xml --cov-report term
-
-    conda install codecov
-    codecov -t $CODECOV_TOKEN
 fi


### PR DESCRIPTION
Depends on: https://github.com/rapidsai/gpuci-scripts/pull/29

Removing CodeCov from the GPU build script in favor of putting it in the pull request builds in Jenkins. Since it is something that should only happen on pull requests, it makes more sense to have it in the Jenkins builds. Other builds that may rely on the gpu build.sh script run into issues with the coverage upload being part of it. 