### PR TITLE
[REVIEW] Fix string partitioning in java API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ## Bug Fixes
 
 - PR #2584 ORC Reader: fix parsing of `DECIMAL` index positions
-
+- PR #2615 fix string category partitioning in java API
 
 # cuDF 0.9.0 (Date TBD)
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -573,7 +573,8 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
         throw new IllegalArgumentException(src + " is not a supported buffer type.");
     }
 
-    assert srcOffset + length <= srcBuffer.length;
+    assert srcOffset + length <= srcBuffer.length : "would copy off end of buffer "
+        + srcOffset + " + " + length + " > " + srcBuffer.length;
     UnsafeMemoryAccessor.getBytes(dst, dstOffset,
         srcBuffer.getAddress() + srcOffset, length);
   }

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -592,7 +592,7 @@ private:
 public:
   gdf_column_wrapper(gdf_size_type size, gdf_dtype dtype, bool has_validity_buffer) {
     if (dtype == GDF_STRING || dtype == GDF_STRING_CATEGORY) {
-      throw std::logic_error("STRINGS ARE NOT SUPPORTED WITH THIS CONSTRUCTOR");
+      throw std::logic_error("TYPES STRING AND STRING_CATEGORY ARE NOT SUPPORTED WITH THIS CONSTRUCTOR");
     }
     col = new gdf_column();
     gdf_column_view(col, nullptr, nullptr, size, dtype);
@@ -604,6 +604,38 @@ public:
       }
     }
   }
+
+  /**
+   * Create a new column wrapper optionally with an empty string category columns.
+   * If empty_cat is true and the input dtype is a GDF_STRING_CATEGORY, the memory for the
+   * offsets array will be allocated, but the NVCategory pointer will not be allocated.
+   *
+   * This will allow you to set it to whatever you want when the time is right.
+   */
+  gdf_column_wrapper(gdf_size_type size, gdf_dtype dtype, bool has_validity_buffer, bool empty_cat) {
+    if (dtype == GDF_STRING) {
+      throw std::logic_error("STRING IS NOT SUPPORTED WITH THIS CONSTRUCTOR");
+    }
+    if (!empty_cat && dtype == GDF_STRING_CATEGORY) {
+      throw std::logic_error("STRING_CATEGORY WAS NOT ENABLED FOR THIS CONSTRUCTOR");
+    }
+    col = new gdf_column();
+    gdf_column_view(col, nullptr, nullptr, size, dtype);
+
+    if (size > 0) {
+      if (dtype == GDF_STRING_CATEGORY) {
+        // allocate offsets which is 1 larger than the number of entries
+        // start_offset = data[i], end_offset = data[i + 1]
+        RMM_TRY(RMM_ALLOC(&col->data, (size + 1) * cudf::size_of(GDF_INT32), 0));
+      } else {
+        RMM_TRY(RMM_ALLOC(&col->data, size * cudf::size_of(col->dtype), 0));
+      }
+      if (has_validity_buffer) {
+        RMM_TRY(RMM_ALLOC(&col->valid, gdf_valid_allocation_size(size), 0));
+      }
+    }
+  }
+
 
   gdf_column_wrapper(gdf_size_type size, gdf_dtype dtype, int null_count, void *data,
                      gdf_valid_type *valid, void *cat = NULL) {
@@ -667,6 +699,32 @@ public:
     gdf_size_type const size = input_table->num_rows();
     for (int i = 0; i < input_table->num_columns(); ++i) {
       wrappers.emplace_back(size, input_cols[i]->dtype, input_cols[i]->valid != NULL);
+    }
+  }
+
+  /**
+   * @brief This constructs a vector of cudf::jni::gdf_column_wrapper using
+   * vector of gdf_columns from the provided cudf::table. The type and validity
+   * vectors of cudf::jni::gdf_column_wrappers are based on the input_cols and
+   * shouldn't be used with operations that expect the output table to be
+   * different in type from the input e.g. joins have more columns than either
+   * one of the input tables and they can also have nulls even if the input
+   * tables don't.
+   *
+   * If empty_cat is true STRING_CATEGORY columns will be allocated, but the
+   * NVCategory pointer in them will not be set.  This is so the caller can decide
+   * what it should be set to.
+   *
+   * @param in env - JNIEnv
+   * @param in input_table - cudf::table on which to base the output table
+   * @param in empty_cat - true if STRING_CATEGORY columns should be supported, else false
+   */
+
+  output_table(JNIEnv *env, cudf::table *const input_table, bool empty_cat) : env(env) {
+    gdf_column **const input_cols = input_table->begin();
+    gdf_size_type const size = input_table->num_rows();
+    for (int i = 0; i < input_table->num_columns(); ++i) {
+      wrappers.emplace_back(size, input_cols[i]->dtype, input_cols[i]->valid != NULL, empty_cat);
     }
   }
 

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -719,12 +719,18 @@ public class TableTest {
            for (int i = 0; i < count; i++) {
              b.append(i / 2);
            }
+         });
+         ColumnVector cIn = ColumnVector.build(DType.STRING_CATEGORY, count, (b) -> {
+           for (int i = 0; i < count; i++) {
+             b.appendUTF8String(String.valueOf(i).getBytes());
+           }
          })) {
+
       HashSet<Long> expected = new HashSet<>();
       for (long i = 0; i < count; i++) {
         expected.add(i);
       }
-      try (Table input = new Table(new ColumnVector[]{aIn, bIn});
+      try (Table input = new Table(new ColumnVector[]{aIn, bIn, cIn});
            PartitionedTable output = input.onColumns(0).partition(5, HashFunction.MURMUR3)) {
         int[] parts = output.getPartitions();
         assertEquals(5, parts.length);
@@ -739,14 +745,18 @@ public class TableTest {
         assertTrue(rows <= count);
         ColumnVector aOut = output.getColumn(0);
         ColumnVector bOut = output.getColumn(1);
+        ColumnVector cOut = output.getColumn(2);
 
         aOut.ensureOnHost();
         bOut.ensureOnHost();
+        cOut.ensureOnHost();
         for (int i = 0; i < count; i++) {
           long fromA = aOut.getLong(i);
           long fromB = bOut.getInt(i);
+          String fromC = cOut.getJavaString(i);
           assertTrue(expected.remove(fromA));
           assertEquals(fromA / 2, fromB);
+          assertEquals(String.valueOf(fromA), fromC, "At Index " + i);
         }
         assertTrue(expected.isEmpty());
       }


### PR DESCRIPTION
Partitioning of strings using the java API failed prior to this change.  Now it works for STRING_CATEGORY, but not STRINGS.