### PR TITLE
Fix `row_inequality_comparator` to avoid erroneous early bail out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@
 - PR #2471 Fix String Column Validity.
 - PR #2481 Fix java validity buffer serialization
 - PR #2485 Updated bytes calculation to use size_t to avoid overflow in column concat
+- PR #2503 Fix early bailout in multi-column sorting.
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/cpp/src/table/legacy/device_table_row_operators.cuh
+++ b/cpp/src/table/legacy/device_table_row_operators.cuh
@@ -271,7 +271,7 @@ struct row_inequality_comparator
       case State::True:
         return true;
       case State::Undecided:
-        break;
+        continue;
       }
     }  
     return false;


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/2502

Changes the `break` to a `continue` to ensure that we continue checking the next value after equivalent values are encountered. 