### PR TITLE
[WIP] Zero copy when deserializing RMM buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - PR #3640 Enable memory_usage in dask_cudf (also adds pd.Index from_pandas)
 - PR #3654 Update Jitify submodule ref to include gcc-8 fix
 - PR #3639 Define and implement `nans_to_nulls`
+- PR #3696 Zero copy when deserializing RMM buffers
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -124,9 +124,8 @@ class Buffer(object):
                 _dummy_iface = types.SimpleNamespace()
                 _dummy_iface.__cuda_array_interface__ = iface
 
-                # Allocating a new RMM CUDA array with shape and dtype as specified
-                # in `iface` and copy the frame data to it, which makes the memory
-                # survive until the new Buffer goes out of scope.
+                # Allocating a new RMM CUDA array with shape and dtype as
+                # specified in `iface` and copy the frame data to it.
                 arr, _ = rmm.auto_device(_dummy_iface)
         return Buffer(arr)
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -28,23 +28,24 @@ class Buffer(object):
         return cls(mem, size=0, capacity=0)
 
     def __init__(self, mem, size=None, capacity=None, categorical=False):
-        if size is None:
-            if categorical:
-                size = len(mem)
-            elif hasattr(mem, "__len__"):
-                if hasattr(mem, "ndim") and mem.ndim == 0:
-                    pass
-                elif len(mem) == 0:
-                    size = 0
-            if hasattr(mem, "size"):
-                size = mem.size
-        if capacity is None:
-            capacity = size
-        self.mem = cudautils.to_device(mem)
-        _BufferSentry(self.mem).ndim(1)
-        self.size = size
-        self.capacity = capacity
-        self.dtype = self.mem.dtype
+        if mem is not None:
+            if size is None:
+                if categorical:
+                    size = len(mem)
+                elif hasattr(mem, "__len__"):
+                    if hasattr(mem, "ndim") and mem.ndim == 0:
+                        pass
+                    elif len(mem) == 0:
+                        size = 0
+                if hasattr(mem, "size"):
+                    size = mem.size
+            if capacity is None:
+                capacity = size
+            self.mem = cudautils.to_device(mem)
+            _BufferSentry(self.mem).ndim(1)
+            self.size = size
+            self.capacity = capacity
+            self.dtype = self.mem.dtype
 
     def serialize(self):
         """Called when dask.distributed is performing a serialization on this

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -1,7 +1,7 @@
+import functools
+import operator
 import pickle
 import types
-import operator
-import functools
 
 import numpy as np
 


### PR DESCRIPTION
This PR implements zero-copy deserializing of RMM buffers info DataFrame `Buffer`.

Now that Dask/Distributed use [RMM buffers](https://github.com/dask/distributed/blob/master/distributed/comm/ucx.py#L50), we can avoid a copy when deserializing.