### PR TITLE
[REVIEW] ORC reader: fix parsing of DECIMAL index stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Bug Fixes
 
+- PR #2584 ORC Reader: fix parsing of `DECIMAL` index positions
+
 
 # cuDF 0.9.0 (Date TBD)
 

--- a/cpp/src/io/orc/stripe_init.cu
+++ b/cpp/src/io/orc/stripe_init.cu
@@ -218,6 +218,12 @@ struct rowindex_state_s
     uint32_t compressed_offset[128][2];
 };
 
+enum {
+    PB_TYPE_VARINT = 0,
+    PB_TYPE_FIXED64 = 1,
+    PB_TYPE_FIXEDLEN = 2,
+    PB_TYPE_FIXED32 = 5
+};
 
 #define PB_ROWINDEXENTRY_ID     ((1*8) + PB_TYPE_FIXEDLEN)
 

--- a/cpp/src/io/orc/stripe_init.cu
+++ b/cpp/src/io/orc/stripe_init.cu
@@ -218,12 +218,6 @@ struct rowindex_state_s
     uint32_t compressed_offset[128][2];
 };
 
-enum {
-    PB_TYPE_VARINT = 0,
-    PB_TYPE_FIXED64 = 1,
-    PB_TYPE_FIXEDLEN = 2,
-    PB_TYPE_FIXED32 = 5
-};
 
 #define PB_ROWINDEXENTRY_ID     ((1*8) + PB_TYPE_FIXEDLEN)
 
@@ -323,7 +317,7 @@ static uint32_t __device__ ProtobufParseRowIndexEntry(rowindex_state_s *s, const
                 s->row_index_entry[1][ci_id] = v;
             if (cur >= start + pos_end)
                 return length;
-            state = STORE_INDEX2;
+            state = (ci_id == CI_DATA && s->chunk.type_kind == DECIMAL) ? STORE_INDEX0 : STORE_INDEX2;
             break;
         case STORE_INDEX2:
             if (ci_id < CI_PRESENT)


### PR DESCRIPTION
Primary data stream index of DECIMAL columns does not include the RLE run