### PR TITLE
[REVIEW] Update rounding algorithm to avoid using fmod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@
 - PR #2873 Fixed dask_cudf read_partition bug by generating ParquetDatasetPiece
 - PR #2850 Fixes dask_cudf.read_parquet on partitioned datasets
 - PR #2896 Properly handle `axis` string keywords in `concat`
+- PR #2926 Update rounding algorithm to avoid using fmod
 
 
 # cuDF 0.9.0 (21 Aug 2019)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2652,6 +2652,13 @@ def test_ndim():
         8,
         9,
         10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
         pytest.param(
             -1,
             marks=[
@@ -2665,9 +2672,8 @@ def test_round(arr, decimal):
     ser = Series(arr)
     result = ser.round(decimal)
     expected = pser.round(decimal)
-    np.testing.assert_array_almost_equal(
-        result.to_pandas(), expected, decimal=10
-    )
+
+    assert_eq(result, expected)
 
     # with nulls, maintaining existing null mask
     arr = arr.astype("float64")  # for pandas nulls
@@ -2678,9 +2684,8 @@ def test_round(arr, decimal):
     ser = Series(arr)
     result = ser.round(decimal)
     expected = pser.round(decimal)
-    np.testing.assert_array_almost_equal(
-        result.to_pandas(), expected, decimal=10
-    )
+
+    assert_eq(result, expected)
     np.array_equal(ser.nullmask.to_array(), result.nullmask.to_array())
 
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2634,6 +2634,7 @@ def test_ndim():
         np.random.normal(-100, 100, 1000),
         np.random.randint(-50, 50, 1000),
         np.zeros(100),
+        np.repeat([-0.6459412758761901], 100),
         np.repeat(np.nan, 100),
         np.array([1.123, 2.343, np.nan, 0.0]),
     ],

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -1,5 +1,5 @@
 import functools
-from math import ceil, isinf, isnan
+from math import ceil, floor, isinf, isnan
 
 import numpy as np
 import pandas as pd
@@ -38,6 +38,26 @@ def check_equals_float(a, b):
         or ((isinf(a) and a < 0) and (isinf(b) and b < 0))
         or ((isinf(a) and a > 0) and (isinf(b) and b > 0))
     )
+
+
+@njit
+def rint(x):
+    """Round to the nearest integer.
+
+    Returns
+    -------
+    The nearest integer, as a float.
+    """
+    y = floor(x)
+    r = x - y
+
+    if r > 0.5:
+        y += 1.0
+    if r == 0.5:
+        r = y - 2.0 * floor(0.5 * y)
+        if r == 1.0:
+            y += 1.0
+    return y
 
 
 @njit


### PR DESCRIPTION
**Summary of Changes**
- Changes the rounding algorithm to avoid the floating point representation issue caused by using Python's `fmod`.
- Adds a utility function `rint` that is the equivalent of numpy's `rint` [C ufunc](https://github.com/numpy/numpy/blob/31ffdecf07d18ed4dbb66b171cb0f998d4b190fa/numpy/core/src/npymath/npy_math_internal.h.src#L279)

This closes #2921 


```python
import cudf
zscores_df = cudf.DataFrame()
for x in range(1,17):
    zscores_df['zscore'] = [float(-0.6459412758761901)]
    zscores_df['zscore'] = zscores_df['zscore'].round(decimals=x)
    print("ZSCORE", zscores_df['zscore'][0])
ZSCORE -0.6
ZSCORE -0.65
ZSCORE -0.646
ZSCORE -0.6459
ZSCORE -0.64594
ZSCORE -0.645941
ZSCORE -0.6459413
ZSCORE -0.64594128
ZSCORE -0.645941276
ZSCORE -0.6459412759
ZSCORE -0.64594127588
ZSCORE -0.645941275876
ZSCORE -0.6459412758762
ZSCORE -0.64594127587619
ZSCORE -0.64594127587619
ZSCORE -0.6459412758761901
```

cc @thomcom 