### PR TITLE
[WIP][HELP-REQ] Implementing `idxmin` and `idxmax` for `Series` and `DataFrame`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # cuDF 0.13.0 (Date TBD)
 
 ## New Features
+- PR #3914 Implimenting `idxmin` and `idxmax` for `Series` and `Dataframe`
 
 ## Improvements
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1523,7 +1523,7 @@ class DataFrame(Frame):
     def take(self, positions):
         positions = as_column(positions)
         if pd.api.types.is_bool_dtype(positions):
-            return self._apply_boolean_mask(positions,)
+            return self._apply_boolean_mask(positions)
         out = self.gather(positions)
         return out
 
@@ -3518,6 +3518,50 @@ class DataFrame(Frame):
         """Identify non-missing values in a DataFrame. Alias for notna.
         """
         return self.notna()
+
+    # `idxmin` and `idxmax` are stubbed here for writing expected tests.
+    # After feedback from the etl team on the libcudf API they will be replaced.
+    def idxmin(self, axis=0, skipna=True):
+        """
+        Return index of first occurrence of minimum over requested axis. NA/null values are excluded.
+
+        Parameters:	
+            axis : {0 or ‘index’, 1 or ‘columns’}, default 0
+                0 or ‘index’ for row-wise, 1 or ‘columns’ for column-wise
+            skipna : boolean, default True
+                Exclude NA/null values. If an entire row/column is NA, the result will be NA.
+
+        Returns:	
+            Series
+                Indexes of minima along the specified axis.
+
+        Raises:	
+            ValueError
+                If the row/column is empty
+        """
+        # Returning pandas.Series.idxmax value until libcudf API requirements established.
+        return self.to_pandas().idxmin(axis=axis, skipna=skipna)
+
+    def idxmax(self, axis=0, skipna=True):
+        """
+        Return index of first occurrence of maximum over requested axis. NA/null values are excluded.
+
+        Parameters:	
+            axis : {0 or ‘index’, 1 or ‘columns’}, default 0
+                0 or ‘index’ for row-wise, 1 or ‘columns’ for column-wise
+            skipna : boolean, default True
+                Exclude NA/null values. If an entire row/column is NA, the result will be NA.
+
+        Returns:	
+            Series
+                Indexes of minima along the specified axis.
+
+        Raises:	
+            ValueError
+                If the row/column is empty
+        """
+        # Returning pandas.Series.idxmax value until libcudf API requirements established.
+        return self.to_pandas().idxmax(axis=axis, skipna=skipna)
 
     def to_pandas(self):
         """

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -3519,48 +3519,55 @@ class DataFrame(Frame):
         """
         return self.notna()
 
-    # `idxmin` and `idxmax` are stubbed here for writing expected tests.
-    # After feedback from the etl team on the libcudf API they will be replaced.
+    # `idxmin` and `idxmax` are stubbed here for writing expected
+    # tests. After feedback from the etl team on the libcudf API
+    # they will be replaced.
     def idxmin(self, axis=0, skipna=True):
         """
-        Return index of first occurrence of minimum over requested axis. NA/null values are excluded.
+        Return index of first occurrence of minimum over requested axis.
+        NA/null values are excluded.
 
-        Parameters:	
+        Parameters:
             axis : {0 or ‘index’, 1 or ‘columns’}, default 0
                 0 or ‘index’ for row-wise, 1 or ‘columns’ for column-wise
             skipna : boolean, default True
-                Exclude NA/null values. If an entire row/column is NA, the result will be NA.
+                Exclude NA/null values. If an entire row/column is NA,
+                the result will be NA.
 
-        Returns:	
+        Returns:
             Series
                 Indexes of minima along the specified axis.
 
-        Raises:	
+        Raises:
             ValueError
                 If the row/column is empty
         """
