### PR TITLE
[REVIEW] Improve DataFrame.insert performance for wide frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PR #3640 Enable memory_usage in dask_cudf (also adds pd.Index from_pandas)
 - PR #3654 Update Jitify submodule ref to include gcc-8 fix
 - PR #3639 Define and implement `nans_to_nulls`
+- PR #3697 Improve column insert performance for wide frames
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1569,9 +1569,8 @@ class DataFrame(object):
             value, forceindex=forceindex, name=column
         )
         keys = list(self._cols.keys())
-        for i, col in enumerate(keys):
-            if num_cols > i >= loc:
-                self._cols.move_to_end(col)
+        for i, col in enumerate(keys[loc:-1]):
+            self._cols.move_to_end(col)
 
     def add_column(self, name, data, forceindex=False):
         """Add a column


### PR DESCRIPTION
Fix the loop in `.insert` so that it doesn't needlessly iterate over columns that won't be moved. 