### PR TITLE
[REVIEW] Update OPS codeowners group name [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,9 @@ python/dask_cudf/  @rapidsai/cudf-dask-codeowners
 java/              @rapidsai/cudf-java-codeowners
 
 #build/ops code owners
-.github/           @rapidsai/cudf-ops-codeowners 
-ci/                @rapidsai/cudf-ops-codeowners
-conda/             @rapidsai/cudf-ops-codeowners
-**/Dockerfile      @rapidsai/cudf-ops-codeowners
-**/.dockerignore   @rapidsai/cudf-ops-codeowners
-docker/            @rapidsai/cudf-ops-codeowners
+.github/           @rapidsai/ops-codeowners 
+ci/                @rapidsai/ops-codeowners
+conda/             @rapidsai/ops-codeowners
+**/Dockerfile      @rapidsai/ops-codeowners
+**/.dockerignore   @rapidsai/ops-codeowners
+docker/            @rapidsai/ops-codeowners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PR #3461 Add a new overload to allocate_like() that takes explicit type and size params.
 - PR #3569 Use `np.asarray` in `StringColumn.deserialize`
 - PR #3553 Support Python NoneType in numeric binops
+- PR #3608 Update OPS codeowner group name
 
 ## Bug Fixes
 


### PR DESCRIPTION
In the middle of giving all repo's codeowners groups, OPS shouldn't be specific to any one repo, so its being renamed to avoid creating a bunch of new groups.