### PR TITLE
Fix segfault when reading compressed CSV files larger than 4GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - PR #3730 CSV reader: Set invalid float values to NaN/null
 - PR #3670 Floor when casting between timestamps of different precisions
 - PR #3728 Fix apply_boolean_mask issue with non-null string column
+- PR #3775 Fix segfault when reading compressed CSV files larger than 4GB
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/cpp/src/io/comp/io_uncomp.h
+++ b/cpp/src/io/comp/io_uncomp.h
@@ -39,7 +39,7 @@ enum {
     IO_UNCOMP_STREAM_TYPE_ZSTD      = 10,
 };
 
-gdf_error io_uncompress_single_h2d(const void *src, cudf::size_type src_size, int strm_type, std::vector<char>& dst);
+gdf_error io_uncompress_single_h2d(const void *src, size_t src_size, int strm_type, std::vector<char>& dst);
 
 gdf_error getUncompressedHostData(const char* h_data, size_t num_bytes,
     const std::string& compression, std::vector<char>& h_uncomp_data);

--- a/cpp/src/io/comp/uncomp.cpp
+++ b/cpp/src/io/comp/uncomp.cpp
@@ -328,7 +328,7 @@ int cpu_inflate_vector(std::vector<char>& dst, const uint8_t *comp_data, size_t 
  * @returns gdf_error with error code on failure, otherwise GDF_SUCCESS
  */
 /* ----------------------------------------------------------------------------*/
-gdf_error io_uncompress_single_h2d(const void *src, cudf::size_type src_size, int strm_type, std::vector<char>& dst)
+gdf_error io_uncompress_single_h2d(const void *src, size_t src_size, int strm_type, std::vector<char>& dst)
 {
     const uint8_t *raw = (const uint8_t *)src;
     const uint8_t *comp_data = nullptr;


### PR DESCRIPTION
Use size_t for the compressed file size instead of int32_t.

Issue #3379 