### PR TITLE
[REVIEW] Make cudf's Cython API externally accessible

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = thirdparty/cub
 	url = https://github.com/rapidsai/thirdparty-cub.git
 	branch = cudf-cub
-[submodule "thirdparty/dlpack"]
-	path = thirdparty/dlpack
-	url = https://github.com/rapidsai/dlpack.git
-	branch=cudf
 [submodule "thirdparty/jitify"]
 	path = thirdparty/jitify
 	url = https://github.com/rapidsai/jitify.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - PR #2329 using libcudf cudf::copy for column deep copy
 - PR #2344 Add docs on how code formatting works for contributors
 - PR #2377 Replace `standard_python_slice` with just `slice.indices()`
+- PR #2392 Remove dlpack submodule; make cuDF's Cython API externally accessible
 
 ## Bug Fixes
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -43,7 +43,7 @@ nvidia-smi
 logger "Activate conda env..."
 source activate gdf
 conda install "rmm=$MINOR_VERSION.*" "nvstrings=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
-              "dask>=2.0" "distributed>=2.0" "numpy>=1.16"
+              "dask>=2.0" "distributed>=2.0" "numpy>=1.16" "dlpack"
 
 # Install the master version of dask and distributed
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps" 

--- a/conda/environments/cudf_dev_cuda10.0.yml
+++ b/conda/environments/cudf_dev_cuda10.0.yml
@@ -38,6 +38,7 @@ dependencies:
 - pre_commit
 - dask>=2.0
 - distributed>=2.0
+- dlpack
 - pip:
   - sphinx-markdown-tables
   - git+https://github.com/dask/dask.git

--- a/conda/environments/cudf_dev_cuda9.2.yml
+++ b/conda/environments/cudf_dev_cuda9.2.yml
@@ -38,6 +38,7 @@ dependencies:
 - pre_commit
 - dask>=2.0
 - distributed>=2.0
+- dlpack
 - pip:
   - sphinx-markdown-tables
   - git+https://github.com/dask/dask.git

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - setuptools
     - numba >=0.41
     - libcudf {{ version }}
+    - dlpack
   run:
     - python
     - pandas >=0.23.4
@@ -31,6 +32,7 @@ requirements:
     - rmm {{ minor_version }}.*
     - nvstrings {{ minor_version }}.*
     - cython >=0.29,<0.30
