### PR TITLE
[REVIEW] Implement unique, nunique, and value_counts for datetime columns via refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #2179 Added Java quantiles
 - PR #2157 Add __array_function__ to DataFrame and Series
 - PR #2212 Java support for ORC reader
+- PR #2316 Unique, nunique, and value_counts for datetime columns
 
 ## Improvements
 

--- a/python/cudf/cudf/dataframe/categorical.py
+++ b/python/cudf/cudf/dataframe/categorical.py
@@ -226,7 +226,7 @@ class CategoricalColumn(columnops.TypedColumnBase):
             return self
         return self.as_numerical.astype(dtype)
 
-    def sort_by_values(self, ascending, na_position="last"):
+    def sort_by_values(self, ascending=True, na_position="last"):
         return self.as_numerical.sort_by_values(ascending, na_position)
 
     def element_indexing(self, index):
@@ -249,31 +249,11 @@ class CategoricalColumn(columnops.TypedColumnBase):
             dictionary=self._categories.to_arrow(),
         )
 
-    def _unique_segments(self):
-        """ Common code for unique, unique_count and value_counts"""
-        # make dense column
-        densecol = self.replace(data=self.to_dense_buffer(), mask=None)
-        # sort the column
-        sortcol, _ = densecol.sort_by_values(ascending=True)
-        # find segments
-        sortedvals = sortcol.to_gpu_array()
-        segs, begins = cudautils.find_segments(sortedvals)
-        return segs, sortedvals
-
     def unique(self, method=None):
         codes = self.as_numerical.unique(method).data
         return CategoricalColumn(
             data=codes, categories=self._categories, ordered=self._ordered
         )
-
-    def unique_count(self, method="sort", dropna=True):
-        if method != "sort":
-            msg = "non sort based unique_count() not implemented yet"
-            raise NotImplementedError(msg)
-        segs, _ = self._unique_segments()
-        if dropna is False and self.null_count > 0:
-            return len(segs) + 1
-        return len(segs)
 
     def value_counts(self, method="sort"):
         if method != "sort":

--- a/python/cudf/cudf/dataframe/column.py
+++ b/python/cudf/cudf/dataframe/column.py
@@ -669,5 +669,28 @@ class Column(object):
         if side == 'right':
             return (self.find_last_value(label) + 1)
 
+    def sort_by_values(self):
+        raise NotImplementedError
+
+    def _unique_segments(self):
+        """ Common code for unique, unique_count and value_counts"""
+        # make dense column
+        densecol = self.replace(data=self.to_dense_buffer(), mask=None)
+        # sort the column
+        sortcol, _ = densecol.sort_by_values()
+        # find segments
+        sortedvals = sortcol.to_gpu_array()
+        segs, begins = cudautils.find_segments(sortedvals)
+        return segs, sortedvals
+
+    def unique_count(self, method="sort", dropna=True):
+        if method != "sort":
+            msg = "non sort based unique_count() not implemented yet"
+            raise NotImplementedError(msg)
+        segs, _ = self._unique_segments()
+        if dropna is False and self.null_count > 0:
+            return len(segs) + 1
+        return len(segs)
+
 
 register_distributed_serializer(Column)

--- a/python/cudf/cudf/dataframe/column.py
+++ b/python/cudf/cudf/dataframe/column.py
@@ -679,7 +679,7 @@ class Column(object):
         # sort the column
         sortcol, _ = densecol.sort_by_values()
         # find segments
-        sortedvals = sortcol.to_gpu_array()
+        sortedvals = sortcol.data.mem
         segs, begins = cudautils.find_segments(sortedvals)
         return segs, sortedvals
 

--- a/python/cudf/cudf/dataframe/datetime.py
+++ b/python/cudf/cudf/dataframe/datetime.py
@@ -236,17 +236,6 @@ class DatetimeColumn(columnops.TypedColumnBase):
         value = columnops.as_column(value).as_numerical[0]
         return self.as_numerical.find_last_value(value)
 
-    def _unique_segments(self):
-        """ Common code for unique, unique_count and value_counts"""
-        # make dense column
-        densecol = self.replace(data=self.to_dense_buffer(), mask=None)
-        # sort the column
-        sortcol, _ = densecol.sort_by_values(ascending=True)
-        # find segments
-        sortedvals = sortcol.to_gpu_array()
-        segs, begins = cudautils.find_segments(sortedvals)
-        return segs, sortedvals
-
     def unique(self, method="sort"):
         # method variable will indicate what algorithm to use to
         # calculate unique, not used right now
