### PR TITLE
Fix Java to pad validity buffers to 64-byte boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
 - PR #3323 Fix `insert` non-assert test case
 - PR #3334 Remove zero-size exception check from make_strings_column factories
 - PR #3333 Fix compilation issues with `constexpr` functions not marked `__device__`
+- PR #3337 Fix Java to pad validity buffers to 64-byte boundary
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/java/src/main/java/ai/rapids/cudf/BitVectorHelper.java
+++ b/java/src/main/java/ai/rapids/cudf/BitVectorHelper.java
@@ -79,14 +79,14 @@ final class BitVectorHelper {
   }
 
   /**
-   * This method returns the allocation size of the validity vector which is long aligned
-   * e.g. getValidityAllocationSizeInBytes(5) => 8 bytes
-   * getValidityAllocationSizeInBytes(14) => 8 bytes
-   * getValidityAllocationSizeInBytes(65) => 16 bytes
+   * This method returns the allocation size of the validity vector which is 64-byte aligned
+   * e.g. getValidityAllocationSizeInBytes(5) => 64 bytes
+   * getValidityAllocationSizeInBytes(14) => 64 bytes
+   * getValidityAllocationSizeInBytes(65) => 128 bytes
    */
   static long getValidityAllocationSizeInBytes(long rows) {
     long numBytes = getValidityLengthInBytes(rows);
-    return ((numBytes + 7) / 8) * 8;
+    return ((numBytes + 63) / 64) * 64;
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
+++ b/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
@@ -512,12 +512,12 @@ public class JCudfSerialization {
   /////////////////////////////////////////////
   // PADDING FOR ALIGNMENT
   /////////////////////////////////////////////
-  private static long padFor64bitAlignment(long orig) {
-    return ((orig + 7) / 8) * 8;
+  private static long padFor64byteAlignment(long orig) {
+    return ((orig + 63) / 64) * 64;
   }
 
-  private static long padFor64bitAlignment(DataWriter out, long bytes) throws IOException {
-    final long paddedBytes = padFor64bitAlignment(bytes);
+  private static long padFor64byteAlignment(DataWriter out, long bytes) throws IOException {
+    final long paddedBytes = padFor64byteAlignment(bytes);
     while (paddedBytes > bytes) {
       out.writeByte((byte)0);
       bytes++;
@@ -543,18 +543,18 @@ public class JCudfSerialization {
     for (ColumnBufferProvider column: columns) {
       DType type = column.getType();
       if (column.getNullCount() > 0) {
-        totalDataSize += padFor64bitAlignment(BitVectorHelper.getValidityLengthInBytes(numRows));
+        totalDataSize += padFor64byteAlignment(BitVectorHelper.getValidityLengthInBytes(numRows));
       }
       if (type == DType.STRING || type == DType.STRING_CATEGORY) {
         // offsets
-        totalDataSize += padFor64bitAlignment((numRows + 1) * 4);
+        totalDataSize += padFor64byteAlignment((numRows + 1) * 4);
 
         // data
         if (numRows > 0) {
-          totalDataSize += padFor64bitAlignment(getRawStringDataLength(column, rowOffset, numRows));
+          totalDataSize += padFor64byteAlignment(getRawStringDataLength(column, rowOffset, numRows));
         }
       } else {
-        totalDataSize += padFor64bitAlignment(column.getType().sizeInBytes * numRows);
+        totalDataSize += padFor64byteAlignment(column.getType().sizeInBytes * numRows);
       }
     }
     return totalDataSize;
@@ -567,11 +567,11 @@ public class JCudfSerialization {
     for (int col = 0; col < numColumns; col++) {
       DType type = types[col];
       if (nullCounts[col] > 0) {
-        totalDataSize += padFor64bitAlignment(BitVectorHelper.getValidityLengthInBytes(numRows));
+        totalDataSize += padFor64byteAlignment(BitVectorHelper.getValidityLengthInBytes(numRows));
       }
       if (type == DType.STRING || type == DType.STRING_CATEGORY) {
         // offsets
-        totalDataSize += padFor64bitAlignment((numRows + 1) * 4);
+        totalDataSize += padFor64byteAlignment((numRows + 1) * 4);
 
         long stringDataLen = 0;
         for (int batchNumber = 0; batchNumber < columnsForEachBatch.length; batchNumber++) {
@@ -579,9 +579,9 @@ public class JCudfSerialization {
           long numRowsInSubColumn = provider.getRowCount();
           stringDataLen += getRawStringDataLength(provider, 0, numRowsInSubColumn);
         }
-        totalDataSize += padFor64bitAlignment(stringDataLen);
+        totalDataSize += padFor64byteAlignment(stringDataLen);
       } else {
-        totalDataSize += padFor64bitAlignment(types[col].sizeInBytes * numRows);
+        totalDataSize += padFor64byteAlignment(types[col].sizeInBytes * numRows);
       }
     }
     return totalDataSize;
@@ -623,23 +623,23 @@ public class JCudfSerialization {
       long data;
       long dataLen;
       if (nullCount > 0) {
-        validityLen = padFor64bitAlignment(BitVectorHelper.getValidityLengthInBytes(numRows));
+        validityLen = padFor64byteAlignment(BitVectorHelper.getValidityLengthInBytes(numRows));
         validity = bufferOffset;
         bufferOffset += validityLen;
       }
 
       if (type == DType.STRING || type == DType.STRING_CATEGORY) {
-        offsetsLen = padFor64bitAlignment((numRows + 1) * 4);
+        offsetsLen = padFor64byteAlignment((numRows + 1) * 4);
         offsets = bufferOffset;
         int startStringOffset = buffer.getInt(bufferOffset);
         int endStringOffset = buffer.getInt(bufferOffset + (numRows * 4));
         bufferOffset += offsetsLen;
 
-        dataLen = padFor64bitAlignment(endStringOffset - startStringOffset);
+        dataLen = padFor64byteAlignment(endStringOffset - startStringOffset);
         data = bufferOffset;
         bufferOffset += dataLen;
       } else {
-        dataLen = padFor64bitAlignment(type.sizeInBytes * numRows);
+        dataLen = padFor64byteAlignment(type.sizeInBytes * numRows);
         data = bufferOffset;
         bufferOffset += dataLen;
       }
@@ -814,7 +814,7 @@ public class JCudfSerialization {
                                        long offset,
                                        long length) throws IOException {
     out.copyDataFrom(column, buffer, offset, length);
-    return padFor64bitAlignment(out, length);
+    return padFor64byteAlignment(out, length);
   }
 
   /////////////////////////////////////////////
@@ -938,7 +938,7 @@ public class JCudfSerialization {
         out.write(arrayBuffer, 0, (rowsStoredInArray + 7) / 8);
       }
     }
-    return padFor64bitAlignment(out, validityLen);
+    return padFor64byteAlignment(out, validityLen);
   }
 
   // Package private for testing
@@ -999,7 +999,7 @@ public class JCudfSerialization {
       int len = (rowsStoredInArray + 7) / 8;
       out.write(arrayBuffer, 0, len);
     }
-    return padFor64bitAlignment(out, validityLen);
+    return padFor64byteAlignment(out, validityLen);
   }
 
   /////////////////////////////////////////////
@@ -1032,7 +1032,7 @@ public class JCudfSerialization {
       out.copyDataFrom(dataBuffer, currentOffset, dataLeft);
       totalCopied += dataLeft;
     }
-    padFor64bitAlignment(out, totalCopied);
+    padFor64byteAlignment(out, totalCopied);
   }
 
   private static long copySlicedOffsets(DataWriter out, ColumnBufferProvider column, long rowOffset,
@@ -1084,7 +1084,7 @@ public class JCudfSerialization {
       out.copyDataFrom(dataBuffer, currentOffset, dataLeft);
       totalCopied += dataLeft;
     }
-    padFor64bitAlignment(out, totalCopied);
+    padFor64byteAlignment(out, totalCopied);
     return dataLens;
   }
 
@@ -1117,7 +1117,7 @@ public class JCudfSerialization {
       out.copyDataFrom(dataBuffer, currentOffset, dataLeft);
       totalCopied += dataLeft;
     }
-    padFor64bitAlignment(out, totalCopied);
+    padFor64byteAlignment(out, totalCopied);
   }
 
   /////////////////////////////////////////////

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -28,6 +28,7 @@
 #include "cudf/legacy/table.hpp"
 #include "utilities/column_utils.hpp"
 #include "cudf/utilities/error.hpp"
+#include "utilities/legacy/error_utils.hpp"
 
 namespace cudf {
 namespace jni {

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -179,7 +179,7 @@ public class ColumnVectorTest extends CudfTestBase {
     try (ColumnVector v0 = ColumnVector.fromBoxedInts(1, 2, 3, 4, 5, 6);
          ColumnVector v1 = ColumnVector.fromBoxedInts(1, 2, 3, null, null, 4, 5, 6)) {
       assertEquals(24, v0.getDeviceMemorySize()); // (6*4B)
-      assertEquals(40, v1.getDeviceMemorySize()); // (8*4B) + 8B(for validity vector)
+      assertEquals(96, v1.getDeviceMemorySize()); // (8*4B) + 64B(for validity vector)
     }
   }
 
@@ -188,7 +188,7 @@ public class ColumnVectorTest extends CudfTestBase {
     try (ColumnVector v0 = ColumnVector.fromStrings("onetwothree", "four", "five");
          ColumnVector v1 = ColumnVector.fromStrings("onetwothree", "four", null, "five")) {
       assertEquals(80, v0.getDeviceMemorySize()); //32B + 24B + 24B
-      assertEquals(112, v1.getDeviceMemorySize()); //32B + 24B + 24B + 24B + 8B(for validity vector)
+      assertEquals(168, v1.getDeviceMemorySize()); //32B + 24B + 24B + 24B + 64B(for validity vector)
     }
   }
 


### PR DESCRIPTION
libcudf expects validity buffer sizes to be padded to a 64-byte boundary, but the Java bindings were only padding to 64 _bits_.  This causes device memory read overruns when libcudf tries to copy a Java-created validity buffer to an output vector.  The invalid read access is more likely to occur when not running with RMM in pooled mode.
