### PR TITLE
[HOTFIX][REVIEW] Remove deadline from two other hypothesis driven tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,8 @@
 - PR #3523 Fix lgenfe issue with debug build
 - PR #3532 Fix potential use-after-free in cudf parquet reader
 - PR #3540 Fix unary_op null_mask bug and add missing test cases
+- PR #3570 HOTFIX Fix CI Issue with hypothesis tests that are flaky
+
 
 # cuDF 0.10.0 (16 Oct 2019)
 

--- a/python/cudf/cudf/tests/test_repr.py
+++ b/python/cudf/cudf/tests/test_repr.py
@@ -128,6 +128,7 @@ def test_integer_series(x):
 
 
 @given(st.lists(st.floats()))
+@settings(deadline=None)
 def test_float_dataframe(x):
     gdf = cudf.DataFrame({"x": cudf.Series(x, nan_as_null=False)})
     pdf = gdf.to_pandas()
@@ -135,6 +136,7 @@ def test_float_dataframe(x):
 
 
 @given(st.lists(st.floats()))
+@settings(deadline=None)
 def test_float_series(x):
     sr = cudf.Series(x, nan_as_null=False)
     ps = pd.Series(x)


### PR DESCRIPTION
CI issues recently cropped up with these hypothesis tests. Hypothesis will automatically timeout tests if they take too long. If a test times out in one generation, but not in another, hypothesis fails the test and calls it flaky.

This PR removes the deadline from the other hypothesis tests.

This could lead to longer run times for tests, or theoretically hung tests. One alternative is to set the deadline to 1000msec instead of None. This moves the goalpost but the same issue could arise again. Opinions?