### PR TITLE
Updating update-version.sh for new docs locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,7 @@
 - PR #3007 Java: Remove unit test that frees RMM invalid pointer
 - PR #3009 Fix orc reader RLEv2 patch position regression from PR #2507
 - PR #3002 Fix CUDA invalid configuration errors reported after loading an ORC file without data
-
+- PR #3035 Update update-version.sh for new docs locations
 
 # cuDF 0.9.0 (21 Aug 2019)
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -49,4 +49,5 @@ function sed_runner() {
 sed_runner 's/'"CUDA_DATAFRAME VERSION .* LANGUAGES"'/'"CUDA_DATAFRAME VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
 
 # RTD update
-sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py
+sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/cudf/source/conf.py
+sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/nvstrings/source/conf.py


### PR DESCRIPTION
Updating `update-version.sh` for new docs locations

Tested with `major` arg and confirmed major version numbers were incremented in .py files in new doc locations.