### PR TITLE
Changelog cleanup for 0.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PR #2111 IO Readers: Support memory buffer, file-like object, and URL inputs
 - PR #2012 Add `reindex()` to DataFrame and Series
 - PR #2097 Add GPU-accelerated AVRO reader
+- PR #2098 Support binary ops on DFs and Series with mismatched indices
 - PR #2160 Merge `dask-cudf` codebase into `cudf` repo
 - PR #2149 CSV Reader: Add `hex` dtype for explicit hexadecimal parsing
 - PR #2156 Add `upper_bound()` and `lower_bound()` for libcudf tables and `searchsorted()` for cuDF Series
@@ -104,7 +105,6 @@
 ## Bug Fixes
 
 - PR #2086 Fixed quantile api behavior mismatch in series & dataframe
-- PR #2098 Align DataFrame and Series indices before executing binary ops
 - PR #2128 Add offset param to host buffer readers in java API.
 - PR #2145 Work around binops validity checks for java
 - PR #2146 Work around unary_math validity checks for java

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@
 - PR #2177 CSV Reader: Add `parse_dates` parameter for explicit date inference
 - PR #1744 cudf::apply_boolean_mask and cudf::drop_nulls support for cudf::table inputs (multi-column)
 - PR #2196 Add `DataFrame.dropna()`
+- PR #2197 CSV Writer: add `chunksize` parameter for `to_csv`
 - PR #2215 `type_dispatcher` benchmark
 - PR #2179 Add Java quantiles
 - PR #2157 Add __array_function__ to DataFrame and Series
 - PR #2212 Java support for ORC reader
+- PR #2224 Add DataFrame isna, isnull, notna functions
+- PR #2236 Add Series.drop_duplicates
 - PR #2105 Add hash-based join benchmark
 - PR #2316 Add unique, nunique, and value_counts for datetime columns
 - PR #2337 Add Java support for slicing a ColumnVector
@@ -59,16 +62,13 @@
 - PR #2186 Add `getitem` and `getattr` style access to Rolling objects
 - PR #2168 Use cudf.Column for CategoricalColumn's categories instead of a tuple
 - PR #2193 DOC: cudf::type_dispatcher documentation for specializing dispatched functors
-- PR #2197 CSV Writer: Expose `chunksize` as a parameter for `to_csv`
 - PR #2199 Better java support for appending strings
 - PR #2176 Added column dtype support for datetime, int8, int16 to csv_writer
 - PR #2209 Matching `get_dummies` & `select_dtypes` behavior to pandas
 - PR #2217 Updated Java bindings to use the new groupby API
 - PR #2214 DOC: Update doc instructions to build/install `cudf` and `dask-cudf`
 - PR #2220 Update Java bindings for reduction rename
-- PR #2224 implement isna, isnull, notna as dataframe functions
 - PR #2232 Move CodeCov upload from build script to Jenkins
-- PR #2236 Implement drop_duplicates for Series
 - PR #2225 refactor to use libcudf for gathering columns in dataframes
 - PR #2293 Improve join performance (faster compute_join_output_size)
 - PR #2300 Create separate dask codeowners for dask-cudf codebase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,43 +2,40 @@
 
 ## New Features
 
+- PR #1993 Add CUDA-accelerated series aggregations: mean, var, std
 - PR #2111 IO Readers: Support memory buffer, file-like object, and URL inputs
 - PR #2012 Add `reindex()` to DataFrame and Series
 - PR #2097 Add GPU-accelerated AVRO reader
-- PR #2098 Align DataFrame and Series indices before executing binary ops
 - PR #2160 Merge `dask-cudf` codebase into `cudf` repo
 - PR #2149 CSV Reader: Add `hex` dtype for explicit hexadecimal parsing
 - PR #2156 Add `upper_bound()` and `lower_bound()` for libcudf tables and `searchsorted()` for cuDF Series
 - PR #2158 CSV Reader: Support single, non-list/dict argument for `dtype`
 - PR #2177 CSV Reader: Add `parse_dates` parameter for explicit date inference
-- PR #2171 Add CodeCov integration, fix doc version, make --skip-tests work when invoking with source
 - PR #1744 cudf::apply_boolean_mask and cudf::drop_nulls support for cudf::table inputs (multi-column)
 - PR #2196 Add `DataFrame.dropna()`
 - PR #2215 `type_dispatcher` benchmark
-- PR #2179 Added Java quantiles
+- PR #2179 Add Java quantiles
 - PR #2157 Add __array_function__ to DataFrame and Series
 - PR #2212 Java support for ORC reader
-- PR #2304 gdf_group_by_without_aggregations returns gdf_column
-- PR #2105 Add google benchmark for hash-based join
-- PR #2293 Improve `compute_join_output_size` performance
-- PR #2316 Unique, nunique, and value_counts for datetime columns
+- PR #2105 Add hash-based join benchmark
+- PR #2316 Add unique, nunique, and value_counts for datetime columns
 - PR #2337 Add Java support for slicing a ColumnVector
