### PR TITLE
[REVIEW] Add dask codeowners [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
 #cpp code owners
-cpp/       @rapidsai/cudf-cpp-codeowners
+cpp/               @rapidsai/cudf-cpp-codeowners
 
 #python code owners
-python/    @rapidsai/cudf-python-codeowners
+python/            @rapidsai/cudf-python-codeowners
+python/dask_cudf/  @rapidsai/cudf-dask-codeowners
 
 #cmake code owners
 **/CMakeLists.txt  @rapidsai/cudf-cmake-codeowners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - PR #2224 implement isna, isnull, notna as dataframe functions
 - PR #2236 Implement drop_duplicates for Series
 - PR #2225 refactor to use libcudf for gathering columns in dataframes
-- PR #XXXX Create separate dask codeowners for dask-cudf codebase
+- PR #2300 Create separate dask codeowners for dask-cudf codebase
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PR #2224 implement isna, isnull, notna as dataframe functions
 - PR #2236 Implement drop_duplicates for Series
 - PR #2225 refactor to use libcudf for gathering columns in dataframes
+- PR #XXXX Create separate dask codeowners for dask-cudf codebase
 
 ## Bug Fixes
 


### PR DESCRIPTION
Separate dask group was already created and populated, just adds it to the github `.CODEOWNERS` file.