### PR TITLE
[REVIEW] Fix java nvtxrange dependency loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@
 - PR #2873 Fixed dask_cudf read_partition bug by generating ParquetDatasetPiece
 - PR #2850 Fixes dask_cudf.read_parquet on partitioned datasets
 - PR #2896 Properly handle `axis` string keywords in `concat`
-- PR #2968 Fix java nvtxrange dependency loading
+- PR #2968 Fix Java dependency loading when using NVTX
 - PR #2963 Fix ORC writer uncompressed block indexing
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 - PR #2873 Fixed dask_cudf read_partition bug by generating ParquetDatasetPiece
 - PR #2850 Fixes dask_cudf.read_parquet on partitioned datasets
 - PR #2896 Properly handle `axis` string keywords in `concat`
+- PR #2968 Fix java nvtxrange dependency loading
 
 
 # cuDF 0.9.0 (21 Aug 2019)

--- a/java/src/main/java/ai/rapids/cudf/NvtxRange.java
+++ b/java/src/main/java/ai/rapids/cudf/NvtxRange.java
@@ -36,6 +36,11 @@ package ai.rapids.cudf;
  */
 public class NvtxRange implements AutoCloseable {
   private static final boolean isEnabled = Boolean.getBoolean("ai.rapids.cudf.nvtx.enabled");
+  static {
+    if (isEnabled) {
+      NativeDepsLoader.loadNativeDeps();
+    }
+  }
 
   public NvtxRange(String name, NvtxColor color) {
     this(name, color.colorBits);


### PR DESCRIPTION
Small fix so if NvtxRange is the first thing loaded by java that it will in turn load any needed native dependencies.