### PR TITLE
CHANGELOG for validity buffer serialization issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@
 - PR #2450 Fix erroneous null handling in `cudf.DataFrame`'s `apply_rows`
 - PR #2470 Fix issues with empty strings and string categories (Java)
 - PR #2471 Fix String Column Validity.
-
+- PR #2481 Fix java validity buffer serialization
 
 # cuDF 0.8.0 (27 June 2019)
 


### PR DESCRIPTION
This is to add an entry to the CHANGELOG to refer to the correct PR that had a change to fix a bug in the java serialization of the validity buffer: https://github.com/rapidsai/cudf/commit/0143c8c0d76f541e2aeeb28069b57fdd79e7a0f4, which was accidentally merged here: https://github.com/rapidsai/cudf/pull/2481