### PR TITLE
[REVIEW] Remove CodeCov Status Failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - PR #2386 Correctly allocate output valids in groupby
 - PR #2411 Fixed failures on binary op on single element string column
 - PR #2422 Fix Pandas logical binary operation incompatibilites
+- PR #2447 Fix CodeCov posting build statuses temporarily
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+#Configuration File for CodeCov
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
Disable CodeCov's ability to post a fail status until we discuss a standard we want to set.