### PR TITLE
[REVIEW] Fix UDF doc markdown formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@
 - PR #3002 Fix CUDA invalid configuration errors reported after loading an ORC file without data
 - PR #3035 Update update-version.sh for new docs locations
 - PR #3038 Fix uninitialized stream parameter in device_table deleter
+- PR #3058 Fix UDF doc markdown formatting
 
 # cuDF 0.9.0 (21 Aug 2019)
 

--- a/docs/cudf/source/guide-to-udfs.ipynb
+++ b/docs/cudf/source/guide-to-udfs.ipynb
@@ -1708,7 +1708,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/cudf/source/guide-to-udfs.ipynb
+++ b/docs/cudf/source/guide-to-udfs.ipynb
@@ -350,7 +350,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DataFrame UDFs\n",
+    "## DataFrame UDFs\n",
     "\n",
     "We could apply a UDF on a DataFrame like we did above with `forall`. We'd need to write a kernel that expects multiple inputs, and pass multiple Series as arguments when we execute our kernel. Because this is fairly common and can be difficult to manage, cuDF provides two APIs to streamline this: `apply_rows` and `apply_chunks`. Below, we walk through an example of using `apply_rows`. `apply_chunks` works in a similar way, but also offers more control over low-level kernel behavior.\n",
     "\n",
@@ -811,7 +811,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# GroupBy DataFrame UDFs\n",
+    "## GroupBy DataFrame UDFs\n",
     "\n",
     "We can also apply UDFs to grouped DataFrames using `apply_grouped`. This example is also drawn and adapted from the RAPIDS [API documentation](https://rapidsai.github.io/projects/cudf/en/0.10.0/api.html#cudf.groupby.legacy_groupby.Groupby.apply_grouped).\n",
     "\n",
@@ -1132,7 +1132,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Numba Kernels on CuPy Arrays\n",
+    "## Numba Kernels on CuPy Arrays\n",
     "\n",
     "We can also execute Numba kernels on CuPy NDArrays, again thanks to the `__cuda_array_interface__`. We can even run the same UDF on the Series and the CuPy array. First, we define a Series and then create a CuPy array from that Series."
    ]
@@ -1236,7 +1236,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Null Handling in UDFs\n",
+    "## Null Handling in UDFs\n",
     "\n",
     "Above, we covered most basic usage of UDFs with cuDF.\n",
     "\n",
@@ -1676,7 +1676,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Summary\n",
+    "## Summary\n",
     "\n",
     "This guide has covered a lot of content. At this point, you should hopefully feel comfortable writing UDFs (with or without null values) that operate on\n",
     "\n",
@@ -1708,7 +1708,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Summary of Changes
- Changes top-level header format H1(#) to H2 (##) for sub-sections; H1 sub-section headers caused incorrect rendering of the Table of Contents