### PR TITLE
[REVIEW] Update numba to 0.46 in conda files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - PR #3694 Allow for null columns parameter in csv_writer`
 - PR #3704 Changed the default delimiter to `whitespace` for nvtext methods.
 - PR #3709 Fix inner_join incorrect result issue
+- PR #3734 Update numba to 0.46 in conda files
 
 
 # cuDF 0.11.0 (11 Dec 2019)
@@ -118,7 +119,7 @@
 - PR #3497 Add DataFrame.drop(..., inplace=False) argument
 - PR #3469 Add string functionality for replace API
 - PR #3527 Add string functionality for merge API
-- PR #3557 Add contiguous_split() function. 
+- PR #3557 Add contiguous_split() function.
 - PR #3507 Define and implement new binary operation APIs
 
 ## Improvements

--- a/conda/environments/cudf_dev_cuda10.0.yml
+++ b/conda/environments/cudf_dev_cuda10.0.yml
@@ -11,7 +11,7 @@ dependencies:
   - cmake>=3.12
   - cmake_setuptools>=0.1.3
   - python>=3.6,<3.8
-  - numba>=0.45.1
+  - numba>=0.46
   - pandas>=0.24.2,<0.25
   - pyarrow=0.15.0
   - fastavro>=0.22.0

--- a/conda/environments/cudf_dev_cuda10.1.yml
+++ b/conda/environments/cudf_dev_cuda10.1.yml
@@ -11,7 +11,7 @@ dependencies:
   - cmake>=3.12
   - cmake_setuptools>=0.1.3
   - python>=3.6,<3.8
-  - numba>=0.45.1
+  - numba>=0.46
   - pandas>=0.24.2,<0.25
   - pyarrow=0.15.0
   - fastavro>=0.22.0

--- a/conda/environments/cudf_dev_cuda9.2.yml
+++ b/conda/environments/cudf_dev_cuda9.2.yml
@@ -11,7 +11,7 @@ dependencies:
   - cmake>=3.12
   - cmake_setuptools>=0.1.3
   - python>=3.6,<3.8
-  - numba>=0.45.1
+  - numba>=0.46
   - pandas>=0.24.2,<0.25
   - pyarrow=0.15.0
   - fastavro>=0.22.0

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
     - cython >=0.29,<0.30
     - setuptools
-    - numba >=0.45.1
+    - numba >=0.46.0
     - dlpack
     - pyarrow 0.15.0.*
     - libcudf {{ version }}
@@ -32,7 +32,7 @@ requirements:
     - python
     - pandas>=0.24.2,<0.25
     - cupy >=6.6.0,<8.0.0a0
-    - numba >=0.45.1
+    - numba >=0.46.0
     - pyarrow 0.15.0.*
     - fastavro >=0.22.0
     - rmm {{ minor_version }}.*


### PR DESCRIPTION
Closes issue #3715 

PR updates numba in conda recipes and developer environments to >0.46.0. Version 0.45 was causing the problem described in the issue above, discovered only in cuML developer environments that had 0.45.1 by default. CI containers already pull 0.46.