@@ -257,15 +246,6 @@ class DatetimeColumn(columnops.TypedColumnBase):
         # gather result
         out_col = cpp_copying.apply_gather_array(sortedvals, segs)
         return out_col
-
-    def unique_count(self, method="sort", dropna=True):
-        if method != "sort":
-            msg = "non sort based unique_count() not implemented yet"
-            raise NotImplementedError(msg)
-        segs, _ = self._unique_segments()
-        if dropna is False and self.null_count > 0:
-            return len(segs) + 1
-        return len(segs)
 
     def value_counts(self, method="sort"):
         if method != "sort":

--- a/python/cudf/cudf/dataframe/datetime.py
+++ b/python/cudf/cudf/dataframe/datetime.py
@@ -15,7 +15,8 @@ from cudf.bindings.nvtx import nvtx_range_pop, nvtx_range_push
 from cudf.comm.serialize import register_distributed_serializer
 from cudf.dataframe import columnops
 from cudf.dataframe.buffer import Buffer
-from cudf.utils import utils
+from cudf.dataframe.numerical import NumericalColumn
+from cudf.utils import cudautils, utils
 from cudf.utils.utils import is_single_value
 
 
@@ -234,6 +235,48 @@ class DatetimeColumn(columnops.TypedColumnBase):
         value = pd.to_datetime(value)
         value = columnops.as_column(value).as_numerical[0]
         return self.as_numerical.find_last_value(value)
+
+    def _unique_segments(self):
+        """ Common code for unique, unique_count and value_counts"""
+        # make dense column
+        densecol = self.replace(data=self.to_dense_buffer(), mask=None)
+        # sort the column
+        sortcol, _ = densecol.sort_by_values(ascending=True)
+        # find segments
+        sortedvals = sortcol.to_gpu_array()
+        segs, begins = cudautils.find_segments(sortedvals)
+        return segs, sortedvals
+
+    def unique(self, method="sort"):
+        # method variable will indicate what algorithm to use to
+        # calculate unique, not used right now
+        if method != "sort":
+            msg = "non sort based unique() not implemented yet"
+            raise NotImplementedError(msg)
+        segs, sortedvals = self._unique_segments()
+        # gather result
+        out_col = cpp_copying.apply_gather_array(sortedvals, segs)
+        return out_col
+
+    def unique_count(self, method="sort", dropna=True):
+        if method != "sort":
+            msg = "non sort based unique_count() not implemented yet"
+            raise NotImplementedError(msg)
+        segs, _ = self._unique_segments()
+        if dropna is False and self.null_count > 0:
+            return len(segs) + 1
+        return len(segs)
+
+    def value_counts(self, method="sort"):
+        if method != "sort":
+            msg = "non sort based value_count() not implemented yet"
+            raise NotImplementedError(msg)
+        segs, sortedvals = self._unique_segments()
+        # Return both values and their counts
+        out_vals = cpp_copying.apply_gather_array(sortedvals, segs)
+        out2 = cudautils.value_count(segs, len(sortedvals))
+        out_counts = NumericalColumn(data=Buffer(out2), dtype=np.intp)
+        return out_vals, out_counts
 
     @property
     def is_unique(self):

--- a/python/cudf/cudf/dataframe/numerical.py
+++ b/python/cudf/cudf/dataframe/numerical.py
@@ -199,17 +199,6 @@ class NumericalColumn(columnops.TypedColumnBase):
         else:
             return out
 
-    def _unique_segments(self):
-        """ Common code for unique, unique_count and value_counts"""
-        # make dense column
-        densecol = self.replace(data=self.to_dense_buffer(), mask=None)
-        # sort the column
-        sortcol, _ = densecol.sort_by_values(ascending=True)
-        # find segments
-        sortedvals = sortcol.to_gpu_array()
-        segs, begins = cudautils.find_segments(sortedvals)
-        return segs, sortedvals
-
     def unique(self, method="sort"):
         # method variable will indicate what algorithm to use to
         # calculate unique, not used right now
@@ -220,15 +209,6 @@ class NumericalColumn(columnops.TypedColumnBase):
         # gather result
         out_col = cpp_copying.apply_gather_array(sortedvals, segs)
         return out_col
