### PR TITLE
[REVIEW] Orc reader: Fix non-deterministic data decoding at end of chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,7 @@
 - PR #2517 Fix device memory leak in to_dlpack tensor deleter
 - PR #2511 Added import of orc, refactored exception handlers to not squash fatal exceptions
 - PR #2527 Fix index and column input handling in dask_cudf read_parquet
-
+- PR #2548 Orc reader: fix non-deterministic data decoding at chunk boundaries
 
 
 

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -1914,7 +1914,8 @@ gpuDecodeOrcColumnData(ColumnDesc *chunks, DictionaryEntry *global_dictionary, i
                 return;
             }
             // Store decoded values to output
-            if (t < min(s->top.data.max_vals, s->top.data.nrows) && s->u.rowdec.row[t] != 0)
+            if (t < min(min(s->top.data.max_vals, s->u.rowdec.nz_count), s->top.data.nrows) && s->u.rowdec.row[t] != 0
+             && s->top.data.cur_row + s->u.rowdec.row[t] - 1 < s->top.data.end_row)
             {
                 size_t row = s->top.data.cur_row + s->u.rowdec.row[t] - 1 - first_row;
                 if (row < max_num_rows)


### PR DESCRIPTION
In chunks with NULLs, threads at the end of the block may read stale row position data and overwrite good data with stale values.