### PR TITLE
[REVIEW] Introduce temporary patched numba array to fix Numba 0.46/CuPy 6.3 Compatibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - PR #3212 Fix string to date casting when format is not specified
 - PR #3218 Fixes `row_lexicographic_comparator` issue with handling two tables
 - PR #3228 Default initialize RMM when Java native dependencies are loaded
+- PR #3236 Fix Numba 0.46+/CuPy 6.3 interface compatibility
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -16,7 +16,7 @@ from cudf.core.column import Column, DatetimeColumn, column
 from cudf.core.index import Index, RangeIndex, as_index
 from cudf.core.indexing import _SeriesIlocIndexer, _SeriesLocIndexer
 from cudf.core.window import Rolling
-from cudf.utils import cudautils, ioutils, utils
+from cudf.utils import cudautils, ioutils, utils, numbautils
 from cudf.utils.docutils import copy_docstring
 from cudf.utils.dtypes import (
     is_categorical_dtype,
@@ -155,7 +155,7 @@ class Series(object):
         if len(self) == 0:
             return cupy.asarray([], dtype=self.dtype)
 
-        return cupy.asarray(self.to_gpu_array())
+        return cupy.asarray(numbautils.PatchedNumbaDeviceArray(self.to_gpu_array()))
 
     @property
     def values_host(self):

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -16,7 +16,7 @@ from cudf.core.column import Column, DatetimeColumn, column
 from cudf.core.index import Index, RangeIndex, as_index
 from cudf.core.indexing import _SeriesIlocIndexer, _SeriesLocIndexer
 from cudf.core.window import Rolling
-from cudf.utils import cudautils, ioutils, utils, numbautils
+from cudf.utils import cudautils, ioutils, numbautils, utils
 from cudf.utils.docutils import copy_docstring
 from cudf.utils.dtypes import (
     is_categorical_dtype,
@@ -155,7 +155,9 @@ class Series(object):
         if len(self) == 0:
             return cupy.asarray([], dtype=self.dtype)
 
-        return cupy.asarray(numbautils.PatchedNumbaDeviceArray(self.to_gpu_array()))
+        return cupy.asarray(
+            numbautils.PatchedNumbaDeviceArray(self.to_gpu_array())
+        )
 
     @property
     def values_host(self):

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -156,6 +156,7 @@ class Series(object):
             return cupy.asarray([], dtype=self.dtype)
 
         return cupy.asarray(
+            # Temporary fix for CuPy < 7.0, numba = 0.46
             numbautils.PatchedNumbaDeviceArray(self.to_gpu_array())
         )
 

--- a/python/cudf/cudf/utils/numbautils.py
+++ b/python/cudf/cudf/utils/numbautils.py
@@ -3,6 +3,8 @@ class PatchedNumbaDeviceArray(object):
         self.parent = numba_ary
 
     def __getattr__(self, name):
+        if name == "parent":
+            raise AttributeError()
         if name != "__cuda_array_interface__":
             return getattr(self.parent, name)
         else:

--- a/python/cudf/cudf/utils/numbautils.py
+++ b/python/cudf/cudf/utils/numbautils.py
@@ -1,13 +1,12 @@
 class PatchedNumbaDeviceArray(object):
     def __init__(self, numba_ary):
         self.parent = numba_ary
-        
+
     def __getattr__(self, name):
-        if name is not '__cuda_array_interface__':
+        if name != "__cuda_array_interface__":
             return getattr(self.parent, name)
         else:
             rtn = self.parent.__cuda_array_interface__
-            if rtn.get('strides') is None:
-                rtn.pop('strides')
+            if rtn.get("strides") is None:
+                rtn.pop("strides")
             return rtn
-            

--- a/python/cudf/cudf/utils/numbautils.py
+++ b/python/cudf/cudf/utils/numbautils.py
@@ -1,0 +1,13 @@
+class PatchedNumbaDeviceArray(object):
+    def __init__(self, numba_ary):
+        self.parent = numba_ary
+        
+    def __getattr__(self, name):
+        if name is not '__cuda_array_interface__':
+            return getattr(self.parent, name)
+        else:
+            rtn = self.parent.__cuda_array_interface__
+            if rtn.get('strides') is None:
+                rtn.pop('strides')
+            return rtn
+            


### PR DESCRIPTION
An [update to numba](https://github.com/numba/numba/pull/4609) in version 0.46+ was recently introduced that corrected the `__cuda_array_interface__` property of `numba` device arrays. In short, the interface now allows for the case where `__cuda_array_interface__['strides'] == None`. However the [CuPy 6.5 release](https://github.com/cupy/cupy/blob/b086a9589c7136ef012315980abcb6953b7e1371/cupy/core/core.pyx#L2516) hasn't caught up to this and while the necessary changes have been merged, they won't be included with `CuPy` until `7.0`. Normally we might choose to pin `numba=0.45.1`, however [the fix for the ucx bug](https://github.com/numba/numba/blob/0.46.0rc1/CHANGE_LOG#L108) is actually included in `numba=0.46`. 

This creates a situation where we need `numba=0.45.1` to fix `numba`->`cupy` array creation, but we need `numba=0.46` for ucx to work and hence an impasse. One solution would be to check for the offending case in our codebase and correct it, but this proves tricky since the `__cuda_array_interface__` is an immutable property. The solution in this PR aims to create a temporary object that walks and talks like a `numba` array and inherits its properties by reference, but corrects its own interface when asked. In particular, it checks if `strides==None` and simply pops the key out if true. This ends up turning the situation into the equivalent case that `cupy=6.3.0` is expecting, which will detect that they key does not exist and set it to `None` anyways, without iterating through the troublesome loop that causes the error. 

