### PR TITLE
[REVIEW] Fixed java code to use new join API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - PR #2794 Fix async race in NVCategory::get_value and get_value_bounds
 - PR #2795 Fix java build/cast error
 - PR #2496 Fix improper merge of two dataframes when names differ
+- PR #2818 Fix java join API to use new C++ join API
 
 
 # cuDF 0.9.0 (21 Aug 2019)

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -1036,7 +1036,8 @@ public final class Table implements AutoCloseable {
      * Table t2 ...
      * Table result = t1.onColumns(0,1).leftJoin(t2.onColumns(2,3));
      * @param rightJoinIndices - Indices of the right table to join on
-     * @return Joined {@link Table}
+     * @return the joined table.  The order of the columns returned will be join columns,
+     * left non-join columns, right non-join columns.
      */
     public Table leftJoin(TableOperation rightJoinIndices) {
       return new Table(gdfLeftJoin(operation.table.nativeHandle, operation.indices,
@@ -1050,7 +1051,8 @@ public final class Table implements AutoCloseable {
      * Table t2 ...
      * Table result = t1.onColumns(0,1).innerJoin(t2.onColumns(2,3));
      * @param rightJoinIndices - Indices of the right table to join on
-     * @return Joined {@link Table}
+     * @return the joined table.  The order of the columns returned will be join columns,
+     * left non-join columns, right non-join columns.
      */
     public Table innerJoin(TableOperation rightJoinIndices) {
       return new Table(gdfInnerJoin(operation.table.nativeHandle, operation.indices,

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -26,6 +26,7 @@
 #include "cudf/legacy/table.hpp"
 #include "cudf/stream_compaction.hpp"
 #include "cudf/types.hpp"
+#include "cudf/join.hpp"
 
 #include "jni_utils.hpp"
 
@@ -328,7 +329,9 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_gdfLeftJoin(
     cudf::table *n_left_table = reinterpret_cast<cudf::table *>(left_table);
     cudf::table *n_right_table = reinterpret_cast<cudf::table *>(right_table);
     cudf::jni::native_jintArray left_join_cols_arr(env, left_col_join_indices);
+    std::vector<int> left_join_cols(left_join_cols_arr.data(), left_join_cols_arr.data() + left_join_cols_arr.size());
     cudf::jni::native_jintArray right_join_cols_arr(env, right_col_join_indices);
+    std::vector<int> right_join_cols(right_join_cols_arr.data(), right_join_cols_arr.data() + right_join_cols_arr.size());
 
     gdf_context context{};
     context.flag_sorted = 0;
@@ -337,25 +340,23 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_gdfLeftJoin(
     context.flag_sort_result = 1;
     context.flag_sort_inplace = 0;
 
-    int result_num_cols =
-        n_left_table->num_columns() + n_right_table->num_columns() - left_join_cols_arr.size();
-
-    // gdf_left_join is allocating the memory for the results so
-    // allocate the output column structures here when we get it back fill in
-    // the the outPtrs
-    cudf::jni::unique_jpointerArray<gdf_column> output_columns(env, result_num_cols);
-    for (int i = 0; i < result_num_cols; i++) {
-      output_columns.reset(i, new gdf_column());
+    int dedupe_size = left_join_cols.size();
+    std::vector<std::pair<gdf_size_type, gdf_size_type>> dedupe(dedupe_size);
+    for (int i = 0; i < dedupe_size; i++) {
+      dedupe[i].first = left_join_cols[i];
+      dedupe[i].second = right_join_cols[i];
     }
-    JNI_GDF_TRY(
-        env, NULL,
-        gdf_left_join(
-            n_left_table->begin(), n_left_table->num_columns(), left_join_cols_arr.data(),
-            n_right_table->begin(), n_right_table->num_columns(), right_join_cols_arr.data(),
-            left_join_cols_arr.size(), result_num_cols,
-            const_cast<gdf_column **>(output_columns.get()), // API does not respect const values
-            nullptr, nullptr, &context));
-    return output_columns.release();
+
+    cudf::table result = cudf::left_join(
+            *n_left_table, *n_right_table,
+            left_join_cols, right_join_cols,
+            dedupe,
+            nullptr, &context);
+
+    cudf::jni::native_jlongArray native_handles(env, reinterpret_cast<jlong *>(result.begin()),
+                                                result.num_columns());
+
+    return native_handles.get_jArray();
   }
   CATCH_STD(env, NULL);
 }
@@ -372,7 +373,9 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_gdfInnerJoin(
     cudf::table *n_left_table = reinterpret_cast<cudf::table *>(left_table);
     cudf::table *n_right_table = reinterpret_cast<cudf::table *>(right_table);
     cudf::jni::native_jintArray left_join_cols_arr(env, left_col_join_indices);
+    std::vector<int> left_join_cols(left_join_cols_arr.data(), left_join_cols_arr.data() + left_join_cols_arr.size());
     cudf::jni::native_jintArray right_join_cols_arr(env, right_col_join_indices);
+    std::vector<int> right_join_cols(right_join_cols_arr.data(), right_join_cols_arr.data() + right_join_cols_arr.size());
 
     gdf_context context{};
     context.flag_sorted = 0;
@@ -381,29 +384,24 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_gdfInnerJoin(
     context.flag_sort_result = 1;
     context.flag_sort_inplace = 0;
 
-    int result_num_cols =
-        n_left_table->num_columns() + n_right_table->num_columns() - left_join_cols_arr.size();
+    int dedupe_size = left_join_cols.size();
+    std::vector<std::pair<gdf_size_type, gdf_size_type>> dedupe(dedupe_size);
+    for (int i = 0; i < dedupe_size; i++) {
+      dedupe[i].first = left_join_cols[i];
+      dedupe[i].second = right_join_cols[i];
+    }
 
-    // gdf_inner_join is allocating the memory for the results so
-    // allocate the output column structures here when we get it back fill in
-    // the the outPtrs
-    cudf::jni::native_jlongArray output_handles(env, result_num_cols);
-    std::vector<std::unique_ptr<gdf_column>> output_columns(result_num_cols);
-    for (int i = 0; i < result_num_cols; i++) {
-      output_columns[i].reset(new gdf_column());
-      output_handles[i] = reinterpret_cast<jlong>(output_columns[i].get());
-    }
-    JNI_GDF_TRY(env, NULL,
-                gdf_inner_join(n_left_table->begin(), n_left_table->num_columns(),
-                               left_join_cols_arr.data(), n_right_table->begin(),
-                               n_right_table->num_columns(), right_join_cols_arr.data(),
-                               left_join_cols_arr.size(), result_num_cols,
-                               reinterpret_cast<gdf_column **>(output_handles.data()), nullptr,
-                               nullptr, &context));
-    for (int i = 0; i < result_num_cols; i++) {
-      output_columns[i].release();
-    }
-    return output_handles.get_jArray();
+    cudf::table result = cudf::inner_join(
+            *n_left_table, *n_right_table,
+            left_join_cols, right_join_cols,
+            dedupe,
+            nullptr, &context);
+
+    cudf::jni::native_jlongArray native_handles(env, reinterpret_cast<jlong *>(result.begin()),
+                                                result.num_columns());
+
+    return native_handles.get_jArray();
+
   }
   CATCH_STD(env, NULL);
 }

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -632,17 +632,17 @@ public class TableTest {
   @Test
   void testLeftJoinWithNulls() {
     try (Table leftTable = new Table.TestBuilder()
-        .column(2, 3, 9, 0, 1, 7, 4, 6, 5, 8)
-        .column(102, 103, 19, 100, 101, 4, 104, 1, 3, 1)
+        .column(  2,   3,   9,   0,   1,   7,   4,   6,   5,   8)
+        .column(100, 101, 102, 103, 104, 105, 106, 107, 108, 109)
         .build();
          Table rightTable = new Table.TestBuilder()
-             .column(6, 5, 9, 8, 10, 32)
-             .column(199, 211, 321, 1233, 33, 392)
+             .column(  6,   5,   9,   8,  10,  32)
+             .column(201, 202, 203, 204, 205, 206)
              .build();
          Table expected = new Table.TestBuilder()
-             .column(100, 101, 102, 103, 104, 3, 1, 4, 1, 19)
-             .column(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-             .column(null, null, null, null, null, 211, 199, null, 1233, 321)
+             .column(   2,    3,   9,    0,    1,    7,    4,   6,   5,   8) // common
+             .column( 100,  101, 102,  103,  104,  105,  106, 107, 108, 109) // left
+             .column(null, null, 203, null, null, null, null, 201, 202, 204) // right
              .build();
          Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0));
          Table orderedJoinedTable = joinedTable.orderBy(true, Table.asc(1))) {
@@ -654,18 +654,18 @@ public class TableTest {
   void testLeftJoin() {
     try (Table leftTable = new Table.TestBuilder()
         .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317)
-        .column(323, 172, 11, 243, 57, 143, 305, 95, 147, 58)
+        .column( 10,  11,  12,  13,  14,  15,  16,  17,  18,  19)
         .build();
          Table rightTable = new Table.TestBuilder()
              .column(306, 301, 360, 109, 335, 254, 317, 361, 251, 326)
-             .column(84, 257, 80, 93, 231, 193, 22, 12, 186, 184)
+             .column( 20,  21,  22,  23,  24,  25,  26,  27,  28,  29)
              .build();
          Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(new int[]{0}));
          Table orderedJoinedTable = joinedTable.orderBy(true, Table.asc(1));
          Table expected = new Table.TestBuilder()
-             .column(57, 305, 11, 147, 243, 58, 172, 95, 323, 143)
-             .column(109, 251, 254, 301, 306, 317, 326, 335, 360, 361)
-             .column(93, 186, 193, 257, 84, 22, 184, 231, 80, 12)
+             .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317) // common
+             .column( 10,  11,  12,  13,  14,  15,  16,  17,  18,  19) // left
+             .column( 22,  29,  25,  20,  23,  27,  28,  24,  21,  26) // right
              .build()) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
@@ -674,17 +674,17 @@ public class TableTest {
   @Test
   void testInnerJoinWithNonCommonKeys() {
     try (Table leftTable = new Table.TestBuilder()
-        .column(2, 3, 9, 0, 1, 7, 4, 6, 5, 8)
-        .column(102, 103, 19, 100, 101, 4, 104, 1, 3, 1)
+        .column(  2,   3,   9,   0,   1,   7,   4,   6,   5,   8)
+        .column(100, 101, 102, 103, 104, 105, 106, 107, 108, 109)
         .build();
          Table rightTable = new Table.TestBuilder()
-             .column(6, 5, 9, 8, 10, 32)
-             .column(199, 211, 321, 1233, 33, 392)
+             .column(  6,   5,   9,   8,  10,  32)
+             .column(200, 201, 202, 203, 204, 205)
              .build();
          Table expected = new Table.TestBuilder()
-             .column(3, 1, 1, 19)
-             .column(5, 6, 8, 9)
-             .column(211, 199, 1233, 321)
+             .column(  9,   6,   5,   8) // common
+             .column(102, 107, 108, 109) // left
+             .column(202, 200, 201, 203) // right
              .build();
          Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0));
          Table orderedJoinedTable = joinedTable.orderBy(true, Table.asc(1))) {
@@ -696,18 +696,18 @@ public class TableTest {
   void testInnerJoinWithOnlyCommonKeys() {
     try (Table leftTable = new Table.TestBuilder()
         .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317)
-        .column(323, 172, 11, 243, 57, 143, 305, 95, 147, 58)
+        .column(100, 101, 102, 103, 104, 105, 106, 107, 108, 109)
         .build();
          Table rightTable = new Table.TestBuilder()
              .column(306, 301, 360, 109, 335, 254, 317, 361, 251, 326)
-             .column(84, 257, 80, 93, 231, 193, 22, 12, 186, 184)
+             .column(200, 201, 202, 203, 204, 205, 206, 207, 208, 209)
              .build();
          Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(new int[]{0}));
          Table orderedJoinedTable = joinedTable.orderBy(true, Table.asc(1));
          Table expected = new Table.TestBuilder()
-             .column(57, 305, 11, 147, 243, 58, 172, 95, 323, 143)
-             .column(109, 251, 254, 301, 306, 317, 326, 335, 360, 361)
-             .column(93, 186, 193, 257, 84, 22, 184, 231, 80, 12)
+             .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317) // common
+             .column(100, 101, 102, 103, 104, 105, 106, 107, 108, 109) // left
+             .column(202, 209, 205, 200, 203, 207, 208, 204, 201, 206) // right
              .build()) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }


### PR DESCRIPTION
The join API recently changed to a C++ API.  This updates the code to use that new API and documents clearly the order of the columns returned, as it has changed.

This also updates the tests to be clearer about the columns returned, and hopefully a clearer in general.