### PR TITLE
[REVIEW] Remove zero-size exception from strings factory functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@
 - PR #3318 Revert arrow to 0.15.0 temporarily to unblock downstream projects CI
 - PR #3317 Fix index-argument bug in dask_cudf parquet reader
 - PR #3323 Fix `insert` non-assert test case
-
+- PR #3334 Remove zero-size exception check from make_strings_column factories
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -38,8 +38,8 @@ std::unique_ptr<column> make_strings_column(
     rmm::mr::device_memory_resource* mr)
 {
     size_type strings_count = strings.size();
-    // maybe a separate factory for creating null strings-column
-    CUDF_EXPECTS(strings_count > 0, "must specify at least one pair");
+    if( strings_count==0 )
+        return strings::detail::make_empty_strings_column(mr,stream);
 
     auto execpol = rmm::exec_policy(stream);
     auto d_strings = strings.data().get();
@@ -100,7 +100,9 @@ std::unique_ptr<column> make_strings_column(
     rmm::mr::device_memory_resource* mr )
 {
     size_type num_strings = offsets.size()-1;
-    CUDF_EXPECTS( num_strings > 0, "strings count must be greater than 0");
+    if( num_strings==0 )
+        return strings::detail::make_empty_strings_column(mr,stream);
+
     CUDF_EXPECTS( null_count < num_strings, "null strings column not yet supported");
     if( null_count > 0 ) {
         CUDF_EXPECTS( !valid_mask.empty(), "Cannot have null elements without a null mask." );

--- a/cpp/tests/strings/factories_test.cu
+++ b/cpp/tests/strings/factories_test.cu
@@ -21,6 +21,7 @@
 #include <cudf/types.hpp>
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/column_utilities.hpp>
+#include "./utilities.h"
 
 #include <gmock/gmock.h>
 
@@ -160,4 +161,18 @@ TEST_F(StringsFactoriesTest, CreateScalar)
     auto string_s = static_cast<cudf::string_scalar*>(s.get());
 
     EXPECT_EQ(string_s->value(), value);
+}
+
+TEST_F(StringsFactoriesTest, EmptyStringsColumn)
+{
+    rmm::device_vector<char> d_chars;
+    rmm::device_vector<cudf::size_type> d_offsets(1,0);
+    rmm::device_vector<cudf::bitmask_type> d_nulls;
+
+    auto results = cudf::make_strings_column( d_chars, d_offsets, d_nulls, 0 );
+    cudf::test::expect_strings_empty(results->view());
+
+    rmm::device_vector<thrust::pair<const char*,cudf::size_type>> d_strings;
+    results = cudf::make_strings_column( d_strings );
+    cudf::test::expect_strings_empty(results->view());
 }


### PR DESCRIPTION
Strings column factory functions were throwing exceptions when given empty data. Zero data should return empty columns instead.
