### PR TITLE
[REVIEW] Fix printing of invalid entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@
 - PR #3435 Fix diff and shift for empty series
 - PR #3439 Fix index-name bug in StringColumn concat
 - PR #3445 Fix ORC Writer default stripe size
+- PR #3459 Fix printing of invalid entries
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -144,10 +144,12 @@ struct column_view_printer {
     out.resize(col.size());
 
     if (col.nullable()) {
-      size_type index = 0;
-      std::transform(h_data.first.begin(), h_data.first.end(), out.begin(), [&h_data, &index](Element el) {
-          return (bit_is_set(h_data.second.data(), index++)) ? std::to_string(el) : std::string("@");
-        });
+      std::transform(thrust::make_counting_iterator(size_type{0}),
+                     thrust::make_counting_iterator(col.size()),
+                     out.begin(),
+                     [&h_data](auto idx) {
+                       return bit_is_set(h_data.second.data(), idx) ? std::to_string(h_data.first[idx]) : std::string("NULL");
+                     });
     } else {
       std::transform(h_data.first.begin(), h_data.first.end(), out.begin(), [](Element el) {
           return std::to_string(el);
@@ -176,10 +178,12 @@ struct column_view_printer {
     out.resize(col.size());
 
     if (col.nullable()) {
-      size_type index = 0;
-      std::transform(h_data.first.begin(), h_data.first.end(), out.begin(), [&h_data, &index](std::string el) {
-          return (bit_is_set(h_data.second.data(), index++)) ? el : std::string("@");
-        });
+      std::transform(thrust::make_counting_iterator(size_type{0}),
+                     thrust::make_counting_iterator(col.size()),
+                     out.begin(),
+                     [&h_data](auto idx) {
+                       return bit_is_set(h_data.second.data(), idx) ? h_data.first[idx] : std::string("NULL");
+                     });
     } else {
       out = std::move(h_data.first);
     }

--- a/cpp/tests/utilities_tests/column_utilities_tests.cu
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cu
@@ -131,9 +131,9 @@ TYPED_TEST(ColumnUtilitiesTestNumeric, PrintColumnWithInvalids) {
 
   std::ostringstream tmp;
   tmp << std::to_string(std_col[0])
-      << delimiter << "@"
+      << delimiter << "NULL"
       << delimiter << std::to_string(std_col[2])
-      << delimiter << "@"
+      << delimiter << "NULL"
       << delimiter << std::to_string(std_col[4]);
   
   EXPECT_EQ(cudf::test::to_string(cudf_col, delimiter), tmp.str());
@@ -150,7 +150,7 @@ TEST_F(ColumnUtilitiesStringsTest, StringsToString) {
   std::ostringstream tmp;
   tmp << h_strings[0]
       << delimiter << h_strings[1]
-      << delimiter << "@"
+      << delimiter << "NULL"
       << delimiter << h_strings[3]
       << delimiter << h_strings[4]
       << delimiter << h_strings[5]


### PR DESCRIPTION
Some issues were discovered in the print column implementation.

First, the std::transform method does not guarantee serial order, so the mechanism used in this implementation might not check validity correctly.

Second, there was confusion about what should be printed in the case of invalid entries.  After some slack discussion, the conclusion was we should change the printed character from @ to NULL.  So a numeric column with values { 0, 1, 2 } where the 1 is invalid would print (with a comma delimiter) as "0,NULL,2".  Similarly, a string column with values { "a", nullptr, "c" } where nullptr is invalid would print (with a comma delimiter) as "a,NULL,c".