### PR TITLE
[REVIEW] contiguous_split function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - PR #3442 Add Bool-index + Multi column + DataFrame support for set-item
 - PR #3172 Define and implement new fill/repeat/copy_range APIs
 - PR #3497 Add DataFrame.drop(..., inplace=False) argument
+- PR #3557 Add contiguous_split() function. 
 
 ## Improvements
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -484,6 +484,7 @@ add_library(cudf
             src/copying/copy.cu
             src/copying/slice.cpp
             src/copying/split.cpp
+            src/copying/contiguous_split.cu
             src/copying/legacy/copy.cpp
             src/copying/legacy/gather.cu
             src/copying/legacy/scatter.cu

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -55,12 +55,21 @@ set(GATHER_BENCH_SRC
 
 ConfigureBench(GATHER_BENCH "${GATHER_BENCH_SRC}")
 
+###################################################################################################
 # - scatter benchmark -----------------------------------------------------------------------------
 
 set(SCATTER_BENCH_SRC
   "${CMAKE_CURRENT_SOURCE_DIR}/copying/scatter_benchmark.cu")
 
 ConfigureBench(SCATTER_BENCH "${SCATTER_BENCH_SRC}")
+
+###################################################################################################
+# - contiguous_split benchmark  -------------------------------------------------------------------
+
+set(CONTIGUOUS_SPLIT_BENCH_SRC
+  "${CMAKE_CURRENT_SOURCE_DIR}/copying/contiguous_split_benchmark.cu")
+
+ConfigureBench(CONTIGUOUS_SPLIT_BENCH "${CONTIGUOUS_SPLIT_BENCH_SRC}")
 
 ###################################################################################################
 # - apply_boolean_mask benchmark ------------------------------------------------------------------------------

--- a/cpp/benchmarks/copying/contiguous_split_benchmark.cu
+++ b/cpp/benchmarks/copying/contiguous_split_benchmark.cu
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <cudf/column/column.hpp>
+
+#include <cudf/copying.hpp>
+
+#include <benchmarks/fixture/benchmark_fixture.hpp>
+#include <benchmarks/synchronization/synchronization.hpp>
+#include <tests/utilities/column_wrapper.hpp>
+
+class ContiguousSplit: public cudf::benchmark {};
+
+void BM_contiguous_split(benchmark::State& state)
+{   
+   int64_t total_desired_bytes = state.range(0);
+   int64_t num_cols = state.range(1);   
+   int64_t num_splits = state.range(2);   
+   bool include_validity = state.range(3) == 0 ? false : true;   
+
+   int64_t el_size = 4;     // ints and floats
+   int64_t num_rows = total_desired_bytes / (num_cols * el_size);   
+
+   // generate splits
+   int split_stride = num_rows / num_splits;
+   std::vector<cudf::size_type> splits;
+   for(int idx=0; idx<num_rows; idx+=split_stride){
+      splits.push_back(idx);
+      splits.push_back(min(idx + split_stride, (int)num_rows));
+   }
+
+   // generate input table
+   srand(31337);
+   auto valids = cudf::test::make_counting_transform_iterator(0, [](auto i) { return true; });
+   std::vector<cudf::test::fixed_width_column_wrapper<int>> src_cols = {};
+   for(int idx=0; idx<num_cols; idx++){
+      auto rand_elements = cudf::test::make_counting_transform_iterator(0, [](int i){return rand();});
+      if(include_validity){
+         src_cols.push_back(cudf::test::fixed_width_column_wrapper<int>(rand_elements, rand_elements + num_rows, valids));
+      } else {
+         src_cols.push_back(cudf::test::fixed_width_column_wrapper<int>(rand_elements, rand_elements + num_rows));
+      }
+   }   
+   std::vector<std::unique_ptr<cudf::column>> columns((size_t)num_cols);
+   for(int idx=0; idx<num_cols; idx++){
+      columns[idx] = src_cols[idx].release();
+      columns[idx]->set_null_count(0);
+   }
+   cudf::experimental::table src_table(std::move(columns));   
+      
+   for(auto _ : state){
+      cuda_event_timer raii(state, true); // flush_l2_cache = true, stream = 0
+      auto result = cudf::experimental::contiguous_split(src_table, splits);      
+   }   
+
+   state.SetBytesProcessed(
+      static_cast<int64_t>(state.iterations())*state.range(0));
+}
+
+
+#define CSBM_BENCHMARK_DEFINE(name, size, num_columns, num_splits, validity)                 \
+BENCHMARK_DEFINE_F(ContiguousSplit, name)(::benchmark::State& state) {                       \
+   BM_contiguous_split(state);                                                               \
+}                                                                                            \
+BENCHMARK_REGISTER_F(ContiguousSplit, name)->Args({size, num_columns, num_splits, validity}) \
+                                           ->Unit(benchmark::kMillisecond)->UseManualTime()  \
+                                           ->Iterations(20);
+                                                                      
+CSBM_BENCHMARK_DEFINE(6Gb512ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 512, 256, 0);
+CSBM_BENCHMARK_DEFINE(6Gb512ColsValidity, (int64_t)6 * 1024 * 1024 * 1024, 512, 256, 1);
+CSBM_BENCHMARK_DEFINE(6Gb10ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 0);
+CSBM_BENCHMARK_DEFINE(6Gb10ColsValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 1);
+
+CSBM_BENCHMARK_DEFINE(1Gb512ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 0);
+CSBM_BENCHMARK_DEFINE(1Gb512ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 1);
+CSBM_BENCHMARK_DEFINE(1Gb10ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 0);
+CSBM_BENCHMARK_DEFINE(1Gb10ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 1);

--- a/cpp/benchmarks/copying/contiguous_split_benchmark.cu
+++ b/cpp/benchmarks/copying/contiguous_split_benchmark.cu
@@ -40,8 +40,7 @@ void BM_contiguous_split(benchmark::State& state)
    int split_stride = num_rows / num_splits;
    std::vector<cudf::size_type> splits;
    for(int idx=0; idx<num_rows; idx+=split_stride){
-      splits.push_back(idx);
-      splits.push_back(min(idx + split_stride, (int)num_rows));
+      splits.push_back(min((int)(idx + split_stride), (int)num_rows));
    }
 
    // generate input table
@@ -79,14 +78,14 @@ BENCHMARK_DEFINE_F(ContiguousSplit, name)(::benchmark::State& state) {          
 }                                                                                            \
 BENCHMARK_REGISTER_F(ContiguousSplit, name)->Args({size, num_columns, num_splits, validity}) \
                                            ->Unit(benchmark::kMillisecond)->UseManualTime()  \
-                                           ->Iterations(20);
+                                           ->Iterations(1);
                                                                       
-CSBM_BENCHMARK_DEFINE(6Gb512ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 512, 256, 0);
+//CSBM_BENCHMARK_DEFINE(6Gb512ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 512, 256, 0);
 CSBM_BENCHMARK_DEFINE(6Gb512ColsValidity, (int64_t)6 * 1024 * 1024 * 1024, 512, 256, 1);
-CSBM_BENCHMARK_DEFINE(6Gb10ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 0);
-CSBM_BENCHMARK_DEFINE(6Gb10ColsValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 1);
+//CSBM_BENCHMARK_DEFINE(6Gb10ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 0);
+//CSBM_BENCHMARK_DEFINE(6Gb10ColsValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 1);
 
-CSBM_BENCHMARK_DEFINE(1Gb512ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 0);
-CSBM_BENCHMARK_DEFINE(1Gb512ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 1);
-CSBM_BENCHMARK_DEFINE(1Gb10ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 0);
-CSBM_BENCHMARK_DEFINE(1Gb10ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 1);
+//CSBM_BENCHMARK_DEFINE(1Gb512ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 0);
+//CSBM_BENCHMARK_DEFINE(1Gb512ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 1);
+//CSBM_BENCHMARK_DEFINE(1Gb10ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 0);
+//CSBM_BENCHMARK_DEFINE(1Gb10ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 1);

--- a/cpp/benchmarks/copying/contiguous_split_benchmark.cu
+++ b/cpp/benchmarks/copying/contiguous_split_benchmark.cu
@@ -39,7 +39,7 @@ void BM_contiguous_split(benchmark::State& state)
    // generate splits
    int split_stride = num_rows / num_splits;
    std::vector<cudf::size_type> splits;
-   for(int idx=0; idx<num_rows; idx+=split_stride){
+   for(int idx=0; idx<num_rows; idx+=split_stride){      
       splits.push_back(min((int)(idx + split_stride), (int)num_rows));
    }
 
@@ -80,12 +80,12 @@ BENCHMARK_REGISTER_F(ContiguousSplit, name)->Args({size, num_columns, num_splits
                                            ->Unit(benchmark::kMillisecond)->UseManualTime()  \
                                            ->Iterations(1);
                                                                       
-//CSBM_BENCHMARK_DEFINE(6Gb512ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 512, 256, 0);
+CSBM_BENCHMARK_DEFINE(6Gb512ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 512, 256, 0);
 CSBM_BENCHMARK_DEFINE(6Gb512ColsValidity, (int64_t)6 * 1024 * 1024 * 1024, 512, 256, 1);
-//CSBM_BENCHMARK_DEFINE(6Gb10ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 0);
-//CSBM_BENCHMARK_DEFINE(6Gb10ColsValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 1);
+CSBM_BENCHMARK_DEFINE(6Gb10ColsNoValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 0);
+CSBM_BENCHMARK_DEFINE(6Gb10ColsValidity, (int64_t)6 * 1024 * 1024 * 1024, 10, 256, 1);
 
-//CSBM_BENCHMARK_DEFINE(1Gb512ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 0);
-//CSBM_BENCHMARK_DEFINE(1Gb512ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 1);
-//CSBM_BENCHMARK_DEFINE(1Gb10ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 0);
-//CSBM_BENCHMARK_DEFINE(1Gb10ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 1);
+CSBM_BENCHMARK_DEFINE(1Gb512ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 0);
+CSBM_BENCHMARK_DEFINE(1Gb512ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 512, 256, 1);
+CSBM_BENCHMARK_DEFINE(1Gb10ColsNoValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 0);
+CSBM_BENCHMARK_DEFINE(1Gb10ColsValidity, (int64_t)1 * 1024 * 1024 * 1024, 10, 256, 1);

--- a/cpp/include/cudf/detail/copy.hpp
+++ b/cpp/include/cudf/detail/copy.hpp
@@ -64,40 +64,10 @@ ColumnView slice(ColumnView const& input,
 }
 
 /**
- * @brief Performs a deep-copy split of a `table_view` into a set of `table_view`s according 
- * to a set of indices derived from expected splits. The memory is allocated in a single
- * contiguous block owned by the `all_data` field in the returned contiguous_split_result. There
- * is no top level owning table.
+ * @copydoc cudf::experimental::contiguous_split
  *
- * The returned views of `input` are constructed from vector of splits, which indicates
- * where the split should occur. The `i`th returned `table_view` is sliced as
- * `[0, splits[i])` if `i`=0, else `[splits[i], input.size())` if `i` is the last view and
- * `splits[i] != input.size()`, or `[splits[i-1], splits[i]]` otherwise.
- *
- * For all `i` it is expected `splits[i] <= splits[i+1] <= input.size()`
- *
- * @note It is the caller's responsibility to ensure that the returned view
- * does not outlive the viewed device memory contained in the `all_data` field of the
- * returned contiguous_split_result.   
- *
- * Example:
- * input:   [{10, 12, 14, 16, 18, 20, 22, 24, 26, 28},
- *           {50, 52, 54, 56, 58, 60, 62, 64, 66, 68}]
- * splits:  {2, 5, 9}
- * output:  [{{10, 12}, {14, 16, 18}, {20, 22, 24, 26}, {28}},
- *           {{50, 52}, {54, 56, 58}, {60, 62, 64, 66}, {68}}]
- *           
- *
- * @throws `cudf::logic_error` if `splits` has end index > size of `input`.
- * @throws `cudf::logic_error` When the value in `splits` is not in the range [0, input.size()).
- * @throws `cudf::logic_error` When the values in the `splits` are 'strictly decreasing'.
- *
- * @param input View of a table to split
- * @param splits A vector of indices where the view will be split
- * @param[in] mr Optional, The resource to use for all allocations
- * @param[in] stream Optional CUDA stream on which to execute kernels
- * @return The set of requested views of `input` indicated by the `splits`.
- */
+ * @param stream Optional CUDA stream on which to execute kernels
+ **/
 std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& input,
                                                       std::vector<size_type> const& splits,
                                                       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),

--- a/cpp/include/cudf/detail/copy.hpp
+++ b/cpp/include/cudf/detail/copy.hpp
@@ -64,6 +64,46 @@ ColumnView slice(ColumnView const& input,
 }
 
 /**
+ * @brief Performs a deep-copy split of a `table_view` into a set of `table_view`s according 
+ * to a set of indices derived from expected splits. The memory is allocated in a single
+ * contiguous block owned by the `all_data` field in the returned contiguous_split_result. There
+ * is no top level owning table.
+ *
+ * The returned views of `input` are constructed from vector of splits, which indicates
+ * where the split should occur. The `i`th returned `table_view` is sliced as
+ * `[0, splits[i])` if `i`=0, else `[splits[i], input.size())` if `i` is the last view and
+ * `splits[i] != input.size()`, or `[splits[i-1], splits[i]]` otherwise.
+ *
+ * For all `i` it is expected `splits[i] <= splits[i+1] <= input.size()`
+ *
+ * @note It is the caller's responsibility to ensure that the returned view
+ * does not outlive the viewed device memory contained in the `all_data` field of the
+ * returned contiguous_split_result.   
+ *
+ * Example:
+ * input:   [{10, 12, 14, 16, 18, 20, 22, 24, 26, 28},
+ *           {50, 52, 54, 56, 58, 60, 62, 64, 66, 68}]
+ * splits:  {2, 5, 9}
+ * output:  [{{10, 12}, {14, 16, 18}, {20, 22, 24, 26}, {28}},
+ *           {{50, 52}, {54, 56, 58}, {60, 62, 64, 66}, {68}}]
+ *           
+ *
+ * @throws `cudf::logic_error` if `splits` has end index > size of `input`.
+ * @throws `cudf::logic_error` When the value in `splits` is not in the range [0, input.size()).
+ * @throws `cudf::logic_error` When the values in the `splits` are 'strictly decreasing'.
+ *
+ * @param input View of a table to split
+ * @param splits A vector of indices where the view will be split
+ * @param[in] mr Optional, The resource to use for all allocations
+ * @param[in] stream Optional CUDA stream on which to execute kernels
+ * @return The set of requested views of `input` indicated by the `splits`.
+ */
+std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& input,
+                                                      std::vector<size_type> const& splits,
+                                                      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+                                                      cudaStream_t stream = 0);
+
+/**
  * @brief Creates an uninitialized new column of the specified size and same type as the `input`.
  * Supports only fixed-width types.
  *

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -1,3 +1,71 @@
+#include <cudf/cudf.h>
+#include <cudf/column/column_view.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/copying.hpp>
+#include <cudf/detail/utilities/cuda.cuh>
+
+namespace cudf {
+
+namespace experimental {
+
+namespace detail {
+
+namespace {
+
+template <size_type block_size, typename T, bool has_validity>
+__launch_bounds__(block_size)
+__global__
+void copy_in_place_kernel( column_device_view const in,
+                           mutable_column_device_view out)
+{
+   const size_type tid = threadIdx.x + blockIdx.x * block_size;
+   const int warp_id = tid / cudf::experimental::detail::warp_size;
+   const size_type warps_per_grid = gridDim.x * block_size / cudf::experimental::detail::warp_size;      
+
+   // begin/end indices for the column data
+   size_type begin = 0;
+   size_type end = in.size();
+   // warp indices.  since 1 warp == 32 threads == sizeof(bit_mask_t) * 8,
+   // each warp will process one (32 bit) of the validity mask via
+   // __ballot_sync()
+   size_type warp_begin = cudf::word_index(begin);
+   size_type warp_end = cudf::word_index(end-1);      
+
+   // lane id within the current warp   
+   const int lane_id = threadIdx.x % cudf::experimental::detail::warp_size;
+   
+   // current warp.
+   size_type warp_cur = warp_begin + warp_id;   
+   size_type index = tid;
+   while(warp_cur <= warp_end){
+      bool in_range = (index >= begin && index < end);
+            
+      bool valid = true;
+      if(has_validity){
+         valid = in_range && in.is_valid(index);
+      }
+      if(in_range){
+         out.element<T>(index) = in.element<T>(index);
+      }
+      
+      // update validity      
+      if(has_validity){
+         // the final validity mask for this warp 
+         int warp_mask = __ballot_sync(0xFFFF'FFFF, valid && in_range);
+         // only one guy in the warp needs to update the mask and count
+         if(lane_id == 0){            
+            out.set_mask_word(warp_cur, warp_mask);            
+         }
+      }            
+
+      // next grid
+      warp_cur += warps_per_grid;
+      index += block_size * gridDim.x;
+   }      
+}
+
+
 static constexpr size_t split_align = 8;
 
 template<typename T>
@@ -11,10 +79,12 @@ struct column_buf_size_functor_impl {
    }
 };
 
-// TODO
 template<>
 struct column_buf_size_functor_impl<string_view> {
-   void operator()(column_view const& c, size_t& running_data_size, size_t& running_validity_size){};
+   void operator()(column_view const& c, size_t& running_data_size, size_t& running_validity_size)
+   {
+      CUDF_FAIL("contiguous_split for strings not implemented yet");
+   };
 };
 
 struct column_buf_size_functor {
@@ -27,12 +97,9 @@ struct column_buf_size_functor {
 };
 
 
-
 template<typename T>
 struct column_copy_functor_impl {
-   void operator()(column_view const& in, char *&dst, std::vector<column_view>& out_cols
-      // PERFORMANCE TEST 4
-      /*, rmm::device_scalar<cudf::size_type> &valid_count*/)
+   void operator()(column_view const& in, char*& dst, std::vector<column_view>& out_cols)
    {      
       // there's some unnecessary recomputation of sizes happening here, but it really shouldn't affect much.
       size_t data_size = 0;
@@ -54,56 +121,25 @@ struct column_copy_functor_impl {
       // so there's a significant performance issue that comes up. our incoming column_view objects
       // are the result of a slice.  because of this, they have an UNKNOWN_NULL_COUNT.  because of that,
       // calling column_device_view::create() will cause a recompute of the count, which ends up being
-      // -extremely- slow because a.) the typical use case here will involve -huge- numbers of calls and
-      // b.) the count recompute involves tons of device allocs and memcopies, which sort of nullifies
-      // the entire point of contiguous_split.
+      // extremely slow because a.) the typical use case here will involve huge numbers of calls and
+      // b.) the count recompute involves tons of device allocs and memcopies.
+      //
       // so to get around this, I am manually constructing a fake-ish view here where the null
-      // count is arbitrarily bashed to 0.
-      //      
-      // I ran 5 performance tests here, all on 6 gigs of input data, 512 columns split 256 ways, for a total of
-      // 128k calls to this function.
+      // count is arbitrarily bashed to 0.            
       //
-      // 1. 500 ms    : no valdity information.
-      // 2. 10,000 ms  : validify information, leaving UNKNOWN_NULL_COUNTS in place. the time difference 
-      //    here is in the null_count() recomputation that happens in column_device_view::create() and the time
-      //    spent allocating/reading from the device scalar to get the resulting null count
-      // 3. 3,600 ms  : validity information, faking 0 input null count,  allocating a device scalar on the spot, 
-      //    recomputing null count in the copy_in_place_kernel and reading it back.
-      // 4. 2,700 ms  : validity information, faking 0 input null count, keeping a global device scalar, 
-      //    recomputing null count in the copy_in_place_kernel and reading it back.
-      // 5. 500 ms    : validity information, faking 0 input null count, setting output null count to UNKNOWN_NULL_COUNT. the
-      //    implication here of course is that someone else might end up paying this price later on down the road.
-      //
-      // Summary : nothing super surprising.  anything that causes memory allocation or copying between host and device
-      //           is super slow and becomes extremely noticeable at scale. best bet here seems to be to go with case 5 and 
-      //           let someone else pay the cost for lazily evaluating null counts down the road.
-      //
-      //
-
-      // see performance note above about null counts.
-      column_view          in_hacked{  in.type(), in.size(), in.head<T>(), 
-                                       in.null_mask(), in.null_mask() == nullptr ? UNKNOWN_NULL_COUNT : 0,
-                                       in.offset() };
+      column_view   in_wrapped{in.type(), in.size(), in.head<T>(), 
+                               in.null_mask(), in.null_mask() == nullptr ? UNKNOWN_NULL_COUNT : 0,
+                               in.offset() };
       mutable_column_view  mcv{in.type(), in.size(), data, 
                                validity, validity == nullptr ? UNKNOWN_NULL_COUNT : 0 };      
-      if(in.nullable()){         
-         // PERFORMANCE TEST 2, 3
-         // rmm::device_scalar<cudf::size_type> valid_count{0, 0, rmm::mr::get_default_resource()};
+      if(in.nullable()){               
          copy_in_place_kernel<block_size, T, true><<<grid.num_blocks, block_size, 0, 0>>>(
-                           *column_device_view::create(in_hacked), 
-                           *mutable_column_device_view::create(mcv)
-                           // PERFORMANCE TEST 2, 3, 4
-                           //, valid_count.data()
-                           );
-         // PERFORMANCE TEST 2, 3, 4
-         // mcv.set_null_count(in.size() - valid_count.value());                  
-      } else
-       {
+                           *column_device_view::create(in_wrapped), 
+                           *mutable_column_device_view::create(mcv));         
+      } else {
          copy_in_place_kernel<block_size, T, false><<<grid.num_blocks, block_size, 0, 0>>>(
-                           *column_device_view::create(in_hacked), 
-                           *mutable_column_device_view::create(mcv)
-                           // PERFORMANCE TEST 2, 3, 4
-                           /*, nullptr*/);
+                           *column_device_view::create(in_wrapped), 
+                           *mutable_column_device_view::create(mcv));
       }
       mcv.set_null_count(cudf::UNKNOWN_NULL_COUNT);
 
@@ -111,440 +147,73 @@ struct column_copy_functor_impl {
    }
 };
 
-// TODO
 template<>
 struct column_copy_functor_impl<string_view> {
-   void operator()(column_view const& in, char *&dst, std::vector<column_view>& out_cols
-                  // PERFORMANCE TEST 4
-                  /*, rmm::device_scalar<cudf::size_type> &valid_count*/)
-   {       
+   void operator()(column_view const& in, char*& dst, std::vector<column_view>& out_cols) 
+   {
+      CUDF_FAIL("contiguous_split for strings not implemented yet");
    };
 };
 
 struct column_copy_functor {
    template<typename T>   
-   void operator()(column_view const& in, char *&dst, std::vector<column_view>& out_cols
-                  // PERFORMANCE TEST 4
-                  /*, rmm::device_scalar<cudf::size_type> &valid_count*/)
+   void operator()(column_view const& in, char*& dst, std::vector<column_view>& out_cols)
    {
       column_copy_functor_impl<T> fn{};      
-      fn(in, dst, out_cols 
-         // PERFORMANCE TEST 4
-         /* , valid_count*/);
+      fn(in, dst, out_cols);
    }
 };
 
-struct contiguous_split_result {
-   cudf::table_view                    table;
-   std::unique_ptr<rmm::device_buffer> all_data;
-};
-typedef std::vector<cudf::column_view> subcolumns;
+contiguous_split_result alloc_and_copy(cudf::table_view const& t, rmm::mr::device_memory_resource* mr, cudaStream_t stream)
+{
+   size_t data_size = 0;
+   size_t validity_size = 0;      
+
+   // compute sizes
+   std::for_each(t.begin(), t.end(), [&data_size, &validity_size](cudf::column_view const& c){
+      cudf::experimental::type_dispatcher(c.type(), column_buf_size_functor{}, c, data_size, validity_size);
+   });
+
+   // allocate 
+   auto device_buf = std::make_unique<rmm::device_buffer>(rmm::device_buffer{data_size + validity_size, stream, mr});   
+   char *buf = static_cast<char*>(device_buf->data());
+
+   // copy
+   std::vector<column_view> out_cols;
+   out_cols.reserve(t.num_columns());
+   std::for_each(t.begin(), t.end(), [&out_cols, &buf](cudf::column_view const& c){
+      cudf::experimental::type_dispatcher(c.type(), column_copy_functor{}, c, buf, out_cols);
+   });
+
+   return contiguous_split_result{cudf::table_view{out_cols}, std::move(device_buf)};
+}
+
+}; // anonymous namespace
 
 std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& input,
                                                       std::vector<size_type> const& splits,
-                                                      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-                                                      cudaStream_t stream = 0)
+                                                      rmm::mr::device_memory_resource* mr,
+                                                      cudaStream_t stream)
 {    
-   // slice each column into a set of sub-columns   
-   std::vector<subcolumns> split_table;
-   split_table.reserve(input.num_columns());
-   for(int idx=0; idx<input.num_columns(); idx++){
-      split_table.push_back(cudf::experimental::slice(input.column(idx), splits));
-   }
-   size_t num_out_tables = split_table[0].size();   
+   auto subtables = cudf::experimental::split(input, splits);      
 
    std::vector<contiguous_split_result> result;
-
-   // DEBUG --------------------------
-      float total_alloc_time = 0.0f;
-      int total_allocs = 0;
-      float total_copy_time = 0.0f;
-      int total_copies = 0;
-   // DEBUG --------------------------
-
-   // PERFORMANCE TEST 4
-   // rmm::device_scalar<cudf::size_type> valid_count{0, 0, rmm::mr::get_default_resource()};
-
-   // output packing for a given table will be:
-   // (C0)(V0)(C1)(V1)
-   // where Cx = column x and Vx = validity mask x
-   // padding to split_align boundaries between each buffer
-   for(size_t t_idx=0; t_idx<num_out_tables; t_idx++){  
-      size_t subtable_data_size = 0;
-      size_t subtable_validity_size = 0;
-
-      // compute sizes
-      size_t sts = split_table.size();
-      for(size_t c_idx=0; c_idx<split_table.size(); c_idx++){
-         column_view const& subcol = split_table[c_idx][t_idx];         
-         cudf::experimental::type_dispatcher(subcol.type(), column_buf_size_functor{}, subcol, subtable_data_size, subtable_validity_size);
-      }
-      
-      // DEBUG --------------------------
-         scope_timer_manual alloc_time;
-         alloc_time.start();      
-      // DEBUG --------------------------
-      // allocate the blob
-      auto device_buf = std::make_unique<rmm::device_buffer>(rmm::device_buffer{subtable_data_size + subtable_validity_size, stream, mr});
-      char* buf = static_cast<char*>(device_buf->data());       
-      // DEBUG --------------------------
-         cudaDeviceSynchronize();
-         alloc_time.end();
-         total_alloc_time += alloc_time.total_time_ms();
-         total_allocs++;
-      // DEBUG --------------------------
-            
-      // DEBUG --------------------------
-         scope_timer_manual copy_time;
-         copy_time.start();
-      // DEBUG --------------------------
-      // create columns for the subtables
-      std::vector<column_view> out_cols;
-      out_cols.reserve(split_table.size());
-      for(size_t c_idx=0; c_idx<split_table.size(); c_idx++){
-         // copy
-         column_view const& subcol = split_table[c_idx][t_idx];                  
-         cudf::experimental::type_dispatcher(subcol.type(), column_copy_functor{}, subcol, buf, out_cols 
-            // PERFORMANCE TEST 4
-            /*, valid_count*/);
-      }     
-      // DEBUG --------------------------
-         cudaDeviceSynchronize();
-         copy_time.end();
-         total_copy_time += copy_time.total_time_ms();
-         total_copies += split_table.size();
-      // DEBUG --------------------------
-   
-      result.push_back(contiguous_split_result{cudf::table_view{out_cols}, std::move(device_buf)});
-   }
- 
-   // DEBUG --------------------------
-      printf("  alloc time : %.2f (%d allocs)\n", total_alloc_time, total_allocs);
-      printf("  copy time : %.2f (%d copies)\n", total_copy_time, total_copies);
-   // DEBUG --------------------------
-
-   // DEBUG --------------------------
-         cudaDeviceSynchronize();
-   // DEBUG --------------------------
+   std::transform(subtables.begin(), subtables.end(), std::back_inserter(result), [mr, stream](table_view const& t) { 
+      return alloc_and_copy(t, mr, stream);
+   });
    
    return result;
 }
 
