### PR TITLE
[REVIEW] Add cache member for number of characters in string_view class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 - PR #3294 Update to arrow-cpp and pyarrow 0.15.1
 - PR #3310 Add `row_hasher` and `element_hasher` utilities
 - PR #3286 Clean up the starter code on README
+- PR #3345 Add cache member for number of characters in string_view class
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/strings/string_view.cuh
+++ b/cpp/include/cudf/strings/string_view.cuh
@@ -41,7 +41,7 @@ using char_utf8 = uint32_t;
 class string_view
 {
  public:
-  string_view() = default;
+  __host__ __device__ string_view();
   /**
    * @brief Create instance from existing device char array.
    *
@@ -55,7 +55,7 @@ class string_view
    *
    * @param data Device char array encoded in UTF8.
    */
-  __device__ string_view(const char* data);
+//  __device__ string_view(const char* data);
   string_view(const string_view&) = default;
   string_view(string_view&&) = default;
   ~string_view() = default;
@@ -298,8 +298,9 @@ class string_view
   __device__ size_type rsplit( const char* delimiter, size_type count, string_view* strs ) const;
 
 private:
-    const char* _data{};   ///< Pointer to device memory contain char array for this string
-    size_type _bytes{};    ///< Number of bytes in _data for this string
+    const char* _data{};           ///< Pointer to device memory contain char array for this string
+    size_type _bytes{};            ///< Number of bytes in _data for this string
+    mutable size_type _nchars{};   ///< Number of characters in this string (computed)
 
   /**
    * @brief Return the character position of the given byte offset.

--- a/cpp/include/cudf/strings/string_view.cuh
+++ b/cpp/include/cudf/strings/string_view.cuh
@@ -46,6 +46,7 @@ class string_view
    * @brief Default constructor represents an empty string.
    */
   __host__ __device__ string_view();
+
   /**
    * @brief Create instance from existing device char array.
    *
@@ -298,7 +299,7 @@ class string_view
 private:
     const char* _data{};           ///< Pointer to device memory contain char array for this string
     size_type _bytes{};            ///< Number of bytes in _data for this string
-    mutable size_type _nchars{};   ///< Number of characters in this string (computed)
+    mutable size_type _length{};   ///< Number of characters in this string (computed)
 
   /**
    * @brief Return the character position of the given byte offset.

--- a/cpp/include/cudf/strings/string_view.cuh
+++ b/cpp/include/cudf/strings/string_view.cuh
@@ -41,6 +41,10 @@ using char_utf8 = uint32_t;
 class string_view
 {
  public:
+
+  /**
+   * @brief Default constructor represents an empty string.
+   */
   __host__ __device__ string_view();
   /**
    * @brief Create instance from existing device char array.
@@ -49,13 +53,7 @@ class string_view
    * @param bytes Number of bytes in data array.
    */
   __host__ __device__ string_view(const char* data, size_type bytes);
-  /**
-   * @brief Create instance from existing device char array. The array must
-   * include a null-terminator ('\0).
-   *
-   * @param data Device char array encoded in UTF8.
-   */
-//  __device__ string_view(const char* data);
+
   string_view(const string_view&) = default;
   string_view(string_view&&) = default;
   ~string_view() = default;

--- a/cpp/include/cudf/strings/string_view.inl
+++ b/cpp/include/cudf/strings/string_view.inl
@@ -22,8 +22,8 @@ namespace
 using BYTE = uint8_t;
 
 // number of characters in a string computed on-demand
-// the _nchars member is initialized to this value as a place-holder
-static constexpr cudf::size_type UNKNOWN_STRING_LENGTH{-1};
+// the _length member is initialized to this value as a place-holder
+constexpr cudf::size_type UNKNOWN_STRING_LENGTH{-1};
 
 /**
  * @brief Returns the number of bytes used to represent the provided byte.
@@ -51,7 +51,7 @@ __host__ __device__ inline cudf::size_type bytes_in_utf8_byte(BYTE byte)
  * @param str Null-terminated array of chars.
  * @return Number of bytes.
  */
-__device__ inline cudf::size_type string_length( const char* str )
+__device__ inline cudf::size_type string_bytes( const char* str )
 {
     if( !str )
         return 0;
@@ -67,11 +67,11 @@ namespace cudf
 {
 
 __host__ __device__ inline string_view::string_view()
-    : _data(""), _bytes(0), _nchars(0)
+    : _data(""), _bytes(0), _length(0)
 {}
 
 __host__ __device__ inline string_view::string_view(const char* data, size_type bytes)
-    : _data(data), _bytes(bytes), _nchars(UNKNOWN_STRING_LENGTH)
+    : _data(data), _bytes(bytes), _length(UNKNOWN_STRING_LENGTH)
 {}
 
 //
@@ -82,9 +82,9 @@ __host__ __device__ inline size_type string_view::size_bytes() const
 
 __device__ inline size_type string_view::length() const
 {
-    if( _nchars <= UNKNOWN_STRING_LENGTH )
-        _nchars = strings::detail::characters_in_string(_data,_bytes);
-    return _nchars;
+    if( _length <= UNKNOWN_STRING_LENGTH )
+        _length = strings::detail::characters_in_string(_data,_bytes);
+    return _length;
 }
 
 __host__ __device__ inline const char* string_view::data() const
@@ -373,7 +373,7 @@ __device__ inline size_type string_view::split(const char* delim, int count, str
         return 1;
     }
 
-    size_type bytes = string_length(delim);
+    size_type bytes = string_bytes(delim);
     size_type delimCount = 0;
     size_type pos = find(delim, bytes);
     while(pos >= 0)
@@ -422,7 +422,7 @@ __device__ inline size_type string_view::rsplit(const char* delim, int count, st
         return 1;
     }
 
-    size_type bytes = string_length(delim);
+    size_type bytes = string_bytes(delim);
     size_type delimCount = 0;
     size_type pos = find(delim, bytes);
     while(pos >= 0)


### PR DESCRIPTION
The `string_view` class encapsulates a utf8 sequence of chars and provides methods for simple view operations on those bytes. The number of characters can be different the size in bytes. String operations that use position or length values are always specified in character units.

Calculating the number of characters for a string requires traversing each character to count them up. This can become expensive for long strings. This PR adds a cached member variable to the `string_view` class to keep the number of characters once computed in the `length()` member function.