### PR TITLE
Fix shutdown hang issues with pinned memory pool init executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@
 - PR #3211 Fix breaking change caused by rapidsai/rmm#167
 - PR #3265 Fix dangling pointer in `is_sorted`
 - PR #3267 ORC writer: fix incorrect ByteRLE encoding of long literal runs
+- PR #3279 Fix shutdown hang issues with pinned memory pool init executor
+
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
+++ b/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
@@ -29,6 +29,7 @@ import java.util.PriorityQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * This provides a pool of pinned memory similar to what RMM does for device memory.
@@ -153,7 +154,11 @@ public final class PinnedMemoryPool implements AutoCloseable {
     if (isInitialized()) {
       throw new IllegalStateException("Can only initialize the pool once.");
     }
-    ExecutorService initService = Executors.newSingleThreadExecutor();
+    ExecutorService initService = Executors.newSingleThreadExecutor(runnable -> {
+      Thread t = new Thread(runnable, "pinned pool init");
+      t.setDaemon(true);
+      return t;
+    });
     initFuture = initService.submit(() -> new PinnedMemoryPool(poolSize));
     initService.shutdown();
   }


### PR DESCRIPTION
`PinnedMemoryPool` uses a single-thread executor to allocate the pinned memory pool in the background on startup.  This background thread is created as a non-daemon thread.  If the executor is never shutdown properly before the application's main thread exits, the application will hang due to the lingering non-daemon worker thread.

This updates the pinned pool initialization to immediately shutdown the executor after the initializtaion task is submitted and also use daemon threads.
