### PR TITLE
[REVIEW] Add support for column names in libcudf++ io readers/writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## New Features
 - PR #3284 Add gpu-accelerated parquet writer
+- PR #3555 Add column names support to libcudf++ io readers and writers
 
 ## Improvements
 

--- a/cpp/include/cudf/io/functions.hpp
+++ b/cpp/include/cudf/io/functions.hpp
@@ -335,11 +335,14 @@ struct write_parquet_args {
   statistics_freq stats_level;
   /// Set of columns to output
   table_view table;
+  /// Optional associated metadata
+  const table_metadata *metadata;
 
   explicit write_parquet_args(sink_info const& sink_, table_view const& table_,
+                              const table_metadata *metadata_ = nullptr,
                               compression_type compression_ = compression_type::AUTO,
                               statistics_freq stats_lvl_ = statistics_freq::STATISTICS_ROWGROUP)
-      : sink(sink_), table(table_), compression(compression_), stats_level(stats_lvl_) {}
+      : sink(sink_), table(table_), metadata(metadata_), compression(compression_), stats_level(stats_lvl_) {}
 };
 
 /**

--- a/cpp/include/cudf/io/functions.hpp
+++ b/cpp/include/cudf/io/functions.hpp
@@ -250,10 +250,13 @@ struct write_orc_args {
   compression_type compression;
   /// Set of columns to output
   table_view table;
+  /// Optional associated metadata
+  const table_metadata *metadata;
 
   explicit write_orc_args(sink_info const& snk, table_view const& table_,
+                          const table_metadata *metadata_ = nullptr,
                           compression_type compression_ = compression_type::AUTO)
-      : sink(snk), table(table_), compression(compression_) {}
+      : sink(snk), table(table_), metadata(metadata_), compression(compression_) {}
 };
 
 /**

--- a/cpp/include/cudf/io/functions.hpp
+++ b/cpp/include/cudf/io/functions.hpp
@@ -46,16 +46,13 @@ struct read_avro_args {
 
   /// Names of column to read; empty is all
   std::vector<std::string> columns;
-  /// Optional output location for table metadata
-  table_metadata *output_metadata = nullptr;
 
   /// Rows to skip from the start; -1 is none
   size_type skip_rows = -1;
   /// Rows to read; -1 is all
   size_type num_rows = -1;
 
-  explicit read_avro_args(source_info const& src, table_metadata *metadata = nullptr)
-      : source(src), output_metadata(metadata) {}
+  explicit read_avro_args(source_info const& src) : source(src) {}
 };
 
 /**
@@ -74,9 +71,9 @@ struct read_avro_args {
  * @param args Settings for controlling reading behavior
  * @param mr Optional resource to use for device memory allocation
  *
- * @return The set of columns
+ * @return The set of columns along with metadata
  */
