### PR TITLE
[REVIEW] apply_rows: pessimistic null handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 - PR #2411 Fixed failures on binary op on single element string column
 - PR #2422 Fix Pandas logical binary operation incompatibilites
 - PR #2447 Fix CodeCov posting build statuses temporarily
+- PR #2450 Fix erroneous null handling in `cudf.DataFrame`'s `apply_rows`
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/python/cudf/cudf/tests/test_apply_rows.py
+++ b/python/cudf/cudf/tests/test_apply_rows.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import cudf
@@ -10,31 +9,16 @@ def _kernel_multiply(a, b, out):
         out[i] = x * y
 
 
-def _expect_multiply(a, b, out):
-    for i, (x, y) in enumerate(zip(a, b)):
-        if x is None or y is None:
-            out[i] = None
-            return
-
-        if x is np.nan or y is np.nan:
-            out[i] = np.nan
-            return
-
-        out[i] = x * y
-
-
-@pytest.mark.parametrize("dtype", ["float32", "float64", "int8", "bool"])
-@pytest.mark.parametrize("has_nulls", ["some", "none"])
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+@pytest.mark.parametrize("has_nulls", [False, True])
 def test_dataframe_apply_rows(dtype, has_nulls):
     count = 1000
     gdf_series_a = gen_rand_series(dtype, count, has_nulls=has_nulls)
     gdf_series_b = gen_rand_series(dtype, count, has_nulls=has_nulls)
-    gdf_series_out = [0] * count
-
-    _expect_multiply(gdf_series_a, gdf_series_b, gdf_series_out)
+    gdf_series_expected = gdf_series_a * gdf_series_b
 
     df_expected = cudf.DataFrame(
-        {"a": gdf_series_a, "b": gdf_series_b, "out": gdf_series_out}
+        {"a": gdf_series_a, "b": gdf_series_b, "out": gdf_series_expected}
     )
 
     df_original = cudf.DataFrame({"a": gdf_series_a, "b": gdf_series_b})

--- a/python/cudf/cudf/tests/test_apply_rows.py
+++ b/python/cudf/cudf/tests/test_apply_rows.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+import cudf
+from cudf.tests.utils import assert_eq, gen_rand_series
+
+
+def _kernel_multiply(a, b, out):
+    for i, (x, y) in enumerate(zip(a, b)):
+        out[i] = x * y
+
+
+def _expect_multiply(a, b, out):
+    for i, (x, y) in enumerate(zip(a, b)):
+        if x is None or y is None:
+            out[i] = None
+            return
+
+        if x is np.nan or y is np.nan:
+            out[i] = np.nan
+            return
+
+        out[i] = x * y
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64", "int8", "bool"])
+@pytest.mark.parametrize("has_nulls", ["some", "none"])
+def test_dataframe_apply_rows(dtype, has_nulls):
+    count = 1000
+    gdf_series_a = gen_rand_series(dtype, count, has_nulls=has_nulls)
+    gdf_series_b = gen_rand_series(dtype, count, has_nulls=has_nulls)
+    gdf_series_out = [0] * count
+
+    _expect_multiply(gdf_series_a, gdf_series_b, gdf_series_out)
+
+    df_expected = cudf.DataFrame(
+        {"a": gdf_series_a, "b": gdf_series_b, "out": gdf_series_out}
+    )
+
+    df_original = cudf.DataFrame({"a": gdf_series_a, "b": gdf_series_b})
+
+    df_actual = df_original.apply_rows(
+        _kernel_multiply, ["a", "b"], {"out": dtype}, {}
+    )
+
+    assert_eq(df_expected, df_actual)

--- a/python/cudf/cudf/tests/utils.py
+++ b/python/cudf/cudf/tests/utils.py
@@ -103,4 +103,4 @@ def gen_rand_series(dtype, size, **kwargs):
     if kwargs.get("has_nulls", False):
         return Series(values)
 
-    return Series.from_masked_array(values, utils.random_bitmask(size))
+    return Series.from_masked_array(values, random_bitmask(size))

--- a/python/cudf/cudf/utils/applyutils.py
+++ b/python/cudf/cudf/utils/applyutils.py
@@ -134,7 +134,7 @@ class ApplyKernelCompilerBase(object):
         for k in sorted(self.outcols):
             outdf[k] = outputs[k]
             if out_mask is not None:
-                outdf[k] = outdf[k].set_mask(out_mask.data.mem)
+                outdf[k] = outdf[k].set_mask(out_mask.data)
 
         return outdf
 

--- a/python/cudf/cudf/utils/applyutils.py
+++ b/python/cudf/cudf/utils/applyutils.py
@@ -13,7 +13,6 @@ from cudf.dataframe.series import Series
 from cudf.utils import cudautils, utils
 from cudf.utils.docutils import docfmt_partial
 
-
 _doc_applyparams = """
 func : function
     The transformation function that will be executed on the CUDA GPU.


### PR DESCRIPTION
Fixes #2155

`apply_rows` had strange behavior for null inputs, causing output location to be skewed/shifted, and nulls to end up at the end. This PR addresses that by introducing pessimistic null handling, wherein if any input is null, all outputs will be null. Why? Because `apply_rows` uses Numba, and Numba doesn't handle nulls. Therefore we have to determine the validity of the output based solely on the input, and not the operation itself. Thus, if we see any invalid input for a given row, we make all output invalid for that row.