-        # Returning pandas.Series.idxmax value until libcudf API requirements established.
+        # Returning pandas.Series.idxmax value until libcudf API
+        # requirements established.
         return self.to_pandas().idxmin(axis=axis, skipna=skipna)
 
     def idxmax(self, axis=0, skipna=True):
         """
-        Return index of first occurrence of maximum over requested axis. NA/null values are excluded.
+        Return index of first occurrence of maximum over requested axis.
+        NA/null values are excluded.
 
-        Parameters:	
+        Parameters:
             axis : {0 or ‘index’, 1 or ‘columns’}, default 0
                 0 or ‘index’ for row-wise, 1 or ‘columns’ for column-wise
             skipna : boolean, default True
-                Exclude NA/null values. If an entire row/column is NA, the result will be NA.
+                Exclude NA/null values. If an entire row/column is NA,
+                the result will be NA.
 
-        Returns:	
+        Returns:
             Series
                 Indexes of minima along the specified axis.
 
-        Raises:	
+        Raises:
             ValueError
                 If the row/column is empty
         """
-        # Returning pandas.Series.idxmax value until libcudf API requirements established.
+        # Returning pandas.Series.idxmax value until libcudf API
+        # requirements established.
         return self.to_pandas().idxmax(axis=axis, skipna=skipna)
 
     def to_pandas(self):

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2196,7 +2196,7 @@ class Series(Frame):
         # numpy.argmin for implimentation reference
         if skipna:
             _sr = self.fillna(np.nan)
-            argmax = _sr.values.argmax()
+            argmin = _sr.values.argmin()
 
         # Returning pandas.Series.idxmax value until libcudf API requirements established.
         return self.to_pandas().idxmin(axis=axis, skipna=skipna)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2178,6 +2178,51 @@ class Series(Frame):
         scaled = cudautils.compute_scale(gpuarr, vmin, vmax)
         return self._copy_construct(data=scaled)
 
+    # `idxmin` and `idxmax` are stubbed here for writing expected tests.
+    # After feedback from the etl team on the libcudf API they will be replaced.
+    def idxmin(self, axis=0, skipna=True):
+        """
+        Return the row label of the minimum value.
+
+        If multiple values equal the minimum, the first row label with that value is returned.
+        
+        Parameters: 
+            skipna : bool, default True
+                Exclude NA/null values. If the entire Series is NA, the result will be NA.
+            axis : int, default 0
+                For compatibility with DataFrame.idxmix. Redundant for application on Series.
+        """
+        # Changing None to numpy.nan so it can be compatible with
+        # numpy.argmin for implimentation reference
+        if skipna:
+            _sr = self.fillna(np.nan)
+            argmax = _sr.values.argmax()
+
+        # Returning pandas.Series.idxmax value until libcudf API requirements established.
+        return self.to_pandas().idxmin(axis=axis, skipna=skipna)
+
+    def idxmax(self, axis=0, skipna=True):
+        """
+        Return the row label of the maximum value.
+
+        If multiple values equal the maximum, the first row label with that value is returned.
+        
+        Parameters: 
+            skipna : bool, default True
+                Exclude NA/null values. If the entire Series is NA, the result will be NA.
+            axis : int, default 0
+                For compatibility with DataFrame.idxmix. Redundant for application on Series.
+
+        """
+        # Changing None to numpy.nan so it can be compatible with
+        # numpy.argmax for implimentation reference
+        if skipna:
+            _sr = self.fillna(np.nan)
+            argmax = _sr.values.argmax()
+
+        # Returning pandas.Series.idxmax value until libcudf API requirements established.
+        return self.to_pandas().idxmax(axis=axis, skipna=skipna)
+
     # Absolute
     def abs(self):
         """Absolute value of each element of the series.

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2178,49 +2178,46 @@ class Series(Frame):
         scaled = cudautils.compute_scale(gpuarr, vmin, vmax)
         return self._copy_construct(data=scaled)
 
-    # `idxmin` and `idxmax` are stubbed here for writing expected tests.
-    # After feedback from the etl team on the libcudf API they will be replaced.
+    # `idxmin` and `idxmax` are stubbed here for writing expected
+    # tests. After feedback from the etl team on the libcudf API
+    # they will be replaced.
     def idxmin(self, axis=0, skipna=True):
         """
         Return the row label of the minimum value.
 
