### PR TITLE
[WIP] Add support to read from hdfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - PR #2486 Java API hash functions
 - PR #2481 Adds the ignore_null_keys option to the java api
 - PR #2490 Java api: support multiple aggregates for the same column
+- PR #2444 IO Readers: Add support to read `avro, csv, json, orc, parquet` from hdfs
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/io/avro.py
+++ b/python/cudf/cudf/io/avro.py
@@ -11,11 +11,12 @@ def read_avro(
     columns=None,
     skip_rows=None,
     num_rows=None,
+    **kwargs,
 ):
     """{docstring}"""
 
     filepath_or_buffer, compression = ioutils.get_filepath_or_buffer(
-        filepath_or_buffer, None
+        filepath_or_buffer, None, **kwargs
     )
     if compression is not None:
         ValueError("URL content-encoding decompression is not supported")

--- a/python/cudf/cudf/io/csv.py
+++ b/python/cudf/cudf/io/csv.py
@@ -40,11 +40,12 @@ def read_csv(
     na_filter=True,
     prefix=None,
     index_col=None,
+    **kwargs,
 ):
     """{docstring}"""
 
     filepath_or_buffer, compression = ioutils.get_filepath_or_buffer(
-        filepath_or_buffer, compression, (BytesIO, StringIO)
+        filepath_or_buffer, compression, (BytesIO, StringIO), **kwargs
     )
     return cpp_read_csv(
         filepath_or_buffer,

--- a/python/cudf/cudf/io/json.py
+++ b/python/cudf/cudf/io/json.py
@@ -29,7 +29,7 @@ def read_json(
         engine = "cudf" if lines else "pandas"
 
     path_or_buf, compression = ioutils.get_filepath_or_buffer(
-        path_or_buf, compression, (BytesIO, StringIO)
+        path_or_buf, compression, (BytesIO, StringIO), **kwargs
     )
     if engine == "cudf":
         df = cpp_read_json(path_or_buf, dtype, lines, compression, byte_range)

--- a/python/cudf/cudf/io/orc.py
+++ b/python/cudf/cudf/io/orc.py
@@ -31,11 +31,12 @@ def read_orc(
     skip_rows=None,
     num_rows=None,
     use_index=True,
+    **kwargs,
 ):
     """{docstring}"""
 
     filepath_or_buffer, compression = ioutils.get_filepath_or_buffer(
-        filepath_or_buffer, None
+        filepath_or_buffer, None, **kwargs
     )
     if compression is not None:
         ValueError("URL content-encoding decompression is not supported")

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -37,7 +37,7 @@ def read_parquet(
     """{docstring}"""
 
     filepath_or_buffer, compression = ioutils.get_filepath_or_buffer(
-        filepath_or_buffer, None
+        filepath_or_buffer, None, **kwargs
     )
     if compression is not None:
         ValueError("URL content-encoding decompression is not supported")

--- a/python/cudf/cudf/io/protocols/__init__.py
+++ b/python/cudf/cudf/io/protocols/__init__.py
@@ -1,0 +1,1 @@
+from cudf.io.protocols.hdfs import get_filepath_or_buffer

--- a/python/cudf/cudf/io/protocols/hdfs.py
+++ b/python/cudf/cudf/io/protocols/hdfs.py
@@ -1,0 +1,18 @@
+import urllib
+from io import BytesIO
+
+from pyarrow import hdfs
+
+
+def get_filepath_or_buffer(path_or_data, compression=None):
+    parsed_url = urllib.parse.urlsplit(path_or_data)
+
+    host = parsed_url.hostname if parsed_url.hostname else "default"
+    port = parsed_url.port if parsed_url.port else 0
+    username = parsed_url.username
+
+    fs = hdfs.connect(host=host, port=port, user=username)
+    with fs.open(parsed_url.path, mode="rb") as f:
+        filepath_or_buffer = BytesIO(f.read())
+
+    return filepath_or_buffer, compression

--- a/python/cudf/cudf/io/protocols/hdfs.py
+++ b/python/cudf/cudf/io/protocols/hdfs.py
@@ -4,14 +4,17 @@ from io import BytesIO
 from pyarrow import hdfs
 
 
-def get_filepath_or_buffer(path_or_data, compression=None):
+def get_filepath_or_buffer(path_or_data, compression=None, **kwargs):
     parsed_url = urllib.parse.urlsplit(path_or_data)
 
     host = parsed_url.hostname if parsed_url.hostname else "default"
     port = parsed_url.port if parsed_url.port else 0
     username = parsed_url.username
+    kerb_ticket = kwargs.get("kerb_ticket")
 
-    fs = hdfs.connect(host=host, port=port, user=username)
+    fs = hdfs.connect(
+        host=host, port=port, user=username, kerb_ticket=kerb_ticket
+    )
     with fs.open(parsed_url.path, mode="rb") as f:
         filepath_or_buffer = BytesIO(f.read())
 

--- a/python/cudf/cudf/tests/test_hdfs.py
+++ b/python/cudf/cudf/tests/test_hdfs.py
@@ -1,0 +1,61 @@
+import os
+from io import BytesIO
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+import cudf
+from cudf.tests.utils import assert_eq
+
+if not os.environ.get("RUN_HDFS_TESTS"):
+    pytestmark = pytest.mark.skip("Env not configured to run HDFS tests")
+
+
+basedir = "/tmp/test-hdfs"
+
+
+@pytest.fixture
+def hdfs():
+    fs = pa.hdfs.connect()
+    try:
+        if not fs.exists(basedir):
+            fs.mkdir(basedir)
+    except pa.lib.ArrowIOError:
+        pytest.skip("hdfs config probably incorrect")
+
+    return fs
+
+
+@pytest.fixture
+def pdf():
+    df = pd.DataFrame()
+    df["Integer"] = np.array([2345, 11987, 9027, 9027])
+    df["Date"] = np.array(
+        ["18/04/1995", "14/07/1994", "07/06/2006", "16/09/2005"]
+    )
+    df["Float"] = np.array([9.001, 8.343, 6, 2.781])
+    df["Integer2"] = np.array([2345, 106, 2088, 789277])
+    df["String"] = np.array(["Alpha", "Beta", "Gamma", "Delta"])
+    df["Boolean"] = np.array([True, False, True, False])
+    return df
+
+
+def test_csv(tmpdir, pdf, hdfs):
+    fname = tmpdir.mkdir("csv").join("file1.csv")
+    # Write to local file system
+    pdf.to_csv(fname)
+    # Read from local file system as buffer
+    with open(fname, mode="rb") as f:
+        buffer = BytesIO(f.read())
+    # Write to hdfs
+    hdfs.upload(basedir + "file.csv", buffer)
+
+    gdf = cudf.read_csv("hdfs://" + basedir + "file.csv")
+
+    # Read pandas from byte buffer
+    with hdfs.open(basedir + "file.csv") as f:
+        pdf = pd.read_csv("file.csv")
+
+    assert_eq(pdf, gdf)

--- a/python/cudf/cudf/tests/test_hdfs.py
+++ b/python/cudf/cudf/tests/test_hdfs.py
@@ -1,9 +1,11 @@
 import os
 from io import BytesIO
 
+import fastavro as fa
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pyarrow.orc as orc
 import pytest
 
 import cudf
@@ -14,11 +16,14 @@ if not os.environ.get("RUN_HDFS_TESTS"):
 
 
 basedir = "/tmp/test-hdfs"
+host = "localhost"  # hadoop hostname
+port = 8020  # hadoop rpc port
 
 
 @pytest.fixture
-def hdfs():
-    fs = pa.hdfs.connect()
+def hdfs(scope="module"):
+    # Default Rpc port can be 8020/9000 depending on the hdfs config
+    fs = pa.hdfs.connect(host=host, port=port)
     try:
         if not fs.exists(basedir):
             fs.mkdir(basedir)
@@ -29,12 +34,9 @@ def hdfs():
 
 
 @pytest.fixture
-def pdf():
+def pdf(scope="module"):
     df = pd.DataFrame()
     df["Integer"] = np.array([2345, 11987, 9027, 9027])
-    df["Date"] = np.array(
-        ["18/04/1995", "14/07/1994", "07/06/2006", "16/09/2005"]
-    )
     df["Float"] = np.array([9.001, 8.343, 6, 2.781])
     df["Integer2"] = np.array([2345, 106, 2088, 789277])
     df["String"] = np.array(["Alpha", "Beta", "Gamma", "Delta"])
@@ -42,20 +44,120 @@ def pdf():
     return df
 
 
-def test_csv(tmpdir, pdf, hdfs):
-    fname = tmpdir.mkdir("csv").join("file1.csv")
+@pytest.mark.parametrize("test_url", [False, True])
+def test_csv(tmpdir, pdf, hdfs, test_url):
+    fname = tmpdir.mkdir("csv").join("file.csv")
     # Write to local file system
     pdf.to_csv(fname)
     # Read from local file system as buffer
     with open(fname, mode="rb") as f:
         buffer = BytesIO(f.read())
     # Write to hdfs
-    hdfs.upload(basedir + "file.csv", buffer)
+    hdfs.upload(basedir + "/file.csv", buffer)
 
-    gdf = cudf.read_csv("hdfs://" + basedir + "file.csv")
+    if test_url:
+        hd_fpath = "hdfs://{}:{}{}/file.csv".format(host, port, basedir)
+    else:
+        hd_fpath = "hdfs://{}/file.csv".format(basedir)
+
+    got = cudf.read_csv(hd_fpath)
 
     # Read pandas from byte buffer
-    with hdfs.open(basedir + "file.csv") as f:
-        pdf = pd.read_csv("file.csv")
+    with hdfs.open(basedir + "/file.csv") as f:
+        expect = pd.read_csv(f)
 
-    assert_eq(pdf, gdf)
+    assert_eq(expect, got)
+
+
+@pytest.mark.parametrize("test_url", [False, True])
+def test_parquet(tmpdir, pdf, hdfs, test_url):
+    fname = tmpdir.mkdir("parquet").join("file.parq")
+    # Write to local file system
+    pdf.to_parquet(fname)
+    # Read from local file system as buffer
+    with open(fname, mode="rb") as f:
+        buffer = BytesIO(f.read())
+    # Write to hdfs
+    hdfs.upload(basedir + "/file.parq", buffer)
+
+    if test_url:
+        hd_fpath = "hdfs://{}:{}{}/file.parq".format(host, port, basedir)
+    else:
+        hd_fpath = "hdfs://{}/file.parq".format(basedir)
+
+    got = cudf.read_parquet(hd_fpath)
+
+    # Read pandas from byte buffer
+    with hdfs.open(basedir + "/file.parq") as f:
+        expect = pd.read_parquet(f)
+
+    assert_eq(expect, got)
+
+
+@pytest.mark.parametrize("test_url", [False, True])
+def test_json(tmpdir, pdf, hdfs, test_url):
+    fname = tmpdir.mkdir("json").join("file.json")
+    # Write to local file system
+    # Sorting by col_name now as pandas sorts by col name while reading json
+
+    pdf.sort_index(axis=1).to_json(fname, orient="records", lines=True)
+    # Read from local file system as buffer
+    with open(fname, mode="rb") as f:
+        buffer = BytesIO(f.read())
+    # Write to hdfs
+    hdfs.upload(basedir + "/file.json", buffer)
+
+    if test_url:
+        hd_fpath = "hdfs://{}:{}{}/file.json".format(host, port, basedir)
+    else:
+        hd_fpath = "hdfs://{}/file.json".format(basedir)
+
+    got = cudf.read_json(hd_fpath, engine="cudf", orient="records", lines=True)
+
+    # Read pandas from byte buffer
+    with hdfs.open(basedir + "/file.json") as f:
+        expect = pd.read_json(f, lines=True)
+
+    assert_eq(expect, got)
+
+
+@pytest.mark.parametrize("test_url", [False, True])
+def test_orc(datadir, hdfs, test_url):
+    fname = datadir / "orc" / "TestOrcFile.testSnappy.orc"
+    # Read from local file system as buffer
+    with open(fname, mode="rb") as f:
+        buffer = BytesIO(f.read())
+    # Write to hdfs
+    hdfs.upload(basedir + "/file.orc", buffer)
+
+    if test_url:
+        hd_fpath = "hdfs://{}:{}{}/file.orc".format(host, port, basedir)
+    else:
+        hd_fpath = "hdfs://{}/file.orc".format(basedir)
+
+    got = cudf.read_orc(hd_fpath)
+    expect = orc.ORCFile(buffer).read().to_pandas()
+    assert_eq(expect, got)
+
+
+@pytest.mark.parametrize("test_url", [False, True])
+def test_avro(datadir, hdfs, test_url):
+    fname = datadir / "avro" / "example.avro"
+    # Read from local file system as buffer
+    with open(fname, mode="rb") as f:
+        buffer = BytesIO(f.read())
+    # Write to hdfs
+    hdfs.upload(basedir + "/file.avro", buffer)
+
+    if test_url:
+        hd_fpath = "hdfs://{}:{}{}/file.avro".format(host, port, basedir)
+    else:
+        hd_fpath = "hdfs://{}/file.avro".format(basedir)
+
+    got = cudf.read_avro(hd_fpath)
+    with open(fname, mode="rb") as f:
+        expect = pd.DataFrame.from_records(fa.reader(f))
+
+    for col in expect.columns:
+        expect[col] = expect[col].astype(got[col].dtype)
+    assert_eq(expect, got)

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -829,7 +829,9 @@ def is_file_like(obj):
         return True
 
 
-def get_filepath_or_buffer(path_or_data, compression=None, iotypes=(BytesIO)):
+def get_filepath_or_buffer(
+    path_or_data, compression=None, iotypes=(BytesIO), **kwargs
+):
     """Return either a filepath string to data, or a memory buffer of data.
     If filepath, then the source filepath is expanded to user's environment.
     If buffer, then data is returned in-memory as bytes or a ByteIO object.
@@ -859,7 +861,7 @@ def get_filepath_or_buffer(path_or_data, compression=None, iotypes=(BytesIO)):
     elif _is_hdfs_url(path_or_data):
         from cudf.io.protocols import hdfs
 
-        return hdfs.get_filepath_or_buffer(path_or_data, compression)
+        return hdfs.get_filepath_or_buffer(path_or_data, compression, **kwargs)
 
     elif isinstance(path_or_data, str):
         return os.path.expanduser(path_or_data), compression


### PR DESCRIPTION
The aim is to allow users to read files from hdfs.
Addresses one part of  #2403 

- [X] Add `_is_hdfs_like` logic to file path_or_buf
- [X] Remove protocol logic for hdfs to return bytes buffer if file path is hdfs
- [X] Add tests (currently skipped until CI is figured out
- [x] Expose `**kwargs` to all readers to allow users to pass additional info like `kerb_ticket` in the case of hdfs.
- [x] ~~Docs / examples in readers (maybe a page for remote storage)~~ Will tackle as a followup pr when other remote systems like s3, gcs etc are merged in.

**Current Approach**
- Use a pandas like approach of checking the url type and sending it to the corresponding file system handler to open the file and create a bytes buffer from it.
- `io/protocols` will have a list of different protocols that can be supported (hdfs, s3 etc.)

 *Questions*
  - Is there a better place for these filesystem handlers to live instead of `io/protocols` (is there a better name than `protocols`)
  - Instead of reading the file as a BytesIO buffer, can the open file handle be passed down to libcudf reader( if faster). 
    - If this is the case there might be a need to add checks to all readers to close the file handle by returning an additional variable during `get_filepath_or_buffer` see: https://github.com/pandas-dev/pandas/blob/master/pandas/io/parquet.py#L121)
  - CI: how would this be modified.
    - The CI machine has Hadoop installed locally?
<!--
- Do not have libraries like `gcsfs` as a dependency but throw import errors in case the user tries to read from gcs.

  *Questions*
  - Is there a better place for these filesystem handlers to live instead of `io/protocols` (is there a better name than `protocols`)
  - Instead of reading the file as a BytesIO buffer, can the open file handle be passed down to libcudf reader( if faster). 
    - If this is the case there might be a need to add checks to all readers to close the file handle by returning an additional variable during `get_filepath_or_buffer` see: https://github.com/pandas-dev/pandas/blob/master/pandas/io/parquet.py#L121)
  - CI: how would this be modified.
    - The CI machine has Hadoop installed locally?
    - Connect to a remote with Hadoop and some data from which the CI tries to read.
    - Have sample data written to our own s3, gcs and azure servers

  *Possible Issues*
  - Changes to upstream s3fs, gcsfs etc might break reading from those sources and would require dev work.

**Alternate approach that can be considered**
- Use filesystem_spec for handling all these remote filesystems and returning the file handle. This is what Dask currently uses. https://github.com/intake/filesystem_spec
- All the filesystems protocols etc are all the responsibility of fsspec which becomes a dependency.
  
  **Things to consider**
  - Haven't explored how easy it would be to integrate this into cudf.
  - Does not include support for adls 
  - Can handle local file systems as well
    - Either we choose to use this only when the file path is not local
    - Rewrite some of the io logic so that any file path provided to any io method first goes through fsspec (similar to dask)
    - If changes to gcsfs etc breaks the way fsspec handles file. Cudf is dependent on fsspec to fix it.


Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->