### PR TITLE
FIX Remove unused CUDA conda labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@
 - PR #3487 Add is_boolean trait and random timestamp generator for testing
 - PR #3492 Small cleanup (remove std::abs) and comment
 - PR #3407 Allow multiple row-groups per task in dask_cudf read_parquet
+- PR #3512 Remove unused CUDA conda labels
 
 ## Bug Fixes
 

--- a/ci/cpu/upload_anaconda.sh
+++ b/ci/cpu/upload_anaconda.sh
@@ -26,7 +26,7 @@ if [ -z "$MY_UPLOAD_KEY" ]; then
 fi
 
 if [ "$UPLOAD_LIBCUDF" == "1" ]; then
-  LABEL_OPTION="--label main --label cuda${CUDA_REL}"
+  LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${LIBNVSTRINGS_FILE}
@@ -41,14 +41,13 @@ if [ "$UPLOAD_LIBCUDF" == "1" ]; then
 fi
 
 if [ "$UPLOAD_CUDF" == "1" ]; then
-  LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0"
+  LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${NVSTRINGS_FILE}
   echo "Upload nvstrings"
   echo ${NVSTRINGS_FILE}
   anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --force ${NVSTRINGS_FILE}
-
 
   test -e ${CUDF_FILE}
   echo "Upload cudf"

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -35,9 +35,10 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
-conda install -c rapidsai/label/cuda${CUDA_REL} -c rapidsai-nightly/label/cuda${CUDA_REL} -c nvidia -c conda-forge \
-    rmm=${RMM_VERSION} nvstrings=${NVSTRINGS_VERSION} sphinx sphinx_rtd_theme numpydoc \
-    sphinxcontrib-websupport nbsphinx ipython pandoc=\<2.0.0 recommonmark doxygen
+conda install -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
+    cudatoolkit=${CUDA_REL} rmm=${RMM_VERSION} nvstrings=${NVSTRINGS_VERSION} \
+    sphinx sphinx_rtd_theme numpydoc sphinxcontrib-websupport nbsphinx ipython \
+    pandoc=\<2.0.0 recommonmark doxygen
 
 pip install sphinx-markdown-tables
 logger "Check versions..."


### PR DESCRIPTION
We no longer rely on these labels for version matching and use cudatoolkit package to do so.