### PR TITLE
[REVIEW] Add fill() function for strings column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 - PR #3243 Use upstream join code in dask_cudf
 - PR #3371 Add `select` method to `table_view`
 - PR #3309 Add java and JNI bindings for search bounds
+- PR #3382 Add fill function for strings column
 
 ## Bug Fixes
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -499,6 +499,7 @@ add_library(cudf
             src/strings/find.cu
             src/strings/convert/convert_integers.cu
             src/strings/convert/convert_booleans.cu
+            src/strings/filling/fill.cu
             src/scalar/scalar.cpp
             src/scalar/scalar_factories.cpp)
 

--- a/cpp/include/cudf/strings/detail/fill.hpp
+++ b/cpp/include/cudf/strings/detail/fill.hpp
@@ -35,9 +35,10 @@ namespace detail
  *
  * @throw cudf::logic_error if [first,last) is outside the range of the input column.
  *
- * @param strings Strings column fill.
- * @param first First row position to include the new string.
- * @param last Last row position (exclusive).
+ * @param strings Strings column to fill.
+ * @param first First row index to include the new string.
+ * @param last Last row index (exclusive).
+ * @param value String to use when filling the range.
  * @param mr Resource for allocating device memory.
  * @param stream CUDA stream to use for any kernels in this function.
  * @return New strings column.

--- a/cpp/include/cudf/strings/detail/fill.hpp
+++ b/cpp/include/cudf/strings/detail/fill.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/column/column.hpp>
+#include <cudf/table/table_view.hpp>
+
+namespace cudf
+{
+namespace strings
+{
+namespace detail
+{
+
+/**
+ * @brief Returns a strings column replacing a range of rows
+ * with the specified string.
+ *
+ * If the value parameter is invalid, the specified rows are filled with
+ * null entries.
+ *
+ * @throw cudf::logic_error if [first,last) is outside the range of the input column.
+ *
+ * @param strings Strings column fill.
+ * @param first First row position to include the new string.
+ * @param last Last row position (exclusive).
+ * @param mr Resource for allocating device memory.
+ * @param stream CUDA stream to use for any kernels in this function.
+ * @return New strings column.
+ */
+std::unique_ptr<column> fill( strings_column_view const& strings,
+                              size_type first, size_type last,
+                              string_scalar const& value,
+                              rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+                              cudaStream_t stream = 0 );
+
+} // namespace detail
+} // namespace strings
+} // namespace cudf

--- a/cpp/src/strings/filling/fill.cu
+++ b/cpp/src/strings/filling/fill.cu
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/null_mask.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/strings/string_view.cuh>
+#include <cudf/strings/combine.hpp>
+#include <cudf/utilities/error.hpp>
+#include <cudf/detail/valid_if.cuh>
+#include "../utilities.hpp"
+#include "../utilities.cuh"
+
+namespace cudf
+{
+namespace strings
+{
+namespace detail
+{
+
+std::unique_ptr<column> fill( strings_column_view const& strings,
+                              size_type first, size_type last,
+                              string_scalar const& value,
+                              rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+                              cudaStream_t stream = 0 )
+{
+    auto strings_count = strings.size();
+    if( strings_count == 0 )
+        return detail::make_empty_strings_column(mr,stream);
+    CUDF_EXPECTS( (first >= 0) && (last <= strings_count), "Parameters [first,last) are outside the range of the provided strings column");
+    CUDF_EXPECTS( first <= last, "Parameters [first,last) have invalid range values");
+    if( first==last ) // return a copy
+        return std::make_unique<column>( strings.parent() );
+
+    auto execpol = rmm::exec_policy(stream);
+    string_view d_value(nullptr,0);
+    if( value.is_valid() )
+        d_value = string_view(value.data(),value.size());
+
+    auto strings_column = column_device_view::create(strings.parent(),stream);
+    auto d_strings = *strings_column;
+
+    // create resulting null mask
+    auto valid_mask = cudf::experimental::detail::valid_if(
+        thrust::make_counting_iterator<size_type>(0),
+        thrust::make_counting_iterator<size_type>(strings_count),
+        [d_strings, first, last, d_value] __device__ (size_type idx) {
+            return ((first <= idx) && (idx < last)) ? !d_value.is_null() : !d_strings.is_null(idx);
+        }, stream, mr );
+    rmm::device_buffer null_mask = valid_mask.first;
+    auto null_count = valid_mask.second;
+
+    // build offsets column
+    auto offsets_transformer = [d_strings, first, last, d_value] __device__ (size_type idx) {
+            if( ((first <= idx) && (idx < last)) ? d_value.is_null() : d_strings.is_null(idx) )
+                return 0;
+            int32_t bytes = d_value.size_bytes();
+            if( (idx < first) || (idx >= last) )
+                bytes = d_strings.element<string_view>(idx).size_bytes();
+            return bytes;
+        };
+    auto offsets_transformer_itr = thrust::make_transform_iterator( thrust::make_counting_iterator<size_type>(0), offsets_transformer );
+    auto offsets_column = detail::make_offsets_child_column(offsets_transformer_itr,
+                                                            offsets_transformer_itr+strings_count,
+                                                            mr, stream);
+    auto offsets_view = offsets_column->view();
+    auto d_offsets = offsets_view.data<int32_t>();
+
+    // create the chars column
+    size_type bytes = thrust::device_pointer_cast(d_offsets)[strings_count];
+    auto chars_column = strings::detail::create_chars_child_column( strings_count, null_count, bytes, mr, stream );
+    // fill the chars column
+    auto chars_view = chars_column->mutable_view();
+    auto d_chars = chars_view.data<char>();
+    thrust::for_each_n(execpol->on(stream), thrust::make_counting_iterator<size_type>(0), strings_count,
+        [d_strings, first, last, d_value, d_offsets, d_chars] __device__(size_type idx){
+            if( ((first <= idx) && (idx < last)) ? d_value.is_null() : d_strings.is_null(idx) )
+                return;
+            string_view d_str = d_value;
+            if( (idx < first) || (idx >= last) )
+                d_str = d_strings.element<string_view>(idx);
+            memcpy( d_chars + d_offsets[idx], d_str.data(), d_str.size_bytes() );
+        });
+
+    return make_strings_column(strings_count, std::move(offsets_column), std::move(chars_column),
+                               null_count, std::move(null_mask), stream, mr);
+}
+
+} // namespace detail
+} // namespace strings
+} // namespace cudf

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -619,7 +619,8 @@ set(STRINGS_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/strings/substring_tests.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/strings/find_tests.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/strings/integers_tests.cu"
-    "${CMAKE_CURRENT_SOURCE_DIR}/strings/booleans_tests.cu")
+    "${CMAKE_CURRENT_SOURCE_DIR}/strings/booleans_tests.cu"
+    "${CMAKE_CURRENT_SOURCE_DIR}/strings/fill_tests.cu")
 
 ConfigureTest(STRINGS_TEST "${STRINGS_TEST_SRC}")
 

