### PR TITLE
[REVIEW] Fixing static char cast from type int to char with arm; issue 2593

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ## Bug Fixes
 
 - PR #2584 ORC Reader: fix parsing of `DECIMAL` index positions
-
+- PR #2611 Types Test: fix static casting from negative int to string
 
 # cuDF 0.9.0 (Date TBD)
 

--- a/cpp/tests/types/types_test.cpp
+++ b/cpp/tests/types/types_test.cpp
@@ -250,7 +250,7 @@ TEST_F(WrappersTestBool8, BooleanOperatorsBool8)
     EXPECT_TRUE(w2 >= w3);
     EXPECT_TRUE(w2 <= w3);
 
-    cudf::bool8 w4{-42};
+    cudf::bool8 w4{static_cast<char>(-42)};
     cudf::bool8 w5{43};
 
     EXPECT_TRUE(w4 == w4);
@@ -283,7 +283,7 @@ TEST_F(WrappersTestBool8, BooleanOperatorsBool8)
 TEST_F(WrappersTestBool8, CastArithmeticTest)
 {
     cudf::bool8 w1{42};
-    cudf::bool8 w2{-42};
+    cudf::bool8 w2{static_cast<char>(-42)};
 
     bool t1{42};
     bool t2{-42};


### PR DESCRIPTION
Take 2...

Fix #2593 by explicitly casting negative int to char to ensure proper compilation on TX2/Xavier/Nano.