### PR TITLE
[REVIEW] Fix mutable_column_device_view head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - PR #3139 Fixed java RMM auto initalization
 - PR #3141 Java fix for relocated IO headers
 - PR #3149 Rename column_wrapper.cuh to column_wrapper.hpp
+- PR #3168 Fix mutable_column_device_view head const_cast
 
 
 # cuDF 0.10.0 (Date TBD)

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -401,11 +401,11 @@ class alignas(16) mutable_column_device_view
    *`data<T>()`.
    *
    * @tparam The type to cast to
-   * @return T const* Typed pointer to underlying data
+   * @return T* Typed pointer to underlying data
    *---------------------------------------------------------------------------**/
   template <typename T = void>
   __host__ __device__ T* head() const noexcept {
-    return const_cast<T*>(detail::column_device_view_base::head());
+    return const_cast<T*>(detail::column_device_view_base::head<T>());
   }
 
   /**---------------------------------------------------------------------------*
@@ -417,11 +417,11 @@ class alignas(16) mutable_column_device_view
    * @TODO Clarify behavior for variable-width types.
    *
    * @tparam T The type to cast to
-   * @return T const* Typed pointer to underlying data, including the offset
+   * @return T* Typed pointer to underlying data, including the offset
    *---------------------------------------------------------------------------**/
   template <typename T>
   __host__ __device__ T* data() const noexcept {
-    return head<T>() + _offset;
+    return const_cast<T*>(detail::column_device_view_base::data<T>());
   }
 
   /**---------------------------------------------------------------------------*


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/3167

`mutable_column_device_view::head<T>()` was calling the default (void) instantiation of `column_device_view_base::head()` which caused the const_cast<T*> to fail. Use the correct instantiation for T instead. Also changed the implementation of data() to call column_device_view_base similarly.