### PR TITLE
Remove managed allocator from hash map classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Improvements
 
+- PR #2581 Removed `managed` allocator from hash map classes.
+
 ## Bug Fixes
 
 

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -20,13 +20,13 @@
 #include <cudf/groupby.hpp>
 #include <cudf/legacy/bitmask.hpp>
 #include <cudf/legacy/table.hpp>
-#include <hash/concurrent_unordered_map.cuh>
 #include <cudf/utilities/legacy/nvcategory_util.hpp>
+#include <cudf/utilities/legacy/type_dispatcher.hpp>
+#include <hash/concurrent_unordered_map.cuh>
 #include <table/legacy/device_table.cuh>
 #include <table/legacy/device_table_row_operators.cuh>
 #include <utilities/column_utils.hpp>
 #include <utilities/cuda_utils.hpp>
-#include <cudf/utilities/legacy/type_dispatcher.hpp>
 #include "aggregation_requests.hpp"
 #include "groupby.hpp"
 #include "groupby_kernels.cuh"
@@ -199,8 +199,12 @@ auto build_aggregation_map(table const& input_keys, table const& input_values,
   gdf_size_type const output_size_estimate{input_keys.num_rows()};
 
   cudf::table sparse_output_values{
-      output_size_estimate, target_dtypes(column_dtypes(input_values), ops),
-      column_dtype_infos(input_values), values_have_nulls, false, stream};
+      output_size_estimate,
+      target_dtypes(column_dtypes(input_values), ops),
+      column_dtype_infos(input_values),
+      values_have_nulls,
+      false,
+      stream};
 
   initialize_with_identity(sparse_output_values, ops, stream);
 
