### PR TITLE
Fix to_dlpack memory leak in dltensor deleter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,6 @@
 - PR #2490 Java api: support multiple aggregates for the same column
 - PR #2510 Java api: uses table based apply_boolean_mask
 
-
 ## Bug Fixes
 
 - PR #2086 Fixed quantile api behavior mismatch in series & dataframe
@@ -143,6 +142,7 @@
 - PR #2481 Fix java validity buffer serialization
 - PR #2485 Updated bytes calculation to use size_t to avoid overflow in column concat
 - PR #2461 Fix groupby multiple aggregations same column
+- PR #2517 Fix device memory leak in to_dlpack tensor deleter
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/cpp/src/io/convert/dlpack/cudf_dlpack.cpp
+++ b/cpp/src/io/convert/dlpack/cudf_dlpack.cpp
@@ -249,7 +249,7 @@ gdf_error gdf_to_dlpack(DLManagedTensor *tensor,
   {
     // TODO switch assert to RMM_TRY once RMM supports throwing exceptions
     if (arg->dl_tensor.ctx.device_type == kDLGPU)
-      assert(RMM_SUCCESS == RMM_FREE(arg->dl_tensor.data, 0));
+      RMM_TRY(RMM_FREE(arg->dl_tensor.data, 0));
     delete [] arg->dl_tensor.shape;
     delete [] arg->dl_tensor.strides;
     delete arg;

--- a/cpp/tests/groupby/hash/single_column_multi_agg.cu
+++ b/cpp/tests/groupby/hash/single_column_multi_agg.cu
@@ -19,7 +19,7 @@
 #include <cudf/legacy/table.hpp>
 #include <tests/utilities/column_wrapper.cuh>
 #include <tests/utilities/compare_column_wrappers.cuh>
-#include <utilities/type_dispatcher.hpp>
+#include <cudf/utils/legacy/type_dispatcher.hpp>
 #include "single_column_groupby_test.cuh"
 #include "type_info.hpp"
 


### PR DESCRIPTION
This replaces an `assert` in the dltensor deleter that prevented freeing device memory in release builds. Uses RMM_TRY as it should now.

Fixes #2400