### PR TITLE
[REVIEW] Remove multiple CMake configure steps in root build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PR #3654 Update Jitify submodule ref to include gcc-8 fix
 - PR #3639 Define and implement `nans_to_nulls`
 - PR #3697 Improve column insert performance for wide frames
+- PR #3710 Remove multiple CMake configuration steps from root build script
 
 ## Bug Fixes
 

--- a/build.sh
+++ b/build.sh
@@ -94,7 +94,7 @@ if hasArg --allgpuarch; then
     BUILD_ALL_GPU_ARCH=1
 fi
 if hasArg benchmarks; then
-    BENCHMARKS="ON"
+    BENCHMARKS=ON
 fi
 
 # If clean given, run it prior to any other steps
@@ -121,14 +121,22 @@ fi
 
 ################################################################################
 # Configure, build, and install libnvstrings
-if buildAll || hasArg libnvstrings; then
+
+if buildAll || hasArg libnvstrings || hasArg libcudf; then
 
     mkdir -p ${LIBNVSTRINGS_BUILD_DIR}
     cd ${LIBNVSTRINGS_BUILD_DIR}
     cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DCMAKE_CXX11_ABI=ON \
           ${GPU_ARCH} \
+          -DBUILD_BENCHMARKS=${BENCHMARKS}
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+fi
+
+if buildAll || hasArg libnvstrings; then
+
+    mkdir -p ${LIBNVSTRINGS_BUILD_DIR}
+    cd ${LIBNVSTRINGS_BUILD_DIR}
     if [[ ${INSTALL_TARGET} != "" ]]; then
         make -j${PARALLEL_LEVEL} install_nvstrings VERBOSE=${VERBOSE}
     else
@@ -138,7 +146,7 @@ fi
 
 # Build and install the nvstrings Python package
 if buildAll || hasArg nvstrings; then
-
+    
     cd ${REPODIR}/python/nvstrings
     if [[ ${INSTALL_TARGET} != "" ]]; then
         python setup.py build_ext
@@ -153,11 +161,6 @@ if buildAll || hasArg libcudf; then
 
     mkdir -p ${LIBCUDF_BUILD_DIR}
     cd ${LIBCUDF_BUILD_DIR}
-    cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
-          -DCMAKE_CXX11_ABI=ON \
-          ${GPU_ARCH} \
-          -DBUILD_BENCHMARKS=${BENCHMARKS} \
-          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
     if [[ ${INSTALL_TARGET} != "" ]]; then
         make -j${PARALLEL_LEVEL} install_cudf VERBOSE=${VERBOSE}
     else

--- a/build.sh
+++ b/build.sh
@@ -37,12 +37,11 @@ HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [-v] [-g] [-n] [-h]
    default action (no args) is to build and install 'libnvstrings' then
    'nvstrings' then 'libcudf' then 'cudf' then 'dask_cudf' targets
 "
-LIBNVSTRINGS_BUILD_DIR=${REPODIR}/cpp/build
+LIB_BUILD_DIR=${REPODIR}/cpp/build
 NVSTRINGS_BUILD_DIR=${REPODIR}/python/nvstrings/build
-LIBCUDF_BUILD_DIR=${REPODIR}/cpp/build
 CUDF_BUILD_DIR=${REPODIR}/python/cudf/build
 DASK_CUDF_BUILD_DIR=${REPODIR}/python/dask_cudf/build
-BUILD_DIRS="${LIBNVSTRINGS_BUILD_DIR} ${NVSTRINGS_BUILD_DIR} ${LIBCUDF_BUILD_DIR} ${CUDF_BUILD_DIR} ${DASK_CUDF_BUILD_DIR}"
+BUILD_DIRS="${LIB_BUILD_DIR} ${NVSTRINGS_BUILD_DIR} ${CUDF_BUILD_DIR} ${DASK_CUDF_BUILD_DIR}"
 
 # Set defaults for vars modified by flags to this script
 VERBOSE=""
@@ -124,8 +123,8 @@ fi
 
 if buildAll || hasArg libnvstrings || hasArg libcudf; then
 
-    mkdir -p ${LIBNVSTRINGS_BUILD_DIR}
-    cd ${LIBNVSTRINGS_BUILD_DIR}
+    mkdir -p ${LIB_BUILD_DIR}
+    cd ${LIB_BUILD_DIR}
     cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DCMAKE_CXX11_ABI=ON \
           ${GPU_ARCH} \
@@ -135,7 +134,6 @@ fi
 
 if buildAll || hasArg libnvstrings; then
 
-    mkdir -p ${LIBNVSTRINGS_BUILD_DIR}
     cd ${LIBNVSTRINGS_BUILD_DIR}
     if [[ ${INSTALL_TARGET} != "" ]]; then
         make -j${PARALLEL_LEVEL} install_nvstrings VERBOSE=${VERBOSE}
@@ -159,7 +157,6 @@ fi
 # Configure, build, and install libcudf
 if buildAll || hasArg libcudf; then
 
-    mkdir -p ${LIBCUDF_BUILD_DIR}
     cd ${LIBCUDF_BUILD_DIR}
     if [[ ${INSTALL_TARGET} != "" ]]; then
         make -j${PARALLEL_LEVEL} install_cudf VERBOSE=${VERBOSE}

--- a/build.sh
+++ b/build.sh
@@ -134,7 +134,7 @@ fi
 
 if buildAll || hasArg libnvstrings; then
 
-    cd ${LIBNVSTRINGS_BUILD_DIR}
+    cd ${LIB_BUILD_DIR}
     if [[ ${INSTALL_TARGET} != "" ]]; then
         make -j${PARALLEL_LEVEL} install_nvstrings VERBOSE=${VERBOSE}
     else
@@ -157,7 +157,7 @@ fi
 # Configure, build, and install libcudf
 if buildAll || hasArg libcudf; then
 
-    cd ${LIBCUDF_BUILD_DIR}
+    cd ${LIB_BUILD_DIR}
     if [[ ${INSTALL_TARGET} != "" ]]; then
         make -j${PARALLEL_LEVEL} install_cudf VERBOSE=${VERBOSE}
     else

--- a/build.sh
+++ b/build.sh
@@ -129,7 +129,7 @@ if buildAll || hasArg libnvstrings || hasArg libcudf; then
     cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DCMAKE_CXX11_ABI=ON \
           ${GPU_ARCH} \
-          -DBUILD_BENCHMARKS=${BENCHMARKS}
+          -DBUILD_BENCHMARKS=${BENCHMARKS} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 fi
 
@@ -146,7 +146,7 @@ fi
 
 # Build and install the nvstrings Python package
 if buildAll || hasArg nvstrings; then
- 
+
     cd ${REPODIR}/python/nvstrings
     if [[ ${INSTALL_TARGET} != "" ]]; then
         python setup.py build_ext

--- a/build.sh
+++ b/build.sh
@@ -146,7 +146,7 @@ fi
 
 # Build and install the nvstrings Python package
 if buildAll || hasArg nvstrings; then
-    
+ 
     cd ${REPODIR}/python/nvstrings
     if [[ ${INSTALL_TARGET} != "" ]]; then
         python setup.py build_ext


### PR DESCRIPTION
There should only be one cmake configure step in the build. Small fix with removing quotes on the benchmarks variable as well.