-        If multiple values equal the minimum, the first row label with that value is returned.
-        
-        Parameters: 
-            skipna : bool, default True
-                Exclude NA/null values. If the entire Series is NA, the result will be NA.
-            axis : int, default 0
-                For compatibility with DataFrame.idxmix. Redundant for application on Series.
-        """
-        # Changing None to numpy.nan so it can be compatible with
-        # numpy.argmin for implimentation reference
-        if skipna:
-            _sr = self.fillna(np.nan)
-            argmin = _sr.values.argmin()
+        If multiple values equal the minimum, the first row label with
+        that value is returned.
 
-        # Returning pandas.Series.idxmax value until libcudf API requirements established.
+        Parameters:
+            skipna : bool, default True
+                Exclude NA/null values. If the entire Series is NA, the
+                result will be NA.
+            axis : int, default 0
+                For compatibility with DataFrame.idxmix. Redundant for
+                application on Series.
+        """
+        # Returning pandas.Series.idxmax value until libcudf API
+        # requirements established.
         return self.to_pandas().idxmin(axis=axis, skipna=skipna)
 
     def idxmax(self, axis=0, skipna=True):
         """
         Return the row label of the maximum value.
 
-        If multiple values equal the maximum, the first row label with that value is returned.
-        
-        Parameters: 
+        If multiple values equal the maximum, the first row label
+        with that value is returned.
+
+        Parameters:
             skipna : bool, default True
-                Exclude NA/null values. If the entire Series is NA, the result will be NA.
+                Exclude NA/null values. If the entire Series is NA,
+                the result will be NA.
             axis : int, default 0
-                For compatibility with DataFrame.idxmix. Redundant for application on Series.
+                For compatibility with DataFrame.idxmix. Redundant
+                for application on Series.
 
         """
-        # Changing None to numpy.nan so it can be compatible with
-        # numpy.argmax for implimentation reference
-        if skipna:
-            _sr = self.fillna(np.nan)
-            argmax = _sr.values.argmax()
-
-        # Returning pandas.Series.idxmax value until libcudf API requirements established.
+        # Returning pandas.Series.idxmax value until libcudf API
+        # requirements established.
         return self.to_pandas().idxmax(axis=axis, skipna=skipna)
 
     # Absolute

--- a/python/cudf/cudf/tests/test_idxmin_idxmax.py
+++ b/python/cudf/cudf/tests/test_idxmin_idxmax.py
@@ -1,15 +1,8 @@
-import array as arr
-import operator
-
-import cupy
-import numpy as np
 import pandas as pd
 import pytest
 
 import cudf
-from cudf.core.dataframe import DataFrame, Series
-from cudf.tests import utils
-from cudf.tests.utils import assert_eq, does_not_raise, gen_rand
+from cudf.tests.utils import assert_eq
 
 
 @pytest.mark.parametrize("axis", [0, 1])

