### PR TITLE
Use YYMMDD tag in custreamz nightly build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,9 @@
 - PR #2806 CSV Reader: Clean-up row offset operations
 - PR #2828 Optimizations of kernel launch configuration for `DataFrame.apply_rows` and `DataFrame.apply_chunks`
 - PR #2831 Add `column` argument to `DataFrame.drop`
-- PR #2810 cudf::allocate_like can optionally always allocate a mask.
 - PR #2833 Parquet reader: align page data allocation sizes to 4-bytes to satisfy cuda-memcheck
 - PR #2856 Update group_split_cudf to use scatter_by_map
+- PR #2830 Use YYMMDD tag in custreamz nightly build
 
 ## Bug Fixes
 

--- a/ci/cpu/custreamz/build_custreamz.sh
+++ b/ci/cpu/custreamz/build_custreamz.sh
@@ -6,5 +6,10 @@ function logger() {
   echo -e "\n>>>> $@\n"
 }
 
+# If nightly build, append current YYMMDD to version
+if [[ "$BUILD_MODE" = "branch" && "$SOURCE_BRANCH" = branch-* ]] ; then
+  export VERSION_SUFFIX=`date +%y%m%d`
+fi
+
 logger "Building custreamz"
 conda build conda/recipes/custreamz --python=$PYTHON

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
-{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
+{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
@@ -15,6 +15,8 @@ source:
 build:
   number: {{ git_revision_count }}
   string: py{{ py_version }}_{{ git_revision_count }}
+  script_env:
+    - VERSION_SUFFIX
 
 requirements:
   host:


### PR DESCRIPTION
Use YYMMDD tag for nightly build. Done as requested in: https://github.com/rapidsai/ops/issues/452