### PR TITLE
[REVIEW] Fix diff and shift for empty series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@
 - PR #3413 Fix dask_cudf read_csv file-list bug
 - PR #3416 Fix memory leak in ColumnVector when pulling strings off the GPU
 - PR #3424 Fix benchmark build by adding libcudacxx to benchmark's CMakeLists.txt
+- PR #3435 Fix diff and shift for empty series
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2426,9 +2426,10 @@ class Series(object):
 
         input_dary = self.data.mem
         output_dary = rmm.device_array_like(input_dary)
-        cudautils.gpu_shift.forall(output_dary.size)(
-            input_dary, output_dary, periods
-        )
+        if output_dary.size > 0:
+            cudautils.gpu_shift.forall(output_dary.size)(
+                input_dary, output_dary, periods
+            )
         return Series(output_dary, name=self.name, index=self.index)
 
     def diff(self, periods=1):
@@ -2452,9 +2453,10 @@ class Series(object):
 
         input_dary = self.data.mem
         output_dary = rmm.device_array_like(input_dary)
-        cudautils.gpu_diff.forall(output_dary.size)(
-            input_dary, output_dary, periods
-        )
+        if output_dary.size > 0:
+            cudautils.gpu_diff.forall(output_dary.size)(
+                input_dary, output_dary, periods
+            )
         return Series(output_dary, name=self.name, index=self.index)
 
     def groupby(

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2625,7 +2625,6 @@ def test_shift(dtype, period, data_empty):
         assert_eq(shifted_outcome, expected_outcome)
 
 
-
 @pytest.mark.parametrize(
     "dtype", ["int8", "int16", "int32", "int64", "float32", "float64"]
 )
@@ -2651,6 +2650,7 @@ def test_diff(dtype, period, data_empty):
         assert_eq(diffed_outcome, expected_outcome, check_index_type=False)
     else:
         assert_eq(diffed_outcome, expected_outcome)
+
 
 def test_isnull_isna():
     # float & strings some missing

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2601,40 +2601,56 @@ def test_get_numeric_data():
     "dtype", ["int8", "int16", "int32", "int64", "float32", "float64"]
 )
 @pytest.mark.parametrize("period", [-1, -5, -10, -20, 0, 1, 5, 10, 20])
-def test_shift(dtype, period):
-    if dtype == np.int8:
-        # to keep data in range
-        data = gen_rand(dtype, 100000, low=-2, high=2)
-    else:
-        data = gen_rand(dtype, 100000)
+@pytest.mark.parametrize("data_empty", [False, True])
+def test_shift(dtype, period, data_empty):
 
-    gdf = DataFrame({"a": data})
-    pdf = pd.DataFrame({"a": data})
+    if data_empty:
+        data = None
+    else:
+        if dtype == np.int8:
+            # to keep data in range
+            data = gen_rand(dtype, 100000, low=-2, high=2)
+        else:
+            data = gen_rand(dtype, 100000)
+
+    gdf = DataFrame({"a": Series(data, dtype=dtype)})
+    pdf = pd.DataFrame({"a": pd.Series(data, dtype=dtype)})
 
     shifted_outcome = gdf.a.shift(period)
     expected_outcome = pdf.a.shift(period).fillna(-1).astype(dtype)
 
-    assert_eq(shifted_outcome, expected_outcome)
+    if data_empty:
+        assert_eq(shifted_outcome, expected_outcome, check_index_type=False)
+    else:
+        assert_eq(shifted_outcome, expected_outcome)
+
 
 
 @pytest.mark.parametrize(
     "dtype", ["int8", "int16", "int32", "int64", "float32", "float64"]
 )
 @pytest.mark.parametrize("period", [-1, -5, -10, -20, 0, 1, 5, 10, 20])
-def test_diff(dtype, period):
-    if dtype == np.int8:
-        # to keep data in range
-        data = gen_rand(dtype, 100000, low=-2, high=2)
+@pytest.mark.parametrize("data_empty", [False, True])
+def test_diff(dtype, period, data_empty):
+    if data_empty:
+        data = None
     else:
-        data = gen_rand(dtype, 100000)
+        if dtype == np.int8:
+            # to keep data in range
+            data = gen_rand(dtype, 100000, low=-2, high=2)
+        else:
+            data = gen_rand(dtype, 100000)
 
-    gdf = DataFrame({"a": data})
-    pdf = pd.DataFrame({"a": data})
+    gdf = DataFrame({"a": Series(data, dtype=dtype)})
+    pdf = pd.DataFrame({"a": pd.Series(data, dtype=dtype)})
 
     diffed_outcome = gdf.a.diff(period)
     expected_outcome = pdf.a.diff(period).fillna(-1).astype(dtype)
-    assert_eq(diffed_outcome, expected_outcome)
 
+    if data_empty:
+        assert_eq(diffed_outcome, expected_outcome, check_index_type=False)
+    else:
+        assert_eq(diffed_outcome, expected_outcome)
 
 def test_isnull_isna():
     # float & strings some missing


### PR DESCRIPTION
This pr adds check for length of device array for shift/diff before launching kernels.
PR fixes issue #3433  . 

- [x] Check for non zero length
- [x] Unit tests for zero length for shift and diff
