### PR TITLE
df.drop(): added inplace=False argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 - PR #3427 Define and Implement new multi-search API
 - PR #3442 Add Bool-index + Multi column + DataFrame support for set-item
 - PR #3172 Define and implement new fill/repeat/copy_range APIs
-
+- PR #3497 Add DataFrame.drop(..., inplace=False) argument
 
 ## Improvements
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1582,7 +1582,14 @@ class DataFrame(object):
             data, forceindex=forceindex, name=name
         )
 
-    def drop(self, labels=None, axis=None, columns=None, errors="raise"):
+    def drop(
+        self,
+        labels=None,
+        axis=None,
+        columns=None,
+        errors="raise",
+        inplace=False,
+    ):
         """Drop column(s)
 
         Parameters
@@ -1594,6 +1601,8 @@ class DataFrame(object):
         columns: array of column names, the same as using labels and axis=1
         errors : {'ignore', 'raise'}, default 'raise'
             This parameter is currently ignored.
+        inplace : bool, default False
+            If True, do operation inplace and return `self`.
 
         Returns
         -------
@@ -1642,7 +1651,10 @@ class DataFrame(object):
             if isinstance(target, (str, numbers.Number))
             else list(target)
         )
-        outdf = self.copy()
+        if inplace:
+            outdf = self
+        else:
+            outdf = self.copy()
         for c in columns:
             outdf._drop_column(c)
         return outdf


### PR DESCRIPTION
Adds an `inplace` argument to `DataFrame.drop()`, which fixes https://github.com/rapidsai/cudf/issues/3493.

Using in-place avoids a copy and can improve performance significantly (see https://github.com/dask/dask/pull/5657)
