### PR TITLE
Fix Serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,7 +166,7 @@
 - PR #3318 Revert arrow to 0.15.0 temporarily to unblock downstream projects CI
 - PR #3317 Fix index-argument bug in dask_cudf parquet reader
 - PR #3323 Fix `insert` non-assert test case
-- PR #3341 Fix `Series` constructor converting NoneType to "None" 
+- PR #3341 Fix `Series` constructor converting NoneType to "None"
 - PR #3326 Fix and test for detail::gather map iterator type inference
 - PR #3334 Remove zero-size exception check from make_strings_column factories
 - PR #3333 Fix compilation issues with `constexpr` functions not marked `__device__`
@@ -177,7 +177,7 @@
 - PR #3386 Removing external includes from `column_view.hpp`
 - PR #3369 Add write_partition to dask_cudf to fix to_parquet bug
 - PR #3388 Support getitem with bools when DataFrame has a MultiIndex
-
+- PR #3408 Fix String and Column (De-)Serialization
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -671,7 +671,7 @@ class StringColumn(column.TypedColumnBase):
             ncount=header["null_count"],
             bdevmem=True,
         )
-        typ = pickle.loads(header['type'])
+        typ = pickle.loads(header["type"])
         return typ(data)
 
     def sort_by_values(self, ascending=True, na_position="last"):

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -671,7 +671,8 @@ class StringColumn(column.TypedColumnBase):
             ncount=header["null_count"],
             bdevmem=True,
         )
-        return data
+        typ = pickle.loads(header['type'])
+        return typ(data)
 
     def sort_by_values(self, ascending=True, na_position="last"):
         if na_position == "last":

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -251,7 +251,8 @@ class DataFrame(object):
         frames.extend(index_frames)
 
         # Use the column directly to avoid duplicating the index
-        header["column_names"] = tuple(self._cols.keys())
+        # need to pickle column names to handle numpy integer columns
+        header["column_names"] = pickle.dumps(tuple(self._cols.keys()))
         column_header, column_frames = column.serialize_columns(self._columns)
         header["columns"] = column_header
         frames.extend(column_frames)
@@ -269,7 +270,7 @@ class DataFrame(object):
         # Reconstruct the columns
         column_frames = frames[header["index_frame_count"] :]
 
-        column_names = header["column_names"]
+        column_names = pickle.loads(header["column_names"])
         columns = column.deserialize_columns(header["columns"], column_frames)
 
         return cls(dict(zip(column_names, columns)), index=index)


### PR DESCRIPTION
PR fixes two things:

- serialize column names (needed when columns are integers9
- call StringColumn constructor when deserializing Strings

Resolves https://github.com/rapidsai/cudf/issues/3406

cc @pentschev 