### PR TITLE
Add is_boolean trait and random timestamp generator for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@
 - PR #3462 Add `make_empty_column` and update `empty_like`.
 - PR #3214 Define and implement new unary operations APIs
 - PR #3475 Add `bitmask_to_host` column utility
+- PR #3487 Add is_boolean trait and random timestamp generator for testing
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/utilities/traits.hpp
+++ b/cpp/include/cudf/utilities/traits.hpp
@@ -104,6 +104,41 @@ constexpr inline bool is_numeric(data_type type) {
 }
 
 /**---------------------------------------------------------------------------*
+ * @brief Indicates whether `T` is a Boolean type.
+ *
+ * `cudf::bool8` is cudf's Boolean type.
+ *
+ * @param type The `data_type` to verify
+ * @return true `type` is Boolean
+ * @return false `type` is not Boolean
+ *---------------------------------------------------------------------------**/
+template <typename T>
+constexpr inline bool is_boolean() {
+  return std::is_same<T, cudf::experimental::bool8>::value ||
+         std::is_same<T, bool>::value;
+}
+
+struct is_boolean_impl {
+  template <typename T>
+  bool operator()() {
+    return is_boolean<T>();
+  }
+};
+
+/**---------------------------------------------------------------------------*
+ * @brief Indicates whether `type` is a Boolean `data_type`.
+ *
+ * `cudf::bool8` is cudf's Boolean type.
+ *
+ * @param type The `data_type` to verify
+ * @return true `type` is a Boolean
+ * @return false `type` is not a Boolean
+ *---------------------------------------------------------------------------**/
+constexpr inline bool is_boolean(data_type type) {
+  return cudf::experimental::type_dispatcher(type, is_boolean_impl{});
+}
+
+/**---------------------------------------------------------------------------*
  * @brief Indicates whether the type `T` is a timestamp type.
  *
  * @tparam T  The type to verify

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -57,7 +57,7 @@ endfunction(ConfigureBench)
 # - include paths ---------------------------------------------------------------------------------
 
 if(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES)
-	include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
+    include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
 endif()
 
 include_directories("${CMAKE_BINARY_DIR}/include"

--- a/cpp/tests/bitmask/bitmask_tests.cu
+++ b/cpp/tests/bitmask/bitmask_tests.cu
@@ -214,10 +214,10 @@ struct CopyBitmaskTest : public cudf::test::BaseFixture,
 
 void cleanEndWord(rmm::device_buffer &mask, int begin_bit, int end_bit) {
   thrust::device_ptr<cudf::bitmask_type> ptr(
-      static_cast<cudf::bitmask_type *>(mask.data()));
-  auto number_of_mask_words = cudf::util::div_rounding_up_safe(
-      static_cast<size_t>(end_bit - begin_bit),
-      cudf::detail::size_in_bits<cudf::bitmask_type>());
+    static_cast<cudf::bitmask_type *>(mask.data()));
+      
+  auto number_of_mask_words = cudf::num_bitmask_words(
+    static_cast<size_t>(end_bit - begin_bit));
   auto number_of_bits = end_bit - begin_bit;
   if (number_of_bits % 32 != 0) {
     auto end_mask = ptr[number_of_mask_words - 1];

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include "cudf_gtest.hpp"
-#include "legacy/cudf_test_utils.cuh"
+#include <tests/utilities/cudf_gtest.hpp>
 #include <cudf/wrappers/bool.hpp>
+#include <cudf/utilities/traits.hpp>
 
 #include <rmm/mr/default_memory_resource.hpp>
 #include <rmm/mr/device_memory_resource.hpp>
@@ -47,10 +47,36 @@ class BaseFixture : public ::testing::Test {
    *---------------------------------------------------------------------------**/
   rmm::mr::device_memory_resource* mr() { return _mr; }
 
-  static void SetUpTestCase() { ASSERT_RMM_SUCCEEDED(rmmInitialize(nullptr)); }
+  static void SetUpTestCase() { ASSERT_EQ(rmmInitialize(nullptr), RMM_SUCCESS); }
 
-  static void TearDownTestCase() { ASSERT_RMM_SUCCEEDED(rmmFinalize()); }
+  static void TearDownTestCase() { ASSERT_EQ(rmmFinalize(), RMM_SUCCESS); }
 };
+
+template <typename T, typename Enable = void>
+struct uniform_distribution_impl{};
+template<typename T>
+struct uniform_distribution_impl<T,
+  std::enable_if_t<std::is_integral<T>::value && not cudf::is_boolean<T>()> > {
+   using type = std::uniform_int_distribution<T>;
+};
+
+template<typename T>
+struct uniform_distribution_impl<T, std::enable_if_t<std::is_floating_point<T>::value > > {
+   using type = std::uniform_real_distribution<T>;
+};
+
+template<typename T>
+struct uniform_distribution_impl<T, std::enable_if_t<cudf::is_boolean<T>() > > {
+   using type = std::bernoulli_distribution;
+};
+
+template<typename T>
+struct uniform_distribution_impl<T, std::enable_if_t<cudf::is_timestamp<T>() > > {
+   using type = std::uniform_int_distribution<typename T::duration::rep>;
+};
+
+template <typename T>
+using uniform_distribution_t = typename uniform_distribution_impl<T>::type;
 
 /**---------------------------------------------------------------------------*
  * @brief Provides uniform random number generation.
@@ -72,13 +98,7 @@ template <typename T = cudf::size_type,
           typename Engine = std::default_random_engine>
 class UniformRandomGenerator {
  public:
-  using uniform_distribution =
-      std::conditional_t<std::is_same<T, bool>::value or
-                             std::is_same<T, experimental::bool8>::value,
-                         std::bernoulli_distribution,
-                         std::conditional_t<std::is_floating_point<T>::value,
-                                            std::uniform_real_distribution<T>,
-                                            std::uniform_int_distribution<T>>>;
+  using uniform_distribution = uniform_distribution_t<T>;
 
   UniformRandomGenerator() = default;
 


### PR DESCRIPTION
This PR adds a few testing improvements

 - [x] `UniformRandomGenerator` now supports timestamp types.
 - [x] Adds `cudf::is_boolean<T>()` trait.
 - [x] Removes legacy includes from `base_fixture.hpp`.

Merge after #3475