### PR TITLE
Drop `ptr=None` from `DeviceBuffer` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Bug Fixes
 
+- PR #3888 Pass `0` to `ptr` of `DeviceBuffer`
+
 
 # cuDF 0.12.0 (Date TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug Fixes
 
-- PR #3888 Pass `0` to `ptr` of `DeviceBuffer`
+- PR #3888 Drop `ptr=None` from `DeviceBuffer` call
 
 
 # cuDF 0.12.0 (Date TBD)

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -84,7 +84,7 @@ class Buffer:
 
     @classmethod
     def empty(cls, size):
-        dbuf = DeviceBuffer(ptr=None, size=size)
+        dbuf = DeviceBuffer(ptr=0, size=size)
         return Buffer(dbuf)
 
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -84,7 +84,7 @@ class Buffer:
 
     @classmethod
     def empty(cls, size):
-        dbuf = DeviceBuffer(ptr=0, size=size)
+        dbuf = DeviceBuffer(size=size)
         return Buffer(dbuf)
 
 


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/3887

cc @kkraus14 @shwina @dantegd