### PR TITLE
[REVIEW] Add concatenation for data-frame with different headers (empty and non-empty)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PR #2669 AVRO reader: fix non-deterministic output
 - PR #2668 Update Java bindings to specify timestamp units for ORC and Parquet readers
 - PR #2679 AVRO reader: fix cuda errors when decoding compressed streams
+- PR #2692 Fix concatenation for empty data-frame
 
 
 # cuDF 0.9.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - PR #2669 AVRO reader: fix non-deterministic output
 - PR #2668 Update Java bindings to specify timestamp units for ORC and Parquet readers
 - PR #2679 AVRO reader: fix cuda errors when decoding compressed streams
-- PR #2692 Fix concatenation for empty data-frame
+- PR #2692 Add concatenation for data-frame with different headers (empty and non-empty)
 
 
 # cuDF 0.9.0 (Date TBD)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1698,16 +1698,22 @@ class DataFrame(object):
         else:
             index = Index._concat([o.index for o in objs])
 
-        all_columns = set()
+        # Currently we only support sort = False
+        # Change below when we want to support sort = True
+        # below functions as an ordered set
+
+        all_columns_list = []
+        all_columns_set = set()
         for o in objs:
-            all_columns.update(o.columns)
+            for col in o.columns:
+                if col not in all_columns_set:
+                    all_columns_list.append(col)
+                    all_columns_set.add(col)
 
         # Concatenate cudf.series for all columns
-
         data = []
