### PR TITLE
[REVIEW] Fix sorted set_index operations in dask_cudf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PR #3548 Replaced CUDA_RT_CALL with CUDA_TRY
 - PR #3622 Fix new warnings and errors when building with gcc-8
 - PR #3588 Remove avro reader column order reversal
+- PR #3637 Fix sorted set_index operations in dask_cudf
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -45,7 +45,11 @@ def optimize(dsk, keys, **kwargs):
 
 
 def finalize(results):
-    return cudf.concat(results)
+    if results and isinstance(
+        results[0], (cudf.DataFrame, cudf.Series, cudf.Index)
+    ):
+        return cudf.concat(results)
+    return results
 
 
 class _Frame(dd.core._Frame, OperatorMethodMixin):

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -46,7 +46,7 @@ def optimize(dsk, keys, **kwargs):
 
 def finalize(results):
     if results and isinstance(
-        results[0], (cudf.DataFrame, cudf.Series, cudf.Index)
+        results[0], (cudf.DataFrame, cudf.Series, cudf.Index, cudf.MultiIndex)
     ):
         return cudf.concat(results)
     return results

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -195,6 +195,24 @@ def test_set_index_w_series():
         dd.assert_eq(expect, got)
 
 
+def test_set_index_sorted():
+    with dask.config.set(scheduler="single-threaded"):
+        df1 = pd.DataFrame({"val": [4, 3, 2, 1, 0], "id": [0, 1, 3, 5, 7]})
+        ddf1 = dd.from_pandas(df1, npartitions=2)
+
+        gdf1 = cudf.from_pandas(df1)
+        gddf1 = dgd.from_cudf(gdf1, npartitions=2)
+
+        expect = ddf1.set_index("id", sorted=True)
+        got = gddf1.set_index("id", sorted=True)
+
+        dd.assert_eq(expect, got)
+
+        with pytest.raises(ValueError):
+            # Cannot set `sorted=True` for non-sorted column
+            gddf1.set_index("val", sorted=True)
+
+
 @pytest.mark.parametrize("nelem", [10, 200, 1333])
 @pytest.mark.parametrize("index", [None, "myindex"])
 def test_rearrange_by_divisions(nelem, index):


### PR DESCRIPTION
Closes #3634 

Currently, `dask_cudf` cannot handle the `sorted=True` argument for `set_index` operations, because it will end up trying to use `cudf.concat` on scalar values.  This is a simple fix, along with a test for `set_index(..., sorted=True)`.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
