### PR TITLE
[REVIEW] Fix ends_with logic for matching string case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PR #3637 Fix sorted set_index operations in dask_cudf
 - PR #3663 Fix libcudf++ ORC reader microseconds and milliseconds conversion
 - PR #3668 Fixing CHECK_CUDA debug build issue
+- PR #3684 Fix ends_with logic for matching string case
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/cpp/src/strings/find.cu
+++ b/cpp/src/strings/find.cu
@@ -230,7 +230,7 @@ std::unique_ptr<column> ends_with( strings_column_view const& strings,
     auto pfn = [] __device__ (string_view d_string, string_view d_target) {
         auto str_length = d_string.length();
         auto tgt_length = d_target.length();
-        if( str_length <= tgt_length )
+        if( str_length < tgt_length )
             return false;
         return d_string.find( d_target, str_length - tgt_length )>=0;
     };

--- a/cpp/tests/strings/find_tests.cu
+++ b/cpp/tests/strings/find_tests.cu
@@ -65,6 +65,16 @@ TEST_F(StringsFindTest, Find)
         auto results = cudf::strings::ends_with(strings_view, cudf::string_scalar("se"));
         cudf::test::expect_columns_equal(*results, expected);
     }
+    {
+        cudf::test::fixed_width_column_wrapper<cudf::experimental::bool8> expected( {0,1,0,0,0,0}, {1,1,0,1,1,1} );
+        auto results = cudf::strings::starts_with(strings_view, cudf::string_scalar("thesé"));
+        cudf::test::expect_columns_equal(*results, expected);
+    }
+    {
+        cudf::test::fixed_width_column_wrapper<cudf::experimental::bool8> expected( {0,1,0,0,0,0}, {1,1,0,1,1,1} );
+        auto results = cudf::strings::ends_with(strings_view, cudf::string_scalar("thesé"));
+        cudf::test::expect_columns_equal(*results, expected);
+    }
 }
 
 TEST_F(StringsFindTest, ZeroSizeStringsColumn)


### PR DESCRIPTION
Closes #3669 

Logic for ends-with incorrectly marks matching string as false.