### PR TITLE
[REVIEW] Allow for null columns parameter in csv_writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - PR #3668 Fixing CHECK_CUDA debug build issue
 - PR #3684 Fix ends_with logic for matching string case
 - PR #3687 Fixed bug while passing input GPU memory pointer in `nvtext.scatter_count()`
+- PR #3694 Allow for null columns parameter in csv_writer`
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/cpp/src/io/csv/legacy/csv_writer.cu
+++ b/cpp/src/io/csv/legacy/csv_writer.cu
@@ -240,7 +240,7 @@ gdf_error write_csv(csv_write_arg* args)
     // when args becomes a struct/class these can be modified
     auto columns = args->columns;
     int count = args->num_cols;
-    cudf::size_type total_rows = columns[0]->size;
+    cudf::size_type total_rows = columns ? columns[0]->size : 0;
     const char* filepath = args->filepath;
     char delimiter[2] = {',','\0'};
     if( args->delimiter )
@@ -257,8 +257,9 @@ gdf_error write_csv(csv_write_arg* args)
 
     // check for issues here
     CUDF_EXPECTS( filepath!=nullptr, "write_csv: filepath not specified" );
-    CUDF_EXPECTS( count!=0, "write_csv: num_cols is required" );
-    CUDF_EXPECTS( columns!=0, "write_csv: invalid data values" );
+    CUDF_EXPECTS( count>=0, "write_csv: num_cols is required" );
+    if( count > 0 )
+        CUDF_EXPECTS( columns!=0, "write_csv: invalid data values" );
 
     // check all columns are the same size
     const bool all_sizes_match = std::all_of( columns, columns+count,


### PR DESCRIPTION
Closes #3666 
The csv_writer C++ code crashes if passed a null columns vector. 
The assert test for this was after the first dereference causing the segfault.
Only minor changes are needed to support null columns parameter and create an empty file as consistent with Pandas to_csv.
I did not see a port of `csv_writer` to libcudf++ at this time.
If that code does exist somewhere, then I could port the fix to that code as well.