### PR TITLE
Adding _constructor properties to Series and DataFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 - PR #2489 Add drop argument to set_index
 - PR #2491 Add Java bindings for ORC reader 'use_np_dtypes' option
 - PR #2213 Support s/ms/us/ns DatetimeColumn time unit resolutions
+- PR #2536 Add _constructor properties to Series and DataFrame
+
 
 ## Improvements
 

--- a/python/cudf/cudf/dataframe/dataframe.py
+++ b/python/cudf/cudf/dataframe/dataframe.py
@@ -167,6 +167,20 @@ class DataFrame(object):
 
         self._add_empty_columns(columns, index)
 
+    @property
+    def _constructor(self):
+        return DataFrame
+
+    @property
+    def _constructor_sliced(self):
+        return Series
+
+    @property
+    def _constructor_expanddim(self):
+        raise NotImplementedError(
+            "_constructor_expanddim not supported for DataFrames!"
+        )
+
     def _add_rows(self, data, index, keys):
         if keys is None:
             data = {i: element for i, element in enumerate(data)}.items()

--- a/python/cudf/cudf/dataframe/series.py
+++ b/python/cudf/cudf/dataframe/series.py
@@ -39,6 +39,22 @@ class Series(object):
     ``Series`` objects are used as columns of ``DataFrame``.
     """
 
+    @property
+    def _constructor(self):
+        return Series
+
+    @property
+    def _constructor_sliced(self):
+        raise NotImplementedError(
+            "_constructor_sliced not supported for Series!"
+        )
+
+    @property
+    def _constructor_expanddim(self):
+        from cudf import DataFrame
+
+        return DataFrame
+
     @classmethod
     def from_categorical(cls, categorical, codes=None):
         """Creates from a pandas.Categorical

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -3894,3 +3894,33 @@ def test_isin_index(data, values):
     expected = psr.index.isin(values)
 
     assert_eq(got.data.mem.copy_to_host(), expected)
+
+
+def test_constructor_properties():
+    df = DataFrame()
+    key1 = "a"
+    key2 = "b"
+    val1 = np.array([123], dtype=np.float64)
+    val2 = np.array([321], dtype=np.float64)
+    df[key1] = val1
+    df[key2] = val2
+
+    # Correct use of _constructor (for DataFrame)
+    assert_eq(df, df._constructor({key1: val1, key2: val2}))
+
+    # Correct use of _constructor (for Series)
+    assert_eq(df[key1], df[key2]._constructor(val1, name=key1))
+
+    # Correct use of _constructor_sliced (for DataFrame)
+    assert_eq(df[key1], df._constructor_sliced(val1, name=key1))
+
+    # Correct use of _constructor_expanddim (for Series)
+    assert_eq(df, df[key2]._constructor_expanddim({key1: val1, key2: val2}))
+
+    # Inorrect use of _constructor_sliced (Raises for Series)
+    with pytest.raises(NotImplementedError):
+        df[key1]._constructor_sliced
+
+    # Inorrect use of _constructor_expanddim (Raises for DataFrame)
+    with pytest.raises(NotImplementedError):
+        df._constructor_expanddim


### PR DESCRIPTION
This PR adds `_constructor`, `_constructor_sliced`, and `_constructor_expanddim` to the python API for `Series` and `DataFrame`.  The motivation for these simple additions are explained a bit in [cudf#2506](https://github.com/rapidsai/cudf/issues/2506) (the `_constructor_sliced` is "needed" to support both pandas and cudf for some sorting work in dask).

Note that the new properties are designed to match [the pandas API](https://pandas.pydata.org/pandas-docs/stable/development/extending.html#override-constructor-properties):
![Screen Shot 2019-08-12 at 10 46 34 AM](https://user-images.githubusercontent.com/20461013/62878471-bff12100-bcee-11e9-9fc0-23a94ce9f53f.png)



<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
