### PR TITLE
Allow building nvstrings python if nvstrings built locally but not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - PR #2703 move dask serialization dispatch into cudf
 - PR #2729 Handle file-handle input in to_csv
 - PR #2741 CSV Reader: Move kernel functions into its own file
+- PR #2766 Improve nvstrings python cmake flexibility
 
 ## Bug Fixes
 

--- a/python/nvstrings/cpp/CMakeLists.txt
+++ b/python/nvstrings/cpp/CMakeLists.txt
@@ -103,21 +103,25 @@ endif (RMM_INCLUDE AND RMM_LIBRARY)
 find_path(
     NVSTRINGS_INCLUDE "nvstrings"
     HINTS "$ENV{NVSTRINGS_ROOT}/include"
+          "../../../cpp/include" # allow building if nvstrings built locally but not installed
 )
 
 find_library(
     NVSTRINGS_LIBRARY "NVStrings"
     HINTS "$ENV{NVSTRINGS_ROOT}/lib"
+          "$ENV{NVSTRINGS_ROOT}"
 )
 
 find_library(
     NVCATEGORY_LIBRARY "NVCategory"
     HINTS "$ENV{NVSTRINGS_ROOT}/lib"
+          "$ENV{NVSTRINGS_ROOT}"
 )
 
 find_library(
     NVTEXT_LIBRARY "NVText"
     HINTS "$ENV{NVSTRINGS_ROOT}/lib"
+          "$ENV{NVSTRINGS_ROOT}"
 )
 
 message(STATUS "NVSTRINGS: NVSTRINGS_INCLUDE set to ${NVSTRINGS_INCLUDE}")

--- a/python/nvstrings/cpp/CMakeLists.txt
+++ b/python/nvstrings/cpp/CMakeLists.txt
@@ -103,7 +103,7 @@ endif (RMM_INCLUDE AND RMM_LIBRARY)
 find_path(
     NVSTRINGS_INCLUDE "nvstrings"
     HINTS "$ENV{NVSTRINGS_ROOT}/include"
-          "../../../cpp/include" # allow building if nvstrings built locally but not installed
+          "../../../cpp/include"
 )
 
 find_library(


### PR DESCRIPTION
Simply adds some additional hints to the NVStrings python cmake to find libnvstrings.so and headers (and nvtext and nvcategory) if they have been built locally and not installed.