-std::unique_ptr<table> read_avro(
+table_with_metadata read_avro(
     read_avro_args const& args,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
@@ -166,11 +163,7 @@ struct read_csv_args {
   /// Cast timestamp columns to a specific type
   data_type timestamp_type{EMPTY};
 
-  /// Optional output location for table metadata
-  table_metadata *output_metadata = nullptr;
-
-  explicit read_csv_args(source_info const& src, table_metadata *metadata = nullptr)
-      : source(src), output_metadata(metadata) {}
+  explicit read_csv_args(source_info const& src) : source(src) {}
 };
 
 /**
@@ -189,9 +182,9 @@ struct read_csv_args {
  * @param args Settings for controlling reading behavior
  * @param mr Optional resource to use for device memory allocation
  *
- * @return The set of columns
+ * @return The set of columns along with metadata
  */
-std::unique_ptr<table> read_csv(
+table_with_metadata read_csv(
     read_csv_args const& args,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
@@ -203,8 +196,6 @@ struct read_orc_args {
 
   /// Names of column to read; empty is all
   std::vector<std::string> columns;
-  /// Optional output location for table metadata
-  table_metadata *output_metadata = nullptr;
 
   /// Stripe to read; -1 is all
   size_type stripe = -1;
@@ -227,8 +218,7 @@ struct read_orc_args {
   /// -1 is auto (column scale), >=0: number of fractional digits
   int forced_decimals_scale = -1;
 
-  explicit read_orc_args(source_info const& src, table_metadata *metadata = nullptr)
-      : source(src), output_metadata(metadata) {}
+  explicit read_orc_args(source_info const& src) : source(src) {}
 };
 
 /**
@@ -249,7 +239,7 @@ struct read_orc_args {
  *
  * @return The set of columns
  */
-std::unique_ptr<table> read_orc(
+table_with_metadata read_orc(
     read_orc_args const& args,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
@@ -313,11 +303,8 @@ struct read_parquet_args {
   bool use_pandas_metadata = true;
   /// Cast timestamp columns to a specific type
   data_type timestamp_type{EMPTY};
-  /// Optional output location for table metadata
-  table_metadata *output_metadata = nullptr;
 
-  explicit read_parquet_args(source_info const& src, table_metadata *metadata = nullptr)
-      : source(src), output_metadata(metadata) {}
+  explicit read_parquet_args(source_info const& src) : source(src) {}
 };
 
 /**
@@ -336,9 +323,9 @@ struct read_parquet_args {
  * @param args Settings for controlling reading behavior
  * @param mr Optional resource to use for device memory allocation
  *
- * @return The set of columns
+ * @return The set of columns along with metadata
  */
-std::unique_ptr<table> read_parquet(
+table_with_metadata read_parquet(
     read_parquet_args const& args,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 

--- a/cpp/include/cudf/io/functions.hpp
+++ b/cpp/include/cudf/io/functions.hpp
@@ -166,7 +166,11 @@ struct read_csv_args {
   /// Cast timestamp columns to a specific type
   data_type timestamp_type{EMPTY};
 
-  explicit read_csv_args(source_info const& src) : source(src) {}
+  /// Optional output location for table metadata
+  table_metadata *output_metadata = nullptr;
+
+  explicit read_csv_args(source_info const& src, table_metadata *metadata = nullptr)
+      : source(src), output_metadata(metadata) {}
 };
 
 /**
@@ -210,7 +214,7 @@ struct read_orc_args {
   size_type num_rows = -1;
 
   /// Whether to use row index to speed-up reading
-  bool use_index = false;
+  bool use_index = true;
 
   /// Whether to use numpy-compatible dtypes
   bool use_np_dtypes = true;

--- a/cpp/include/cudf/io/functions.hpp
+++ b/cpp/include/cudf/io/functions.hpp
@@ -294,8 +294,11 @@ struct read_parquet_args {
   bool use_pandas_metadata = true;
   /// Cast timestamp columns to a specific type
   data_type timestamp_type{EMPTY};
+  /// Optional output location for table metadata
+  table_metadata *output_metadata = nullptr;
 
-  explicit read_parquet_args(source_info const& src) : source(src) {}
+  explicit read_parquet_args(source_info const& src, table_metadata *metadata = nullptr)
+      : source(src), output_metadata(metadata) {}
 };
 
 /**

--- a/cpp/include/cudf/io/functions.hpp
+++ b/cpp/include/cudf/io/functions.hpp
@@ -199,6 +199,8 @@ struct read_orc_args {
 
   /// Names of column to read; empty is all
   std::vector<std::string> columns;
+  /// Optional output location for table metadata
+  table_metadata *output_metadata = nullptr;
 
   /// Stripe to read; -1 is all
   size_type stripe = -1;
@@ -215,7 +217,8 @@ struct read_orc_args {
   /// Cast timestamp columns to a specific type
   data_type timestamp_type{EMPTY};
 
-  explicit read_orc_args(source_info const& src) : source(src) {}
+  explicit read_orc_args(source_info const& src, table_metadata *metadata = nullptr)
+      : source(src), output_metadata(metadata) {}
 };
 
 /**

--- a/cpp/include/cudf/io/functions.hpp
+++ b/cpp/include/cudf/io/functions.hpp
@@ -46,13 +46,16 @@ struct read_avro_args {
 
   /// Names of column to read; empty is all
   std::vector<std::string> columns;
+  /// Optional output location for table metadata
+  table_metadata *output_metadata = nullptr;
 
   /// Rows to skip from the start; -1 is none
   size_type skip_rows = -1;
   /// Rows to read; -1 is all
   size_type num_rows = -1;
 
-  explicit read_avro_args(source_info const& src) : source(src) {}
+  explicit read_avro_args(source_info const& src, table_metadata *metadata = nullptr)
+      : source(src), output_metadata(metadata) {}
 };
 
 /**

--- a/cpp/include/cudf/io/readers.hpp
+++ b/cpp/include/cudf/io/readers.hpp
@@ -275,11 +275,13 @@ class reader {
   /**
    * @brief Reads the entire dataset.
    *
+   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
    * @return The set of columns
    */
-  std::unique_ptr<table> read_all(cudaStream_t stream = 0);
+  std::unique_ptr<table> read_all(table_metadata *metadata = nullptr,
+                                  cudaStream_t stream = 0);
 
   /**
    * @brief Reads all the rows within a byte range.
@@ -290,11 +292,13 @@ class reader {
    *
    * @param offset Byte offset from the start
    * @param size Number of bytes from the offset; set to 0 for all remaining
+   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
    * @return The set of columns
    */
   std::unique_ptr<table> read_byte_range(size_t offset, size_t size,
+                                         table_metadata *metadata = nullptr,
                                          cudaStream_t stream = 0);
 
   /**
@@ -303,12 +307,15 @@ class reader {
    * @param skip_rows Number of rows to skip from the start
    * @param skip_rows_end Number of rows to skip from the end
    * @param num_rows Number of rows to read; use `0` for all remaining data
+   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
    * @return The set of columns
    */
   std::unique_ptr<table> read_rows(size_type skip_rows, size_type skip_rows_end,
-                                   size_type num_rows, cudaStream_t stream = 0);
+                                   size_type num_rows,
+                                   table_metadata *metadata = nullptr,
+                                   cudaStream_t stream = 0);
 };
 
 }  // namespace csv

--- a/cpp/include/cudf/io/readers.hpp
+++ b/cpp/include/cudf/io/readers.hpp
@@ -121,12 +121,10 @@ class reader {
    * @brief Reads the entire dataset.
    *
    * @param stream Optional stream to use for device memory alloc and kernels
-   * @param metadata Optional location to return table metadata
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_all(table_metadata *metadata = nullptr,
-                                  cudaStream_t stream = 0);
+  table_with_metadata read_all(cudaStream_t stream = 0);
 
   /**
    * @brief Reads and returns a range of rows.
@@ -136,11 +134,10 @@ class reader {
    * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_rows(size_type skip_rows, size_type num_rows,
-                                   table_metadata *metadata = nullptr,
-                                   cudaStream_t stream = 0);
+  table_with_metadata read_rows(size_type skip_rows, size_type num_rows,
+                                cudaStream_t stream = 0);
 };
 
 }  // namespace avro
@@ -276,12 +273,10 @@ class reader {
    * @brief Reads the entire dataset.
    *
    * @param metadata Optional location to return table metadata
-   * @param stream Optional stream to use for device memory alloc and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_all(table_metadata *metadata = nullptr,
-                                  cudaStream_t stream = 0);
+  table_with_metadata read_all(cudaStream_t stream = 0);
 
   /**
    * @brief Reads all the rows within a byte range.
@@ -292,14 +287,12 @@ class reader {
    *
    * @param offset Byte offset from the start
    * @param size Number of bytes from the offset; set to 0 for all remaining
-   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_byte_range(size_t offset, size_t size,
-                                         table_metadata *metadata = nullptr,
-                                         cudaStream_t stream = 0);
+  table_with_metadata read_byte_range(size_t offset, size_t size,
+                                      cudaStream_t stream = 0);
 
   /**
    * @brief Reads a range of rows.
@@ -307,15 +300,13 @@ class reader {
    * @param skip_rows Number of rows to skip from the start
    * @param skip_rows_end Number of rows to skip from the end
    * @param num_rows Number of rows to read; use `0` for all remaining data
-   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_rows(size_type skip_rows, size_type skip_rows_end,
-                                   size_type num_rows,
-                                   table_metadata *metadata = nullptr,
-                                   cudaStream_t stream = 0);
+  table_with_metadata read_rows(size_type skip_rows, size_type skip_rows_end,
+                                size_type num_rows,
+                                cudaStream_t stream = 0);
 };
 
 }  // namespace csv
@@ -408,40 +399,34 @@ class reader {
   /**
    * @brief Reads the entire dataset.
    *
-   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_all(table_metadata *metadata = nullptr,
-                                  cudaStream_t stream = 0);
+  table_with_metadata read_all(cudaStream_t stream = 0);
 
   /**
    * @brief Reads and returns a specific stripe.
    *
    * @param stripe Index of the stripe
-   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_stripe(size_type stripe,
-                                     table_metadata *metadata = nullptr,
-                                     cudaStream_t stream = 0);
+  table_with_metadata read_stripe(size_type stripe,
+                                  cudaStream_t stream = 0);
 
   /**
    * @brief Reads and returns a range of rows.
    *
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read; use `0` for all remaining data
-   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_rows(size_type skip_rows, size_type num_rows,
-                                   table_metadata *metadata = nullptr,
-                                   cudaStream_t stream = 0);
+  table_with_metadata read_rows(size_type skip_rows, size_type num_rows,
+                                cudaStream_t stream = 0);
 };
 
 }  // namespace orc
@@ -537,39 +522,33 @@ class reader {
    * @brief Reads the entire dataset.
    *
    * @param stream Optional stream to use for device memory alloc and kernels
-   * @param metadata Optional location to return table metadata
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_all(table_metadata *metadata = nullptr,
-                                  cudaStream_t stream = 0);
+  table_with_metadata read_all(cudaStream_t stream = 0);
 
   /**
    * @brief Reads a specific group of rows.
    *
    * @param row_group Index of the row group
-   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_row_group(size_type row_group,
-                                        table_metadata *metadata = nullptr,
-                                        cudaStream_t stream = 0);
+  table_with_metadata read_row_group(size_type row_group,
+                                     cudaStream_t stream = 0);
 
   /**
    * @brief Reads a range of rows.
    *
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read; use `0` for all remaining data
-   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with table metadata
    */
-  std::unique_ptr<table> read_rows(size_type skip_rows, size_type num_rows,
-                                   table_metadata *metadata = nullptr,
-                                   cudaStream_t stream = 0);
+  table_with_metadata read_rows(size_type skip_rows, size_type num_rows,
+                                cudaStream_t stream = 0);
 };
 
 }  // namespace parquet

--- a/cpp/include/cudf/io/readers.hpp
+++ b/cpp/include/cudf/io/readers.hpp
@@ -438,7 +438,6 @@ struct reader_options {
   bool strings_to_categorical = false;
   bool use_pandas_metadata = false;
   data_type timestamp_type{EMPTY};
-  table_metadata *output_metadata = nullptr;
 
   reader_options() = default;
   reader_options(reader_options const &) = default;
@@ -450,16 +449,13 @@ struct reader_options {
    * @param strings_to_categorical Whether to return strings as category
    * @param use_pandas_metadata Whether to always load PANDAS index columns
    * @param timestamp_type Cast timestamp columns to a specific type
-   * @param metadata Optional table metadata to return column names and user data
    */
   reader_options(std::vector<std::string> columns, bool strings_to_categorical,
-                 bool use_pandas_metadata, data_type timestamp_type,
-                 table_metadata *metadata = nullptr)
+                 bool use_pandas_metadata, data_type timestamp_type)
       : columns(std::move(columns)),
         strings_to_categorical(strings_to_categorical),
         use_pandas_metadata(use_pandas_metadata),
-        timestamp_type(timestamp_type),
-        output_metadata(metadata) {}
+        timestamp_type(timestamp_type) {}
 };
 
 /**
@@ -522,20 +518,24 @@ class reader {
    * @brief Reads the entire dataset.
    *
    * @param stream Optional stream to use for device memory alloc and kernels
+   * @param metadata Optional location to return table metadata
    *
    * @return The set of columns
    */
-  std::unique_ptr<table> read_all(cudaStream_t stream = 0);
+  std::unique_ptr<table> read_all(table_metadata *metadata = nullptr,
+                                  cudaStream_t stream = 0);
 
   /**
    * @brief Reads a specific group of rows.
    *
    * @param row_group Index of the row group
+   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
    * @return The set of columns
    */
   std::unique_ptr<table> read_row_group(size_type row_group,
+                                        table_metadata *metadata = nullptr,
                                         cudaStream_t stream = 0);
 
   /**
@@ -543,11 +543,13 @@ class reader {
    *
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read; use `0` for all remaining data
+   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
    * @return The set of columns
    */
   std::unique_ptr<table> read_rows(size_type skip_rows, size_type num_rows,
+                                   table_metadata *metadata = nullptr,
                                    cudaStream_t stream = 0);
 };
 

--- a/cpp/include/cudf/io/readers.hpp
+++ b/cpp/include/cudf/io/readers.hpp
@@ -121,21 +121,25 @@ class reader {
    * @brief Reads the entire dataset.
    *
    * @param stream Optional stream to use for device memory alloc and kernels
+   * @param metadata Optional location to return table metadata
    *
    * @return The set of columns
    */
-  std::unique_ptr<table> read_all(cudaStream_t stream = 0);
+  std::unique_ptr<table> read_all(table_metadata *metadata = nullptr,
+                                  cudaStream_t stream = 0);
 
   /**
    * @brief Reads and returns a range of rows.
    *
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read; use `0` for all remaining data
+   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
    * @return The set of columns
    */
   std::unique_ptr<table> read_rows(size_type skip_rows, size_type num_rows,
+                                   table_metadata *metadata = nullptr,
                                    cudaStream_t stream = 0);
 };
 

--- a/cpp/include/cudf/io/readers.hpp
+++ b/cpp/include/cudf/io/readers.hpp
@@ -396,32 +396,39 @@ class reader {
   /**
    * @brief Reads the entire dataset.
    *
+   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
    * @return The set of columns
    */
-  std::unique_ptr<table> read_all(cudaStream_t stream = 0);
+  std::unique_ptr<table> read_all(table_metadata *metadata = nullptr,
+                                  cudaStream_t stream = 0);
 
   /**
    * @brief Reads and returns a specific stripe.
    *
    * @param stripe Index of the stripe
+   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
    * @return The set of columns
    */
-  std::unique_ptr<table> read_stripe(size_type stripe, cudaStream_t stream = 0);
+  std::unique_ptr<table> read_stripe(size_type stripe,
+                                     table_metadata *metadata = nullptr,
+                                     cudaStream_t stream = 0);
 
   /**
    * @brief Reads and returns a range of rows.
    *
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read; use `0` for all remaining data
+   * @param metadata Optional location to return table metadata
    * @param stream Optional stream to use for device memory alloc and kernels
    *
    * @return The set of columns
    */
   std::unique_ptr<table> read_rows(size_type skip_rows, size_type num_rows,
+                                   table_metadata *metadata = nullptr,
                                    cudaStream_t stream = 0);
 };
 

--- a/cpp/include/cudf/io/readers.hpp
+++ b/cpp/include/cudf/io/readers.hpp
@@ -434,6 +434,7 @@ struct reader_options {
   bool strings_to_categorical = false;
   bool use_pandas_metadata = false;
   data_type timestamp_type{EMPTY};
+  table_metadata *output_metadata = nullptr;
 
   reader_options() = default;
   reader_options(reader_options const &) = default;
@@ -445,13 +446,16 @@ struct reader_options {
    * @param strings_to_categorical Whether to return strings as category
    * @param use_pandas_metadata Whether to always load PANDAS index columns
    * @param timestamp_type Cast timestamp columns to a specific type
+   * @param metadata Optional table metadata to return column names and user data
    */
   reader_options(std::vector<std::string> columns, bool strings_to_categorical,
-                 bool use_pandas_metadata, data_type timestamp_type)
+                 bool use_pandas_metadata, data_type timestamp_type,
+                 table_metadata *metadata = nullptr)
       : columns(std::move(columns)),
         strings_to_categorical(strings_to_categorical),
         use_pandas_metadata(use_pandas_metadata),
-        timestamp_type(timestamp_type) {}
+        timestamp_type(timestamp_type),
+        output_metadata(metadata) {}
 };
 
 /**

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -86,8 +86,8 @@ enum statistics_freq {
  * @brief Table metadata for io readers/writers (primarily column names)
  */
 struct table_metadata {
-  std::vector<std::string> column_names;
-  std::map<std::string, std::string> user_data;
+  std::vector<std::string> column_names; //!< Names of columns contained in the table
+  std::map<std::string, std::string> user_data; //!< Format-dependent metadata as key-values pairs
 };
 
 /**

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <cudf/types.hpp>
 
 // Forward declarations
 namespace arrow {
@@ -101,6 +102,15 @@ struct table_metadata {
   std::vector<std::string> column_names; //!< Names of columns contained in the table
   std::map<std::string, std::string> user_data; //!< Format-dependent metadata as key-values pairs
 };
+
+/**
+ * @brief Table with table metadata used by io readers to return the metadata by value
+ */
+struct table_with_metadata {
+  std::unique_ptr<table> tbl;
+  table_metadata metadata;
+};
+
 
 /**
  * @brief Source information for read interfaces

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -84,6 +84,18 @@ enum statistics_freq {
 
 /**
  * @brief Table metadata for io readers/writers (primarily column names)
+ * For nested types (structs, maps, unions), the ordering of names in the column_names vector
+ * corresponds to a pre-order traversal of the column tree.
+ * In the example below (2 top-level columns: struct column "col1" and string column "col2"),
+ *  column_names = {"co1", "s3", "f5", "f6", "f4", "col2"}.
+ *
+ *     col1     col2 
+ *      / \ 
+ *     /   \ 
+ *   s3    f4 
+ *   / \ 
+ *  /   \ 
+ * f5    f6 
  */
 struct table_metadata {
   std::vector<std::string> column_names; //!< Names of columns contained in the table

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -22,7 +22,9 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 #include <string>
+#include <map>
 
 // Forward declarations
 namespace arrow {
@@ -78,6 +80,14 @@ enum statistics_freq {
   STATISTICS_NONE = 0,     //!< No column statistics
   STATISTICS_ROWGROUP = 1, //!< Per-Rowgroup column statistics
   STATISTICS_PAGE = 2,     //!< Per-page column statistics
+};
+
+/**
+ * @brief Table metadata for io readers/writers (primarily column names)
+ */
+struct table_metadata {
+  std::vector<std::string> column_names;
+  std::map<std::string, std::string> user_data;
 };
 
 /**

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -87,7 +87,7 @@ enum statistics_freq {
  * For nested types (structs, maps, unions), the ordering of names in the column_names vector
  * corresponds to a pre-order traversal of the column tree.
  * In the example below (2 top-level columns: struct column "col1" and string column "col2"),
- *  column_names = {"co1", "s3", "f5", "f6", "f4", "col2"}.
+ *  column_names = {"col1", "s3", "f5", "f6", "f4", "col2"}.
  *
  *     col1     col2 
  *      / \ 

--- a/cpp/include/cudf/io/writers.hpp
+++ b/cpp/include/cudf/io/writers.hpp
@@ -87,9 +87,10 @@ class writer {
    * @brief Writes the entire dataset.
    *
    * @param table Set of columns to output
+   * @param metadata Table metadata and column names
    * @param stream Optional stream to use for device memory alloc and kernels
    */
-  void write_all(table_view const& table, cudaStream_t stream = 0);
+  void write_all(table_view const& table, const table_metadata *metadata = nullptr, cudaStream_t stream = 0);
 };
 
 }  // namespace orc

--- a/cpp/include/cudf/io/writers.hpp
+++ b/cpp/include/cudf/io/writers.hpp
@@ -148,9 +148,10 @@ class writer {
    * @brief Writes the entire dataset.
    *
    * @param table Set of columns to output
+   * @param metadata Table metadata and column names
    * @param stream Optional stream to use for device memory alloc and kernels
    */
-  void write_all(table_view const& table, cudaStream_t stream = 0);
+  void write_all(table_view const& table, const table_metadata *metadata = nullptr, cudaStream_t stream = 0);
 };
 
 }  // namespace parquet

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -469,7 +469,6 @@ std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows,
     for (const auto& kv : _metadata->user_data) {
       metadata_out->user_data.insert({kv.first, kv.second});
     }
-
   }
 
   return std::make_unique<table>(std::move(out_columns));

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -363,10 +363,10 @@ reader::impl::impl(std::unique_ptr<datasource> source,
   _metadata = std::make_unique<metadata>(_source.get());
 }
 
-std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows,
-                                          table_metadata *metadata_out,
-                                          cudaStream_t stream) {
+table_with_metadata reader::impl::read(int skip_rows, int num_rows,
+                                       cudaStream_t stream) {
   std::vector<std::unique_ptr<column>> out_columns;
+  table_metadata metadata_out;
 
   // Select and read partial metadata / schema within the subset of rows
   _metadata->init_and_select_rows(skip_rows, num_rows);
@@ -457,18 +457,15 @@ std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows,
     }
   }
 
-  // Return metadata
-  if (metadata_out) {
-    // Return column names (must match order of returned columns)
-    metadata_out->column_names.resize(selected_columns.size());
-    for (size_t i = 0; i < selected_columns.size(); i++) {
-      metadata_out->column_names[i] = selected_columns[i].second;
-    }
-    // Return user metadata
-    metadata_out->user_data = _metadata->user_data;
+  // Return column names (must match order of returned columns)
+  metadata_out.column_names.resize(selected_columns.size());
+  for (size_t i = 0; i < selected_columns.size(); i++) {
+    metadata_out.column_names[i] = selected_columns[i].second;
   }
+  // Return user metadata
+  metadata_out.user_data = _metadata->user_data;
 
-  return std::make_unique<table>(std::move(out_columns));
+  return { std::make_unique<table>(std::move(out_columns)), std::move(metadata_out) };
 }
 
 // Forward to implementation
@@ -493,16 +490,15 @@ reader::reader(std::shared_ptr<arrow::io::RandomAccessFile> file,
 reader::~reader() = default;
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_all(table_metadata *md, cudaStream_t stream) {
-  return _impl->read(0, -1, md, stream);
+table_with_metadata reader::read_all(cudaStream_t stream) {
+  return _impl->read(0, -1, stream);
 }
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_rows(size_type skip_rows,
+table_with_metadata reader::read_rows(size_type skip_rows,
                                          size_type num_rows,
-                                         table_metadata *md,
                                          cudaStream_t stream) {
-  return _impl->read(skip_rows, (num_rows != 0) ? num_rows : -1, md, stream);
+  return _impl->read(skip_rows, (num_rows != 0) ? num_rows : -1, stream);
 }
 
 }  // namespace avro

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -465,10 +465,7 @@ std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows,
       metadata_out->column_names[i] = selected_columns[i].second;
     }
     // Return user metadata
-    metadata_out->user_data.clear();
-    for (const auto& kv : _metadata->user_data) {
-      metadata_out->user_data.insert({kv.first, kv.second});
-    }
+    metadata_out->user_data = _metadata->user_data;
   }
 
   return std::make_unique<table>(std::move(out_columns));

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -364,6 +364,7 @@ reader::impl::impl(std::unique_ptr<datasource> source,
 }
 
 std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows,
+                                          table_metadata *metadata_out,
                                           cudaStream_t stream) {
   std::vector<std::unique_ptr<column>> out_columns;
 
@@ -456,6 +457,21 @@ std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows,
     }
   }
 
