### PR TITLE
[BUG] Add nvstrings python build instructions to contributing.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@
 - PR #3002 Fix CUDA invalid configuration errors reported after loading an ORC file without data
 - PR #3035 Update update-version.sh for new docs locations
 - PR #3038 Fix uninitialized stream parameter in device_table deleter
+- PR #3059 Add nvstrings python build instructions to contributing.md
 
 # cuDF 0.9.0 (21 Aug 2019)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,12 @@ $ ./build.sh libcudf                   # compile the cuDF libraries and install 
 $ make test
 ```
 
+- Build the `nvstrings` python packages, in the `python/nvstrings` folder:
+```bash
+$ cd $CUDF_HOME/python/nvstrings
+$ python setup.py install
+```
+
 - Build the `cudf` python package, in the `python/cudf` folder:
 ```bash
 $ cd $CUDF_HOME/python/cudf
@@ -212,12 +218,6 @@ $ python setup.py install
 ```bash
 $ cd $CUDF_HOME
 $ ./build.sh dask_cudf
-```
-
-- You will also need the following environment variables, including `$CUDA_HOME`.
-```bash
-NUMBAPRO_NVVM=$CUDA_HOME/nvvm/lib64/libnvvm.so
-NUMBAPRO_LIBDEVICE=$CUDA_HOME/nvvm/libdevice
 ```
 
 - To run Python tests (Optional):


### PR DESCRIPTION
The PR updates the instructions for building `nvstrings` python packages in the contributing.md documentation.
