### PR TITLE
[REVIEW] Add column argument to cudf drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - PR #2645 libcudf unique_count for Series.nunique 
 - PR #2823 improve java data movement debugging
 - PR #2806 CSV Reader: Clean-up row offset operations
+- PR #2831 Add `column` argument to `DataFrame.drop`
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1405,7 +1405,7 @@ class DataFrame(object):
             data, forceindex=forceindex, name=name
         )
 
-    def drop(self, labels, axis=None, errors="raise"):
+    def drop(self, labels=None, axis=None, columns=None, errors="raise"):
         """Drop column(s)
 
         Parameters
@@ -1414,6 +1414,7 @@ class DataFrame(object):
             Name of column(s) to be dropped.
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Only axis=1 is currently supported.
+        columns: array of column names, the same as using labels and axis=1
         errors : {'ignore', 'raise'}, default 'raise'
             This parameter is currently ignored.
 
@@ -1447,11 +1448,22 @@ class DataFrame(object):
             raise NotImplementedError("Can only drop columns, not rows")
         if errors != "raise":
             raise NotImplementedError("errors= keyword not implemented")
+        if labels is None and columns is None:
+            raise ValueError(
+                "Need to specify at least one of 'labels' or 'columns'"
+            )
+        if labels is not None and columns is not None:
+            raise ValueError("Cannot specify both 'labels' and 'columns'")
+
+        if labels is not None:
+            target = labels
+        else:
+            target = columns
 
         columns = (
-            [labels]
-            if isinstance(labels, (str, numbers.Number))
-            else list(labels)
+            [target]
+            if isinstance(target, (str, numbers.Number))
+            else list(target)
         )
         outdf = self.copy()
         for c in columns:

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1444,7 +1444,7 @@ class DataFrame(object):
         3    3
         4    4
         """
-        if axis == 0:
+        if axis == 0 and labels is not None:
             raise NotImplementedError("Can only drop columns, not rows")
         if errors != "raise":
             raise NotImplementedError("errors= keyword not implemented")

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -212,6 +212,16 @@ def test_dataframe_drop_method():
     assert tuple(df.columns) == ("a", "b", "c")
     assert tuple(df.drop(["a", "b"]).columns) == ("c",)
     assert tuple(df.columns) == ("a", "b", "c")
+    assert tuple(df.drop(["a", "b"]).columns) == ("c",)
+    assert tuple(df.columns) == ("a", "b", "c")
+    assert tuple(df.drop(columns=["a", "b"]).columns) == ("c",)
+    assert tuple(df.columns) == ("a", "b", "c")
+    assert tuple(df.drop(columns="a").columns) == ("b", "c")
+    assert tuple(df.columns) == ("a", "b", "c")
+    assert tuple(df.drop(columns=["a"]).columns) == ("b", "c")
+    assert tuple(df.columns) == ("a", "b", "c")
+    assert tuple(df.drop(columns=["a", "b", "c"]).columns) == (,)
+    assert tuple(df.columns) == ("a", "b", "c")
 
     # Test drop error
     with pytest.raises(NameError) as raises:
@@ -220,6 +230,12 @@ def test_dataframe_drop_method():
     with pytest.raises(NameError) as raises:
         df.drop(["a", "d", "b"])
     raises.match("column 'd' does not exist")
+    with pytest.raises(ValueError) as raises:
+        df.drop("a", axis=1, columns="a")
+    raises.match("Cannot specify both")
+    with pytest.raises(ValueError) as raises:
+        df.drop(axis=1)
+    raises.match("Need to specify at least")
 
 
 def test_dataframe_column_add_drop():

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -220,7 +220,7 @@ def test_dataframe_drop_method():
     assert tuple(df.columns) == ("a", "b", "c")
     assert tuple(df.drop(columns=["a"]).columns) == ("b", "c")
     assert tuple(df.columns) == ("a", "b", "c")
-    assert tuple(df.drop(columns=["a", "b", "c"]).columns) == (,)
+    assert tuple(df.drop(columns=["a", "b", "c"]).columns) == tuple()
     assert tuple(df.columns) == ("a", "b", "c")
 
     # Test drop error

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -393,3 +393,10 @@ def test_boolean_index(gdf, gddf):
     gddf2 = gddf[gddf.x > 2]
 
     dd.assert_eq(gdf2, gddf2)
+
+
+def test_drop(gdf, gddf):
+    gdf2 = gdf.drop(columns="x")
+    gddf2 = gddf.drop(columns="x").compute()
+
+    dd.assert_eq(gdf2, gddf2)


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/2686

Our `DataFrame::drop` method didn't support `column` as an argument like Pandas. It does now.