### PR TITLE
[REVIEW] Adding to_parquet and write_partition definitions to dask_cudf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@
 - PR #3340 Make all benchmarks use cudf base fixture to initialize RMM pool
 - PR #3337 Fix Java to pad validity buffers to 64-byte boundary
 - PR #3357 Disabling `column_view` iterators for non fixed-width types
+- PR #3369 Add write_partition to dask_cudf to fix to_parquet bug
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -267,7 +267,7 @@ class DataFrame(_Frame, dd.core.DataFrame):
         """ Calls dask.dataframe.io.to_parquet with CudfEngine backend """
         from dask_cudf.io import to_parquet
 
-        to_parquet(self, path, *args, **kwargs)
+        return to_parquet(self, path, *args, **kwargs)
 
     @derived_from(pd.DataFrame)
     def var(

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -263,6 +263,12 @@ class DataFrame(_Frame, dd.core.DataFrame):
         results = [p for i, p in enumerate(parts) if uniques[i]]
         return from_delayed(results, meta=self._meta).reset_index()
 
+    def to_parquet(self, path, *args, **kwargs):
+        """ Calls dask.dataframe.io.to_parquet with CudfEngine backend """
+        from dask_cudf.io import to_parquet
+
+        to_parquet(self, path, *args, **kwargs)
+
     @derived_from(pd.DataFrame)
     def var(
         self,

--- a/python/dask_cudf/dask_cudf/io/__init__.py
+++ b/python/dask_cudf/dask_cudf/io/__init__.py
@@ -3,6 +3,6 @@ from .json import read_json
 from .orc import read_orc
 
 try:
-    from .parquet import read_parquet
+    from .parquet import read_parquet, to_parquet
 except ImportError:
     pass

--- a/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
@@ -60,6 +60,17 @@ def test_roundtrip_from_dask(tmpdir):
     assert_eq(ddf[["y"]], ddf2)
 
 
+def test_roundtrip_from_dask_cudf(tmpdir):
+    tmpdir = str(tmpdir)
+    gddf = dask_cudf.from_dask_dataframe(ddf)
+    gddf.to_parquet(tmpdir)
+
+    # NOTE: Need `.compute()` to resolve correct index
+    #       name after `from_dask_dataframe`
+    gddf2 = dask_cudf.read_parquet(tmpdir)
+    assert_eq(gddf.compute(), gddf2)
+
+
 def test_roundtrip_from_pandas(tmpdir):
     fn = str(tmpdir.join("test.parquet"))
 


### PR DESCRIPTION
Closes #3365 

This PR adds explicit definitions for `to_parquet` and `write_partition` in dask_cudf.  Previously, dask_cudf was falling back to upstream dask for this functionality.  However, there is pandas-specific code in [`write_partition`](https://github.com/dask/dask/blob/4a42071f50d12f30e15afe1348a147cb45ebaa69/dask/dataframe/io/parquet/arrow.py#L464) that is causing problems for cudf-based dask dataframes.  Since we will soon need to define a `CudfEngine` implementation of `write_partition` when a GPU-accelerated `cudf.io.to_parquet` is supported,  it probably makes sense to add an initial implementation to address the #3365 bug.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
