### PR TITLE
[REVIEW] Python changes to align index on input Series to setitem calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - PR #3728 Fix apply_boolean_mask issue with non-null string column
 - PR #3783 Bind cuDF operators to Dask Dataframe
 - PR #3775 Fix segfault when reading compressed CSV files larger than 4GB
+- PR #3799 Align indices of Series inputs when adding as columns to DataFrame 
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -516,6 +516,15 @@ class DataFrame(Table):
                 if arg in self._data:
                     if is_scalar(value):
                         value = utils.scalar_broadcast_to(value, len(self))
+                    if len(self) == 0:
+                        if isinstance(value, (pd.Series, Series)):
+                            self._index = as_index(value.index)
+                        elif len(value) > 0:
+                            self._index = RangeIndex(start=0, stop=len(value))
+                    elif isinstance(value, (pd.Series, Series)):
+                        value = Series(value)._align_to_index(
+                            self._index, how="right"
+                        )
                     self._data[arg] = column.as_column(value)
                 else:
                     # disc. with pandas here
@@ -872,7 +881,7 @@ class DataFrame(Table):
                         r_opr = other_cols[col]
                         l_opr = Series(
                             column_empty(
-                                len(self), masked=True, dtype=other.dtype,
+                                len(self), masked=True, dtype=other.dtype
                             )
                         )
                     if col not in other_cols_keys:
@@ -1540,6 +1549,8 @@ class DataFrame(Table):
                             masked=True,
                             newsize=len(value),
                         )
+        elif isinstance(value, (pd.Series, Series)):
+            value = Series(value)._align_to_index(self._index, how="right")
 
         value = column.as_column(value)
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -780,9 +780,7 @@ class DataFrame(Table):
                 and not self._data[col].dtype == "O"
                 and not is_datetime_dtype(self._data[col].dtype)
             ):
-                output[col] = (
-                    output._data[col].astype("str").str().fillna("null")
-                )
+                output[col] = output._data[col].astype("str").fillna("null")
             else:
                 output[col] = output._data[col]
         if isinstance(self.columns, cudf.MultiIndex):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -3199,7 +3199,7 @@ class DataFrame(Table):
         )
 
     def hash_columns(self, columns=None):
-        """Hash the given *columns* and return a new Series
+        """Hash the given *columns* and return a new device array
 
         Parameters
         ----------
@@ -3213,7 +3213,7 @@ class DataFrame(Table):
             columns = self.columns
 
         cols = [self[k]._column for k in columns]
-        return Series(numerical.column_hash_values(*cols))
+        return Series(numerical.column_hash_values(*cols)).values
 
     def partition_by_hash(self, columns, nparts):
         """Partition the dataframe by the hashed value of data in *columns*.

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -67,10 +67,10 @@ def concat(objs, axis=0, ignore_index=False, sort=None):
                 if o.name is None:
                     # pandas uses 0-offset
                     name = idx - 1
-                df[name] = o
+                df[name] = o._column
             else:
                 for col in o.columns:
-                    df[col] = o[col]
+                    df[col] = o._data[col]
         if isinstance(objs[0], DataFrame) and isinstance(
             objs[0].columns, MultiIndex
         ):

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -62,6 +62,8 @@ def concat(objs, axis=0, ignore_index=False, sort=None):
         assert typs.issubset(allowed_typs)
         df = DataFrame()
         for idx, o in enumerate(objs):
+            if idx == 0:
+                df.index = o.index
             if isinstance(o, Series):
                 name = o.name
                 if o.name is None:
@@ -70,7 +72,7 @@ def concat(objs, axis=0, ignore_index=False, sort=None):
                 df[name] = o._column
             else:
                 for col in o.columns:
-                    df[col] = o._data[col]
+                    df[col] = o[col]._column
         if isinstance(objs[0], DataFrame) and isinstance(
             objs[0].columns, MultiIndex
         ):

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2207,7 +2207,7 @@ class Series(Table):
         """
         from cudf.core.column import numerical
 
-        return Series(numerical.column_hash_values(self._column))
+        return Series(numerical.column_hash_values(self._column)).values
 
     def hash_encode(self, stop, use_name=False):
         """Encode column values as ints in [0, stop) using hash function.
@@ -2586,7 +2586,7 @@ class Series(Table):
         A Column of insertion points with the same shape as value
         """
         outcol = self._column.searchsorted(value, side)
-        return Series(outcol)
+        return Series(outcol).values
 
     @property
     def is_unique(self):

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -757,14 +757,14 @@ def test_dataframe_hash_columns(nrows):
 
     # Check default
     out_all = gdf.hash_columns()
-    np.testing.assert_array_equal(out.to_array(), out_all.to_array())
+    np.testing.assert_array_equal(cupy.asnumpy(out), cupy.asnumpy(out_all))
 
     # Check single column
-    out_one = gdf.hash_columns(["a"]).to_array()
+    out_one = cupy.asnumpy(gdf.hash_columns(["a"]))
     # First matches last
     assert out_one[0] == out_one[-1]
     # Equivalent to the Series.hash_values()
-    np.testing.assert_array_equal(gdf.a.hash_values().to_array(), out_one)
+    np.testing.assert_array_equal(cupy.asnumpy(gdf.a.hash_values()), out_one)
 
 
 @pytest.mark.parametrize("nrows", [3, 10, 100, 1000])

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -751,7 +751,7 @@ def test_dataframe_hash_columns(nrows):
     gdf["a"] = data
     gdf["b"] = gdf.a + 100
     out = gdf.hash_columns(["a", "b"])
-    assert isinstance(out, Series)
+    assert isinstance(out, cupy.ndarray)
     assert len(out) == nrows
     assert out.dtype == np.int32
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2020, NVIDIA CORPORATION.
 
 import array as arr
 import operator
