### PR TITLE
[REVIEW] Fix strings column concatenate handling zero-sized columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,7 @@
 - PR #3478 Fix as_index deep copy via Index.rename inplace arg
 - PR #3476 Fix ORC reader timezone conversion
 - PR #3188 Repr slices up large DataFrames
+- PR #3519 Fix strings column concatenate handling zero-sized columns
 
 
 # cuDF 0.10.0 (16 Oct 2019)

--- a/cpp/include/cudf/strings/strings_column_view.hpp
+++ b/cpp/include/cudf/strings/strings_column_view.hpp
@@ -22,10 +22,10 @@
 
 namespace cudf {
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Given a column-view of strings type, an instance of this class
  * provides a wrapper on this compound column for strings operations.
- *---------------------------------------------------------------------------**/
+ */
 class strings_column_view : private column_view
 {
 public:
@@ -45,27 +45,38 @@ public:
     using column_view::has_nulls;
     using column_view::offset;
 
-    /**---------------------------------------------------------------------------*
-    * @brief Returns the parent column.
-    *---------------------------------------------------------------------------**/
+    /**
+     * @brief Returns the parent column.
+     */
     column_view parent() const;
 
-    /**---------------------------------------------------------------------------*
-    * @brief Returns the internal column of offsets
-    *---------------------------------------------------------------------------**/
+    /**
+     * @brief Returns the internal column of offsets
+     *
+     * @throw cudf::logic error if this is an empty column
+     */
     column_view offsets() const;
 
-    /**---------------------------------------------------------------------------*
-    * @brief Returns the internal column of chars
-    *---------------------------------------------------------------------------**/
+    /**
+     * @brief Returns the internal column of chars
+     *
+     * @throw cudf::logic error if this is an empty column
+     */
     column_view chars() const;
 
+    /**
+     * @brief Returns the number of bytes in the chars child column.
+     *
+     * This accounts for the offset of the strings' column_view and
+     * for empty columns.
+     */
+    size_type chars_size() const noexcept;
 };
 
 namespace strings
 {
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Prints the strings to stdout.
  *
  * @param strings Strings instance for this operation.
@@ -75,12 +86,12 @@ namespace strings
  *        Specify -1 to print all characters.
  * @param delimiter The chars to print between each string.
  *        Default is new-line character.
- *---------------------------------------------------------------------------**/
+ */
 void print( strings_column_view strings,
             size_type start=0, size_type end=-1,
             size_type max_width=-1, const char* delimiter = "\n" );
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Create output per Arrow strings format.
  * The return pair is the vector of chars and the vector of offsets.
  *
@@ -88,7 +99,7 @@ void print( strings_column_view strings,
  * @param stream CUDA stream to use kernels in this method.
  * @param mr Resource for allocating device memory.
  * @return Pair containing a vector of chars and a vector of offsets.
- *---------------------------------------------------------------------------**/
+ */
 std::pair<rmm::device_vector<char>, rmm::device_vector<size_type>>
     create_offsets( strings_column_view strings,
                     cudaStream_t stream=0,

--- a/cpp/tests/strings/concatenate_tests.cu
+++ b/cpp/tests/strings/concatenate_tests.cu
@@ -32,13 +32,14 @@ struct StringsConcatenateTest : public cudf::test::BaseFixture {};
 TEST_F(StringsConcatenateTest, Concatenate)
 {
     std::vector<const char*> h_strings{ "aaa", "bb", "", "cccc", "d", "ééé", "ff", "gggg", "", "h", "iiii", "jjj", "k", "lllllll", "mmmmm", "n", "oo", "ppp" };
-
     cudf::test::strings_column_wrapper strings1( h_strings.data(), h_strings.data()+6 );
     cudf::test::strings_column_wrapper strings2( h_strings.data()+6, h_strings.data()+10 );
     cudf::test::strings_column_wrapper strings3( h_strings.data()+10, h_strings.data()+h_strings.size() );
+    cudf::column_view zero_size_strings_column( cudf::data_type{cudf::STRING}, 0, nullptr, nullptr, 0);
 
     std::vector<cudf::strings_column_view> strings_columns;
     strings_columns.push_back(cudf::strings_column_view(strings1));
+    strings_columns.push_back(cudf::strings_column_view(zero_size_strings_column));
     strings_columns.push_back(cudf::strings_column_view(strings2));
     strings_columns.push_back(cudf::strings_column_view(strings3));
 


### PR DESCRIPTION
Strings column concatenate does not handle zero-sized columns correctly.
Additionally, the code is not handling the column_view offset when creating the output column.
The following test was causing a seg-fault:
```
    cudf::column_view zero_size_strings_column( cudf::data_type{cudf::STRING}, 0, nullptr, nullptr, 0);
    std::vector<cudf::strings_column_view> strings_columns;
    strings_columns.push_back(cudf::strings_column_view(zero_size_strings_column));
    std::vector<const char*> h_strings{ "aaa", "bb", "" };
    cudf::test::strings_column_wrapper strings1( h_strings.begin(), h_strings.end() );
    strings_columns.push_back(cudf::strings_column_view(strings1));

    cudf::strings::detail::concatenate(strings_columns);
```
