### PR TITLE
Default initialize RMM when Java native dependencies are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - PR #3204 ORC writer: Fix ByteRLE encoding of NULLs
 - PR #2994 Fix split_out-support but with hash_object_dispatch
 - PR #3218 Fixes `row_lexicographic_comparator` issue with handling two tables
+- PR #3228 Default initialize RMM when Java native dependencies are loaded
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -51,6 +51,7 @@ public class NativeDepsLoader {
           loadDep(os, arch, toLoad);
         }
         loaded = true;
+        Rmm.defaultInitialize();
       } catch (Throwable t) {
         log.error("Could not load cudf jni library...", t);
       }

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -22,8 +22,6 @@ public class Rmm {
   private static volatile boolean defaultInitialized;
   static {
     NativeDepsLoader.loadNativeDeps();
-    initializeInternal(RmmAllocationMode.CUDA_DEFAULT, false, 0);
-    defaultInitialized = true;
   }
 
   /**
@@ -48,6 +46,16 @@ public class Rmm {
       }
     }
     initializeInternal(allocationMode, enableLogging, poolSize);
+  }
+
+  /**
+   * Initialize RMM in CUDA default mode.
+   */
+  static synchronized void defaultInitialize() {
+    if (!defaultInitialized && !isInitializedInternal()) {
+      initializeInternal(RmmAllocationMode.CUDA_DEFAULT, false, 0);
+      defaultInitialized = true;
+    }
   }
 
   private static native void initializeInternal(int allocationMode, boolean enableLogging, long poolSize)


### PR DESCRIPTION
Fixes #3215 

This default-initializes RMM when the Java native dependencies are loaded.  This addresses the issue in #3139 where the `ai.rapids.cudf.Rmm` class may not be referenced before native code is executed and therefore leave RMM uninitialized.  By hooking it into the native deps loader, this makes it impossible to call libcudf code without default-initializing RMM first.

