### PR TITLE
[REVIEW] gdf_group_by_without_aggregations returns gdf_column close #2239

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PR #2179 Added Java quantiles
 - PR #2157 Add __array_function__ to DataFrame and Series
 - PR #2212 Java support for ORC reader
+- PR #2239 gdf_group_by_without_aggregations return gdf_column
 
 ## Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - PR #2179 Added Java quantiles
 - PR #2157 Add __array_function__ to DataFrame and Series
 - PR #2212 Java support for ORC reader
-- PR #2239 gdf_group_by_without_aggregations return gdf_column
+- PR #2304 gdf_group_by_without_aggregations returns gdf_column
 
 ## Improvements
 

--- a/cpp/include/cudf/groupby.hpp
+++ b/cpp/include/cudf/groupby.hpp
@@ -191,10 +191,10 @@ gdf_unique_indices(cudf::table const& input_table, gdf_context const& context);
  * @returns A tuple containing:
  *          - A cudf::table containing a set of columns sorted by the key
  * columns.
- *          - A device vector containing the first index of every unique row
+ *          - A GDF column containing the first index of every unique row
  */
 std::pair<cudf::table,
-          thrust::device_vector<gdf_index_type, rmm_allocator<gdf_index_type>>>
+          gdf_column>
 gdf_group_by_without_aggregations(cudf::table const& input_table,
                                   gdf_size_type num_key_cols,
                                   gdf_index_type const* key_col_indices,

--- a/cpp/include/cudf/groupby.hpp
+++ b/cpp/include/cudf/groupby.hpp
@@ -167,9 +167,10 @@ std::pair<cudf::table, cudf::table> groupby(cudf::table const& keys,
  * nulls context->flag_null_sort_behavior GDF_NULL_AS_LARGEST = Nulls are
  * treated as largest, GDF_NULL_AS_SMALLEST = Nulls are treated as smallest,
  *
- * @returns A device vector containing the first index of every unique row.
+ * @returns A gdf_column containing the first index of every unique row.
+ * It can return only GDF_INT32 type and cannot contain null values.
  */
-thrust::device_vector<gdf_index_type, rmm_allocator<gdf_index_type>>
+gdf_column
 gdf_unique_indices(cudf::table const& input_table, gdf_context const& context);
 
 /**
@@ -192,6 +193,7 @@ gdf_unique_indices(cudf::table const& input_table, gdf_context const& context);
  *          - A cudf::table containing a set of columns sorted by the key
  * columns.
  *          - A GDF column containing the first index of every unique row
+ *            It can return only GDF_INT32 type and cannot contain null values.
  */
 std::pair<cudf::table,
           gdf_column>

--- a/cpp/include/cudf/groupby.hpp
+++ b/cpp/include/cudf/groupby.hpp
@@ -167,8 +167,7 @@ std::pair<cudf::table, cudf::table> groupby(cudf::table const& keys,
  * nulls context->flag_null_sort_behavior GDF_NULL_AS_LARGEST = Nulls are
  * treated as largest, GDF_NULL_AS_SMALLEST = Nulls are treated as smallest,
  *
- * @returns A gdf_column containing the first index of every unique row.
- * It can return only GDF_INT32 type and cannot contain null values.
+ * @returns A non-nullable column of `GDF_INT32` elements containing the indices of the first occurrences of each unique row.
  */
 gdf_column
 gdf_unique_indices(cudf::table const& input_table, gdf_context const& context);
@@ -192,8 +191,7 @@ gdf_unique_indices(cudf::table const& input_table, gdf_context const& context);
  * @returns A tuple containing:
  *          - A cudf::table containing a set of columns sorted by the key
  * columns.
- *          - A GDF column containing the first index of every unique row
- *            It can return only GDF_INT32 type and cannot contain null values.
+ *          - A non-nullable column of `GDF_INT32` elements containing the indices of the first occurrences of each unique row.
  */
 std::pair<cudf::table,
           gdf_column>

--- a/cpp/src/groupby/new_groupby.cu
+++ b/cpp/src/groupby/new_groupby.cu
@@ -290,7 +290,7 @@ gdf_group_by_without_aggregations(cudf::table const& input_table,
   unique_indices.dtype = cudf::gdf_dtype_of<gdf_index_type>();
 
   if (0 == input_table.num_rows()) {
-    return std::make_pair(cudf::table(), unique_indices);
+    return std::make_pair(cudf::empty_like(input_table), unique_indices);
   }
 
   gdf_size_type nrows = input_table.num_rows();

--- a/cpp/src/groupby/new_groupby.cu
+++ b/cpp/src/groupby/new_groupby.cu
@@ -268,11 +268,14 @@ gdf_unique_indices(cudf::table const& input_table, gdf_context const& context)
 
   // size of the GDF column is being resized
   unique_indices.size = thrust::distance(static_cast<gdf_index_type *>(unique_indices.data), result_end);
+  gdf_column resized_unique_indices = cudf::copy(unique_indices);
+  // Free old column, as we have resized (implicitly)
+  gdf_column_free (&unique_indices);
 
   cudaStreamSynchronize(stream);
   cudaStreamDestroy(stream);
 
-  return unique_indices;
+  return resized_unique_indices;
 }
 
 std::pair<cudf::table, gdf_column>

--- a/cpp/tests/groupby/without_agg/groupby_wo_agg_test.cu
+++ b/cpp/tests/groupby/without_agg/groupby_wo_agg_test.cu
@@ -191,12 +191,10 @@ struct GroupByWoAggTest : public GdfTest {
                                                                             groupby_col_indices.data(),
                                                                             &context));
 
-    copy_output_with_array(output_table.begin(), cpu_data_cols_out, (gdf_size_type *)indices_col.data, indices_col.size, this->cpu_out_indices);
+    copy_output_with_array(output_table.begin(), cpu_data_cols_out, static_cast<gdf_size_type *>(indices_col.data), indices_col.size, this->cpu_out_indices);
 
     // Free results
-    RMM_TRY(RMM_FREE(indices_col.data, 0));
-    indices_col.data = nullptr;
-    indices_col.size = 0;
+    gdf_column_free(&indices_col);
     std::for_each(output_table.begin(), output_table.end(), [](gdf_column* col){
       RMM_FREE(col->data, 0);
       RMM_FREE(col->valid, 0);
@@ -409,12 +407,10 @@ struct GroupValidTest : public GroupByWoAggTest<test_parameters>
                                                                             groupby_col_indices.data(),
                                                                             &this->context));
     copy_output_with_array_with_nulls(
-            output_table.begin(), this->cpu_data_cols_out, this->cpu_data_cols_out_valid, (gdf_size_type *)indices_col.data, indices_col.size, this->cpu_out_indices);
+            output_table.begin(), this->cpu_data_cols_out, this->cpu_data_cols_out_valid, static_cast<gdf_size_type *>(indices_col.data), indices_col.size, this->cpu_out_indices);
 
     // Free results
-    RMM_TRY(RMM_FREE(indices_col.data, 0));
-    indices_col.data = nullptr;
-    indices_col.size = 0;
+    gdf_column_free(&indices_col);
     std::for_each(output_table.begin(), output_table.end(), [](gdf_column* col){
       RMM_FREE(col->data, 0);
       RMM_FREE(col->valid, 0);

--- a/cpp/tests/groupby/without_agg/groupby_wo_agg_test.cu
+++ b/cpp/tests/groupby/without_agg/groupby_wo_agg_test.cu
@@ -184,14 +184,14 @@ struct GroupByWoAggTest : public GdfTest {
     cudf::table input_table(group_by_input_key, num_columns);
     
     cudf::table output_table;
-    rmm::device_vector<gdf_index_type> indices_arr;
+    gdf_column indices_col;
     EXPECT_NO_THROW(std::tie(output_table,
-                            indices_arr) = gdf_group_by_without_aggregations(input_table,
+                            indices_col) = gdf_group_by_without_aggregations(input_table,
                                                                             num_columns,
                                                                             groupby_col_indices.data(),
                                                                             &context));
 
-    copy_output_with_array(output_table.begin(), cpu_data_cols_out, indices_arr.data().get(), indices_arr.size(), this->cpu_out_indices);
+    copy_output_with_array(output_table.begin(), cpu_data_cols_out, (gdf_size_type *)indices_col.data, indices_col.size, this->cpu_out_indices);
 
     // Free results
     std::for_each(output_table.begin(), output_table.end(), [](gdf_column* col){
@@ -202,6 +202,7 @@ struct GroupByWoAggTest : public GdfTest {
   }
 
   void compare_gdf_result(map_t& reference_map) {
+
     ASSERT_EQ(cpu_out_indices.size(), reference_map.size()) << "Size of gdf result does not match reference result\n";
 
       auto ref_size = reference_map.size();
@@ -398,14 +399,14 @@ struct GroupValidTest : public GroupByWoAggTest<test_parameters>
     cudf::table input_table(group_by_input_key, num_columns);
 
     cudf::table output_table;
-    rmm::device_vector<gdf_index_type> indices_arr;
+    gdf_column indices_col;
     EXPECT_NO_THROW(std::tie(output_table,
-                            indices_arr) = gdf_group_by_without_aggregations(input_table,
+                            indices_col) = gdf_group_by_without_aggregations(input_table,
                                                                             num_columns,
                                                                             groupby_col_indices.data(),
                                                                             &this->context));
     copy_output_with_array_with_nulls(
-            output_table.begin(), this->cpu_data_cols_out, this->cpu_data_cols_out_valid, indices_arr.data().get(), indices_arr.size(), this->cpu_out_indices);
+            output_table.begin(), this->cpu_data_cols_out, this->cpu_data_cols_out_valid, (int *)indices_col.data, indices_col.size, this->cpu_out_indices);
 
     // Free results
     std::for_each(output_table.begin(), output_table.end(), [](gdf_column* col){
@@ -468,6 +469,5 @@ TYPED_TEST(GroupValidTest, AllKeysDifferent)
     this->compute_gdf_result_with_nulls();
     this->compare_gdf_result_with_nulls(reference_map);
 }
-
 
 } //namespace: without_agg

--- a/cpp/tests/groupby/without_agg/groupby_wo_agg_test.cu
+++ b/cpp/tests/groupby/without_agg/groupby_wo_agg_test.cu
@@ -194,11 +194,14 @@ struct GroupByWoAggTest : public GdfTest {
     copy_output_with_array(output_table.begin(), cpu_data_cols_out, (gdf_size_type *)indices_col.data, indices_col.size, this->cpu_out_indices);
 
     // Free results
+    RMM_TRY(RMM_FREE(indices_col.data, 0));
+    indices_col.data = nullptr;
+    indices_col.size = 0;
     std::for_each(output_table.begin(), output_table.end(), [](gdf_column* col){
       RMM_FREE(col->data, 0);
       RMM_FREE(col->valid, 0);
       delete col;
-    });    
+    });
   }
 
   void compare_gdf_result(map_t& reference_map) {
@@ -406,9 +409,12 @@ struct GroupValidTest : public GroupByWoAggTest<test_parameters>
                                                                             groupby_col_indices.data(),
                                                                             &this->context));
     copy_output_with_array_with_nulls(
-            output_table.begin(), this->cpu_data_cols_out, this->cpu_data_cols_out_valid, (int *)indices_col.data, indices_col.size, this->cpu_out_indices);
+            output_table.begin(), this->cpu_data_cols_out, this->cpu_data_cols_out_valid, (gdf_size_type *)indices_col.data, indices_col.size, this->cpu_out_indices);
 
     // Free results
+    RMM_TRY(RMM_FREE(indices_col.data, 0));
+    indices_col.data = nullptr;
+    indices_col.size = 0;
     std::for_each(output_table.begin(), output_table.end(), [](gdf_column* col){
       RMM_FREE(col->data, 0);
       RMM_FREE(col->valid, 0);


### PR DESCRIPTION
gdf_group_by_without_aggregations was returning device_vector and it had to return column, so the current set of changes will return gdf_column, once cudf column is available, it will be changed to it close #2239 .