+}; // namespace detail
 
-void verify_split_results( cudf::experimental::table const& src_table, 
-                           std::vector<contiguous_split_result> const &dst_tables,
-                           std::vector<size_type> const& splits,
-                           int verbosity = 0)
-{     
-   table_view src_v(src_table.view());
-
-   // printf("Verification : \n");
-   // printf("%d, %d\n", src_v.num_columns(), (int)splits.size());   
-
-   int col_count = 0;
-   for(size_t c_idx = 0; c_idx<(size_t)src_v.num_columns(); c_idx++){
-      for(size_t s_idx=0; s_idx<splits.size(); s_idx+=2){         
-         // grab the subpiece of the src table
-         auto src_subcol = cudf::experimental::slice(src_v.column(c_idx), std::vector<size_type>{splits[s_idx], splits[s_idx+1]});         
-         
-         // make sure it's the same as the output subtable's equivalent column
-         size_t subtable_index = s_idx/2;         
-         cudf::test::expect_columns_equal(src_subcol[0], dst_tables[subtable_index].table.column(c_idx), true);
-         if(verbosity > 0 && (col_count % verbosity == 0)){
-            printf("----------------------------\n");            
-            print_column(src_subcol[0], false, 20);
-            print_column(dst_tables[subtable_index].table.column(c_idx), false, 20);
-            printf("----------------------------\n");
-         }
-         col_count++;        
-      }
-   }   
+std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& input,
+                                                      std::vector<size_type> const& splits,
+                                                      rmm::mr::device_memory_resource* mr)
+{    
+   return cudf::experimental::detail::contiguous_split(input, splits, mr, (cudaStream_t)0);   
 }
 