--- a/cpp/tests/strings/fill_tests.cu
+++ b/cpp/tests/strings/fill_tests.cu
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/strings/detail/fill.hpp>
+
+#include <tests/utilities/base_fixture.hpp>
+#include <tests/utilities/column_wrapper.hpp>
+#include <tests/utilities/column_utilities.hpp>
+#include "./utilities.h"
+
+#include <vector>
+#include <gmock/gmock.h>
+
+
+struct StringsFillTest : public cudf::test::BaseFixture {};
+
+TEST_F(StringsFillTest, Fill)
+{
+    std::vector<const char*> h_strings{ "eee", "bb", nullptr, "", "aa", "bbb", "ééé" };
+    cudf::test::strings_column_wrapper strings( h_strings.begin(), h_strings.end(),
+        thrust::make_transform_iterator( h_strings.begin(), [] (auto str) { return str!=nullptr; }));
+    cudf::strings_column_view view(strings);
+    {
+        auto results = cudf::strings::detail::fill(view,1,5,cudf::string_scalar("zz"));
+
+        std::vector<const char*> h_expected{ "eee", "zz", "zz", "zz", "zz", "bbb", "ééé" };
+        cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end(),
+            thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
+        cudf::test::expect_columns_equal(*results,expected);
+    }
+    {
+        auto results = cudf::strings::detail::fill(view,2,4,cudf::string_scalar("",false));
+
+        std::vector<const char*> h_expected{ "eee", "bb", nullptr, nullptr, "aa", "bbb", "ééé" };
+        cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end(),
+            thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
+        cudf::test::expect_columns_equal(*results,expected);
+    }
+    {
+        auto results = cudf::strings::detail::fill(view,5,5,cudf::string_scalar("zz"));
+        cudf::test::expect_columns_equal(*results,view.parent());
+    }
+}
+
+TEST_F(StringsFillTest, ZeroSizeStringsColumns)
+{
+    cudf::column_view zero_size_strings_column( cudf::data_type{cudf::STRING}, 0, nullptr, nullptr, 0);
+    auto results = cudf::strings::detail::fill(cudf::strings_column_view(zero_size_strings_column),0,1,cudf::string_scalar(""));
+    cudf::test::expect_strings_empty(results->view());
+}
+
+TEST_F(StringsFillTest, FillRangeError)
+{
+    std::vector<const char*> h_strings{ "eee", "bb", nullptr, "", "aa", "bbb", "ééé" };
+    cudf::test::strings_column_wrapper strings( h_strings.begin(), h_strings.end(),
+        thrust::make_transform_iterator( h_strings.begin(), [] (auto str) { return str!=nullptr; }));
+    cudf::strings_column_view view(strings);
+
+    EXPECT_THROW(cudf::strings::detail::fill(view,5,1,cudf::string_scalar("")), cudf::logic_error);
+    EXPECT_THROW(cudf::strings::detail::fill(view,5,9,cudf::string_scalar("")), cudf::logic_error);
+}


### PR DESCRIPTION
Create a `strings::detail::fill()` function to fill a column of strings with a `string_scalar`.

```
std::unique_ptr<column> cudf::strings::detail::fill( strings_column_view const& strings,
                              size_type first, size_type last,
                              string_scalar const& value,
                              memory_resource, stream );
```