--- a/python/cudf/cudf/tests/test_idxmin_idxmax.py
+++ b/python/cudf/cudf/tests/test_idxmin_idxmax.py
@@ -1,0 +1,85 @@
+import array as arr
+import operator
+
+import cupy
+import numpy as np
+import pandas as pd
+import pytest
+
+import cudf
+from cudf.core.dataframe import DataFrame, Series
+from cudf.tests import utils
+from cudf.tests.utils import assert_eq, does_not_raise, gen_rand
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("skipna", [True, False])
+def test_dataframe_idxmin(skipna, axis):
+    if skipna:
+        pdf = pd.DataFrame(
+            {"A": [4, 5, 2, None], "B": [11, 2, None, 8], "C": [1, 8, 66, 4]}
+        )
+    else:
+        pdf = pd.DataFrame(
+            {"A": [4, 5, 2, 6], "B": [11, 2, 5, 8], "C": [1, 8, 66, 4]}
+        )
+
+    gdf = cudf.from_pandas(pdf)
+    assert_eq(
+        pdf.idxmin(skipna=skipna, axis=axis),
+        gdf.idxmin(skipna=skipna, axis=axis),
+    )
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("skipna", [True, False])
+def test_dataframe_idxmax(skipna, axis):
+    if True:
+        pdf = pd.DataFrame(
+            {"A": [4, 5, 2, None], "B": [11, 2, None, 8], "C": [1, 8, 66, 4]}
+        )
+    else:
+        pdf = pd.DataFrame(
+            {"A": [4, 5, 2, 6], "B": [11, 2, 5, 8], "C": [1, 8, 66, 4]}
+        )
+
+    gdf = cudf.from_pandas(pdf)
+    assert_eq(
+        pdf.idxmax(skipna=skipna, axis=axis),
+        gdf.idxmax(skipna=skipna, axis=axis),
+    )
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("skipna", [True, False])
+def test_series_idxmin(skipna, axis):
+    if True:
+        psr = pd.Series(
+            data=[1, None, 4, 3, 4], index=["A", "B", "C", "D", "E"]
+        )
+    else:
+        psr = pd.Series(data=[1, 2, 4, 3, 4], index=["A", "B", "C", "D", "E"])
+
+    gsr = cudf.from_pandas(psr)
+    assert_eq(
+        psr.idxmin(skipna=skipna, axis=axis),
+        gsr.idxmin(skipna=skipna, axis=axis),
+    )
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("skipna", [True, False])
+def test_series_idxmax(skipna, axis):
+    if True:
+        psr = pd.Series(
+            data=[1, None, 4, 3, 4], index=["A", "B", "C", "D", "E"]
+        )
+    else:
+        psr = pd.Series(data=[1, 2, 4, 3, 4], index=["A", "B", "C", "D", "E"])
+
+    psr = pd.Series(data=[1, None, 4, 3, 4], index=["A", "B", "C", "D", "E"])
+    gsr = cudf.from_pandas(psr)
+    assert_eq(
+        psr.idxmin(skipna=skipna, axis=axis),
+        gsr.idxmin(skipna=skipna, axis=axis),
+    )


### PR DESCRIPTION
## Overview
I have stubbed out the functions for `idxmin/max` for the `pandas` matching `DataFrame` and `Series` `idxmin` and `idxmax`  functions. I have also set up a complete test suite. I have removed my `libcudf` `C++` experiments and created this PR to get some dialog and guidance on implementing the `C++` API.

I am fairly new to `libcudf` development and would enjoy some direction on where to place the operations as well as anything that may not be obvious in implementation. Does `idxmin/max` fit under any existing `cudf` operation namespace? I did not see anywhere it would fit easily, but it doesn't feel significant enough to make it's own space.

## `pandas.Series.idxmin/idxmax` Operations 
For ease of reference to aid discussion, here are the locations of the operations in `pandas`.
```
       skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
        i = nanops.nanargmax(com.values_from_object(self), skipna=skipna)
        if i == -1:
            return np.nan
        return self.index[i]
```
`pd` validate the `argmax` with `skipna` and get the value of that object as the index location for it's value. `nanargmax` will return the appropriate location based off applied `mask` and `skipna` while managing and filling `dtypes` appropriately. Finally, Returning `np.nan` if the selected object value is -1 and returning an index for the value if not.

### Code Links
- https://github.com/pandas-dev/pandas/blob/v0.25.3/pandas/core/series.py#L2214-L2283
- https://github.com/pandas-dev/pandas/blob/62a87bf4a2af02a8d3bc271ad26e5994292b8e6a/pandas/compat/numpy/function.py#L97-L132
- https://github.com/pandas-dev/pandas/blob/62a87bf4a2af02a8d3bc271ad26e5994292b8e6a/pandas/core/nanops.py#L856-L883
- https://github.com/pandas-dev/pandas/blob/62a87bf4a2af02a8d3bc271ad26e5994292b8e6a/pandas/compat/numpy/function.py#L97

## `pandas.DataFrame.idxmin/idxmax` Operations 
```
        axis = self._get_axis_number(axis)
        indices = nanops.nanargmin(self.values, axis=axis, skipna=skipna)
        index = self._get_axis(axis)
        result = [index[i] if i >= 0 else np.nan for i in indices]
        return Series(result, index=self._get_agg_axis(axis))
```

### Code Links
- https://github.com/pandas-dev/pandas/blob/v0.25.3/pandas/core/frame.py#L8047-L8082

closes #2188
