### PR TITLE
[REVIEW] Fix incorrect base value mask in 64-bit ORC RLEv2 mode2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@
 - PR #2557 fix cudautils import in string.py
 - PR #2521 Fix casting datetimes from/to the same resolution
 - PR #2560 Remove duplicate `dlpack` definition in conda recipe
+- PR #2567 Fix ColumnVector.fromScalar issues while dealing with null scalars
 - PR #2565 Orc reader: fix incorrect data decoding of int64 data types
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@
 - PR #2548 Orc reader: fix non-deterministic data decoding at chunk boundaries
 - PR #2557 fix cudautils import in string.py
 - PR #2521 Fix casting datetimes from/to the same resolution
+- PR #2565 Orc reader: fix incorrect data decoding of int64 data types
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -798,7 +798,7 @@ static __device__ uint32_t Integer_RLEv2(orc_bytestream_s *bs, volatile orc_rlev
                         {
                             uint64_t baseval, mask;
                             bytestream_readbe(bs, pos * 8, bw * 8, baseval);
-                            mask = 2;
+                            mask = 1;
                             mask <<= (bw*8) - 1;
                             mask -= 1;
                             rle->baseval.u64[r] = (baseval > mask) ? (-(int64_t)(baseval & mask)) : baseval;


### PR DESCRIPTION
Resolves incorrect data decoding for RLEv2 mode2 with negative base values.