### PR TITLE
[REVIEW] Fix java hash aggregate compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - PR #2830 Use YYMMDD tag in custreamz nightly build
 - PR #2887 Minor snappy decompression optimization
 - PR #2899 Use new RMM API based on Cython
+- PR #2919 Change java API to use operators in groupby namespace
 
 ## Bug Fixes
 

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -544,9 +544,9 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_gdfGroupByAggregate(
     cudf::table const n_keys_table(n_keys_cols);
     cudf::table const n_values_table(n_values_cols);
 
-    std::vector<cudf::groupby::hash::operators> ops;
+    std::vector<cudf::groupby::operators> ops;
     for (int i = 0; i < n_ops.size(); i++) {
-      ops.push_back(static_cast<cudf::groupby::hash::operators>(n_ops[i]));
+      ops.push_back(static_cast<cudf::groupby::operators>(n_ops[i]));
     }
 
     std::pair<cudf::table, cudf::table> result = cudf::groupby::hash::groupby(


### PR DESCRIPTION
Fixes java side to use operators in `cudf::groupby::operators`

RE: https://github.com/rapidsai/cudf/pull/2605