### PR TITLE
[REVIEW] Disabling `column_view` iterators for non fixed-width types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 - PR #3334 Remove zero-size exception check from make_strings_column factories
 - PR #3333 Fix compilation issues with `constexpr` functions not marked `__device__`
 - PR #3337 Fix Java to pad validity buffers to 64-byte boundary
+- PR #3357 Disabling `column_view` iterators for non fixed-width types
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -100,7 +100,7 @@ class column_view_base {
    *---------------------------------------------------------------------------**/
   template <typename T>
   T const* end() const noexcept {
-    static_assert(is_fixed_width<T>(), "column_view::begin only supports fixed-width types");
+    static_assert(is_fixed_width<T>(), "column_view::end only supports fixed-width types");
     return begin<T>() + size();
   }
 
@@ -410,7 +410,7 @@ class mutable_column_view : public detail::column_view_base {
    *---------------------------------------------------------------------------**/
   template <typename T>
   T* begin() const noexcept {
-    static_assert(is_fixed_width<T>(), "column_view::begin only supports fixed-width types");
+    static_assert(is_fixed_width<T>(), "mutable_column_view::begin only supports fixed-width types");
     return data<T>();
   }
 
@@ -423,7 +423,7 @@ class mutable_column_view : public detail::column_view_base {
    *---------------------------------------------------------------------------**/
   template <typename T>
   T* end() const noexcept {
-    static_assert(is_fixed_width<T>(), "column_view::begin only supports fixed-width types");
+    static_assert(is_fixed_width<T>(), "mutable_column_view::end only supports fixed-width types");
     return begin<T>() + size();
   }
 

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <vector>
@@ -86,6 +87,7 @@ class column_view_base {
    *---------------------------------------------------------------------------**/
   template <typename T>
   T const* begin() const noexcept {
+    static_assert(is_fixed_width<T>(), "column_view::begin only supports fixed-width types");
     return data<T>();
   }
 
@@ -98,6 +100,7 @@ class column_view_base {
    *---------------------------------------------------------------------------**/
   template <typename T>
   T const* end() const noexcept {
+    static_assert(is_fixed_width<T>(), "column_view::begin only supports fixed-width types");
     return begin<T>() + size();
   }
 
@@ -407,6 +410,7 @@ class mutable_column_view : public detail::column_view_base {
    *---------------------------------------------------------------------------**/
   template <typename T>
   T* begin() const noexcept {
+    static_assert(is_fixed_width<T>(), "column_view::begin only supports fixed-width types");
     return data<T>();
   }
 
@@ -419,6 +423,7 @@ class mutable_column_view : public detail::column_view_base {
    *---------------------------------------------------------------------------**/
   template <typename T>
   T* end() const noexcept {
+    static_assert(is_fixed_width<T>(), "column_view::begin only supports fixed-width types");
     return begin<T>() + size();
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
Disabling `column_view` iterators for non fixed-width types.

close #3355