### PR TITLE
[REVIEW] Fixed size calculation in NVStrings::byte_count()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - PR #3835 Fix memory leak in Cython when dealing with nulls in string columns
 - PR #3858 Fixes the broken debug build after #3728
 - PR #3850 Fix merge typecast scope issue and resulting memory leak
+- PR #3869 Fixed size calculation in NVStrings::byte_count()
 
 
 # cuDF 0.11.0 (11 Dec 2019)


### PR DESCRIPTION
The `NVStrings::byte_count()` member function returns `int64` by the internal calculation was truncating into an `int32` value. The code logic was modified to ensure the `int64` value is not truncated.