### PR TITLE
[REVIEW] Fix unary_op null_mask bug and add missing test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,7 @@
 - PR #3188 Repr slices up large DataFrames
 - PR #3530 Fix copy_if_else test case fail issue
 - PR #3523 Fix lgenfe issue with debug build
-
+- PR #3540 Fix unary_op null_mask bug and add missing test cases
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -58,6 +58,11 @@ struct launcher {
         CUDF_EXPECTS(input.size() > 0,                   "Launcher requires input size to be non-zero.");
         CUDF_EXPECTS(input.size() == output_view.size(), "Launcher requires input and output size to be equal.");
 
+        if (input.nullable())
+            output->set_null_mask(
+                rmm::device_buffer{ input.null_mask(), bitmask_allocation_size_bytes(input.size()) },
+                input.null_count());
+
         thrust::transform(
             rmm::exec_policy(stream)->on(stream),
             input.begin<T>(),

--- a/cpp/tests/unary/unary_ops_test.cu
+++ b/cpp/tests/unary/unary_ops_test.cu
@@ -90,6 +90,14 @@ TYPED_TEST(cudf_logical_test, SimpleLogicalNot)
     cudf::test::expect_columns_equal(expected, output->view());
 }
 
+TYPED_TEST(cudf_logical_test, SimpleLogicalNotWithNullMask)
+{
+    cudf::test::fixed_width_column_wrapper<TypeParam>                 input    {{ true,  true, true,  true  }, { 1, 0, 1, 1 }};
+    cudf::test::fixed_width_column_wrapper<cudf::experimental::bool8> expected {{ false, true, false, false }, { 1, 0, 1, 1 }};
+    auto output = cudf::experimental::unary_operation(input, cudf::experimental::unary_op::NOT);
+    cudf::test::expect_columns_equal(expected, output->view());
+}
+
 TYPED_TEST(cudf_logical_test, EmptyLogicalNot)
 {
     cudf::test::fixed_width_column_wrapper<TypeParam>                 input    {};
@@ -169,6 +177,14 @@ TYPED_TEST(cudf_math_test, SimpleSQRT)
 {
     cudf::test::fixed_width_column_wrapper<TypeParam> input    {{ 1, 4, 9, 16 }};
     cudf::test::fixed_width_column_wrapper<TypeParam> expected {{ 1, 2, 3, 4  }};
+    auto output = cudf::experimental::unary_operation(input, cudf::experimental::unary_op::SQRT);
+    cudf::test::expect_columns_equal(expected, output->view());
+}
+
+TYPED_TEST(cudf_math_test, SimpleSQRTWithNullMask)
+{
+    cudf::test::fixed_width_column_wrapper<TypeParam> input    {{ 1, 4, 9, 16 }, { 1, 1, 0, 1}};
+    cudf::test::fixed_width_column_wrapper<TypeParam> expected {{ 1, 2, 9, 4  }, { 1, 1, 0, 1}};
     auto output = cudf::experimental::unary_operation(input, cudf::experimental::unary_op::SQRT);
     cudf::test::expect_columns_equal(expected, output->view());
 }


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/3534

This addresses: https://github.com/rapidsai/cudf/issues/3534#issuecomment-562218380

Add missing `null_mask` copy and corresponding test cases.