### PR TITLE
[REVIEW] Rename column_wrapper.cuh to column_wrapper.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PR #3041 Fixed exp to experimental namespace name change issue
 - PR #3060 Move copying.hpp includes to legacy
 - PR #3141 Java fix for relocated IO headers
+- PR #3149 Rename column_wrapper.cuh to column_wrapper.hpp
 
 
 # cuDF 0.10.0 (Date TBD)

--- a/cpp/tests/strings/array_tests.cu
+++ b/cpp/tests/strings/array_tests.cu
@@ -23,7 +23,7 @@
 
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/column_wrapper.hpp>
-#include <tests/utilities/column_utilities.cuh>
+#include <tests/utilities/column_utilities.hpp>
 #include "./utilities.h"
 
 #include <vector>

--- a/cpp/tests/strings/factories_test.cu
+++ b/cpp/tests/strings/factories_test.cu
@@ -18,7 +18,7 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
 #include <tests/utilities/base_fixture.hpp>
-#include <tests/utilities/column_utilities.cuh>
+#include <tests/utilities/column_utilities.hpp>
 
 #include <gmock/gmock.h>
 

--- a/cpp/tests/strings/utilities.cu
+++ b/cpp/tests/strings/utilities.cu
@@ -17,7 +17,7 @@
 #include "./utilities.h"
 
 #include <cudf/column/column_factories.hpp>
-#include <tests/utilities/column_utilities.cuh>
+#include <tests/utilities/column_utilities.hpp>
 
 #include <cstring>
 #include <thrust/execution_policy.h>

--- a/cpp/tests/utilities/column_wrapper.hpp
+++ b/cpp/tests/utilities/column_wrapper.hpp
@@ -49,7 +49,8 @@ namespace test {
  * ```
  *
  * @param start The starting value of the counting iterator
- * @param f The unary function to apply to the counting iterator
+ * @param f The unary function to apply to the counting iterator.
+ * This should be a host function and not a device function.
  * @return auto A transform iterator that applies `f` to a counting iterator
  *---------------------------------------------------------------------------**/
 template <typename UnaryFunction>
@@ -178,8 +179,8 @@ auto make_chars_and_offsets(StringsIterator begin, StringsIterator end,
                             ValidityIterator v) {
   std::vector<char> chars{};
   std::vector<int32_t> offsets(1, 0);
-  for (; begin < end; ++begin) {
-    std::string tmp = (*v++) ? std::string(*begin) : std::string{};
+  for( auto str = begin; str < end; ++str) {
+    std::string tmp = (*v++) ? std::string(*str) : std::string{};
     chars.insert(chars.end(), std::cbegin(tmp), std::cend(tmp));
     offsets.push_back(offsets.back() + tmp.length());
   }
@@ -205,8 +206,8 @@ class fixed_width_column_wrapper : public detail::column_wrapper {
    *
    * Example:
    * ```c++
-   * // Creates a non-nullable column of INT32 elements with 5 elements: {0, 1, 2, 3, 4}
-   * auto elements = make_counting_transform_iterator(0, [](auto i){return i;});
+   * // Creates a non-nullable column of INT32 elements with 5 elements: {0, 2, 4, 6, 8}
+   * auto elements = make_counting_transform_iterator(0, [](auto i){return i*2;});
    * fixed_width_column_wrapper<int32_t> w(elements, elements + 5);
    * ```
    *

--- a/cpp/tests/utilities_tests/column_wrapper_tests.cu
+++ b/cpp/tests/utilities_tests/column_wrapper_tests.cu
@@ -15,7 +15,7 @@
  */
 
 #include <tests/utilities/base_fixture.hpp>
-#include <tests/utilities/column_utilities.cuh>
+#include <tests/utilities/column_utilities.hpp>
 #include <tests/utilities/column_wrapper.hpp>
 #include <tests/utilities/cudf_gtest.hpp>
 #include <tests/utilities/type_lists.hpp>


### PR DESCRIPTION
Merge of #2971 caused automatic merge of #3130.
But the rename of this file was left out of 2917 and in causing a build issue.

```
/cudf/cpp/tests/utilities_tests/column_wrapper_tests.cu:18:48: fatal error: tests/utilities/column_utilities.cuh: No such file or directory
compilation terminated.
...
```
This PR fixes the affected files and also completes the changes requested on 3130.