### PR TITLE
Fix Java/JNI compile failure from CUDF_TRY deprecation

### DIFF
--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -27,6 +27,7 @@
 #include "cudf/cudf.h"
 #include "cudf/legacy/table.hpp"
 #include "utilities/column_utils.hpp"
+#include "utilities/legacy/error_utils.hpp"
 #include "cudf/utilities/error.hpp"
 
 namespace cudf {


### PR DESCRIPTION
16d9be5e deprecated CUDF_TRY, and moved it to a legacy header.
Most of the code using CUDF_TRY was modified to include the
legacy header. `java/src/main/native/include/jni_utils.hpp` was not.

Edit: The compilation failure looks thus:
```
:~/workspace/dev/cudf/java $ mvn clean package -DskipTests
[INFO] Scanning for projects...
[INFO]
[INFO] ---------------------------< ai.rapids:cudf >---------------------------
...
     [exec] /home/mithunr/workspace/dev/cudf/java/src/main/native/src/ColumnVectorJni.cpp: In function ‘jlong Java_ai_rapids_cudf_ColumnVector_has
g, jint)’:
     [exec] /home/mithunr/workspace/dev/cudf/java/src/main/native/src/ColumnVectorJni.cpp:645:7: error: ‘CUDF_TRY’ was not declared in this scope
     [exec]        CUDF_TRY(gdf_hash(1, &n_column, hash_func, nullptr, result.get()));
     [exec]        ^~~~~~~~
     [exec] /home/mithunr/workspace/dev/cudf/java/src/main/native/src/ColumnVectorJni.cpp:645:7: note: suggested alternative: ‘CUDA_TRY’
     [exec]        CUDF_TRY(gdf_hash(1, &n_column, hash_func, nullptr, result.get()));
     [exec]        ^~~~~~~~
     [exec]        CUDA_TRY
     [exec] CMakeFiles/cudfjni.dir/build.make:101: recipe for target 'CMakeFiles/cudfjni.dir/src/ColumnVectorJni.cpp.o' failed
...
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.280 s
[INFO] Finished at: 2019-11-10T17:38:00-08:00
[INFO] ------------------------------------------------------------------------
```

This commit fixes the problem.