### PR TITLE
[WIP] update gather_bitmask_kernel to use or remove unused template parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@
 - PR #3425 Strings column copy_if_else implementation
 - PR #3422 Move utilities to legacy
 - PR #3201 Define and implement new datetime_ops APIs
+- PR #3444 Removed unused type argument from `gather_bitmask_kernel`.
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -48,7 +48,7 @@ struct bounds_checker {
 
 
 
-template <bool ignore_out_of_bounds, typename MapIterator>
+template <typename MapIterator>
 __global__ void gather_bitmask_kernel(table_device_view source_table,
                                       MapIterator gather_map,
                                       bitmask_type * masks[],
@@ -319,8 +319,7 @@ gather(table_view const& source_table, MapIterator gather_map_begin,
 
   rmm::device_vector<cudf::size_type> valid_counts(source_table.num_columns(), 0);
 
-  auto bitmask_kernel =
-    ignore_out_of_bounds ? gather_bitmask_kernel<true, decltype(gather_map_begin)> : gather_bitmask_kernel<false, decltype(gather_map_begin)>;
+  auto bitmask_kernel = gather_bitmask_kernel<decltype(gather_map_begin)>;
 
   int gather_grid_size;
   int gather_block_size;


### PR DESCRIPTION
`gather_bitmask_kernel` isn't using its `ignore_out_of_bounds` type argument. Removing it.