### PR TITLE
[REVIEW] Correct end-of-string checking in strings timestamp parsing.  Fixes #3353

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@
 - PR #3388 Support getitem with bools when DataFrame has a MultiIndex
 - PR #3408 Fix String and Column (De-)Serialization
 - PR #3372 Fix dask-distributed scatter_by_map bug
+- PR #3419 Fix a bug in parse_into_parts (incomplete input causing walking past the end of string).
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/cpp/custrings/strings/datetime.cu
+++ b/cpp/custrings/strings/datetime.cu
@@ -215,6 +215,9 @@ struct parse_datetime
             DTFormatItem item = items[idx];
             int slen = (int)item.length;
             //printf("%d:%c=%d\n",(int)fmt.ftype,ch,(int)slen);
+            if( length < slen ){
+                return 1;
+            }
             if(item.item_type==false)
             {
                 // consume fmt.len bytes from datetime
@@ -223,8 +226,6 @@ struct parse_datetime
                 length -= slen;
                 continue;
             }
-            if( length < slen )
-                return 1;
 
             // special logic for each specifier
             switch(item.specifier)

--- a/cpp/custrings/tests/test_datetime.cu
+++ b/cpp/custrings/tests/test_datetime.cu
@@ -13,22 +13,22 @@ TEST_F(TestTimestamp, ToTimestamp)
 {
     {    
         std::vector<const char*> hstrs{"1974-02-28T01:23:45Z", "2019-07-17T21:34:37Z",
-                                       nullptr, "" };
+                                       nullptr, "", "1974" };
         NVStrings* strs = NVStrings::create_from_array(hstrs.data(),hstrs.size());
         thrust::device_vector<unsigned long> results(hstrs.size(),0);
         strs->timestamp2long("%Y-%m-%dT%H:%M:%SZ", NVStrings::seconds, results.data().get());
-        int expected[] = { 131246625, 1563399277, 0,0 };
+        int expected[] = { 131246625, 1563399277, 0, 0, 0 };
         for( int idx = 0; idx < (int) hstrs.size(); ++idx )
             EXPECT_EQ((int)results[idx],expected[idx]);
         NVStrings::destroy(strs);
     }
 
     {    
-        std::vector<const char*> hstrs{"12.28.1982", "07.17.2019" };
+        std::vector<const char*> hstrs{"12.28.1982", "07.17.2019", "06" };
         NVStrings* strs = NVStrings::create_from_array(hstrs.data(),hstrs.size());
         thrust::device_vector<unsigned long> results(hstrs.size(),0);
         strs->timestamp2long("%m-%d-%Y", NVStrings::days, results.data().get());
-        int expected[] = { 4744, 18094 };
+        int expected[] = { 4744, 18094, 0 };
         for( int idx = 0; idx < (int) hstrs.size(); ++idx )
             EXPECT_EQ((int)results[idx],expected[idx]);
         NVStrings::destroy(strs);


### PR DESCRIPTION

Fixed a bug in parse_into_parts where we weren't checking for end-of-string at the right place.  This could cause length (an unsigned int) to roll negative which would prevent us from every bailing early. 

I just moved the if check before the other if(){continue;} check that was causing the rollover.  Also added some tests to verify this new behavior.
