### PR TITLE
[REVIEW] Add safe versions of `is_null`/`is_valid`. Rename the old ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - PR #2977 Moved old C++ test utilities to legacy directory.
 - PR #2965 Fix slow orc reader perf with large uncompressed blocks
 - PR #2995 Move JIT type utilities to legacy directory
+- PR #3008 Make safe versions of `is_null` and `is_valid` in `column_device_view`
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -16,10 +16,10 @@
 #pragma once
 
 #include <cudf/column/column_view.hpp>
-#include <cudf/types.hpp>
-#include <cudf/utilities/bit.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/bit.cuh>
 
 namespace cudf {
 
@@ -110,7 +110,7 @@ class alignas(16) column_device_view_base {
    * @return false All elements are valid
    *---------------------------------------------------------------------------**/
   __host__ __device__ bool has_nulls() const noexcept {
-    return _null_count > 0;
+    return null_count() > 0;
   }
 
   /**---------------------------------------------------------------------------*
@@ -132,24 +132,46 @@ class alignas(16) column_device_view_base {
 
   /**---------------------------------------------------------------------------*
    * @brief Returns whether the specified element holds a valid value (i.e., not
-   * null)
+   * null).
    *
-   * @note It is undefined behavior to call this function if `nullable() ==
-   * false`.
+   * Checks first for the existence of the null bitmask. If `nullable() ==
+   * false`, this function always returns true.
+   *
+   * @note If `nullable() == true` can be guaranteed, then it is more performant
+   * to use `is_valid_nocheck()`.
    *
    * @param element_index The index of the element to query
    * @return true The element is valid
    * @return false The element is null
    *---------------------------------------------------------------------------**/
   __device__ bool is_valid(size_type element_index) const noexcept {
+    return not nullable() or is_valid_nocheck(element_index);
+  }
+
+  /**---------------------------------------------------------------------------*
+   * @brief Returns whether the specified element holds a valid value (i.e., not
+   * null)
+   *
+   * This function does *not* verify the existence of the bitmask before
+   * attempting to read it. Therefore, it is undefined behavior to call this
+   * function if `nullable() == false`.
+   *
+   * @param element_index The index of the element to query
+   * @return true The element is valid
+   * @return false The element is null
+   *---------------------------------------------------------------------------**/
+  __device__ bool is_valid_nocheck(size_type element_index) const noexcept {
     return bit_is_set(_null_mask, element_index);
   }
 
   /**---------------------------------------------------------------------------*
-   * @brief Returns whether the specified element is null
+   * @brief Returns whether the specified element is null.
    *
-   * @note It is undefined behavior to call this function if `nullable() ==
-   * false`.
+   * Checks first for the existence of the null bitmask. If `nullable() ==
+   * false`, this function always returns false.
+   *
+   * @note If `nullable() == true` can be guaranteed, then it is more performant
+   * to use `is_null_nocheck()`.
    *
    * @param element_index The index of the element to query
    * @return true The element is null
@@ -157,6 +179,21 @@ class alignas(16) column_device_view_base {
    *---------------------------------------------------------------------------**/
   __device__ bool is_null(size_type element_index) const noexcept {
     return not is_valid(element_index);
+  }
+
+  /**---------------------------------------------------------------------------*
+   * @brief Returns whether the specified element is null
+   *
+   * This function does *not* verify the existence of the bitmask before
+   * attempting to read it. Therefore, it is undefined behavior to call this
+   * function if `nullable() == false`.
+   *
+   * @param element_index The index of the element to query
+   * @return true The element is null
+   * @return false The element is valid
+   *---------------------------------------------------------------------------**/
+  __device__ bool is_null_nocheck(size_type element_index) const noexcept {
+    return not is_valid_nocheck(element_index);
   }
 
   /**---------------------------------------------------------------------------*
@@ -210,20 +247,21 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
 
   /**---------------------------------------------------------------------------*
    * @brief Creates an instance of this class using the specified host memory
-   * pointer (h_ptr) to store child objects and the device memory pointer (d_ptr)
-   * as a base for any child object pointers.
+   * pointer (h_ptr) to store child objects and the device memory pointer
+   *(d_ptr) as a base for any child object pointers.
    *
    * @param column Column view from which to create this instance.
    * @param h_ptr Host memory pointer on which to place any child data.
    * @param d_ptr Device memory pointer on which to base any child pointers.
    *---------------------------------------------------------------------------**/
-  column_device_view( column_view column, ptrdiff_t h_ptr, ptrdiff_t d_ptr );
- 
+  column_device_view(column_view column, ptrdiff_t h_ptr, ptrdiff_t d_ptr);
+
   /**---------------------------------------------------------------------------*
    * @brief Returns reference to element at the specified index.
-   * 
-   * If the element at the specified index is NULL, i.e., `is_null(element_index) == true`,
-   * then any attempt to use the result will lead to undefined behavior. 
+   *
+   * If the element at the specified index is NULL, i.e.,
+   *`is_null(element_index) == true`, then any attempt to use the result will
+   *lead to undefined behavior.
    *
    * This function accounts for the offset.
    *
@@ -268,8 +306,8 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
 
   /**---------------------------------------------------------------------------*
    * @brief Return the size in bytes of the amount of memory needed to hold a
-   * device view of the specified column and it's children. 
-   * 
+   * device view of the specified column and it's children.
+   *
    * @param source_view The `column_view` to use for this calculation.
    *---------------------------------------------------------------------------**/
   static size_type extent(column_view source_view);
@@ -319,14 +357,15 @@ class alignas(16) mutable_column_device_view
 
   /**---------------------------------------------------------------------------*
    * @brief Creates an instance of this class using the specified host memory
-   * pointer (h_ptr) to store child objects and the device memory pointer (d_ptr)
-   * as a base for any child object pointers.
+   * pointer (h_ptr) to store child objects and the device memory pointer
+   *(d_ptr) as a base for any child object pointers.
    *
    * @param column Column view from which to create this instance.
    * @param h_ptr Host memory pointer on which to place any child data.
    * @param d_ptr Device memory pointer on which to base any child pointers.
    *---------------------------------------------------------------------------**/
-  mutable_column_device_view( mutable_column_view column, ptrdiff_t h_ptr, ptrdiff_t d_ptr );
+  mutable_column_device_view(mutable_column_view column, ptrdiff_t h_ptr,
+                             ptrdiff_t d_ptr);
 
   /**---------------------------------------------------------------------------*
    * @brief Factory to construct a column view that is usable in device memory.
@@ -347,8 +386,9 @@ class alignas(16) mutable_column_device_view
    * @return A `unique_ptr` to a `mutable_column_device_view` that makes the
    *data from `source_view` available in device memory.
    *---------------------------------------------------------------------------**/
-  static std::unique_ptr<mutable_column_device_view, std::function<void(mutable_column_device_view*)>>
-    create(mutable_column_view source_view, cudaStream_t stream = 0);
+  static std::unique_ptr<mutable_column_device_view,
+                         std::function<void(mutable_column_device_view*)>>
+  create(mutable_column_view source_view, cudaStream_t stream = 0);
 
   /**---------------------------------------------------------------------------*
    * @brief Returns pointer to the base device memory allocation casted to
@@ -462,8 +502,8 @@ class alignas(16) mutable_column_device_view
 
   /**---------------------------------------------------------------------------*
    * @brief Return the size in bytes of the amount of memory needed to hold a
-   * device view of the specified column and it's children. 
-   * 
+   * device view of the specified column and it's children.
+   *
    * @param source_view The `column_view` to use for this calculation.
    *---------------------------------------------------------------------------**/
   static size_type extent(mutable_column_view source_view);
@@ -493,14 +533,13 @@ class alignas(16) mutable_column_device_view
    * allocated to hold the child views.
    *---------------------------------------------------------------------------**/
   void destroy();
-
 };
 
 /**---------------------------------------------------------------------------*
  * @brief Returns `string_view` to the string element at the specified index.
  *
- * If the element at the specified index is NULL, i.e., `is_null(element_index) == true`,
- * then any attempt to use the result will lead to undefined behavior. 
+ * If the element at the specified index is NULL, i.e., `is_null(element_index)
+ *== true`, then any attempt to use the result will lead to undefined behavior.
  *
  * This function accounts for the offset.
  *
@@ -510,11 +549,14 @@ class alignas(16) mutable_column_device_view
 template <>
 __device__ inline string_view const column_device_view::element<string_view>(
     size_type element_index) const noexcept {
-      size_type index = element_index + offset(); // account for this view's _offset
-      const int32_t* d_offsets = d_children[strings_column_view::offsets_column_index].data<int32_t>();
-      const char* d_strings = d_children[strings_column_view::chars_column_index].data<char>();
-      size_type offset = d_offsets[index];
-      return string_view{d_strings + offset, d_offsets[index+1] - offset};
+  size_type index =
+      element_index + offset();  // account for this view's _offset
+  const int32_t* d_offsets =
+      d_children[strings_column_view::offsets_column_index].data<int32_t>();
+  const char* d_strings =
+      d_children[strings_column_view::chars_column_index].data<char>();
+  size_type offset = d_offsets[index];
+  return string_view{d_strings + offset, d_offsets[index + 1] - offset};
 }
 
 }  // namespace cudf


### PR DESCRIPTION
For performance reasons, the previous `column_device_view::is_null` and `column_device_view::is_valid` functions would _not_ first check for the existence of the null bitmask before attempting to read the specified bit. Therefore it was undefined behavior to invoke this functions if `nullable() == false`.

This may violate the principle of least surprise for some users. Therefore, the old behavior for `is_null/is_valid` functions have been renamed to `is_null_nocheck`/`is_valid_nocheck`. The new `is_null/is_valid` will now check for `nullable() == false` before attempting to read the bits. 