### PR TITLE
[REVIEW] Return RangeIndex from contiguous slice of RangeIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - PR #2658 Fix astype() for null categorical columns
 - PR #2660 fix column string category and timeunit concat in the java API
 - PR #2664 ORC reader: fix `skip_rows` larger than first stripe
-
+- PR #2698 Return RangeIndex from contiguous slice of RangeIndex
 
 # cuDF 0.9.0 (Date TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PR #2664 ORC reader: fix `skip_rows` larger than first stripe
 - PR #2698 Return RangeIndex from contiguous slice of RangeIndex
 
+
 # cuDF 0.9.0 (Date TBD)
 
 ## New Features

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -418,6 +418,8 @@ class RangeIndex(Index):
             stop += self._start
             if sln == 0:
                 return RangeIndex(0)
+            elif step == 1:
+                return RangeIndex(start, stop)
             else:
                 return index_from_range(start, stop, step)
 

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -552,8 +552,15 @@ class RangeIndex(Index):
         return self._start >= self._stop
 
     def get_slice_bound(self, label, side, kind):
-        # TODO: Range-specific implementation here
-        raise (NotImplementedError)
+        if label < self._start:
+            return 0
+        elif label >= self._stop:
+            return len(self)
+        else:
+            if side == "left":
+                return label - self._start
+            elif side == "right":
+                return (label - self._start) + 1
 
     @property
     def __cuda_array_interface__(self):

--- a/python/cudf/cudf/tests/test_monotonic.py
+++ b/python/cudf/cudf/tests/test_monotonic.py
@@ -236,6 +236,23 @@ def test_get_slice_bound(testlist, side, kind):
         ) == index_pd.get_slice_bound(label, side, kind)
 
 
+@pytest.mark.parametrize("bounds", [(0, 10), (0, 1), (3, 4), (0, 0), (3, 3)])
+@pytest.mark.parametrize(
+    "indices",
+    [[-1, 0, 5, 10, 11], [-1, 0, 1, 2], [2, 3, 4, 5], [-1, 0, 1], [2, 3, 4]],
+)
+@pytest.mark.parametrize("side", ["left", "right"])
+@pytest.mark.parametrize("kind", ["getitem", "loc", "ix"])
+def test_rangeindex_get_slice_bound(bounds, indices, side, kind):
+    start, stop = bounds
+    pd_index = pd.RangeIndex(start, stop)
+    cudf_index = RangeIndex(start, stop)
+    for idx in indices:
+        expect = pd_index.get_slice_bound(idx, side, kind)
+        got = cudf_index.get_slice_bound(idx, side, kind)
+        assert expect == got
+
+
 @pytest.mark.parametrize("label", [1, 3, 5, 7, 9, 11])
 @pytest.mark.parametrize("side", ["left", "right"])
 @pytest.mark.parametrize("kind", ["ix", "loc", "getitem", None])


### PR DESCRIPTION
Addresses https://github.com/rapidsai/cudf/issues/1957.

Dask uses `iloc` to chop up cuDF dataframes. Without this fix, the sum memory footprint of the resulting distributed dataframe will be larger then that of the original due to the pieces carrying `GenericIndex` instead of `RangeIndex` objects, which are lighter.  