### PR TITLE
[REVIEW] Fix length of RLEv2 delta sequence with nonzero delta residual width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - PR #2234 Fix issue with local build script not properly building
 - PR #2223 Fix CUDA invalid configuration errors reported after loading small compressed ORC files
 - PR #2162 Setting is_unique and is_monotonic-related attributes
+- PR #2244 Fix ORC RLEv2 delta mode decoding with nonzero residual delta width
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -725,7 +725,7 @@ static __device__ uint32_t Integer_RLEv2(orc_bytestream_s *bs, volatile orc_rlev
                     // 11wwwwwn.nnnnnnnn.<base>.<delta>: delta encoding
                     uint32_t deltapos = varint_length<T>(bs, pos);
                     deltapos += varint_length<T>(bs, pos + deltapos);
-                    l = (l > 1) ? (l * n + 7) >> 3 : 0;
+                    l = (l > 1 && n > 2) ? (l * (n - 2) + 7) >> 3 : 0;
                     l += deltapos;
                 }
             }


### PR DESCRIPTION
The first two values must be excluded from the number of delta residuals
Fixes #2238