### PR TITLE
[REVIEW] Fix storing invalid RMM exec policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 - PR #3279 Fix shutdown hang issues with pinned memory pool init executor
 - PR #3280 Invalid children check in mutable_column_device_view
 - PR #3293 Fix loading of csv files zipped on MacOS (disabled zip min version check)
+- PR #3295 Fix storing storing invalid RMM exec policies.
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/cpp/include/cudf/detail/unary.hpp
+++ b/cpp/include/cudf/detail/unary.hpp
@@ -48,9 +48,8 @@ std::unique_ptr<column> true_if(InputIterator begin, InputIterator end,
     auto output = make_numeric_column(data_type(BOOL8), size, UNALLOCATED, stream, mr);
     auto output_mutable_view = output->mutable_view();
     auto output_data = output_mutable_view.data<cudf::experimental::bool8>();
-    auto exec = rmm::exec_policy(stream)->on(stream);
 
-    thrust::transform(exec, begin, end, output_data, p);
+    thrust::transform(rmm::exec_policy(stream)->on(stream), begin, end, output_data, p);
 
     return output;
 }

--- a/cpp/src/filling/legacy/repeat.cu
+++ b/cpp/src/filling/legacy/repeat.cu
@@ -44,16 +44,15 @@ cudf::table repeat(const cudf::table &in, const gdf_column& count, cudaStream_t 
     return cudf::empty_like(in);
   }
   
-  auto exec_policy = rmm::exec_policy(stream)->on(stream);
   rmm::device_vector<cudf::size_type> offset(count.size);
   auto count_data = static_cast <cudf::size_type*> (count.data);
   
-  thrust::inclusive_scan(exec_policy, count_data, count_data + count.size, offset.begin());
+  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream), count_data, count_data + count.size, offset.begin());
 
   cudf::size_type output_size = offset.back();
 
   rmm::device_vector<cudf::size_type> indices(output_size);
-  thrust::upper_bound(exec_policy,
+  thrust::upper_bound(rmm::exec_policy(stream)->on(stream),
                       offset.begin(), offset.end(),
                       thrust::make_counting_iterator(0),
                       thrust::make_counting_iterator(output_size),

--- a/cpp/src/filling/legacy/tile.cu
+++ b/cpp/src/filling/legacy/tile.cu
@@ -42,7 +42,6 @@ cudf::table tile(const cudf::table &in, gdf_size_type count,
     return cudf::empty_like(in);
   }
   
-  auto exec = rmm::exec_policy(stream)->on(stream);
 
   gdf_size_type out_num_rows = count * num_rows;
 
@@ -53,7 +52,7 @@ cudf::table tile(const cudf::table &in, gdf_size_type count,
 
   // make gather map
   rmm::device_vector<gdf_size_type> gather_map(out_num_rows);
-  thrust::copy(exec, tiled_it, tiled_it + out_num_rows, gather_map.begin());
+  thrust::copy(rmm::exec_policy(stream)->on(stream), tiled_it, tiled_it + out_num_rows, gather_map.begin());
 
   // Allocate `output` with out_num_rows elements
   cudf::table output = cudf::allocate_like(in, out_num_rows);

--- a/cpp/src/groupby/legacy/groupby_without_aggregation.cu
+++ b/cpp/src/groupby/legacy/groupby_without_aggregation.cu
@@ -39,7 +39,6 @@ gdf_column gdf_unique_indices(cudf::table const& input_table,
   cudf::size_type* result_end;
   cudaStream_t stream;
   cudaStreamCreate(&stream);
-  auto exec = rmm::exec_policy(stream)->on(stream);
 
   // Allocating memory for GDF column
   gdf_column unique_indices{};
@@ -52,13 +51,13 @@ gdf_column gdf_unique_indices(cudf::table const& input_table,
   bool nullable = device_input_table.get()->has_nulls();
   if (nullable) {
     auto comp = row_equality_comparator<true>(*device_input_table, true);
-    result_end = thrust::unique_copy(
-        exec, counting_iter, counting_iter + nrows,
+    result_end = thrust::unique_copy(rmm::exec_policy(stream)->on(stream),
+        counting_iter, counting_iter + nrows,
         static_cast<cudf::size_type*>(unique_indices.data), comp);
   } else {
     auto comp = row_equality_comparator<false>(*device_input_table, true);
-    result_end = thrust::unique_copy(
-        exec, counting_iter, counting_iter + nrows,
+    result_end = thrust::unique_copy(rmm::exec_policy(stream)->on(stream),
+         counting_iter, counting_iter + nrows,
         static_cast<cudf::size_type*>(unique_indices.data), comp);
   }
 

--- a/cpp/src/unary/legacy/null_ops.cu
+++ b/cpp/src/unary/legacy/null_ops.cu
@@ -37,9 +37,8 @@ gdf_column null_op(gdf_column const& input, bool nulls_are_false = true, cudaStr
 	cudf::fill(&output, value, 0, output.size);
     } else {
         const bit_mask_t* __restrict__ typed_input_valid = reinterpret_cast<bit_mask_t*>(input.valid);
-        auto exec = rmm::exec_policy(stream)->on(stream);
 
-        thrust::transform(exec,
+        thrust::transform(rmm::exec_policy(stream)->on(stream),
                           thrust::make_counting_iterator(static_cast<gdf_size_type>(0)),
                           thrust::make_counting_iterator(static_cast<gdf_size_type>(input.size)),
                           static_cast<bool*>(output.data),


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/2636
Statements like this are a bug:
`auto exec = rmm::exec_policy(stream)->on(stream);`
This is because you'll be left with a reference to an invalid object.
Instead:
```
thrust::sort(rmm::exec_policy(stream)->on(stream), ...);
// or
auto exec = rmm::exec_policy(stream);
thrust::sort(exec->on(stream), ...);
```
The reason is `rmm::exec_policy(stream)` returns a unique_ptr to a Thrust execution policy object. Invoking `->on(stream)` returns another execution policy to run on a stream.
The problem is that when `rmm::exec_policy(stream)->on(stream)` returns, the unique_ptr is destroyed and exec references a deleted object. 

This PR fixes a number of latent, silent errors in libcudf. 