### PR TITLE
[REVIEW] Remove extra type-dispatcher call from merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - PR #3684 Fix ends_with logic for matching string case
 - PR #3687 Fixed bug while passing input GPU memory pointer in `nvtext.scatter_count()`
 - PR #3694 Allow for null columns parameter in csv_writer`
+- PR #3706 Removed extra type-dispatcher call from merge
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/cpp/include/cudf/detail/merge.cuh
+++ b/cpp/include/cudf/detail/merge.cuh
@@ -31,19 +31,19 @@ namespace detail{
 enum class side : bool { LEFT, RIGHT };
 
 /**
- * @brief Tagged index type: `thrust::get<0>` indicates left/right side, 
+ * @brief Tagged index type: `thrust::get<0>` indicates left/right side,
  * `thrust::get<1>` indicates the row index
- */  
-using index_type = thrust::tuple<side, cudf::size_type>;  
+ */
+using index_type = thrust::tuple<side, cudf::size_type>;
 
 /**
  * @brief tagged_element_relational_comparator uses element_relational_comparator to provide "tagged-index" comparation logic.
  *
- * Special treatment is necessary in several thrust algorithms (e.g., merge()) where 
- * the index affinity to the side is not guaranteed; i.e., the algorithms rely on 
+ * Special treatment is necessary in several thrust algorithms (e.g., merge()) where
+ * the index affinity to the side is not guaranteed; i.e., the algorithms rely on
  * binary functors (predicates) where the operands may transparently switch sides.
  *
- * For example, 
+ * For example,
  *         thrust::merge(left_container,
  *                       right_container,
  *                       predicate(lhs, rhs){...});
@@ -57,15 +57,15 @@ using index_type = thrust::tuple<side, cudf::size_type>;
  * Because of that, one cannot rely on the predicate having *fixed* references to the containers.
  * Each invocation may land in a different situation (among the 4 above) than any other invocation.
  * Also, one cannot just manipulate lhs, rhs (indices) alone; because, if predicate always applies
- * one index to one container and the other index to the other container, 
- * switching the indices alone won't suffice in the cases (3) or (4), 
- * where the also the containers must be changed (to just one instead of two) 
+ * one index to one container and the other index to the other container,
+ * switching the indices alone won't suffice in the cases (3) or (4),
+ * where the also the containers must be changed (to just one instead of two)
  * independently of indices;
  *
  * As a result, a special comparison logic is necessary whereby the index is "tagged" with side information
- * and consequently comparator functors (predicates) must operate 
+ * and consequently comparator functors (predicates) must operate
  * on these tagged indices rather than on raw indices.
- *  
+ *
  */
 template <bool has_nulls = true>
 struct tagged_element_relational_comparator {
@@ -78,13 +78,9 @@ struct tagged_element_relational_comparator {
   {
   }
 
-
-  template <typename Element,
-            std::enable_if_t<cudf::is_relationally_comparable<
-                               Element, Element>()>* = nullptr>
   __device__
-  weak_ordering operator()(index_type lhs_tagged_index,
-                           index_type rhs_tagged_index) const noexcept {
+  weak_ordering compare(index_type lhs_tagged_index,
+                        index_type rhs_tagged_index) const noexcept {
 
     side l_side = thrust::get<0>(lhs_tagged_index);
     side r_side = thrust::get<0>(rhs_tagged_index);
@@ -93,26 +89,17 @@ struct tagged_element_relational_comparator {
     cudf::size_type r_indx = thrust::get<1>(rhs_tagged_index);
 
     column_device_view const* ptr_left_dview{l_side == side::LEFT ? &lhs : &rhs };
-    
+
     column_device_view const* ptr_right_dview{r_side == side::LEFT ? &lhs : &rhs };
- 
+
     auto erl_comparator = element_relational_comparator<has_nulls>(*ptr_left_dview, *ptr_right_dview, null_precedence);
 
     return cudf::experimental::type_dispatcher(lhs.type(),
                                                erl_comparator,
                                                l_indx, r_indx);
-    
+
   }
 
-  template <typename Element,
-            std::enable_if_t<not cudf::is_relationally_comparable<
-                Element, Element>()>* = nullptr>
-  __device__
-  weak_ordering operator()(index_type lhs_tagged_index,
-                           index_type rhs_tagged_index) const noexcept {
-    release_assert(false &&
-                   "Attempted to compare elements of uncomparable types.");
-  }
 private:
   column_device_view lhs;
   column_device_view rhs;
@@ -123,7 +110,7 @@ private:
  * @brief The equivalent of `row_lexicographic_comparator` for tagged indices.
  */
 template <bool has_nulls = true>
-struct row_lexicographic_tagged_comparator { 
+struct row_lexicographic_tagged_comparator {
   row_lexicographic_tagged_comparator(table_device_view lhs, table_device_view rhs,
                                       order const* column_order = nullptr,
                                       null_order const* null_precedence = nullptr)
@@ -143,15 +130,13 @@ struct row_lexicographic_tagged_comparator {
       bool ascending =
           (_column_order == nullptr) or (_column_order[i] == order::ASCENDING);
 
-      weak_ordering state{weak_ordering::EQUIVALENT};
       null_order null_precedence = _null_precedence == nullptr ?
                                      null_order::BEFORE: _null_precedence[i];
 
       auto comparator = tagged_element_relational_comparator<has_nulls>{
           _lhs.column(i), _rhs.column(i), null_precedence};
 
-      state = cudf::experimental::type_dispatcher(_lhs.column(i).type(), comparator,
-                                         lhs_tagged_index, rhs_tagged_index);
+      weak_ordering state = comparator.compare(lhs_tagged_index, rhs_tagged_index);
 
       if (state == weak_ordering::EQUIVALENT) {
         continue;

--- a/cpp/include/cudf/detail/merge.cuh
+++ b/cpp/include/cudf/detail/merge.cuh
@@ -16,9 +16,8 @@
 
 #pragma once
 
-#include <cudf/cudf.h>
-#include <cudf/types.hpp>
 #include <cudf/table/row_operators.cuh>
+#include <cudf/utilities/type_dispatcher.hpp>
 
 namespace cudf {
 namespace experimental {


### PR DESCRIPTION
There is an extra type-dispatcher call in merge.cuh that is unnecessary.
Removing this extra call seems to fix an nvcc infinite compile for code changes in an unrelated PR.
Hoping this change will prevent possible future compile issues.

**Details**
The template Element argument defined here is not used.
https://github.com/rapidsai/cudf/blob/0659418df9adc233f222dc37726efc8bc4410490/cpp/include/cudf/detail/merge.cuh#L82
Therefore, the extra type-dispatch call here is not required:
https://github.com/rapidsai/cudf/blob/0659418df9adc233f222dc37726efc8bc4410490/cpp/include/cudf/detail/merge.cuh#L153

Also, in the process of debugging this, I found several unnecessary header file includes that can be removed as well.