+    - dlpack
 
 test:
   commands:

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -30,8 +30,10 @@ requirements:
     - librmm {{ minor_version }}.*
     - libnvstrings {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
+    - dlpack
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
+    - dlpack
 
 test:
   commands:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -143,6 +143,16 @@ if (RMM_INCLUDE AND RMM_LIBRARY)
 endif (RMM_INCLUDE AND RMM_LIBRARY)
 
 ###################################################################################################
+# - DLPACK -------------------------------------------------------------------------------------------
+
+find_path(DLPACK_INCLUDE "dlpack"
+          HINTS "$ENV{DLPACK_ROOT}/include"
+                "$ENV{CONDA_PREFIX}/include/dlpack"
+                "$ENV{CONDA_PREFIX}/include")
+
+message(STATUS "DLPACK: DLPACK_INCLUDE set to ${DLPACK_INCLUDE}")
+
+###################################################################################################
 # - NVStrings -------------------------------------------------------------------------------------
 
 find_path(NVSTRINGS_INCLUDE "nvstrings"
@@ -236,11 +246,11 @@ include_directories("${CMAKE_BINARY_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/src"
                     "${CMAKE_SOURCE_DIR}/thirdparty/cub"
                     "${CMAKE_SOURCE_DIR}/thirdparty/jitify"
-                    "${CMAKE_SOURCE_DIR}/thirdparty/dlpack/include"
                     "${ARROW_INCLUDE_DIR}"
                     "${FLATBUFFERS_INCLUDE_DIR}"
                     "${ZLIB_INCLUDE_DIRS}"
                     "${RMM_INCLUDE}"
+		    "${DLPACK_INCLUDE}"
                     "${NVSTRINGS_INCLUDE}")
 
 ###################################################################################################

--- a/cpp/tests/io/convert/dlpack_test.cu
+++ b/cpp/tests/io/convert/dlpack_test.cu
@@ -148,7 +148,7 @@ TEST_F(DLPackTest, InvalidDeviceType)
   int num_columns = 0;
 
   // We support kDLGPU, kDLCPU, and kDLCPUPinned
-  for (int i = kDLOpenCL; i <= kDLExtDev; i++) {
+  for (int i = kDLOpenCL; i <= kDLROCM; i++) {
     mng_tensor->dl_tensor.ctx.device_type = static_cast<DLDeviceType>(i);
     ASSERT_EQ(gdf_from_dlpack(&columns, &num_columns, mng_tensor), 
                               GDF_INVALID_API_CALL);

--- a/python/cudf/cudf/bindings/binops.pxd
+++ b/python/cudf/cudf/bindings/binops.pxd
@@ -9,7 +9,7 @@ from cudf.bindings.cudf_cpp cimport *
 
 from libcpp.string cimport string
 
-cdef extern from "binaryop.hpp" nogil:
+cdef extern from "cudf/binaryop.hpp" nogil:
 
     ctypedef enum gdf_binary_operator:
         GDF_ADD,
@@ -34,7 +34,7 @@ cdef extern from "binaryop.hpp" nogil:
         GDF_LOGICAL_OR,
         GDF_INVALID_BINARY
 
-cdef extern from "binaryop.hpp" namespace "cudf" nogil:
+cdef extern from "cudf/binaryop.hpp" namespace "cudf" nogil:
 
     cdef void binary_operation(
         gdf_column* out,

--- a/python/cudf/cudf/bindings/concat.pxd
+++ b/python/cudf/cudf/bindings/concat.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
 
     cdef gdf_error gdf_column_concat(
         gdf_column *output,

--- a/python/cudf/cudf/bindings/copying.pxd
+++ b/python/cudf/cudf/bindings/copying.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "copying.hpp" namespace "cudf" nogil:
+cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
 
     cdef void scatter(
         const cudf_table* source_table,

--- a/python/cudf/cudf/bindings/csv.pxd
+++ b/python/cudf/cudf/bindings/csv.pxd
@@ -11,7 +11,7 @@ from cudf.bindings.io cimport *
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 
-cdef extern from "cudf.h" namespace "cudf::io::csv" nogil:
+cdef extern from "cudf/cudf.h" namespace "cudf::io::csv" nogil:
 
     ctypedef enum quote_style:
         QUOTE_MINIMAL = 0,
@@ -70,7 +70,7 @@ cdef extern from "cudf.h" namespace "cudf::io::csv" nogil:
             gdf_size_type num_rows
         ) except +
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
     # See cpp/include/cudf/io_types.h:146
     ctypedef struct csv_write_arg:
         # Arguments to csv writer function

--- a/python/cudf/cudf/bindings/cudf_cpp.pxd
+++ b/python/cudf/cudf/bindings/cudf_cpp.pxd
@@ -61,7 +61,7 @@ cpdef check_gdf_error(errcode)
 # First version of bindings has no changes to the cudf.h header, so this file
 # mirrors the structure in cpp/include
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
 
     ctypedef int           gdf_size_type
     ctypedef gdf_size_type gdf_index_type
@@ -358,7 +358,7 @@ cdef extern from "cudf.h" nogil:
     cdef gdf_error gdf_nvtx_range_pop() except +
 
 
-cdef extern from "legacy/bitmask.hpp" nogil:
+cdef extern from "cudf/legacy/bitmask.hpp" nogil:
 
     cdef gdf_error gdf_count_nonzero_mask(
         gdf_valid_type* masks,
@@ -367,7 +367,7 @@ cdef extern from "legacy/bitmask.hpp" nogil:
     ) except +
 
 
-cdef extern from "table.hpp" namespace "cudf" nogil:
+cdef extern from "cudf/table.hpp" namespace "cudf" nogil:
 
     cdef cppclass cudf_table "cudf::table":
 

--- a/python/cudf/cudf/bindings/dlpack.pxd
+++ b/python/cudf/cudf/bindings/dlpack.pxd
@@ -12,7 +12,7 @@ from libc.stdint cimport int64_t
 from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
 
-cdef extern from "dlpack.h" nogil:
+cdef extern from "dlpack/dlpack.h" nogil:
 
     ctypedef struct DLManagedTensor:
         void(*deleter)(DLManagedTensor*)

--- a/python/cudf/cudf/bindings/gpuarrow.pxd
+++ b/python/cudf/cudf/bindings/gpuarrow.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
 
     ctypedef struct _OpaqueIpcParser:
         pass

--- a/python/cudf/cudf/bindings/groupby/common.pxd
+++ b/python/cudf/cudf/bindings/groupby/common.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp import *
 from cudf.bindings.cudf_cpp cimport *
 
-cdef extern from "groupby.hpp" namespace "cudf::groupby":
+cdef extern from "cudf/groupby.hpp" namespace "cudf::groupby":
     cdef cppclass Options:
         Options(bool _ignore_null_keys) except +
         Options() except +

--- a/python/cudf/cudf/bindings/groupby/hash.pxd
+++ b/python/cudf/cudf/bindings/groupby/hash.pxd
@@ -13,7 +13,7 @@ from cudf.bindings.cudf_cpp cimport *
 
 cimport cudf.bindings.groupby.common as groupby_common
 
-cdef extern from "groupby.hpp" namespace "cudf::groupby::hash" nogil:
+cdef extern from "cudf/groupby.hpp" namespace "cudf::groupby::hash" nogil:
     cdef cppclass Options(groupby_common.Options):
         pass
 

--- a/python/cudf/cudf/bindings/hash.pxd
+++ b/python/cudf/cudf/bindings/hash.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
 
     ctypedef enum gdf_hash_func:
         GDF_HASH_MURMUR3=0,

--- a/python/cudf/cudf/bindings/io.pxd
+++ b/python/cudf/cudf/bindings/io.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
 
     # See cpp/include/cudf/io_types.h:22
     ctypedef enum gdf_input_type:

--- a/python/cudf/cudf/bindings/join.pxd
+++ b/python/cudf/cudf/bindings/join.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
 
     cdef gdf_error gdf_inner_join(
         gdf_column **left_cols,

--- a/python/cudf/cudf/bindings/json.pxd
+++ b/python/cudf/cudf/bindings/json.pxd
@@ -12,7 +12,7 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 
 
-cdef extern from "cudf.h" namespace "cudf::io::json" nogil:
+cdef extern from "cudf/cudf.h" namespace "cudf::io::json" nogil:
 
     cdef struct reader_options:
         gdf_input_type source_type

--- a/python/cudf/cudf/bindings/orc.pxd
+++ b/python/cudf/cudf/bindings/orc.pxd
@@ -10,7 +10,7 @@ from cudf.bindings.cudf_cpp cimport *
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 
-cdef extern from "cudf.h" namespace "cudf::io::orc" nogil:
+cdef extern from "cudf/cudf.h" namespace "cudf::io::orc" nogil:
 
     cdef cppclass reader_options:
         vector[string] columns

--- a/python/cudf/cudf/bindings/parquet.pxd
+++ b/python/cudf/cudf/bindings/parquet.pxd
@@ -11,7 +11,7 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 
 
-cdef extern from "cudf.h" namespace "cudf::io::parquet" nogil:
+cdef extern from "cudf/cudf.h" namespace "cudf::io::parquet" nogil:
 
     cdef cppclass reader_options:
         vector[string] columns

--- a/python/cudf/cudf/bindings/reduce.pxd
+++ b/python/cudf/cudf/bindings/reduce.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "reduction.hpp" namespace "cudf::reduction" nogil:
+cdef extern from "cudf/reduction.hpp" namespace "cudf::reduction" nogil:
 
     ctypedef enum operators:
         SUM = 0,
@@ -20,7 +20,7 @@ cdef extern from "reduction.hpp" namespace "cudf::reduction" nogil:
         VAR,
         STD,
 
-cdef extern from "reduction.hpp" nogil:
+cdef extern from "cudf/reduction.hpp" nogil:
 
     ctypedef enum gdf_scan_op:
         GDF_SCAN_SUM = 0,
@@ -28,7 +28,7 @@ cdef extern from "reduction.hpp" nogil:
         GDF_SCAN_MAX,
         GDF_SCAN_PRODUCT,
 
-cdef extern from "reduction.hpp" namespace "cudf" nogil:
+cdef extern from "cudf/reduction.hpp" namespace "cudf" nogil:
 
     cdef gdf_scalar reduce(
         gdf_column *inp,

--- a/python/cudf/cudf/bindings/replace.pxd
+++ b/python/cudf/cudf/bindings/replace.pxd
@@ -7,7 +7,7 @@
 
 from cudf.bindings.cudf_cpp cimport *
 
-cdef extern from "replace.hpp" namespace "cudf" nogil:
+cdef extern from "cudf/replace.hpp" namespace "cudf" nogil:
 
     cdef gdf_column replace_nulls(
         const gdf_column& inp,

--- a/python/cudf/cudf/bindings/rolling.pxd
+++ b/python/cudf/cudf/bindings/rolling.pxd
@@ -7,7 +7,7 @@
 
 from cudf.bindings.cudf_cpp cimport *
 
-cdef extern from "rolling.hpp" namespace "cudf" nogil:
+cdef extern from "cudf/rolling.hpp" namespace "cudf" nogil:
     gdf_column* rolling_window(
         const gdf_column &input_col,
         gdf_size_type window,

--- a/python/cudf/cudf/bindings/sort.pxd
+++ b/python/cudf/cudf/bindings/sort.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
 
     ctypedef struct _OpaqueSegmentedRadixsortPlan:
         pass

--- a/python/cudf/cudf/bindings/stream_compaction.pxd
+++ b/python/cudf/cudf/bindings/stream_compaction.pxd
@@ -7,7 +7,7 @@
 
 from cudf.bindings.cudf_cpp cimport *
 
-cdef extern from "stream_compaction.hpp" namespace "cudf" nogil:
+cdef extern from "cudf/stream_compaction.hpp" namespace "cudf" nogil:
 
     # defined in cpp/include/stream_compaction.hpp
     ctypedef enum duplicate_keep_option:

--- a/python/cudf/cudf/bindings/transpose.pxd
+++ b/python/cudf/cudf/bindings/transpose.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
 
     cdef gdf_error gdf_transpose(
         gdf_size_type ncols,

--- a/python/cudf/cudf/bindings/types.pxd
+++ b/python/cudf/cudf/bindings/types.pxd
@@ -10,7 +10,7 @@ from cudf.bindings.cudf_cpp cimport *
 from libcpp.vector cimport vector
 
 
-cdef extern from "table.hpp" namespace "cudf" nogil:
+cdef extern from "cudf/table.hpp" namespace "cudf" nogil:
 
     cdef cppclass table:
 

--- a/python/cudf/cudf/bindings/unaryops.pxd
+++ b/python/cudf/cudf/bindings/unaryops.pxd
@@ -8,7 +8,7 @@
 from cudf.bindings.cudf_cpp cimport *
 
 
-cdef extern from "cudf.h" nogil:
+cdef extern from "cudf/cudf.h" nogil:
 
     ctypedef enum gdf_unary_math_op:
         GDF_SIN,

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
-
+import os
+import sysconfig
 from distutils.sysconfig import get_python_lib
 
 import versioneer
@@ -18,6 +19,7 @@ extensions = [
         include_dirs=[
             "../../cpp/include",
             "../../cpp/thirdparty/dlpack/include/dlpack/",
+            os.path.dirname(sysconfig.get_path("include")),
         ],
         library_dirs=[get_python_lib()],
         libraries=["cudf"],
@@ -46,6 +48,10 @@ setup(
     setup_requires=["cython"],
     ext_modules=cythonize(extensions),
     packages=find_packages(include=["cudf", "cudf.*"]),
+    package_data={
+        "cudf.bindings": ["*.pxd"],
+        "cudf.bindings.groupby": ["*.pxd"],
+    },
     cmdclass=versioneer.get_cmdclass(),
     install_requires=install_requires,
     zip_safe=False,

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -16,7 +16,6 @@ extensions = [
         "*",
         sources=cython_files,
         include_dirs=[
-            "../../cpp/include/cudf",
             "../../cpp/include",
             "../../cpp/thirdparty/dlpack/include/dlpack/",
         ],

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -18,7 +18,6 @@ extensions = [
         sources=cython_files,
         include_dirs=[
             "../../cpp/include",
-            "../../cpp/thirdparty/dlpack/include/dlpack/",
             os.path.dirname(sysconfig.get_path("include")),
         ],
         library_dirs=[get_python_lib()],


### PR DESCRIPTION
- [x] Remove `dlpack` as a submodule and use conda package instead
- [x] Modify Cython to use a single include directory

External packages wanting to use our Cython API (i.e, `cimport` things from `cudf.bindings`) will need to add `os.path.dirname(sysconfig.get_path('include'))` to the `include_directories` in their `setup.py` (similar to ours).

Closes #2379 