### PR TITLE
[Review] Fix Index (De-)Serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@
 - PR #2565 Orc reader: fix incorrect data decoding of int64 data types
 - PR #2577 Fix search benchmark compilation error by adding necessary header
 - PR #2604 Fix a bug in copying.pyx:_normalize_types that upcasted int32 to int64
+- PR #2610 Fix a bug in index serialization (properly pass DeviceNDArray)
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## New Features
 
 - PR #2522 Add Java bindings for NVStrings backed upper and lower case mutators
-- PR #2607 Add Java bindings for parsing JSON 
+- PR #2607 Add Java bindings for parsing JSON
 
 ## Improvements
 
@@ -13,6 +13,7 @@
 ## Bug Fixes
 
 - PR #2584 ORC Reader: fix parsing of `DECIMAL` index positions
+- PR #2610 Fix a bug in index serialization (properly pass DeviceNDArray)
 
 
 # cuDF 0.9.0 (Date TBD)
@@ -187,7 +188,6 @@
 - PR #2565 Orc reader: fix incorrect data decoding of int64 data types
 - PR #2577 Fix search benchmark compilation error by adding necessary header
 - PR #2604 Fix a bug in copying.pyx:_normalize_types that upcasted int32 to int64
-- PR #2610 Fix a bug in index serialization (properly pass DeviceNDArray)
 
 
 # cuDF 0.8.0 (27 June 2019)

--- a/python/cudf/cudf/dataframe/column.py
+++ b/python/cudf/cudf/dataframe/column.py
@@ -254,7 +254,7 @@ class Column(object):
         else:
             header["mask_buffer"] = []
             header["mask_frame_count"] = 0
-            mask_frames = {}
+            mask_frames = []
 
         frames.extend(mask_frames)
         header["frame_count"] = len(frames)

--- a/python/cudf/cudf/dataframe/index.py
+++ b/python/cudf/cudf/dataframe/index.py
@@ -35,13 +35,7 @@ class Index(object):
         header["index_column"] = {}
         # store metadata values of index separately
         # Indexes: Numerical/DateTime/String are often GPU backed
-        if isinstance(self, RangeIndex):
-            header["index_column"]["start"] = self._start
-            header["index_column"]["stop"] = self._stop
-            # We don't need to store the GPU buffer for RangeIndexes
-            frames = []
-        else:
-            header["index_column"], frames = self._values.serialize()
+        header["index_column"], frames = self._values.serialize()
 
         header["name"] = pickle.dumps(self.name)
         header["dtype"] = pickle.dumps(self.dtype)
@@ -56,14 +50,10 @@ class Index(object):
         h = header["index_column"]
         idx_typ = pickle.loads(header["type"])
         name = pickle.loads(header["name"])
-        if idx_typ == RangeIndex:
-            start = h["start"]
-            stop = h["stop"]
-            return RangeIndex(start=start, stop=stop, name=name)
-        else:
-            col_typ = pickle.loads(h["type"])
-            index = col_typ.deserialize(h, frames[: header["frame_count"]])
-            return idx_typ(index)
+
+        col_typ = pickle.loads(h["type"])
+        index = col_typ.deserialize(h, frames[: header["frame_count"]])
+        return idx_typ(index, name=name)
 
     def take(self, indices):
         """Gather only the specific subset of indices
@@ -456,6 +446,36 @@ class RangeIndex(Index):
             return self._start == other._start and self._stop == other._stop
         else:
             return (self == other)._values.all()
+
+    def serialize(self):
+        """Serialize Index file storage or network transmission.
+        """
+        header = {}
+        header["index_column"] = {}
+
+        # store metadata values of index separately
+        # We don't need to store the GPU buffer for RangeIndexes
+        # cuDF only needs to store start/stop and rehydrate
+        # during de-serialization
+        header["index_column"]["start"] = self._start
+        header["index_column"]["stop"] = self._stop
+        frames = []
+
+        header["name"] = pickle.dumps(self.name)
+        header["dtype"] = pickle.dumps(self.dtype)
+        header["type"] = pickle.dumps(type(self))
+        header["frame_count"] = 0
+        return header, frames
+
+    @classmethod
+    def deserialize(cls, header, frames):
+        """
+        """
+        h = header["index_column"]
+        name = pickle.loads(header["name"])
+        start = h["start"]
+        stop = h["stop"]
+        return RangeIndex(start=start, stop=stop, name=name)
 
     @property
     def dtype(self):

--- a/python/cudf/cudf/tests/test_serialize.py
+++ b/python/cudf/cudf/tests/test_serialize.py
@@ -92,7 +92,7 @@ def test_serialize_series():
 
 def test_serialize_range_index():
     index = cudf.dataframe.index.RangeIndex(10, 20)
-    outindex = cudf.dataframe.index.Index.deserialize(*index.serialize())
+    outindex = cudf.dataframe.index.RangeIndex.deserialize(*index.serialize())
     assert_eq(index, outindex)
 
 


### PR DESCRIPTION
This PR changes how serialization is done for indexes.  Previously, the serialization scheme only stored the pickle-able data.  This is both inefficient and probably wrong.   Now cuDF will grab with DeviceNDArray if the index is GPU backed. 

cc @kkraus14 