### PR TITLE
Fix copy behaviour for GenericIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 - PR #2244 Fix ORC RLEv2 delta mode decoding with nonzero residual delta width
 - PR #2297 Work around `var/std` unsupported only at debug build
 - PR #2302 Fixed java serialization corner case
-
+- PR #2311 Fix copy behaviour for GenericIndex
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/python/cudf/cudf/dataframe/index.py
+++ b/python/cudf/cudf/dataframe/index.py
@@ -29,6 +29,7 @@ from cudf.utils import cudautils, ioutils, utils
 class Index(object):
     """The root interface for all Series indexes.
     """
+
     def serialize(self, serialize):
         """Serialize into pickle format suitable for file storage or network
         transmission.
@@ -306,7 +307,7 @@ class Index(object):
 
     @property
     def is_unique(self):
-        raise(NotImplementedError)
+        raise (NotImplementedError)
 
     @property
     def is_monotonic(self):
@@ -314,14 +315,14 @@ class Index(object):
 
     @property
     def is_monotonic_increasing(self):
-        raise(NotImplementedError)
+        raise (NotImplementedError)
 
     @property
     def is_monotonic_decreasing(self):
-        raise(NotImplementedError)
+        raise (NotImplementedError)
 
     def get_slice_bound(self, label, side, kind):
-        raise(NotImplementedError)
+        raise (NotImplementedError)
 
 
 class RangeIndex(Index):
@@ -484,7 +485,7 @@ class RangeIndex(Index):
 
     def get_slice_bound(self, label, side, kind):
         # TODO: Range-specific implementation here
-        raise(NotImplementedError)
+        raise (NotImplementedError)
 
 
 def index_from_range(start, stop=None, step=None):
@@ -550,7 +551,7 @@ class GenericIndex(Index):
         return self._values.__sizeof__()
 
     def __reduce__(self):
-        return GenericIndex, tuple([self._values])
+        return self.__class__, tuple([self._values])
 
     def __len__(self):
         return len(self._values)

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -725,3 +725,11 @@ def test_groupby_sort():
         pdf.groupby(["c", "b"], sort=False).sum().sort_index(),
         gdf.groupby(["c", "b"], sort=False).sum().to_pandas().sort_index(),
     )
+
+
+def test_groupby_index_type():
+    df = cudf.DataFrame()
+    df["string_col"] = ["a", "b", "c"]
+    df["counts"] = [1, 2, 3]
+    res = df.groupby(by="string_col").counts.sum()
+    assert isinstance(res.index, cudf.dataframe.index.StringIndex)

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import cudf
 from cudf.dataframe import DataFrame
 from cudf.dataframe.index import (
     CategoricalIndex,
@@ -207,3 +208,20 @@ def test_set_index_as_property():
 
     head = cdf.head().to_pandas()
     np.testing.assert_array_equal(head.index.values, idx[:5])
+
+
+@pytest.mark.parametrize(
+    "idx",
+    [
+        cudf.dataframe.index.RangeIndex(1, 5),
+        cudf.dataframe.index.DatetimeIndex(["2001", "2003", "2003"]),
+        cudf.dataframe.index.StringIndex(["a", "b", "c"]),
+        cudf.dataframe.index.GenericIndex([1, 2, 3]),
+        cudf.dataframe.index.CategoricalIndex(["a", "b", "c"]),
+    ],
+)
+@pytest.mark.parametrize("deep", [True, False])
+def test_index_copy(idx, deep):
+    idx_copy = idx.copy(deep=deep)
+    assert_eq(idx, idx_copy)
+    assert type(idx) == type(idx_copy)


### PR DESCRIPTION
GenericIndex.copy() is broken leading to issues such as #2310 and the following:

```
In [1]: import cudf                                 

In [2]: a = cudf.dataframe.index.StringIndex(['a', 'b', 'c'])                                           

In [3]: a                                           
Out[3]: StringIndex(['a' 'b' 'c'], dtype='object')

In [4]: a.rename('b')                               
Out[4]: GenericIndex(['a', 'b', 'c'], dtype=object, name='b')
```

Fixes #2310 