### PR TITLE
[REVIEW] Add select method to table_view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - PR #3299 Define and implement new `is_sorted` APIs
 - PR #3328 Partition by stripes in dask_cudf ORC reader
 - PR #3243 Use upstream join code in dask_cudf
+- PR #3371 Add `select` method to `table_view`
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/table/table.hpp
+++ b/cpp/include/cudf/table/table.hpp
@@ -103,7 +103,7 @@ class table {
   /**---------------------------------------------------------------------------*
    * @brief Returns a table_view with set of specified columns.
    *
-   * @throws cudf::logic_error
+   * @throws std::out_of_range
    * If any element in `column_indices` is outside [0, num_columns())
    *
    * @param column_indices Indices of columns in the table

--- a/cpp/include/cudf/table/table_view.hpp
+++ b/cpp/include/cudf/table/table_view.hpp
@@ -109,7 +109,7 @@ class table_view_base {
    * @param column_index The index of the desired column
    * @return A reference to the desired column
    *---------------------------------------------------------------------------**/
-  ColumnView const& column(size_type column_index) const noexcept;
+  ColumnView const& column(size_type column_index) const;
 
   /**---------------------------------------------------------------------------*
    * @brief Returns the number of columns
@@ -141,6 +141,19 @@ class table_view_base {
  *---------------------------------------------------------------------------**/
 class table_view : public detail::table_view_base<column_view> {
   using detail::table_view_base<column_view>::table_view_base;
+
+ public:
+  /**---------------------------------------------------------------------------*
+   * @brief Returns a table_view with set of specified columns.
+   *
+   * @throws cudf::logic_error
+   * If any element in `column_indices` is outside [0, num_columns())
+   *
+   * @param column_indices Indices of columns in the table
+   * @return A table_view consisting of columns from the original table
+   * specified by the elements of `column_indices`
+   *---------------------------------------------------------------------------**/
+  table_view select(std::vector<size_type> const& column_indices) const;
 };
 
 /**---------------------------------------------------------------------------*
@@ -153,7 +166,7 @@ class mutable_table_view : public detail::table_view_base<mutable_column_view> {
   using detail::table_view_base<mutable_column_view>::table_view_base;
 
 public:
-  mutable_column_view& column(size_type column_index) const noexcept {
+  mutable_column_view& column(size_type column_index) const {
     return const_cast<mutable_column_view&>(table_view_base::column(column_index));
   }
   /**---------------------------------------------------------------------------*

--- a/cpp/include/cudf/table/table_view.hpp
+++ b/cpp/include/cudf/table/table_view.hpp
@@ -106,6 +106,9 @@ class table_view_base {
   /**---------------------------------------------------------------------------*
    * @brief Returns a reference to the view of the specified column
    *
+   * @throws std::out_of_range
+   * If `column_index` is out of the range [0, num_columns)
+   * 
    * @param column_index The index of the desired column
    * @return A reference to the desired column
    *---------------------------------------------------------------------------**/
@@ -146,7 +149,7 @@ class table_view : public detail::table_view_base<column_view> {
   /**---------------------------------------------------------------------------*
    * @brief Returns a table_view with set of specified columns.
    *
-   * @throws cudf::logic_error
+   * @throws std::out_of_range
    * If any element in `column_indices` is outside [0, num_columns())
    *
    * @param column_indices Indices of columns in the table

--- a/cpp/src/table/table.cpp
+++ b/cpp/src/table/table.cpp
@@ -81,8 +81,6 @@ std::vector<std::unique_ptr<column>> table::release() {
 
 // Returns a table_view with set of specified columns
 table_view table::select(std::vector<cudf::size_type> const& column_indices) const {
-    CUDF_EXPECTS(column_indices.size() <= _columns.size(), "Requested too many columns.");
-
     std::vector<column_view> columns;
     for (auto index : column_indices) {
       columns.push_back(_columns.at(index)->view());

--- a/cpp/src/table/table_view.cpp
+++ b/cpp/src/table/table_view.cpp
@@ -44,10 +44,8 @@ table_view_base<ColumnView>::table_view_base(
 
 template <typename ColumnView>
 ColumnView const& table_view_base<ColumnView>::column(
-    size_type column_index) const noexcept {
-  assert(column_index >= 0);
-  assert(column_index < _columns.size());
-  return _columns[column_index];
+    size_type column_index) const {
+  return _columns.at(column_index);
 }
 
 // Explicit instantiation for a table of `column_view`s
@@ -56,6 +54,14 @@ template class table_view_base<column_view>;
 // Explicit instantiation for a table of `mutable_column_view`s
 template class table_view_base<mutable_column_view>;
 }  // namespace detail
+
+// Returns a table_view with set of specified columns
+table_view table_view::select(std::vector<size_type> const& column_indices) const {
+  std::vector<column_view> columns(column_indices.size());
+  std::transform(column_indices.begin(), column_indices.end(), columns.begin(),
+    [this](auto index) { return this->column(index); });
+  return table_view(columns);
+}
 
 // Convert mutable view to immutable view
 mutable_table_view::operator table_view() {

--- a/cpp/tests/table/table_tests.cpp
+++ b/cpp/tests/table/table_tests.cpp
@@ -77,7 +77,7 @@ TEST_F(TableTest, GetTableWithSelectedColumns)
   cudf::test::expect_columns_equal(t.view().column(3), selected_tview.column(1));
 }
 
-TEST_F(TableTest, SelectingMoreThanNumberOfColumns)
+TEST_F(TableTest, SelectingOutOfBounds)
 {
   column_wrapper <int8_t > col1{{1,2,3,4}};
   column_wrapper <int16_t> col2{{1,2,3,4}};
@@ -88,7 +88,7 @@ TEST_F(TableTest, SelectingMoreThanNumberOfColumns)
 
   Table t(std::move(cols));
 
-  EXPECT_THROW (t.select(std::vector<cudf::size_type>{0,1,2}), cudf::logic_error);
+  EXPECT_THROW (t.select(std::vector<cudf::size_type>{0,1,2}), std::out_of_range);
 }
 
 TEST_F(TableTest, SelectingNoColumns)

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -84,3 +84,45 @@ TEST_F(TableViewTest, TestLexicographicalComparatorSameTable)
     cudf::test::expect_columns_equal(expected, got->view());
 }
 
+TEST_F(TableViewTest, Select)
+{
+    using cudf::test::fixed_width_column_wrapper;
+    using cudf::test::expect_columns_equal;
+
+    fixed_width_column_wrapper<int8_t>  col1{{1,2,3,4}};
+    fixed_width_column_wrapper<int16_t> col2{{1,2,3,4}};
+    fixed_width_column_wrapper<int32_t> col3{{4,5,6,7}};
+    fixed_width_column_wrapper<int64_t> col4{{4,5,6,7}};
+    cudf::table_view t({col1, col2, col3, col4});
+
+    cudf::table_view selected = t.select({2, 3});
+    expect_columns_equal(t.column(2), selected.column(0));
+    expect_columns_equal(t.column(3), selected.column(1));
+}
+
+TEST_F(TableViewTest, SelectOutOfBounds)
+{
+    using cudf::test::fixed_width_column_wrapper;
+
+    fixed_width_column_wrapper<int8_t>  col1{{1,2,3,4}};
+    fixed_width_column_wrapper<int16_t> col2{{1,2,3,4}};
+    fixed_width_column_wrapper<int32_t> col3{{4,5,6,7}};
+    fixed_width_column_wrapper<int64_t> col4{{4,5,6,7}};
+    cudf::table_view t({col1, col2});
+
+    EXPECT_THROW(t.select({2, 3, 4}), std::out_of_range);
+}
+
+TEST_F(TableViewTest, SelectNoColumns)
+{
+    using cudf::test::fixed_width_column_wrapper;
+
+    fixed_width_column_wrapper<int8_t>  col1{{1,2,3,4}};
+    fixed_width_column_wrapper<int16_t> col2{{1,2,3,4}};
+    fixed_width_column_wrapper<int32_t> col3{{4,5,6,7}};
+    fixed_width_column_wrapper<int64_t> col4{{4,5,6,7}};
+    cudf::table_view t({col1, col2, col3, col4});
+
+    cudf::table_view selected = t.select({});
+    EXPECT_EQ(selected.num_columns(), 0);
+}


### PR DESCRIPTION
Add `select` to table_view
Remove asserts in `table_view::column` and use `std::vector::at` instead
Remove `column_indices` size check from `table::select`