### PR TITLE
[REVIEW] Init RMM with no pooling at the beginning

### DIFF
--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -22,10 +22,13 @@
 
 extern "C" {
 
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initialize(JNIEnv *env, jclass clazz,
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(JNIEnv *env, jclass clazz,
                                                           jint allocation_mode,
                                                           jboolean enable_logging,
                                                           jlong pool_size) {
+  if (rmmIsInitialized(nullptr)) {
+    JNI_THROW_NEW(env, "java/lang/IllegalStateException", "RMM already initialized", );
+  }
   rmmOptions_t opts;
   opts.allocation_mode = static_cast<rmmAllocationMode_t>(allocation_mode);
   opts.enable_logging = enable_logging == JNI_TRUE;
@@ -33,7 +36,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initialize(JNIEnv *env, jclass cl
   JNI_RMM_TRY(env, , rmmInitialize(&opts));
 }
 
-JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Rmm_isInitialized(JNIEnv *env, jclass clazz) {
+JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Rmm_isInitializedInternal(JNIEnv *env, jclass clazz) {
   return rmmIsInitialized(nullptr);
 }
 

--- a/java/src/test/java/ai/rapids/cudf/BinaryOpTest.java
+++ b/java/src/test/java/ai/rapids/cudf/BinaryOpTest.java
@@ -21,9 +21,8 @@ package ai.rapids.cudf;
 import org.junit.jupiter.api.Test;
 
 import static ai.rapids.cudf.TableTest.assertColumnsAreEqual;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class BinaryOpTest {
+public class BinaryOpTest extends CudfTestBase {
   private static final Integer[] INTS_1 = new Integer[]{1, 2, 3, 4, 5, null, 100};
   private static final Integer[] INTS_2 = new Integer[]{10, 20, 30, 40, 50, 60, 100};
   private static final Byte[] BYTES_1 = new Byte[]{-1, 7, 123, null, 50, 60, 100};
@@ -92,7 +91,6 @@ public class BinaryOpTest {
 
   @Test
   public void testAdd() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv1 = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector icv2 = ColumnVector.fromBoxedInts(INTS_2);
          ColumnVector bcv1 = ColumnVector.fromBoxedBytes(BYTES_1);
@@ -164,7 +162,6 @@ public class BinaryOpTest {
 
   @Test
   public void testSub() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv1 = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector icv2 = ColumnVector.fromBoxedInts(INTS_2);
          ColumnVector bcv1 = ColumnVector.fromBoxedBytes(BYTES_1);
@@ -242,7 +239,6 @@ public class BinaryOpTest {
 
   @Test
   public void testMul() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.mul(dcv);
@@ -267,7 +263,6 @@ public class BinaryOpTest {
 
   @Test
   public void testDiv() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.div(dcv);
@@ -292,7 +287,6 @@ public class BinaryOpTest {
 
   @Test
   public void testTrueDiv() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.trueDiv(dcv);
@@ -317,7 +311,6 @@ public class BinaryOpTest {
 
   @Test
   public void testFloorDiv() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.floorDiv(dcv);
@@ -342,7 +335,6 @@ public class BinaryOpTest {
 
   @Test
   public void testMod() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.mod(dcv);
@@ -367,7 +359,6 @@ public class BinaryOpTest {
 
   @Test
   public void testPow() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.pow(dcv);
@@ -392,7 +383,6 @@ public class BinaryOpTest {
 
   @Test
   public void testEqual() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.equalTo(dcv);
@@ -417,7 +407,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryEqualScalar() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -442,7 +431,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryEqualScalarNotPresent() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", null, "b", null)) {
       Scalar s = Scalar.fromString("boo");
@@ -461,7 +449,6 @@ public class BinaryOpTest {
 
   @Test
   public void testNotEqual() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.notEqualTo(dcv);
@@ -486,7 +473,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryNotEqualScalar() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -511,7 +497,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryNotEqualScalarNotPresent() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", null, "b", null)) {
       Scalar s = Scalar.fromString("abc");
@@ -530,7 +515,6 @@ public class BinaryOpTest {
 
   @Test
   public void testLessThan() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.lessThan(dcv);
@@ -555,7 +539,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryLessThanScalar() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -581,7 +564,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryLessThanScalarNotPresent() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -606,7 +588,6 @@ public class BinaryOpTest {
 
   @Test
   public void testGreaterThan() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.greaterThan(dcv);
@@ -631,7 +612,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryGreaterThanScalar() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -656,7 +636,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryGreaterThanScalarNotPresent() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -681,7 +660,6 @@ public class BinaryOpTest {
 
   @Test
   public void testLessOrEqualTo() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.lessOrEqualTo(dcv);
@@ -706,7 +684,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryLessOrEqualToScalar() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -731,7 +708,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryLessOrEqualToScalarNotPresent() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -756,7 +732,6 @@ public class BinaryOpTest {
 
   @Test
   public void testGreaterOrEqualTo() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1)) {
       try (ColumnVector answer = icv.greaterOrEqualTo(dcv);
@@ -781,7 +756,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryGreaterOrEqualToScalar() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -806,7 +780,6 @@ public class BinaryOpTest {
 
   @Test
   public void testStringCategoryGreaterOrEqualToScalarNotPresent() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector a = ColumnVector.categoryFromStrings("a", "b", "c", "d");
          ColumnVector b = ColumnVector.categoryFromStrings("a", "b", "b", "a");
          ColumnVector c = ColumnVector.categoryFromStrings("a", null, "b", null)) {
@@ -831,7 +804,6 @@ public class BinaryOpTest {
 
   @Test
   public void testBitAnd() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv1 = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector icv2 = ColumnVector.fromBoxedInts(INTS_2)) {
       try (ColumnVector answer = icv1.bitAnd(icv2);
@@ -856,7 +828,6 @@ public class BinaryOpTest {
 
   @Test
   public void testBitOr() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv1 = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector icv2 = ColumnVector.fromBoxedInts(INTS_2)) {
       try (ColumnVector answer = icv1.bitOr(icv2);
@@ -881,7 +852,6 @@ public class BinaryOpTest {
 
   @Test
   public void testBitXor() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv1 = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector icv2 = ColumnVector.fromBoxedInts(INTS_2)) {
       try (ColumnVector answer = icv1.bitXor(icv2);
@@ -906,8 +876,7 @@ public class BinaryOpTest {
 
   @Test
   public void testAnd() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-    try (ColumnVector icv1 = ColumnVector.fromBoxedBooleans(BOOLEANS_1); 
+    try (ColumnVector icv1 = ColumnVector.fromBoxedBooleans(BOOLEANS_1);
          ColumnVector icv2 = ColumnVector.fromBoxedBooleans(BOOLEANS_2)) {
       try (ColumnVector answer = icv1.and(icv2);
            ColumnVector expected = forEach(DType.BOOL8, icv1, icv2,
@@ -943,8 +912,7 @@ public class BinaryOpTest {
 
   @Test
   public void testOr() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-    try (ColumnVector icv1 = ColumnVector.fromBoxedBooleans(BOOLEANS_1); 
+    try (ColumnVector icv1 = ColumnVector.fromBoxedBooleans(BOOLEANS_1);
          ColumnVector icv2 = ColumnVector.fromBoxedBooleans(BOOLEANS_2)) {
       try (ColumnVector answer = icv1.or(icv2);
            ColumnVector expected = forEach(DType.BOOL8, icv1, icv2,

--- a/java/src/test/java/ai/rapids/cudf/ByteColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ByteColumnVectorTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ByteColumnVectorTest {
+public class ByteColumnVectorTest extends CudfTestBase {
 
   @Test
   public void testCreateColumnVectorBuilder() {

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -27,7 +27,7 @@ import static ai.rapids.cudf.TableTest.assertColumnsAreEqual;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class ColumnVectorTest {
+public class ColumnVectorTest extends CudfTestBase {
 
   public static final double DELTA = 0.0001;
 
@@ -117,7 +117,6 @@ public class ColumnVectorTest {
 
   @Test
   void isNotNullTestEmptyColumn() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v = ColumnVector.fromBoxedInts();
          ColumnVector expected = ColumnVector.fromBoxedBooleans(); 
          ColumnVector result = v.isNotNull()) {
@@ -127,7 +126,6 @@ public class ColumnVectorTest {
 
   @Test
   void isNotNullTest() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v = ColumnVector.fromBoxedInts(1, 2, null, 4, null, 6);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, false, true);
          ColumnVector result = v.isNotNull()) {
@@ -137,7 +135,6 @@ public class ColumnVectorTest {
 
   @Test
   void isNotNullTestAllNulls() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v = ColumnVector.fromBoxedInts(null, null, null, null, null, null);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, false, false, false, false);
          ColumnVector result = v.isNotNull()) {
@@ -147,7 +144,6 @@ public class ColumnVectorTest {
 
   @Test
   void isNotNullTestAllNotNulls() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v = ColumnVector.fromBoxedInts(1,2,3,4,5,6);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, true, true, true, true);
          ColumnVector result = v.isNotNull()) {
@@ -157,7 +153,6 @@ public class ColumnVectorTest {
 
   @Test
   void isNullTest() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v = ColumnVector.fromBoxedInts(1, 2, null, 4, null, 6);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, true, false, true, false);
          ColumnVector result = v.isNull()) {
@@ -167,7 +162,6 @@ public class ColumnVectorTest {
 
   @Test
   void testFromScalarProducesEmptyColumn() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromScalar(Scalar.fromInt(1), 0);
          ColumnVector expected = ColumnVector.fromBoxedInts()) {
       assertColumnsAreEqual(input, expected);
@@ -176,7 +170,6 @@ public class ColumnVectorTest {
 
   @Test
   void testFromScalarFloat() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromScalar(Scalar.fromFloat(1.123f), 4);
          ColumnVector expected = ColumnVector.fromBoxedFloats(1.123f, 1.123f, 1.123f, 1.123f)) {
       assertColumnsAreEqual(input, expected);
@@ -185,7 +178,6 @@ public class ColumnVectorTest {
 
   @Test
   void testFromNullScalarInteger() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromScalar(Scalar.fromNull(DType.INT32), 6);
          ColumnVector expected = ColumnVector.fromBoxedInts(null, null, null, null, null, null)) {
       assertEquals(input.getNullCount(), expected.getNullCount());
@@ -195,7 +187,6 @@ public class ColumnVectorTest {
 
   @Test
   void testSetToNullScalarInteger() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromScalar(Scalar.fromInt(123), 6);
          ColumnVector expected = ColumnVector.fromBoxedInts(null, null, null, null, null, null)) {
       input.fill(Scalar.fromNull(DType.INT32));
@@ -206,7 +197,6 @@ public class ColumnVectorTest {
 
   @Test
   void testSetToNullScalarByte() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     int numNulls = 3000;
     try (ColumnVector input = ColumnVector.fromScalar(Scalar.fromNull(DType.INT8), numNulls)) {
       assertEquals(input.getNullCount(), numNulls);
@@ -219,7 +209,6 @@ public class ColumnVectorTest {
 
   @Test
   void testSetToNullThenBackScalarByte() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     int numNulls = 3000;
     try (ColumnVector input = ColumnVector.fromScalar(Scalar.fromNull(DType.INT8), numNulls)) {
       assertEquals(input.getNullCount(), numNulls);
@@ -234,14 +223,12 @@ public class ColumnVectorTest {
 
   @Test
   void testFromScalarStringThrows() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     assertThrows(IllegalArgumentException.class, () ->
       ColumnVector.fromScalar(Scalar.fromString("test"), 1));
   }
 
   @Test
   void testReplaceEmptyColumn() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromBoxedBooleans();
          ColumnVector expected = ColumnVector.fromBoxedBooleans();
          ColumnVector result = input.replaceNulls(Scalar.fromBool(false))) {
@@ -251,7 +238,6 @@ public class ColumnVectorTest {
 
   @Test
   void testReplaceNullBoolsWithAllNulls() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromBoxedBooleans(null, null, null, null);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, false, false);
          ColumnVector result = input.replaceNulls(Scalar.fromBool(false))) {
@@ -261,7 +247,6 @@ public class ColumnVectorTest {
 
   @Test
   void testReplaceSomeNullBools() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromBoxedBooleans(false, null, null, false);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(false, true, true, false);
          ColumnVector result = input.replaceNulls(Scalar.fromBool(true))) {
@@ -271,7 +256,6 @@ public class ColumnVectorTest {
 
   @Test
   void testReplaceNullIntegersWithAllNulls() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromBoxedInts(null, null, null, null);
          ColumnVector expected = ColumnVector.fromBoxedInts(0, 0, 0, 0);
          ColumnVector result = input.replaceNulls(Scalar.fromInt(0))) {
@@ -281,7 +265,6 @@ public class ColumnVectorTest {
 
   @Test
   void testReplaceSomeNullIntegers() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromBoxedInts(1, 2, null, 4, null);
          ColumnVector expected = ColumnVector.fromBoxedInts(1, 2, 999, 4, 999);
          ColumnVector result = input.replaceNulls(Scalar.fromInt(999))) {
@@ -291,7 +274,6 @@ public class ColumnVectorTest {
 
   @Test
   void testReplaceNullsFailsOnTypeMismatch() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromBoxedInts(1, 2, null, 4, null)) {
       assertThrows(CudfException.class, () -> {
         long nativePtr = Cudf.replaceNulls(input, Scalar.fromBool(true));
@@ -304,7 +286,6 @@ public class ColumnVectorTest {
 
   @Test
   void testReplaceNullsFailsOnNullScalar() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector input = ColumnVector.fromBoxedInts(1, 2, null, 4, null)) {
       assertThrows(CudfException.class, () -> {
         long nativePtr = Cudf.replaceNulls(input, Scalar.fromNull(input.getType()));
@@ -320,7 +301,6 @@ public class ColumnVectorTest {
 
   @Test
   void testQuantilesOnIntegerInput() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     int[] approxExpected = {-1, 1, 1, 2, 9};
     double[][] exactExpected = {
         {-1.0,   1.0,   1.0,   2.5,   9.0},  // LINEAR
@@ -345,7 +325,6 @@ public class ColumnVectorTest {
 
   @Test
   void testQuantilesOnDoubleInput() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     double[] approxExpected = {-1.01, 0.8, 0.8, 2.13, 6.8};
     double[][] exactExpected = {
         {-1.01, 0.8, 0.9984, 2.13, 6.8},  // LINEAR
@@ -370,7 +349,6 @@ public class ColumnVectorTest {
 
   @Test
   void testSliceWithArray() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try(ColumnVector cv = ColumnVector.fromBoxedInts(10, 12, null, null, 18, 20, 22, 24, 26, 28)) {
       Integer[][] expectedSlice = {
           {12, null},
@@ -408,7 +386,6 @@ public class ColumnVectorTest {
 
   @Test
   void testWithOddSlices() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector cv = ColumnVector.fromBoxedInts(10, 12, null, null, 18, 20, 22, 24, 26, 28)) {
       assertThrows(CudfException.class, () -> cv.slice(1, 3, 5, 9, 2, 4, 8));
     }
@@ -416,7 +393,6 @@ public class ColumnVectorTest {
 
   @Test
   void testSliceWithColumnVector() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try(ColumnVector cv = ColumnVector.fromBoxedInts(10, 12, null, null, 18, 20, 22, 24, 26, 28);
         ColumnVector indices = ColumnVector.fromInts(1, 3, 5, 9, 2, 4, 8, 8)) {
       Integer[][] expectedSlice = {
@@ -613,7 +589,6 @@ public class ColumnVectorTest {
 
   @Test
   void testNVStringManipulationWithNulls() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     // Special characters in order of usage, capital and small cyrillic koppa
     // Latin A with macron, and cyrillic komi de
     // \ud720 and \ud721 are UTF-8 characters without corresponding upper and lower characters
@@ -638,7 +613,6 @@ public class ColumnVectorTest {
 
   @Test
   void testNVStringManipulation() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v = ColumnVector.fromStrings("a", "B", "cd", "\u0480\u0481", "E\tf",
                                                    "g\nH", "IJ\"\u0100\u0101\u0500\u0501",
                                                    "kl m", "Nop1", "\\qRs2", "3tuV\'",

--- a/java/src/test/java/ai/rapids/cudf/CudfTestBase.java
+++ b/java/src/test/java/ai/rapids/cudf/CudfTestBase.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package ai.rapids.cudf;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class CudfTestBase {
+  static final long RMM_POOL_SIZE_DEFAULT = 512 * 1024 * 1024;
+
+  final int rmmAllocationMode;
+  final long rmmPoolSize;
+
+  CudfTestBase() {
+    this(RmmAllocationMode.POOL, RMM_POOL_SIZE_DEFAULT);
+  }
+
+  CudfTestBase(int allocationMode, long poolSize) {
+    this.rmmAllocationMode = allocationMode;
+    this.rmmPoolSize = poolSize;
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    assumeTrue(Cuda.isEnvCompatibleForTesting());
+    if (!Rmm.isInitialized()) {
+      Rmm.initialize(rmmAllocationMode, false, rmmPoolSize);
+    }
+  }
+
+  @AfterAll
+  static void afterAll() {
+    if (Rmm.isInitialized()) {
+      Rmm.shutdown();
+    }
+  }
+}

--- a/java/src/test/java/ai/rapids/cudf/Date32ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/Date32ColumnVectorTest.java
@@ -21,9 +21,8 @@ package ai.rapids.cudf;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class Date32ColumnVectorTest {
+public class Date32ColumnVectorTest extends CudfTestBase {
 
   private static final int[] DATES = {17897, //Jan 01, 2019
       17532, //Jan 01, 2018
@@ -39,7 +38,6 @@ public class Date32ColumnVectorTest {
 
   @Test
   public void getYear() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector date32ColumnVector = ColumnVector.datesFromInts(DATES);
          ColumnVector result = date32ColumnVector.year()) {
       result.ensureOnHost();
@@ -52,7 +50,6 @@ public class Date32ColumnVectorTest {
 
   @Test
   public void getMonth() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector date32ColumnVector = ColumnVector.datesFromInts(DATES);
          ColumnVector result = date32ColumnVector.month()) {
       result.ensureOnHost();
@@ -64,7 +61,6 @@ public class Date32ColumnVectorTest {
 
   @Test
   public void getDay() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector date32ColumnVector = ColumnVector.datesFromInts(DATES_2);
          ColumnVector result = date32ColumnVector.day()) {
       result.ensureOnHost();
@@ -76,7 +72,6 @@ public class Date32ColumnVectorTest {
 
   @Test
   public void castToDate32() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector intColumnVector = ColumnVector.fromInts(DATES);
          ColumnVector date32ColumnVector = intColumnVector.asDate32()) {
       date32ColumnVector.ensureOnHost();

--- a/java/src/test/java/ai/rapids/cudf/Date64ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/Date64ColumnVectorTest.java
@@ -21,17 +21,14 @@ package ai.rapids.cudf;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class Date64ColumnVectorTest {
+public class Date64ColumnVectorTest extends CudfTestBase {
   private static final long[] DATES = {-131968727238L,   //'1965-10-26 14:01:12.762'
       1530705600000L,   //'2018-07-04 12:00:00.000'
       1674631932929L};  //'2023-01-25 07:32:12.929'
 
   @Test
   public void getYear() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-
     try (ColumnVector date64ColumnVector = ColumnVector.datesFromLongs(DATES);
          ColumnVector result = date64ColumnVector.year()) {
       result.ensureOnHost();
@@ -43,7 +40,6 @@ public class Date64ColumnVectorTest {
 
   @Test
   public void getMonth() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector date64ColumnVector = ColumnVector.datesFromLongs(DATES);
          ColumnVector result = date64ColumnVector.month()) {
       result.ensureOnHost();
@@ -55,7 +51,6 @@ public class Date64ColumnVectorTest {
 
   @Test
   public void getDay() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector date64ColumnVector = ColumnVector.datesFromLongs(DATES);
          ColumnVector result = date64ColumnVector.day()) {
       result.ensureOnHost();
@@ -67,7 +62,6 @@ public class Date64ColumnVectorTest {
 
   @Test
   public void getHour() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector date64ColumnVector = ColumnVector.datesFromLongs(DATES);
          ColumnVector result = date64ColumnVector.hour()) {
       result.ensureOnHost();
@@ -79,7 +73,6 @@ public class Date64ColumnVectorTest {
 
   @Test
   public void getMinute() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector date64ColumnVector = ColumnVector.datesFromLongs(DATES);
          ColumnVector result = date64ColumnVector.minute()) {
       result.ensureOnHost();
@@ -91,7 +84,6 @@ public class Date64ColumnVectorTest {
 
   @Test
   public void getSecond() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector date64ColumnVector = ColumnVector.datesFromLongs(DATES);
          ColumnVector result = date64ColumnVector.second()) {
       result.ensureOnHost();

--- a/java/src/test/java/ai/rapids/cudf/DoubleColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/DoubleColumnVectorTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DoubleColumnVectorTest {
+public class DoubleColumnVectorTest extends CudfTestBase {
 
   @Test
   public void testCreateColumnVectorBuilder() {

--- a/java/src/test/java/ai/rapids/cudf/FloatColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/FloatColumnVectorTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FloatColumnVectorTest {
+public class FloatColumnVectorTest extends CudfTestBase {
 
   @Test
   public void testCreateColumnVectorBuilder() {

--- a/java/src/test/java/ai/rapids/cudf/HostMemoryBufferTest.java
+++ b/java/src/test/java/ai/rapids/cudf/HostMemoryBufferTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class HostMemoryBufferTest {
+public class HostMemoryBufferTest extends CudfTestBase {
   @Test
   void testRefCountLeak() throws InterruptedException {
     assumeTrue(Boolean.getBoolean("ai.rapids.cudf.flaky-tests-enabled"));
@@ -84,7 +84,6 @@ public class HostMemoryBufferTest {
 
   @Test
   public void testCopyFromDeviceBuffer() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (HostMemoryBuffer init = HostMemoryBuffer.allocate(16);
          DeviceMemoryBuffer tmp = DeviceMemoryBuffer.allocate(16);
          HostMemoryBuffer to = HostMemoryBuffer.allocate(16)) {

--- a/java/src/test/java/ai/rapids/cudf/IntColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/IntColumnVectorTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IntColumnVectorTest {
+public class IntColumnVectorTest extends CudfTestBase {
 
   @Test
   public void testCreateColumnVectorBuilder() {

--- a/java/src/test/java/ai/rapids/cudf/LongColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/LongColumnVectorTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LongColumnVectorTest {
+public class LongColumnVectorTest extends CudfTestBase {
 
   @Test
   public void testCreateColumnVectorBuilder() {

--- a/java/src/test/java/ai/rapids/cudf/PinnedMemoryPoolTest.java
+++ b/java/src/test/java/ai/rapids/cudf/PinnedMemoryPoolTest.java
@@ -19,21 +19,14 @@
 package ai.rapids.cudf;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-class PinnedMemoryPoolTest {
+class PinnedMemoryPoolTest extends CudfTestBase {
   private static final Logger log = LoggerFactory.getLogger(PinnedMemoryPoolTest.class);
-
-  @BeforeEach
-  void setup() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-  }
 
   @AfterEach
   void teardown() {

--- a/java/src/test/java/ai/rapids/cudf/ReductionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ReductionTest.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class ReductionTest {
+class ReductionTest extends CudfTestBase {
 
   public static final double DELTAD = 0.00001;
   public static final float DELTAF = 0.00001f;

--- a/java/src/test/java/ai/rapids/cudf/RmmMemoryAccessorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/RmmMemoryAccessorTest.java
@@ -23,13 +23,13 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-class RmmMemoryAccessorTest {
+class RmmMemoryAccessorTest extends CudfTestBase {
   @Test
   public void log() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     if (Rmm.isInitialized()) {
       Rmm.shutdown();
     }
@@ -47,7 +47,6 @@ class RmmMemoryAccessorTest {
 
   @Test
   public void init() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     if (Rmm.isInitialized()) {
       Rmm.shutdown();
     }
@@ -60,12 +59,21 @@ class RmmMemoryAccessorTest {
 
   @Test
   public void allocate() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     long address = Rmm.alloc(10, 0);
     try {
       assertNotEquals(0, address);
     } finally {
       Rmm.free(address, 0);
     }
+  }
+
+  @Test
+  public void doubleInitFails() {
+    if (!Rmm.isInitialized()) {
+      Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, false, 0);
+    }
+    assertThrows(IllegalStateException.class, () -> {
+      Rmm.initialize(RmmAllocationMode.POOL, false, 1024 * 1024);
+    });
   }
 }

--- a/java/src/test/java/ai/rapids/cudf/ShortColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ShortColumnVectorTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ShortColumnVectorTest {
+public class ShortColumnVectorTest extends CudfTestBase {
 
   @Test
   public void testCreateColumnVectorBuilder() {

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -31,9 +31,8 @@ import java.util.stream.LongStream;
 import static ai.rapids.cudf.Aggregate.max;
 import static ai.rapids.cudf.Table.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class TableTest {
+public class TableTest extends CudfTestBase {
   private static final File TEST_PARQUET_FILE = new File("src/test/resources/acq.parquet");
   private static final File TEST_ORC_FILE = new File("src/test/resources/TestOrcFile.orc");
   private static final File TEST_ORC_TIMESTAMP_DATE_FILE = new File(
@@ -176,7 +175,6 @@ public class TableTest {
 
   @Test
   void testOrderByAD() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (Table table = new Table.TestBuilder()
         .column(5, 3, 3, 1, 1)
         .column(5, 3, 4, 1, 2)
@@ -194,7 +192,6 @@ public class TableTest {
 
   @Test
   void testOrderByDD() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (Table table = new Table.TestBuilder()
         .column(5, 3, 3, 1, 1)
         .column(5, 3, 4, 1, 2)
@@ -212,7 +209,6 @@ public class TableTest {
 
   @Test
   void testOrderByWithNulls() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (Table table = new Table.TestBuilder()
         .column(5, null, 3, 1, 1)
         .column(5, 3, 4, null, null)
@@ -232,7 +228,6 @@ public class TableTest {
 
   @Test
   void testOrderByWithNullsAndStrings() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (Table table = new Table.TestBuilder()
 	.categoryColumn("4", "3", "2", "1", "0")
         .column(5, null, 3, 1, 1)
@@ -252,7 +247,6 @@ public class TableTest {
 
   @Test
   void testTableCreationIncreasesRefCount() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     //tests the Table increases the refcount on column vectors
     assertThrows(IllegalStateException.class, () -> {
       try (ColumnVector v1 = ColumnVector.build(DType.INT32, 5, Range.appendInts(5));
@@ -269,7 +263,6 @@ public class TableTest {
 
   @Test
   void testGetRows() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v1 = ColumnVector.build(DType.INT32, 5, Range.appendInts(5));
          ColumnVector v2 = ColumnVector.build(DType.INT32, 5, Range.appendInts(5));
          Table t = new Table(new ColumnVector[]{v1, v2})) {
@@ -285,7 +278,6 @@ public class TableTest {
 
   @Test
   void testAllRowsSize() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v1 = ColumnVector.build(DType.INT32, 4, Range.appendInts(4));
          ColumnVector v2 = ColumnVector.build(DType.INT32, 5, Range.appendInts(5))) {
       assertThrows(AssertionError.class, () -> {
@@ -297,7 +289,6 @@ public class TableTest {
 
   @Test
   void testGetNumberOfColumns() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector v1 = ColumnVector.build(DType.INT32, 5, Range.appendInts(5));
          ColumnVector v2 = ColumnVector.build(DType.INT32, 5, Range.appendInts(5));
          Table t = new Table(new ColumnVector[]{v1, v2})) {
@@ -307,7 +298,6 @@ public class TableTest {
 
   @Test
   void testReadCSVPrune() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     Schema schema = Schema.builder()
         .column(DType.INT32, "A")
         .column(DType.FLOAT64, "B")
@@ -328,7 +318,6 @@ public class TableTest {
 
   @Test
   void testReadCSVBufferInferred() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     CSVOptions opts = CSVOptions.builder()
         .includeColumn("A")
         .includeColumn("B")
@@ -358,7 +347,6 @@ public class TableTest {
 
   @Test
   void testReadCSVBuffer() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     CSVOptions opts = CSVOptions.builder()
         .includeColumn("A")
         .includeColumn("B")
@@ -379,7 +367,6 @@ public class TableTest {
 
   @Test
   void testReadCSVWithOffset() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     CSVOptions opts = CSVOptions.builder()
         .includeColumn("A")
         .includeColumn("B")
@@ -419,7 +406,6 @@ public class TableTest {
         .column(DType.STRING, "D")
         .build();
 
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     CSVOptions opts = CSVOptions.builder()
         .includeColumn("A", "B", "D")
         .hasHeader(true)
@@ -440,7 +426,6 @@ public class TableTest {
 
   @Test
   void testReadCSV() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     Schema schema = Schema.builder()
         .column(DType.INT32, "A")
         .column(DType.FLOAT64, "B")
@@ -460,7 +445,6 @@ public class TableTest {
 
   @Test
   void testReadParquet() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     ParquetOptions opts = ParquetOptions.builder()
         .includeColumn("loan_id")
         .includeColumn("zip")
@@ -475,7 +459,6 @@ public class TableTest {
 
   @Test
   void testReadParquetBuffer() throws IOException {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     ParquetOptions opts = ParquetOptions.builder()
         .includeColumn("loan_id")
         .includeColumn("coborrow_credit_score")
@@ -496,7 +479,6 @@ public class TableTest {
 
   @Test
   void testReadParquetFull() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (Table table = Table.readParquet(TEST_PARQUET_FILE)) {
       long rows = table.getRowCount();
       assertEquals(1000, rows);
@@ -536,7 +518,6 @@ public class TableTest {
 
   @Test
   void testReadORC() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     ORCOptions opts = ORCOptions.builder()
         .includeColumn("string1")
         .includeColumn("float1")
@@ -554,7 +535,6 @@ public class TableTest {
 
   @Test
   void testReadORCBuffer() throws IOException {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     ORCOptions opts = ORCOptions.builder()
         .includeColumn("string1")
         .includeColumn("float1")
@@ -576,7 +556,6 @@ public class TableTest {
 
   @Test
   void testReadORCFull() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (Table expected = new Table.TestBuilder()
         .column(false, true)
         .column((byte)1, (byte)100)
@@ -594,7 +573,6 @@ public class TableTest {
 
   @Test
   void testReadORCNumPyTypes() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     // by default ORC will promote DATE32 to DATE64
     // and TIMESTAMP is kept as it is
     try (Table table = Table.readORC(TEST_ORC_TIMESTAMP_DATE_FILE)) {
@@ -614,7 +592,6 @@ public class TableTest {
 
   @Test
   void testReadORCTimeUnit() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     // specifying no NumPy types should load them as DATE32 and TIMESTAMP
     // specifying TimeUnit will return the result in that unit
     ORCOptions opts = ORCOptions.builder()
@@ -1289,7 +1266,6 @@ public class TableTest {
 
   @Test
   void testMaskWithValidity() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     final int numRows = 5;
     try (ColumnVector.Builder builder = ColumnVector.builder(DType.BOOL8, numRows)) {
       for (int i = 0; i < numRows; ++i) {
@@ -1314,7 +1290,6 @@ public class TableTest {
 
   @Test
   void testMaskDataOnly() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     byte[] maskVals = new byte[]{0, 1, 0, 1, 1};
     try (ColumnVector mask = ColumnVector.boolFromBytes(maskVals);
          Table input = new Table(ColumnVector.fromBoxedBytes((byte) 1, null, (byte) 2, (byte) 3, null));
@@ -1331,7 +1306,6 @@ public class TableTest {
 
   @Test
   void testAllFilteredFromData() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     Boolean[] maskVals = new Boolean[5];
     Arrays.fill(maskVals, false);
     try (ColumnVector mask = ColumnVector.fromBoxedBooleans(maskVals);
@@ -1345,7 +1319,6 @@ public class TableTest {
 
   @Test
   void testAllFilteredFromValidity() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     final int numRows = 5;
     try (ColumnVector.Builder builder = ColumnVector.builder(DType.BOOL8, numRows)) {
       for (int i = 0; i < numRows; ++i) {
@@ -1364,7 +1337,6 @@ public class TableTest {
 
   @Test
   void testMismatchedSizes() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     Boolean[] maskVals = new Boolean[3];
     Arrays.fill(maskVals, true);
     try (ColumnVector mask = ColumnVector.fromBoxedBooleans(maskVals);
@@ -1375,7 +1347,6 @@ public class TableTest {
 
   @Test
   void testTableBasedFilter() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     byte[] maskVals = new byte[]{0, 1, 0, 1, 1};
     try (ColumnVector mask = ColumnVector.boolFromBytes(maskVals);
          Table input = new Table(
@@ -1391,7 +1362,6 @@ public class TableTest {
 
   @Test
   void testStringsAreNotSupported() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     Boolean[] maskVals = new Boolean[5];
     Arrays.fill(maskVals, true);
     try (ColumnVector mask = ColumnVector.fromBoxedBooleans(maskVals);

--- a/java/src/test/java/ai/rapids/cudf/TimestampColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TimestampColumnVectorTest.java
@@ -22,9 +22,8 @@ import org.junit.jupiter.api.Test;
 
 import static ai.rapids.cudf.TableTest.assertColumnsAreEqual;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class TimestampColumnVectorTest {
+public class TimestampColumnVectorTest extends CudfTestBase {
   static final long[] TIMES_S = {-131968728L,   //'1965-10-26 14:01:12'
                                  1530705600L,   //'2018-07-04 12:00:00'
                                  1674631932L,   //'2023-01-25 07:32:12'
@@ -77,8 +76,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void getYear() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-
     try (ColumnVector timestampColumnVector = ColumnVector.timestampsFromLongs(TIMES_MS)) {
       assert timestampColumnVector.getTimeUnit() == TimeUnit.MILLISECONDS;
       ColumnVector result = timestampColumnVector.year();
@@ -100,7 +97,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void getMonth() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector timestampColumnVector = ColumnVector.timestampsFromLongs(TIMES_MS);
          ColumnVector result = timestampColumnVector.month()) {
       assert timestampColumnVector.getTimeUnit() == TimeUnit.MILLISECONDS;
@@ -122,7 +118,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void getDay() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector timestampColumnVector = ColumnVector.timestampsFromLongs(TIMES_MS)) {
       assert timestampColumnVector.getTimeUnit() == TimeUnit.MILLISECONDS;
       try (ColumnVector result = timestampColumnVector.day()) {
@@ -145,7 +140,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void getHour() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector timestampColumnVector = ColumnVector.timestampsFromLongs(TIMES_MS)) {
       assert timestampColumnVector.getTimeUnit() == TimeUnit.MILLISECONDS;
       try (ColumnVector result = timestampColumnVector.hour()) {
@@ -168,7 +162,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void getMinute() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector timestampColumnVector = ColumnVector.timestampsFromLongs(TIMES_MS)) {
       assert timestampColumnVector.getTimeUnit() == TimeUnit.MILLISECONDS;
       try (ColumnVector result = timestampColumnVector.minute()) {
@@ -191,7 +184,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void getSecond() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector timestampColumnVector = ColumnVector.timestampsFromLongs(TIMES_MS)) {
       assert timestampColumnVector.getTimeUnit() == TimeUnit.MILLISECONDS;
       try (ColumnVector result = timestampColumnVector.second()) {
@@ -214,7 +206,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void testCastToTimestamp() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector date64ColumnVector = ColumnVector.timestampsFromLongs(TIMES_MS);
          ColumnVector timestampColumnVector = date64ColumnVector.asTimestamp(TimeUnit.SECONDS)) {
       timestampColumnVector.ensureOnHost();
@@ -226,8 +217,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void testTimestampToLongSecond() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-
     try (ColumnVector s_string_times = ColumnVector.fromStrings(TIMES_S_STRING);
          ColumnVector ms_string_times = ColumnVector.fromStrings(TIMES_MS_STRING);
          ColumnVector us_string_times = ColumnVector.fromStrings(TIMES_US_STRING);
@@ -246,8 +235,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void testTimestampToLongMillisecond() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-
     try (ColumnVector s_string_times = ColumnVector.fromStrings(TIMES_S_STRING);
          ColumnVector ms_string_times = ColumnVector.fromStrings(TIMES_MS_STRING);
          ColumnVector us_string_times = ColumnVector.fromStrings(TIMES_US_STRING);
@@ -268,8 +255,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void testTimestampToLongMicrosecond() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-
     try (ColumnVector s_string_times = ColumnVector.fromStrings(TIMES_S_STRING);
          ColumnVector ms_string_times = ColumnVector.fromStrings(TIMES_MS_STRING);
          ColumnVector us_string_times = ColumnVector.fromStrings(TIMES_US_STRING);
@@ -291,8 +276,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void testTimestampToLongNanosecond() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-
     try (ColumnVector s_string_times = ColumnVector.fromStrings(TIMES_S_STRING);
          ColumnVector ms_string_times = ColumnVector.fromStrings(TIMES_MS_STRING);
          ColumnVector us_string_times = ColumnVector.fromStrings(TIMES_US_STRING);
@@ -315,8 +298,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void testCategoryTimestampToLongSecond() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-
     try (ColumnVector s_string_times = ColumnVector.categoryFromStrings(TIMES_S_STRING);
          ColumnVector ms_string_times = ColumnVector.categoryFromStrings(TIMES_MS_STRING);
          ColumnVector us_string_times = ColumnVector.categoryFromStrings(TIMES_US_STRING);
@@ -335,8 +316,6 @@ public class TimestampColumnVectorTest {
 
   @Test
   public void testCategoryTimestampToSubsecond() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
-
     try (ColumnVector ms_string_times = ColumnVector.categoryFromStrings(TIMES_MS_STRING);
          ColumnVector us_string_times = ColumnVector.categoryFromStrings(TIMES_US_STRING);
          ColumnVector ns_string_times = ColumnVector.categoryFromStrings(TIMES_NS_STRING);

--- a/java/src/test/java/ai/rapids/cudf/UnaryOpTest.java
+++ b/java/src/test/java/ai/rapids/cudf/UnaryOpTest.java
@@ -22,9 +22,8 @@ package ai.rapids.cudf;
 import org.junit.jupiter.api.Test;
 
 import static ai.rapids.cudf.TableTest.assertColumnsAreEqual;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class UnaryOpTest {
+public class UnaryOpTest extends CudfTestBase {
   private static final Double[] DOUBLES_1 = new Double[]{1.0, 10.0, -100.1, 5.3, 50.0, 100.0, null};
   private static final Integer[] INTS_1 = new Integer[]{1, 10, -100, 5, 50, 100, null};
   private static final Boolean[] BOOLEANS_1 = new Boolean[]{true, false, true, false, true, false, null};
@@ -116,7 +115,6 @@ public class UnaryOpTest {
 
   @Test
   public void testSin() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.sin();
          ColumnVector expected = forEach(dcv, doubleFun(Math::sin))) {
@@ -126,7 +124,6 @@ public class UnaryOpTest {
 
   @Test
   public void testCos() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.cos();
          ColumnVector expected = forEach(dcv, doubleFun(Math::cos))) {
@@ -136,7 +133,6 @@ public class UnaryOpTest {
 
   @Test
   public void testTan() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.tan();
          ColumnVector expected = forEach(dcv, doubleFun(Math::tan))) {
@@ -146,7 +142,6 @@ public class UnaryOpTest {
 
   @Test
   public void testArcsin() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.arcsin();
          ColumnVector expected = forEach(dcv, doubleFun(Math::asin))) {
@@ -156,7 +151,6 @@ public class UnaryOpTest {
 
   @Test
   public void testArccos() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.arccos();
          ColumnVector expected = forEach(dcv, doubleFun(Math::acos))) {
@@ -166,7 +160,6 @@ public class UnaryOpTest {
 
   @Test
   public void testArctan() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.arctan();
          ColumnVector expected = forEach(dcv, doubleFun(Math::atan))) {
@@ -176,7 +169,6 @@ public class UnaryOpTest {
 
   @Test
   public void testExp() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.exp();
          ColumnVector expected = forEach(dcv, doubleFun(Math::exp))) {
@@ -186,7 +178,6 @@ public class UnaryOpTest {
 
   @Test
   public void testLog() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.log();
          ColumnVector expected = forEach(dcv, doubleFun(Math::log))) {
@@ -196,7 +187,6 @@ public class UnaryOpTest {
 
   @Test
   public void testSqrt() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.sqrt();
          ColumnVector expected = forEach(dcv, doubleFun(Math::sqrt))) {
@@ -206,7 +196,6 @@ public class UnaryOpTest {
 
   @Test
   public void testCeil() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.ceil();
          ColumnVector expected = forEach(dcv, doubleFun(Math::ceil))) {
@@ -216,7 +205,6 @@ public class UnaryOpTest {
 
   @Test
   public void testFloor() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.floor();
          ColumnVector expected = forEach(dcv, doubleFun(Math::floor))) {
@@ -226,7 +214,6 @@ public class UnaryOpTest {
 
   @Test
   public void testAbs() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector dcv = ColumnVector.fromBoxedDoubles(DOUBLES_1);
          ColumnVector answer = dcv.abs();
          ColumnVector expected = forEach(dcv, doubleFun(Math::abs))) {
@@ -236,7 +223,6 @@ public class UnaryOpTest {
 
   @Test
   public void testBitInvert() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedInts(INTS_1);
          ColumnVector answer = icv.bitInvert();
          ColumnVector expected = forEach(icv, intFun((i) -> ~i))) {
@@ -246,7 +232,6 @@ public class UnaryOpTest {
 
   @Test
   public void testNot() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector icv = ColumnVector.fromBoxedBooleans(BOOLEANS_1);
          ColumnVector answer = icv.not();
          ColumnVector expected = forEach(icv, boolFun((i) -> !i))) {
@@ -257,7 +242,6 @@ public class UnaryOpTest {
   // String to string cat conversion has more to do with correctness as we wrote that all ourselves
   @Test
   public void testStringCastFullCircle() {
-    assumeTrue(Cuda.isEnvCompatibleForTesting());
     try (ColumnVector origStr = ColumnVector.fromStrings(STRINGS_1);
          ColumnVector origCat = ColumnVector.categoryFromStrings(STRINGS_1);
          ColumnVector cat = origStr.asStringCategories();


### PR DESCRIPTION
I doubt this can go in.  It fixes all of the unit test failure we have been seeing in java for 0.10 and is the equivalent for the fixes #3139 and #3092