-float frand()
-{
-   return (static_cast<float>(rand()) / static_cast<float>(RAND_MAX)) * 65535.0f;
-}
+}; // namespace experimental
 
-void single_split_test( int64_t total_desired_bytes, 
-                        int64_t num_cols,                     
-                        int64_t num_rows,
-                        int64_t num_splits,
-                        bool include_validity)
-{
-   printf("total data size : %.2f GB\n", (float)total_desired_bytes / (float)(1024 * 1024 * 1024));
-   
-   srand(31337);
-
-   // generate input columns and table   
-   std::vector<std::unique_ptr<column>> columns(num_cols);
-   scope_timer_manual src_table_gen("src table gen");
-   src_table_gen.start();
-   std::vector<bool> all_valid(num_rows);
-   if(include_validity){
-      for(int idx=0; idx<num_rows; idx++){
-         all_valid[idx] = true;
-      }
-   }   
-   std::vector<int> icol(num_rows);
-   std::vector<float> fcol(num_rows);
-   for(int idx=0; idx<num_cols; idx++){
-      if(idx % 2 == 0){                  
-         for(int e_idx=0; e_idx<num_rows; e_idx++){
-            icol[e_idx] = rand();
-         }
-         if(include_validity){            
-            wrapper<int> cw(icol.begin(), icol.end(), all_valid.begin());            
-            columns[idx] = cw.release();
-            columns[idx]->set_null_count(0);
-         } else {
-            wrapper<int> cw(icol.begin(), icol.end());
-            columns[idx] = cw.release();
-            columns[idx]->set_null_count(0);
-         }         
-      } else {         
-         for(int e_idx=0; e_idx<num_rows; e_idx++){
-            fcol[e_idx] = frand();
-         }
-         if(include_validity){
-            wrapper<float> cw(fcol.begin(), fcol.end(), all_valid.begin());
-            columns[idx] = cw.release();
-            columns[idx]->set_null_count(0);
-         } else {
-            wrapper<float> cw(fcol.begin(), fcol.end());
-            columns[idx] = cw.release();
-            columns[idx]->set_null_count(0);
-         }         
-      }
-   }
-   cudf::experimental::table src_table(std::move(columns));
-   src_table_gen.end();
-   printf("# columns : %d\n", (int)num_cols);
-
-   // generate splits   
-   int split_stride = num_rows / num_splits;
-   std::vector<size_type> splits;  
-   scope_timer_manual split_gen("split gen");
-   split_gen.start();
-   for(int idx=0; idx<num_rows; idx+=split_stride){
-      splits.push_back(idx);
-      splits.push_back(min(idx + split_stride, (int)num_rows));
-   }
-   split_gen.end();
-
-   printf("# splits : %d\n", (int)splits.size() / 2);
-   /*
-   printf("splits : ");
-   for(size_t idx=0; idx<splits.size(); idx+=2){
-      printf("(%d, %d) ", splits[idx], splits[idx+1]);
-   }
-   */
-
-   // do the split
-   scope_timer_manual split_time("contiguous_split total");
-   split_time.start();
-   auto dst_tables = contiguous_split(src_table.view(), splits);
-   cudaDeviceSynchronize();
-   split_time.end();
-
-   scope_timer_manual verify_time("verify_split_results");
-   verify_time.start();
-   verify_split_results(src_table, dst_tables, splits);
-   verify_time.end();
-
-   scope_timer_manual free_time("free buffers");
-   free_time.start();   
-   for(size_t idx=0; idx<dst_tables.size(); idx++){
-      rmm::device_buffer *buf = dst_tables[idx].all_data.release();
-      delete buf;   
-   }
-   cudaDeviceSynchronize();
-   free_time.end();   
-}
-
-void large_split_tests()
-{      
-   // single_split_test does ints and floats only
-   int el_size = 4;
-      
-   /*
-   {
-      // Tesla T4, 16 GB (all times in milliseconds)
-      // total data size : 2.00 GB
-      // src table gen : 8442.80 ms
-      // # columns : 512
-      // split gen : 0.00 ms
-      // # splits : 256
-      //    alloc time : 77.27 (256 allocs)     <------
-      //    copy time : 436.92 (131072 copies)  <------
-      // contiguous_split total : 524.31 ms     <------
-      // verify_split_results : 6763.76 ms
-      // free buffers : 0.18 ms                 <------
- 
-      // pick some numbers
-      int64_t total_desired_bytes = (int64_t)2 * (1024 * 1024 * 1024);
-      int64_t num_cols = 512;      
-      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
-      int64_t num_splits = num_cols / 2;
-      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, false);
-   }
-   */  
-   
-   /*
-   {
-      // Tesla T4, 16 GB (all times in milliseconds)
-      // total data size : 2.00 GB
-      // src table gen : 9383.00 ms
-      // # columns : 512
-      // split gen : 0.00 ms
-      // # splits : 256
-      //    alloc time : 43.93 (256 allocs)     <------
-      //    copy time : 413.77 (131072 copies)  <------
-      // contiguous_split total : 469.21 ms     <------
-      // verify_split_results : 11387.72 ms
-      // free buffers : 0.20 ms                 <------
- 
-      // pick some numbers
-      int64_t total_desired_bytes = (int64_t)2 * (1024 * 1024 * 1024);
-      int64_t num_cols = 512;      
-      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
-      int64_t num_splits = num_cols / 2;
-      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, true);
-   }
-   */  
-
-   /*      
-   {
-      // Tesla T4, 16 GB (all times in milliseconds)
-      // total data size : 4.00 GB
-      // src table gen : 16917.02 ms
-      // # columns : 512
-      // split gen : 0.00 ms
-      // # splits : 256
-      //    alloc time : 79.27 (256 allocs)     <------
-      //    copy time : 454.59 (131072 copies)  <------
-      // contiguous_split total : 541.54 ms     <------
-      // verify_split_results : 6777.47 ms
-      // free buffers : 0.18 ms                 <------
- 
-      // pick some numbers
-      int64_t total_desired_bytes = (int64_t)4 * (1024 * 1024 * 1024);
-      int64_t num_cols = 512;      
-      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
-      int64_t num_splits = num_cols / 2;
-      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, false);
-   } 
-   */        
-
-   /* 
-   {
-      // Tesla T4, 16 GB (all times in milliseconds)
-      // total data size : 4.00 GB
-      // src table gen : 18649.68 ms
-      // # columns : 512
-      // split gen : 0.00 ms
-      // # splits : 256
-      //    alloc time : 47.73 (256 allocs)     <------
-      //    copy time : 446.58 (131072 copies)  <------
-      // contiguous_split total : 503.26 ms     <------
-      // verify_split_results : 11802.98 ms
-      // free buffers : 0.26 ms                 <------
- 
-      // pick some numbers
-      int64_t total_desired_bytes = (int64_t)4 * (1024 * 1024 * 1024);
-      int64_t num_cols = 512;      
-      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
-      int64_t num_splits = num_cols / 2;
-      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, true);
-   }   
-   */
-   
-   /*
-   {
-      // Tesla T4, 16 GB
-      // total data size : 6.00 GB
-      // src table gen : 25230.81 ms
-      // # columns : 512
-      // split gen : 0.00 ms
-      // # splits : 256
-      //    alloc time : 48.01 (256 allocs)     <------
-      //    copy time : 416.30 (131072 copies)  <------
-      // contiguous_split total : 471.48 ms     <------
-      // verify_split_results : 53921.47 ms
-      // free buffers : 0.20 ms                 <------
-
-      // pick some numbers
-      int64_t total_desired_bytes = (int64_t)6 * (1024 * 1024 * 1024);
-      int64_t num_cols = 512;      
-      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
-      int64_t num_splits = num_cols / 2;
-      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, false);
-   } 
-   */
-   
-   /*
-   {
-      // Tesla T4, 16 GB
-      // total data size : 6.00 GB
-      // src table gen : 27897.44 ms
-      // # columns : 512
-      // split gen : 0.00 ms
-      // # splits : 256
-      //    alloc time : 61.25 (256 allocs)     <------
-      //    copy time : 447.05 (131072 copies)  <------
-      // contiguous_split total : 517.05 ms     <------
-      // verify_split_results : 13794.44 ms
-      // free buffers : 0.20 ms                 <------
- 
-      // pick some numbers
-      int64_t total_desired_bytes = (int64_t)6 * (1024 * 1024 * 1024);
-      int64_t num_cols = 512;      
-      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
-      int64_t num_splits = num_cols / 2;
-      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, true);
-   }*/ 
-   
-   /*
-   {
-      // Tesla T4, 16 GB
-      // total data size : 6.00 GB
-      // src table gen : 28402.29 ms
-      // # columns : 10
-      // split gen : 0.01 ms
-      // # splits : 257
-      //    alloc time : 45.74 (257 allocs)     <------
-      //    copy time : 70.60 (2570 copies)     <------
-      // contiguous_split total : 116.76 ms     <------
-      // verify_split_results : 1962.77 ms
-      // free buffers : 0.24 ms                 <------
- 
-      // pick some numbers
-      int64_t total_desired_bytes = (int64_t)6 * (1024 * 1024 * 1024);
-      int64_t num_cols = 10;
-      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
-      int64_t num_splits = 256;
-      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, false);
-   }
-   */
-
-    {
-      // Tesla T4, 16 GB
-      // total data size : 6.00 GB
-      // src table gen : 30930.70 ms
-      // # columns : 10
-      // split gen : 0.00 ms
-      // # splits : 257
-      //    alloc time : 42.77 (257 allocs)     <------
-      //    copy time : 72.51 (2570 copies)     <------
-      // contiguous_split total : 115.61 ms     <------
-      // verify_split_results : 2088.58 ms
-      // free buffers : 0.25 ms                 <------
- 
-      // pick some numbers
-      int64_t total_desired_bytes = (int64_t)6 * (1024 * 1024 * 1024);
-      int64_t num_cols = 10;
-      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
-      int64_t num_splits = 256;
-      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, true);
-   }
-}
+}; // namespace cudf

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -16,6 +16,13 @@ namespace detail {
 
 namespace {
 
+/**
+ * @brief Copies contents of `in` to `out`.  Copies validity if present
+ * but does not compute null count.
+ *  
+ * @param in column_view to copy from
+ * @param out mutable_column_view to copy to.
+ */
 template <size_type block_size, typename T, bool has_validity>
 __launch_bounds__(block_size)
 __global__
@@ -68,9 +75,16 @@ void copy_in_place_kernel( column_device_view const in,
    }      
 }
 
-static constexpr size_t split_align = 8;
+/**
+ * @brief Functor called by the `type_dispatcher` to incrementally compute total
+ * memory buffer size needed to allocate a contiguous copy of all columns within
+ * a source table. 
+ */
+struct column_buffer_size_functor {
+   // align all column size allocations to this boundary so that all output column buffers
+   // start at that alignment.
+   static constexpr size_t split_align = 64;
 
-struct column_buf_size_functor {   
    template <typename T, std::enable_if_t<not is_fixed_width<T>()>* = nullptr>
    std::pair<size_t, size_t> operator()(std::pair<size_t, size_t> sizes, column_view const& c)
    {
@@ -80,16 +94,22 @@ struct column_buf_size_functor {
 
    template <typename T, std::enable_if_t<is_fixed_width<T>()>* = nullptr>
    std::pair<size_t, size_t> operator()(std::pair<size_t, size_t> sizes, column_view const& c)
-   {
-      size_t data_size = sizes.first + (cudf::util::div_rounding_up_safe(c.size() * sizeof(T), split_align) * split_align);
+   {      
+      size_t data_size = sizes.first + cudf::util::round_up_safe(c.size() * sizeof(T), split_align);  
       size_t validity_size = sizes.second + (c.nullable() ? cudf::bitmask_allocation_size_bytes(c.size(), split_align) : 0);
       return std::pair<size_t, size_t>(data_size, validity_size);
    }
 };
 
-struct column_copy_functor {   
+/**
+ * @brief Functor called by the `type_dispatcher` to copy a column into a contiguous
+ * buffer of output memory. 
+ * 
+ * Used for copying each column in a source table into one contiguous buffer of memory.
+ */
+struct column_copy_functor {
    template <typename T, std::enable_if_t<not is_fixed_width<T>()>* = nullptr>
-   void operator()(column_view const& in, char*& dst, std::vector<column_view>& out_cols) 
+   void operator()(column_view const& in, char*& dst, std::vector<column_view>& out_cols)
    {
       CUDF_FAIL("contiguous_split for strings not implemented yet");
    }
@@ -98,7 +118,7 @@ struct column_copy_functor {
    void operator()(column_view const& in, char*& dst, std::vector<column_view>& out_cols)
    {
       // there's some unnecessary recomputation of sizes happening here, but it really shouldn't affect much.      
-      auto sizes = column_buf_size_functor{}.operator()<T>(std::pair<size_t, size_t>(0, 0), in);
+      auto sizes = column_buffer_size_functor{}.operator()<T>(std::pair<size_t, size_t>(0, 0), in);
       size_t data_size = sizes.first;
       size_t validity_size = sizes.second;
    
@@ -107,7 +127,7 @@ struct column_copy_functor {
       bitmask_type* validity = validity_size == 0 ? nullptr : reinterpret_cast<bitmask_type*>(dst + data_size);
 
       // increment working buffer
-      dst += (data_size + validity_size);      
+      dst += (data_size + validity_size);
 
       // custom copy kernel (which should probably just be an in-place copy() function in cudf.
       cudf::size_type num_els = cudf::util::round_up_safe(in.size(), cudf::experimental::detail::warp_size);
@@ -123,6 +143,7 @@ struct column_copy_functor {
       // so to get around this, I am manually constructing a fake-ish view here where the null
       // count is arbitrarily bashed to 0.            
       //            
+      // Remove this hack once rapidsai/cudf#3600 is fixed.
       column_view   in_wrapped{in.type(), in.size(), in.head<T>(), 
                                in.null_mask(), in.null_mask() == nullptr ? UNKNOWN_NULL_COUNT : 0,
                                in.offset() };
@@ -137,23 +158,32 @@ struct column_copy_functor {
                            *column_device_view::create(in_wrapped), 
                            *mutable_column_device_view::create(mcv));
       }
-      mcv.set_null_count(cudf::UNKNOWN_NULL_COUNT);                  
+      mcv.set_null_count(cudf::UNKNOWN_NULL_COUNT);                 
 
       out_cols.push_back(mcv);
    }
 };
 
+/**
+ * @brief Creates a contiguous_split_result object which contains a deep-copy of the input
+ * table_view into a single contiguous block of memory. 
+ * 
+ * The table_view contained within the contiguous_split_result will pass an expect_tables_equal()
+ * call with the input table.  The memory referenced by the table_view and its internal column_views
+ * is entirely contained in single block of memory.
+ */
 contiguous_split_result alloc_and_copy(cudf::table_view const& t, rmm::mr::device_memory_resource* mr, cudaStream_t stream)      
 {   
    // compute sizes  
-   auto sizes = std::accumulate(t.begin(), t.end(), std::pair<size_t, size_t>(0, 0), [](std::pair<size_t, size_t> sizes, cudf::column_view const& c){
-      return cudf::experimental::type_dispatcher(c.type(), column_buf_size_functor{}, sizes, c);
-   });
+   auto sizes = std::accumulate(t.begin(), t.end(), std::pair<size_t, size_t>(0, 0), 
+      [](std::pair<size_t, size_t> sizes, cudf::column_view const& c){
+         return cudf::experimental::type_dispatcher(c.type(), column_buffer_size_functor{}, sizes, c);
+      });
    size_t data_size = sizes.first;
    size_t validity_size = sizes.second;   
 
    // allocate 
-   auto device_buf = std::make_unique<rmm::device_buffer>(rmm::device_buffer{data_size + validity_size, stream, mr});   
+   auto device_buf = std::make_unique<rmm::device_buffer>(data_size + validity_size, stream, mr);
    char *buf = static_cast<char*>(device_buf->data());
 
    // copy

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -1,0 +1,550 @@
+static constexpr size_t split_align = 8;
+
+template<typename T>
+struct column_buf_size_functor_impl {
+   void operator()(column_view const& c, size_t& running_data_size, size_t& running_validity_size)
+   {
+      running_data_size += cudf::util::div_rounding_up_safe(c.size() * sizeof(T), split_align) * split_align;      
+      if(c.nullable()){
+         running_validity_size += cudf::bitmask_allocation_size_bytes(c.size(), split_align);         
+      }
+   }
+};
+
+// TODO
+template<>
+struct column_buf_size_functor_impl<string_view> {
+   void operator()(column_view const& c, size_t& running_data_size, size_t& running_validity_size){};
+};
+
+struct column_buf_size_functor {
+   template<typename T>
+   void operator()(column_view const& c, size_t& running_data_size, size_t& running_validity_size)
+   {
+      column_buf_size_functor_impl<T> sizer{};
+      sizer(c, running_data_size, running_validity_size);
+   }
+};
+
+
+
+template<typename T>
+struct column_copy_functor_impl {
+   void operator()(column_view const& in, char *&dst, std::vector<column_view>& out_cols
+      // PERFORMANCE TEST 4
+      /*, rmm::device_scalar<cudf::size_type> &valid_count*/)
+   {      
+      // there's some unnecessary recomputation of sizes happening here, but it really shouldn't affect much.
+      size_t data_size = 0;
+      size_t validity_size = 0;      
+      column_buf_size_functor_impl<T>{}(in, data_size, validity_size);
+
+      // outgoing pointers
+      char* data = dst;
+      bitmask_type* validity = validity_size == 0 ? nullptr : reinterpret_cast<bitmask_type*>(dst + data_size);
+
+      // increment working buffer
+      dst += (data_size + validity_size);      
+
+      // custom copy kernel (which should probably just be an in-place copy() function in cudf.
+      cudf::size_type num_els = cudf::util::round_up_safe(in.size(), cudf::experimental::detail::warp_size);
+      constexpr int block_size = 256;
+      cudf::experimental::detail::grid_1d grid{num_els, block_size, 1};      
+      
+      // so there's a significant performance issue that comes up. our incoming column_view objects
+      // are the result of a slice.  because of this, they have an UNKNOWN_NULL_COUNT.  because of that,
+      // calling column_device_view::create() will cause a recompute of the count, which ends up being
+      // -extremely- slow because a.) the typical use case here will involve -huge- numbers of calls and
+      // b.) the count recompute involves tons of device allocs and memcopies, which sort of nullifies
+      // the entire point of contiguous_split.
+      // so to get around this, I am manually constructing a fake-ish view here where the null
+      // count is arbitrarily bashed to 0.
+      //      
+      // I ran 5 performance tests here, all on 6 gigs of input data, 512 columns split 256 ways, for a total of
+      // 128k calls to this function.
+      //
+      // 1. 500 ms    : no valdity information.
+      // 2. 10,000 ms  : validify information, leaving UNKNOWN_NULL_COUNTS in place. the time difference 
+      //    here is in the null_count() recomputation that happens in column_device_view::create() and the time
+      //    spent allocating/reading from the device scalar to get the resulting null count
+      // 3. 3,600 ms  : validity information, faking 0 input null count,  allocating a device scalar on the spot, 
+      //    recomputing null count in the copy_in_place_kernel and reading it back.
+      // 4. 2,700 ms  : validity information, faking 0 input null count, keeping a global device scalar, 
+      //    recomputing null count in the copy_in_place_kernel and reading it back.
+      // 5. 500 ms    : validity information, faking 0 input null count, setting output null count to UNKNOWN_NULL_COUNT. the
+      //    implication here of course is that someone else might end up paying this price later on down the road.
+      //
+      // Summary : nothing super surprising.  anything that causes memory allocation or copying between host and device
+      //           is super slow and becomes extremely noticeable at scale. best bet here seems to be to go with case 5 and 
+      //           let someone else pay the cost for lazily evaluating null counts down the road.
+      //
+      //
+
+      // see performance note above about null counts.
+      column_view          in_hacked{  in.type(), in.size(), in.head<T>(), 
+                                       in.null_mask(), in.null_mask() == nullptr ? UNKNOWN_NULL_COUNT : 0,
+                                       in.offset() };
+      mutable_column_view  mcv{in.type(), in.size(), data, 
+                               validity, validity == nullptr ? UNKNOWN_NULL_COUNT : 0 };      
+      if(in.nullable()){         
+         // PERFORMANCE TEST 2, 3
+         // rmm::device_scalar<cudf::size_type> valid_count{0, 0, rmm::mr::get_default_resource()};
+         copy_in_place_kernel<block_size, T, true><<<grid.num_blocks, block_size, 0, 0>>>(
+                           *column_device_view::create(in_hacked), 
+                           *mutable_column_device_view::create(mcv)
+                           // PERFORMANCE TEST 2, 3, 4
+                           //, valid_count.data()
+                           );
+         // PERFORMANCE TEST 2, 3, 4
+         // mcv.set_null_count(in.size() - valid_count.value());                  
+      } else
+       {
+         copy_in_place_kernel<block_size, T, false><<<grid.num_blocks, block_size, 0, 0>>>(
+                           *column_device_view::create(in_hacked), 
+                           *mutable_column_device_view::create(mcv)
+                           // PERFORMANCE TEST 2, 3, 4
+                           /*, nullptr*/);
+      }
+      mcv.set_null_count(cudf::UNKNOWN_NULL_COUNT);
+
+      out_cols.push_back(mcv);
+   }
+};
+
+// TODO
+template<>
+struct column_copy_functor_impl<string_view> {
+   void operator()(column_view const& in, char *&dst, std::vector<column_view>& out_cols
+                  // PERFORMANCE TEST 4
+                  /*, rmm::device_scalar<cudf::size_type> &valid_count*/)
+   {       
+   };
+};
+
+struct column_copy_functor {
+   template<typename T>   
+   void operator()(column_view const& in, char *&dst, std::vector<column_view>& out_cols
+                  // PERFORMANCE TEST 4
+                  /*, rmm::device_scalar<cudf::size_type> &valid_count*/)
+   {
+      column_copy_functor_impl<T> fn{};      
+      fn(in, dst, out_cols 
+         // PERFORMANCE TEST 4
+         /* , valid_count*/);
+   }
+};
+
+struct contiguous_split_result {
+   cudf::table_view                    table;
+   std::unique_ptr<rmm::device_buffer> all_data;
+};
+typedef std::vector<cudf::column_view> subcolumns;
+
+std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& input,
+                                                      std::vector<size_type> const& splits,
+                                                      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+                                                      cudaStream_t stream = 0)
+{    
+   // slice each column into a set of sub-columns   
+   std::vector<subcolumns> split_table;
+   split_table.reserve(input.num_columns());
+   for(int idx=0; idx<input.num_columns(); idx++){
+      split_table.push_back(cudf::experimental::slice(input.column(idx), splits));
+   }
+   size_t num_out_tables = split_table[0].size();   
+
+   std::vector<contiguous_split_result> result;
+
+   // DEBUG --------------------------
+      float total_alloc_time = 0.0f;
+      int total_allocs = 0;
+      float total_copy_time = 0.0f;
+      int total_copies = 0;
+   // DEBUG --------------------------
+
+   // PERFORMANCE TEST 4
+   // rmm::device_scalar<cudf::size_type> valid_count{0, 0, rmm::mr::get_default_resource()};
+
+   // output packing for a given table will be:
+   // (C0)(V0)(C1)(V1)
+   // where Cx = column x and Vx = validity mask x
+   // padding to split_align boundaries between each buffer
+   for(size_t t_idx=0; t_idx<num_out_tables; t_idx++){  
+      size_t subtable_data_size = 0;
+      size_t subtable_validity_size = 0;
+
+      // compute sizes
+      size_t sts = split_table.size();
+      for(size_t c_idx=0; c_idx<split_table.size(); c_idx++){
+         column_view const& subcol = split_table[c_idx][t_idx];         
+         cudf::experimental::type_dispatcher(subcol.type(), column_buf_size_functor{}, subcol, subtable_data_size, subtable_validity_size);
+      }
+      
+      // DEBUG --------------------------
+         scope_timer_manual alloc_time;
+         alloc_time.start();      
+      // DEBUG --------------------------
+      // allocate the blob
+      auto device_buf = std::make_unique<rmm::device_buffer>(rmm::device_buffer{subtable_data_size + subtable_validity_size, stream, mr});
+      char* buf = static_cast<char*>(device_buf->data());       
+      // DEBUG --------------------------
+         cudaDeviceSynchronize();
+         alloc_time.end();
+         total_alloc_time += alloc_time.total_time_ms();
+         total_allocs++;
+      // DEBUG --------------------------
+            
+      // DEBUG --------------------------
+         scope_timer_manual copy_time;
+         copy_time.start();
+      // DEBUG --------------------------
+      // create columns for the subtables
+      std::vector<column_view> out_cols;
+      out_cols.reserve(split_table.size());
+      for(size_t c_idx=0; c_idx<split_table.size(); c_idx++){
+         // copy
+         column_view const& subcol = split_table[c_idx][t_idx];                  
+         cudf::experimental::type_dispatcher(subcol.type(), column_copy_functor{}, subcol, buf, out_cols 
+            // PERFORMANCE TEST 4
+            /*, valid_count*/);
+      }     
+      // DEBUG --------------------------
+         cudaDeviceSynchronize();
+         copy_time.end();
+         total_copy_time += copy_time.total_time_ms();
+         total_copies += split_table.size();
+      // DEBUG --------------------------
+   
+      result.push_back(contiguous_split_result{cudf::table_view{out_cols}, std::move(device_buf)});
+   }
+ 
+   // DEBUG --------------------------
+      printf("  alloc time : %.2f (%d allocs)\n", total_alloc_time, total_allocs);
+      printf("  copy time : %.2f (%d copies)\n", total_copy_time, total_copies);
+   // DEBUG --------------------------
+
+   // DEBUG --------------------------
+         cudaDeviceSynchronize();
+   // DEBUG --------------------------
+   
+   return result;
+}
+
+
+void verify_split_results( cudf::experimental::table const& src_table, 
+                           std::vector<contiguous_split_result> const &dst_tables,
+                           std::vector<size_type> const& splits,
+                           int verbosity = 0)
+{     
+   table_view src_v(src_table.view());
+
+   // printf("Verification : \n");
+   // printf("%d, %d\n", src_v.num_columns(), (int)splits.size());   
+
+   int col_count = 0;
+   for(size_t c_idx = 0; c_idx<(size_t)src_v.num_columns(); c_idx++){
+      for(size_t s_idx=0; s_idx<splits.size(); s_idx+=2){         
+         // grab the subpiece of the src table
+         auto src_subcol = cudf::experimental::slice(src_v.column(c_idx), std::vector<size_type>{splits[s_idx], splits[s_idx+1]});         
+         
+         // make sure it's the same as the output subtable's equivalent column
+         size_t subtable_index = s_idx/2;         
+         cudf::test::expect_columns_equal(src_subcol[0], dst_tables[subtable_index].table.column(c_idx), true);
+         if(verbosity > 0 && (col_count % verbosity == 0)){
+            printf("----------------------------\n");            
+            print_column(src_subcol[0], false, 20);
+            print_column(dst_tables[subtable_index].table.column(c_idx), false, 20);
+            printf("----------------------------\n");
+         }
+         col_count++;        
+      }
+   }   
+}
+
+float frand()
+{
+   return (static_cast<float>(rand()) / static_cast<float>(RAND_MAX)) * 65535.0f;
+}
+
+void single_split_test( int64_t total_desired_bytes, 
+                        int64_t num_cols,                     
+                        int64_t num_rows,
+                        int64_t num_splits,
+                        bool include_validity)
+{
+   printf("total data size : %.2f GB\n", (float)total_desired_bytes / (float)(1024 * 1024 * 1024));
+   
+   srand(31337);
+
+   // generate input columns and table   
+   std::vector<std::unique_ptr<column>> columns(num_cols);
+   scope_timer_manual src_table_gen("src table gen");
+   src_table_gen.start();
+   std::vector<bool> all_valid(num_rows);
+   if(include_validity){
+      for(int idx=0; idx<num_rows; idx++){
+         all_valid[idx] = true;
+      }
+   }   
+   std::vector<int> icol(num_rows);
+   std::vector<float> fcol(num_rows);
+   for(int idx=0; idx<num_cols; idx++){
+      if(idx % 2 == 0){                  
+         for(int e_idx=0; e_idx<num_rows; e_idx++){
+            icol[e_idx] = rand();
+         }
+         if(include_validity){            
+            wrapper<int> cw(icol.begin(), icol.end(), all_valid.begin());            
+            columns[idx] = cw.release();
+            columns[idx]->set_null_count(0);
+         } else {
+            wrapper<int> cw(icol.begin(), icol.end());
+            columns[idx] = cw.release();
+            columns[idx]->set_null_count(0);
+         }         
+      } else {         
+         for(int e_idx=0; e_idx<num_rows; e_idx++){
+            fcol[e_idx] = frand();
+         }
+         if(include_validity){
+            wrapper<float> cw(fcol.begin(), fcol.end(), all_valid.begin());
+            columns[idx] = cw.release();
+            columns[idx]->set_null_count(0);
+         } else {
+            wrapper<float> cw(fcol.begin(), fcol.end());
+            columns[idx] = cw.release();
+            columns[idx]->set_null_count(0);
+         }         
+      }
+   }
+   cudf::experimental::table src_table(std::move(columns));
+   src_table_gen.end();
+   printf("# columns : %d\n", (int)num_cols);
+
+   // generate splits   
+   int split_stride = num_rows / num_splits;
+   std::vector<size_type> splits;  
+   scope_timer_manual split_gen("split gen");
+   split_gen.start();
+   for(int idx=0; idx<num_rows; idx+=split_stride){
+      splits.push_back(idx);
+      splits.push_back(min(idx + split_stride, (int)num_rows));
+   }
+   split_gen.end();
+
+   printf("# splits : %d\n", (int)splits.size() / 2);
+   /*
+   printf("splits : ");
+   for(size_t idx=0; idx<splits.size(); idx+=2){
+      printf("(%d, %d) ", splits[idx], splits[idx+1]);
+   }
+   */
+
+   // do the split
+   scope_timer_manual split_time("contiguous_split total");
+   split_time.start();
+   auto dst_tables = contiguous_split(src_table.view(), splits);
+   cudaDeviceSynchronize();
+   split_time.end();
+
+   scope_timer_manual verify_time("verify_split_results");
+   verify_time.start();
+   verify_split_results(src_table, dst_tables, splits);
+   verify_time.end();
+
+   scope_timer_manual free_time("free buffers");
+   free_time.start();   
+   for(size_t idx=0; idx<dst_tables.size(); idx++){
+      rmm::device_buffer *buf = dst_tables[idx].all_data.release();
+      delete buf;   
+   }
+   cudaDeviceSynchronize();
+   free_time.end();   
+}
+
+void large_split_tests()
+{      
+   // single_split_test does ints and floats only
+   int el_size = 4;
+      
+   /*
+   {
+      // Tesla T4, 16 GB (all times in milliseconds)
+      // total data size : 2.00 GB
+      // src table gen : 8442.80 ms
+      // # columns : 512
+      // split gen : 0.00 ms
+      // # splits : 256
+      //    alloc time : 77.27 (256 allocs)     <------
+      //    copy time : 436.92 (131072 copies)  <------
+      // contiguous_split total : 524.31 ms     <------
+      // verify_split_results : 6763.76 ms
+      // free buffers : 0.18 ms                 <------
+ 
+      // pick some numbers
+      int64_t total_desired_bytes = (int64_t)2 * (1024 * 1024 * 1024);
+      int64_t num_cols = 512;      
+      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
+      int64_t num_splits = num_cols / 2;
+      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, false);
+   }
+   */  
+   
+   /*
+   {
+      // Tesla T4, 16 GB (all times in milliseconds)
+      // total data size : 2.00 GB
+      // src table gen : 9383.00 ms
+      // # columns : 512
+      // split gen : 0.00 ms
+      // # splits : 256
+      //    alloc time : 43.93 (256 allocs)     <------
+      //    copy time : 413.77 (131072 copies)  <------
+      // contiguous_split total : 469.21 ms     <------
+      // verify_split_results : 11387.72 ms
+      // free buffers : 0.20 ms                 <------
+ 
+      // pick some numbers
+      int64_t total_desired_bytes = (int64_t)2 * (1024 * 1024 * 1024);
+      int64_t num_cols = 512;      
+      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
+      int64_t num_splits = num_cols / 2;
+      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, true);
+   }
+   */  
+
+   /*      
+   {
+      // Tesla T4, 16 GB (all times in milliseconds)
+      // total data size : 4.00 GB
+      // src table gen : 16917.02 ms
+      // # columns : 512
+      // split gen : 0.00 ms
+      // # splits : 256
+      //    alloc time : 79.27 (256 allocs)     <------
+      //    copy time : 454.59 (131072 copies)  <------
+      // contiguous_split total : 541.54 ms     <------
+      // verify_split_results : 6777.47 ms
+      // free buffers : 0.18 ms                 <------
+ 
+      // pick some numbers
+      int64_t total_desired_bytes = (int64_t)4 * (1024 * 1024 * 1024);
+      int64_t num_cols = 512;      
+      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
+      int64_t num_splits = num_cols / 2;
+      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, false);
+   } 
+   */        
+
+   /* 
+   {
+      // Tesla T4, 16 GB (all times in milliseconds)
+      // total data size : 4.00 GB
+      // src table gen : 18649.68 ms
+      // # columns : 512
+      // split gen : 0.00 ms
+      // # splits : 256
+      //    alloc time : 47.73 (256 allocs)     <------
+      //    copy time : 446.58 (131072 copies)  <------
+      // contiguous_split total : 503.26 ms     <------
+      // verify_split_results : 11802.98 ms
+      // free buffers : 0.26 ms                 <------
+ 
+      // pick some numbers
+      int64_t total_desired_bytes = (int64_t)4 * (1024 * 1024 * 1024);
+      int64_t num_cols = 512;      
+      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
+      int64_t num_splits = num_cols / 2;
+      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, true);
+   }   
+   */
+   
+   /*
+   {
+      // Tesla T4, 16 GB
+      // total data size : 6.00 GB
+      // src table gen : 25230.81 ms
+      // # columns : 512
+      // split gen : 0.00 ms
+      // # splits : 256
+      //    alloc time : 48.01 (256 allocs)     <------
+      //    copy time : 416.30 (131072 copies)  <------
+      // contiguous_split total : 471.48 ms     <------
+      // verify_split_results : 53921.47 ms
+      // free buffers : 0.20 ms                 <------
+
+      // pick some numbers
+      int64_t total_desired_bytes = (int64_t)6 * (1024 * 1024 * 1024);
+      int64_t num_cols = 512;      
+      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
+      int64_t num_splits = num_cols / 2;
+      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, false);
+   } 
+   */
+   
+   /*
+   {
+      // Tesla T4, 16 GB
+      // total data size : 6.00 GB
+      // src table gen : 27897.44 ms
+      // # columns : 512
+      // split gen : 0.00 ms
+      // # splits : 256
+      //    alloc time : 61.25 (256 allocs)     <------
+      //    copy time : 447.05 (131072 copies)  <------
+      // contiguous_split total : 517.05 ms     <------
+      // verify_split_results : 13794.44 ms
+      // free buffers : 0.20 ms                 <------
+ 
+      // pick some numbers
+      int64_t total_desired_bytes = (int64_t)6 * (1024 * 1024 * 1024);
+      int64_t num_cols = 512;      
+      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
+      int64_t num_splits = num_cols / 2;
+      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, true);
+   }*/ 
+   
+   /*
+   {
+      // Tesla T4, 16 GB
+      // total data size : 6.00 GB
+      // src table gen : 28402.29 ms
+      // # columns : 10
+      // split gen : 0.01 ms
+      // # splits : 257
+      //    alloc time : 45.74 (257 allocs)     <------
+      //    copy time : 70.60 (2570 copies)     <------
+      // contiguous_split total : 116.76 ms     <------
+      // verify_split_results : 1962.77 ms
+      // free buffers : 0.24 ms                 <------
+ 
+      // pick some numbers
+      int64_t total_desired_bytes = (int64_t)6 * (1024 * 1024 * 1024);
+      int64_t num_cols = 10;
+      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
+      int64_t num_splits = 256;
+      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, false);
+   }
+   */
+
+    {
+      // Tesla T4, 16 GB
+      // total data size : 6.00 GB
+      // src table gen : 30930.70 ms
+      // # columns : 10
+      // split gen : 0.00 ms
+      // # splits : 257
+      //    alloc time : 42.77 (257 allocs)     <------
+      //    copy time : 72.51 (2570 copies)     <------
+      // contiguous_split total : 115.61 ms     <------
+      // verify_split_results : 2088.58 ms
+      // free buffers : 0.25 ms                 <------
+ 
+      // pick some numbers
+      int64_t total_desired_bytes = (int64_t)6 * (1024 * 1024 * 1024);
+      int64_t num_cols = 10;
+      int64_t num_rows = total_desired_bytes / (num_cols * el_size);
+      int64_t num_splits = 256;
+      single_split_test(total_desired_bytes, num_cols, num_rows, num_splits, true);
+   }
+}

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -4,6 +4,9 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/copying.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
+#include <cudf/utilities/bit.hpp>
+
+#include <numeric>
 
 namespace cudf {
 
@@ -65,40 +68,75 @@ void copy_in_place_kernel( column_device_view const in,
    }      
 }
 
-
 static constexpr size_t split_align = 8;
 
-template<typename T>
-struct column_buf_size_functor_impl {
-   void operator()(column_view const& c, size_t& running_data_size, size_t& running_validity_size)
-   {
-      running_data_size += cudf::util::div_rounding_up_safe(c.size() * sizeof(T), split_align) * split_align;      
-      if(c.nullable()){
-         running_validity_size += cudf::bitmask_allocation_size_bytes(c.size(), split_align);         
-      }
-   }
-};
-
-template<>
-struct column_buf_size_functor_impl<string_view> {
-   void operator()(column_view const& c, size_t& running_data_size, size_t& running_validity_size)
+struct column_buf_size_functor {   
+   template <typename T, std::enable_if_t<not is_fixed_width<T>()>* = nullptr>
+   std::pair<size_t, size_t> operator()(std::pair<size_t, size_t> sizes, column_view const& c)
    {
       CUDF_FAIL("contiguous_split for strings not implemented yet");
-   };
-};
+      return std::pair<size_t, size_t>(0, 0);
+   }
 
-struct column_buf_size_functor {
-   template<typename T>
-   void operator()(column_view const& c, size_t& running_data_size, size_t& running_validity_size)
+   template <typename T, std::enable_if_t<is_fixed_width<T>()>* = nullptr>
+   std::pair<size_t, size_t> operator()(std::pair<size_t, size_t> sizes, column_view const& c)
    {
-      column_buf_size_functor_impl<T> sizer{};
-      sizer(c, running_data_size, running_validity_size);
+      size_t data_size = sizes.first + (cudf::util::div_rounding_up_safe(c.size() * sizeof(T), split_align) * split_align);
+      size_t validity_size = sizes.second + (c.nullable() ? cudf::bitmask_allocation_size_bytes(c.size(), split_align) : 0);
+      return std::pair<size_t, size_t>(data_size, validity_size);
    }
 };
 
-struct column_copy_functor {
+cudaStream_t stream1, stream2;
+
+__global__ void _copy_offset_bitmask(bitmask_type *__restrict__ destination,
+                                    bitmask_type const *__restrict__ source,
+                                    size_type source_begin_bit,
+                                    size_type source_end_bit,
+                                    size_type number_of_mask_words) {
+  for (size_type destination_word_index = threadIdx.x + blockIdx.x * blockDim.x;
+       destination_word_index < number_of_mask_words;
+       destination_word_index += blockDim.x * gridDim.x) {
+    size_type source_word_index =
+        destination_word_index + word_index(source_begin_bit);
+    bitmask_type curr_word = source[source_word_index];
+    bitmask_type next_word = 0;
+    if ((word_index(source_begin_bit) != 0) &&
+        (word_index(source_end_bit) >
+          word_index(source_begin_bit +
+            destination_word_index * cudf::detail::size_in_bits<bitmask_type>()))) {
+      next_word = source[source_word_index + 1];
+    }
+    bitmask_type write_word =
+      __funnelshift_r(curr_word, next_word, source_begin_bit);
+    destination[destination_word_index] = write_word;
+  }
+}
+
+// Create a bitmask from a specific range
+void _copy_bitmask(bitmask_type *dest_mask, bitmask_type const *mask, size_type begin_bit,
+                                size_type end_bit, cudaStream_t stream) {
+  CUDF_EXPECTS(begin_bit >= 0, "Invalid range.");
+  CUDF_EXPECTS(begin_bit <= end_bit, "Invalid bit range.");  
+  auto num_bytes = bitmask_allocation_size_bytes(end_bit - begin_bit);  
+    
+   auto number_of_mask_words = cudf::util::div_rounding_up_safe(
+      static_cast<size_t>(end_bit - begin_bit),
+      cudf::detail::size_in_bits<bitmask_type>());
+   
+   if (begin_bit == 0) {
+      cudaMemcpyAsync(dest_mask, mask, num_bytes, cudaMemcpyDeviceToDevice, stream); 
+  } else {     
+      cudf::experimental::detail::grid_1d config(number_of_mask_words, 256);
+      _copy_offset_bitmask<<<config.num_blocks, config.num_threads_per_block, 0,
+                           stream>>>(dest_mask, mask, begin_bit, end_bit, number_of_mask_words);
+  }
+   CUDA_CHECK_LAST();    
+}
+
+struct column_copy_functor {   
    template <typename T, std::enable_if_t<not is_fixed_width<T>()>* = nullptr>
-   void operator()(strings_column_view const& in, char*& dst, std::vector<column_view>& out_cols) 
+   void operator()(column_view const& in, char*& dst, std::vector<column_view>& out_cols) 
    {
       CUDF_FAIL("contiguous_split for strings not implemented yet");
    }
@@ -106,11 +144,11 @@ struct column_copy_functor {
    template <typename T, std::enable_if_t<is_fixed_width<T>()>* = nullptr>
    void operator()(column_view const& in, char*& dst, std::vector<column_view>& out_cols)
    {
-      // there's some unnecessary recomputation of sizes happening here, but it really shouldn't affect much.
-      size_t data_size = 0;
-      size_t validity_size = 0;      
-      column_buf_size_functor_impl<T>{}(in, data_size, validity_size);
-
+      // there's some unnecessary recomputation of sizes happening here, but it really shouldn't affect much.      
+      auto sizes = column_buf_size_functor{}.operator()<T>(std::pair<size_t, size_t>(0, 0), in);
+      size_t data_size = sizes.first;
+      size_t validity_size = sizes.second;
+   
       // outgoing pointers
       char* data = dst;
       bitmask_type* validity = validity_size == 0 ? nullptr : reinterpret_cast<bitmask_type*>(dst + data_size);
@@ -121,7 +159,14 @@ struct column_copy_functor {
       // custom copy kernel (which should probably just be an in-place copy() function in cudf.
       cudf::size_type num_els = cudf::util::round_up_safe(in.size(), cudf::experimental::detail::warp_size);
       constexpr int block_size = 256;
-      cudf::experimental::detail::grid_1d grid{num_els, block_size, 1};      
+      cudf::experimental::detail::grid_1d grid{num_els, block_size, 1};
+                                          
+      cudaMemcpyAsync(data, in.data<T>(), data_size, cudaMemcpyDeviceToDevice, stream1);
+      if(in.nullable()){           
+         _copy_bitmask(validity, in.null_mask(), in.offset(), in.offset() + in.size(), (cudaStream_t)stream2);
+      }
+      mutable_column_view  mcv{in.type(), in.size(), data, 
+                               validity, UNKNOWN_NULL_COUNT };             
       
       // so there's a significant performance issue that comes up. our incoming column_view objects
       // are the result of a slice.  because of this, they have an UNKNOWN_NULL_COUNT.  because of that,
@@ -131,7 +176,8 @@ struct column_copy_functor {
       //
       // so to get around this, I am manually constructing a fake-ish view here where the null
       // count is arbitrarily bashed to 0.            
-      //
+      //      
+      /*
       column_view   in_wrapped{in.type(), in.size(), in.head<T>(), 
                                in.null_mask(), in.null_mask() == nullptr ? UNKNOWN_NULL_COUNT : 0,
                                in.offset() };
@@ -146,24 +192,25 @@ struct column_copy_functor {
                            *column_device_view::create(in_wrapped), 
                            *mutable_column_device_view::create(mcv));
       }
-      mcv.set_null_count(cudf::UNKNOWN_NULL_COUNT);
+      mcv.set_null_count(cudf::UNKNOWN_NULL_COUNT);                  
+      */
 
       out_cols.push_back(mcv);
    }
 };
 
+#include <inttypes.h>
 contiguous_split_result alloc_and_copy(cudf::table_view const& t, rmm::mr::device_memory_resource* mr, cudaStream_t stream)
-{
-   size_t data_size = 0;
-   size_t validity_size = 0;      
-
-   // compute sizes   
-   std::for_each(t.begin(), t.end(), [&data_size, &validity_size](cudf::column_view const& c){
-      cudf::experimental::type_dispatcher(c.type(), column_buf_size_functor{}, c, data_size, validity_size);
-   });   
+{      
+   // compute sizes  
+   auto sizes = std::accumulate(t.begin(), t.end(), std::pair<size_t, size_t>(0, 0), [](std::pair<size_t, size_t> sizes, cudf::column_view const& c){
+      return cudf::experimental::type_dispatcher(c.type(), column_buf_size_functor{}, sizes, c);
+   });
+   size_t data_size = sizes.first;
+   size_t validity_size = sizes.second;   
 
    // allocate 
-   auto device_buf = std::make_unique<rmm::device_buffer>(rmm::device_buffer{data_size + validity_size, stream, mr});   
+   auto device_buf = std::make_unique<rmm::device_buffer>(rmm::device_buffer{data_size + validity_size, stream1, mr});   
    char *buf = static_cast<char*>(device_buf->data());
 
    // copy
@@ -172,7 +219,7 @@ contiguous_split_result alloc_and_copy(cudf::table_view const& t, rmm::mr::devic
    std::for_each(t.begin(), t.end(), [&out_cols, &buf](cudf::column_view const& c){
       cudf::experimental::type_dispatcher(c.type(), column_copy_functor{}, c, buf, out_cols);
    });
-
+   
    return contiguous_split_result{cudf::table_view{out_cols}, std::move(device_buf)};
 }
 
@@ -183,12 +230,20 @@ std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& in
                                                       rmm::mr::device_memory_resource* mr,
                                                       cudaStream_t stream)
 {    
+   cudaStreamCreate(&stream1);
+   cudaStreamCreate(&stream2);
+
+   printf("%" PRIx64 ", %" PRIx64 "\n", (long unsigned int)stream1, (long unsigned int)stream2);
+
    auto subtables = cudf::experimental::split(input, splits);      
 
    std::vector<contiguous_split_result> result;
    std::transform(subtables.begin(), subtables.end(), std::back_inserter(result), [mr, stream](table_view const& t) { 
       return alloc_and_copy(t, mr, stream);
    });
+
+   cudaStreamSynchronize(stream1);
+   cudaStreamSynchronize(stream2);
    
    return result;
 }

--- a/cpp/src/copying/slice.cpp
+++ b/cpp/src/copying/slice.cpp
@@ -56,8 +56,9 @@ std::vector<cudf::table_view> slice(cudf::table_view const& input,
     // sliced_table[i][j]
     // where i is the i'th column of the j'th table_view
     std::vector<std::vector<cudf::column_view>> sliced_table;
-    std::for_each(input.begin(), input.end(), [&sliced_table, indices](cudf::column_view const& c){
-        sliced_table.emplace_back(slice(c, indices));
+    sliced_table.reserve(indices.size() + 1);
+    std::transform(input.begin(), input.end(), std::back_inserter(sliced_table), [&indices](cudf::column_view const& c){
+       return slice(c, indices);
     });
 
     // distribute columns into outgoing table_views

--- a/cpp/src/copying/slice.cpp
+++ b/cpp/src/copying/slice.cpp
@@ -42,5 +42,36 @@ std::vector<cudf::column_view> slice(cudf::column_view const& input,
     return result;
 };
 
+std::vector<cudf::table_view> slice(cudf::table_view const& input,
+                                                std::vector<size_type> const& indices){
+
+    CUDF_EXPECTS(indices.size()%2 == 0, "indices size must be even");
+    std::vector<cudf::table_view> result{};
+
+    if(indices.size() == 0 or input.num_columns() == 0) {
+        return result;
+    }
+
+    // 2d arrangement of column_views that represent the outgoing table_views    
+    // sliced_table[i][j]
+    // where i is the i'th column of the j'th table_view
+    std::vector<std::vector<cudf::column_view>> sliced_table;
+    std::for_each(input.begin(), input.end(), [&sliced_table, indices](cudf::column_view const& c){
+        sliced_table.emplace_back(slice(c, indices));
+    });
+
+    // distribute columns into outgoing table_views
+    size_t num_output_tables = indices.size()/2;
+    for(size_t i = 0; i < num_output_tables; i++){        
+        std::vector<cudf::column_view> table_columns;
+        for(size_t j = 0; j<input.num_columns(); j++){
+            table_columns.emplace_back(sliced_table[j][i]);
+        }
+        result.emplace_back(table_view{table_columns});
+    }
+
+    return result;
+};
+
 } // experimental
 } // cudf

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -744,6 +744,6 @@ enable_testing()
 # - iterator benchmarks----------------------------------------------------------------------------
 
 set(LEGACY_ITERATOR_BENCH_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/iterator/legacy/iterator_bench.cu")
+    "${CMAKE_CURRENT_SOURCE_DIR}/iterator/iterator_bench.cu")
 
   ConfigureBench(LEGACY_ITERATOR_BENCH "${LEGACY_ITERATOR_BENCH_SRC}")

--- a/cpp/tests/copying/slice_tests.cu
+++ b/cpp/tests/copying/slice_tests.cu
@@ -19,6 +19,7 @@
 #include <cudf/copying.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <tests/utilities/column_utilities.hpp>
+#include <tests/utilities/table_utilities.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <tests/utilities/type_lists.hpp>
 #include <tests/utilities/column_wrapper.hpp>
@@ -27,48 +28,11 @@
 #include <string>
 #include <vector>
 
-template <typename T, typename InputIterator>
-cudf::test::fixed_width_column_wrapper<T> create_fixed_columns(cudf::size_type start, cudf::size_type size, InputIterator valids) {
-    auto iter = cudf::test::make_counting_transform_iterator(start, [](auto i) { return T(i);});
+#include <cudf/strings/string_view.cuh>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/wrappers/timestamps.hpp>
 
-        return cudf::test::fixed_width_column_wrapper<T> (iter, iter + size, valids);
-
-}
-
-template <typename T>
-std::vector<cudf::test::fixed_width_column_wrapper<T>> create_expected_columns(std::vector<cudf::size_type> indices, bool nullable) {
-
-    std::vector<cudf::test::fixed_width_column_wrapper<T>> result = {};
-
-    for(unsigned long index = 0; index < indices.size(); index+=2) {
-        auto iter = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return T(i);});
-
-        if(not nullable) {
-            result.push_back(cudf::test::fixed_width_column_wrapper<T> (iter, iter + (indices[index+1] - indices[index])));
-        } else {
-            auto valids = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return i%2==0? true:false; });
-            result.push_back(cudf::test::fixed_width_column_wrapper<T> (iter, iter + (indices[index+1] - indices[index]), valids));
-        }
-    }
-
-    return result;
-}
-
-std::vector<cudf::test::strings_column_wrapper> create_expected_string_columns(std::vector<std::string> strings, std::vector<cudf::size_type> indices, bool nullable) {
-
-    std::vector<cudf::test::strings_column_wrapper> result = {};
-
-    for(unsigned long index = 0; index < indices.size(); index+=2) {
-        if(not nullable) {
-            result.push_back(cudf::test::strings_column_wrapper (strings.begin()+indices[index],  strings.begin()+indices[index+1]));
-        } else {
-            auto valids = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return i%2==0? true:false; });
-            result.push_back(cudf::test::strings_column_wrapper (strings.begin()+indices[index], strings.begin()+indices[index+1], valids));
-        }
-    }
-
-    return result;
-}
+#include <tests/copying/slice_tests.cuh>
 
 template <typename T>
 struct SliceTest : public cudf::test::BaseFixture {};
@@ -172,4 +136,128 @@ TEST_F(SliceCornerCases, NegativeOffset) {
     std::vector<cudf::size_type> indices{-1, 4};
 
     EXPECT_THROW(cudf::experimental::slice(col, indices), cudf::logic_error);
+}
+
+
+template <typename T>
+struct SliceTableTest : public cudf::test::BaseFixture {};
+
+TYPED_TEST_CASE(SliceTableTest, cudf::test::NumericTypes);
+
+TYPED_TEST(SliceTableTest, NumericColumnsWithInValids) {
+    using T = TypeParam;
+
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5; 
+    cudf::experimental::table src_table = create_fixed_table<T>(num_cols, start, col_size, valids);        
+
+    std::vector<cudf::size_type> indices{1, 3, 2, 2, 5, 9};
+    std::vector<cudf::experimental::table> expected = create_expected_tables<T>(num_cols, indices, true);
+
+    std::vector<cudf::table_view> result = cudf::experimental::slice(src_table, indices);
+
+    EXPECT_EQ(expected.size(), result.size());
+
+    for (unsigned long index = 0; index < result.size(); index++) {        
+        cudf::test::expect_tables_equal(expected[index], result[index]);
+    }        
+}
+
+struct SliceStringTableTest : public SliceTableTest <std::string>{};
+
+TEST_F(SliceStringTableTest, StringWithInvalids) {    
+    auto valids = cudf::test::make_counting_transform_iterator(0, [](auto i) { return i%2==0? true:false; });
+    
+    std::vector<std::string> strings[2]     = { {"", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"}, 
+                                                {"", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"} };
+    cudf::test::strings_column_wrapper sw[2] = { {strings[0].begin(), strings[0].end(), valids},
+                                                {strings[1].begin(), strings[1].end(), valids} };
+                                                
+    std::vector<std::unique_ptr<cudf::column>> scols;
+    scols.push_back(sw[0].release());
+    scols.push_back(sw[1].release());    
+    cudf::experimental::table src_table(std::move(scols));
+
+    std::vector<cudf::size_type> indices{1, 3, 2, 4, 1, 9};
+
+    std::vector<cudf::experimental::table> expected = create_expected_string_tables(strings, indices, true);
+        
+    std::vector<cudf::table_view> result = cudf::experimental::slice(src_table, indices);
+
+    EXPECT_EQ(expected.size(), result.size());
+
+    for (unsigned long index = 0; index < result.size(); index++) {        
+        cudf::test::expect_table_properties_equal(expected[index], result[index]);
+    }        
+}
+
+struct SliceTableCornerCases : public SliceTableTest <int8_t>{};
+
+TEST_F(SliceTableCornerCases, EmptyTable) {        
+    std::vector<cudf::size_type> indices{1, 3, 2, 4, 5, 9};
+
+    cudf::experimental::table src_table{};    
+    std::vector<cudf::table_view> result = cudf::experimental::slice(src_table.view(), indices);
+
+    unsigned long expected = 0;
+
+    EXPECT_EQ(expected, result.size());
+}
+
+TEST_F(SliceTableCornerCases, EmptyIndices) {
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5; 
+    cudf::experimental::table src_table = create_fixed_table<int8_t>(num_cols, start, col_size, valids);    
+    std::vector<cudf::size_type> indices{};
+
+    std::vector<cudf::table_view> result = cudf::experimental::slice(src_table, indices);
+    
+    unsigned long expected = 0;
+
+    EXPECT_EQ(expected, result.size());
+}
+
+TEST_F(SliceTableCornerCases, InvalidSetOfIndices) {
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+        
+    cudf::size_type num_cols = 5; 
+    cudf::experimental::table src_table = create_fixed_table<int8_t>(num_cols, start, col_size, valids);    
+    
+    std::vector<cudf::size_type> indices{11, 12};
+
+    EXPECT_THROW(cudf::experimental::slice(src_table, indices), cudf::logic_error);
+}
+
+TEST_F(SliceTableCornerCases, ImproperRange) {
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5; 
+    cudf::experimental::table src_table = create_fixed_table<int8_t>(num_cols, start, col_size, valids);    
+    
+    std::vector<cudf::size_type> indices{5, 4};
+
+    EXPECT_THROW(cudf::experimental::slice(src_table, indices), cudf::logic_error);
+}
+
+TEST_F(SliceTableCornerCases, NegativeOffset) {
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5; 
+    cudf::experimental::table src_table = create_fixed_table<int8_t>(num_cols, start, col_size, valids);    
+    
+    std::vector<cudf::size_type> indices{-1, 4};
+
+    EXPECT_THROW(cudf::experimental::slice(src_table, indices), cudf::logic_error);
 }

--- a/cpp/tests/copying/slice_tests.cu
+++ b/cpp/tests/copying/slice_tests.cu
@@ -39,7 +39,7 @@ struct SliceTest : public cudf::test::BaseFixture {};
 
 TYPED_TEST_CASE(SliceTest, cudf::test::NumericTypes);
 
-TYPED_TEST(SliceTest, NumericColumnsWithInValids) {
+TYPED_TEST(SliceTest, NumericColumnsWithNulls) {
     using T = TypeParam;
 
     cudf::size_type start = 0;
@@ -61,7 +61,7 @@ TYPED_TEST(SliceTest, NumericColumnsWithInValids) {
 
 struct SliceStringTest : public SliceTest <std::string>{};
 
-TEST_F(SliceStringTest, StringWithInvalids) {
+TEST_F(SliceStringTest, StringWithNulls) {
     std::vector<std::string> strings{"", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"};
     auto valids = cudf::test::make_counting_transform_iterator(0, [](auto i) { return i%2==0? true:false; });
     cudf::test::strings_column_wrapper s(strings.begin(), strings.end(), valids);
@@ -144,7 +144,7 @@ struct SliceTableTest : public cudf::test::BaseFixture {};
 
 TYPED_TEST_CASE(SliceTableTest, cudf::test::NumericTypes);
 
-TYPED_TEST(SliceTableTest, NumericColumnsWithInValids) {
+TYPED_TEST(SliceTableTest, NumericColumnsWithNulls) {
     using T = TypeParam;
 
     cudf::size_type start = 0;
@@ -168,7 +168,7 @@ TYPED_TEST(SliceTableTest, NumericColumnsWithInValids) {
 
 struct SliceStringTableTest : public SliceTableTest <std::string>{};
 
-TEST_F(SliceStringTableTest, StringWithInvalids) {    
+TEST_F(SliceStringTableTest, StringWithNulls) {    
     auto valids = cudf::test::make_counting_transform_iterator(0, [](auto i) { return i%2==0? true:false; });
     
     std::vector<std::string> strings[2]     = { {"", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"}, 

--- a/cpp/tests/copying/slice_tests.cuh
+++ b/cpp/tests/copying/slice_tests.cuh
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/cudf.h>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/column_wrapper.hpp>
+#include <tests/utilities/column_utilities.hpp>
+
+template <typename T, typename InputIterator>
+cudf::test::fixed_width_column_wrapper<T> create_fixed_columns(cudf::size_type start, cudf::size_type size, InputIterator valids) {
+    auto iter = cudf::test::make_counting_transform_iterator(start, [](auto i) { return T(i);});
+
+    return cudf::test::fixed_width_column_wrapper<T> (iter, iter + size, valids);
+
+}
+
+template <typename T, typename InputIterator>
+cudf::experimental::table create_fixed_table(cudf::size_type num_cols, cudf::size_type start, cudf::size_type col_size, InputIterator valids) {        
+    std::vector<std::unique_ptr<cudf::column>> cols;    
+    for(int idx=0; idx<num_cols; idx++){
+        cudf::test::fixed_width_column_wrapper<T> wrap = create_fixed_columns<T>(start + (idx * num_cols), col_size, valids);
+        cols.push_back(wrap.release());
+    }    
+    return cudf::experimental::table(std::move(cols));    
+}
+
+template <typename T>
+std::vector<cudf::test::fixed_width_column_wrapper<T>> create_expected_columns(std::vector<cudf::size_type> const& indices, bool nullable) {
+
+    std::vector<cudf::test::fixed_width_column_wrapper<T>> result = {};
+
+    for(unsigned long index = 0; index < indices.size(); index+=2) {
+        auto iter = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return T(i);});
+
+        if(not nullable) {
+            result.push_back(cudf::test::fixed_width_column_wrapper<T> (iter, iter + (indices[index+1] - indices[index])));
+        } else {
+            auto valids = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return i%2==0? true:false; });
+            result.push_back(cudf::test::fixed_width_column_wrapper<T> (iter, iter + (indices[index+1] - indices[index]), valids));
+        }
+    }
+
+    return result;
+}
+
+template <typename T>
+std::vector<cudf::experimental::table> create_expected_tables(cudf::size_type num_cols, std::vector<cudf::size_type> const& indices, bool nullable) {
+
+    std::vector<cudf::experimental::table> result;
+
+    for(unsigned long index = 0; index < indices.size(); index+=2) {
+        std::vector<std::unique_ptr<cudf::column>> cols = {};
+        
+        for(int idx=0; idx<num_cols; idx++){            
+            auto iter = cudf::test::make_counting_transform_iterator(indices[index] + (idx * num_cols), [](auto i) { return T(i);});
+
+            if(not nullable) {                
+                cudf::test::fixed_width_column_wrapper<T> wrap(iter, iter + (indices[index+1] - indices[index]));
+                cols.push_back(wrap.release());
+            } else {               
+                auto valids = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return i%2==0? true:false; });
+                cudf::test::fixed_width_column_wrapper<T> wrap(iter, iter + (indices[index+1] - indices[index]), valids);
+                cols.push_back(wrap.release());
+            }
+        }
+
+        result.push_back(cudf::experimental::table(std::move(cols)));
+    }
+
+    return result;
+}
+
+inline std::vector<cudf::test::strings_column_wrapper> create_expected_string_columns(std::vector<std::string> const& strings, std::vector<cudf::size_type> const& indices, bool nullable) {
+
+    std::vector<cudf::test::strings_column_wrapper> result = {};
+
+    for(unsigned long index = 0; index < indices.size(); index+=2) {
+        if(not nullable) {
+            result.push_back(cudf::test::strings_column_wrapper (strings.begin()+indices[index],  strings.begin()+indices[index+1]));
+        } else {
+            auto valids = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return i%2==0? true:false; });
+            result.push_back(cudf::test::strings_column_wrapper (strings.begin()+indices[index], strings.begin()+indices[index+1], valids));
+        }
+    }
+
+    return result;
+}
+
+inline std::vector<cudf::experimental::table> create_expected_string_tables(std::vector<std::string> const strings[2], std::vector<cudf::size_type> const& indices, bool nullable) {
+
+    std::vector<cudf::experimental::table> result = {};
+
+    for(unsigned long index = 0; index < indices.size(); index+=2) {
+        std::vector<std::unique_ptr<cudf::column>> cols = {};
+        
+        for(int idx=0; idx<2; idx++){     
+            if(not nullable) {
+                cudf::test::strings_column_wrapper wrap(strings[idx].begin()+indices[index], strings[idx].begin()+indices[index+1]);
+                cols.push_back(wrap.release());
+            } else {
+                auto valids = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return i%2==0? true:false; });
+                cudf::test::strings_column_wrapper wrap(strings[idx].begin()+indices[index], strings[idx].begin()+indices[index+1], valids);
+                cols.push_back(wrap.release());
+            }
+        }
+
+        result.push_back(cudf::experimental::table(std::move(cols)));
+    }
+
+    return result;
+}

--- a/cpp/tests/copying/split_tests.cu
+++ b/cpp/tests/copying/split_tests.cu
@@ -19,6 +19,7 @@
 #include <cudf/copying.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <tests/utilities/column_utilities.hpp>
+#include <tests/utilities/table_utilities.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <tests/utilities/type_lists.hpp>
 #include <tests/utilities/column_wrapper.hpp>
@@ -26,6 +27,8 @@
 #include <tests/utilities/legacy/cudf_test_utils.cuh>
 #include <string>
 #include <vector>
+
+#include <tests/copying/slice_tests.cuh>
 
 std::vector<cudf::size_type> splits_to_indices(std::vector<cudf::size_type> splits, cudf::size_type size){
     std::vector<cudf::size_type> indices{0};
@@ -45,49 +48,29 @@ std::vector<cudf::size_type> splits_to_indices(std::vector<cudf::size_type> spli
     return indices;
 }
 
-template <typename T, typename InputIterator>
-cudf::test::fixed_width_column_wrapper<T> create_fixed_columns_for_splits(cudf::size_type start, cudf::size_type size, InputIterator valids) {
-    auto iter = cudf::test::make_counting_transform_iterator(start, [](auto i) { return T(i);});
+template <typename T>
+std::vector<cudf::test::fixed_width_column_wrapper<T>> create_expected_columns_for_splits(std::vector<cudf::size_type> const& splits, cudf::size_type size, bool nullable) {
 
-        return cudf::test::fixed_width_column_wrapper<T> (iter, iter + size, valids);
+    // convert splits to slice indices
+    std::vector<cudf::size_type> indices = splits_to_indices(splits, size);
+    return create_expected_columns<T>(indices, nullable);
+}
 
+std::vector<cudf::test::strings_column_wrapper> create_expected_string_columns_for_splits(std::vector<std::string> strings, std::vector<cudf::size_type> const& splits, bool nullable) {
+
+    std::vector<cudf::size_type> indices = splits_to_indices(splits, strings.size());
+    return create_expected_string_columns(strings, indices, nullable);   
 }
 
 template <typename T>
-std::vector<cudf::test::fixed_width_column_wrapper<T>> create_expected_columns(std::vector<cudf::size_type> splits, cudf::size_type size, bool nullable) {
-
-    std::vector<cudf::test::fixed_width_column_wrapper<T>> result = {};
-    std::vector<cudf::size_type> indices = splits_to_indices(splits, size);
-
-    for(unsigned long index = 0; index < indices.size(); index+=2) {
-        auto iter = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return T(i);});
-
-        if(not nullable) {
-            result.push_back(cudf::test::fixed_width_column_wrapper<T> (iter, iter + (indices[index+1] - indices[index])));
-        } else {
-            auto valids = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return i%2==0? true:false; });
-            result.push_back(cudf::test::fixed_width_column_wrapper<T> (iter, iter + (indices[index+1] - indices[index]), valids));
-        }
-    }
-
-    return result;
+std::vector<cudf::experimental::table> create_expected_tables_for_splits(cudf::size_type num_cols, std::vector<cudf::size_type> const& splits, cudf::size_type col_size, bool nullable){
+    std::vector<cudf::size_type> indices = splits_to_indices(splits, col_size);    
+    return create_expected_tables<T>(num_cols, indices, nullable);
 }
 
-std::vector<cudf::test::strings_column_wrapper> create_expected_string_columns_for_splits(std::vector<std::string> strings, std::vector<cudf::size_type> splits, bool nullable) {
-
-    std::vector<cudf::test::strings_column_wrapper> result = {};
-    std::vector<cudf::size_type> indices = splits_to_indices(splits, strings.size());
-
-    for(unsigned long index = 0; index < indices.size(); index+=2) {
-        if(not nullable) {
-            result.push_back(cudf::test::strings_column_wrapper (strings.begin()+indices[index],  strings.begin()+indices[index+1]));
-        } else {
-            auto valids = cudf::test::make_counting_transform_iterator(indices[index], [](auto i) { return i%2==0? true:false; });
-            result.push_back(cudf::test::strings_column_wrapper (strings.begin()+indices[index], strings.begin()+indices[index+1], valids));
-        }
-    }
-
-    return result;
+std::vector<cudf::experimental::table> create_expected_string_tables_for_splits(std::vector<std::string> const strings[2], std::vector<cudf::size_type> const& splits, bool nullable){    
+    std::vector<cudf::size_type> indices = splits_to_indices(splits, strings[0].size());    
+    return create_expected_string_tables(strings, indices, nullable);
 }
 
 template <typename T>
@@ -102,10 +85,10 @@ TYPED_TEST(SplitTest, SplitEndLessThanSize) {
     cudf::size_type size = 10;
     auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
 
-    cudf::test::fixed_width_column_wrapper<T> col = create_fixed_columns_for_splits<T>(start, size, valids);
+    cudf::test::fixed_width_column_wrapper<T> col = create_fixed_columns<T>(start, size, valids);
 
     std::vector<cudf::size_type> splits{2, 5, 7};
-    std::vector<cudf::test::fixed_width_column_wrapper<T>> expected = create_expected_columns<T>(splits, size, true);
+    std::vector<cudf::test::fixed_width_column_wrapper<T>> expected = create_expected_columns_for_splits<T>(splits, size, true);
     std::vector<cudf::column_view> result = cudf::experimental::split(col, splits);
 
     EXPECT_EQ(expected.size(), result.size());
@@ -122,10 +105,10 @@ TYPED_TEST(SplitTest, SplitEndToSize) {
     cudf::size_type size = 10;
     auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
 
-    cudf::test::fixed_width_column_wrapper<T> col = create_fixed_columns_for_splits<T>(start, size, valids);
+    cudf::test::fixed_width_column_wrapper<T> col = create_fixed_columns<T>(start, size, valids);
 
     std::vector<cudf::size_type> splits{2, 5, 10};
-    std::vector<cudf::test::fixed_width_column_wrapper<T>> expected = create_expected_columns<T>(splits, size, true);
+    std::vector<cudf::test::fixed_width_column_wrapper<T>> expected = create_expected_columns_for_splits<T>(splits, size, true);
     std::vector<cudf::column_view> result = cudf::experimental::split(col, splits);
 
     EXPECT_EQ(expected.size(), result.size());
@@ -172,7 +155,7 @@ TEST_F(SplitCornerCases, EmptyIndices) {
     cudf::size_type size = 10;
     auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
 
-    cudf::test::fixed_width_column_wrapper<int8_t> col = create_fixed_columns_for_splits<int8_t>(start, size, valids);
+    cudf::test::fixed_width_column_wrapper<int8_t> col = create_fixed_columns<int8_t>(start, size, valids);
     std::vector<cudf::size_type> splits{};
 
     std::vector<cudf::column_view> result = cudf::experimental::split(col, splits);
@@ -186,7 +169,7 @@ TEST_F(SplitCornerCases, InvalidSetOfIndices) {
     cudf::size_type start = 0;
     cudf::size_type size = 10;
     auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
-    cudf::test::fixed_width_column_wrapper<int8_t> col = create_fixed_columns_for_splits<int8_t>(start, size, valids);
+    cudf::test::fixed_width_column_wrapper<int8_t> col = create_fixed_columns<int8_t>(start, size, valids);
     std::vector<cudf::size_type> splits{11, 12};
 
     EXPECT_THROW(cudf::experimental::split(col, splits), cudf::logic_error);
@@ -197,7 +180,7 @@ TEST_F(SplitCornerCases, ImproperRange) {
     cudf::size_type size = 10;
     auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
 
-    cudf::test::fixed_width_column_wrapper<int8_t> col = create_fixed_columns_for_splits<int8_t>(start, size, valids);
+    cudf::test::fixed_width_column_wrapper<int8_t> col = create_fixed_columns<int8_t>(start, size, valids);
     std::vector<cudf::size_type> splits{5, 4};
 
     EXPECT_THROW(cudf::experimental::split(col, splits), cudf::logic_error);
@@ -208,8 +191,256 @@ TEST_F(SplitCornerCases, NegativeValue) {
     cudf::size_type size = 10;
     auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
 
-    cudf::test::fixed_width_column_wrapper<int8_t> col = create_fixed_columns_for_splits<int8_t>(start, size, valids);
+    cudf::test::fixed_width_column_wrapper<int8_t> col = create_fixed_columns<int8_t>(start, size, valids);
     std::vector<cudf::size_type> splits{-1, 4};
 
     EXPECT_THROW(cudf::experimental::split(col, splits), cudf::logic_error);
+}
+
+// common functions for testing split/contiguous_split
+template<typename T, typename SplitFunc>
+void split_end_less_than_size(SplitFunc Split)
+{
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5;
+    cudf::experimental::table src_table = create_fixed_table<T>(num_cols, start, col_size, valids);
+
+    std::vector<cudf::size_type> splits{2, 5, 7};
+    std::vector<cudf::experimental::table> expected = create_expected_tables_for_splits<T>(num_cols, splits, col_size, true);
+    
+    auto result = Split(src_table, splits);
+
+    EXPECT_EQ(expected.size(), result.size());
+        
+    for (unsigned long index = 0; index < result.size(); index++) {        
+        cudf::test::expect_tables_equal(expected[index], result[index]);
+    }    
+}
+
+template<typename T, typename SplitFunc>
+void split_end_to_size(SplitFunc Split)
+{
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5;
+    cudf::experimental::table src_table = create_fixed_table<T>(num_cols, start, col_size, valids);    
+
+    std::vector<cudf::size_type> splits{2, 5, 10};
+    std::vector<cudf::experimental::table> expected = create_expected_tables_for_splits<T>(num_cols, splits, col_size, true);
+    
+    auto result = Split(src_table, splits);
+
+    EXPECT_EQ(expected.size(), result.size());
+
+    for (unsigned long index = 0; index < result.size(); index++) {
+        cudf::test::expect_tables_equal(expected[index], result[index]);
+    }
+}
+
+template<typename SplitFunc>
+void split_empty_table(SplitFunc Split)
+{
+    std::vector<cudf::size_type> splits{2, 5, 9};
+
+    cudf::experimental::table src_table{}; 
+    auto result = Split(src_table, splits);
+
+    unsigned long expected = 0;
+
+    EXPECT_EQ(expected, result.size());
+}
+
+template<typename SplitFunc>
+void split_empty_indices(SplitFunc Split)
+{
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5;    
+    cudf::experimental::table src_table = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
+    std::vector<cudf::size_type> splits{};
+
+    auto result = Split(src_table, splits);
+
+    unsigned long expected = 0;
+
+    EXPECT_EQ(expected, result.size());
+}
+
+template<typename SplitFunc>
+void split_invalid_indices(SplitFunc Split)
+{
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5; 
+    cudf::experimental::table src_table = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
+    
+    std::vector<cudf::size_type> splits{11, 12};
+
+    EXPECT_THROW(Split(src_table, splits), cudf::logic_error);
+}
+
+template<typename SplitFunc>
+void split_improper_range(SplitFunc Split)
+{
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5; 
+    cudf::experimental::table src_table = create_fixed_table<int8_t>(num_cols, start, col_size, valids);    
+
+    std::vector<cudf::size_type> splits{5, 4};
+
+    EXPECT_THROW(Split(src_table, splits), cudf::logic_error);
+}
+
+template<typename SplitFunc>
+void split_negative_value(SplitFunc Split)
+{
+    cudf::size_type start = 0;
+    cudf::size_type col_size = 10;
+    auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return i%2==0? true:false; });
+
+    cudf::size_type num_cols = 5; 
+    cudf::experimental::table src_table = create_fixed_table<int8_t>(num_cols, start, col_size, valids);    
+
+    std::vector<cudf::size_type> splits{-1, 4};
+
+    EXPECT_THROW(Split(src_table, splits), cudf::logic_error);
+}
+
+// regular splits
+template <typename T>
+struct SplitTableTest : public cudf::test::BaseFixture {};
+TYPED_TEST_CASE(SplitTableTest, cudf::test::NumericTypes);
+
+TYPED_TEST(SplitTableTest, SplitEndLessThanSize) {
+    split_end_less_than_size<TypeParam>([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::split(t, splits); 
+    });
+}
+
+TYPED_TEST(SplitTableTest, SplitEndToSize) {
+    split_end_to_size<TypeParam>([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::split(t, splits); 
+    });
+}
+
+struct SplitTableCornerCases : public SplitTest <int8_t>{};
+
+TEST_F(SplitTableCornerCases, EmptyTable) {
+    split_empty_table([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::split(t, splits); 
+    });
+}
+
+TEST_F(SplitTableCornerCases, EmptyIndices) {   
+    split_empty_indices([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::split(t, splits); 
+    }); 
+}
+
+TEST_F(SplitTableCornerCases, InvalidSetOfIndices) {    
+    split_invalid_indices([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::split(t, splits); 
+    }); 
+}
+
+TEST_F(SplitTableCornerCases, ImproperRange) {    
+    split_improper_range([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::split(t, splits); 
+    }); 
+}
+
+TEST_F(SplitTableCornerCases, NegativeValue) {   
+    split_negative_value([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::split(t, splits); 
+    }); 
+}
+
+
+// contiguous splits
+template <typename T>
+struct ContiguousSplitTableTest : public cudf::test::BaseFixture {};
+TYPED_TEST_CASE(ContiguousSplitTableTest, cudf::test::NumericTypes);
+
+TYPED_TEST(ContiguousSplitTableTest, SplitEndLessThanSize) {
+    split_end_less_than_size<TypeParam>([](cudf::table_view const& t, std::vector<cudf::size_type> const &splits){ 
+       return cudf::experimental::contiguous_split(t, splits); 
+    });
+}
+
+TYPED_TEST(ContiguousSplitTableTest, SplitEndToSize) {
+    split_end_to_size<TypeParam>([](cudf::table_view const& t, std::vector<cudf::size_type> const &splits){ 
+       return cudf::experimental::contiguous_split(t, splits); 
+    });
+}
+
+struct ContiguousSplitTableCornerCases : public SplitTest <int8_t>{};
+
+TEST_F(ContiguousSplitTableCornerCases, EmptyTable) {
+    split_empty_table([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::contiguous_split(t, splits); 
+    });
+}
+
+TEST_F(ContiguousSplitTableCornerCases, EmptyIndices) {   
+    split_empty_indices([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::contiguous_split(t, splits); 
+    }); 
+}
+
+TEST_F(ContiguousSplitTableCornerCases, InvalidSetOfIndices) {    
+    split_invalid_indices([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::contiguous_split(t, splits); 
+    }); 
+}
+
+TEST_F(ContiguousSplitTableCornerCases, ImproperRange) {    
+    split_improper_range([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::contiguous_split(t, splits); 
+    }); 
+}
+
+TEST_F(ContiguousSplitTableCornerCases, NegativeValue) {   
+    split_negative_value([](cudf::table_view const& t, std::vector<cudf::size_type> const& splits){ 
+       return cudf::experimental::contiguous_split(t, splits); 
+    }); 
+}
+
+struct SplitStringTableTest : public SplitTest <std::string>{};
+
+TEST_F(SplitStringTableTest, StringWithInvalids) {
+    auto valids = cudf::test::make_counting_transform_iterator(0, [](auto i) { return i%2==0? true:false; });
+
+    std::vector<std::string> strings[2]     = { {"", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"}, 
+                                                {"", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"} };
+    cudf::test::strings_column_wrapper sw[2] = { {strings[0].begin(), strings[0].end(), valids},
+                                                {strings[1].begin(), strings[1].end(), valids} };
+
+    std::vector<std::unique_ptr<cudf::column>> scols;
+    scols.push_back(sw[0].release());
+    scols.push_back(sw[1].release());    
+    cudf::experimental::table src_table(std::move(scols));
+
+    std::vector<cudf::size_type> splits{2, 5, 9};
+    
+    std::vector<cudf::experimental::table> expected = create_expected_string_tables_for_splits(strings, splits, true);
+
+    std::vector<cudf::table_view> result = cudf::experimental::split(src_table, splits);
+
+    EXPECT_EQ(expected.size(), result.size());
+
+    for (unsigned long index = 0; index < result.size(); index++) {
+        cudf::test::expect_table_properties_equal(expected[index], result[index]);
+    }
 }


### PR DESCRIPTION
Implementation of contiguous_split() functionality.   Performs a deep-copying split operation on a table_view where the output is arranged in a memory-contiguous way per output table-view.  That is, each output table_view and all associated internal column_views share one contiguous chunk of allocated memory.  Thus, these various objects are not owned by top level tables or columns and have a special lifetime controlled by the returned contiguous_split_result objects.  


The basic algorithm is structured as:

```
for(each input column in a table){
   split_table_subcolumns[i] = slice(in.column(i), splits);
}
for(each output table i){
    contiguous_buf_size = 0;
    for(each subcolumn j){
       contiguous_buf_size += compute(split_table_columns[j][i]);
    }
    buf = alloc(contiguous_buf_size);
    for(each subcolumn j){
        // buf gets incremented each call
        copy_column(buf, split_table_columns[j][i]);
    }
}
```
O(numsplits) allocations and O(numsplits * numcolumns) copies. 

The underlying column views returned from this function have UNKNOWN_NULL_COUNT as a byproduct of the way cudf::split() and cudf::slice() work.   There is an open issue for this  (https://github.com/rapidsai/cudf/issues/3600).  Once fixed, there's a very simple change that can be made to contiguous_split() to propagate the actual null counts.
