### PR TITLE
[WIP] Append YYMMDD to version tag for nightly conda pkgs

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -24,6 +24,13 @@ cd $WORKSPACE
 export GIT_DESCRIBE_TAG=`git describe --abbrev=0 --tags`
 export GIT_DESCRIBE_NUMBER=`git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count`
 
+# If nightly build, append current YYMMDD to tag
+#### NOTE: if statement disabled during testing to trigger on PR for validation
+#if [ ! -z "$NIGHTLY_UPLOAD_KEY" ] ; then
+  TS=`date +%y%m%d`
+  export GIT_DESCRIBE_TAG="${GIT_DESCRIBE_TAG}${TS}"
+#fi
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -20,6 +20,7 @@ build:
     - CXX
     - CUDAHOSTCXX
     - PARALLEL_LEVEL
+    - GIT_DESCRIBE_TAG
   run_exports:
     - {{ pin_subpackage("libcudf", max_pin="x.x") }}
 


### PR DESCRIPTION
Idea is this will ensure people always get the latest version. This way we won't run into the issue we face now of older packages favored over newer ones due to the conda dep solver.