### PR TITLE
[REVIEW] Fix is_sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - PR #3236 Fix Numba 0.46+/CuPy 6.3 interface compatibility
 - PR #3256 Fix orc writer crash with multiple string columns
 - PR #3211 Fix breaking change caused by rapidsai/rmm#167
+- PR #3265 Fix dangling pointer in `is_sorted`
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/cpp/src/predicates/is_sorted.cu
+++ b/cpp/src/predicates/is_sorted.cu
@@ -31,9 +31,8 @@ bool is_sorted(cudf::table const& table,
 {
   cudaStream_t stream = 0;
   bool sorted = false;
-  auto ord_vect_size = descending.size();
 
-  if (ord_vect_size != 0)
+  if (not descending.empty())
   {
       CUDF_EXPECTS(static_cast <unsigned int>(table.num_columns()) == descending.size(), "Number of columns in the table doesn't match the vector descending's size .\n");
   }
@@ -48,18 +47,22 @@ bool is_sorted(cudf::table const& table,
   bool const nullable = cudf::has_nulls(table);
 
   cudf::size_type nrows = table.num_rows();
+
+  rmm::device_vector<int8_t> d_order(descending);
  
   if (nullable)
-  { 
-      auto ineq_op = row_inequality_comparator<true>(*device_input_table, nulls_are_smallest, 
-                                                        (ord_vect_size != 0)? (rmm::device_vector<int8_t> (descending)).data().get() : nullptr);
-      sorted = thrust::is_sorted (exec, thrust::make_counting_iterator(0), thrust::make_counting_iterator(nrows), ineq_op);
+  {
+    auto ineq_op = row_inequality_comparator<true>(
+        *device_input_table, nulls_are_smallest, d_order.data().get());
+    sorted = thrust::is_sorted(exec, thrust::make_counting_iterator(0),
+                               thrust::make_counting_iterator(nrows), ineq_op);
   }
   else
   {
-      auto ineq_op = row_inequality_comparator<false>(*device_input_table, nulls_are_smallest, 
-                                                        (ord_vect_size != 0)? (rmm::device_vector<int8_t> (descending)).data().get() : nullptr);
-      sorted = thrust::is_sorted (exec, thrust::make_counting_iterator(0), thrust::make_counting_iterator(nrows), ineq_op);
+    auto ineq_op = row_inequality_comparator<false>(
+        *device_input_table, nulls_are_smallest, d_order.data().get());
+    sorted = thrust::is_sorted(exec, thrust::make_counting_iterator(0),
+                               thrust::make_counting_iterator(nrows), ineq_op);
   }
 
   return sorted;


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/3221

The old `is_sorted` was constructing a temporary `device_vector` when constructing the `row_inequality_comparator`. This ends up getting free'd as soon as the constructor exits, which leaves the comparator object with a dangling pointer. 