### PR TITLE
[REVIEW] Fix nvstrings.slice and slice_from for range (0,0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
 - PR #2751 Replace value with null
 - PR #2765 Fix Java inequality comparisons for string category
 - PR #2818 Fix java join API to use new C++ join API
-
+- PR #2841 Fix nvstrings.slice and slice_from for range (0,0)
 
 # cuDF 0.9.0 (21 Aug 2019)
 

--- a/cpp/custrings/strings/substr.cu
+++ b/cpp/custrings/strings/substr.cu
@@ -52,7 +52,7 @@ NVStrings* NVStrings::slice( int start, int stop, int step )
             custring_view* dstr = d_strings[idx];
             if( !dstr )
                 return;
-            int len = ( stop <= 0 ? dstr->chars_count() : stop ) - start;
+            int len = ( stop < 0 ? dstr->chars_count() : stop ) - start;
             unsigned int size = dstr->substr_size((unsigned)start,(unsigned)len,(unsigned)step);
             size = ALIGN_SIZE(size);
             d_lengths[idx] = (size_t)size;
@@ -74,7 +74,7 @@ NVStrings* NVStrings::slice( int start, int stop, int step )
             if( !dstr )
                 return;
             char* buffer = d_buffer + d_offsets[idx];
-            int len = ( stop <= 0 ? dstr->chars_count() : stop ) - start;
+            int len = ( stop < 0 ? dstr->chars_count() : stop ) - start;
             d_results[idx] = dstr->substr((unsigned)start,(unsigned)len,(unsigned)step,buffer);
         });
     //
@@ -97,7 +97,7 @@ NVStrings* NVStrings::slice_from( const int* starts, const int* stops )
                 return;
             int start = (starts ? starts[idx]:0);
             int stop = (stops ? stops[idx]: -1);
-            int len = ( stop <= 0 ? dstr->chars_count() : stop ) - start;
+            int len = ( stop < 0 ? dstr->chars_count() : stop ) - start;
             unsigned int size = dstr->substr_size((unsigned)start,(unsigned)len);
             size = ALIGN_SIZE(size);
             d_lengths[idx] = (size_t)size;
@@ -121,7 +121,7 @@ NVStrings* NVStrings::slice_from( const int* starts, const int* stops )
             int start = (starts ? starts[idx]:0);
             int stop = (stops ? stops[idx]: -1);
             char* buffer = d_buffer + d_offsets[idx];
-            int len = ( stop <= 0 ? dstr->chars_count() : stop ) - start;
+            int len = ( stop < 0 ? dstr->chars_count() : stop ) - start;
             d_results[idx] = dstr->substr((unsigned)start,(unsigned)len,1,buffer);
         });
     //

--- a/python/nvstrings/tests/test_substr.py
+++ b/python/nvstrings/tests/test_substr.py
@@ -14,14 +14,18 @@ def test_slice_from():
     strs = nvstrings.to_device(
         ["hello world", "holy accéntéd", "batman", None, ""]
     )
-    d_arr = rmm.to_device(np.asarray([2, 3, -1, -1, -1], dtype=np.int32))
-    got = strs.slice_from(starts=d_arr.device_ctypes_pointer.value)
+    d_starts = rmm.to_device(np.asarray([2, 3, 0, -1, -1], dtype=np.int32))
+    d_stops = rmm.to_device(np.asarray([-1, -1, 0, -1, -1], dtype=np.int32))
+    got = strs.slice_from(
+        starts=d_starts.device_ctypes_pointer.value,
+        stops=d_stops.device_ctypes_pointer.value
+    )
     expected = ["llo world", "y accéntéd", "", None, ""]
     assert_eq(got, expected)
 
 
-@pytest.mark.parametrize("start", [2, 2, 2, 2])
-@pytest.mark.parametrize("stop", [8, 15, 8, 8])
+@pytest.mark.parametrize("start", [2, 2, 2, 2, 0])
+@pytest.mark.parametrize("stop", [8, 15, 8, 8, 0])
 @pytest.mark.parametrize("step", [None, None, 2, 5])
 def test_slice(start, stop, step):
     s = ["abcdefghij", "0123456789", "9876543210", None, "accénted", ""]

--- a/python/nvstrings/tests/test_substr.py
+++ b/python/nvstrings/tests/test_substr.py
@@ -18,7 +18,7 @@ def test_slice_from():
     d_stops = rmm.to_device(np.asarray([-1, -1, 0, -1, -1], dtype=np.int32))
     got = strs.slice_from(
         starts=d_starts.device_ctypes_pointer.value,
-        stops=d_stops.device_ctypes_pointer.value
+        stops=d_stops.device_ctypes_pointer.value,
     )
     expected = ["llo world", "y accéntéd", "", None, ""]
     assert_eq(got, expected)


### PR DESCRIPTION
Closes #2782 
This fixes the `nvstrings` `slice` and `slice_from` methods which were handling the (0,0) range incorrectly as described in the issue.

The expected behavior is to return empty strings for this case like Pandas does.