-        # done to ensure consistency with pandas
-        # pandas sorts columns by their names
-        for c in sorted(all_columns):
+
+        for c in all_columns_list:
             series_list = [
                 o[c]
                 if c in o.columns

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1688,9 +1688,7 @@ class DataFrame(object):
     def _concat(cls, objs, axis=0, ignore_index=False):
 
         # remove empty dataframes from the list
-
         non_empty_objs = [obj for obj in objs if len(obj.columns) > 0]
-
         if len(non_empty_objs) == 0:
             return objs[0]
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1686,6 +1686,16 @@ class DataFrame(object):
 
     @classmethod
     def _concat(cls, objs, axis=0, ignore_index=False):
+
+        # remove empty dataframes from the list
+
+        non_empty_objs = [obj for obj in objs if len(obj.columns) > 0]
+
+        if len(non_empty_objs) == 0:
+            return objs[0]
+
+        objs = non_empty_objs
+
         libcudf.nvtx.nvtx_range_push("CUDF_CONCAT", "orange")
         if len(set(frozenset(o.columns) for o in objs)) != 1:
             what = set(frozenset(o.columns) for o in objs)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1702,9 +1702,7 @@ class DataFrame(object):
         # Change below when we want to support sort = True
         # below functions as an ordered set
         all_columns_ls = [col for o in objs for col in o.columns]
-        unique_columns_ordered_ls = OrderedDict.fromkeys(
-            all_columns_ls, None
-        ).keys()
+        unique_columns_ordered_ls = OrderedDict.fromkeys(all_columns_ls).keys()
 
         # Concatenate cudf.series for all columns
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -750,16 +750,27 @@ def test_dataframe_concat_different_column_types():
         gd.concat([df1, df2])
 
 
-def test_dataframe_empty_concat():
-    gdf1 = DataFrame()
-    gdf1["a"] = []
-    gdf1["b"] = []
+@pytest.mark.parametrize(
+    "df_1", [DataFrame({"a": [1, 2], "b": [1, 3]}), DataFrame({})]
+)
+@pytest.mark.parametrize(
+    "df_2", [DataFrame({"a": [], "b": []}), DataFrame({})]
+)
+def test_concat_empty_dataframe(df_1, df_2):
 
-    gdf2 = gdf1.copy()
+    got = gd.concat([df_1, df_2])
+    expect = pd.concat([df_1.to_pandas(), df_2.to_pandas()])
 
-    gdf3 = gd.concat([gdf1, gdf2])
-    assert len(gdf3) == 0
-    assert len(gdf3.columns) == 2
+    pd.testing.assert_frame_equal(got.to_pandas(), expect, check_dtype=False)
+
+
+@pytest.mark.parametrize("ser_1", [pd.Series([1, 2, 3]), pd.Series([])])
+@pytest.mark.parametrize("ser_2", [pd.Series([])])
+def test_concat_empty_series(ser_1, ser_2):
+    got = gd.concat([Series(ser_1), Series(ser_2)])
+    expect = pd.concat([ser_1, ser_2])
+
+    pd.testing.assert_series_equal(got.to_pandas(), expect)
 
 
 def test_concat_with_axis():

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -761,6 +761,9 @@ def test_concat_empty_dataframe(df_1, df_2):
     got = gd.concat([df_1, df_2])
     expect = pd.concat([df_1.to_pandas(), df_2.to_pandas()])
 
+    # ignoring dtypes as pandas upcasts int to float
+    # on concatenation with empty dataframes
+
     pd.testing.assert_frame_equal(got.to_pandas(), expect, check_dtype=False)
 
 

--- a/python/cudf/cudf/tests/test_multi.py
+++ b/python/cudf/cudf/tests/test_multi.py
@@ -115,10 +115,6 @@ def test_concat_errors():
     with pytest.raises(ValueError):
         gd.concat([gdf2, gdf3])
 
-    # Mismatched columns
-    with pytest.raises(ValueError):
-        gd.concat([gdf, gdf2])
-
 
 def test_concat_misordered_columns():
     df, df2, gdf, gdf2 = make_frames(False)

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -179,6 +179,27 @@ def compare_and_get_name(a, b):
     return None
 
 
+def get_null_series(size, dtype=np.bool):
+    """
+    Creates a null series of provided dtype and size
+
+    Parameters
+    ----------
+    size:  length of series
+    dtype: dtype of series to create; defaults to bool.
+
+    Returns
+    -------
+    a null cudf series of provided `size` and `dtype`
+    """
+    from cudf.utils import cudautils
+    from cudf.core import Series
+
+    device_array = cudautils.zeros(size, dtype=dtype)
+    mask = cudautils.zeros(len(device_array), dtype=np.uint8)
+    return Series(device_array).set_mask(mask, null_count=len(mask))
+
+
 # taken from dask array
 # https://github.com/dask/dask/blob/master/dask/array/utils.py#L352-L363
 def _is_nep18_active():

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -192,12 +192,10 @@ def get_null_series(size, dtype=np.bool):
     -------
     a null cudf series of provided `size` and `dtype`
     """
-    from cudf.utils import cudautils
-    from cudf.core import Series
+    from cudf.core import Series, column
 
-    device_array = cudautils.zeros(size, dtype=dtype)
-    mask = cudautils.zeros(len(device_array), dtype=np.uint8)
-    return Series(device_array).set_mask(mask, null_count=len(mask))
+    empty_col = column.column_empty(size, dtype, True)
+    return Series(empty_col)
 
 
 # taken from dask array


### PR DESCRIPTION
This pr closes #188 and #1162 . 

- [x] Allow concatenation of columns with different headers
- [x] Add tests for empty headers
- [x] Add tests for dataframes with different headers
 
#### Implementation Note 

#### Sorting column order on concatenation

Currently, in `cudf` we don't support `sort = True` and `pandas` currently by default `sorts` columns (which will be depreciated soon to `sort` = `False` ) .  

This implementation only supports `sort` = `False` we can do a follow up pr to allow `sort=True` if the need arises. 

See: https://github.com/rapidsai/cudf/blob/50a9dc7f8f207ffd9236b5409d7e0694168bb908/python/cudf/cudf/core/reshape.py#L26-L27


#### Does not support concatenation of  non string column with string columns

Currently, we don't support concatenation of non string column with string columns. 

Though doing this is just a one line change i think we should not implicitly support this behavior as we may run into a lot of issues when we use this with `dask-cudf` as we can silently cast up to strings leading to memory shoot ups and other metadata dtype problems . 

#### Testing Note  
In the tests, currently i am ignoring dtype equivalence with  `pandas` as `pandas` on concatenation with empty data frames up casts `ints` to `floats` while we stick to `ints` .

See below:

##### Pandas Behavior:

```python
df_1 = pd.DataFrame({'a':[],'b':[]})
df_2 = pd.DataFrame({'a':np.asarray([1,2] , dtype=np.int32),'b':np.asarray([1,3], dtype=np.int32)})
pd.concat([df_1,df_2]).dtypes
```
```python
a    float64
b    float64
dtype: object
```

##### Cudf Behavior:
```python
df_1 = cudf.DataFrame({'a':[],'b':[]})
df_2 = cudf.DataFrame({'a':np.asarray([1,2] , dtype=np.int32),'b':np.asarray([1,3], dtype=np.int32)})
cudf.concat([df_1,df_2]).dtypes
```

```python
a    int32
b    int32
dtype: object
```
