### PR TITLE
Fix is_sorted, again. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 - PR #3211 Fix breaking change caused by rapidsai/rmm#167
 - PR #3265 Fix dangling pointer in `is_sorted`
 - PR #3267 ORC writer: fix incorrect ByteRLE encoding of long literal runs
+- PR #3277 Fix invalid reference to deleted temporary in `is_sorted`.
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/cpp/src/predicates/legacy/is_sorted.cu
+++ b/cpp/src/predicates/legacy/is_sorted.cu
@@ -42,7 +42,7 @@ bool is_sorted(cudf::table const& table,
       return true;
   }
 
-  auto exec = rmm::exec_policy(stream)->on(stream);
+  auto exec = rmm::exec_policy(stream);
   auto device_input_table = device_table::create(table);
   bool const nullable = cudf::has_nulls(table);
 
@@ -54,14 +54,14 @@ bool is_sorted(cudf::table const& table,
   {
     auto ineq_op = row_inequality_comparator<true>(
         *device_input_table, nulls_are_smallest, d_order.data().get());
-    sorted = thrust::is_sorted(exec, thrust::make_counting_iterator(0),
+    sorted = thrust::is_sorted(exec->on(stream), thrust::make_counting_iterator(0),
                                thrust::make_counting_iterator(nrows), ineq_op);
   }
   else
   {
     auto ineq_op = row_inequality_comparator<false>(
         *device_input_table, nulls_are_smallest, d_order.data().get());
-    sorted = thrust::is_sorted(exec, thrust::make_counting_iterator(0),
+    sorted = thrust::is_sorted(exec->on(stream), thrust::make_counting_iterator(0),
                                thrust::make_counting_iterator(nrows), ineq_op);
   }
 


### PR DESCRIPTION
Another case of using a temporary that is immediately deleted and leaves `exec` with a reference to a destroyed object.

```
auto exec = rmm::exec_policy(stream)->on(stream);
```

`rmm::exec_policy(stream)` returns a `unique_ptr` to a Thrust execution policy object. Invoking `->on(stream)` returns another execution policy to run on a stream.

The problem is that when `rmm::exec_policy(stream)->on(stream)` returns, the `unique_ptr` is destroyed and `exec` references a deleted object. 