+  // Return metadata
+  if (metadata_out) {
+    // Return column names (must match order of returned columns)
+    metadata_out->column_names.resize(selected_columns.size());
+    for (size_t i = 0; i < selected_columns.size(); i++) {
+      metadata_out->column_names[i] = selected_columns[i].second;
+    }
+    // Return user metadata
+    metadata_out->user_data.clear();
+    for (const auto& kv : _metadata->user_data) {
+      metadata_out->user_data.insert({kv.first, kv.second});
+    }
+
+  }
+
   return std::make_unique<table>(std::move(out_columns));
 }
 
@@ -481,15 +497,16 @@ reader::reader(std::shared_ptr<arrow::io::RandomAccessFile> file,
 reader::~reader() = default;
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_all(cudaStream_t stream) {
-  return _impl->read(0, -1, stream);
+std::unique_ptr<table> reader::read_all(table_metadata *md, cudaStream_t stream) {
+  return _impl->read(0, -1, md, stream);
 }
 
 // Forward to implementation
 std::unique_ptr<table> reader::read_rows(size_type skip_rows,
                                          size_type num_rows,
+                                         table_metadata *md,
                                          cudaStream_t stream) {
-  return _impl->read(skip_rows, (num_rows != 0) ? num_rows : -1, stream);
+  return _impl->read(skip_rows, (num_rows != 0) ? num_rows : -1, md, stream);
 }
 
 }  // namespace avro

--- a/cpp/src/io/avro/reader_impl.hpp
+++ b/cpp/src/io/avro/reader_impl.hpp
@@ -68,11 +68,13 @@ class reader::impl {
    *
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read
+   * @param metadata Optional location to return table metadata
    * @param stream Stream to use for memory allocation and kernels
    *
    * @return The set of columns
    */
-  std::unique_ptr<table> read(int skip_rows, int num_rows, cudaStream_t stream);
+  std::unique_ptr<table> read(int skip_rows, int num_rows,
+                              table_metadata *metadata, cudaStream_t stream);
 
  private:
   /**

--- a/cpp/src/io/avro/reader_impl.hpp
+++ b/cpp/src/io/avro/reader_impl.hpp
@@ -68,13 +68,12 @@ class reader::impl {
    *
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read
-   * @param metadata Optional location to return table metadata
    * @param stream Stream to use for memory allocation and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with metadata
    */
-  std::unique_ptr<table> read(int skip_rows, int num_rows,
-                              table_metadata *metadata, cudaStream_t stream);
+  table_with_metadata read(int skip_rows, int num_rows,
+                           cudaStream_t stream);
 
  private:
   /**

--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -264,12 +264,12 @@ std::vector<std::string> setColumnNames(std::vector<char> const &header,
   return col_names;
 }
 
-std::unique_ptr<table> reader::impl::read(size_t range_offset,
-                                          size_t range_size, int skip_rows,
-                                          int skip_end_rows, int num_rows,
-                                          table_metadata *metadata,
-                                          cudaStream_t stream) {
+table_with_metadata reader::impl::read(size_t range_offset,
+                                       size_t range_size, int skip_rows,
+                                       int skip_end_rows, int num_rows,
+                                       cudaStream_t stream) {
   std::vector<std::unique_ptr<column>> out_columns;
+  table_metadata metadata;
 
   if (range_offset > 0 || range_size > 0) {
     CUDF_EXPECTS(compression_type_ == "none",
@@ -281,11 +281,6 @@ std::unique_ptr<table> reader::impl::read(size_t range_offset,
     map_range_size = range_size + calculateMaxRowSize(num_columns);
   }
 
-  if (metadata) {
-    metadata->column_names.clear();
-    metadata->user_data.clear();
-  }
-
   // Support delayed opening of the file if using memory mapping datasource
   // This allows only mapping of a subset of the file if using byte range
   if (source_ == nullptr) {
@@ -295,7 +290,7 @@ std::unique_ptr<table> reader::impl::read(size_t range_offset,
 
   // Return an empty dataframe if no data and no column metadata to process
   if (source_->empty() && (args_.names.empty() || args_.dtype.empty())) {
-    return std::make_unique<table>(std::move(out_columns));
+    return { std::make_unique<table>(std::move(out_columns)), std::move(metadata) };
   }
 
   // Transfer source data to GPU
@@ -410,7 +405,7 @@ std::unique_ptr<table> reader::impl::read(size_t range_offset,
 
   // Return empty table rather than exception if nothing to load
   if (num_active_cols == 0) {
-    return std::make_unique<table>(std::move(out_columns));
+    return { std::make_unique<table>(std::move(out_columns)), std::move(metadata) };
   }
 
   std::vector<data_type> column_types = gather_column_types(stream);
@@ -421,9 +416,7 @@ std::unique_ptr<table> reader::impl::read(size_t range_offset,
     if (h_column_flags[col] & column_parse::enabled) {
       out_buffers.emplace_back(column_types[active_col], num_records, stream,
                                mr_);
-      if (metadata) {
-        metadata->column_names.emplace_back(col_names[col]);
-      }
+      metadata.column_names.emplace_back(col_names[col]);
       active_col++;
     }
   }
@@ -454,7 +447,7 @@ std::unique_ptr<table> reader::impl::read(size_t range_offset,
     }
   }*/
 
-  return std::make_unique<table>(std::move(out_columns));
+  return { std::make_unique<table>(std::move(out_columns)), std::move(metadata) };
 }
 
 void reader::impl::gather_row_offsets(const char *h_data, size_t h_size,
@@ -831,27 +824,25 @@ reader::reader(std::shared_ptr<arrow::io::RandomAccessFile> file,
 reader::~reader() = default;
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_all(table_metadata *metadata, cudaStream_t stream) {
-  return _impl->read(0, 0, 0, 0, -1, metadata, stream);
+table_with_metadata reader::read_all(cudaStream_t stream) {
+  return _impl->read(0, 0, 0, 0, -1, stream);
 }
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_byte_range(size_t offset, size_t size,
-                                               table_metadata *metadata,
-                                               cudaStream_t stream) {
-  return _impl->read(offset, size, 0, 0, -1, metadata, stream);
+table_with_metadata reader::read_byte_range(size_t offset, size_t size,
+                                            cudaStream_t stream) {
+  return _impl->read(offset, size, 0, 0, -1, stream);
 }
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_rows(size_type num_skip_header,
-                                         size_type num_skip_footer,
-                                         size_type num_rows,
-                                         table_metadata *metadata,
-                                         cudaStream_t stream) {
+table_with_metadata reader::read_rows(size_type num_skip_header,
+                                      size_type num_skip_footer,
+                                      size_type num_rows,
+                                      cudaStream_t stream) {
   CUDF_EXPECTS(num_rows == -1 || num_skip_footer == 0,
                "Cannot use both `num_rows` and `num_skip_footer`");
 
-  return _impl->read(0, 0, num_skip_header, num_skip_footer, num_rows, metadata, stream);
+  return _impl->read(0, 0, num_skip_header, num_skip_footer, num_rows, stream);
 }
 
 }  // namespace csv

--- a/cpp/src/io/csv/reader_impl.hpp
+++ b/cpp/src/io/csv/reader_impl.hpp
@@ -70,12 +70,14 @@ class reader::impl {
    * @param skip_rows Number of rows to skip from the start
    * @param skip_rows_end Number of rows to skip from the end
    * @param num_rows Number of rows to read
+   * @param metadata Optional location to return table metadata
    * @param stream Stream to use for memory allocation and kernels
    *
    * @return The set of columns
    */
   std::unique_ptr<table> read(size_t range_offset, size_t range_size,
                               int skip_rows, int skip_end_rows, int num_rows,
+                              table_metadata *metadata,
                               cudaStream_t stream);
 
  private:

--- a/cpp/src/io/csv/reader_impl.hpp
+++ b/cpp/src/io/csv/reader_impl.hpp
@@ -73,12 +73,11 @@ class reader::impl {
    * @param metadata Optional location to return table metadata
    * @param stream Stream to use for memory allocation and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with metadata
    */
-  std::unique_ptr<table> read(size_t range_offset, size_t range_size,
-                              int skip_rows, int skip_end_rows, int num_rows,
-                              table_metadata *metadata,
-                              cudaStream_t stream);
+  table_with_metadata read(size_t range_offset, size_t range_size,
+                           int skip_rows, int skip_end_rows, int num_rows,
+                           cudaStream_t stream);
 
  private:
   /**

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -160,15 +160,15 @@ std::unique_ptr<table> read_parquet(read_parquet_args const& args,
 
   parquet::reader_options options{args.columns, args.strings_to_categorical,
                                   args.use_pandas_metadata,
-                                  args.timestamp_type, args.output_metadata};
+                                  args.timestamp_type};
   auto reader = make_reader<parquet::reader>(args.source, options, mr);
 
   if (args.row_group != -1) {
-    return reader->read_row_group(args.row_group);
+    return reader->read_row_group(args.row_group, args.output_metadata);
   } else if (args.skip_rows != -1 || args.num_rows != -1) {
-    return reader->read_rows(args.skip_rows, args.num_rows);
+    return reader->read_rows(args.skip_rows, args.num_rows, args.output_metadata);
   } else {
-    return reader->read_all();
+    return reader->read_all(args.output_metadata);
   }
 }
 

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -116,11 +116,13 @@ std::unique_ptr<table> read_csv(read_csv_args const& args,
 
   if (args.byte_range_offset != 0 || args.byte_range_size != 0) {
     return reader->read_byte_range(args.byte_range_offset,
-                                   args.byte_range_size);
+                                   args.byte_range_size,
+                                   args.output_metadata);
   } else if (args.skiprows != -1 || args.skipfooter != -1 || args.nrows != -1) {
-    return reader->read_rows(args.skiprows, args.skipfooter, args.nrows);
+    return reader->read_rows(args.skiprows, args.skipfooter, args.nrows,
+                             args.output_metadata);
   } else {
-    return reader->read_all();
+    return reader->read_all(args.output_metadata);
   }
 }
 

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -150,7 +150,7 @@ void write_orc(write_orc_args const& args,
   orc::writer_options options{args.compression};
   auto writer = make_writer<orc::writer>(args.sink, options, mr);
 
-  writer->write_all(args.table);
+  writer->write_all(args.table, args.metadata);
 }
 
 // Freeform API wraps the detail reader class API

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -134,11 +134,11 @@ std::unique_ptr<table> read_orc(read_orc_args const& args,
   auto reader = make_reader<orc::reader>(args.source, options, mr);
 
   if (args.stripe != -1) {
-    return reader->read_stripe(args.stripe);
+    return reader->read_stripe(args.stripe, args.output_metadata);
   } else if (args.skip_rows != -1 || args.num_rows != -1) {
-    return reader->read_rows(args.skip_rows, args.num_rows);
+    return reader->read_rows(args.skip_rows, args.num_rows, args.output_metadata);
   } else {
-    return reader->read_all();
+    return reader->read_all(args.output_metadata);
   }
 }
 

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -66,9 +66,9 @@ std::unique_ptr<table> read_avro(read_avro_args const& args,
   auto reader = make_reader<avro::reader>(args.source, options, mr);
 
   if (args.skip_rows != -1 || args.num_rows != -1) {
-    return reader->read_rows(args.skip_rows, args.num_rows);
+    return reader->read_rows(args.skip_rows, args.num_rows, args.output_metadata);
   } else {
-    return reader->read_all();
+    return reader->read_all(args.output_metadata);
   }
 }
 

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -160,7 +160,7 @@ std::unique_ptr<table> read_parquet(read_parquet_args const& args,
 
   parquet::reader_options options{args.columns, args.strings_to_categorical,
                                   args.use_pandas_metadata,
-                                  args.timestamp_type};
+                                  args.timestamp_type, args.output_metadata};
   auto reader = make_reader<parquet::reader>(args.source, options, mr);
 
   if (args.row_group != -1) {

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -180,7 +180,7 @@ void write_parquet(write_parquet_args const& args,
   parquet::writer_options options{args.compression, args.stats_level};
   auto writer = make_writer<parquet::writer>(args.sink, options, mr);
 
-  writer->write_all(args.table);
+  writer->write_all(args.table, args.metadata);
 }
 
 }  // namespace io

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -58,22 +58,22 @@ std::unique_ptr<writer> make_writer(sink_info const& sink,
 }  // namespace
 
 // Freeform API wraps the detail reader class API
-std::unique_ptr<table> read_avro(read_avro_args const& args,
-                                 rmm::mr::device_memory_resource* mr) {
+table_with_metadata read_avro(read_avro_args const& args,
+                              rmm::mr::device_memory_resource* mr) {
   namespace avro = cudf::experimental::io::detail::avro;
 
   avro::reader_options options{args.columns};
   auto reader = make_reader<avro::reader>(args.source, options, mr);
 
   if (args.skip_rows != -1 || args.num_rows != -1) {
-    return reader->read_rows(args.skip_rows, args.num_rows, args.output_metadata);
+    return reader->read_rows(args.skip_rows, args.num_rows);
   } else {
-    return reader->read_all(args.output_metadata);
+    return reader->read_all();
   }
 }
 
 // Freeform API wraps the detail reader class API
-std::unique_ptr<table> read_csv(read_csv_args const& args,
+table_with_metadata read_csv(read_csv_args const& args,
                                 rmm::mr::device_memory_resource* mr) {
   namespace csv = cudf::experimental::io::detail::csv;
 
@@ -116,18 +116,16 @@ std::unique_ptr<table> read_csv(read_csv_args const& args,
 
   if (args.byte_range_offset != 0 || args.byte_range_size != 0) {
     return reader->read_byte_range(args.byte_range_offset,
-                                   args.byte_range_size,
-                                   args.output_metadata);
+                                   args.byte_range_size);
   } else if (args.skiprows != -1 || args.skipfooter != -1 || args.nrows != -1) {
-    return reader->read_rows(args.skiprows, args.skipfooter, args.nrows,
-                             args.output_metadata);
+    return reader->read_rows(args.skiprows, args.skipfooter, args.nrows);
   } else {
-    return reader->read_all(args.output_metadata);
+    return reader->read_all();
   }
 }
 
 // Freeform API wraps the detail reader class API
-std::unique_ptr<table> read_orc(read_orc_args const& args,
+table_with_metadata read_orc(read_orc_args const& args,
                                 rmm::mr::device_memory_resource* mr) {
   namespace orc = cudf::experimental::io::detail::orc;
 
@@ -137,11 +135,11 @@ std::unique_ptr<table> read_orc(read_orc_args const& args,
   auto reader = make_reader<orc::reader>(args.source, options, mr);
 
   if (args.stripe != -1) {
-    return reader->read_stripe(args.stripe, args.output_metadata);
+    return reader->read_stripe(args.stripe);
   } else if (args.skip_rows != -1 || args.num_rows != -1) {
-    return reader->read_rows(args.skip_rows, args.num_rows, args.output_metadata);
+    return reader->read_rows(args.skip_rows, args.num_rows);
   } else {
-    return reader->read_all(args.output_metadata);
+    return reader->read_all();
   }
 }
 
@@ -157,7 +155,7 @@ void write_orc(write_orc_args const& args,
 }
 
 // Freeform API wraps the detail reader class API
-std::unique_ptr<table> read_parquet(read_parquet_args const& args,
+table_with_metadata read_parquet(read_parquet_args const& args,
                                     rmm::mr::device_memory_resource* mr) {
   namespace parquet = cudf::experimental::io::detail::parquet;
 
@@ -167,11 +165,11 @@ std::unique_ptr<table> read_parquet(read_parquet_args const& args,
   auto reader = make_reader<parquet::reader>(args.source, options, mr);
 
   if (args.row_group != -1) {
-    return reader->read_row_group(args.row_group, args.output_metadata);
+    return reader->read_row_group(args.row_group);
   } else if (args.skip_rows != -1 || args.num_rows != -1) {
-    return reader->read_rows(args.skip_rows, args.num_rows, args.output_metadata);
+    return reader->read_rows(args.skip_rows, args.num_rows);
   } else {
-    return reader->read_all(args.output_metadata);
+    return reader->read_all();
   }
 }
 

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -602,10 +602,10 @@ reader::impl::impl(std::unique_ptr<datasource> source,
   _decimals_as_int_scale = options.forced_decimals_scale;
 }
 
-std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows, int stripe,
-                                          table_metadata *metadata_out,
-                                          cudaStream_t stream) {
+table_with_metadata reader::impl::read(int skip_rows, int num_rows, int stripe,
+                                       cudaStream_t stream) {
   std::vector<std::unique_ptr<column>> out_columns;
+  table_metadata out_metadata;
 
   // Select only stripes required (aka row groups)
   const auto selected_stripes =
@@ -769,21 +769,17 @@ std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows, int strip
     }
   }
 
-  // Return metadata
-  if (metadata_out) {
-    // Return column names (must match order of returned columns)
-    metadata_out->column_names.resize(_selected_columns.size());
-    for (size_t i = 0; i < _selected_columns.size(); i++) {
-      metadata_out->column_names[i] = _metadata->ff.GetColumnName(_selected_columns[i]);
-    }
-    // Return user metadata
-    metadata_out->user_data.clear();
-    for (const auto& kv : _metadata->ff.metadata) {
-      metadata_out->user_data.insert({kv.name, kv.value});
-    }
+  // Return column names (must match order of returned columns)
+  out_metadata.column_names.resize(_selected_columns.size());
+  for (size_t i = 0; i < _selected_columns.size(); i++) {
+    out_metadata.column_names[i] = _metadata->ff.GetColumnName(_selected_columns[i]);
+  }
+  // Return user metadata
+  for (const auto& kv : _metadata->ff.metadata) {
+    out_metadata.user_data.insert({kv.name, kv.value});
   }
 
-  return std::make_unique<table>(std::move(out_columns));
+  return { std::make_unique<table>(std::move(out_columns)), std::move(out_metadata) };
 }
 
 // Forward to implementation
@@ -808,24 +804,21 @@ reader::reader(std::shared_ptr<arrow::io::RandomAccessFile> file,
 reader::~reader() = default;
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_all(table_metadata *md,
+table_with_metadata reader::read_all(cudaStream_t stream) {
+  return _impl->read(0, -1, -1, stream);
+}
+
+// Forward to implementation
+table_with_metadata reader::read_stripe(size_type stripe,
                                         cudaStream_t stream) {
-  return _impl->read(0, -1, -1, md, stream);
+  return _impl->read(0, -1, stripe, stream);
 }
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_stripe(size_type stripe,
-                                           table_metadata *md,
-                                           cudaStream_t stream) {
-  return _impl->read(0, -1, stripe, md, stream);
-}
-
-// Forward to implementation
-std::unique_ptr<table> reader::read_rows(size_type skip_rows,
-                                         size_type num_rows,
-                                         table_metadata *md,
-                                         cudaStream_t stream) {
-  return _impl->read(skip_rows, (num_rows != 0) ? num_rows : -1, -1, md, stream);
+table_with_metadata reader::read_rows(size_type skip_rows,
+                                      size_type num_rows,
+                                      cudaStream_t stream) {
+  return _impl->read(skip_rows, (num_rows != 0) ? num_rows : -1, -1, stream);
 }
 
 }  // namespace orc

--- a/cpp/src/io/orc/reader_impl.hpp
+++ b/cpp/src/io/orc/reader_impl.hpp
@@ -72,12 +72,13 @@ class reader::impl {
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read
    * @param stripe Stripe index to select
+   * @param metadata Optional location to return table metadata
    * @param stream Stream to use for memory allocation and kernels
    *
    * @return The set of columns
    */
   std::unique_ptr<table> read(int skip_rows, int num_rows, int stripe,
-                              cudaStream_t stream);
+                              table_metadata *metadata, cudaStream_t stream);
 
  private:
   /**

--- a/cpp/src/io/orc/reader_impl.hpp
+++ b/cpp/src/io/orc/reader_impl.hpp
@@ -72,13 +72,12 @@ class reader::impl {
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read
    * @param stripe Stripe index to select
-   * @param metadata Optional location to return table metadata
    * @param stream Stream to use for memory allocation and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with metadata
    */
-  std::unique_ptr<table> read(int skip_rows, int num_rows, int stripe,
-                              table_metadata *metadata, cudaStream_t stream);
+  table_with_metadata read(int skip_rows, int num_rows, int stripe,
+                           cudaStream_t stream);
 
  private:
   /**

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -79,9 +79,10 @@ class writer::impl {
    * @brief Write an entire dataset to ORC format.
    *
    * @param table The set of columns
+   * @param metadata The metadata associated with the table
    * @param stream Stream to use for memory allocation and kernels
    **/
-  void write(table_view const& table, cudaStream_t stream);
+  void write(table_view const& table, const table_metadata *metadata, cudaStream_t stream);
 
  private:
   /**

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -558,9 +558,10 @@ reader::impl::impl(std::unique_ptr<datasource> source,
   _strings_to_categorical = options.strings_to_categorical;
 }
 
-std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows, int row_group,
-                                          table_metadata *out_metadata, cudaStream_t stream) {
+table_with_metadata reader::impl::read(int skip_rows, int num_rows, int row_group,
+                                       cudaStream_t stream) {
   std::vector<std::unique_ptr<column>> out_columns;
+  table_metadata out_metadata;
 
   // Select only row groups required
   const auto selected_row_groups =
@@ -687,21 +688,17 @@ std::unique_ptr<table> reader::impl::read(int skip_rows, int num_rows, int row_g
     }
   }
 
-  // Return metadata
-  if (out_metadata) {
-    // Return column names (must match order of returned columns)
-    out_metadata->column_names.resize(_selected_columns.size());
-    for (size_t i = 0; i < _selected_columns.size(); i++) {
-      out_metadata->column_names[i] = _selected_columns[i].second;
-    }
-    // Return user metadata
-    out_metadata->user_data.clear();
-    for (const auto& kv : _metadata->key_value_metadata) {
-      out_metadata->user_data.insert({kv.key, kv.value});
-    }
+  // Return column names (must match order of returned columns)
+  out_metadata.column_names.resize(_selected_columns.size());
+  for (size_t i = 0; i < _selected_columns.size(); i++) {
+    out_metadata.column_names[i] = _selected_columns[i].second;
+  }
+  // Return user metadata
+  for (const auto& kv : _metadata->key_value_metadata) {
+    out_metadata.user_data.insert({kv.key, kv.value});
   }
 
-  return std::make_unique<table>(std::move(out_columns));
+  return { std::make_unique<table>(std::move(out_columns)), std::move(out_metadata) };
 }
 
 // Forward to implementation
@@ -729,23 +726,21 @@ reader::~reader() = default;
 std::string reader::get_pandas_index() { return _impl->get_pandas_index(); }
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_all(table_metadata *md, cudaStream_t stream) {
-  return _impl->read(0, -1, -1, md, stream);
+table_with_metadata reader::read_all(cudaStream_t stream) {
+  return _impl->read(0, -1, -1, stream);
 }
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_row_group(size_type row_group,
-                                              table_metadata *md,
-                                              cudaStream_t stream) {
-  return _impl->read(0, -1, row_group, md, stream);
+table_with_metadata reader::read_row_group(size_type row_group,
+                                           cudaStream_t stream) {
+  return _impl->read(0, -1, row_group, stream);
 }
 
 // Forward to implementation
-std::unique_ptr<table> reader::read_rows(size_type skip_rows,
-                                         size_type num_rows,
-                                         table_metadata *md,
-                                         cudaStream_t stream) {
-  return _impl->read(skip_rows, (num_rows != 0) ? num_rows : -1, -1, md, stream);
+table_with_metadata reader::read_rows(size_type skip_rows,
+                                      size_type num_rows,
+                                      cudaStream_t stream) {
+  return _impl->read(skip_rows, (num_rows != 0) ? num_rows : -1, -1, stream);
 }
 
 }  // namespace parquet

--- a/cpp/src/io/parquet/reader_impl.hpp
+++ b/cpp/src/io/parquet/reader_impl.hpp
@@ -147,6 +147,7 @@ class reader::impl {
   std::string _pandas_index;
   bool _strings_to_categorical = false;
   data_type _timestamp_type{type_id::EMPTY};
+  table_metadata *_out_metadata = nullptr;
 };
 
 }  // namespace parquet

--- a/cpp/src/io/parquet/reader_impl.hpp
+++ b/cpp/src/io/parquet/reader_impl.hpp
@@ -76,13 +76,12 @@ class reader::impl {
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read
    * @param row_group Row group index to select
-   * @param out_metadata Optional location to return table metadata
    * @param stream Stream to use for memory allocation and kernels
    *
-   * @return The set of columns
+   * @return The set of columns along with metadata
    */
-  std::unique_ptr<table> read(int skip_rows, int num_rows, int row_group,
-                              table_metadata *out_metadata, cudaStream_t stream);
+  table_with_metadata read(int skip_rows, int num_rows, int row_group,
+                           cudaStream_t stream);
 
  private:
   /**

--- a/cpp/src/io/parquet/reader_impl.hpp
+++ b/cpp/src/io/parquet/reader_impl.hpp
@@ -76,12 +76,13 @@ class reader::impl {
    * @param skip_rows Number of rows to skip from the start
    * @param num_rows Number of rows to read
    * @param row_group Row group index to select
+   * @param out_metadata Optional location to return table metadata
    * @param stream Stream to use for memory allocation and kernels
    *
    * @return The set of columns
    */
   std::unique_ptr<table> read(int skip_rows, int num_rows, int row_group,
-                              cudaStream_t stream);
+                              table_metadata *out_metadata, cudaStream_t stream);
 
  private:
   /**
@@ -147,7 +148,6 @@ class reader::impl {
   std::string _pandas_index;
   bool _strings_to_categorical = false;
   data_type _timestamp_type{type_id::EMPTY};
-  table_metadata *_out_metadata = nullptr;
 };
 
 }  // namespace parquet

--- a/cpp/src/io/parquet/writer_impl.hpp
+++ b/cpp/src/io/parquet/writer_impl.hpp
@@ -74,9 +74,10 @@ class writer::impl {
    * @brief Write an entire dataset to parquet format.
    *
    * @param table The set of columns
+   * @param metadata The metadata associated with the table
    * @param stream Stream to use for memory allocation and kernels
    **/
-  void write(table_view const& table, cudaStream_t stream);
+  void write(table_view const& table, const table_metadata *metadata, cudaStream_t stream);
 
  private:
   /**

--- a/cpp/tests/io/csv_test.cu
+++ b/cpp/tests/io/csv_test.cu
@@ -130,7 +130,7 @@ TYPED_TEST(CsvReaderNumericTypeTest, SingleColumn) {
   in_args.header = -1;
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   expect_column_data_equal(
       std::vector<TypeParam>(sequence, sequence + num_rows), view.column(0));
 }
@@ -165,7 +165,7 @@ TEST_F(CsvReaderTest, MultiColumn) {
   in_args.header = -1;
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   expect_column_data_equal(int8_values, view.column(0));
   expect_column_data_equal(int16_values, view.column(1));
   expect_column_data_equal(int16_values, view.column(2));
@@ -196,7 +196,7 @@ TEST_F(CsvReaderTest, Booleans) {
   auto result = cudf_io::read_csv(in_args);
 
   // Booleans are the same (integer) data type, but valued at 0 or 1
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(4, view.num_columns());
   ASSERT_EQ(cudf::type_id::INT32, view.column(0).type().id());
   ASSERT_EQ(cudf::type_id::INT32, view.column(1).type().id());
@@ -229,7 +229,7 @@ TEST_F(CsvReaderTest, Dates) {
   in_args.header = -1;
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::TIMESTAMP_MILLISECONDS, view.column(0).type().id());
 
@@ -257,7 +257,7 @@ TEST_F(CsvReaderTest, DatesCastToTimestampSeconds) {
   in_args.timestamp_type = cudf::data_type{cudf::type_id::TIMESTAMP_SECONDS};
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::TIMESTAMP_SECONDS, view.column(0).type().id());
 
@@ -286,7 +286,7 @@ TEST_F(CsvReaderTest, DatesCastToTimestampMilliSeconds) {
       cudf::data_type{cudf::type_id::TIMESTAMP_MILLISECONDS};
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::TIMESTAMP_MILLISECONDS, view.column(0).type().id());
 
@@ -315,7 +315,7 @@ TEST_F(CsvReaderTest, DatesCastToTimestampMicroSeconds) {
       cudf::data_type{cudf::type_id::TIMESTAMP_MICROSECONDS};
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::TIMESTAMP_MICROSECONDS, view.column(0).type().id());
 
@@ -345,7 +345,7 @@ TEST_F(CsvReaderTest, DatesCastToTimestampNanoSeconds) {
       cudf::data_type{cudf::type_id::TIMESTAMP_NANOSECONDS};
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::TIMESTAMP_NANOSECONDS, view.column(0).type().id());
 
@@ -372,7 +372,7 @@ TEST_F(CsvReaderTest, FloatingPoint) {
   in_args.header = -1;
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::FLOAT32, view.column(0).type().id());
 
@@ -400,7 +400,7 @@ TEST_F(CsvReaderTest, Strings) {
   in_args.quoting = cudf_io::quote_style::NONE;
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(2, view.num_columns());
   ASSERT_EQ(cudf::type_id::INT32, view.column(0).type().id());
   ASSERT_EQ(cudf::type_id::STRING, view.column(1).type().id());
@@ -429,7 +429,7 @@ TEST_F(CsvReaderTest, DISABLED_StringsQuotes) {
   in_args.quotechar = '`';
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(2, view.num_columns());
   ASSERT_EQ(cudf::type_id::INT32, view.column(0).type().id());
   ASSERT_EQ(cudf::type_id::STRING, view.column(1).type().id());
@@ -459,7 +459,7 @@ TEST_F(CsvReaderTest, StringsQuotesIgnored) {
   in_args.doublequote = false;  // do not replace double quotechar with single
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(2, view.num_columns());
   ASSERT_EQ(cudf::type_id::INT32, view.column(0).type().id());
   ASSERT_EQ(cudf::type_id::STRING, view.column(1).type().id());
@@ -486,7 +486,7 @@ TEST_F(CsvReaderTest, SkiprowsNrows) {
   in_args.nrows = 2;
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::INT32, view.column(0).type().id());
 
@@ -508,7 +508,7 @@ TEST_F(CsvReaderTest, ByteRange) {
   in_args.byte_range_size = 15;
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::INT32, view.column(0).type().id());
 
@@ -530,7 +530,7 @@ TEST_F(CsvReaderTest, BlanksAndComments) {
   in_args.comment = '#';
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::INT32, view.column(0).type().id());
 
@@ -548,7 +548,7 @@ TEST_F(CsvReaderTest, EmptyFile) {
   cudf_io::read_csv_args in_args{cudf_io::source_info{filepath}};
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(0, view.num_columns());
 }
 
@@ -562,7 +562,7 @@ TEST_F(CsvReaderTest, NoDataFile) {
   cudf_io::read_csv_args in_args{cudf_io::source_info{filepath}};
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(0, view.num_columns());
 }
 
@@ -580,7 +580,7 @@ TEST_F(CsvReaderTest, ArrowFileSource) {
   in_args.dtype = {"int8"};
   auto result = cudf_io::read_csv(in_args);
 
-  const auto view = result->view();
+  const auto view = result.tbl->view();
   EXPECT_EQ(1, view.num_columns());
   ASSERT_EQ(cudf::type_id::INT8, view.column(0).type().id());
 

--- a/cpp/tests/io/orc_test.cu
+++ b/cpp/tests/io/orc_test.cu
@@ -231,12 +231,13 @@ TEST_F(OrcWriterTest, MultiColumn) {
   column_wrapper<float> col4{col4_data.begin(), col4_data.end(), validity};
   column_wrapper<double> col5{col5_data.begin(), col5_data.end(), validity};
 
-  // column_set_name(col0.get(), "bools");
-  // column_set_name(col1.get(), "int8s");
-  // column_set_name(col2.get(), "int16s");
-  // column_set_name(col3.get(), "int32s");
-  // column_set_name(col4.get(), "floats");
-  // column_set_name(col5.get(), "doubles");
+  cudf_io::table_metadata expected_metadata;
+  //expected_metadata.column_names.emplace_back("bools");
+  expected_metadata.column_names.emplace_back("int8s");
+  expected_metadata.column_names.emplace_back("int16s");
+  expected_metadata.column_names.emplace_back("int32s");
+  expected_metadata.column_names.emplace_back("floats");
+  expected_metadata.column_names.emplace_back("doubles");
 
   std::vector<std::unique_ptr<column>> cols;
   // cols.push_back(col0.release());
@@ -250,14 +251,16 @@ TEST_F(OrcWriterTest, MultiColumn) {
 
   auto filepath = temp_env->get_temp_filepath("OrcMultiColumn.orc");
   cudf_io::write_orc_args out_args{cudf_io::sink_info{filepath},
-                                   expected->view()};
+                                   expected->view(), &expected_metadata};
   cudf_io::write_orc(out_args);
 
-  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}};
+  cudf_io::table_metadata result_metadata;
+  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}, &result_metadata};
   in_args.use_index = false;
   auto result = cudf_io::read_orc(in_args);
 
   expect_tables_equal(expected->view(), result->view());
+  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
 }
 
 TEST_F(OrcWriterTest, MultiColumnWithNulls) {
@@ -290,12 +293,13 @@ TEST_F(OrcWriterTest, MultiColumnWithNulls) {
   column_wrapper<float> col4{col4_data.begin(), col4_data.end(), col4_mask};
   column_wrapper<double> col5{col5_data.begin(), col5_data.end(), col5_mask};
 
-  // column_set_name(col0.get(), "bools");
-  // column_set_name(col1.get(), "int8s");
-  // column_set_name(col2.get(), "int16s");
-  // column_set_name(col3.get(), "int32s");
-  // column_set_name(col4.get(), "floats");
-  // column_set_name(col5.get(), "doubles");
+  cudf_io::table_metadata expected_metadata;
+  //expected_metadata.column_names.emplace_back("bools");
+  expected_metadata.column_names.emplace_back("int8s");
+  expected_metadata.column_names.emplace_back("int16s");
+  expected_metadata.column_names.emplace_back("int32s");
+  expected_metadata.column_names.emplace_back("floats");
+  expected_metadata.column_names.emplace_back("doubles");
 
   std::vector<std::unique_ptr<column>> cols;
   // cols.push_back(col0.release());
@@ -309,14 +313,16 @@ TEST_F(OrcWriterTest, MultiColumnWithNulls) {
 
   auto filepath = temp_env->get_temp_filepath("OrcMultiColumnWithNulls.orc");
   cudf_io::write_orc_args out_args{cudf_io::sink_info{filepath},
-                                   expected->view()};
+                                   expected->view(), &expected_metadata};
   cudf_io::write_orc(out_args);
 
-  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}};
+  cudf_io::table_metadata result_metadata;
+  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}, &result_metadata};
   in_args.use_index = false;
   auto result = cudf_io::read_orc(in_args);
 
   expect_tables_equal(expected->view(), result->view());
+  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
 }
 
 TEST_F(OrcWriterTest, Strings) {
@@ -333,9 +339,10 @@ TEST_F(OrcWriterTest, Strings) {
   column_wrapper<cudf::string_view> col1{strings.begin(), strings.end()};
   column_wrapper<float> col2{seq_col2.begin(), seq_col2.end(), validity};
 
-  // column_set_name(col0.get(), "col_other");
-  // column_set_name(col1.get(), "col_string");
-  // column_set_name(col2.get(), "col_another");
+  cudf_io::table_metadata expected_metadata;
+  expected_metadata.column_names.emplace_back("col_other");
+  expected_metadata.column_names.emplace_back("col_string");
+  expected_metadata.column_names.emplace_back("col_another");
 
   std::vector<std::unique_ptr<column>> cols;
   cols.push_back(col0.release());
@@ -346,12 +353,14 @@ TEST_F(OrcWriterTest, Strings) {
 
   auto filepath = temp_env->get_temp_filepath("OrcStrings.orc");
   cudf_io::write_orc_args out_args{cudf_io::sink_info{filepath},
-                                   expected->view()};
+                                   expected->view(), &expected_metadata};
   cudf_io::write_orc(out_args);
 
-  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}};
+  cudf_io::table_metadata result_metadata;
+  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}, &result_metadata};
   in_args.use_index = false;
   auto result = cudf_io::read_orc(in_args);
 
   expect_tables_equal(expected->view(), result->view());
+  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
 }

--- a/cpp/tests/io/orc_test.cu
+++ b/cpp/tests/io/orc_test.cu
@@ -128,7 +128,7 @@ TYPED_TEST(OrcWriterNumericTypeTest, SingleColumn) {
   in_args.use_index = false;
   auto result = cudf_io::read_orc(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
+  expect_tables_equal(expected->view(), result.tbl->view());
 }
 
 TYPED_TEST(OrcWriterNumericTypeTest, SingleColumnWithNulls) {
@@ -154,7 +154,7 @@ TYPED_TEST(OrcWriterNumericTypeTest, SingleColumnWithNulls) {
   in_args.use_index = false;
   auto result = cudf_io::read_orc(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
+  expect_tables_equal(expected->view(), result.tbl->view());
 }
 
 TYPED_TEST(OrcWriterTimestampTypeTest, Timestamps) {
@@ -181,7 +181,7 @@ TYPED_TEST(OrcWriterTimestampTypeTest, Timestamps) {
   in_args.timestamp_type = this->type();
   auto result = cudf_io::read_orc(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
+  expect_tables_equal(expected->view(), result.tbl->view());
 }
 
 TYPED_TEST(OrcWriterTimestampTypeTest, TimestampsWithNulls) {
@@ -208,7 +208,7 @@ TYPED_TEST(OrcWriterTimestampTypeTest, TimestampsWithNulls) {
   in_args.timestamp_type = this->type();
   auto result = cudf_io::read_orc(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
+  expect_tables_equal(expected->view(), result.tbl->view());
 }
 
 TEST_F(OrcWriterTest, MultiColumn) {
@@ -254,13 +254,12 @@ TEST_F(OrcWriterTest, MultiColumn) {
                                    expected->view(), &expected_metadata};
   cudf_io::write_orc(out_args);
 
-  cudf_io::table_metadata result_metadata;
-  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}, &result_metadata};
+  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}};
   in_args.use_index = false;
   auto result = cudf_io::read_orc(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
-  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
+  expect_tables_equal(expected->view(), result.tbl->view());
+  EXPECT_EQ(expected_metadata.column_names, result.metadata.column_names);
 }
 
 TEST_F(OrcWriterTest, MultiColumnWithNulls) {
@@ -316,13 +315,12 @@ TEST_F(OrcWriterTest, MultiColumnWithNulls) {
                                    expected->view(), &expected_metadata};
   cudf_io::write_orc(out_args);
 
-  cudf_io::table_metadata result_metadata;
-  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}, &result_metadata};
+  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}};
   in_args.use_index = false;
   auto result = cudf_io::read_orc(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
-  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
+  expect_tables_equal(expected->view(), result.tbl->view());
+  EXPECT_EQ(expected_metadata.column_names, result.metadata.column_names);
 }
 
 TEST_F(OrcWriterTest, Strings) {
@@ -356,11 +354,10 @@ TEST_F(OrcWriterTest, Strings) {
                                    expected->view(), &expected_metadata};
   cudf_io::write_orc(out_args);
 
-  cudf_io::table_metadata result_metadata;
-  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}, &result_metadata};
+  cudf_io::read_orc_args in_args{cudf_io::source_info{filepath}};
   in_args.use_index = false;
   auto result = cudf_io::read_orc(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
-  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
+  expect_tables_equal(expected->view(), result.tbl->view());
+  EXPECT_EQ(expected_metadata.column_names, result.metadata.column_names);
 }

--- a/cpp/tests/io/parquet_test.cu
+++ b/cpp/tests/io/parquet_test.cu
@@ -227,12 +227,13 @@ TEST_F(ParquetWriterTest, MultiColumn) {
   column_wrapper<float> col4{col4_data.begin(), col4_data.end(), validity};
   column_wrapper<double> col5{col5_data.begin(), col5_data.end(), validity};
 
-  // column_set_name(col0.get(), "bools");
-  // column_set_name(col1.get(), "int8s");
-  // column_set_name(col2.get(), "int16s");
-  // column_set_name(col3.get(), "int32s");
-  // column_set_name(col4.get(), "floats");
-  // column_set_name(col5.get(), "doubles");
+  cudf_io::table_metadata expected_metadata;
+  //expected_metadata.column_names.emplace_back("bools");
+  expected_metadata.column_names.emplace_back("int8s");
+  expected_metadata.column_names.emplace_back("int16s");
+  expected_metadata.column_names.emplace_back("int32s");
+  expected_metadata.column_names.emplace_back("floats");
+  expected_metadata.column_names.emplace_back("doubles");
 
   std::vector<std::unique_ptr<column>> cols;
   // cols.push_back(col0.release());
@@ -246,13 +247,15 @@ TEST_F(ParquetWriterTest, MultiColumn) {
 
   auto filepath = temp_env->get_temp_filepath("MultiColumn.parquet");
   cudf_io::write_parquet_args out_args{cudf_io::sink_info{filepath},
-                                       expected->view()};
+                                       expected->view(), &expected_metadata};
   cudf_io::write_parquet(out_args);
 
-  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}};
+  cudf_io::table_metadata result_metadata;
+  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}, &result_metadata};
   auto result = cudf_io::read_parquet(in_args);
 
   expect_tables_equal(expected->view(), result->view());
+  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
 }
 
 TEST_F(ParquetWriterTest, MultiColumnWithNulls) {
@@ -285,12 +288,13 @@ TEST_F(ParquetWriterTest, MultiColumnWithNulls) {
   column_wrapper<float> col4{col4_data.begin(), col4_data.end(), col4_mask};
   column_wrapper<double> col5{col5_data.begin(), col5_data.end(), col5_mask};
 
-  // column_set_name(col0.get(), "bools");
-  // column_set_name(col1.get(), "int8s");
-  // column_set_name(col2.get(), "int16s");
-  // column_set_name(col3.get(), "int32s");
-  // column_set_name(col4.get(), "floats");
-  // column_set_name(col5.get(), "doubles");
+  cudf_io::table_metadata expected_metadata;
+  //expected_metadata.column_names.emplace_back("bools");
+  expected_metadata.column_names.emplace_back("int8s");
+  expected_metadata.column_names.emplace_back("int16s");
+  expected_metadata.column_names.emplace_back("int32s");
+  expected_metadata.column_names.emplace_back("floats");
+  expected_metadata.column_names.emplace_back("doubles");
 
   std::vector<std::unique_ptr<column>> cols;
   // cols.push_back(col0.release());
@@ -304,13 +308,15 @@ TEST_F(ParquetWriterTest, MultiColumnWithNulls) {
 
   auto filepath = temp_env->get_temp_filepath("MultiColumnWithNulls.parquet");
   cudf_io::write_parquet_args out_args{cudf_io::sink_info{filepath},
-                                       expected->view()};
+                                       expected->view(), &expected_metadata};
   cudf_io::write_parquet(out_args);
 
-  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}};
+  cudf_io::table_metadata result_metadata;
+  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}, &result_metadata};
   auto result = cudf_io::read_parquet(in_args);
 
   expect_tables_equal(expected->view(), result->view());
+  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
 }
 
 TEST_F(ParquetWriterTest, Strings) {
@@ -327,9 +333,10 @@ TEST_F(ParquetWriterTest, Strings) {
   column_wrapper<cudf::string_view> col1{strings.begin(), strings.end()};
   column_wrapper<float> col2{seq_col2.begin(), seq_col2.end(), validity};
 
-  // column_set_name(col0.get(), "col_other");
-  // column_set_name(col1.get(), "col_string");
-  // column_set_name(col2.get(), "col_another");
+  cudf_io::table_metadata expected_metadata;
+  expected_metadata.column_names.emplace_back("col_other");
+  expected_metadata.column_names.emplace_back("col_string");
+  expected_metadata.column_names.emplace_back("col_another");
 
   std::vector<std::unique_ptr<column>> cols;
   cols.push_back(col0.release());
@@ -340,11 +347,13 @@ TEST_F(ParquetWriterTest, Strings) {
 
   auto filepath = temp_env->get_temp_filepath("Strings.parquet");
   cudf_io::write_parquet_args out_args{cudf_io::sink_info{filepath},
-                                       expected->view()};
+                                       expected->view(), &expected_metadata};
   cudf_io::write_parquet(out_args);
 
-  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}};
+  cudf_io::table_metadata result_metadata;
+  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}, &result_metadata};
   auto result = cudf_io::read_parquet(in_args);
 
   expect_tables_equal(expected->view(), result->view());
+  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
 }

--- a/cpp/tests/io/parquet_test.cu
+++ b/cpp/tests/io/parquet_test.cu
@@ -127,7 +127,7 @@ TYPED_TEST(ParquetWriterNumericTypeTest, SingleColumn) {
   cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}};
   auto result = cudf_io::read_parquet(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
+  expect_tables_equal(expected->view(), result.tbl->view());
 }
 
 TYPED_TEST(ParquetWriterNumericTypeTest, SingleColumnWithNulls) {
@@ -152,7 +152,7 @@ TYPED_TEST(ParquetWriterNumericTypeTest, SingleColumnWithNulls) {
   cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}};
   auto result = cudf_io::read_parquet(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
+  expect_tables_equal(expected->view(), result.tbl->view());
 }
 
 TYPED_TEST(ParquetWriterTimestampTypeTest, Timestamps) {
@@ -178,7 +178,7 @@ TYPED_TEST(ParquetWriterTimestampTypeTest, Timestamps) {
   in_args.timestamp_type = this->type();
   auto result = cudf_io::read_parquet(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
+  expect_tables_equal(expected->view(), result.tbl->view());
 }
 
 TYPED_TEST(ParquetWriterTimestampTypeTest, TimestampsWithNulls) {
@@ -204,7 +204,7 @@ TYPED_TEST(ParquetWriterTimestampTypeTest, TimestampsWithNulls) {
   in_args.timestamp_type = this->type();
   auto result = cudf_io::read_parquet(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
+  expect_tables_equal(expected->view(), result.tbl->view());
 }
 
 TEST_F(ParquetWriterTest, MultiColumn) {
@@ -250,12 +250,11 @@ TEST_F(ParquetWriterTest, MultiColumn) {
                                        expected->view(), &expected_metadata};
   cudf_io::write_parquet(out_args);
 
-  cudf_io::table_metadata result_metadata;
-  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}, &result_metadata};
+  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}};
   auto result = cudf_io::read_parquet(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
-  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
+  expect_tables_equal(expected->view(), result.tbl->view());
+  EXPECT_EQ(expected_metadata.column_names, result.metadata.column_names);
 }
 
 TEST_F(ParquetWriterTest, MultiColumnWithNulls) {
@@ -311,12 +310,11 @@ TEST_F(ParquetWriterTest, MultiColumnWithNulls) {
                                        expected->view(), &expected_metadata};
   cudf_io::write_parquet(out_args);
 
-  cudf_io::table_metadata result_metadata;
-  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}, &result_metadata};
+  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}};
   auto result = cudf_io::read_parquet(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
-  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
+  expect_tables_equal(expected->view(), result.tbl->view());
+  EXPECT_EQ(expected_metadata.column_names, result.metadata.column_names);
 }
 
 TEST_F(ParquetWriterTest, Strings) {
@@ -350,10 +348,9 @@ TEST_F(ParquetWriterTest, Strings) {
                                        expected->view(), &expected_metadata};
   cudf_io::write_parquet(out_args);
 
-  cudf_io::table_metadata result_metadata;
-  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}, &result_metadata};
+  cudf_io::read_parquet_args in_args{cudf_io::source_info{filepath}};
   auto result = cudf_io::read_parquet(in_args);
 
-  expect_tables_equal(expected->view(), result->view());
-  EXPECT_EQ(expected_metadata.column_names, result_metadata.column_names);
+  expect_tables_equal(expected->view(), result.tbl->view());
+  EXPECT_EQ(expected_metadata.column_names, result.metadata.column_names);
 }


### PR DESCRIPTION
- [x] Define table metadata structure to return names and user data
- [x] Add names to parquet reader
- [x] Add names to parquet writer
- [x] Add names to ORC reader
- [x] Add names to ORC writer
- [x] Add names to AVRO reader
- [x] Add names to CSV reader
- [x] Add names to CPP tests

Resolves #3522 

This change adds a table_metadata struct to pass in the column names and user metadata (see types.hpp).
For (future) nesting support, the ordering of names in the column_names vector is a pre-order traversal of the column tree. In the example below (2 top-level columns: struct column "col1" and string column "col2"), the column names would consist of 6 entries ordered as  `{"col1", "s3", "f5", "f6", "f4", "col2"}`.

```
      col1     col2 
       / \ 
      /   \ 
    s3    f4 
    / \ 
   /   \ 
 f5    f6 
```

This is similar to the order described in the [ORC specification](https://orc.apache.org/specification/ORCv1/) with the root node removed (or considering the table as the root node with the top-level columns as children).