### PR TITLE
[REVIEW] Fix missing headers / libs needed for cuspatial build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - PR #2648 Cython/Python reorg
 - PR #2588 Update Series.append documentation
 - PR #2632 Replace dask-cudf set_index code with upstream
-
+- PR #2747 Add missing Cython headers / cudftestutil lib to conda package for cuspatial build
 
 ## Bug Fixes
 

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -44,6 +44,7 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/lib/libcudf.so
+    - test -f $PREFIX/lib/libcudftestutil.a
     - test -f $PREFIX/include/cudf/legacy/bitmask.hpp
     - test -f $PREFIX/include/cudf/legacy/column.hpp
     - test -f $PREFIX/include/cudf/legacy/table.hpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -510,6 +510,10 @@ add_custom_target(install_cudf
                   COMMAND "${CMAKE_COMMAND}" -DCOMPONENT=cudf -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
                   DEPENDS cudf)
 
+if(BUILD_TESTS)
+    add_dependencies(install_cudf cudftestutil)
+endif(BUILD_TESTS)
+
 add_custom_target(install_nvstrings
                   COMMAND "${CMAKE_COMMAND}" -DCOMPONENT=nvstrings -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
                   DEPENDS nvstrings)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -16,6 +16,10 @@ add_library(cudftestutil STATIC
 
 target_link_libraries(cudftestutil cudf)
 
+install(TARGETS cudftestutil
+        DESTINATION lib
+        COMPONENT cudf)
+
 ###################################################################################################
 # - compiler function -----------------------------------------------------------------------------
 

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=find_packages(include=["cudf", "cudf.*"]),
     package_data={
         "cudf._lib": ["*.pxd"],
-        "cudf._lib.groupby": ["*.pxd"],
+        "cudf._lib.includes": ["*.pxd"],
         "cudf._lib.arrow": ["*.pxd"],
     },
     cmdclass=versioneer.get_cmdclass(),

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -54,6 +54,7 @@ setup(
     package_data={
         "cudf._lib": ["*.pxd"],
         "cudf._lib.includes": ["*.pxd"],
+        "cudf._lib.includes.groupby": ["*.pxd"],
         "cudf._lib.arrow": ["*.pxd"],
     },
     cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
cuSpatial can't find the `cudf.pxd` header because of a missing `__init__.pxd`, so fixing shipping the headers in general after the Python reorg.

Additionally, shipping the `libcudftestutil.a` static lib as part of the libcudf conda package.