### PR TITLE
[REVIEW] Allow non-outer joins in align_indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #2588 Update Series.append documentation
 - PR #2632 Replace dask-cudf set_index code with upstream
 - PR #2703 move dask serialization dispatch into cudf
+- PR #2714 Allow non-outer joins in align_indices
 
 
 ## Bug Fixes

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2549,7 +2549,7 @@ class DatetimeProperties(object):
         return Series(data=out_column, index=self.series._index)
 
 
-def _align_indices(lhs, rhs):
+def _align_indices(lhs, rhs, join="outer"):
     """
     Internal util to align the indices of two Series. Returns a tuple of the
     aligned series, or the original arguments if the indices are the same, or
@@ -2557,5 +2557,5 @@ def _align_indices(lhs, rhs):
     """
     if isinstance(rhs, Series) and not lhs.index.equals(rhs.index):
         lhs, rhs = lhs.to_frame(0), rhs.to_frame(1)
-        lhs, rhs = lhs.join(rhs, how="outer", sort=True)._cols.values()
+        lhs, rhs = lhs.join(rhs, how=join, sort=True)._cols.values()
     return lhs, rhs


### PR DESCRIPTION
**Summary of Changes**
- Allows `_align_indices` to use joins other than `outer`, but sets the default as `outer` for compatibility with current usage.