### PR TITLE
Add num_bitmask_words 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - PR #3261 Small cleanup: remove `== true`
 - PR #3239 Adding floating point specialization to comparators for NaNs
 - PR #3270 Move predicates files to legacy
+- PR #3282 Add `num_bitmask_words`
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <cudf/types.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/types.hpp>
 
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device_memory_resource.hpp>
@@ -47,6 +47,21 @@ size_type state_null_count(mask_state state, size_type size);
  *---------------------------------------------------------------------------**/
 std::size_t bitmask_allocation_size_bytes(size_type number_of_bits,
                                           std::size_t padding_boundary = 64);
+
+/**
+ * @brief Returns the number of `bitmask_type` words required to represent the
+ * specified number of bits.
+ *
+ * Unlike `bitmask_allocation_size_bytes`, which returns the number of *bytes*
+ * needed for a bitmask allocation (including padding), this function returns
+ * the *actual* number `bitmask_type` elements necessary to represent
+ * `number_of_bits`. This is useful when one wishes to process all of the bits
+ * in a bitmask and ignore the padding/slack bits.
+ *
+ * @param number_of_bits The number of bits that need to be represented
+ * @return size_type The necessary number of `bitmask_type` elements
+ */
+size_type num_bitmask_words(size_type number_of_bits);
 
 /**---------------------------------------------------------------------------*
  * @brief Creates a `device_buffer` for use as a null value indicator bitmask of
@@ -118,7 +133,7 @@ cudf::size_type count_unset_bits(bitmask_type const* bitmask, size_type start,
  * `[begin_bit, end_bit)` from `mask`.
  *---------------------------------------------------------------------------**/
 rmm::device_buffer copy_bitmask(
-    bitmask_type const * mask, size_type begin_bit, size_type end_bit,
+    bitmask_type const* mask, size_type begin_bit, size_type end_bit,
     cudaStream_t stream = 0,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
@@ -142,6 +157,6 @@ rmm::device_buffer copy_bitmask(
  * `[view.offset(), view.offset() + view.size())` from `view`'s bitmask.
  *---------------------------------------------------------------------------**/
 rmm::device_buffer copy_bitmask(column_view const& view, cudaStream_t stream,
-               rmm::mr::device_memory_resource *mr);
+                                rmm::mr::device_memory_resource* mr);
 
 }  // namespace cudf

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -16,12 +16,12 @@
 
 #include <cudf/null_mask.hpp>
 #include <cudf/utilities/bit.cuh>
-#include <utilities/cuda_utils.hpp>
 #include <cudf/utilities/error.hpp>
+#include <utilities/cuda_utils.hpp>
 #include <utilities/integer_utils.hpp>
 
-#include <thrust/device_ptr.h>
 #include <thrust/copy.h>
+#include <thrust/device_ptr.h>
 #include <thrust/extrema.h>
 #include <cub/cub.cuh>
 #include <rmm/device_buffer.hpp>
@@ -56,6 +56,12 @@ std::size_t bitmask_allocation_size_bytes(size_type number_of_bits,
       padding_boundary * cudf::util::div_rounding_up_safe<size_type>(
                              necessary_bytes, padding_boundary);
   return padded_bytes;
+}
+
+// Computes number of *actual* bitmask_type elements needed
+size_type num_bitmask_words(size_type number_of_bits) {
+  return cudf::util::div_rounding_up_safe<size_type>(
+      number_of_bits, detail::size_in_bits<bitmask_type>());
 }
 
 // Create a device_buffer for a null mask
