### PR TITLE
Add Java bindings for NVTX ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #2559 Add Series.tolist()
 - PR #2653 Add Java bindings for rolling window operations
 - PR #2674 Add __contains__ for Index/Series/Column
+- PR #2722 Add Java bindings for NVTX ranges
 
 ## Improvements
 

--- a/java/src/main/java/ai/rapids/cudf/NvtxColor.java
+++ b/java/src/main/java/ai/rapids/cudf/NvtxColor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.rapids.cudf;
+
+public enum NvtxColor {
+  GREEN(0xff00ff00),
+  BLUE(0xff0000ff),
+  YELLOW(0xffffff00),
+  PURPLE(0xffff00ff),
+  CYAN(0xff00ffff),
+  RED(0xffff0000),
+  WHITE(0xffffffff),
+  DARK_GREEN(0xff006600),
+  ORANGE(0xffffa500);
+
+  final int colorBits;
+
+  NvtxColor(int colorBits) {
+    this.colorBits = colorBits;
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/NvtxRange.java
+++ b/java/src/main/java/ai/rapids/cudf/NvtxRange.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.rapids.cudf;
+
+/**
+ * Utility class to mark an NVTX profiling range.
+ *
+ * The constructor pushes an NVTX range and the close method pops off the most recent range that
+ * was pushed. Therefore instances of this class should always be used in a try-with-resources
+ * block to guarantee that ranges are always closed in the proper order. For example:
+ * <pre>
+ *   try (NvtxRange a = new NvtxRange("a", NvtxColor.RED)) {
+ *     ...
+ *     try (NvtxRange b = new NvtxRange("b", NvtxColor.BLUE)) {
+ *       ...
+ *     }
+ *     ...
+ *   }
+ * </pre>
+ *
+ * Instances should be associated with a single thread to avoid pushing an NVTX range in
+ * one thread and then trying to pop the range in a different thread.
+ */
+public class NvtxRange implements AutoCloseable {
+  private static final boolean isEnabled = Boolean.getBoolean("ai.rapids.cudf.nvtx.enabled");
+
+  public NvtxRange(String name, NvtxColor color) {
+    this(name, color.colorBits);
+  }
+
+  public NvtxRange(String name, int colorBits) {
+    if (isEnabled) {
+      push(name, colorBits);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (isEnabled) {
+      pop();
+    }
+  }
+
+  private native void push(String name, int colorBits);
+  private native void pop();
+}

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -201,6 +201,7 @@ set(SOURCE_FILES
     "src/CudfJni.cpp"
     "src/CudaJni.cpp"
     "src/ColumnVectorJni.cpp"
+    "src/NvtxRangeJni.cpp"
     "src/RmmJni.cpp"
     "src/TableJni.cpp")
 add_library(cudfjni SHARED ${SOURCE_FILES})

--- a/java/src/main/native/src/NvtxRangeJni.cpp
+++ b/java/src/main/native/src/NvtxRangeJni.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include "cudf/cudf.h"
+
+#include "jni_utils.hpp"
+
+extern "C" {
+
+JNIEXPORT void JNICALL
+Java_ai_rapids_cudf_NvtxRange_push(JNIEnv *env, jclass clazz,
+    jstring name, jint color_bits) {
+  try {
+    cudf::jni::native_jstring range_name(env, name);
+    JNI_GDF_TRY(env, , gdf_nvtx_range_push_hex(range_name.get(), color_bits));
+  }
+  CATCH_STD(env, );
+}
+
+JNIEXPORT void JNICALL
+Java_ai_rapids_cudf_NvtxRange_pop(JNIEnv *env, jclass clazz) {
+  try {
+    JNI_GDF_TRY(env, , gdf_nvtx_range_pop());
+  }
+  CATCH_STD(env, );
+}
+
+} // extern "C"


### PR DESCRIPTION
Adding Java bindings to libcudf's NVTX APIs so Java code can create NVTX ranges. The range is designed to be used always in a try-with-resources block to ensure ranges are closed in the proper order.