-- PR #2049 Implemented merge functionality
+- PR #2049 Add cudf::merge (sorted merge)
 - PR #2368 Full cudf+dask Parquet Support
 - PR #2380 New cudf::is_sorted checks whether cudf::table is sorted
 - PR #2356 Java column vector standard deviation support
-- PR #2221 MultiIndex Full Indexing - Support iloc and wildcards for loc
-- PR #2429 Java column vector: added support for getting length of strings in a ColumnVector
-- PR #2415 Revamp `value_counts` to use groupby count series of any type
+- PR #2221 MultiIndex full indexing - Support iloc and wildcards for loc
+- PR #2429 Java support for getting length of strings in a ColumnVector
+- PR #2415 Add `value_counts` for series of any type
 - PR #2446 Add __array_function__ for index
 - PR #2437 ORC reader: Add 'use_np_dtypes' option
 - PR #2382 Add CategoricalAccessor add, remove, rename, and ordering methods
 - PR #2464 Native implement `__cuda_array_interface__` for Series/Index/Column objects
-- PR #2425 Allow rolling window to accept array-based user-defined functions
+- PR #2425 Rolling window now accepts array-based user-defined functions
 - PR #2442 Add __setitem__
-- PR #2449 Java column vector: added support for getting byte count of strings in a ColumnVector
+- PR #2449 Java support for getting byte count of strings in a ColumnVector
 - PR #2492 Add groupby.size() method
-- PR #2358 Add the function to convert column of floating points with `nan`s into `bitmask`
+- PR #2358 Add cudf::nans_to_nulls: convert floating point column into bitmask
 - PR #2489 Add drop argument to set_index
 - PR #2491 Add Java bindings for ORC reader 'use_np_dtypes' option
 - PR #2213 Support s/ms/us/ns DatetimeColumn time unit resolutions
@@ -56,29 +53,31 @@
 - PR #2131 Chunk rows logic added to csv_writer
 - PR #2129 Add functions in the Java API to support nullable column filtering
 - PR #2165 made changes to get_dummies api for it to be available in MethodCache
+- PR #2171 Add CodeCov integration, fix doc version, make --skip-tests work when invoking with source
 - PR #2184 handle remote orc files for dask-cudf
 - PR #2186 Add `getitem` and `getattr` style access to Rolling objects
 - PR #2168 Use cudf.Column for CategoricalColumn's categories instead of a tuple
-- PR #2193 Added more docuemtnation to `type_dispatcher` for specializing dispatched functors
+- PR #2193 DOC: cudf::type_dispatcher documentation for specializing dispatched functors
 - PR #2197 CSV Writer: Expose `chunksize` as a parameter for `to_csv`
 - PR #2199 Better java support for appending strings
 - PR #2176 Added column dtype support for datetime, int8, int16 to csv_writer
 - PR #2209 Matching `get_dummies` & `select_dtypes` behavior to pandas
 - PR #2217 Updated Java bindings to use the new groupby API
 - PR #2214 DOC: Update doc instructions to build/install `cudf` and `dask-cudf`
-- PR #1993 Add iterator driven reduction for mean, var, std
 - PR #2220 Update Java bindings for reduction rename
 - PR #2224 implement isna, isnull, notna as dataframe functions
 - PR #2232 Move CodeCov upload from build script to Jenkins
 - PR #2236 Implement drop_duplicates for Series
 - PR #2225 refactor to use libcudf for gathering columns in dataframes
+- PR #2293 Improve join performance (faster compute_join_output_size)
 - PR #2300 Create separate dask codeowners for dask-cudf codebase
+- PR #2304 gdf_group_by_without_aggregations returns gdf_column
 - PR #2309 Java readers: remove redundant copy of result pointers
 - PR #2307 Add `black` and `isort` to style checker script
 - PR #2345 Restore removal of old groupby implementation
 - PR #2342 Improve `astype()` to operate all ways
 - PR #2329 using libcudf cudf::copy for column deep copy
-- PR #2344 Add docs on how code formatting works for contributors
+- PR #2344 DOC: docs on code formatting for contributors
 - PR #2376 Add inoperative axis= and win_type= arguments to Rolling()
 - PR #2378 remove dask for (de-)serialization of cudf objects
 - PR #2353 Bump Arrow and Dask versions
@@ -105,6 +104,7 @@
 ## Bug Fixes
 
 - PR #2086 Fixed quantile api behavior mismatch in series & dataframe
+- PR #2098 Align DataFrame and Series indices before executing binary ops
 - PR #2128 Add offset param to host buffer readers in java API.
 - PR #2145 Work around binops validity checks for java
 - PR #2146 Work around unary_math validity checks for java


### PR DESCRIPTION
Cleanup of changelog for 0.9 release. Moved a few things from improvement to new feature and vice versa. Fixed typos, inconsistencies, long lines.