### PR TITLE
[REVIEW] Support getitem with bools when DataFrame has a MultiIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@
 - PR #3357 Disabling `column_view` iterators for non fixed-width types
 - PR #3386 Removing external includes from `column_view.hpp`
 - PR #3369 Add write_partition to dask_cudf to fix to_parquet bug
+- PR #3388 Support getitem with bools when DataFrame has a MultiIndex
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -398,7 +398,7 @@ class DataFrame(object):
             df = DataFrame()
             if mask.dtype == "bool":
                 # New df-wide index
-                index = as_index(self.index.as_column()[mask])
+                index = self.index.take(mask)
                 for col in self._cols:
                     df[col] = Series(self._cols[col][arg], index=index)
                 df = df.set_index(index)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1736,14 +1736,14 @@ def test_dataframe_boolmask(mask_shape):
         pytest.param(
             Series([True, False, True]),
             marks=pytest.mark.xfail(
-                reason="Pandas doesn't support indexing a multiindex with a Series"
+                reason="Pandas can't index a multiindex with a Series"
             ),
         ),
     ],
 )
 def test_dataframe_multiindex_boolmask(mask):
     gdf = DataFrame(
-        {"w": [3, 2, 1], "x": [1, 2, 3], "y": [0, 1, 0], "z": [1, 1, 1],}
+        {"w": [3, 2, 1], "x": [1, 2, 3], "y": [0, 1, 0], "z": [1, 1, 1]}
     )
     gdg = gdf.groupby(["w", "x"]).count()
     pdg = gdg.to_pandas()

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1729,22 +1729,23 @@ def test_dataframe_boolmask(mask_shape):
         )
 
 
-@pytest.mark.parametrize('mask', [
-    [True, False, True],
-    pytest.param(
-        Series([True, False, True]),
-        marks=pytest.mark.xfail(
-            reason="Pandas doesn't support indexing a multiindex with a Series"
+@pytest.mark.parametrize(
+    "mask",
+    [
+        [True, False, True],
+        pytest.param(
+            Series([True, False, True]),
+            marks=pytest.mark.xfail(
+                reason="Pandas doesn't support indexing a multiindex with a Series"
+            ),
         ),
-    ),
-])
+    ],
+)
 def test_dataframe_multiindex_boolmask(mask):
-    gdf = DataFrame({'w': [3, 2, 1],
-                     'x': [1, 2, 3],
-                     'y': [0, 1, 0],
-                     'z': [1, 1, 1],
-                     })
-    gdg = gdf.groupby(['w', 'x']).count()
+    gdf = DataFrame(
+        {"w": [3, 2, 1], "x": [1, 2, 3], "y": [0, 1, 0], "z": [1, 1, 1],}
+    )
+    gdg = gdf.groupby(["w", "x"]).count()
     pdg = gdg.to_pandas()
     assert_eq(gdg[mask], pdg[mask])
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1728,6 +1728,25 @@ def test_dataframe_boolmask(mask_shape):
             gdf[col].fillna(-1).to_pandas().values, pdf[col].fillna(-1).values
         )
 
+@pytest.mark.parametrize('mask', [
+    [True, False, True],
+    pytest.param(
+        Series([True, False, True]),
+        marks=pytest.mark.xfail(
+            reason="Pandas doesn't support indexing a multiindex with a Series"
+        ),
+    ),
+])
+def test_dataframe_multiindex_boolmask(mask):
+    gdf = DataFrame({'w': [3, 2, 1],
+                     'x': [1, 2, 3],
+                     'y': [0, 1, 0],
+                     'z': [1, 1, 1],
+                     })
+    gdg = gdf.groupby(['w', 'x']).count()
+    pdg = gdg.to_pandas()
+    assert_eq(gdg[mask], pdg[mask])
+
 
 def test_dataframe_assignment():
     pdf = pd.DataFrame()

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1728,6 +1728,7 @@ def test_dataframe_boolmask(mask_shape):
             gdf[col].fillna(-1).to_pandas().values, pdf[col].fillna(-1).values
         )
 
+
 @pytest.mark.parametrize('mask', [
     [True, False, True],
     pytest.param(


### PR DESCRIPTION
This small change enables functionality like `df[[True, False, False]]` when the DataFrame is indexed with a MultiIndex. 