### PR TITLE
[REVIEW] Specialize hash functions for floating point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 - PR #3284 Add gpu-accelerated parquet writer
 
 ## Improvements
-- PR #3502 ORC reader: add option to read DECIMALs as INT64
 
+- PR #3502 ORC reader: add option to read DECIMALs as INT64
 - PR #3461 Add a new overload to allocate_like() that takes explicit type and size params.
+- PR #3590 Specialize hash functions for floating point
 
 ## Bug Fixes
+
 - PR #3549 Fix index name issue with iloc with RangeIndex
 - PR #3562 Fix 4GB limit for gzipped-compressed csv files
 

--- a/cpp/include/cudf/detail/utilities/hash_functions.cuh
+++ b/cpp/include/cudf/detail/utilities/hash_functions.cuh
@@ -33,7 +33,6 @@ using hash_value_type = uint32_t;
 template <typename Key>
 struct MurmurHash3_32
 {
-
     using argument_type = Key;
     using result_type = hash_value_type;
     
@@ -76,80 +75,15 @@ struct MurmurHash3_32
       return combined;
     }
     
-    template <typename TKey = Key>
-    typename std::enable_if_t<std::is_same<TKey, cudf::bool8>::value, result_type>
-    CUDA_HOST_DEVICE_CALLABLE operator()(const TKey& key) const
+    result_type
+    CUDA_HOST_DEVICE_CALLABLE operator()(Key const& key) const
     {
-      return this->operator()(static_cast<int8_t>(key));
+      return compute(key);
     }
 
-    template <typename TKey = Key>
-    typename std::enable_if_t<std::is_same<TKey, cudf::experimental::bool8>::value, result_type>
-    CUDA_HOST_DEVICE_CALLABLE operator()(const TKey& key) const
-    {
-      return this->operator()(static_cast<uint8_t>(key));
-    }
-
-    /**
-    * @brief Specialization of MurmurHash3_32 operator for strings.
-    */
-    template <typename TKey = Key>
-    typename std::enable_if_t<std::is_same<TKey, cudf::string_view>::value, result_type>
-    CUDA_HOST_DEVICE_CALLABLE operator()(const TKey& key) const
-    {
-        const int len = (int)key.size_bytes();
-        const uint8_t* data = (const uint8_t*)key.data();
-        const int nblocks = len / 4;
-        result_type h1 = m_seed;
-        constexpr uint32_t c1 = 0xcc9e2d51;
-        constexpr uint32_t c2 = 0x1b873593;
-        auto getblock32 = [] __host__ __device__(const uint32_t* p, int i) -> uint32_t {
-          // Individual byte reads for unaligned accesses (very likely)
-          #ifndef __CUDA_ARCH__
-            CUDF_FAIL("Hashing a string in host code is not supported.");
-          #else
-            auto q = (const uint8_t*)(p + i);
-            return q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
-          #endif
-        };
-
-        //----------
-        // body
-        const uint32_t* const blocks = (const uint32_t*)(data + nblocks * 4);
-        for (int i = -nblocks; i; i++) {
-          uint32_t k1 = getblock32(blocks, i);
-          k1 *= c1;
-          k1 = rotl32(k1, 15);
-          k1 *= c2;
-          h1 ^= k1;
-          h1 = rotl32(h1, 13);
-          h1 = h1 * 5 + 0xe6546b64;
-        }
-        //----------
-        // tail
-        const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
-        uint32_t k1 = 0;
-        switch (len & 3) {
-          case 3: k1 ^= tail[2] << 16;
-          case 2: k1 ^= tail[1] << 8;
-          case 1: k1 ^= tail[0];
-            k1 *= c1; k1 = rotl32(k1, 15); k1 *= c2; h1 ^= k1;
-        };
-        //----------
-        // finalization
-        h1 ^= len;
-        h1 = fmix32(h1);
-        return h1;
-    }
-
-    template <typename TKey = Key>
-    typename std::enable_if_t<
-      !std::is_same<TKey, cudf::bool8>::value &&
-      !std::is_same<TKey, cudf::string_view>::value &&
-      !std::is_same<TKey, cudf::experimental::bool8>::value,
-    result_type>
-    CUDA_HOST_DEVICE_CALLABLE operator()(const TKey& key) const
-    {
+    template <typename TKey>
+    result_type
+    CUDA_HOST_DEVICE_CALLABLE compute(TKey const& key) const {
         constexpr int len = sizeof(argument_type);
         const uint8_t * const data = (const uint8_t*)&key;
         constexpr int nblocks = len / 4;
@@ -187,9 +121,96 @@ struct MurmurHash3_32
         h1 = fmix32(h1);
         return h1;
     }
+
 private:
     uint32_t m_seed;
 };
