### PR TITLE
[REVIEW] Upgrade arrow-cpp and pyarrow to v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - PR #3288 Make `bit.cuh` utilities usable from host code.
 - PR #3287 Move rolling windows files to legacy
 - PR #3182 Define and implement new unary APIs `is_null` and `is_not_null`
+- PR #3294 Update to arrow-cpp and pyarrow 0.15.1
 
 ## Bug Fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,7 +322,7 @@ flag. Below is a list of the available arguments and their purpose:
 | `NUMBA_VERSION` | newest | >=0.40.0 | set numba version |
 | `NUMPY_VERSION` | newest | >=1.14.3 | set numpy version |
 | `PANDAS_VERSION` | newest | >=0.23.4 | set pandas version |
-| `PYARROW_VERSION` | 0.15.0 | Not supported | set pyarrow version |
+| `PYARROW_VERSION` | 0.15.1 | Not supported | set pyarrow version |
 | `CMAKE_VERSION` | newest | >=3.12 | set cmake version |
 | `CYTHON_VERSION` | 0.29 | Not supported | set Cython version |
 | `PYTHON_VERSION` | 3.6 | 3.7 | set python version |

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -45,7 +45,7 @@ source activate gdf
 conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
               "dask>=2.1.0" "distributed>=2.1.0" "numpy>=1.16" "double-conversion" \
               "rapidjson" "flatbuffers" "boost-cpp" "fsspec>=0.3.3" "dlpack" \
-              "feather-format" "cupy>=6.0.0" "arrow-cpp=0.15.0" "pyarrow=0.15.0" \
+              "feather-format" "cupy>=6.0.0" "arrow-cpp=0.15.1" "pyarrow=0.15.1" \
               "fastavro>=0.22.0" "pandas>=0.24.2,<0.25" "hypothesis" "s3fs" "gcsfs" \
               "boto3" "moto" "httpretty" "streamz"
 

--- a/conda/environments/cudf_dev_cuda10.0.yml
+++ b/conda/environments/cudf_dev_cuda10.0.yml
@@ -13,7 +13,7 @@ dependencies:
   - python>=3.6,<3.8
   - numba>=0.45.1
   - pandas>=0.24.2,<0.25
-  - pyarrow=0.15.0
+  - pyarrow=0.15.1
   - fastavro>=0.22.0
   - notebook>=0.5.0
   - cython>=0.29,<0.30
@@ -38,7 +38,7 @@ dependencies:
   - distributed>=2.1.0
   - streamz
   - dlpack
-  - arrow-cpp=0.15.0
+  - arrow-cpp=0.15.1
   - boost-cpp
   - double-conversion
   - rapidjson

--- a/conda/environments/cudf_dev_cuda10.1.yml
+++ b/conda/environments/cudf_dev_cuda10.1.yml
@@ -13,7 +13,7 @@ dependencies:
   - python>=3.6,<3.8
   - numba>=0.45.1
   - pandas>=0.24.2,<0.25
-  - pyarrow=0.15.0
+  - pyarrow=0.15.1
   - fastavro>=0.22.0
   - notebook>=0.5.0
   - cython>=0.29,<0.30
@@ -38,7 +38,7 @@ dependencies:
   - distributed>=2.1.0
   - streamz
   - dlpack
-  - arrow-cpp=0.15.0
+  - arrow-cpp=0.15.1
   - boost-cpp
   - double-conversion
   - rapidjson

--- a/conda/environments/cudf_dev_cuda9.2.yml
+++ b/conda/environments/cudf_dev_cuda9.2.yml
@@ -13,7 +13,7 @@ dependencies:
   - python>=3.6,<3.8
   - numba>=0.45.1
   - pandas>=0.24.2,<0.25
-  - pyarrow=0.15.0
+  - pyarrow=0.15.1
   - fastavro>=0.22.0
   - notebook>=0.5.0
   - cython>=0.29,<0.30
@@ -38,7 +38,7 @@ dependencies:
   - distributed>=2.1.0
   - streamz
   - dlpack
-  - arrow-cpp=0.15.0
+  - arrow-cpp=0.15.1
   - boost-cpp
   - double-conversion
   - rapidjson

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -25,13 +25,13 @@ requirements:
     - setuptools
     - numba >=0.45.1
     - dlpack
-    - pyarrow 0.15.0.*
+    - pyarrow 0.15.1.*
     - libcudf {{ version }}
   run:
     - python
     - pandas>=0.24.2,<0.25
     - numba >=0.45.1
-    - pyarrow 0.15.0.*
+    - pyarrow 0.15.1.*
     - fastavro >=0.22.0
     - rmm {{ minor_version }}.*
     - nvstrings {{ minor_version }}.*

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - librmm {{ minor_version }}.*
     - libnvstrings {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
-    - arrow-cpp 0.15.0.*
+    - arrow-cpp 0.15.1.*
     - double-conversion
     - rapidjson
     - flatbuffers
@@ -39,7 +39,7 @@ requirements:
     - dlpack
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - arrow-cpp 0.15.0.*
+    - arrow-cpp 0.15.1.*
     - dlpack
 
 test:

--- a/conda/recipes/libnvstrings/meta.yaml
+++ b/conda/recipes/libnvstrings/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   host:
     - librmm {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
-    - arrow-cpp 0.15.0.*
+    - arrow-cpp 0.15.1.*
     - double-conversion
     - rapidjson
     - flatbuffers

--- a/cpp/cmake/Templates/Arrow.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/Arrow.CMakeLists.txt.cmake
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(Arrow
                     GIT_REPOSITORY    https://github.com/apache/arrow.git
-                    GIT_TAG           apache-arrow-0.15.0
+                    GIT_TAG           apache-arrow-0.15.1
                     SOURCE_DIR        "${ARROW_ROOT}/arrow"
                     SOURCE_SUBDIR     "cpp"
                     BINARY_DIR        "${ARROW_ROOT}/build"


### PR DESCRIPTION
Upgrades Arrow to v0.15.1 to eliminate nvcc compiler warnings.