### PR TITLE
[REVIEW] Fix ColumnVector concatenate for string categories and to keep timestamp units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - PR #2615 fix string category partitioning in java API
 - PR #2641 fix string category and timeunit concat in the java API
 - PR #2658 Fix astype() for null categorical columns
-- PR #2656 fix column string category and timeunit concat in the java API
+- PR #2660 fix column string category and timeunit concat in the java API
 
 
 # cuDF 0.9.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PR #2615 fix string category partitioning in java API
 - PR #2641 fix string category and timeunit concat in the java API
 - PR #2658 Fix astype() for null categorical columns
+- PR #2656 fix column string category and timeunit concat in the java API
 
 
 # cuDF 0.9.0 (Date TBD)

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -335,8 +335,11 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_concatenate(JNIEnv *env
       cudf::jni::throw_java_exception(env, "java/lang/IllegalArgumentException",
                                       "resulting column is too large");
     }
-    cudf::jni::gdf_column_wrapper outcol(total_size, columns[0]->dtype, need_validity);
+    cudf::jni::gdf_column_wrapper outcol(total_size, columns[0]->dtype, need_validity, true);
     JNI_GDF_TRY(env, 0, gdf_column_concat(outcol.get(), columns.data(), columns.size()));
+    if (outcol->dtype == GDF_TIMESTAMP) {
+      outcol->dtype_info.time_unit = columns[0]->dtype_info.time_unit;
+    }
     return reinterpret_cast<jlong>(outcol.release());
   }
   CATCH_STD(env, 0);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -91,6 +91,31 @@ public class ColumnVectorTest {
   }
 
   @Test
+  void testConcaCategories() {
+    try (ColumnVector v0 = ColumnVector.categoryFromStrings("0","1","2",null);
+         ColumnVector v1 = ColumnVector.categoryFromStrings(null, "5", "6","7");
+         ColumnVector expected = ColumnVector.categoryFromStrings(
+           "0","1","2",null,
+           null,"5","6","7");
+         ColumnVector v = ColumnVector.concatenate(v0, v1)) {
+      assertColumnsAreEqual(v, expected);
+    }
+  }
+
+  @Test
+  void testConcaTimestamps() {
+    try (ColumnVector v0 = ColumnVector.timestampsFromBoxedLongs(TimeUnit.MICROSECONDS, 0L, 1L, 2L, null);
+         ColumnVector v1 = ColumnVector.timestampsFromBoxedLongs(TimeUnit.MICROSECONDS, null, 5L, 6L, 7L);
+         ColumnVector expected = ColumnVector.timestampsFromBoxedLongs(
+           TimeUnit.MICROSECONDS,
+           0L, 1L, 2L, null,
+           null, 5L, 6L, 7L);
+         ColumnVector v = ColumnVector.concatenate(v0, v1)) {
+      assertColumnsAreEqual(v, expected);
+    }
+  }
+
+  @Test
   void isNotNullTestEmptyColumn() {
     assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v = ColumnVector.fromBoxedInts();


### PR DESCRIPTION
This PR is the column version of: https://github.com/rapidsai/cudf/pull/2641

Arguably we should refactor the table concat to use the column concat, but I am not sure if there will be a table based concat in cudf c++, so I am leaving them independent for now.