### PR TITLE
Fix CUDA kernel logic in apply_grouped moving average example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 - PR #3829 Parquet writer: fix empty dataframe causing cuda launch errors
 - PR #3835 Fix memory leak in Cython when dealing with nulls in string columns
 - PR #3850 Fix merge typecast scope issue and resulting memory leak
+- PR #3868 Fix apply_grouped moving average example 
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/python/cudf/cudf/core/groupby/legacy_groupby.py
+++ b/python/cudf/cudf/core/groupby/legacy_groupby.py
@@ -481,9 +481,8 @@ class Groupby(object):
             # sliding window
             def rolling_avg(val, avg):
                 win_size = 3
-                for row, i in enumerate(range(cuda.threadIdx.x,
-                                              len(val), cuda.blockDim.x)):
-                    if row < win_size - 1:
+                for i in range(cuda.threadIdx.x, len(val), cuda.blockDim.x):
+                    if i < win_size - 1:
                         # If there is not enough data to fill the window,
                         # take the average to be NaN
                         avg[i] = np.nan


### PR DESCRIPTION
This kernel contains what looks like extra enumeration logic that prevents it from producing the correct result when there is more than one thread per block. 

Fixes https://github.com/rapidsai/cudf/issues/3615