@@ -221,9 +225,8 @@ auto build_aggregation_map(table const& input_keys, table const& input_values,
       concurrent_unordered_map<gdf_size_type, gdf_size_type, decltype(hasher),
                                decltype(rows_equal)>;
 
-  auto map =
-      std::make_unique<map_type>(compute_hash_table_size(input_keys.num_rows()),
-                                 unused_key, unused_value, hasher, rows_equal);
+  auto map = map_type::create(compute_hash_table_size(input_keys.num_rows()),
+                              unused_key, unused_value, hasher, rows_equal);
 
   // TODO: Explore optimal block size and work per thread.
   cudf::util::cuda::grid_config_1d grid_params{input_keys.num_rows(), 256};
@@ -232,13 +235,13 @@ auto build_aggregation_map(table const& input_keys, table const& input_values,
     auto row_bitmask{cudf::row_bitmask(input_keys, stream)};
     build_aggregation_map<true, values_have_nulls>
         <<<grid_params.num_blocks, grid_params.num_threads_per_block, 0,
-           stream>>>(map.get(), d_input_keys, d_input_values,
+           stream>>>(*map, d_input_keys, d_input_values,
                      *d_sparse_output_values, d_ops.data().get(),
                      row_bitmask.data().get());
   } else {
     build_aggregation_map<false, values_have_nulls>
         <<<grid_params.num_blocks, grid_params.num_threads_per_block, 0,
-           stream>>>(map.get(), d_input_keys, d_input_values,
+           stream>>>(*map, d_input_keys, d_input_values,
                      *d_sparse_output_values, d_ops.data().get(), nullptr);
   }
   CHECK_STREAM(stream);
@@ -249,9 +252,10 @@ auto build_aggregation_map(table const& input_keys, table const& input_values,
 template <bool keys_have_nulls, bool values_have_nulls, typename Map>
 auto extract_results(table const& input_keys, table const& input_values,
                      device_table const& d_input_keys,
-                     table const& sparse_output_values, Map* map,
+                     table const& sparse_output_values, Map const& map,
                      cudaStream_t stream) {
-  cudf::table output_keys{cudf::allocate_like(input_keys, keys_have_nulls, stream)};
+  cudf::table output_keys{
+      cudf::allocate_like(input_keys, keys_have_nulls, stream)};
   cudf::table output_values{
       cudf::allocate_like(sparse_output_values, values_have_nulls, stream)};
 
@@ -386,7 +390,7 @@ auto compute_hash_groupby(cudf::table const& keys, cudf::table const& values,
   cudf::table simple_output_values;
   std::tie(output_keys, simple_output_values) =
       extract_results<keys_have_nulls, values_have_nulls>(
-          keys, values, *d_input_keys, sparse_output_values, map.get(), stream);
+          keys, values, *d_input_keys, sparse_output_values, *map, stream);
 
   // Delete intermediate results storage
   sparse_output_values.destroy();
@@ -440,7 +444,8 @@ std::pair<cudf::table, cudf::table> groupby(cudf::table const& keys,
   if (keys.num_rows() == 0) {
     return std::make_pair(
         cudf::empty_like(keys),
-        cudf::table(0, target_dtypes(column_dtypes(values), ops), column_dtype_infos(values)));
+        cudf::table(0, target_dtypes(column_dtypes(values), ops),
+                    column_dtype_infos(values)));
   }
 
   auto compute_groupby = groupby_null_specialization(keys, values);

--- a/cpp/src/groupby/hash/groupby_kernels.cuh
+++ b/cpp/src/groupby/hash/groupby_kernels.cuh
@@ -270,8 +270,7 @@ struct row_hasher {
  * @tparam values_have_nulls Indicates if rows in `input_values` contain null
  * values
  * @tparam Map The type of the hash map
- * @param map Pointer to hash map object to insert key,value pairs into.
- * (Assumed to be allocated with managed memory)
+ * @param map Hash map object to insert key,value pairs into.
  * @param input_keys The table whose rows will be keys of the hash map
  * @param input_values The table whose rows will be aggregated in the values of
  * the hash map
@@ -285,7 +284,7 @@ struct row_hasher {
  *---------------------------------------------------------------------------**/
 template <bool skip_rows_with_nulls, bool values_have_nulls, typename Map>
 __global__ void build_aggregation_map(
-    Map* map, device_table input_keys, device_table input_values,
+    Map map, device_table input_keys, device_table input_values,
     device_table output_values, operators* ops,
     bit_mask::bit_mask_t const* const __restrict__ row_bitmask) {
   gdf_size_type i = threadIdx.x + blockIdx.x * blockDim.x;
@@ -296,7 +295,7 @@ __global__ void build_aggregation_map(
       continue;
     }
 
-    auto result = map->insert(thrust::make_pair(i, i));
+    auto result = map.insert(thrust::make_pair(i, i));
 
     aggregate_row<values_have_nulls>(output_values, result.first->second,
                                      input_values, i, ops);
@@ -331,7 +330,7 @@ __global__ void build_aggregation_map(
  * result size.
  *---------------------------------------------------------------------------**/
 template <bool keys_have_nulls, bool values_have_nulls, typename Map>
-__global__ void extract_groupby_result(Map* map, device_table const input_keys,
+__global__ void extract_groupby_result(Map map, device_table const input_keys,
                                        device_table output_keys,
                                        device_table const sparse_output_values,
                                        device_table dense_output_values,
@@ -340,9 +339,9 @@ __global__ void extract_groupby_result(Map* map, device_table const input_keys,
 
   using pair_type = typename Map::value_type;
 
-  pair_type const* const __restrict__ table_pairs{map->data()};
+  pair_type const* const __restrict__ table_pairs{map.data()};
 
-  while (i < map->capacity()) {
+  while (i < map.capacity()) {
     gdf_size_type source_key_row_index;
     gdf_size_type source_value_row_index;
 
@@ -350,7 +349,7 @@ __global__ void extract_groupby_result(Map* map, device_table const input_keys,
     // equal, but lets be generic just in case that ever changes.
     thrust::tie(source_key_row_index, source_value_row_index) = table_pairs[i];
 
-    if (source_key_row_index != map->get_unused_key()) {
+    if (source_key_row_index != map.get_unused_key()) {
       auto output_index = atomicAdd(output_write_index, 1);
 
       // TODO: Optimize setting bits in output bitmask. Currently, we rely on

--- a/cpp/src/hash/concurrent_unordered_map.cuh
+++ b/cpp/src/hash/concurrent_unordered_map.cuh
@@ -356,6 +356,12 @@ class concurrent_unordered_map {
     return GDF_SUCCESS;
   }
 
+  /**---------------------------------------------------------------------------*
+   * @brief Frees the contents of the map and destroys the map object.
+   *
+   * This function is invoked as the deleter of the `std::unique_ptr` returned
+   * from the `create()` factory function.
+   *---------------------------------------------------------------------------**/
   void destroy() {
     m_allocator.deallocate(m_hashtbl_values, m_capacity);
     delete this;

--- a/cpp/src/hash/concurrent_unordered_map.cuh
+++ b/cpp/src/hash/concurrent_unordered_map.cuh
@@ -30,20 +30,10 @@
 #include <type_traits>
 
 namespace {
-template <std::size_t N>
-struct packed {
-  using type = void;
-};
-template <>
-struct packed<sizeof(uint64_t)> {
-  using type = uint64_t;
-};
-template <>
-struct packed<sizeof(uint32_t)> {
-  using type = uint32_t;
-};
-template <typename pair_type>
-using packed_t = typename packed<sizeof(pair_type)>::type;
+template <std::size_t N> struct packed { using type = void; };
+template <> struct packed<sizeof(uint64_t)> { using type = uint64_t; };
+template <> struct packed<sizeof(uint32_t)> { using type = uint32_t; };
+template <typename pair_type> using packed_t = typename packed<sizeof(pair_type)>::type; 
 
 /**---------------------------------------------------------------------------*
  * @brief Indicates if a pair type can be packed.

--- a/cpp/src/hash/concurrent_unordered_map.cuh
+++ b/cpp/src/hash/concurrent_unordered_map.cuh
@@ -144,7 +144,7 @@ class concurrent_unordered_map : public managed {
 
     auto deleter = [](Self* p) { p->destroy(); };
 
-    return std::unique_ptr<Self, decltype(deleter)>{
+    return std::unique_ptr<Self, std::function<void(Self*)>>{
         new Self(capacity, unused_element, unused_key, hf, eql, allocator),
         deleter};
   }
@@ -367,12 +367,9 @@ class concurrent_unordered_map : public managed {
   }
 
   concurrent_unordered_map() = default;
-
   concurrent_unordered_map(concurrent_unordered_map const&) = default;
-  concurrent_unordered_map& operator=(concurrent_unordered_map const&) =
-      default;
-
   concurrent_unordered_map(concurrent_unordered_map&&) = default;
+  concurrent_unordered_map& operator=(concurrent_unordered_map const&) = default;
   concurrent_unordered_map& operator=(concurrent_unordered_map&&) = default;
   ~concurrent_unordered_map() = default;
 

--- a/cpp/src/hash/concurrent_unordered_map.cuh
+++ b/cpp/src/hash/concurrent_unordered_map.cuh
@@ -31,55 +31,64 @@
 #include <type_traits>
 
 namespace {
-    template <std::size_t N> struct packed { using type = void; };
-    template <> struct packed<sizeof(uint64_t)> { using type = uint64_t; };
-    template <> struct packed<sizeof(uint32_t)> { using type = uint32_t; };
-    template <typename pair_type>
-    using packed_t = typename packed<sizeof(pair_type)>::type;
+template <std::size_t N>
+struct packed {
+  using type = void;
+};
+template <>
+struct packed<sizeof(uint64_t)> {
+  using type = uint64_t;
+};
+template <>
+struct packed<sizeof(uint32_t)> {
+  using type = uint32_t;
+};
+template <typename pair_type>
+using packed_t = typename packed<sizeof(pair_type)>::type;
 
-    /**---------------------------------------------------------------------------*
-     * @brief Indicates if a pair type can be packed.
-     *
-     * When the size of the key,value pair being inserted into the hash table is
-     * equal in size to a type where atomicCAS is natively supported, it is more
-     * efficient to "pack" the pair and insert it with a single atomicCAS.
-     *
-     * @note Only integral key and value types may be packed because we use
-     * bitwise equality comparison, which may not be valid for non-integral
-     * types.
-     *
-     * @tparam pair_type The pair type in question
-     * @return true If the pair type can be packed
-     * @return false  If the pair type cannot be packed
-     *---------------------------------------------------------------------------**/
-    template <typename pair_type,
-              typename key_type = typename pair_type::first_type,
-              typename value_type = typename pair_type::second_type>
-    constexpr bool is_packable() {
-      return std::is_integral<key_type>::value and
-             std::is_integral<value_type>::value and
-             not std::is_void<packed_t<pair_type>>::value;
-    }
+/**---------------------------------------------------------------------------*
+ * @brief Indicates if a pair type can be packed.
+ *
+ * When the size of the key,value pair being inserted into the hash table is
+ * equal in size to a type where atomicCAS is natively supported, it is more
+ * efficient to "pack" the pair and insert it with a single atomicCAS.
+ *
+ * @note Only integral key and value types may be packed because we use
+ * bitwise equality comparison, which may not be valid for non-integral
+ * types.
+ *
+ * @tparam pair_type The pair type in question
+ * @return true If the pair type can be packed
+ * @return false  If the pair type cannot be packed
+ *---------------------------------------------------------------------------**/
+template <typename pair_type,
+          typename key_type = typename pair_type::first_type,
+          typename value_type = typename pair_type::second_type>
+constexpr bool is_packable() {
+  return std::is_integral<key_type>::value and
+         std::is_integral<value_type>::value and
+         not std::is_void<packed_t<pair_type>>::value;
+}
 
-    /**---------------------------------------------------------------------------*
-     * @brief Allows viewing a pair in a packed representation
-     *
-     * Used as an optimization for inserting when a pair can be inserted with a
-     * single atomicCAS
-     *---------------------------------------------------------------------------**/
-    template <typename pair_type, typename Enable = void>
-    union pair_packer;
+/**---------------------------------------------------------------------------*
+ * @brief Allows viewing a pair in a packed representation
+ *
+ * Used as an optimization for inserting when a pair can be inserted with a
+ * single atomicCAS
+ *---------------------------------------------------------------------------**/
+template <typename pair_type, typename Enable = void>
+union pair_packer;
 
-    template <typename pair_type>
-    union pair_packer<pair_type, std::enable_if_t<is_packable<pair_type>()>> {
-      using packed_type = packed_t<pair_type>;
-      packed_type const packed;
-      pair_type const pair;
+template <typename pair_type>
+union pair_packer<pair_type, std::enable_if_t<is_packable<pair_type>()>> {
+  using packed_type = packed_t<pair_type>;
+  packed_type const packed;
+  pair_type const pair;
 
-      __device__ pair_packer(pair_type _pair) : pair{_pair} {}
+  __device__ pair_packer(pair_type _pair) : pair{_pair} {}
 
-      __device__ pair_packer(packed_type _packed) : packed{_packed} {}
-    };
+  __device__ pair_packer(packed_type _packed) : packed{_packed} {}
+};
 }  // namespace
 
 /**
@@ -93,42 +102,42 @@ template <typename Key, typename Element, typename Hasher = default_hash<Key>,
           typename Equality = equal_to<Key>,
           typename Allocator = legacy_allocator<thrust::pair<Key, Element>>>
 class concurrent_unordered_map : public managed {
-public:
-    using size_type = size_t;
-    using hasher = Hasher;
-    using key_equal = Equality;
-    using allocator_type = Allocator;
-    using key_type = Key;
-    using mapped_type = Element;
-    using value_type = thrust::pair<Key, Element>;
-    using iterator = cycle_iterator_adapter<value_type*>;
-    using const_iterator = const cycle_iterator_adapter<value_type*>;
+ public:
+  using size_type = size_t;
+  using hasher = Hasher;
+  using key_equal = Equality;
+  using allocator_type = Allocator;
+  using key_type = Key;
+  using mapped_type = Element;
+  using value_type = thrust::pair<Key, Element>;
+  using iterator = cycle_iterator_adapter<value_type*>;
+  using const_iterator = const cycle_iterator_adapter<value_type*>;
 
-public:
- /**---------------------------------------------------------------------------*
+ public:
+  /**---------------------------------------------------------------------------*
    * @brief Construct new concurrent unordered map with of a specified
    *m_capacity.
-  *
-  * @note The implementation of this unordered_map uses sentinel values to
+   *
+   * @note The implementation of this unordered_map uses sentinel values to
    * indicate an entry in the hash table that is empty, i.e., if a hash bucket
    *is empty, the pair residing there will be equal to (unused_key,
    *unused_element). As a result, attempting to insert a key equal to
    *`unused_key` results in undefined behavior.
-  *
-  * @param _capacity The desired m_capacity of the hash table
-  * @param unused_element The sentinel value to use for an empty value
-  * @param unused_key The sentinel value to use for an empty key
-  * @param hf The hash function to use for hashing keys
-  * @param eql The equality comparison function for comparing if two keys are
-  * equal
-  * @param allocator The allocator to use for allocation the hash table's
-  * storage
-  *---------------------------------------------------------------------------**/
+   *
+   * @param _capacity The desired m_capacity of the hash table
+   * @param unused_element The sentinel value to use for an empty value
+   * @param unused_key The sentinel value to use for an empty key
+   * @param hf The hash function to use for hashing keys
+   * @param eql The equality comparison function for comparing if two keys are
+   * equal
+   * @param allocator The allocator to use for allocation the hash table's
+   * storage
+   *---------------------------------------------------------------------------**/
   static auto create(
       size_type capacity,
-     const mapped_type unused_element = std::numeric_limits<key_type>::max(),
-     const key_type unused_key = std::numeric_limits<key_type>::max(),
-     const Hasher& hf = hasher(), const Equality& eql = key_equal(),
+      const mapped_type unused_element = std::numeric_limits<key_type>::max(),
+      const key_type unused_key = std::numeric_limits<key_type>::max(),
+      const Hasher& hf = hasher(), const Equality& eql = key_equal(),
       const allocator_type& allocator = allocator_type()) {
     using Self =
         concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>;
@@ -138,239 +147,243 @@ public:
     return std::unique_ptr<Self, decltype(deleter)>{
         new Self(capacity, unused_element, unused_key, hf, eql, allocator),
         deleter};
-    }
-    
-    __device__ iterator begin() {
-      return iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
-                      m_hashtbl_values);
-    }
-    __device__ const_iterator begin() const {
-      return const_iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
-                            m_hashtbl_values);
-    }
-    __device__ iterator end() {
-      return iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
-                      m_hashtbl_values + m_capacity);
-    }
-    __device__ const_iterator end() const {
-      return const_iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
-                            m_hashtbl_values + m_capacity);
-    }
-    __device__ value_type* data() const { return m_hashtbl_values; }
+  }
 
-    __host__ __device__ key_type get_unused_key() const { return m_unused_key; }
+  __device__ iterator begin() {
+    return iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
+                    m_hashtbl_values);
+  }
+  __device__ const_iterator begin() const {
+    return const_iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
+                          m_hashtbl_values);
+  }
+  __device__ iterator end() {
+    return iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
+                    m_hashtbl_values + m_capacity);
+  }
+  __device__ const_iterator end() const {
+    return const_iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
+                          m_hashtbl_values + m_capacity);
+  }
+  __device__ value_type* data() const { return m_hashtbl_values; }
 
-    __host__ __device__ mapped_type get_unused_element() const {
-      return m_unused_element;
-    }
+  __host__ __device__ key_type get_unused_key() const { return m_unused_key; }
 
-    __host__ __device__ size_type capacity() const { return m_capacity; }
+  __host__ __device__ mapped_type get_unused_element() const {
+    return m_unused_element;
+  }
 
-   private:
-    /**---------------------------------------------------------------------------*
+  __host__ __device__ size_type capacity() const { return m_capacity; }
+
+ private:
+  /**---------------------------------------------------------------------------*
    * @brief Enumeration of the possible results of attempting to insert into
    *a hash bucket
-     *---------------------------------------------------------------------------**/
-    enum class insert_result {
+   *---------------------------------------------------------------------------**/
+  enum class insert_result {
     CONTINUE,  ///< Insert did not succeed, continue trying to insert
                ///< (collision)
-      SUCCESS,   ///< New pair inserted successfully
-      DUPLICATE  ///< Insert did not succeed, key is already present
-    };
+    SUCCESS,   ///< New pair inserted successfully
+    DUPLICATE  ///< Insert did not succeed, key is already present
+  };
 
-    /**---------------------------------------------------------------------------*
-     * @brief Specialization for value types that can be packed.
-     *
+  /**---------------------------------------------------------------------------*
+   * @brief Specialization for value types that can be packed.
+   *
    * When the size of the key,value pair being inserted is equal in size to
    *a type where atomicCAS is natively supported, this optimization path
    *will insert the pair in a single atomicCAS operation.
-     *---------------------------------------------------------------------------**/
-    template <typename pair_type = value_type>
-    __device__ std::enable_if_t<is_packable<pair_type>(), insert_result>
-    attempt_insert(value_type* insert_location, value_type const& insert_pair) {
-      pair_packer<pair_type> const unused{
-          thrust::make_pair(m_unused_key, m_unused_element)};
-      pair_packer<pair_type> const new_pair{insert_pair};
-      pair_packer<pair_type> const old{atomicCAS(
-          reinterpret_cast<typename pair_packer<pair_type>::packed_type*>(
-              insert_location),
-          unused.packed, new_pair.packed)};
+   *---------------------------------------------------------------------------**/
+  template <typename pair_type = value_type>
+  __device__ std::enable_if_t<is_packable<pair_type>(), insert_result>
+  attempt_insert(value_type* insert_location, value_type const& insert_pair) {
+    pair_packer<pair_type> const unused{
+        thrust::make_pair(m_unused_key, m_unused_element)};
+    pair_packer<pair_type> const new_pair{insert_pair};
+    pair_packer<pair_type> const old{atomicCAS(
+        reinterpret_cast<typename pair_packer<pair_type>::packed_type*>(
+            insert_location),
+        unused.packed, new_pair.packed)};
 
-      if (old.packed == unused.packed) {
-        return insert_result::SUCCESS;
-      }
-
-      if (m_equal(old.pair.first, insert_pair.first)) {
-        return insert_result::DUPLICATE;
-      }
-      return insert_result::CONTINUE;
+    if (old.packed == unused.packed) {
+      return insert_result::SUCCESS;
     }
 
-    /**---------------------------------------------------------------------------*
-     * @brief Atempts to insert a key,value pair at the specified hash bucket.
-     *
-     * @param[in] insert_location Pointer to hash bucket to attempt insert
-     * @param[in] insert_pair The pair to insert
-     * @return Enum indicating result of insert attempt.
-     *---------------------------------------------------------------------------**/
-    template <typename pair_type = value_type>
-    __device__ std::enable_if_t<not is_packable<pair_type>(), insert_result>
-    attempt_insert(value_type* const __restrict__ insert_location,
-                   value_type const& insert_pair) {
+    if (m_equal(old.pair.first, insert_pair.first)) {
+      return insert_result::DUPLICATE;
+    }
+    return insert_result::CONTINUE;
+  }
+
+  /**---------------------------------------------------------------------------*
+   * @brief Atempts to insert a key,value pair at the specified hash bucket.
+   *
+   * @param[in] insert_location Pointer to hash bucket to attempt insert
+   * @param[in] insert_pair The pair to insert
+   * @return Enum indicating result of insert attempt.
+   *---------------------------------------------------------------------------**/
+  template <typename pair_type = value_type>
+  __device__ std::enable_if_t<not is_packable<pair_type>(), insert_result>
+  attempt_insert(value_type* const __restrict__ insert_location,
+                 value_type const& insert_pair) {
     key_type const old_key{
         atomicCAS(&(insert_location->first), m_unused_key, insert_pair.first)};
 
-      // Hash bucket empty
-      if (m_equal(m_unused_key, old_key)) {
-        insert_location->second = insert_pair.second;
-        return insert_result::SUCCESS;
-      }
-
-      // Key already exists
-      if (m_equal(old_key, insert_pair.first)) {
-        return insert_result::DUPLICATE;
-      }
-
-      return insert_result::CONTINUE;
+    // Hash bucket empty
+    if (m_equal(m_unused_key, old_key)) {
+      insert_location->second = insert_pair.second;
+      return insert_result::SUCCESS;
     }
 
-   public:
-    /**---------------------------------------------------------------------------*
-     * @brief Attempts to insert a key, value pair into the map.
-     *
-     * Returns an iterator, boolean pair.
-     *
-     * If the new key already present in the map, the iterator points to
-     * the location of the existing key and the boolean is `false` indicating
-     * that the insert did not succeed.
-     *
+    // Key already exists
+    if (m_equal(old_key, insert_pair.first)) {
+      return insert_result::DUPLICATE;
+    }
+
+    return insert_result::CONTINUE;
+  }
+
+ public:
+  /**---------------------------------------------------------------------------*
+   * @brief Attempts to insert a key, value pair into the map.
+   *
+   * Returns an iterator, boolean pair.
+   *
+   * If the new key already present in the map, the iterator points to
+   * the location of the existing key and the boolean is `false` indicating
+   * that the insert did not succeed.
+   *
    * If the new key was not present, the iterator points to the location
    *where the insert occured and the boolean is `true` indicating that the
    *insert succeeded.
-     *
-     * @param insert_pair The key and value pair to insert
+   *
+   * @param insert_pair The key and value pair to insert
    * @return Iterator, Boolean pair. Iterator is to the location of the
    *newly inserted pair, or the existing pair that prevented the insert.
    *Boolean indicates insert success.
-     *---------------------------------------------------------------------------**/
-    __device__ thrust::pair<iterator, bool> insert(
-        value_type const& insert_pair) {
-      const size_type key_hash{m_hf(insert_pair.first)};
-      size_type index{key_hash % m_capacity};
+   *---------------------------------------------------------------------------**/
+  __device__ thrust::pair<iterator, bool> insert(
+      value_type const& insert_pair) {
+    const size_type key_hash{m_hf(insert_pair.first)};
+    size_type index{key_hash % m_capacity};
 
-      insert_result status{insert_result::CONTINUE};
+    insert_result status{insert_result::CONTINUE};
 
-      value_type* current_bucket{nullptr};
+    value_type* current_bucket{nullptr};
 
-      while (status == insert_result::CONTINUE) {
-        current_bucket = &m_hashtbl_values[index];
-        status = attempt_insert(current_bucket, insert_pair);
-        index = (index + 1) % m_capacity;
-      }
-
-      bool const insert_success =
-          (status == insert_result::SUCCESS) ? true : false;
-
-      return thrust::make_pair(
-          iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
-                   current_bucket),
-          insert_success);
+    while (status == insert_result::CONTINUE) {
+      current_bucket = &m_hashtbl_values[index];
+      status = attempt_insert(current_bucket, insert_pair);
+      index = (index + 1) % m_capacity;
     }
 
-    /**---------------------------------------------------------------------------*
-     * @brief Searches the map for the specified key.
-     *
-     * @note `find` is not threadsafe with `insert`. I.e., it is not safe to
-     *do concurrent `insert` and `find` operations.
-     *
-     * @param k The key to search for
-     * @return An iterator to the key if it exists, else map.end()
-     *---------------------------------------------------------------------------**/
-    __device__ const_iterator find(key_type const& k) const {
-      size_type const key_hash = m_hf(k);
-      size_type index = key_hash % m_capacity;
+    bool const insert_success =
+        (status == insert_result::SUCCESS) ? true : false;
 
-      value_type* current_bucket = &m_hashtbl_values[index];
+    return thrust::make_pair(
+        iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
+                 current_bucket),
+        insert_success);
+  }
 
-      while (true) {
-        key_type const existing_key = current_bucket->first;
+  /**---------------------------------------------------------------------------*
+   * @brief Searches the map for the specified key.
+   *
+   * @note `find` is not threadsafe with `insert`. I.e., it is not safe to
+   *do concurrent `insert` and `find` operations.
+   *
+   * @param k The key to search for
+   * @return An iterator to the key if it exists, else map.end()
+   *---------------------------------------------------------------------------**/
+  __device__ const_iterator find(key_type const& k) const {
+    size_type const key_hash = m_hf(k);
+    size_type index = key_hash % m_capacity;
 
-        if (m_equal(k, existing_key)) {
-          return const_iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
-                                current_bucket);
-        }
-        if (m_equal(m_unused_key, existing_key)) {
-          return this->end();
-        }
-        index = (index + 1) % m_capacity;
-        current_bucket = &m_hashtbl_values[index];
+    value_type* current_bucket = &m_hashtbl_values[index];
+
+    while (true) {
+      key_type const existing_key = current_bucket->first;
+
+      if (m_equal(k, existing_key)) {
+        return const_iterator(m_hashtbl_values, m_hashtbl_values + m_capacity,
+                              current_bucket);
       }
+      if (m_equal(m_unused_key, existing_key)) {
+        return this->end();
+      }
+      index = (index + 1) % m_capacity;
+      current_bucket = &m_hashtbl_values[index];
     }
+  }
 
   gdf_error assign_async(const concurrent_unordered_map& other,
                          cudaStream_t stream = 0) {
     if (other.m_capacity <= m_capacity) {
-            m_capacity = other.m_capacity;
-        } else {
+      m_capacity = other.m_capacity;
+    } else {
       m_allocator.deallocate(m_hashtbl_values, m_capacity);
-            m_capacity = other.m_capacity;
-            m_capacity = other.m_capacity;
-            
+      m_capacity = other.m_capacity;
+      m_capacity = other.m_capacity;
+
       m_hashtbl_values = m_allocator.allocate(m_capacity);
-        }
+    }
     CUDA_TRY(cudaMemcpyAsync(m_hashtbl_values, other.m_hashtbl_values,
                              m_capacity * sizeof(value_type), cudaMemcpyDefault,
                              stream));
-        return GDF_SUCCESS;
-    }
-    
+    return GDF_SUCCESS;
+  }
+
   void clear_async(cudaStream_t stream = 0) {
-        constexpr int block_size = 128;
+    constexpr int block_size = 128;
     init_hashtbl<<<((m_capacity - 1) / block_size) + 1, block_size, 0,
                    stream>>>(m_hashtbl_values, m_capacity, m_unused_key,
                              m_unused_element);
-    }
-    
+  }
+
   void print() {
     for (size_type i = 0; i < m_capacity; ++i) {
       std::cout << i << ": " << m_hashtbl_values[i].first << ","
                 << m_hashtbl_values[i].second << std::endl;
-        }
     }
-    
+  }
+
   gdf_error prefetch(const int dev_id, cudaStream_t stream = 0) {
-        cudaPointerAttributes hashtbl_values_ptr_attributes;
+    cudaPointerAttributes hashtbl_values_ptr_attributes;
     cudaError_t status = cudaPointerGetAttributes(
         &hashtbl_values_ptr_attributes, m_hashtbl_values);
-        
+
     if (cudaSuccess == status && isPtrManaged(hashtbl_values_ptr_attributes)) {
       CUDA_TRY(cudaMemPrefetchAsync(
           m_hashtbl_values, m_capacity * sizeof(value_type), dev_id, stream));
-        }
+    }
     CUDA_TRY(cudaMemPrefetchAsync(this, sizeof(*this), dev_id, stream));
 
-        return GDF_SUCCESS;
-    }
+    return GDF_SUCCESS;
+  }
 
   void destroy() {
     m_allocator.deallocate(m_hashtbl_values, m_capacity);
     delete this;
   }
 
-  concurrent_unordered_map() = delete;
+  concurrent_unordered_map() = default;
+
+  concurrent_unordered_map(concurrent_unordered_map const&) = default;
+  concurrent_unordered_map& operator=(concurrent_unordered_map const&) =
+      default;
+
+  concurrent_unordered_map(concurrent_unordered_map&&) = default;
+  concurrent_unordered_map& operator=(concurrent_unordered_map&&) = default;
   ~concurrent_unordered_map() = default;
 
-   private:
-    hasher const m_hf;
-    key_equal const m_equal;
-
-    mapped_type const m_unused_element;
-    key_type const m_unused_key;
-
-    allocator_type m_allocator;
-
-    size_type m_capacity;
-    value_type* m_hashtbl_values;
+ private:
+  hasher m_hf;
+  key_equal m_equal;
+  mapped_type m_unused_element;
+  key_type m_unused_key;
+  allocator_type m_allocator;
+  size_type m_capacity;
+  value_type* m_hashtbl_values;
 
   /**---------------------------------------------------------------------------*
    * @brief Construct new concurrent unordered map with of a specified

--- a/cpp/src/hash/concurrent_unordered_map.cuh
+++ b/cpp/src/hash/concurrent_unordered_map.cuh
@@ -20,7 +20,6 @@
 #include <utilities/device_atomics.cuh>
 #include "hash_functions.cuh"
 #include "helper_functions.cuh"
-#include "managed.cuh"
 #include "managed_allocator.cuh"
 
 #include <thrust/pair.h>
@@ -101,7 +100,7 @@ union pair_packer<pair_type, std::enable_if_t<is_packable<pair_type>()>> {
 template <typename Key, typename Element, typename Hasher = default_hash<Key>,
           typename Equality = equal_to<Key>,
           typename Allocator = legacy_allocator<thrust::pair<Key, Element>>>
-class concurrent_unordered_map : public managed {
+class concurrent_unordered_map {
  public:
   using size_type = size_t;
   using hasher = Hasher;
@@ -369,7 +368,8 @@ class concurrent_unordered_map : public managed {
   concurrent_unordered_map() = default;
   concurrent_unordered_map(concurrent_unordered_map const&) = default;
   concurrent_unordered_map(concurrent_unordered_map&&) = default;
-  concurrent_unordered_map& operator=(concurrent_unordered_map const&) = default;
+  concurrent_unordered_map& operator=(concurrent_unordered_map const&) =
+      default;
   concurrent_unordered_map& operator=(concurrent_unordered_map&&) = default;
   ~concurrent_unordered_map() = default;
 

--- a/cpp/src/hash/concurrent_unordered_map.cuh
+++ b/cpp/src/hash/concurrent_unordered_map.cuh
@@ -367,7 +367,7 @@ class concurrent_unordered_map {
     delete this;
   }
 
-  concurrent_unordered_map() = default;
+  concurrent_unordered_map() = delete;
   concurrent_unordered_map(concurrent_unordered_map const&) = default;
   concurrent_unordered_map(concurrent_unordered_map&&) = default;
   concurrent_unordered_map& operator=(concurrent_unordered_map const&) =

--- a/cpp/src/hash/concurrent_unordered_multimap.cuh
+++ b/cpp/src/hash/concurrent_unordered_multimap.cuh
@@ -17,17 +17,17 @@
 #ifndef CONCURRENT_UNORDERED_MULTIMAP_CUH
 #define CONCURRENT_UNORDERED_MULTIMAP_CUH
 
+#include <cudf/cudf.h>
+#include <cassert>
 #include <iostream>
 #include <iterator>
 #include <type_traits>
-#include <cassert>
-#include <cudf/cudf.h>
 
 #include <thrust/pair.h>
 
-#include "managed_allocator.cuh"
-#include "managed.cuh"
 #include "hash_functions.cuh"
+#include "managed.cuh"
+#include "managed_allocator.cuh"
 
 #include "helper_functions.cuh"
 
@@ -40,446 +40,476 @@
  *  - add constructor that takes pointer to hash_table to avoid allocations
  *  - extend interface to accept streams
  */
-template <typename Key,
-          typename Element,
-          typename size_type,
-          Key unused_key,
-          Element unused_element,
-          typename Hasher = default_hash<Key>,
+template <typename Key, typename Element, typename size_type, Key unused_key,
+          Element unused_element, typename Hasher = default_hash<Key>,
           typename Equality = equal_to<Key>,
-          typename Allocator = managed_allocator<thrust::pair<Key, Element> >,
+          typename Allocator = managed_allocator<thrust::pair<Key, Element>>,
           bool count_collisions = false>
-class concurrent_unordered_multimap : public managed
-{
+class concurrent_unordered_multimap : public managed {
+ public:
+  using hasher = Hasher;
+  using key_equal = Equality;
+  using allocator_type = Allocator;
+  using key_type = Key;
+  using value_type = thrust::pair<Key, Element>;
+  using mapped_type = Element;
+  using iterator = cycle_iterator_adapter<value_type*>;
+  using const_iterator = const cycle_iterator_adapter<value_type*>;
 
-public:
-    using hasher = Hasher;
-    using key_equal = Equality;
-    using allocator_type = Allocator;
-    using key_type = Key;
-    using value_type = thrust::pair<Key, Element>;
-    using mapped_type = Element;
-    using iterator = cycle_iterator_adapter<value_type*>;
-    using const_iterator = const cycle_iterator_adapter<value_type*>;
+ private:
+  union pair2longlong {
+    unsigned long long int longlong;
+    value_type pair;
+  };
 
-private:
-    union pair2longlong
-    {
-        unsigned long long int  longlong;
-        value_type              pair;
-    };
-    
-public:
+ public:
+  /**---------------------------------------------------------------------------*
+   * @brief Factory to construct a new concurrent unordered multimap.
+   *
+   * Returns a `std::unique_ptr` to a new concurrent unordered multimap object.
+   * The map is non-owning and trivially copyable and should be passed by value
+   * into kernels. The `unique_ptr` contains a custom deleter that will free the
+   * map's contents.
+   *
+   * @note The implementation of this multimap uses sentinel values to
+   * indicate an entry in the hash table that is empty, i.e., if a hash bucket
+   *is empty, the pair residing there will be equal to (unused_key,
+   *unused_element). As a result, attempting to insert a key equal to
+   *`unused_key` results in undefined behavior.
+   *
+   * @param capacity The maximum number of pairs the map may hold.
+   * @param init Indicates if the map should be initialized with the unused
+   * key/values
+   * @param hash_function The hash function to use for hashing keys
+   * @param equal The equality comparison function for comparing if two keys are
+   * equal
+   * @param allocator The allocator to use for allocation of the map's storage.
+   *---------------------------------------------------------------------------**/
+  static auto create(size_type capacity, const bool init = true,
+                     const Hasher& hash_function = hasher(),
+                     const Equality& equal = key_equal(),
+                     const allocator_type& allocator = allocator_type()) {
+    using Self =
+        concurrent_unordered_multimap<Key, Element, size_type, unused_key,
+                                      unused_element, Hasher, Equality,
+                                      Allocator, count_collisions>;
 
-    /* --------------------------------------------------------------------------*/
-    /**
-     * @brief Allocates memory and optionally fills the hash map with unused keys/values
-     *
-     * @param[in] n The size of the hash table (the number of key-value pairs)
-     * @param[in] init Initialize the hash table with the unused keys/values
-     * @param[in] hf An optional hashing function
-     * @param[in] eql An optional functor for comparing if two keys are equal
-     * @param[in] a An optional functor for allocating the hash table memory
-     */
-    /* ----------------------------------------------------------------------------*/
-    explicit concurrent_unordered_multimap(size_type n,
-                                           const bool init = true,
-                                           const Hasher& hf = hasher(),
-                                           const Equality& eql = key_equal(),
-                                           const allocator_type& a = allocator_type())
-        : m_hf(hf), m_equal(eql), m_allocator(a), m_hashtbl_size(n), m_hashtbl_capacity(n), m_collisions(0)
-    {
-        m_hashtbl_values = m_allocator.allocate( m_hashtbl_capacity );
-        constexpr int block_size = 128;
-        {
-            cudaPointerAttributes hashtbl_values_ptr_attributes;
-            cudaError_t status = cudaPointerGetAttributes( &hashtbl_values_ptr_attributes, m_hashtbl_values );
-            
-            if ( cudaSuccess == status && isPtrManaged(hashtbl_values_ptr_attributes) ) {
-                int dev_id = 0;
-                CUDA_RT_CALL( cudaGetDevice( &dev_id ) );
-                CUDA_RT_CALL( cudaMemPrefetchAsync(m_hashtbl_values, m_hashtbl_size*sizeof(value_type), dev_id, 0) );
-            }
+    auto deleter = [](Self* p) { p->destroy(); };
+
+    return std::unique_ptr<Self, std::function<void(Self*)>>{
+        new Self(capacity, init, hash_function, equal, allocator), deleter};
+  }
+
+  /**---------------------------------------------------------------------------*
+   * @brief Frees the contents of the map and destroys the map object.
+   *
+   * This function is invoked as the deleter of the `std::unique_ptr` returned
+   * from the `create()` factory function.
+   *---------------------------------------------------------------------------**/
+  void destroy() {
+    m_allocator.deallocate(m_hashtbl_values, m_hashtbl_capacity);
+    delete this;
+  }
+
+  __host__ __device__ iterator begin() {
+    return iterator(m_hashtbl_values, m_hashtbl_values + m_hashtbl_size,
+                    m_hashtbl_values);
+  }
+  __host__ __device__ const_iterator begin() const {
+    return const_iterator(m_hashtbl_values, m_hashtbl_values + m_hashtbl_size,
+                          m_hashtbl_values);
+  }
+  __host__ __device__ iterator end() {
+    return iterator(m_hashtbl_values, m_hashtbl_values + m_hashtbl_size,
+                    m_hashtbl_values + m_hashtbl_size);
+  }
+  __host__ __device__ const_iterator end() const {
+    return const_iterator(m_hashtbl_values, m_hashtbl_values + m_hashtbl_size,
+                          m_hashtbl_values + m_hashtbl_size);
+  }
+
+  __forceinline__ static constexpr __host__ __device__ key_type
+  get_unused_key() {
+    return unused_key;
+  }
+
+  /* --------------------------------------------------------------------------*/
+  /**
+   * @brief Computes a hash value for a key
+   *
+   * @param[in] the_key The key to compute a hash for
+   * @tparam hash_value_type The datatype of the hash value
+   *
+   * @returns   The hash value for the key
+   */
+  /* ----------------------------------------------------------------------------*/
+  template <typename hash_value_type = typename Hasher::result_type>
+  __forceinline__ __host__ __device__ hash_value_type
+  get_hash(const key_type& the_key) const {
+    return m_hf(the_key);
+  }
+
+  /* --------------------------------------------------------------------------*/
+  /**
+   * @brief Computes the destination hash map partition for a key
+   *
+   * @param[in] the_key The key to search for
+   * @param[in] num_parts The total number of partitions in the partitioned
+   * hash table
+   * @param[in] precomputed_hash A flag indicating whether or not a precomputed
+   * hash value is passed in
+   * @param[in] precomputed_hash_value A precomputed hash value to use for
+   * determing the write location of the key into the hash map instead of
+   * computing the the hash value directly from the key
+   * @tparam hash_value_type The datatype of the hash value
+   *
+   * @returns   The destination hash table partition for the specified key
+   */
+  /* ----------------------------------------------------------------------------*/
+  template <typename hash_value_type = typename Hasher::result_type>
+  __forceinline__ __host__ __device__ int get_partition(
+      const key_type& the_key, const int num_parts = 1,
+      bool precomputed_hash = false,
+      hash_value_type precomputed_hash_value = 0) const {
+    hash_value_type hash_value{0};
+
+    // If a precomputed hash value has been passed in, then use it to determine
+    // the location of the key
+    if (true == precomputed_hash) {
+      hash_value = precomputed_hash_value;
+    }
+    // Otherwise, compute the hash value from the key
+    else {
+      hash_value = m_hf(the_key);
+    }
+
+    size_type hash_tbl_idx = hash_value % m_hashtbl_size;
+
+    const size_type partition_size = m_hashtbl_size / num_parts;
+
+    int dest_part = hash_tbl_idx / partition_size;
+    // Note that if m_hashtbl_size % num_parts != 0 then dest_part can be
+    // num_parts for the last few elements and we remap that to the
+    // num_parts-1 partition
+    if (dest_part == num_parts) dest_part = num_parts - 1;
+
+    return dest_part;
+  }
+
+  /* --------------------------------------------------------------------------*/
+  /**
+   * @brief  Inserts a (key, value) pair into the hash map
+   *
+   * @param[in] x The (key, value) pair to insert
+   * @param[in] precomputed_hash A flag indicating whether or not a precomputed
+   * hash value is passed in
+   * @param[in] precomputed_hash_value A precomputed hash value to use for
+   * determing the write location of the key into the hash map instead of
+   * computing the the hash value directly from the key
+   * @param[in] keys_are_equal An optional functor for comparing if two keys are
+   * equal
+   * @tparam hash_value_type The datatype of the hash value
+   * @tparam comparison_type The type of the key comparison functor
+   *
+   * @returns An iterator to the newly inserted (key, value) pair
+   */
+  /* ----------------------------------------------------------------------------*/
+  template <typename hash_value_type = typename Hasher::result_type,
+            typename comparison_type = key_equal>
+  __forceinline__ __device__ iterator
+  insert(const value_type& x, bool precomputed_hash = false,
+         hash_value_type precomputed_hash_value = 0,
+         comparison_type keys_are_equal = key_equal()) {
+    const size_type hashtbl_size = m_hashtbl_size;
+    value_type* hashtbl_values = m_hashtbl_values;
+
+    hash_value_type hash_value{0};
+
+    // If a precomputed hash value has been passed in, then use it to determine
+    // the write location of the new key
+    if (true == precomputed_hash) {
+      hash_value = precomputed_hash_value;
+    }
+    // Otherwise, compute the hash value from the new key
+    else {
+      hash_value = m_hf(x.first);
+    }
+
+    size_type hash_tbl_idx = hash_value % hashtbl_size;
+
+    value_type* it = 0;
+
+    size_type attempt_counter{0};
+
+    while (0 == it) {
+      value_type* tmp_it = hashtbl_values + hash_tbl_idx;
+
+      if (std::numeric_limits<key_type>::is_integer &&
+          std::numeric_limits<mapped_type>::is_integer &&
+          sizeof(unsigned long long int) == sizeof(value_type)) {
+        pair2longlong converter = {0ull};
+        converter.pair = thrust::make_pair(unused_key, unused_element);
+        const unsigned long long int unused = converter.longlong;
+        converter.pair = x;
+        const unsigned long long int value = converter.longlong;
+        const unsigned long long int old_val = atomicCAS(
+            reinterpret_cast<unsigned long long int*>(tmp_it), unused, value);
+        if (old_val == unused) {
+          it = tmp_it;
+        } else if (count_collisions) {
+          atomicAdd(&m_collisions, 1);
         }
+      } else {
+        const key_type old_key =
+            atomicCAS(&(tmp_it->first), unused_key, x.first);
 
-        if( init )
-        {
-            init_hashtbl<<<((m_hashtbl_size-1)/block_size)+1,block_size>>>( m_hashtbl_values, m_hashtbl_size, unused_key, unused_element );
-            CUDA_RT_CALL( cudaGetLastError() );
-            CUDA_RT_CALL( cudaStreamSynchronize(0) );
+        if (keys_are_equal(unused_key, old_key)) {
+          (m_hashtbl_values + hash_tbl_idx)->second = x.second;
+          it = tmp_it;
+        } else if (count_collisions) {
+          atomicAdd(&m_collisions, 1);
         }
+      }
+
+      hash_tbl_idx = (hash_tbl_idx + 1) % hashtbl_size;
+
+      attempt_counter++;
+      if (attempt_counter > hashtbl_size) {
+        printf("Attempted to insert to multimap but the map is full!\n");
+        return this->end();
+      }
     }
-    
-    ~concurrent_unordered_multimap()
+
+    return iterator(m_hashtbl_values, m_hashtbl_values + hashtbl_size, it);
+  }
+
+  /* --------------------------------------------------------------------------*/
+  /**
+   * @brief  Inserts a (key, value) pair into the hash map partition. This
+   * is useful when building the hash table in multiple passes, one
+   * contiguous partition at a time, or when building the hash table
+   * distributed between multiple devices.
+   *
+   * @param[in] x The (key, value) pair to insert
+   * @param[in] part The partition number for the partitioned hash table build
+   * @param[in] num_parts The total number of partitions in the partitioned
+   * hash table
+   * @param[in] precomputed_hash A flag indicating whether or not a precomputed
+   * hash value is passed in
+   * @param[in] precomputed_hash_value A precomputed hash value to use for
+   * determing the write location of the key into the hash map instead of
+   * computing the the hash value directly from the key
+   * @param[in] keys_are_equal An optional functor for comparing if two keys are
+   * equal
+   * @tparam hash_value_type The datatype of the hash value
+   * @tparam comparison_type The type of the key comparison functor
+   *
+   * @returns An iterator to the newly inserted (key, value) pair
+   */
+  /* ----------------------------------------------------------------------------*/
+  template <typename hash_value_type = typename Hasher::result_type,
+            typename comparison_type = key_equal>
+  __forceinline__ __device__ iterator insert_part(
+      const value_type& x, const int part = 0, const int num_parts = 1,
+      bool precomputed_hash = false, hash_value_type precomputed_hash_value = 0,
+      comparison_type keys_are_equal = key_equal()) {
+    hash_value_type hash_value{0};
+
+    // If a precomputed hash value has been passed in, then use it to determine
+    // the write location of the new key
+    if (true == precomputed_hash) {
+      hash_value = precomputed_hash_value;
+    }
+    // Otherwise, compute the hash value from the new key
+    else {
+      hash_value = m_hf(x.first);
+    }
+
+    // Find the destination partition index
+    int dest_part = get_partition(x.first, num_parts, true, hash_value);
+
+    // Only insert if the key belongs to the specified partition
+    if (dest_part != part)
+      return end();
+    else
+      return insert(x, true, hash_value, keys_are_equal);
+  }
+
+  /* --------------------------------------------------------------------------*/
+  /**
+   * @brief Searches for a key in the hash map and returns an iterator to the
+   * first instance of the key in the map.
+   *
+   * @param[in] the_key The key to search for
+   * @param[in] precomputed_hash A flag indicating whether or not a precomputed
+   * hash value is passed in
+   * @param[in] precomputed_hash_value A precomputed hash value to use for
+   * determing the write location of the key into the hash map instead of
+   * computing the the hash value directly from the key
+   * @param[in] keys_are_equal An optional functor for comparing if two keys are
+   * equal
+   * @tparam hash_value_type The datatype of the hash value
+   * @tparam comparison_type The type of the key comparison functor
+   *
+   * @returns   An iterator to the first instance of the key in the map
+   */
+  /* ----------------------------------------------------------------------------*/
+  template <typename hash_value_type = typename Hasher::result_type,
+            typename comparison_type = key_equal>
+  __forceinline__ __host__ __device__ const_iterator
+  find(const key_type& the_key, bool precomputed_hash = false,
+       hash_value_type precomputed_hash_value = 0,
+       comparison_type keys_are_equal = key_equal()) const {
+    hash_value_type hash_value{0};
+
+    // If a precomputed hash value has been passed in, then use it to determine
+    // the location of the key
+    if (true == precomputed_hash) {
+      hash_value = precomputed_hash_value;
+    }
+    // Otherwise, compute the hash value from the key
+    else {
+      hash_value = m_hf(the_key);
+    }
+
+    size_type hash_tbl_idx = hash_value % m_hashtbl_size;
+
+    value_type* begin_ptr = 0;
+
+    size_type counter = 0;
+    while (0 == begin_ptr) {
+      value_type* tmp_ptr = m_hashtbl_values + hash_tbl_idx;
+      const key_type tmp_val = tmp_ptr->first;
+      if (keys_are_equal(the_key, tmp_val)) {
+        begin_ptr = tmp_ptr;
+        break;
+      }
+      if (keys_are_equal(unused_key, tmp_val) || (counter > m_hashtbl_size)) {
+        begin_ptr = m_hashtbl_values + m_hashtbl_size;
+        break;
+      }
+      hash_tbl_idx = (hash_tbl_idx + 1) % m_hashtbl_size;
+      ++counter;
+    }
+
+    return const_iterator(m_hashtbl_values, m_hashtbl_values + m_hashtbl_size,
+                          begin_ptr);
+  }
+
+  gdf_error assign_async(const concurrent_unordered_multimap& other,
+                         cudaStream_t stream = 0) {
+    m_collisions = other.m_collisions;
+    if (other.m_hashtbl_size <= m_hashtbl_capacity) {
+      m_hashtbl_size = other.m_hashtbl_size;
+    } else {
+      m_allocator.deallocate(m_hashtbl_values, m_hashtbl_capacity);
+      m_hashtbl_capacity = other.m_hashtbl_size;
+      m_hashtbl_size = other.m_hashtbl_size;
+
+      m_hashtbl_values = m_allocator.allocate(m_hashtbl_capacity);
+    }
+    CUDA_TRY(cudaMemcpyAsync(m_hashtbl_values, other.m_hashtbl_values,
+                             m_hashtbl_size * sizeof(value_type),
+                             cudaMemcpyDefault, stream));
+
+    return GDF_SUCCESS;
+  }
+
+  void clear_async(cudaStream_t stream = 0) {
+    constexpr int block_size = 128;
+    init_hashtbl<<<((m_hashtbl_size - 1) / block_size) + 1, block_size, 0,
+                   stream>>>(m_hashtbl_values, m_hashtbl_size, unused_key,
+                             unused_element);
+    if (count_collisions) m_collisions = 0;
+  }
+
+  unsigned long long get_num_collisions() const { return m_collisions; }
+
+  void print() {
+    for (size_type i = 0; i < m_hashtbl_size; ++i) {
+      std::cout << i << ": " << m_hashtbl_values[i].first << ","
+                << m_hashtbl_values[i].second << std::endl;
+    }
+  }
+
+  gdf_error prefetch(const int dev_id, cudaStream_t stream = 0) {
+    cudaPointerAttributes hashtbl_values_ptr_attributes;
+    cudaError_t status = cudaPointerGetAttributes(
+        &hashtbl_values_ptr_attributes, m_hashtbl_values);
+
+    if (cudaSuccess == status && isPtrManaged(hashtbl_values_ptr_attributes)) {
+      CUDA_TRY(cudaMemPrefetchAsync(m_hashtbl_values,
+                                    m_hashtbl_size * sizeof(value_type), dev_id,
+                                    stream));
+    }
+    CUDA_TRY(cudaMemPrefetchAsync(this, sizeof(*this), dev_id, stream));
+    return GDF_SUCCESS;
+  }
+
+  concurrent_unordered_multimap() = delete;
+  concurrent_unordered_multimap(concurrent_unordered_multimap const&) = default;
+  concurrent_unordered_multimap(concurrent_unordered_multimap&&) = default;
+  concurrent_unordered_multimap& operator=(
+      concurrent_unordered_multimap const&) = default;
+  concurrent_unordered_multimap& operator=(concurrent_unordered_multimap&&) =
+      default;
+  ~concurrent_unordered_multimap() = default;
+
+ private:
+  hasher m_hf;
+  key_equal m_equal;
+  allocator_type m_allocator;
+  size_type m_hashtbl_size;
+  size_type m_hashtbl_capacity;
+  value_type* m_hashtbl_values;
+  unsigned long long m_collisions;
+
+  /**
+   * @brief Private constructor used by `create` factory function.
+   *
+   * Allocates memory and optionally fills the hash map with unused
+   * keys/values
+   *
+   * @param[in] n The size of the hash table (the number of key-value pairs)
+   * @param[in] init Initialize the hash table with the unused keys/values
+   * @param[in] hash_function An optional hashing function
+   * @param[in] equal An optional functor for comparing if two keys are equal
+   * @param[in] a An optional functor for allocating the hash table memory
+   */
+  explicit concurrent_unordered_multimap(
+      size_type n, const bool init = true,
+      const Hasher& hash_function = hasher(),
+      const Equality& equal = key_equal(),
+      const allocator_type& a = allocator_type())
+      : m_hf(hash_function),
+        m_equal(equal),
+        m_allocator(a),
+        m_hashtbl_size(n),
+        m_hashtbl_capacity(n),
+        m_collisions(0) {
+    m_hashtbl_values = m_allocator.allocate(m_hashtbl_capacity);
+    constexpr int block_size = 128;
     {
-        m_allocator.deallocate( m_hashtbl_values, m_hashtbl_capacity );
-    }
-    
-    __host__ __device__ iterator begin()
-    {
-        return iterator( m_hashtbl_values,m_hashtbl_values+m_hashtbl_size,m_hashtbl_values );
-    }
-    __host__ __device__ const_iterator begin() const
-    {
-        return const_iterator( m_hashtbl_values,m_hashtbl_values+m_hashtbl_size,m_hashtbl_values );
-    }
-    __host__ __device__ iterator end()
-    {
-        return iterator( m_hashtbl_values,m_hashtbl_values+m_hashtbl_size,m_hashtbl_values+m_hashtbl_size );
-    }
-    __host__ __device__ const_iterator end() const
-    {
-        return const_iterator( m_hashtbl_values,m_hashtbl_values+m_hashtbl_size,m_hashtbl_values+m_hashtbl_size );
-    }
-    
-    __forceinline__
-    static constexpr __host__ __device__ key_type get_unused_key()
-    {
-        return unused_key;
-    }
-   
-    /* --------------------------------------------------------------------------*/
-    /**
-     * @brief Computes a hash value for a key
-     *
-     * @param[in] the_key The key to compute a hash for
-     * @tparam hash_value_type The datatype of the hash value
-     *
-     * @returns   The hash value for the key
-     */
-    /* ----------------------------------------------------------------------------*/
-    template <typename hash_value_type = typename Hasher::result_type>
-    __forceinline__
-    __host__ __device__ hash_value_type get_hash(const key_type& the_key) const
-    {
-        return m_hf(the_key);
+      cudaPointerAttributes hashtbl_values_ptr_attributes;
+      cudaError_t status = cudaPointerGetAttributes(
+          &hashtbl_values_ptr_attributes, m_hashtbl_values);
+
+      if (cudaSuccess == status &&
+          isPtrManaged(hashtbl_values_ptr_attributes)) {
+        int dev_id = 0;
+        CUDA_RT_CALL(cudaGetDevice(&dev_id));
+        CUDA_RT_CALL(cudaMemPrefetchAsync(
+            m_hashtbl_values, m_hashtbl_size * sizeof(value_type), dev_id, 0));
+      }
     }
 
-    /* --------------------------------------------------------------------------*/
-    /**
-     * @brief Computes the destination hash map partition for a key
-     *
-     * @param[in] the_key The key to search for
-     * @param[in] num_parts The total number of partitions in the partitioned
-     * hash table
-     * @param[in] precomputed_hash A flag indicating whether or not a precomputed
-     * hash value is passed in
-     * @param[in] precomputed_hash_value A precomputed hash value to use for determing
-     * the write location of the key into the hash map instead of computing the
-     * the hash value directly from the key
-     * @tparam hash_value_type The datatype of the hash value
-     *
-     * @returns   The destination hash table partition for the specified key
-     */
-    /* ----------------------------------------------------------------------------*/
-    template <typename hash_value_type = typename Hasher::result_type>
-    __forceinline__
-    __host__ __device__ int get_partition(const key_type& the_key,
-                                          const int num_parts = 1,
-                                          bool precomputed_hash = false,
-                                          hash_value_type precomputed_hash_value = 0) const
-    {
-        hash_value_type hash_value{0};
-
-        // If a precomputed hash value has been passed in, then use it to determine
-        // the location of the key
-        if(true == precomputed_hash) {
-          hash_value = precomputed_hash_value;
-        }
-        // Otherwise, compute the hash value from the key
-        else {
-          hash_value = m_hf(the_key);
-        }
-
-        size_type hash_tbl_idx = hash_value % m_hashtbl_size;
-
-        const size_type partition_size  = m_hashtbl_size/num_parts;
-
-        int dest_part = hash_tbl_idx/partition_size;
-        // Note that if m_hashtbl_size % num_parts != 0 then dest_part can be
-        // num_parts for the last few elements and we remap that to the
-        // num_parts-1 partition
-        if (dest_part == num_parts) dest_part = num_parts-1;
-
-        return dest_part;
+    if (init) {
+      init_hashtbl<<<((m_hashtbl_size - 1) / block_size) + 1, block_size>>>(
+          m_hashtbl_values, m_hashtbl_size, unused_key, unused_element);
+      CUDA_RT_CALL(cudaGetLastError());
+      CUDA_RT_CALL(cudaStreamSynchronize(0));
     }
-
-    /* --------------------------------------------------------------------------*/
-    /** 
-     * @brief  Inserts a (key, value) pair into the hash map
-     * 
-     * @param[in] x The (key, value) pair to insert
-     * @param[in] precomputed_hash A flag indicating whether or not a precomputed 
-     * hash value is passed in
-     * @param[in] precomputed_hash_value A precomputed hash value to use for determing
-     * the write location of the key into the hash map instead of computing the
-     * the hash value directly from the key
-     * @param[in] keys_are_equal An optional functor for comparing if two keys are equal
-     * @tparam hash_value_type The datatype of the hash value
-     * @tparam comparison_type The type of the key comparison functor
-     * 
-     * @returns An iterator to the newly inserted (key, value) pair
-     */
-    /* ----------------------------------------------------------------------------*/
-    template < typename hash_value_type = typename Hasher::result_type,
-               typename comparison_type = key_equal>
-    __forceinline__
-    __device__ iterator insert(const value_type& x,
-                               bool precomputed_hash = false,
-                               hash_value_type precomputed_hash_value = 0,
-                               comparison_type keys_are_equal = key_equal())
-    {
-        const size_type hashtbl_size    = m_hashtbl_size;
-        value_type* hashtbl_values      = m_hashtbl_values;
-
-        hash_value_type hash_value{0};
-
-        // If a precomputed hash value has been passed in, then use it to determine
-        // the write location of the new key
-        if(true == precomputed_hash)
-        {
-          hash_value = precomputed_hash_value;
-        }
-        // Otherwise, compute the hash value from the new key
-        else
-        {
-          hash_value = m_hf(x.first);
-        }
-
-        size_type hash_tbl_idx = hash_value % hashtbl_size;
-
-        value_type* it = 0;
-
-        size_type attempt_counter{0};
-        
-        while (0 == it) {
-            value_type* tmp_it = hashtbl_values + hash_tbl_idx;
-
-            if ( std::numeric_limits<key_type>::is_integer && std::numeric_limits<mapped_type>::is_integer &&
-                 sizeof(unsigned long long int) == sizeof(value_type) )
-            {
-                pair2longlong converter = {0ull};
-                converter.pair = thrust::make_pair( unused_key, unused_element );
-                const unsigned long long int unused = converter.longlong;
-                converter.pair = x;
-                const unsigned long long int value = converter.longlong;
-                const unsigned long long int old_val = atomicCAS( reinterpret_cast<unsigned long long int*>(tmp_it), unused, value );
-                if ( old_val == unused ) {
-                    it = tmp_it;
-                }
-                else if ( count_collisions )
-                {
-                    atomicAdd( &m_collisions, 1 );
-                }
-            } 
-            else 
-            {
-                const key_type old_key = atomicCAS( &(tmp_it->first), unused_key, x.first );
-
-                if ( keys_are_equal( unused_key, old_key ) ) 
-                {
-                    (m_hashtbl_values+hash_tbl_idx)->second = x.second;
-                    it = tmp_it;
-                }
-                else if ( count_collisions )
-                {
-                    atomicAdd( &m_collisions, 1 );
-                }
-            }
-
-            hash_tbl_idx = (hash_tbl_idx+1)%hashtbl_size;
-
-            attempt_counter++;
-            if( attempt_counter > hashtbl_size)
-            {
-              printf("Attempted to insert to multimap but the map is full!\n");
-              return this->end();
-            }
-        }
-        
-        return iterator( m_hashtbl_values,m_hashtbl_values+hashtbl_size,it);
-    }
-
-    /* --------------------------------------------------------------------------*/
-    /**
-     * @brief  Inserts a (key, value) pair into the hash map partition. This
-     * is useful when building the hash table in multiple passes, one
-     * contiguous partition at a time, or when building the hash table
-     * distributed between multiple devices.
-     *
-     * @param[in] x The (key, value) pair to insert
-     * @param[in] part The partition number for the partitioned hash table build
-     * @param[in] num_parts The total number of partitions in the partitioned
-     * hash table
-     * @param[in] precomputed_hash A flag indicating whether or not a precomputed
-     * hash value is passed in
-     * @param[in] precomputed_hash_value A precomputed hash value to use for determing
-     * the write location of the key into the hash map instead of computing the
-     * the hash value directly from the key
-     * @param[in] keys_are_equal An optional functor for comparing if two keys are equal
-     * @tparam hash_value_type The datatype of the hash value
-     * @tparam comparison_type The type of the key comparison functor
-     *
-     * @returns An iterator to the newly inserted (key, value) pair
-     */
-    /* ----------------------------------------------------------------------------*/
-    template < typename hash_value_type = typename Hasher::result_type,
-               typename comparison_type = key_equal>
-    __forceinline__
-    __device__ iterator insert_part(const value_type& x,
-                                    const int part = 0,
-                                    const int num_parts = 1,
-                                    bool precomputed_hash = false,
-                                    hash_value_type precomputed_hash_value = 0,
-                                    comparison_type keys_are_equal = key_equal())
-    {
-        hash_value_type hash_value{0};
-
-        // If a precomputed hash value has been passed in, then use it to determine
-        // the write location of the new key
-        if(true == precomputed_hash)
-        {
-          hash_value = precomputed_hash_value;
-        }
-        // Otherwise, compute the hash value from the new key
-        else
-        {
-          hash_value = m_hf(x.first);
-        }
-
-	// Find the destination partition index 
-	int dest_part = get_partition(x.first, num_parts, true, hash_value);
-
-        // Only insert if the key belongs to the specified partition
-        if ( dest_part != part )
-          return end();
-        else
-          return insert(x, true, hash_value, keys_are_equal);
-    }
-    
-    /* --------------------------------------------------------------------------*/
-    /** 
-     * @brief Searches for a key in the hash map and returns an iterator to the first
-     * instance of the key in the map.
-     * 
-     * @param[in] the_key The key to search for
-     * @param[in] precomputed_hash A flag indicating whether or not a precomputed 
-     * hash value is passed in
-     * @param[in] precomputed_hash_value A precomputed hash value to use for determing
-     * the write location of the key into the hash map instead of computing the
-     * the hash value directly from the key
-     * @param[in] keys_are_equal An optional functor for comparing if two keys are equal
-     * @tparam hash_value_type The datatype of the hash value
-     * @tparam comparison_type The type of the key comparison functor
-     * 
-     * @returns   An iterator to the first instance of the key in the map
-     */
-    /* ----------------------------------------------------------------------------*/
-    template < typename hash_value_type = typename Hasher::result_type,
-               typename comparison_type = key_equal>
-    __forceinline__
-    __host__ __device__ const_iterator find(const key_type& the_key,
-                                            bool precomputed_hash = false,
-                                            hash_value_type precomputed_hash_value = 0,
-                                            comparison_type keys_are_equal = key_equal()) const
-    {
-        hash_value_type hash_value{0};
-
-        // If a precomputed hash value has been passed in, then use it to determine
-        // the location of the key 
-        if(true == precomputed_hash) {
-          hash_value = precomputed_hash_value;
-        }
-        // Otherwise, compute the hash value from the key
-        else {
-          hash_value = m_hf(the_key);
-        }
-
-        size_type hash_tbl_idx = hash_value % m_hashtbl_size;
-
-        value_type* begin_ptr = 0;
-        
-        size_type counter = 0;
-        while ( 0 == begin_ptr ) 
-        {
-            value_type* tmp_ptr = m_hashtbl_values + hash_tbl_idx;
-            const key_type tmp_val = tmp_ptr->first;
-            if ( keys_are_equal( the_key, tmp_val ) ) {
-                begin_ptr = tmp_ptr;
-                break;
-            }
-            if ( keys_are_equal( unused_key , tmp_val ) || (counter > m_hashtbl_size) ) {
-                begin_ptr = m_hashtbl_values + m_hashtbl_size;
-                break;
-            }
-            hash_tbl_idx = (hash_tbl_idx+1)%m_hashtbl_size;
-            ++counter;
-        }
-        
-        return const_iterator( m_hashtbl_values,m_hashtbl_values+m_hashtbl_size,begin_ptr);
-    }
-
-    gdf_error assign_async( const concurrent_unordered_multimap& other, cudaStream_t stream = 0 )
-    {
-        m_collisions = other.m_collisions;
-        if ( other.m_hashtbl_size <= m_hashtbl_capacity ) {
-            m_hashtbl_size = other.m_hashtbl_size;
-        } else {
-            m_allocator.deallocate( m_hashtbl_values, m_hashtbl_capacity );
-            m_hashtbl_capacity = other.m_hashtbl_size;
-            m_hashtbl_size = other.m_hashtbl_size;
-            
-            m_hashtbl_values = m_allocator.allocate( m_hashtbl_capacity );
-        }
-        CUDA_TRY( cudaMemcpyAsync( m_hashtbl_values, other.m_hashtbl_values, m_hashtbl_size*sizeof(value_type), cudaMemcpyDefault, stream ) );
-
-        return GDF_SUCCESS;
-    }
-    
-    void clear_async( cudaStream_t stream = 0 ) 
-    {
-        constexpr int block_size = 128;
-        init_hashtbl<<<((m_hashtbl_size-1)/block_size)+1,block_size,0,stream>>>( m_hashtbl_values, m_hashtbl_size, unused_key, unused_element );
-        if ( count_collisions )
-            m_collisions = 0;
-    }
-    
-    unsigned long long get_num_collisions() const
-    {
-        return m_collisions;
-    }
-    
-    void print()
-    {
-        for (size_type i = 0; i < m_hashtbl_size; ++i) 
-        {
-            std::cout<<i<<": "<<m_hashtbl_values[i].first<<","<<m_hashtbl_values[i].second<<std::endl;
-        }
-    }
-    
-    gdf_error prefetch( const int dev_id, cudaStream_t stream = 0 )
-    {
-        cudaPointerAttributes hashtbl_values_ptr_attributes;
-        cudaError_t status = cudaPointerGetAttributes( &hashtbl_values_ptr_attributes, m_hashtbl_values );
-        
-        if ( cudaSuccess == status && isPtrManaged(hashtbl_values_ptr_attributes) ) {
-            CUDA_TRY( cudaMemPrefetchAsync(m_hashtbl_values, m_hashtbl_size*sizeof(value_type), dev_id, stream) );
-        }
-        CUDA_TRY( cudaMemPrefetchAsync(this, sizeof(*this), dev_id, stream) );
-        return GDF_SUCCESS;
-    }
-    
-private:
-    const hasher            m_hf;
-    const key_equal         m_equal;
-    
-    allocator_type              m_allocator;
-    
-    size_type   m_hashtbl_size;
-    size_type   m_hashtbl_capacity;
-    value_type* m_hashtbl_values;
-    
-    unsigned long long m_collisions;
+  }
 };
 
-#endif //CONCURRENT_UNORDERED_MULTIMAP_CUH
+#endif  // CONCURRENT_UNORDERED_MULTIMAP_CUH

--- a/cpp/src/hash/concurrent_unordered_multimap.cuh
+++ b/cpp/src/hash/concurrent_unordered_multimap.cuh
@@ -45,7 +45,7 @@ template <typename Key, typename Element, typename size_type, Key unused_key,
           typename Equality = equal_to<Key>,
           typename Allocator = managed_allocator<thrust::pair<Key, Element>>,
           bool count_collisions = false>
-class concurrent_unordered_multimap : public managed {
+class concurrent_unordered_multimap {
  public:
   using hasher = Hasher;
   using key_equal = Equality;
@@ -442,7 +442,6 @@ class concurrent_unordered_multimap : public managed {
                                     m_hashtbl_size * sizeof(value_type), dev_id,
                                     stream));
     }
-    CUDA_TRY(cudaMemPrefetchAsync(this, sizeof(*this), dev_id, stream));
     return GDF_SUCCESS;
   }
 

--- a/cpp/src/hash/hash_functions.cuh
+++ b/cpp/src/hash/hash_functions.cuh
@@ -119,7 +119,7 @@ struct MurmurHash3_32
         return h1;
     }
 private:
-    const uint32_t m_seed;
+    uint32_t m_seed;
 };
 
 /* --------------------------------------------------------------------------*/

--- a/cpp/src/join/join_compute_api.h
+++ b/cpp/src/join/join_compute_api.h
@@ -61,7 +61,7 @@ template <JoinType join_type,
           typename multimap_type>
 gdf_error estimate_join_output_size(device_table const & build_table,
                                     device_table const & probe_table,
-                                    multimap_type const & hash_table,
+                                    multimap_type hash_table,
                                     gdf_size_type * join_output_size_estimate)
 {
   const gdf_size_type build_table_num_rows{build_table.num_rows()};
@@ -143,7 +143,7 @@ gdf_error estimate_join_output_size(device_table const & build_table,
                              multimap_type,
                              block_size,
                              DEFAULT_CUDA_CACHE_SIZE>
-    <<<numBlocks * num_sms, block_size>>>(&hash_table,
+    <<<numBlocks * num_sms, block_size>>>(hash_table,
                                           build_table,
                                           probe_table,
                                           sample_probe_num_rows,
@@ -256,7 +256,7 @@ gdf_error compute_hash_join(
   size_t const hash_table_size =
       std::max(compute_hash_table_size(build_table_num_rows), size_t{1});
 
-  std::unique_ptr<multimap_type> hash_table(new multimap_type(hash_table_size));
+  auto hash_table = multimap_type::create(hash_table_size);
 
   // FIXME: use GPU device id from the context?
   // (although should be possible once we move to Arrow)
@@ -277,7 +277,7 @@ gdf_error compute_hash_join(
   if(build_table_num_rows > 0)
   {
     const gdf_size_type build_grid_size{(build_table_num_rows + block_size - 1)/block_size};
-    build_hash_table<<<build_grid_size, block_size>>>(hash_table.get(),
+    build_hash_table<<<build_grid_size, block_size>>>(*hash_table,
                                                       *build_table,
                                                       build_table_num_rows,
                                                       d_gdf_error_code);
@@ -342,7 +342,7 @@ gdf_error compute_hash_join(
                      output_index_type,
                      block_size,
                      DEFAULT_CUDA_CACHE_SIZE>
-    <<<probe_grid_size, block_size>>> (hash_table.get(),
+    <<<probe_grid_size, block_size>>> (*hash_table,
                                        *build_table,
                                        *probe_table,
                                        probe_table->num_rows(),

--- a/cpp/src/join/join_kernels.cuh
+++ b/cpp/src/join/join_kernels.cuh
@@ -48,7 +48,7 @@ enum class JoinType {
 */
 /* ----------------------------------------------------------------------------*/
 template<typename multimap_type>
-__global__ void build_hash_table( multimap_type * const multi_map,
+__global__ void build_hash_table( multimap_type multi_map,
                                   device_table build_table,
                                   const gdf_size_type build_table_num_rows,
                                   gdf_error * gdf_error_code)
@@ -62,11 +62,11 @@ __global__ void build_hash_table( multimap_type * const multi_map,
       // Insert the (row hash value, row index) into the map
       // using the row hash value to determine the location in the
       // hash map where the new pair should be inserted
-      const auto insert_location = multi_map->insert(
+      const auto insert_location = multi_map.insert(
           thrust::make_pair(row_hash_value, i), true, row_hash_value);
 
       // If the insert failed, set the error code accordingly
-      if (multi_map->end() == insert_location) {
+      if (multi_map.end() == insert_location) {
         *gdf_error_code = GDF_HASH_TABLE_INSERT_FAILURE;
       }
       i += blockDim.x * gridDim.x;
@@ -122,7 +122,7 @@ template< JoinType join_type,
           typename multimap_type,
           int block_size,
           int output_cache_size>
-__global__ void compute_join_output_size( multimap_type const * const multi_map,
+__global__ void compute_join_output_size( multimap_type multi_map,
                                           device_table build_table,
                                           device_table probe_table,
                                           const gdf_size_type probe_table_num_rows,
@@ -137,8 +137,8 @@ __global__ void compute_join_output_size( multimap_type const * const multi_map,
   gdf_size_type thread_counter {0};
   const gdf_size_type start_idx = threadIdx.x + blockIdx.x * blockDim.x;
   const gdf_size_type stride = blockDim.x * gridDim.x;
-  const auto unused_key = multi_map->get_unused_key();
-  const auto end = multi_map->end();
+  const auto unused_key = multi_map.get_unused_key();
+  const auto end = multi_map.end();
 
   for (gdf_size_type probe_row_index = start_idx; probe_row_index < probe_table_num_rows; probe_row_index += stride) {
 
@@ -149,7 +149,7 @@ __global__ void compute_join_output_size( multimap_type const * const multi_map,
     hash_value_type probe_row_hash_value{0};
     // Search the hash map for the hash value of the probe row
     probe_row_hash_value = hash_row(probe_table,probe_row_index);
-    found = multi_map->find(probe_row_hash_value, true, probe_row_hash_value);
+    found = multi_map.find(probe_row_hash_value, true, probe_row_hash_value);
 
     // for left-joins we always need to add an output
     bool running = (join_type == JoinType::LEFT_JOIN) || (end != found); 
@@ -181,7 +181,7 @@ __global__ void compute_join_output_size( multimap_type const * const multi_map,
         ++found;
         // If you hit the end of the hash map, wrap around to the beginning
         if(end == found)
-          found = multi_map->begin();
+          found = multi_map.begin();
         // Next entry is empty, stop searching
         if(unused_key == found->first)
           running = false;
@@ -192,7 +192,7 @@ __global__ void compute_join_output_size( multimap_type const * const multi_map,
         ++found;
         // If you hit the end of the hash map, wrap around to the beginning
         if(end == found)
-          found = multi_map->begin();
+          found = multi_map.begin();
         // Next entry is empty, stop searching
         if(unused_key == found->first)
           running = false;
@@ -244,7 +244,7 @@ template< JoinType join_type,
           typename output_index_type,
           gdf_size_type block_size,
           gdf_size_type output_cache_size>
-__global__ void probe_hash_table( multimap_type const * const multi_map,
+__global__ void probe_hash_table( multimap_type multi_map,
                                   device_table build_table,
                                   device_table probe_table,
                                   const gdf_size_type probe_table_num_rows,
@@ -285,8 +285,8 @@ __global__ void probe_hash_table( multimap_type const * const multi_map,
 #endif
   if ( probe_row_index < probe_table_num_rows ) {
 
-    const auto unused_key = multi_map->get_unused_key();
-    const auto end = multi_map->end();  
+    const auto unused_key = multi_map.get_unused_key();
+    const auto end = multi_map.end();  
     auto found = end;    
 
     // Search the hash map for the hash value of the probe row using the row's
@@ -296,7 +296,7 @@ __global__ void probe_hash_table( multimap_type const * const multi_map,
     hash_value_type probe_row_hash_value{0};
     // Search the hash map for the hash value of the probe row
     probe_row_hash_value = hash_row(probe_table,probe_row_index);
-    found = multi_map->find(probe_row_hash_value, true, probe_row_hash_value);
+    found = multi_map.find(probe_row_hash_value, true, probe_row_hash_value);
 
     bool running = (join_type == JoinType::LEFT_JOIN) || (end != found);	// for left-joins we always need to add an output
     bool found_match = false;
@@ -334,7 +334,7 @@ __global__ void probe_hash_table( multimap_type const * const multi_map,
           ++found;
           // If you hit the end of the hash map, wrap around to the beginning
           if(end == found)
-            found = multi_map->begin();
+            found = multi_map.begin();
           // Next entry is empty, stop searching
           if(unused_key == found->first)
             running = false;
@@ -345,7 +345,7 @@ __global__ void probe_hash_table( multimap_type const * const multi_map,
           ++found;
           // If you hit the end of the hash map, wrap around to the beginning
           if(end == found)
-            found = multi_map->begin();
+            found = multi_map.begin();
           // Next entry is empty, stop searching
           if(unused_key == found->first)
             running = false;

--- a/cpp/tests/hash_map/map_test.cu
+++ b/cpp/tests/hash_map/map_test.cu
@@ -58,13 +58,10 @@ struct InsertTest : public GdfTest {
 };
 
 using TestTypes = ::testing::Types<
-    key_value_types<int32_t, int32_t>
-    /*,
-         key_value_types<int64_t, int64_t>,
-        key_value_types<int8_t, int8_t>, key_value_types<int16_t, int16_t>,
-        key_value_types<int8_t, float>, key_value_types<int16_t, double>,
-        key_value_types<int32_t, float>, key_value_types<int64_t, double> */
-    >;
+    key_value_types<int32_t, int32_t>, key_value_types<int64_t, int64_t>,
+    key_value_types<int8_t, int8_t>, key_value_types<int16_t, int16_t>,
+    key_value_types<int8_t, float>, key_value_types<int16_t, double>,
+    key_value_types<int32_t, float>, key_value_types<int64_t, double>>;
 
 TYPED_TEST_CASE(InsertTest, TestTypes);
 

--- a/cpp/tests/hash_map/map_test.cu
+++ b/cpp/tests/hash_map/map_test.cu
@@ -18,19 +18,19 @@
 #include <tests/utilities/cudf_test_fixtures.h>
 #include <hash/concurrent_unordered_map.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <gtest/gtest.h>
-#include <iostream>
-#include <vector>
-#include <unordered_map>
-#include <random>
+#include <rmm/thrust_rmm_allocator.h>
 #include <thrust/device_vector.h>
-#include <cstdlib>
-#include <limits>
 #include <thrust/logical.h>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <unordered_map>
+#include <vector>
 
 template <typename K, typename V>
-struct key_value_types{
+struct key_value_types {
   using key_type = K;
   using value_type = V;
   using pair_type = thrust::pair<K, V>;
@@ -44,18 +44,17 @@ struct InsertTest : public GdfTest {
   using pair_type = typename T::pair_type;
   using map_type = typename T::map_type;
 
-  InsertTest(){
-
-      // prevent overflow of small types
-      const size_t input_size = std::min(static_cast<key_type>(size), std::numeric_limits<key_type>::max());
-
-      pairs.resize(input_size);
-      map.reset(new map_type(compute_hash_table_size(size)));
-    }
+  InsertTest() {
+    // prevent overflow of small types
+    const size_t input_size = std::min(static_cast<key_type>(size),
+                                       std::numeric_limits<key_type>::max());
+    pairs.resize(input_size);
+    map = std::move(map_type::create(compute_hash_table_size(size)));
+  }
 
   const gdf_size_type size{10000};
   rmm::device_vector<pair_type> pairs;
-  std::unique_ptr<map_type> map;
+  std::unique_ptr<map_type, std::function<void(map_type*)>> map;
 };
 
 using TestTypes = ::testing::Types<
@@ -68,38 +67,37 @@ TYPED_TEST_CASE(InsertTest, TestTypes);
 
 template <typename map_type, typename pair_type>
 struct insert_pair {
-  insert_pair(map_type* _map) : map{_map} {}
+  insert_pair(map_type _map) : map{_map} {}
 
   __device__ bool operator()(pair_type const& pair) {
-
-    auto result = map->insert(pair);
-    if (result.first == map->end()) {
+    auto result = map.insert(pair);
+    if (result.first == map.end()) {
       return false;
     }
     return result.second;
   }
 
-  map_type* map;
+  map_type map;
 };
 
 template <typename map_type, typename pair_type>
 struct find_pair {
-  find_pair(map_type* _map) : map{_map} {}
+  find_pair(map_type _map) : map{_map} {}
 
   __device__ bool operator()(pair_type const& pair) {
-    auto result = map->find(pair.first);
-    if (result == map->end()) {
+    auto result = map.find(pair.first);
+    if (result == map.end()) {
       return false;
     }
     return *result == pair;
   }
-  map_type* map;
+  map_type map;
 };
 
 template <typename pair_type,
           typename key_type = typename pair_type::first_type,
           typename value_type = typename pair_type::second_type>
-struct unique_pair_generator{
+struct unique_pair_generator {
   __device__ pair_type operator()(gdf_size_type i) {
     return thrust::make_pair(key_type(i), value_type(i));
   }
@@ -122,8 +120,7 @@ template <typename pair_type,
           typename key_type = typename pair_type::first_type,
           typename value_type = typename pair_type::second_type>
 struct identical_key_generator {
-  identical_key_generator(key_type k = 42)
-      : key{k}{}
+  identical_key_generator(key_type k = 42) : key{k} {}
   __device__ pair_type operator()(gdf_size_type i) {
     return thrust::make_pair(key, value_type(i));
   }

--- a/cpp/tests/hash_map/map_test.cu
+++ b/cpp/tests/hash_map/map_test.cu
@@ -58,10 +58,13 @@ struct InsertTest : public GdfTest {
 };
 
 using TestTypes = ::testing::Types<
-    key_value_types<int32_t, int32_t>, key_value_types<int64_t, int64_t>,
-    key_value_types<int8_t, int8_t>, key_value_types<int16_t, int16_t>,
-    key_value_types<int8_t, float>, key_value_types<int16_t, double>,
-    key_value_types<int32_t, float>, key_value_types<int64_t, double>>;
+    key_value_types<int32_t, int32_t>
+    /*,
+         key_value_types<int64_t, int64_t>,
+        key_value_types<int8_t, int8_t>, key_value_types<int16_t, int16_t>,
+        key_value_types<int8_t, float>, key_value_types<int16_t, double>,
+        key_value_types<int32_t, float>, key_value_types<int64_t, double> */
+    >;
 
 TYPED_TEST_CASE(InsertTest, TestTypes);
 
@@ -133,13 +136,12 @@ TYPED_TEST(InsertTest, UniqueKeysUniqueValues) {
   thrust::tabulate(this->pairs.begin(), this->pairs.end(),
                    unique_pair_generator<pair_type>{});
   // All pairs should be new inserts
-  EXPECT_TRUE(
-      thrust::all_of(this->pairs.begin(), this->pairs.end(),
-                     insert_pair<map_type, pair_type>{this->map.get()}));
+  EXPECT_TRUE(thrust::all_of(this->pairs.begin(), this->pairs.end(),
+                             insert_pair<map_type, pair_type>{*this->map}));
 
   // All pairs should be present in the map
   EXPECT_TRUE(thrust::all_of(this->pairs.begin(), this->pairs.end(),
-                             find_pair<map_type, pair_type>{this->map.get()}));
+                             find_pair<map_type, pair_type>{*this->map}));
 }
 
 TYPED_TEST(InsertTest, IdenticalKeysIdenticalValues) {
@@ -148,17 +150,15 @@ TYPED_TEST(InsertTest, IdenticalKeysIdenticalValues) {
   thrust::tabulate(this->pairs.begin(), this->pairs.end(),
                    identical_pair_generator<pair_type>{});
   // Insert a single pair
-  EXPECT_TRUE(
-      thrust::all_of(this->pairs.begin(), this->pairs.begin() + 1,
-                     insert_pair<map_type, pair_type>{this->map.get()}));
+  EXPECT_TRUE(thrust::all_of(this->pairs.begin(), this->pairs.begin() + 1,
+                             insert_pair<map_type, pair_type>{*this->map}));
   // Identical inserts should all return false (no new insert)
-  EXPECT_FALSE(
-      thrust::all_of(this->pairs.begin(), this->pairs.end(),
-                     insert_pair<map_type, pair_type>{this->map.get()}));
+  EXPECT_FALSE(thrust::all_of(this->pairs.begin(), this->pairs.end(),
+                              insert_pair<map_type, pair_type>{*this->map}));
 
   // All pairs should be present in the map
   EXPECT_TRUE(thrust::all_of(this->pairs.begin(), this->pairs.end(),
-                             find_pair<map_type, pair_type>{this->map.get()}));
+                             find_pair<map_type, pair_type>{*this->map}));
 }
 
 TYPED_TEST(InsertTest, IdenticalKeysUniqueValues) {
@@ -168,19 +168,17 @@ TYPED_TEST(InsertTest, IdenticalKeysUniqueValues) {
                    identical_key_generator<pair_type>{});
 
   // Insert a single pair
-  EXPECT_TRUE(
-      thrust::all_of(this->pairs.begin(), this->pairs.begin() + 1,
-                     insert_pair<map_type, pair_type>{this->map.get()}));
+  EXPECT_TRUE(thrust::all_of(this->pairs.begin(), this->pairs.begin() + 1,
+                             insert_pair<map_type, pair_type>{*this->map}));
 
   // Identical key inserts should all return false (no new insert)
-  EXPECT_FALSE(
-      thrust::all_of(this->pairs.begin() + 1, this->pairs.end(),
-                     insert_pair<map_type, pair_type>{this->map.get()}));
+  EXPECT_FALSE(thrust::all_of(this->pairs.begin() + 1, this->pairs.end(),
+                              insert_pair<map_type, pair_type>{*this->map}));
 
   // Only first pair is present in map
   EXPECT_TRUE(thrust::all_of(this->pairs.begin(), this->pairs.begin() + 1,
-                             find_pair<map_type, pair_type>{this->map.get()}));
+                             find_pair<map_type, pair_type>{*this->map}));
 
   EXPECT_FALSE(thrust::all_of(this->pairs.begin() + 1, this->pairs.end(),
-                              find_pair<map_type, pair_type>{this->map.get()}));
+                              find_pair<map_type, pair_type>{*this->map}));
 }

--- a/cpp/tests/hash_map/multimap_test.cu
+++ b/cpp/tests/hash_map/multimap_test.cu
@@ -24,86 +24,74 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
-#include <vector>
 #include <limits>
+#include <vector>
 
 #include <cstdlib>
 
-// This is necessary to do a parametrized typed-test over multiple template arguments
+// This is necessary to do a parametrized typed-test over multiple template
+// arguments
 template <typename Key, typename Value>
-struct KeyValueTypes
-{
+struct KeyValueTypes {
   using key_type = Key;
   using value_type = Value;
 };
 
-
-// A new instance of this class will be created for each *TEST(MultimapTest, ...)
-// Put all repeated stuff for each test here
+// A new instance of this class will be created for each *TEST(MultimapTest,
+// ...) Put all repeated stuff for each test here
 template <class T>
-class MultimapTest : public GdfTest
-{
-public:
+class MultimapTest : public GdfTest {
+ public:
   using key_type = typename T::key_type;
   using value_type = typename T::value_type;
   using size_type = int;
 
+  using multimap_type =
+      concurrent_unordered_multimap<key_type, value_type, size_type,
+                                    std::numeric_limits<key_type>::max(),
+                                    std::numeric_limits<value_type>::max()>;
 
-  concurrent_unordered_multimap<key_type, 
-                                value_type, 
-                                size_type,
-                                std::numeric_limits<key_type>::max(),
-                                std::numeric_limits<value_type>::max() > the_map;
+  std::unique_ptr<multimap_type, std::function<void(multimap_type*)>> the_map;
 
   const key_type unused_key = std::numeric_limits<key_type>::max();
   const value_type unused_value = std::numeric_limits<value_type>::max();
 
   const size_type size;
 
-
   MultimapTest(const size_type hash_table_size = 100)
-    : the_map(hash_table_size), size(hash_table_size)
-  {
+      : the_map(multimap_type::create(hash_table_size)),
+        size(hash_table_size) {}
 
-
-  }
-
-  ~MultimapTest(){
-  }
-
-
+  ~MultimapTest() {}
 };
 
-// Google Test can only do a parameterized typed-test over a single type, so we have
-// to nest multiple types inside of the KeyValueTypes struct above
+// Google Test can only do a parameterized typed-test over a single type, so we
+// have to nest multiple types inside of the KeyValueTypes struct above
 // KeyValueTypes<type1, type2> implies key_type = type1, value_type = type2
 // This list is the types across which Google Test will run our tests
-typedef ::testing::Types< KeyValueTypes<int,int>, 
-                          KeyValueTypes<int,long long int>,
-                          KeyValueTypes<int,unsigned long long int>,
-                          KeyValueTypes<unsigned long long int, int>,
-                          KeyValueTypes<unsigned long long int, long long int>,
-                          KeyValueTypes<unsigned long long int, unsigned long long int>
-                          > Implementations;
+typedef ::testing::Types<
+    KeyValueTypes<int, int>, KeyValueTypes<int, long long int>,
+    KeyValueTypes<int, unsigned long long int>,
+    KeyValueTypes<unsigned long long int, int>,
+    KeyValueTypes<unsigned long long int, long long int>,
+    KeyValueTypes<unsigned long long int, unsigned long long int>>
+    Implementations;
 
 TYPED_TEST_CASE(MultimapTest, Implementations);
 
-TYPED_TEST(MultimapTest, InitialState)
-{
+TYPED_TEST(MultimapTest, InitialState) {
   using key_type = typename TypeParam::key_type;
   using value_type = typename TypeParam::value_type;
 
-  auto begin = this->the_map.begin();
-  auto end = this->the_map.end();
-  EXPECT_NE(begin,end);
-
+  auto begin = this->the_map->begin();
+  auto end = this->the_map->end();
+  EXPECT_NE(begin, end);
 }
 
-TYPED_TEST(MultimapTest, CheckUnusedValues){
+TYPED_TEST(MultimapTest, CheckUnusedValues) {
+  EXPECT_EQ(this->the_map->get_unused_key(), this->unused_key);
 
-  EXPECT_EQ(this->the_map.get_unused_key(), this->unused_key);
-
-  auto begin = this->the_map.begin();
+  auto begin = this->the_map->begin();
   EXPECT_EQ(begin->first, this->unused_key);
   EXPECT_EQ(begin->second, this->unused_value);
 }


### PR DESCRIPTION
Removes the dependence of the `concurrent_unordered_map` and `concurrent_unordered_multimap` classes on managed memory allocation.

`concurrented_unordered_map`
- [x] Move constructor to private
- [x] Add `create` factory to return `unique_ptr` with custom deleter
- [x] Update to be passed by value into kernels
- [x] Update tests
- [x] Remove inheritance from the `managed` class

`concurrented_unordered_multimap`
- [x] Move constructor to private
- [x] Add `create` factory to return `unique_ptr` with custom deleter
- [x] Update to be passed by value into kernels
- [x] Update tests
- [x] Remove inheritance from the `managed` class

I also had to remove the `const` from members from either map class as `const` members implicitly delete the copy-assignment operator. The copy-assignment operator is required (for some reason) in functors passed to Thrust. In short, if you want a `map` object to be a member (instead of what was previously a _pointer_) of a functor passed to Thrust, it needs to have a copy-assignment operator.