-
-    def unique_count(self, method="sort", dropna=True):
-        if method != "sort":
-            msg = "non sort based unique_count() not implemented yet"
-            raise NotImplementedError(msg)
-        segs, _ = self._unique_segments()
-        if dropna is False and self.null_count > 0:
-            return len(segs) + 1
-        return len(segs)
 
     def value_counts(self, method="sort"):
         if method != "sort":

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -259,7 +259,6 @@ def test_datetime_nunique(data, nulls):
         'none',
         'some',
     ])
-# @pytest.mark.xfail(reason="our quantile result is a DataFrame, not a Series")
 def test_datetime_value_counts(data, nulls):
     psr = pd.Series(data)
 

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -183,3 +183,99 @@ def test_to_from_pandas_nulls(data, nulls):
     got = gdf_data.to_pandas()
 
     assert_eq(expect, got)
+
+
+@pytest.mark.parametrize(
+    'data',
+    [
+        [],
+        pd.Series(pd.date_range('2010-01-01', '2010-02-01')),
+        pytest.param(pd.Series([None, None], dtype='datetime64[ns]'),
+                     marks=pytest.mark.xfail),
+    ])
+@pytest.mark.parametrize(
+    'nulls',
+    [
+        'none',
+        pytest.param('some', marks=pytest.mark.xfail),
+    ])
+def test_datetime_unique(data, nulls):
+    psr = pd.Series(data)
+
+    print(data)
+    print(nulls)
+
+    if len(data) > 0:
+        if nulls == 'some':
+            p = np.random.randint(0, len(data), 2)
+            psr[p] = None
+
+    gsr = cudf.from_pandas(psr)
+    expected = psr.unique()
+    got = gsr.unique()
+
+    # convert to int64 for equivalence testing
+    np.testing.assert_array_almost_equal(got.to_pandas().astype(int),
+                                         expected.astype(int))
+
+
+@pytest.mark.parametrize(
+    'data',
+    [
+        [],
+        pd.Series(pd.date_range('2010-01-01', '2010-02-01')),
+        pd.Series([None, None], dtype='datetime64[ns]'),
+    ])
+@pytest.mark.parametrize(
+    'nulls',
+    [
+        'none',
+        'some',
+    ])
+def test_datetime_nunique(data, nulls):
+    psr = pd.Series(data)
+
+    if len(data) > 0:
+        if nulls == 'some':
+            p = np.random.randint(0, len(data), 2)
+            psr[p] = None
+
+    gsr = cudf.from_pandas(psr)
+    expected = psr.nunique()
+    got = gsr.nunique()
+    assert_eq(got, expected)
+
+
+@pytest.mark.parametrize(
+    'data',
+    [
+        [],
+        pd.Series(pd.date_range('2010-01-01', '2010-02-01')),
+        pd.Series([None, None], dtype='datetime64[ns]'),
+    ])
+@pytest.mark.parametrize(
+    'nulls',
+    [
+        'none',
+        'some',
+    ])
+# @pytest.mark.xfail(reason="our quantile result is a DataFrame, not a Series")
+def test_datetime_value_counts(data, nulls):
+    psr = pd.Series(data)
+
+    if len(data) > 0:
+        if nulls == 'one':
+            p = np.random.randint(0, len(data))
+            psr[p] = None
+        elif nulls == 'some':
+            p = np.random.randint(0, len(data), 2)
+            psr[p] = None
+
+    gsr = cudf.from_pandas(psr)
+    expected = psr.value_counts()
+    got = gsr.value_counts()
+
+    pandas_dict = expected.to_dict()
+    gdf_dict = got.to_pandas().to_dict()
+
+    assert pandas_dict == gdf_dict


### PR DESCRIPTION
**Summary of Changes**
- This PR factors out `_unique_segments` and `unique_count` from the column subclasses and brings them to the parent Column class to reduce code copying. I think this also makes sense logically as these methods are not conceptually tied to any type of column, but the column itself.
- Adds a not implemented `sort_by_values` to the Column class, requiring it to be implemented by the subclasses. Not bringing it into the parent class as the categorical column implementation relies on knowledge that it can become a numerical column. This is the same reason that the implementations of unique are kept in the subclasses.
- Implements `unique`, `nunique`, and `value_counts` for Datetime columns.

This closes #2314 and should allow #2245 to avoid additional branching logic for handling datetime columns.
