### PR TITLE
Just use `slice.indices()` to get slice start/stop/step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - PR #2345 Restore removal of old groupby implementation
 - PR #2329 using libcudf cudf::copy for column deep copy
 - PR #2344 Add docs on how code formatting works for contributors
+- PR #2377 Replace `standard_python_slice` with just `slice.indices()`
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/dataframe/index.py
+++ b/python/cudf/cudf/dataframe/index.py
@@ -381,9 +381,9 @@ class RangeIndex(Index):
 
     def __getitem__(self, index):
         if isinstance(index, slice):
-            start, stop, step, sln = utils.standard_python_slice(
-                len(self), index
-            )
+            start, stop, step = index.indices(len(self))
+            sln = (stop - start) // step
+            sln = max(0, sln)
             start += self._start
             stop += self._start
             if sln == 0:

--- a/python/cudf/cudf/dataframe/multiindex.py
+++ b/python/cudf/cudf/dataframe/multiindex.py
@@ -369,9 +369,7 @@ class MultiIndex(Index):
         elif isinstance(indices, Series):
             indices = indices.to_gpu_array()
         elif isinstance(indices, slice):
-            start, stop, step, sln = utils.standard_python_slice(
-                len(self), indices
-            )
+            start, stop, step = indices.indices(len(self))
             indices = cudautils.arange(start, stop, step)
         result = MultiIndex(source_data=self._source_data.take(indices))
         result.names = self.names

--- a/python/cudf/cudf/dataframe/multiindex.py
+++ b/python/cudf/cudf/dataframe/multiindex.py
@@ -10,7 +10,7 @@ import pandas as pd
 from cudf.comm.serialize import register_distributed_serializer
 from cudf.dataframe import columnops
 from cudf.dataframe.index import Index, StringIndex, as_index
-from cudf.utils import cudautils, utils
+from cudf.utils import cudautils
 
 
 class MultiIndex(Index):

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -101,50 +101,6 @@ def normalize_index(index, size, doraise=True):
     return min(index, size)
 
 
-# borrowed from a wonderful blog:
-# https://avilpage.com/2015/03/a-slice-of-python-intelligence-behind.html
-def standard_python_slice(len_idx, arg):
-    """ Figuring out the missing parameters of slice"""
-
-    start = arg.start
-    stop = arg.stop
-    step = arg.step
-
-    if step is None:
-        step = 1
-    if step == 0:
-        raise Exception("Step cannot be zero.")
-
-    if start is None:
-        start = 0 if step > 0 else len_idx - 1
-    else:
-        if start < 0:
-            start += len_idx
-        if start < 0:
-            start = 0 if step > 0 else -1
-        if start >= len_idx:
-            start = len_idx if step > 0 else len_idx - 1
-
-    if stop is None:
-        stop = len_idx if step > 0 else -1
-    else:
-        if stop < 0:
-            stop += len_idx
-        if stop < 0:
-            stop = 0 if step > 0 else -1
-        if stop >= len_idx:
-            stop = len_idx if step > 0 else len_idx - 1
-
-    if (step < 0 and stop >= start) or (step > 0 and start >= stop):
-        slice_length = 0
-    elif step < 0:
-        slice_length = (stop - start + 1) // step + 1
-    else:
-        slice_length = (stop - start - 1) // step + 1
-
-    return start, stop, step, slice_length
-
-
 list_types_tuple = (list, np.array)
 
 


### PR DESCRIPTION
`slice` objects already have an `indices()` method, obviating the need for the current `standard_python_slice` utility.