### PR TITLE
[REVIEW] Fix async race in NVCategory::get_value and get_value_bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - PR #2749 Fix apply_rows/apply_chunks pessimistic null mask to use in_cols null masks only
 - PR #2752 CSV Reader: Fix exception when there's no rows to process
 - PR #2716 Added Exception for `StringMethods` in string methods
+- PR #2794 Fix async race in NVCategory::get_value and get_value_bounds
 
 
 # cuDF 0.9.0 (21 Aug 2019)

--- a/cpp/custrings/category/NVCategory.cu
+++ b/cpp/custrings/category/NVCategory.cu
@@ -760,7 +760,10 @@ int NVCategory::get_value(unsigned int index)
     int* d_map = pImpl->getMapPtr();
     int rtn = -1;
     if( d_map )
+    {
         CUDA_TRY(cudaMemcpyAsync(&rtn,d_map+index,sizeof(int),cudaMemcpyDeviceToHost))
+        CUDA_TRY(cudaStreamSynchronize(0))
+    }
     return rtn;
 }
 
@@ -857,6 +860,7 @@ std::pair<int,int> NVCategory::get_value_bounds(const char* str)
     //
     int first = 0; // get the position back into host memory
     CUDA_TRY(cudaMemcpyAsync(&first,keys.data().get(),sizeof(int),cudaMemcpyDeviceToHost))
+    CUDA_TRY(cudaStreamSynchronize(0))
     rtn.first = first-1; // range is always
     rtn.second = first;  // position and previous one
     if( d_str )

--- a/cpp/custrings/category/NVCategory.cu
+++ b/cpp/custrings/category/NVCategory.cu
@@ -760,10 +760,7 @@ int NVCategory::get_value(unsigned int index)
     int* d_map = pImpl->getMapPtr();
     int rtn = -1;
     if( d_map )
-    {
-        CUDA_TRY(cudaMemcpyAsync(&rtn,d_map+index,sizeof(int),cudaMemcpyDeviceToHost))
-        CUDA_TRY(cudaStreamSynchronize(0))
-    }
+        CUDA_TRY(cudaMemcpy(&rtn,d_map+index,sizeof(int),cudaMemcpyDeviceToHost))
     return rtn;
 }
 
@@ -859,8 +856,7 @@ std::pair<int,int> NVCategory::get_value_bounds(const char* str)
         [d_seqdata, count, d_indexes] __device__ (int idx) { return d_seqdata[idx]==count; });
     //
     int first = 0; // get the position back into host memory
-    CUDA_TRY(cudaMemcpyAsync(&first,keys.data().get(),sizeof(int),cudaMemcpyDeviceToHost))
-    CUDA_TRY(cudaStreamSynchronize(0))
+    CUDA_TRY(cudaMemcpy(&first,keys.data().get(),sizeof(int),cudaMemcpyDeviceToHost))
     rtn.first = first-1; // range is always
     rtn.second = first;  // position and previous one
     if( d_str )


### PR DESCRIPTION
Fixes #2755 by synchronizing the default stream after the async copy.

This only addresses the two instances identified where NVCategory code was directly accessing host memory while a device write could still be pending.  It does not address potential issues where NVCategory calls can return with device-to-host writes still pending (e.g.: `create_index`, `get_values`).
