### PR TITLE
[REVIEW] Update cudf meta for pandas version #3486 [skip-ci]

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - rmm {{ minor_version }}.*
   run:
     - python
-    - pandas>=0.24.2,<0.25
+    - pandas >=0.25,<0.26
     - cupy >=6.6.0,<8.0.0a0,!=7.1.0
     - numba >=0.46.0
     - pyarrow 0.15.0.*


### PR DESCRIPTION
#3486 did not bump the conda recipe version