### PR TITLE
[REVIEW] Port NVStrings boolean to/from strings converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - PR #3202 Rename and move error.hpp to public headers
 - PR #2878 Use upstream merge code in dask_cudf
 - PR #3217 Port NVStrings upper and lower case conversion functions
+- PR #3350 Port NVStrings booleans convert functions
 - PR #3231 Add `column::release()` to give up ownership of contents.
 - PR #3157 Use enum class rather than enum for mask_allocation_policy
 - PR #3245 Move binaryop files to legacy

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -495,6 +495,7 @@ add_library(cudf
             src/strings/char_types/char_types.cu
             src/strings/case.cu
             src/strings/find.cu
+            src/strings/convert/convert_booleans.cu
             src/scalar/scalar.cpp
             src/scalar/scalar_factories.cpp)
 

--- a/cpp/include/cudf/strings/convert/convert_booleans.hpp
+++ b/cpp/include/cudf/strings/convert/convert_booleans.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/column/column.hpp>
+#include <cudf/scalar/scalar.hpp>
+
+namespace cudf
+{
+namespace strings
+{
+
+/**
+ * @brief Returns a new BOOL8 column parsing boolean values from the
+ * provided strings column.
+ *
+ * Any null entries will result in corresponding null entries in the output column.
+ *
+ * @param strings Strings instance for this operation.
+ * @param true_string String to expect for true. Non-matching strings are false.
+ * @param mr Resource for allocating device memory.
+ * @return New BOOL8 column converted from strings.
+ */
+std::unique_ptr<column> to_booleans( strings_column_view const& strings,
+                                     string_scalar const& true_string = string_scalar("true"),
+                                     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+
+/**
+ * @brief Returns a new strings column converting the boolean values from the
+ * provided column into strings.
+ *
+ * Any null entries will result in corresponding null entries in the output column.
+ *
+ * @throw cudf::logic_error if input column is not BOOL8 type.
+ *
+ * @param column Boolean column to convert.
+ * @param true_string String to use for true.
+ * @param false_string String to use for false.
+ * @param mr Resource for allocating device memory.
+ * @return New strings column.
+ */
+std::unique_ptr<column> from_booleans( column_view const& booleans,
+                                       string_scalar const& true_string = string_scalar("true"),
+                                       string_scalar const& false_string = string_scalar("false"),
+                                       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+
+} // namespace strings
+} // namespace cudf

--- a/cpp/include/cudf/strings/convert/convert_booleans.hpp
+++ b/cpp/include/cudf/strings/convert/convert_booleans.hpp
@@ -25,8 +25,8 @@ namespace strings
 {
 
 /**
- * @brief Returns a new BOOL8 column parsing boolean values from the
- * provided strings column.
+ * @brief Returns a new BOOL8 column by parsing boolean values from the strings
+ * in the provided strings column.
  *
  * Any null entries will result in corresponding null entries in the output column.
  *
@@ -45,11 +45,11 @@ std::unique_ptr<column> to_booleans( strings_column_view const& strings,
  *
  * Any null entries will result in corresponding null entries in the output column.
  *
- * @throw cudf::logic_error if input column is not BOOL8 type.
+ * @throw cudf::logic_error if the input column is not BOOL8 type.
  *
  * @param column Boolean column to convert.
- * @param true_string String to use for true.
- * @param false_string String to use for false.
+ * @param true_string String to use for true in the output column.
+ * @param false_string String to use for false in the output column.
  * @param mr Resource for allocating device memory.
  * @return New strings column.
  */

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -35,7 +35,7 @@ namespace strings
 namespace detail
 {
 
-//
+// Convert strings column to boolean column
 std::unique_ptr<column> to_booleans( strings_column_view const& strings,
                                      string_scalar const& true_string = string_scalar("true"),
                                      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
@@ -83,6 +83,7 @@ std::unique_ptr<column> to_booleans( strings_column_view const& strings,
 namespace detail
 {
 
+// Convert boolean column to strings column
 std::unique_ptr<column> from_booleans( column_view const& booleans,
                                        string_scalar const& true_string = string_scalar("true"),
                                        string_scalar const& false_string = string_scalar("false"),
@@ -93,6 +94,7 @@ std::unique_ptr<column> from_booleans( column_view const& booleans,
     if( strings_count == 0 )
         return make_empty_strings_column(mr,stream);
 
+    CUDF_EXPECTS( booleans.type().id()==BOOL8, "Input column must be boolean type" );
     CUDF_EXPECTS( true_string.is_valid() && true_string.size()>0, "Parameter true_string must not be empty.");
     auto d_true = string_view( true_string.data(), true_string.size());
     CUDF_EXPECTS( false_string.is_valid() && false_string.size()>0, "Parameter false_string must not be empty.");

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/strings/convert/convert_booleans.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/type_dispatcher.hpp>
+#include <cudf/utilities/traits.hpp>
+#include "../utilities.hpp"
+#include "../utilities.cuh"
+
+#include <rmm/thrust_rmm_allocator.h>
+#include <thrust/transform.h>
+#include <thrust/iterator/counting_iterator.h>
+
+namespace cudf
+{
+namespace strings
+{
+namespace detail
+{
+
+//
+std::unique_ptr<column> to_booleans( strings_column_view const& strings,
+                                     string_scalar const& true_string = string_scalar("true"),
+                                     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+                                     cudaStream_t stream = 0)
+{
+    size_type strings_count = strings.size();
+    if( strings_count == 0 )
+        return make_numeric_column( data_type{BOOL8}, 0 );
+
+    CUDF_EXPECTS( true_string.is_valid() && true_string.size()>0, "Parameter true_string must not be empty.");
+    auto d_true = string_view( true_string.data(), true_string.size());
+
+    auto strings_column = column_device_view::create(strings.parent(), stream);
+    auto d_strings = *strings_column;
+    // create output column copying the strings' null-mask
+    auto results = make_numeric_column( data_type{BOOL8}, strings_count,
+        copy_bitmask( strings.parent(), stream, mr), strings.null_count(), stream, mr);
+    auto results_view = results->mutable_view();
+    auto d_results = results_view.data<experimental::bool8>();
+
+    thrust::transform( rmm::exec_policy(stream)->on(stream),
+        thrust::make_counting_iterator<size_type>(0),
+        thrust::make_counting_iterator<size_type>(strings_count),
+        d_results,
+        [d_strings, d_true] __device__ (size_type idx) {
+            bool result = false;
+            if( !d_strings.is_null(idx) )
+                result = d_strings.element<string_view>(idx).compare(d_true)==0;
+            return result;
+        });
+    results->set_null_count(strings.null_count());
+    return results;
+}
+
+} // namespace detail
+
+// external API
+std::unique_ptr<column> to_booleans( strings_column_view const& strings,
+                                     string_scalar const& true_string,
+                                     rmm::mr::device_memory_resource* mr)
+{
+    return detail::to_booleans(strings, true_string, mr );
+}
+
+namespace detail
+{
+
+std::unique_ptr<column> from_booleans( column_view const& booleans,
+                                       string_scalar const& true_string = string_scalar("true"),
+                                       string_scalar const& false_string = string_scalar("false"),
+                                       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+                                       cudaStream_t stream = 0)
+{
+    size_type strings_count = booleans.size();
+    if( strings_count == 0 )
+        return make_empty_strings_column(mr,stream);
+
+    CUDF_EXPECTS( true_string.is_valid() && true_string.size()>0, "Parameter true_string must not be empty.");
+    auto d_true = string_view( true_string.data(), true_string.size());
+    CUDF_EXPECTS( false_string.is_valid() && false_string.size()>0, "Parameter false_string must not be empty.");
+    auto d_false = string_view( false_string.data(), false_string.size());
+
+    auto column = column_device_view::create(booleans, stream);
+    auto d_column = *column;
+
+    // copy null mask
+    rmm::device_buffer null_mask = copy_bitmask(booleans,stream,mr);
+    // build offsets column
+    auto offsets_transformer_itr = thrust::make_transform_iterator( thrust::make_counting_iterator<int32_t>(0),
+        [d_column, d_true, d_false] __device__ (size_type idx) {
+            if( d_column.is_null(idx) )
+                return 0;
+            size_type bytes = 0;
+            if( d_column.element<experimental::bool8>(idx) )
+                bytes = d_true.size_bytes();
+            else
+                bytes = d_false.size_bytes();
+            return bytes;
+        });
+    auto offsets_column = make_offsets_child_column(offsets_transformer_itr,
+                                                    offsets_transformer_itr+strings_count,
+                                                    mr, stream);
+    auto offsets_view = offsets_column->view();
+    auto d_offsets = offsets_view.data<int32_t>();
+
+    // build chars column
+    size_type bytes = thrust::device_pointer_cast(d_offsets)[strings_count];
+    auto chars_column = create_chars_child_column( strings_count, booleans.null_count(), bytes, mr, stream );
+    auto chars_view = chars_column->mutable_view();
+    auto d_chars = chars_view.data<char>();
+    thrust::for_each_n(rmm::exec_policy(stream)->on(stream), thrust::make_counting_iterator<size_type>(0), strings_count,
+        [d_column, d_true, d_false, d_offsets, d_chars] __device__ (size_type idx) {
+            if( d_column.is_null(idx) )
+                return;
+            string_view result = ( d_column.element<experimental::bool8>(idx) ? d_true : d_false );
+            memcpy( d_chars + d_offsets[idx], result.data(), result.size_bytes() );
+        });
+    //
+    return make_strings_column(strings_count, std::move(offsets_column), std::move(chars_column),
+                               booleans.null_count(), std::move(null_mask), stream, mr);
+}
+
+} // namespace detail
+
+// external API
+
+std::unique_ptr<column> from_booleans( column_view const& booleans,
+                                       string_scalar const& true_string,
+                                       string_scalar const& false_string,
+                                       rmm::mr::device_memory_resource* mr)
+{
+    return detail::from_booleans(booleans,true_string,false_string,mr);
+}
+
+} // namespace strings
+} // namespace cudf

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -596,7 +596,8 @@ set(STRINGS_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/strings/attrs_tests.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/strings/combine_tests.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/strings/substring_tests.cu"
-    "${CMAKE_CURRENT_SOURCE_DIR}/strings/find_tests.cu")
+    "${CMAKE_CURRENT_SOURCE_DIR}/strings/find_tests.cu"
+    "${CMAKE_CURRENT_SOURCE_DIR}/strings/booleans_tests.cu")
 
 ConfigureTest(STRINGS_TEST "${STRINGS_TEST_SRC}")
 

--- a/cpp/tests/strings/booleans_tests.cu
+++ b/cpp/tests/strings/booleans_tests.cu
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/strings/convert/convert_booleans.hpp>
+#include <tests/utilities/base_fixture.hpp>
+#include <tests/utilities/column_wrapper.hpp>
+#include <tests/utilities/column_utilities.hpp>
+#include "./utilities.h"
+
+#include <gmock/gmock.h>
+#include <vector>
+
+
+struct StringsConvertTest : public cudf::test::BaseFixture {};
+
+
+TEST_F(StringsConvertTest, ToBooleans)
+{
+    std::vector<const char*> h_strings{ "false", nullptr, "", "true", "True", "False" };
+    cudf::test::strings_column_wrapper strings( h_strings.begin(), h_strings.end(),
+        thrust::make_transform_iterator( h_strings.begin(), [] (auto str) { return str!=nullptr; }));
+
+    auto strings_view = cudf::strings_column_view(strings);
+    auto results = cudf::strings::to_booleans(strings_view);
+
+    std::vector<cudf::experimental::bool8> h_expected{ false, false, false, true, false, false };
+    cudf::test::fixed_width_column_wrapper<cudf::experimental::bool8> expected( h_expected.begin(), h_expected.end(),
+        thrust::make_transform_iterator( h_strings.begin(), [] (auto str) { return str!=nullptr; }));
+    cudf::test::expect_columns_equal(*results, expected);
+}
+
+TEST_F(StringsConvertTest, FromBooleans)
+{
+    std::vector<const char*> h_strings{ "true", nullptr, "false", "true", "true", "false" };
+    cudf::test::strings_column_wrapper strings( h_strings.begin(), h_strings.end(),
+        thrust::make_transform_iterator( h_strings.begin(), [] (auto str) { return str!=nullptr; }));
+
+    std::vector<cudf::experimental::bool8> h_column{ true, false, false, true, true, false };
+    cudf::test::fixed_width_column_wrapper<cudf::experimental::bool8> column( h_column.begin(), h_column.end(),
+        thrust::make_transform_iterator( h_strings.begin(), [] (auto str) { return str!=nullptr; }));
+
+    auto results = cudf::strings::from_booleans(column);
+    cudf::test::expect_columns_equal(*results, strings);
+}
+
+TEST_F(StringsConvertTest, ZeroSizeStringsColumnBoolean)
+{
+    cudf::column_view zero_size_column( cudf::data_type{cudf::BOOL8}, 0, nullptr, nullptr, 0);
+    auto results = cudf::strings::from_booleans(zero_size_column);
+    cudf::test::expect_strings_empty(results->view());
+}
+
+TEST_F(StringsConvertTest, ZeroSizeBooleansColumn)
+{
+    cudf::column_view zero_size_column( cudf::data_type{cudf::STRING}, 0, nullptr, nullptr, 0);
+    auto results = cudf::strings::to_booleans(zero_size_column);
+    EXPECT_EQ(0,results->size());
+}

--- a/cpp/tests/strings/booleans_tests.cu
+++ b/cpp/tests/strings/booleans_tests.cu
@@ -70,3 +70,9 @@ TEST_F(StringsConvertTest, ZeroSizeBooleansColumn)
     auto results = cudf::strings::to_booleans(zero_size_column);
     EXPECT_EQ(0,results->size());
 }
+
+TEST_F(StringsConvertTest, BooleanError)
+{
+    auto column = cudf::make_numeric_column(cudf::data_type{cudf::INT32}, 100);
+    EXPECT_THROW(cudf::strings::from_booleans(column->view()), cudf::logic_error);
+}


### PR DESCRIPTION
Port NVStrings `to_booleans` and `from_booleans` APIs to cudf strings column.
These convert boolean columns to strings column and vice versa.