### PR TITLE
[BUG] Add header to search benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@
 - PR #2560 Remove duplicate `dlpack` definition in conda recipe
 - PR #2567 Fix ColumnVector.fromScalar issues while dealing with null scalars
 - PR #2565 Orc reader: fix incorrect data decoding of int64 data types
+- PR #2577 Fix search benchmark compilation error by adding necessary header
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/cpp/benchmarks/search/search_benchmark.cu
+++ b/cpp/benchmarks/search/search_benchmark.cu
@@ -21,6 +21,8 @@
 
 #include <benchmark/benchmark.h>
 
+#include <random>
+
 #include "../fixture/benchmark_fixture.hpp"
 #include "../synchronization/synchronization.hpp"
 


### PR DESCRIPTION
Currently search benchmark cannot compile because it's missing `<random>` header.
```
/home/hao/cudf/cpp/benchmarks/search/search_benchmark.cu(89): error: namespace "std" has no member "mt19937"
```

This PR fixes the issue.