### PR TITLE
[REVIEW] Repair issue involving `split_out`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - PR #3858 Fixes the broken debug build after #3728
 - PR #3850 Fix merge typecast scope issue and resulting memory leak
 - PR #3868 Fix apply_grouped moving average example 
+- PR #3871 Fix `split_out` error
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -443,7 +443,16 @@ class DataFrame(Table):
                 df[k] = col[arg]
             return df
         elif isinstance(
-            arg, (list, cupy.ndarray, np.ndarray, pd.Series, Series, Index, pd.Index)
+            arg,
+            (
+                list,
+                cupy.ndarray,
+                np.ndarray,
+                pd.Series,
+                Series,
+                Index,
+                pd.Index,
+            ),
         ):
             mask = arg
             if isinstance(mask, list):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -443,7 +443,7 @@ class DataFrame(Table):
                 df[k] = col[arg]
             return df
         elif isinstance(
-            arg, (list, np.ndarray, pd.Series, Series, Index, pd.Index)
+            arg, (list, cupy.ndarray, np.ndarray, pd.Series, Series, Index, pd.Index)
         ):
             mask = arg
             if isinstance(mask, list):

--- a/python/cudf/cudf/core/indexing.py
+++ b/python/cudf/cudf/core/indexing.py
@@ -106,7 +106,7 @@ class _DataFrameIndexer(object):
             # tuple arguments into MultiIndex dataframes.
             try:
                 return self._getitem_tuple_arg(arg)
-            except (TypeError, KeyError, IndexError):
+            except (TypeError, KeyError, IndexError, ValueError):
                 return self._getitem_tuple_arg((arg, slice(None)))
         else:
             if not isinstance(arg, tuple):

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -219,7 +219,7 @@ class MultiIndex(Index):
 
         lookup = DataFrame()
         for idx, row in enumerate(row_tuple):
-            if row == slice(None):
+            if isinstance(row, slice) and row == slice(None):
                 continue
             lookup[index._source_data.columns[idx]] = Series(row)
         data_table = concat(
@@ -332,6 +332,9 @@ class MultiIndex(Index):
 
     def _get_row_major(self, df, row_tuple):
         from cudf import Series
+
+        if pd.api.types.is_bool_dtype(row_tuple):
+            return df[row_tuple]
 
         valid_indices = self._get_valid_indices_by_tuple(
             df.index, row_tuple, len(df.index)

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -251,7 +251,7 @@ def test_groupby_string_index_name(myindex):
 ])
 def test_groupby_split_out_multiindex(agg_func):
     df = cudf.DataFrame(
-        {"a": np.arange(100), "b": np.arange(100), "c": np.random.random(100)}
+        {"a": np.random.randint(0, 10, 100), "b": np.random.randint(0, 5, 100), "c": np.random.random(100)}
     )
     ddf = dask_cudf.from_cudf(df, 5)
     pddf = dd.from_pandas(df.to_pandas(), 5)

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -243,15 +243,22 @@ def test_groupby_string_index_name(myindex):
     assert gdf.compute().index.name == gdf.index.name
 
 
-@pytest.mark.parametrize("agg_func", [
-    lambda gb: gb.agg({"c": "count"}, split_out=2),
-    lambda gb: gb.agg({"c": ["count", "sum"]}, split_out=2),
-    lambda gb: gb.count(split_out=2),
-    lambda gb: gb.c.count(split_out=2),
-])
+@pytest.mark.parametrize(
+    "agg_func",
+    [
+        lambda gb: gb.agg({"c": "count"}, split_out=2),
+        lambda gb: gb.agg({"c": ["count", "sum"]}, split_out=2),
+        lambda gb: gb.count(split_out=2),
+        lambda gb: gb.c.count(split_out=2),
+    ],
+)
 def test_groupby_split_out_multiindex(agg_func):
     df = cudf.DataFrame(
-        {"a": np.random.randint(0, 10, 100), "b": np.random.randint(0, 5, 100), "c": np.random.random(100)}
+        {
+            "a": np.random.randint(0, 10, 100),
+            "b": np.random.randint(0, 5, 100),
+            "c": np.random.random(100),
+        }
     )
     ddf = dask_cudf.from_cudf(df, 5)
     pddf = dd.from_pandas(df.to_pandas(), 5)

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -241,3 +241,19 @@ def test_groupby_string_index_name(myindex):
     gdf = ddf.groupby("index").agg({"data": "count"})
 
     assert gdf.compute().index.name == gdf.index.name
+
+
+def test_groupby_split_out_multiindex():
+    import cudf
+    import dask.dataframe as dd
+    import dask_cudf
+    import numpy as np
+
+    df = cudf.DataFrame(
+        {"a": np.arange(100), "b": np.arange(100), "c": np.random.random(100)}
+    )
+    ddf = dask_cudf.from_cudf(df, 5)
+    pddf = dd.from_pandas(df.to_pandas(), 5)
+    gr = ddf.groupby(["a", "b"]).agg({"c": "count"}, split_out=2)
+    pr = pddf.groupby(["a", "b"]).agg({"c": "count"}, split_out=2)
+    dd.assert_eq(gr.compute(), pr.compute())

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -250,11 +250,6 @@ def test_groupby_string_index_name(myindex):
     lambda gb: gb.c.count(split_out=2),
 ])
 def test_groupby_split_out_multiindex(agg_func):
-    import cudf
-    import dask.dataframe as dd
-    import dask_cudf
-    import numpy as np
-
     df = cudf.DataFrame(
         {"a": np.arange(100), "b": np.arange(100), "c": np.random.random(100)}
     )


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/3784

This issue had two causes: We didn't properly handle `cupy.ndarray` as a boolean row-mask, and we didn't support use of `iloc[[]]` as a syntax for boolean row-mask. This PR corrects those issues.