### PR TITLE
[REVIEW] Set cmake cuda version variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PR #3135 Add nvtx utilities to cudf::nvtx namespace
 - PR #3021 Java host side concat of serialized buffers
 - PR #3138 Movey unary files to legacy
+- PR #3175 Set cmake cuda version variables
 
 
 ## Bug Fixes

--- a/build.sh
+++ b/build.sh
@@ -108,7 +108,7 @@ if hasArg clean; then
 fi
 
 if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
-    GPU_ARCH=""
+    GPU_ARCH="-DGPU_ARCHS="
     echo "Building for the architecture of the GPU in the system..."
 else
     GPU_ARCH="-DGPU_ARCHS=ALL"

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean libnvstrings nvstrings libcudf cudf dask_cudf benchmarks -v -g -n -h"
+VALIDARGS="clean libnvstrings nvstrings libcudf cudf dask_cudf benchmarks -v -g -n --allgpuarch -h"
 HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [-v] [-g] [-n] [-h]
    clean        - remove all existing build artifacts and configuration (start
                   over)
@@ -31,6 +31,7 @@ HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [-v] [-g] [-n] [-h]
    -v           - verbose build mode
    -g           - build for debug
    -n           - no install step
+   --allgpuarch - build for all supported GPU architectures
    -h           - print this text
 
    default action (no args) is to build and install 'libnvstrings' then
@@ -48,6 +49,7 @@ VERBOSE=""
 BUILD_TYPE=Release
 INSTALL_TARGET=install
 BENCHMARKS=OFF
+BUILD_ALL_GPU_ARCH=0
 
 # Set defaults for vars that may not have been defined externally
 #  FIXME: if INSTALL_PREFIX is not set, check PREFIX, then check
@@ -84,6 +86,9 @@ fi
 if hasArg -n; then
     INSTALL_TARGET=""
 fi
+if hasArg --allgpuarch; then
+    BUILD_ALL_GPU_ARCH=1
+fi
 if hasArg benchmarks; then
     BENCHMARKS="ON"
 fi
@@ -102,6 +107,14 @@ if hasArg clean; then
     done
 fi
 
+if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
+    GPU_ARCH=""
+    echo "Building for the architecture of the GPU in the system..."
+else
+    GPU_ARCH="-DGPU_ARCHS=ALL"
+    echo "Building for *ALL* supported GPU architectures..."
+fi
+
 ################################################################################
 # Configure, build, and install libnvstrings
 if (( ${NUMARGS} == 0 )) || hasArg libnvstrings; then
@@ -110,6 +123,7 @@ if (( ${NUMARGS} == 0 )) || hasArg libnvstrings; then
     cd ${LIBNVSTRINGS_BUILD_DIR}
     cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DCMAKE_CXX11_ABI=ON \
+          ${GPU_ARCH} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
     if [[ ${INSTALL_TARGET} != "" ]]; then
         make -j${PARALLEL_LEVEL} install_nvstrings VERBOSE=${VERBOSE}
@@ -136,6 +150,7 @@ if (( ${NUMARGS} == 0 )) || hasArg libcudf; then
     cd ${LIBCUDF_BUILD_DIR}
     cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DCMAKE_CXX11_ABI=ON \
+          ${GPU_ARCH} \
           -DBUILD_BENCHMARKS=${BENCHMARKS} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
     if [[ ${INSTALL_TARGET} != "" ]]; then

--- a/conda/recipes/libcudf/build.sh
+++ b/conda/recipes/libcudf/build.sh
@@ -7,4 +7,4 @@ printenv
 # Cleanup local git
 git clean -xdf
 # build libcudf with verbose output
-./build.sh -v libcudf
+./build.sh -v libcudf --allgpuarch

--- a/conda/recipes/libnvstrings/build.sh
+++ b/conda/recipes/libnvstrings/build.sh
@@ -7,4 +7,4 @@ printenv
 # Cleanup local git
 git clean -xdf
 # build libnvstrings with verbose output
-./build.sh -v libnvstrings
+./build.sh -v libnvstrings --allgpuarch

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -61,6 +61,21 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif(CMAKE_CXX11_ABI)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
+if(CMAKE_CUDA_COMPILER_VERSION)
+  # Compute the version. from  CMAKE_CUDA_COMPILER_VERSION
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\1" CUDA_VERSION_MAJOR ${CMAKE_CUDA_COMPILER_VERSION})
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\2" CUDA_VERSION_MINOR ${CMAKE_CUDA_COMPILER_VERSION})
+  set(CUDA_VERSION "${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}" CACHE STRING "Version of CUDA as computed from nvcc.")
+  mark_as_advanced(CUDA_VERSION)
+endif()
+
+message(STATUS "CUDA_VERSION_MAJOR: ${CUDA_VERSION_MAJOR}")
+message(STATUS "CUDA_VERSION_MINOR: ${CUDA_VERSION_MINOR}")
+message(STATUS "CUDA_VERSION: ${CUDA_VERSION}")
+
+# Always set this convenience variable
+set(CUDA_VERSION_STRING "${CUDA_VERSION}")
+
 # Auto-detect available GPU compute architectures
 set(GPU_ARCHS "ALL" CACHE STRING
   "List of GPU architectures (semicolon-separated) to be compiled for. Pass 'ALL' if you want to compile for all supported GPU architectures. Empty string means to auto-detect the GPUs on the current system")


### PR DESCRIPTION
Sets `CUDA_VERSION`, `CUDA_MAJOR_VERSION`, and `CUDA_MINOR_VERSION` variables that were previously set by the deprecated `FindCUDA` cmake package. 

See also:
* [Modern cmake + cuda examples](https://gitlab.kitware.com/robertmaynard/cmake_cuda_tests)
* [FindCUDALibs.cmake](https://gitlab.kitware.com/robertmaynard/cmake_cuda_tests/blob/fa997dbf80b2bfb3168149a7e9375d5c4c51c0fb/cmake/FindCUDALibs.cmake)