### PR TITLE
[REVIEW] Add setup.py install for nvstrings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,6 @@ RUN source activate cudf && \
 RUN source activate cudf && \
     cd /cudf/python/cudf && \
     python setup.py build_ext --inplace && \
+    python setup.py install && \
+    cd /cudf/python/nvstrings && \
     python setup.py install


### PR DESCRIPTION
Fixes #2889 - Building cudf from Dockerfile

1. README example works after this fix:

```bash
(cudf) root@dd6b538dd424:/cudf/python/cudf# python
Python 3.7.3 | packaged by conda-forge | (default, Jul  1 2019, 21:52:21) 
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cudf, io, requests
/conda/envs/cudf/lib/python3.7/site-packages/numba/cuda/envvars.py:16: NumbaDeprecationWarning: 
Environment variables with the 'NUMBAPRO' prefix are deprecated, found use of NUMBAPRO_NVVM=/usr/local/cuda/nvvm/lib64/libnvvm.so.

For more information visit http://numba.pydata.org/numba-doc/latest/reference/deprecation.html#deprecation-of-numbapro-environment-variables
  warnings.warn(errors.NumbaDeprecationWarning(msg))
/conda/envs/cudf/lib/python3.7/site-packages/numba/cuda/envvars.py:16: NumbaDeprecationWarning: 
Environment variables with the 'NUMBAPRO' prefix are deprecated, found use of NUMBAPRO_LIBDEVICE=/usr/local/cuda/nvvm/libdevice/.

For more information visit http://numba.pydata.org/numba-doc/latest/reference/deprecation.html#deprecation-of-numbapro-environment-variables
  warnings.warn(errors.NumbaDeprecationWarning(msg))
>>> from io import StringIO
>>> 
>>> url="https://github.com/plotly/datasets/raw/master/tips.csv"
>>> content = requests.get(url).content.decode('utf-8')
>>> 
>>> tips_df = cudf.read_csv(StringIO(content))
>>> tips_df['tip_percentage'] = tips_df['tip']/tips_df['total_bill']*100
>>> 
>>> # display average tip by dining party size
... print(tips_df.groupby('size').tip_percentage.mean())
size
1    21.729202
2    16.571919
3    15.215685
4    14.594901
5    14.149549
6    15.622920
Name: tip_percentage, dtype: float64
```
2. py.test finishes after this fix

```bash
(cudf) root@dd6b538dd424:/cudf/python/cudf# py.test -v
...
============================================================= 14672 passed, 860 skipped, 240 xfailed, 19 xpassed, 1967 warnings in 875.54s (0:14:35) ==============================================================
```