### PR TITLE
Fix uninitialized stream parameter in device_table deleter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,7 @@
 - PR #3007 Java: Remove unit test that frees RMM invalid pointer
 - PR #3009 Fix orc reader RLEv2 patch position regression from PR #2507
 - PR #3002 Fix CUDA invalid configuration errors reported after loading an ORC file without data
-
+- PR #3038 Fix uninitialized stream parameter in device_table deleter
 
 # cuDF 0.9.0 (21 Aug 2019)
 

--- a/cpp/src/table/legacy/device_table.cuh
+++ b/cpp/src/table/legacy/device_table.cuh
@@ -74,7 +74,7 @@ class device_table {
    *---------------------------------------------------------------------------**/
   static auto create(gdf_size_type num_columns, gdf_column const* const* cols,
                      cudaStream_t stream = 0) {
-    auto deleter = [](device_table* d) { d->destroy(); };
+    auto deleter = [stream](device_table* d) { d->destroy(stream); };
 
     std::unique_ptr<device_table, decltype(deleter)> p{
         new device_table(num_columns, cols, stream), deleter};
@@ -104,8 +104,8 @@ class device_table {
    * unique_ptr returned from device_table::create.
    *
    *---------------------------------------------------------------------------**/
-  __host__ void destroy(void) {
-    RMM_FREE(device_columns, _stream);
+  __host__ void destroy(cudaStream_t stream) {
+    RMM_FREE(device_columns, stream);
     delete this;
   }
 
@@ -133,8 +133,6 @@ class device_table {
   bool _has_nulls;
   gdf_column* device_columns{
       nullptr};  ///< Array of `gdf_column`s in device memory
-  cudaStream_t
-      _stream;  ///< Stream used to allocate/free the table's device memory
 
  protected:
   /**---------------------------------------------------------------------------*


### PR DESCRIPTION
The `_stream` member of legacy `device_table` was never initialized. Fixed by just capturing the `create()` stream parameter in the deleter lambda and passing it to `destroy()`, rather than keeping a member stream around since it isn't used elsewhere.

Fixes #3037