### PR TITLE
[REVIEW] Ensure order is preserved in CategoricalAccessor._set_categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 - PR #2297 Work around `var/std` unsupported only at debug build
 - PR #2302 Fixed java serialization corner case
 - PR #2311 Fix copy behaviour for GenericIndex
-
+- PR #2328 Ensure order is preserved in CategoricalAccessor._set_categories
 
 # cuDF 0.8.0 (27 June 2019)
 

--- a/python/cudf/cudf/dataframe/categorical.py
+++ b/python/cudf/cudf/dataframe/categorical.py
@@ -83,7 +83,8 @@ class CategoricalAccessor(object):
         new_codes = cudautils.arange(len(new_cats), dtype=cur_codes.dtype)
         old_codes = cudautils.arange(len(cur_cats), dtype=cur_codes.dtype)
 
-        cur_df = DataFrame({"old_codes": cur_codes})
+        cur_df = DataFrame({"old_codes": cur_codes,
+                            "order": cudautils.arange(len(cur_codes))})
         old_df = DataFrame({"old_codes": old_codes, "cats": cur_cats})
         new_df = DataFrame({"new_codes": new_codes, "cats": new_cats})
 
@@ -91,6 +92,7 @@ class CategoricalAccessor(object):
         df = old_df.merge(new_df, on="cats", how="left")
         # Join the old and new codes to "recode" the codes data buffer
         df = cur_df.merge(df, on="old_codes", how="left")
+        df = df.sort_values(by="order").reset_index(True)
 
         kwargs = df["new_codes"]._column._replace_defaults()
         kwargs.update(categories=new_cats)

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -367,3 +367,10 @@ def test_categorical_set_categories():
     expect = psr.cat.set_categories(["a", "b"])
     got = sr.cat.set_categories(["a", "b"])
     assert_eq(expect, got)
+
+
+def test_categorical_set_categories_preserves_order():
+    series = pd.Series([1,0,0,0,0,0,0,0,2]).astype('category')
+    # reassigning categories should preserve element ordering
+    assert_eq(series.cat.set_categories([1,2]),
+              Series(series).cat.set_categories([1,2]))

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -370,7 +370,7 @@ def test_categorical_set_categories():
 
 
 def test_categorical_set_categories_preserves_order():
-    series = pd.Series([1,0,0,0,0,0,0,0,2]).astype('category')
+    series = pd.Series([1, 0, 0, 0, 2]).astype('category')
     # reassigning categories should preserve element ordering
-    assert_eq(series.cat.set_categories([1,2]),
-              Series(series).cat.set_categories([1,2]))
+    assert_eq(series.cat.set_categories([1, 2]),
+              Series(series).cat.set_categories([1, 2]))


### PR DESCRIPTION
Ensure `set_categories` preserves current element order. Closes https://github.com/rapidsai/cudf/issues/2306.


<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