@@ -155,12 +161,14 @@ __global__ void count_set_bits_kernel(bitmask_type const *bitmask,
  * @param number_of_mask_words The number of words of type bitmask_type to copy
  *---------------------------------------------------------------------------**/
 __global__ void copy_offset_bitmask(bitmask_type *__restrict__ destination,
-                                     bitmask_type const *__restrict__ source,
-                                     size_type bit_offset,
-                                     size_type number_of_mask_words) {
+                                    bitmask_type const *__restrict__ source,
+                                    size_type bit_offset,
+                                    size_type number_of_mask_words) {
   for (size_type destination_word_index = threadIdx.x + blockIdx.x * blockDim.x;
-      destination_word_index < number_of_mask_words; destination_word_index += blockDim.x*gridDim.x) {
-    size_type source_word_index = destination_word_index + word_index(bit_offset);
+       destination_word_index < number_of_mask_words;
+       destination_word_index += blockDim.x * gridDim.x) {
+    size_type source_word_index =
+        destination_word_index + word_index(bit_offset);
     bitmask_type curr_word = source[source_word_index];
     bitmask_type next_word = 0;
     if (destination_word_index + 1 < number_of_mask_words) {
@@ -228,41 +236,41 @@ cudf::size_type count_unset_bits(bitmask_type const *bitmask, size_type start,
 }
 
 // Create a bitmask from a specific range
-rmm::device_buffer copy_bitmask(
-    bitmask_type const * mask, size_type begin_bit, size_type end_bit,
-    cudaStream_t stream, rmm::mr::device_memory_resource *mr) {
+rmm::device_buffer copy_bitmask(bitmask_type const *mask, size_type begin_bit,
+                                size_type end_bit, cudaStream_t stream,
+                                rmm::mr::device_memory_resource *mr) {
   CUDF_EXPECTS(begin_bit >= 0, "Invalid range.");
   CUDF_EXPECTS(begin_bit <= end_bit, "Invalid bit range.");
   rmm::device_buffer dest_mask{};
   auto num_bytes = bitmask_allocation_size_bytes(end_bit - begin_bit);
-  if ((mask == nullptr) || (num_bytes == 0)) { return dest_mask; }
+  if ((mask == nullptr) || (num_bytes == 0)) {
+    return dest_mask;
+  }
   if (begin_bit == 0) {
-    dest_mask = rmm::device_buffer{static_cast<void const *>(mask),
-      num_bytes, stream, mr};
+    dest_mask = rmm::device_buffer{static_cast<void const *>(mask), num_bytes,
+                                   stream, mr};
   } else {
     auto number_of_mask_words = cudf::util::div_rounding_up_safe(
-        static_cast<size_t>(end_bit - begin_bit), detail::size_in_bits<bitmask_type>());
+        static_cast<size_t>(end_bit - begin_bit),
+        detail::size_in_bits<bitmask_type>());
     dest_mask = rmm::device_buffer{num_bytes, stream, mr};
     cudf::util::cuda::grid_config_1d config(number_of_mask_words, 256);
     copy_offset_bitmask<<<config.num_blocks, config.num_threads_per_block, 0,
-                 stream>>>(
-    static_cast<bitmask_type *>(dest_mask.data()), mask,
-    begin_bit, number_of_mask_words);
+                          stream>>>(
+        static_cast<bitmask_type *>(dest_mask.data()), mask, begin_bit,
+        number_of_mask_words);
     CUDA_CHECK_LAST()
   }
   return dest_mask;
 }
 
 // Create a bitmask from a specific range
-rmm::device_buffer copy_bitmask(column_view const& view, cudaStream_t stream,
-               rmm::mr::device_memory_resource *mr) {
+rmm::device_buffer copy_bitmask(column_view const &view, cudaStream_t stream,
+                                rmm::mr::device_memory_resource *mr) {
   rmm::device_buffer null_mask{};
   if (view.nullable()) {
-    null_mask = copy_bitmask(
-          view.null_mask(),
-          view.offset(),
-          view.offset() + view.size(),
-          stream, mr);
+    null_mask = copy_bitmask(view.null_mask(), view.offset(),
+                             view.offset() + view.size(), stream, mr);
   }
   return null_mask;
 }

--- a/cpp/tests/bitmask/bitmask_tests.cu
+++ b/cpp/tests/bitmask/bitmask_tests.cu
@@ -15,15 +15,46 @@
  */
 #include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
-#include <tests/utilities/base_fixture.hpp>
-#include <tests/utilities/cudf_gtest.hpp>
 #include <cudf/utilities/error.hpp>
-#include <tests/utilities/column_wrapper.hpp>
+#include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/column_utilities.hpp>
+#include <tests/utilities/column_wrapper.hpp>
+#include <tests/utilities/cudf_gtest.hpp>
 
 #include <gmock/gmock.h>
 
 #include <thrust/device_vector.h>
+
+struct BitmaskUtilitiesTest : public cudf::test::BaseFixture {};
+
+TEST_F(BitmaskUtilitiesTest, StateNullCount) {
+  EXPECT_EQ(0, cudf::state_null_count(cudf::mask_state::UNALLOCATED, 42));
+  EXPECT_EQ(cudf::UNKNOWN_NULL_COUNT,
+            cudf::state_null_count(cudf::mask_state::UNINITIALIZED, 42));
+  EXPECT_EQ(42, cudf::state_null_count(cudf::mask_state::ALL_NULL, 42));
+  EXPECT_EQ(0, cudf::state_null_count(cudf::mask_state::ALL_VALID, 42));
+}
+
+TEST_F(BitmaskUtilitiesTest, BitmaskAllocationSize) {
+  EXPECT_EQ(0u, cudf::bitmask_allocation_size_bytes(0));
+  EXPECT_EQ(64u, cudf::bitmask_allocation_size_bytes(1));
+  EXPECT_EQ(64u, cudf::bitmask_allocation_size_bytes(512));
+  EXPECT_EQ(128u, cudf::bitmask_allocation_size_bytes(513));
+  EXPECT_EQ(128u, cudf::bitmask_allocation_size_bytes(1023));
+  EXPECT_EQ(128u, cudf::bitmask_allocation_size_bytes(1024));
+  EXPECT_EQ(192u, cudf::bitmask_allocation_size_bytes(1025));
+}
+
+TEST_F(BitmaskUtilitiesTest, NumBitmaskWords) {
+  EXPECT_EQ(0, cudf::num_bitmask_words(0));
+  EXPECT_EQ(1, cudf::num_bitmask_words(1));
+  EXPECT_EQ(1, cudf::num_bitmask_words(31));
+  EXPECT_EQ(1, cudf::num_bitmask_words(32));
+  EXPECT_EQ(2, cudf::num_bitmask_words(33));
+  EXPECT_EQ(2, cudf::num_bitmask_words(63));
+  EXPECT_EQ(2, cudf::num_bitmask_words(64));
+  EXPECT_EQ(3, cudf::num_bitmask_words(65));
+}
 
 struct CountBitmaskTest : public cudf::test::BaseFixture {};
 
@@ -174,21 +205,21 @@ TEST_F(CountUnsetBitsTest, MultipleWordsSingleBit) {
   EXPECT_EQ(1, cudf::count_unset_bits(mask.data().get(), 67, 68));
 }
 
-struct CopyBitmaskTest
-    : public cudf::test::BaseFixture,
-      cudf::test::UniformRandomGenerator<int> {
-  CopyBitmaskTest()
-      : cudf::test::UniformRandomGenerator<int>{0, 1} {}
+struct CopyBitmaskTest : public cudf::test::BaseFixture,
+                         cudf::test::UniformRandomGenerator<int> {
+  CopyBitmaskTest() : cudf::test::UniformRandomGenerator<int>{0, 1} {}
 };
 
-void cleanEndWord(rmm::device_buffer& mask, int begin_bit, int end_bit) {
-  thrust::device_ptr<cudf::bitmask_type> ptr(static_cast<cudf::bitmask_type*>(mask.data()));
+void cleanEndWord(rmm::device_buffer &mask, int begin_bit, int end_bit) {
+  thrust::device_ptr<cudf::bitmask_type> ptr(
+      static_cast<cudf::bitmask_type *>(mask.data()));
   auto number_of_mask_words = cudf::util::div_rounding_up_safe(
-      static_cast<size_t>(end_bit - begin_bit), cudf::detail::size_in_bits<cudf::bitmask_type>());
+      static_cast<size_t>(end_bit - begin_bit),
+      cudf::detail::size_in_bits<cudf::bitmask_type>());
   auto number_of_bits = end_bit - begin_bit;
   if (number_of_bits % 32 != 0) {
-    auto end_mask = ptr[number_of_mask_words-1];
-    end_mask = end_mask & ((1<<(number_of_bits%32)) - 1);
+    auto end_mask = ptr[number_of_mask_words - 1];
+    end_mask = end_mask & ((1 << (number_of_bits % 32)) - 1);
   }
 }
 
@@ -217,44 +248,46 @@ TEST_F(CopyBitmaskTest, NullPtr) {
 
 TEST_F(CopyBitmaskTest, TestZeroOffset) {
   thrust::host_vector<int> validity_bit(1000);
-  for (auto &m : validity_bit) { m = this->generate(); }
-  auto input_mask = cudf::test::detail::make_null_mask(
-      validity_bit.begin(),
-      validity_bit.end());
+  for (auto &m : validity_bit) {
+    m = this->generate();
+  }
+  auto input_mask = cudf::test::detail::make_null_mask(validity_bit.begin(),
+                                                       validity_bit.end());
 
   int begin_bit = 0;
   int end_bit = 800;
   auto gold_splice_mask = cudf::test::detail::make_null_mask(
-      validity_bit.begin() + begin_bit,
-      validity_bit.begin() + end_bit);
+      validity_bit.begin() + begin_bit, validity_bit.begin() + end_bit);
 
   auto splice_mask = cudf::copy_bitmask(
-      static_cast<const cudf::bitmask_type*>(input_mask.data()),
-      begin_bit, end_bit);
+      static_cast<const cudf::bitmask_type *>(input_mask.data()), begin_bit,
+      end_bit);
 
   cleanEndWord(splice_mask, begin_bit, end_bit);
   auto number_of_bits = end_bit - begin_bit;
-  cudf::test::expect_equal_buffers(gold_splice_mask.data(), splice_mask.data(), number_of_bits/CHAR_BIT);
+  cudf::test::expect_equal_buffers(gold_splice_mask.data(), splice_mask.data(),
+                                   number_of_bits / CHAR_BIT);
 }
 
 TEST_F(CopyBitmaskTest, TestNonZeroOffset) {
   thrust::host_vector<int> validity_bit(1000);
-  for (auto &m : validity_bit) { m = this->generate(); }
-  auto input_mask = cudf::test::detail::make_null_mask(
-      validity_bit.begin(),
-      validity_bit.end());
+  for (auto &m : validity_bit) {
+    m = this->generate();
+  }
+  auto input_mask = cudf::test::detail::make_null_mask(validity_bit.begin(),
+                                                       validity_bit.end());
 
   int begin_bit = 321;
   int end_bit = 998;
   auto gold_splice_mask = cudf::test::detail::make_null_mask(
-      validity_bit.begin() + begin_bit,
-      validity_bit.begin() + end_bit);
+      validity_bit.begin() + begin_bit, validity_bit.begin() + end_bit);
 
   auto splice_mask = cudf::copy_bitmask(
-      static_cast<const cudf::bitmask_type*>(input_mask.data()),
-      begin_bit, end_bit);
+      static_cast<const cudf::bitmask_type *>(input_mask.data()), begin_bit,
+      end_bit);
 
   cleanEndWord(splice_mask, begin_bit, end_bit);
   auto number_of_bits = end_bit - begin_bit;
-  cudf::test::expect_equal_buffers(gold_splice_mask.data(), splice_mask.data(), number_of_bits/CHAR_BIT);
+  cudf::test::expect_equal_buffers(gold_splice_mask.data(), splice_mask.data(),
+                                   number_of_bits / CHAR_BIT);
 }


### PR DESCRIPTION
Adds utility function to get the number of bitmask words necessary to represent `n` bits. 

Adds some tests for other bitmask utilities as well. 