### PR TITLE
[REVIEW] Update libxx cython types.hpp path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - PR #3694 Allow for null columns parameter in csv_writer`
 - PR #3704 Changed the default delimiter to `whitespace` for nvtext methods.
 - PR #3709 Fix inner_join incorrect result issue
+- PR #3738 Update libxx cython types.hpp path
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/python/cudf/cudf/_libxx/lib.pxd
+++ b/python/cudf/cudf/_libxx/lib.pxd
@@ -5,7 +5,7 @@ from libcpp.memory cimport unique_ptr
 
 from rmm._lib.device_buffer cimport device_buffer, DeviceBuffer, move
 
-cdef extern from "types.hpp" namespace "cudf" nogil:
+cdef extern from "cudf/types.hpp" namespace "cudf" nogil:
     ctypedef int32_t size_type
     ctypedef uint32_t bitmask_type
 


### PR DESCRIPTION
Updates the "types.hpp" path in `libxx/lib.pxd` to unblock cuGraph CI builds (related: https://github.com/BradReesWork/cugraph/pull/1)