### PR TITLE
[WIP] Infer index during DataFrame construction from Series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - PR #3730 CSV reader: Set invalid float values to NaN/null
 - PR #3670 Floor when casting between timestamps of different precisions
 - PR #3728 Fix apply_boolean_mask issue with non-null string column
+- PR #3770 Infer index during DataFrame construction from Series
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4103,7 +4103,7 @@ def test_df_sr_binop(gsr, colnames, op):
     ],
 )
 @pytest.mark.parametrize(
-    "gsr", [Series([1, 2, 3, 4, 5], index=["a", "b", "d", "0", "12"])],
+    "gsr", [Series([1, 2, 3, 4, 5], index=["a", "b", "d", "0", "12"])]
 )
 def test_df_sr_binop_col_order(gsr, op):
     colnames = [0, 1, 2]
@@ -4236,3 +4236,17 @@ def test_memory_usage_multi():
     expect += 3 * 8  # Level 1
 
     assert expect == gdf.index.memory_usage(deep=deep)
+
+
+@pytest.mark.parametrize("index", [True, False])
+def test_dataframe_from_series_items(index):
+
+    pdf = pd.DataFrame({"id": [2, 4, 6], "a": ["X", "Y", "Z"], "b": [0, 1, 2]})
+    if index:
+        pdf = pdf.set_index("id")
+    pdf2 = pd.DataFrame({"a": pdf["a"], "b": pdf["b"]})
+
+    df = gd.from_pandas(pdf)
+    df2 = gd.DataFrame({"a": df["a"], "b": df["b"]})
+
+    pd.testing.assert_frame_equal(pdf2, df2.to_pandas())

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -240,3 +240,17 @@ def test_groupby_string_index_name(myindex):
     gdf = ddf.groupby("index").agg({"data": "count"})
 
     assert gdf.compute().index.name == gdf.index.name
+
+
+def test_group_by_agg():
+    # GH-Issue #3533
+    gdf = cudf.datasets.randomdata(5)
+    pdf = gdf.to_pandas()
+
+    gddf = dask_cudf.from_cudf(gdf, npartitions=2)
+    gb_gddf = gddf.groupby("id").agg({"x": ["sum", "mean"]})
+
+    pddf = dd.from_pandas(pdf, npartitions=2)
+    gb_pddf = pddf.groupby("id").agg({"x": ["sum", "mean"]})
+
+    dd.assert_eq(gb_gddf.compute(), gb_pddf.compute())


### PR DESCRIPTION
Most likely addresses the remaining problem in #3533

As demonstrated [in this comment](https://github.com/rapidsai/cudf/issues/3533#issuecomment-573795576),  the cudf DataFrame constructor does not behave the same way as pandas when a dictionary is passed containing Series objects.  More specifically, pandas will preserve the indices of the Series objects during the construction of the DataFrame.  Cudf, on the other hand, does **not**.

Since Dask assumes that the indices will be preserved for some types of groupby aggregation, this can lead to incorrect dask_cudf groupby results.  this PR includes the minimal changes needed to avoid the groupby errors (see `cudf/python/dask_cudf/dask_cudf/tests/test_groupby.py::test_group_by_agg`).

Note that these changes do **not** result in a direct match with pandas behavior.  In pandas, the various Series objects are effectively joined using thier original indices to construct the new DataFrame.  This means that the indices do not need to be the same for all inputs to the DataFrame constructor.  In this PR, we are currently assuming that all indices must match.  *However, it may be better follow the pandas approach more closely here (at least when the input objects are all Series, rather than columns).*

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