+
+template <>
+hash_value_type CUDA_HOST_DEVICE_CALLABLE MurmurHash3_32<cudf::bool8>::operator()(cudf::bool8 const& key) const {
+  return this->compute(static_cast<int8_t>(key));
+}
+
+template <>
+hash_value_type CUDA_HOST_DEVICE_CALLABLE MurmurHash3_32<cudf::experimental::bool8>::operator()(cudf::experimental::bool8 const& key) const {
+  return this->compute(static_cast<uint8_t>(key));
+}
+
+/**
+ * @brief Specialization of MurmurHash3_32 operator for strings.
+ */
+template <>
+hash_value_type CUDA_HOST_DEVICE_CALLABLE MurmurHash3_32<cudf::string_view>::operator()(cudf::string_view const& key) const {
+  const int len = (int)key.size_bytes();
+  const uint8_t* data = (const uint8_t*)key.data();
+  const int nblocks = len / 4;
+  result_type h1 = m_seed;
+  constexpr uint32_t c1 = 0xcc9e2d51;
+  constexpr uint32_t c2 = 0x1b873593;
+  auto getblock32 = [] __host__ __device__(const uint32_t* p, int i) -> uint32_t {
+    // Individual byte reads for unaligned accesses (very likely)
+#ifndef __CUDA_ARCH__
+    CUDF_FAIL("Hashing a string in host code is not supported.");
+#else
+    auto q = (const uint8_t*)(p + i);
+    return q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
+#endif
+  };
+
+  //----------
+  // body
+  const uint32_t* const blocks = (const uint32_t*)(data + nblocks * 4);
+  for (int i = -nblocks; i; i++) {
+    uint32_t k1 = getblock32(blocks, i);
+    k1 *= c1;
+    k1 = rotl32(k1, 15);
+    k1 *= c2;
+    h1 ^= k1;
+    h1 = rotl32(h1, 13);
+    h1 = h1 * 5 + 0xe6546b64;
+  }
+  //----------
+  // tail
+  const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
+  uint32_t k1 = 0;
+  switch (len & 3) {
+  case 3: k1 ^= tail[2] << 16;
+  case 2: k1 ^= tail[1] << 8;
+  case 1: k1 ^= tail[0];
+    k1 *= c1; k1 = rotl32(k1, 15); k1 *= c2; h1 ^= k1;
+  };
+  //----------
+  // finalization
+  h1 ^= len;
+  h1 = fmix32(h1);
+  return h1;
+}
+
+// Specialization for float, make sure 0.0 and NaN hash consistently
+template <>
+hash_value_type CUDA_HOST_DEVICE_CALLABLE MurmurHash3_32<float>::operator()(float const& key) const {
+  if (key == 0.0f) {
+    return 0;
+  } else if (isnan(key)) {
+    float nan = std::numeric_limits<float>::quiet_NaN();
+    return this->compute(nan);
+  } else {
+    return this->compute(key);
+  }
+}
+
+// Specialization for double, make sure 0.0 and NaN hash consistently
+template <>
+hash_value_type CUDA_HOST_DEVICE_CALLABLE MurmurHash3_32<double>::operator()(double const& key) const {
+  if (key == 0.0) {
+    return 0;
+  } else if (isnan(key)) {
+    double nan = std::numeric_limits<double>::quiet_NaN();
+    return this->compute(nan);
+  } else {
+    return this->compute(key);
+  }
+}
 
 /* --------------------------------------------------------------------------*/
 /** 

--- a/cpp/tests/hashing/hash_test.cpp
+++ b/cpp/tests/hashing/hash_test.cpp
@@ -149,3 +149,28 @@ TYPED_TEST(HashTestTyped, EqualityNulls)
   EXPECT_EQ(input1.num_rows(), output1->size());
   expect_columns_equal(output1->view(), output2->view());
 }
+
+template <typename T>
+class HashTestFloatTyped : public cudf::test::BaseFixture {};
+
+TYPED_TEST_CASE(HashTestFloatTyped, cudf::test::FloatingPointTypes);
+
+TYPED_TEST(HashTestFloatTyped, TestExtremes)
+{
+  TypeParam min = std::numeric_limits<TypeParam>::min();
+  TypeParam max = std::numeric_limits<TypeParam>::max();
+  TypeParam nan = std::numeric_limits<TypeParam>::quiet_NaN();
+  TypeParam inf = std::numeric_limits<TypeParam>::infinity();
+  
+  fixed_width_column_wrapper<TypeParam> const col1( {  0.0, 100.0, -100.0, min, max,  nan, inf, -inf } );
+  fixed_width_column_wrapper<TypeParam> const col2( { -0.0, 100.0, -100.0, min, max, -nan, inf, -inf } );
+
+  auto const input1 = cudf::table_view({col1});
+  auto const input2 = cudf::table_view({col2});
+
+  auto const output1 = cudf::hash(input1);
+  auto const output2 = cudf::hash(input2);
+
+  expect_columns_equal(output1->view(), output2->view(), true);
+}
+

--- a/cpp/tests/utilities/type_lists.hpp
+++ b/cpp/tests/utilities/type_lists.hpp
@@ -63,6 +63,18 @@ constexpr auto types_to_ids() {
 }
 }  // namespace detail
 
+/**
+ * @brief Provides a list of all floating point types supported in libcudf for
+ * use in a GTest typed test.
+ *
+ * Example:
+ * ```
+ * // Invokes all typed fixture tests for all numeric types in libcudf
+ * TYPED_TEST_CASE(MyTypedFixture, cudf::test::NumericTypes);
+ * ```
+ */
+using FloatingPointTypes = cudf::test::Types<float, double>;
+
 /**---------------------------------------------------------------------------*
  * @brief Provides a list of all numeric types supported in libcudf for use in a
  * GTest typed test.

--- a/cpp/tests/utilities/type_lists.hpp
+++ b/cpp/tests/utilities/type_lists.hpp
@@ -69,8 +69,8 @@ constexpr auto types_to_ids() {
  *
  * Example:
  * ```
- * // Invokes all typed fixture tests for all numeric types in libcudf
- * TYPED_TEST_CASE(MyTypedFixture, cudf::test::NumericTypes);
+ * // Invokes all typed fixture tests for all floating point types in libcudf
+ * TYPED_TEST_CASE(MyTypedFixture, cudf::test::FloatingPointTypes);
  * ```
  */
 using FloatingPointTypes = cudf::test::Types<float, double>;


### PR DESCRIPTION
Closes #3233 

Restructured the MurmurHash function to do traditional template specialization rather than SFINAE.  The SFINAE definitions were getting too complicated, this seems much simpler to me.

Added specialization for float and double.  Added unit tests for float and double checking 0.0, -0.0, NaN, -NaN and infinity to make sure they all work properly.
