### PR TITLE
[REVIEW] exp to experimental namespace name change issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## Bug Fixes
 
-- PR #3040 Fixed exp to experimental namespace name change issue
+- PR #3041 Fixed exp to experimental namespace name change issue
 
 
 # cuDF 0.10.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ## Bug Fixes
 
+- PR #3040 Fixed exp to experimental namespace name change issue
+
 
 # cuDF 0.10.0 (Date TBD)
 

--- a/cpp/include/cudf/utilities/traits.hpp
+++ b/cpp/include/cudf/utilities/traits.hpp
@@ -127,7 +127,7 @@ struct is_timestamp_impl {
  * @return false `type` is not a timestamp
  *---------------------------------------------------------------------------**/
 constexpr inline bool is_timestamp(data_type type) {
-  return cudf::exp::type_dispatcher(type, is_timestamp_impl{});
+  return cudf::experimental::type_dispatcher(type, is_timestamp_impl{});
 }
 
 /**---------------------------------------------------------------------------*

--- a/cpp/tests/wrappers/timestamps_test.cu
+++ b/cpp/tests/wrappers/timestamps_test.cu
@@ -29,7 +29,7 @@ template <typename T>
 struct TimestampColumnTest : public cudf::test::BaseFixture {
   cudaStream_t stream() { return cudaStream_t(0); }
   cudf::size_type size() { return cudf::size_type(100); }
-  cudf::data_type type() { return cudf::data_type{cudf::exp::type_to_id<T>()}; }
+  cudf::data_type type() { return cudf::data_type{cudf::experimental::type_to_id<T>()}; }
 };
 
 template <typename Timestamp>
@@ -66,7 +66,7 @@ TYPED_TEST(TimestampColumnTest, TimestampDurationsMatchPrimitiveRepresentation) 
                                                           time_point_ms(start),
                                                           time_point_ms(stop_));
 
-  auto primitive_type = cudf::data_type{cudf::exp::type_to_id<Rep>()};
+  auto primitive_type = cudf::data_type{cudf::experimental::type_to_id<Rep>()};
 
   auto primitive_col = cudf::make_numeric_column(primitive_type, this->size(),
                                                  cudf::mask_state::ALL_VALID,


### PR DESCRIPTION
Namespace name change from `exp` to `experimental` was merged with old name.
This PR is to fix the error so builds will not fail.