### PR TITLE
[REVIEW] Switch jitify branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "thirdparty/jitify"]
 	path = thirdparty/jitify
 	url = https://github.com/rapidsai/jitify.git
-	branch = feature/api_v2
+	branch = feature/api_v2_v0.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - PR #2672 Fix null and integer handling in round
 - PR #2725 Fix Jitify issue with running on Turing using CUDA version < 10
 - PR #2731 Fix building of benchmarks
+- PR #2736 Pin Jitify branch to v0.10 version
 
 
 # cuDF 0.9.0 (Date TBD)


### PR DESCRIPTION
Just pinning the jitify branch to `feature/api_v2 branch_v0.10` per conversation with @devavret 