### PR TITLE
[REVIEW] Add bitmask_to_host column utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,8 @@
 - PR #3425 Strings column copy_if_else implementation
 - PR #3422 Move utilities to legacy
 - PR #3201 Define and implement new datetime_ops APIs
-- PR #3462 Add `make_empty_column` and update `empty_like`.
+- PR #3462 Add `make_empty_column` and update `empty_like`
+- PR #3485 Add `bitmask_to_host` column utility
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@
 - PR #3422 Move utilities to legacy
 - PR #3201 Define and implement new datetime_ops APIs
 - PR #3462 Add `make_empty_column` and update `empty_like`
-- PR #3485 Add `bitmask_to_host` column utility
+- PR #3475 Add `bitmask_to_host` column utility
 
 ## Bug Fixes
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -484,7 +484,7 @@ set(LEGACY_NVSTRING_SCATTER_TEST_SRC
 
 set(UTILITIES_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/utilities_tests/type_list_tests.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/utilities_tests/column_utilities_tests.cu"
+    "${CMAKE_CURRENT_SOURCE_DIR}/utilities_tests/column_utilities_tests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/utilities_tests/column_wrapper_tests.cu")
 
 ConfigureTest(UTILITIES_TEST "${UTILITIES_TEST_SRC}")

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -34,7 +34,7 @@ namespace cudf {
 namespace test {
 
 // Property equality
-void expect_column_properties_equal(cudf::column_view lhs, cudf::column_view rhs) {
+void expect_column_properties_equal(cudf::column_view const& lhs, cudf::column_view const& rhs) {
   EXPECT_EQ(lhs.type(), rhs.type());
   EXPECT_EQ(lhs.size(), rhs.size());
   EXPECT_EQ(lhs.null_count(), rhs.null_count());
@@ -57,7 +57,7 @@ public:
   }
 };
 
-void expect_columns_equal(cudf::column_view lhs, cudf::column_view rhs, bool print_all_differences) {
+void expect_columns_equal(cudf::column_view const& lhs, cudf::column_view const& rhs, bool print_all_differences) {
   expect_column_properties_equal(lhs, rhs);
 
   auto d_lhs = cudf::table_device_view::create(table_view{{lhs}});
@@ -136,6 +136,19 @@ void expect_equal_buffers(void const* lhs, void const* rhs,
                             typed_rhs));
 }
 
+// copy column bitmask to host (used by to_host())
+std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c) {
+  std::vector<bitmask_type> host_bitmask;
+  if (c.nullable()) {
+    auto num_bitmasks = bitmask_allocation_size_bytes(c.size()) / sizeof(bitmask_type);
+    host_bitmask.resize(num_bitmasks);
+    CUDA_TRY(cudaMemcpy(host_bitmask.data(), c.null_mask(), num_bitmasks * sizeof(bitmask_type),
+                        cudaMemcpyDeviceToHost));
+  }
+  return host_bitmask;
+}
+
+
 struct column_view_printer {
   template <typename Element, typename std::enable_if_t<is_numeric<Element>()>* = nullptr>
   void operator()(cudf::column_view const& col, std::vector<std::string> & out) {
@@ -176,7 +189,6 @@ struct column_view_printer {
     auto h_data = cudf::test::to_host<std::string>(col);
 
     out.resize(col.size());
-
     if (col.nullable()) {
       std::transform(thrust::make_counting_iterator(size_type{0}),
                      thrust::make_counting_iterator(col.size()),

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -57,7 +57,8 @@ public:
   }
 };
 
-void expect_columns_equal(cudf::column_view const& lhs, cudf::column_view const& rhs, bool print_all_differences) {
+void expect_columns_equal(cudf::column_view const& lhs, cudf::column_view const& rhs,
+                          bool print_all_differences) {
   expect_column_properties_equal(lhs, rhs);
 
   auto d_lhs = cudf::table_device_view::create(table_view{{lhs}});

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -139,14 +139,18 @@ void expect_equal_buffers(void const* lhs, void const* rhs,
 
 // copy column bitmask to host (used by to_host())
 std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c) {
-  std::vector<bitmask_type> host_bitmask;
   if (c.nullable()) {
     auto num_bitmasks = bitmask_allocation_size_bytes(c.size()) / sizeof(bitmask_type);
-    host_bitmask.resize(num_bitmasks);
+    std::vector<bitmask_type> host_bitmask(num_bitmasks);
+
     CUDA_TRY(cudaMemcpy(host_bitmask.data(), c.null_mask(), num_bitmasks * sizeof(bitmask_type),
                         cudaMemcpyDeviceToHost));
+
+    return host_bitmask;
   }
-  return host_bitmask;
+  else {
+    return std::vector<bitmask_type>{};
+  }
 }
 
 

--- a/cpp/tests/utilities/column_utilities.hpp
+++ b/cpp/tests/utilities/column_utilities.hpp
@@ -98,16 +98,9 @@ std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c);
  */
 template <typename T>
 std::pair<std::vector<T>, std::vector<bitmask_type>> to_host(column_view c) {
-  std::vector<T> host_data;
-
-  if (c.size() > 0) {
-    host_data.resize(c.size());
-    CUDA_TRY(cudaMemcpy(host_data.data(), c.head<T>(), c.size() * sizeof(T),
-                        cudaMemcpyDeviceToHost));
-  }
-
-  std::vector<bitmask_type> host_bitmask = bitmask_to_host(c);
-  return std::make_pair(host_data, host_bitmask);
+  std::vector<T> host_data(c.size());
+  CUDA_TRY(cudaMemcpy(host_data.data(), c.head<T>(), c.size() * sizeof(T), cudaMemcpyDeviceToHost));
+  return { host_data, bitmask_to_host(c) };
 }
 
 /**
@@ -122,26 +115,27 @@ std::pair<std::vector<T>, std::vector<bitmask_type>> to_host(column_view c) {
  */
 template <>
 inline std::pair<std::vector<std::string>, std::vector<bitmask_type>> to_host(column_view c) {
-  std::vector<std::string> host_data;
-
-  auto strings = strings_column_view(c);
-  auto strings_data = cudf::strings::create_offsets(strings);
-  thrust::host_vector<char> h_chars(strings_data.first);         // copies vectors to
-  thrust::host_vector<size_type> h_offsets(strings_data.second); // host automatically
-
+  auto strings_data = cudf::strings::create_offsets(strings_column_view(c));
+  thrust::host_vector<char> h_chars(strings_data.first);
+  thrust::host_vector<size_type> h_offsets(strings_data.second);
+  
   // build std::string vector from chars and offsets
-  if( !h_chars.empty() ) // check for all nulls case
-  {
-    for( size_type idx=0; idx < strings.size(); ++idx )
+  if( !h_chars.empty() ) { // check for all nulls case
+    std::vector<std::string> host_data;
+    host_data.reserve(c.size());
+
+    // When C++17, replace this loop with std::adjacent_difference()
+    for( size_type idx=0; idx < c.size(); ++idx )
     {
         auto offset = h_offsets[idx];
         auto length = h_offsets[idx+1] - offset;
         host_data.push_back(std::string( h_chars.data()+offset, length));
     }
-  }
 
-  std::vector<bitmask_type> host_bitmask = bitmask_to_host(c);
-  return std::make_pair(host_data, host_bitmask);
+    return { host_data, bitmask_to_host(c) };
+  }
+  else 
+    return { std::vector<std::string>{}, bitmask_to_host(c) };
 }
 
 }  // namespace test

--- a/cpp/tests/utilities/column_utilities.hpp
+++ b/cpp/tests/utilities/column_utilities.hpp
@@ -43,7 +43,8 @@ void expect_column_properties_equal(cudf::column_view const& lhs, cudf::column_v
  * @param rhs                   The second column
  * @param print_all_differences If true display all differences
  *---------------------------------------------------------------------------**/
-void expect_columns_equal(cudf::column_view lhs, cudf::column_view rhs, bool print_all_differences = false);
+void expect_columns_equal(cudf::column_view const& lhs, cudf::column_view const& rhs,
+                          bool print_all_differences = false);
 
 /**
  * @brief Verifies the bitwise equality of two device memory buffers.

--- a/cpp/tests/utilities/column_utilities.hpp
+++ b/cpp/tests/utilities/column_utilities.hpp
@@ -32,7 +32,7 @@ namespace test {
  * @param lhs The first column
  * @param rhs The second column
  */
-void expect_column_properties_equal(cudf::column_view lhs, cudf::column_view rhs);
+void expect_column_properties_equal(cudf::column_view const& lhs, cudf::column_view const& rhs);
 
 /**
  * @brief Verifies the element-wise equality of two columns.

--- a/cpp/tests/utilities/timestamp_utilities.cuh
+++ b/cpp/tests/utilities/timestamp_utilities.cuh
@@ -70,8 +70,9 @@ generate_timestamps(int32_t count, time_point_ms start, time_point_ms stop) {
     auto mask = cudf::test::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
     return cudf::test::fixed_width_column_wrapper<T>(iter, iter + count, mask);
   }
-
-  return cudf::test::fixed_width_column_wrapper<T>(iter, iter + count);
+  else {
+    return cudf::test::fixed_width_column_wrapper<T>(iter, iter + count);
+  }
 }
 
 }  // namespace test

--- a/cpp/tests/utilities/timestamp_utilities.cuh
+++ b/cpp/tests/utilities/timestamp_utilities.cuh
@@ -71,6 +71,7 @@ generate_timestamps(int32_t count, time_point_ms start, time_point_ms stop) {
     return cudf::test::fixed_width_column_wrapper<T>(iter, iter + count, mask);
   }
   else {
+    // This needs to be in an else to quash `statement_not_reachable` warnings
     return cudf::test::fixed_width_column_wrapper<T>(iter, iter + count);
   }
 }

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -21,6 +21,8 @@
 #include <tests/utilities/cudf_gtest.hpp>
 #include <tests/utilities/type_lists.hpp>
 
+#include <thrust/iterator/constant_iterator.h>
+
 template <typename T>
 struct ColumnUtilitiesTest : public cudf::test::BaseFixture
 {
@@ -88,6 +90,7 @@ TEST_F(ColumnUtilitiesStringsTest, StringsToHost)
   auto result_itr = host_data.first.begin();
   for( auto itr = h_strings.begin(); itr != h_strings.end(); ++itr, ++result_itr )
   {
+
     if(*itr)
       EXPECT_TRUE((*result_itr)==(*itr));
   }

--- a/cpp/tests/utilities_tests/column_utilities_tests.cu
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cu
@@ -22,14 +22,13 @@
 #include <tests/utilities/type_lists.hpp>
 
 template <typename T>
+struct ColumnUtilitiesTest : public cudf::test::BaseFixture
+{
+  cudf::test::UniformRandomGenerator<cudf::size_type> random;
 
-struct ColumnUtilitiesTest
-    : public cudf::test::BaseFixture,
-      cudf::test::UniformRandomGenerator<cudf::size_type> {
-  ColumnUtilitiesTest()
-      : cudf::test::UniformRandomGenerator<cudf::size_type>{1000, 5000} {}
+  ColumnUtilitiesTest() : random{1000, 5000} {}
 
-  auto size() { return this->generate(); }
+  auto size() { return random.generate(); }
 
   auto data_type() {
     return cudf::data_type{cudf::experimental::type_to_id<T>()};
@@ -61,8 +60,7 @@ TYPED_TEST(ColumnUtilitiesTest, NullableToHostAllValid) {
   auto sequence = cudf::test::make_counting_transform_iterator(
       0, [](auto i) { return TypeParam(i); });
 
-  auto all_valid = cudf::test::make_counting_transform_iterator(
-      0, [](auto i) { return true; });
+  auto all_valid = thrust::make_constant_iterator<bool>(true);
 
   auto size = this->size();
 
@@ -74,7 +72,7 @@ TYPED_TEST(ColumnUtilitiesTest, NullableToHostAllValid) {
 
   EXPECT_TRUE(std::equal(data.begin(), data.end(), host_data.first.begin()));
 
-  auto masks = cudf::test::detail::make_null_mask_vector(all_valid, all_valid+size);
+  auto masks = cudf::test::detail::make_null_mask_vector(all_valid, all_valid + size);
 
   EXPECT_TRUE(std::equal(masks.begin(), masks.end(), host_data.second.begin()));
 }


### PR DESCRIPTION
`to_host` handles copying the bit mask to the host differently for strings and fixed-width columns. This PR adds a single utility, `bitmask_to_host()` which both `to_host` functions now use, so they behave the same.