### PR TITLE
[REVIEW] Invalid children check in mutable_column_device_view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - PR #3265 Fix dangling pointer in `is_sorted`
 - PR #3267 ORC writer: fix incorrect ByteRLE encoding of long literal runs
 - PR #3274 ORC writer: fix integer RLEv2 mode2 unsigned base value encoding
+- PR #3280 Invalid children check in mutable_column_device_view
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/cpp/src/column/column_device_view.cu
+++ b/cpp/src/column/column_device_view.cu
@@ -111,7 +111,7 @@ mutable_column_device_view::mutable_column_device_view( mutable_column_view sour
                                       source.null_count(), source.offset()}
 {
   // TODO children may not be actually possible for mutable columns
-  CUDF_EXPECTS(source.num_children()>0, "Mutable columns with children are not currently supported.");
+  CUDF_EXPECTS(source.num_children()==0, "Mutable columns with children are not currently supported.");
 }
 
 mutable_column_device_view::mutable_column_device_view( mutable_column_view source, ptrdiff_t h_ptr, ptrdiff_t d_ptr )
@@ -120,7 +120,7 @@ mutable_column_device_view::mutable_column_device_view( mutable_column_view sour
                                       source.null_count(), source.offset()}
 {
   // TODO children may not be actually possible for mutable columns
-  CUDF_EXPECTS(source.num_children()>0, "Mutable columns with children are not currently supported.");
+  CUDF_EXPECTS(source.num_children()==0, "Mutable columns with children are not currently supported.");
 }
 
 // Handle freeing children
@@ -133,7 +133,7 @@ void mutable_column_device_view::destroy() {
 std::unique_ptr<mutable_column_device_view, std::function<void(mutable_column_device_view*)>>
   mutable_column_device_view::create(mutable_column_view source, cudaStream_t stream) {
   // TODO children may not be actually possible for mutable columns
-  CUDF_EXPECTS(source.num_children()>0, "Mutable columns with children are not currently supported.");
+  CUDF_EXPECTS(source.num_children()==0, "Mutable columns with children are not currently supported.");
   auto deleter = [](mutable_column_device_view* v) { v->destroy(); };
   std::unique_ptr<mutable_column_device_view, decltype(deleter)> p{
       new mutable_column_device_view(source), deleter};


### PR DESCRIPTION
Children are not supported for mutable_column_device_view. The CUDF_EXPECTS check for this was incorrect and fixed by this PR.