### PR TITLE
[REVIEW] Fix Local Build Script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - PR #2187 fix to honor dtype when numpy arrays are passed to columnops.as_column
 - PR #2190 Fix issue in astype conversion of string column to 'str'
 - PR #2208 Fix issue with calling `head()` on one row dataframe
+- PR #2234 Fix issue with local build script not properly building
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -26,6 +26,7 @@ export CUDA_REL=${CUDA_VERSION%.*}
 export HOME=$WORKSPACE
 
 # Parse git describe
+cd $WORKSPACE
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -73,7 +73,6 @@ set -e
 WORKSPACE=${REPO_PATH_IN_CONTAINER}
 PREBUILD_SCRIPT=${REPO_PATH_IN_CONTAINER}/ci/gpu/prebuild.sh
 BUILD_SCRIPT=${REPO_PATH_IN_CONTAINER}/ci/gpu/build.sh
-cd ${WORKSPACE}
 if [ -f \${PREBUILD_SCRIPT} ]; then
     source \${PREBUILD_SCRIPT}
 fi


### PR DESCRIPTION
Sometimes the most annoying and confusing issues are solved with a single line...

This should fix `local/build.sh` from breaking as it was not properly recognizing the directory as a git repo. This results in `git describe --tags` providing empty output. This obviously leads to conda installs being wrong and the script ultimately failing.