### PR TITLE
[REVIEW] Fix memory leak with strings when pulling data off the GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@
 - PR #3388 Support getitem with bools when DataFrame has a MultiIndex
 - PR #3408 Fix String and Column (De-)Serialization
 - PR #3372 Fix dask-distributed scatter_by_map bug
+- PR #3416 Fix memory leak in ColumnVector when pulling strings off the GPU
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,6 @@
 - PR #3416 Fix memory leak in ColumnVector when pulling strings off the GPU
 
 
-
 # cuDF 0.10.0 (16 Oct 2019)
 
 ## New Features

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -473,6 +473,12 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
       MemoryListener.deviceDeallocation(amount, internalId);
       // Just do it to make sure the cache is updated
       offHeap.getDeviceMemoryLength(type, true);
+      // We have to free the cudf column to handle Strings properly
+      if (offHeap.nativeCudfColumnHandle != 0) {
+        freeCudfColumn(offHeap.nativeCudfColumnHandle, false);
+        offHeap.nativeCudfColumnHandle = 0;
+      }
+
     }
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

When using the java api  and pulling a columnt hat contains strings back off the GPU to host memory, we leak memory.  The reason for this is the NVStrings are special so we can't just RMM free the memory address, we have to actually delete the NVString. This patch uses freeCudfColumn just like OffHeapState.cleanImpl does.

I tested this on both a small file where we put data on GPU, then pull it back off to do a udf. Without this patch if you dump out the rmm log you will see leaked memory, with this patch no more leaked memory.  I also ran it on the Mortgage ETL example where I was regularly seeing OOM with partition sizes over 512MB, and those errors went away.