@@ -4193,7 +4193,7 @@ def test_df_sr_binop(gsr, colnames, op):
     ],
 )
 @pytest.mark.parametrize(
-    "gsr", [Series([1, 2, 3, 4, 5], index=["a", "b", "d", "0", "12"])],
+    "gsr", [Series([1, 2, 3, 4, 5], index=["a", "b", "d", "0", "12"])]
 )
 def test_df_sr_binop_col_order(gsr, op):
     colnames = [0, 1, 2]
@@ -4326,3 +4326,68 @@ def test_memory_usage_multi():
     expect += 3 * 8  # Level 1
 
     assert expect == gdf.index.memory_usage(deep=deep)
+
+
+@pytest.mark.parametrize(
+    "list_input",
+    [
+        pytest.param([1, 2, 3, 4], id="smaller"),
+        pytest.param([1, 2, 3, 4, 5, 6], id="larger"),
+    ],
+)
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param("list_test", id="new_column"),
+        pytest.param("id", id="existing_column"),
+    ],
+)
+def test_setitem_diff_size_list(list_input, key):
+    gdf = gd.datasets.randomdata(5)
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot insert Column of different length into OrderedColumnDict"
+        ),
+    ):
+        gdf[key] = list_input
+
+
+@pytest.mark.parametrize(
+    "series_input",
+    [
+        pytest.param(gd.Series([1, 2, 3, 4]), id="smaller_cudf"),
+        pytest.param(gd.Series([1, 2, 3, 4, 5, 6]), id="larger_cudf"),
+        pytest.param(gd.Series([1, 2, 3], index=[4, 5, 6]), id="index_cudf"),
+        pytest.param(pd.Series([1, 2, 3, 4]), id="smaller_pandas"),
+        pytest.param(pd.Series([1, 2, 3, 4, 5, 6]), id="larger_pandas"),
+        pytest.param(pd.Series([1, 2, 3], index=[4, 5, 6]), id="index_pandas"),
+    ],
+)
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param("list_test", id="new_column"),
+        pytest.param("id", id="existing_column"),
+    ],
+)
+def test_setitem_diff_size_series(series_input, key):
+    gdf = gd.datasets.randomdata(5)
+    pdf = gdf.to_pandas()
+
+    pandas_input = series_input
+    if isinstance(pandas_input, gd.Series):
+        pandas_input = pandas_input.to_pandas()
+
+    expect = pdf
+    expect[key] = pandas_input
+
+    got = gdf
+    got[key] = series_input
+
+    # Pandas uses NaN and typecasts to float64 if there's missing values on
+    # alignment, so need to typecast to float64 for equality comparison
+    expect = expect.astype("float64")
+    got = got.astype("float64")
+
+    assert_eq(expect, got)

--- a/python/cudf/cudf/tests/test_search.py
+++ b/python/cudf/cudf/tests/test_search.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
+import cupy
 import pytest
 
 import cudf
@@ -29,7 +30,7 @@ def test_searchsorted(side, obj_class):
     expect = psr.searchsorted(pvals, side)
     got = sr.searchsorted(vals, side)
 
-    assert_eq(expect, got.to_array())
+    assert_eq(expect, cupy.asnumpy(got))
 
 
 @pytest.mark.parametrize("side", ["left", "right"])

--- a/python/cudf/cudf/tests/test_search.py
+++ b/python/cudf/cudf/tests/test_search.py
@@ -51,7 +51,7 @@ def test_searchsorted_categorical(side):
     expect = psr1.searchsorted(psr2, side)
     got = sr1.searchsorted(sr2, side)
 
-    assert_eq(expect, got.to_array())
+    assert_eq(expect, cupy.asnumpy(got))
 
 
 @pytest.mark.parametrize("side", ["left", "right"])
@@ -81,4 +81,4 @@ def test_searchsorted_datetime(side):
     expect = psr1.searchsorted(psr2, side)
     got = sr1.searchsorted(sr2, side)
 
-    assert_eq(expect, got.to_array())
+    assert_eq(expect, cupy.asnumpy(got))

--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -73,7 +73,6 @@ def test_dataframe_setitem_scaler_keyerror():
 
 
 # set_item_series inconsistency
-@pytest.mark.xfail()
 def test_series_setitem_index():
     df = pd.DataFrame(
         data={"b": [-1, -2, -3], "c": [1, 2, 3]}, index=[1, 2, 3]

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -54,7 +54,7 @@ try:
     @hash_object_dispatch.register(cudf.DataFrame)
     def hash_object_cudf(frame, index=True):
         if index:
-            return _string_safe_hash(frame.reset_index)
+            return _string_safe_hash(frame.reset_index())
         return _string_safe_hash(frame)
 
     @hash_object_dispatch.register(cudf.Index)

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -456,3 +456,15 @@ def test_memory_usage(gdf, gddf, index, deep):
         gdf.memory_usage(deep=deep, index=index),
         gddf.memory_usage(deep=deep, index=index),
     )
+
+
+@pytest.mark.parametrize("index", [True, False])
+def test_hash_object_dispatch(index):
+    obj = cudf.DataFrame(
+        {"x": ["a", "b", "c"], "y": [1, 2, 3]}, index=[2, 4, 6]
+    )
+
+    result = dd.utils.hash_object_dispatch(obj, index=index)
+    expected = dgd.backends.hash_object_cudf(obj, index=index)
+
+    dd.assert_eq(cudf.Series(result), cudf.Series(expected))


### PR DESCRIPTION
Fixes #3735
Fixes #3779

Uses the newly added `Series._align_to_index` to align inputs to handle `__setitem__`, `assign`, and `insert` calls where the input is a pandas Series or a cudf Series that can differ in size from the dataframe.
