### PR TITLE
[REVIEW] Fix race condition in AVRO reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #2658 Fix astype() for null categorical columns
 - PR #2660 fix column string category and timeunit concat in the java API
 - PR #2664 ORC reader: fix `skip_rows` larger than first stripe
+- PR #2669 AVRO reader: fix non-deterministic output
 
 
 # cuDF 0.9.0 (Date TBD)


### PR DESCRIPTION
Scratch block data in shared mem was shared between all warps instead of having one scratch space per warp
Resolves #2666 