### PR TITLE
Change expect_columns_equal() to ignore nullability of inputs as part of the condition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 - PR #3391 Move device_atomics_tests.cu files to legacy
 - PR #3389 Move quantiles.hpp + group_quantiles.hpp files to legacy
 - PR #3398 Move reshape.hpp files to legacy
+- PR #3426 Change expect_columns_equal() to ignore nullability of inputs as part of the condition.
 
 ## Bug Fixes
 


### PR DESCRIPTION

Split expect_column_properties_equal into two pieces.  expect_column_properties_equal_semantic which checks everything except nullability, and expect_column_properties_equal which adds on the additional nullability check.  The use case for the semantic check is expect_columns_equal() where nullability of inputs isn't relevant to their effective equality.