### PR TITLE
Small cleanup and comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@
 - PR #3458 Update strings sections in the transition guide
 - PR #3462 Add `make_empty_column` and update `empty_like`.
 - PR #3214 Define and implement new unary operations APIs
+- PR #3492 Small cleanup (remove std::abs) and comment
 
 ## Bug Fixes
 

--- a/cpp/tests/utilities/timestamp_utilities.cuh
+++ b/cpp/tests/utilities/timestamp_utilities.cuh
@@ -60,9 +60,10 @@ generate_timestamps(int32_t count, time_point_ms start, time_point_ms stop) {
                  .time_since_epoch()
                  .count();
 
+  // When C++17, auto [min, max] = std::minmax(lhs, rhs)
   auto min = std::min(lhs, rhs);
   auto max = std::max(lhs, rhs);
-  auto range = static_cast<Rep>(std::abs(max - min));
+  auto range = static_cast<Rep>(max - min);
   auto iter = cudf::test::make_counting_transform_iterator(
       0, [=](auto i) { return min + (range / count) * i; });
 


### PR DESCRIPTION
Unnecessary use of `std::abs` after calculating `min` and `max` and really we should be using `std::minmax` but until C++17 when we have structured bindings it doesn't improve things much - so just left a comment.