### PR TITLE
[REVIEW] dask cudf groupby `.agg` multicolumn handling fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@
 - PR #3871 Fix `split_out` error
 - PR #3886 Fix string column materialization from column view
 - PR #3893 Parquet reader: fix segfault reading empty parquet file
+- PR #3931 Groupby agg structure regression affecting dask
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@
 - PR #3871 Fix `split_out` error
 - PR #3886 Fix string column materialization from column view
 - PR #3893 Parquet reader: fix segfault reading empty parquet file
-- PR #3931 Groupby agg structure regression affecting dask
+- PR #3931 Dask-cudf groupby `.agg` multicolumn handling fix
 
 
 # cuDF 0.11.0 (11 Dec 2019)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1297,7 +1297,6 @@ class DataFrame(Table):
             """
             self.multi_cols = columns
         elif isinstance(columns, pd.MultiIndex):
-            breakpoint()
             self.multi_cols = cudf.MultiIndex.from_pandas(columns)
         else:
             if hasattr(self, "multi_cols"):
@@ -1485,9 +1484,9 @@ class DataFrame(Table):
             return df
 
     def reset_index(self, drop=False, inplace=False):
-        out = DataFrame()
         if isinstance(self.columns, pd.MultiIndex):
             self.columns = cudf.MultiIndex.from_pandas(self.columns)
+        out = DataFrame()
         if not drop:
             if isinstance(self.index, cudf.core.multiindex.MultiIndex):
                 framed = self.index.to_frame()

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1501,12 +1501,6 @@ class DataFrame(Table):
             for col_name, col_value in self._data.items():
                 out[col_name] = col_value
             if isinstance(self.columns, (cudf.core.multiindex.MultiIndex)):
-                """
-                if len(list(self.columns)) <= 1:
-                    out[list(self.columns)[0]] = out[0]
-                    out = out.drop(0)
-                else:
-                """
                 ncols = len(self.columns.levels)
                 mi_columns = dict(zip(range(ncols), [name, len(name) * [""]]))
                 top = DataFrame(mi_columns)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1486,6 +1486,8 @@ class DataFrame(Table):
 
     def reset_index(self, drop=False, inplace=False):
         out = DataFrame()
+        if isinstance(self.columns, pd.MultiIndex):
+            self.columns = cudf.MultiIndex.from_pandas(self.columns)
         if not drop:
             if isinstance(self.index, cudf.core.multiindex.MultiIndex):
                 framed = self.index.to_frame()

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1297,7 +1297,7 @@ class DataFrame(Table):
             """
             self.multi_cols = columns
         elif isinstance(columns, pd.MultiIndex):
-            # breakpoint()
+            breakpoint()
             self.multi_cols = cudf.MultiIndex.from_pandas(columns)
         else:
             if hasattr(self, "multi_cols"):
@@ -1499,23 +1499,25 @@ class DataFrame(Table):
                 out[name] = self.index._values
             for col_name, col_value in self._data.items():
                 out[col_name] = col_value
-            if isinstance(self.columns, cudf.core.multiindex.MultiIndex):
-                if len(list(self.columns)) == 1:
+            if isinstance(self.columns, (cudf.core.multiindex.MultiIndex)):
+                """
+                if len(list(self.columns)) <= 1:
                     out[list(self.columns)[0]] = out[0]
                     out = out.drop(0)
                 else:
-                    ncols = len(self.columns.levels)
-                    mi_columns = dict(
-                        zip(range(ncols), [name, len(name) * [""]])
-                    )
-                    top = DataFrame(mi_columns)
-                    bottom = self.columns.to_frame().reset_index(drop=True)
-                    index_frame = cudf.concat([top, bottom])
-                    mc_df = DataFrame()
-                    for idx, key in enumerate(out._data):
-                        mc_df[idx] = out[key]
-                    mc_df.columns = cudf.MultiIndex.from_frame(index_frame)
-                    out = mc_df
+                """
+                ncols = len(self.columns.levels)
+                mi_columns = dict(zip(range(ncols), [name, len(name) * [""]]))
+                top = DataFrame(mi_columns)
+                bottom = self.columns.to_frame().reset_index(drop=True)
+                if isinstance(bottom, pd.DataFrame):
+                    bottom = cudf.from_pandas(bottom)
+                index_frame = cudf.concat([top, bottom])
+                mc_df = DataFrame()
+                for idx, key in enumerate(out._data):
+                    mc_df[idx] = out[key]
+                mc_df.columns = cudf.MultiIndex.from_frame(index_frame)
+                out = mc_df
         else:
             out = self
         if inplace is True:

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -460,14 +460,14 @@ class DataFrame(Table):
                 # New df-wide index
                 index = self.index.take(mask)
                 for col in self._data:
-                    df[col] = self._data[col][arg]
+                    df[col] = self[col][arg]
                 df = df.set_index(index)
             else:
                 if len(arg) == 0:
                     df.index = self.index
                     return df
                 for col in arg:
-                    df[col] = self._data[col]
+                    df[col] = self[col]
                 df.index = self.index
             return df
         elif isinstance(arg, DataFrame):
@@ -1537,8 +1537,6 @@ class DataFrame(Table):
         positions = Series(positions)
         columns = self.columns
         column_values = list(self._data.values())
-
-        # import pdb; pdb.set_trace()
 
         result = DataFrame()
         for idx in range(len(positions)):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -249,8 +249,15 @@ class DataFrame(Table):
         else:
             self._index = as_index(index)
 
-        for (i, col_name) in enumerate(data):
-            self.insert(i, col_name, data[col_name])
+        if len(data.keys()) != 0 and all(
+            isinstance(key, tuple) for key in data.keys()
+        ):
+            for (i, col_name) in enumerate(data):
+                self.insert(i, i, data[col_name])
+            self.columns = cudf.MultiIndex.from_tuples(data.keys())
+        else:
+            for (i, col_name) in enumerate(data):
+                self.insert(i, col_name, data[col_name])
 
     @staticmethod
     def _align_input_series_indices(data, index):
@@ -1274,7 +1281,7 @@ class DataFrame(Table):
             return self.multi_cols
         else:
             name = self._columns_name
-            return pd.Index(self._data.keys(), name=name)
+            return pd.Index(self._data.keys(), name=name, tupleize_cols=False)
 
     @columns.setter
     def columns(self, columns):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1297,7 +1297,7 @@ class DataFrame(Table):
             """
             self.multi_cols = columns
         elif isinstance(columns, pd.MultiIndex):
-            self.multi_cols = cudf.MultiIndex.from_pandas(columns)
+            self.columns = cudf.MultiIndex.from_pandas(columns)
         else:
             if hasattr(self, "multi_cols"):
                 delattr(self, "multi_cols")
@@ -1500,13 +1500,11 @@ class DataFrame(Table):
                 out[name] = self.index._values
             for col_name, col_value in self._data.items():
                 out[col_name] = col_value
-            if isinstance(self.columns, (cudf.core.multiindex.MultiIndex)):
+            if isinstance(self.columns, cudf.core.multiindex.MultiIndex):
                 ncols = len(self.columns.levels)
                 mi_columns = dict(zip(range(ncols), [name, len(name) * [""]]))
                 top = DataFrame(mi_columns)
                 bottom = self.columns.to_frame().reset_index(drop=True)
-                if isinstance(bottom, pd.DataFrame):
-                    bottom = cudf.from_pandas(bottom)
                 index_frame = cudf.concat([top, bottom])
                 mc_df = DataFrame()
                 for idx, key in enumerate(out._data):

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -353,10 +353,6 @@ class _GroupbyHelper(object):
         """
         Computes the groupby result
         """
-        if hasattr(agg, "copy"):
-            self.original_aggs = agg.copy()
-        else:
-            self.original_aggs = agg
         self.normalize_agg(agg)
         self.normalize_values()
         aggs_as_list = self.get_aggs_as_list()
@@ -385,6 +381,10 @@ class _GroupbyHelper(object):
 
         For a Series, the dictionary has a single key ``None``
         """
+        if hasattr(agg, "copy"):
+            self.original_aggs = agg.copy()
+        else:
+            self.original_aggs = agg
         if isinstance(agg, collections.abc.Mapping):
             for col_name, agg_name in agg.items():
                 if not isinstance(agg_name, list):
@@ -525,6 +525,20 @@ class _GroupbyHelper(object):
             else:
                 return aggs_as_list
         else:
+            return_multi_index = True
+            if isinstance(self.original_aggs, str):
+                return_multi_index = False
+            if isinstance(self.original_aggs, collections.abc.Mapping):
+                return_multi_index = False
+                for key in self.original_aggs:
+                    if not isinstance(self.original_aggs[key], str):
+                        return_multi_index = True
+                        break
+            if return_multi_index:
+                return MultiIndex.from_tuples(zip(value_names, aggs_as_list))
+            else:
+                return value_names
+            """
             if (
                 isinstance(self.original_aggs, collections.abc.Mapping)
                 and len(self.original_aggs) == 1
@@ -544,6 +558,7 @@ class _GroupbyHelper(object):
                     return MultiIndex.from_tuples(
                         zip(value_names, aggs_as_list)
                     )
+            """
 
     def get_aggs_as_list(self):
         """

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -352,6 +352,7 @@ class _GroupbyHelper(object):
         """
         Computes the groupby result
         """
+        self.original_aggs = agg
         self.normalize_agg(agg)
         self.normalize_values()
         aggs_as_list = self.get_aggs_as_list()
@@ -520,7 +521,9 @@ class _GroupbyHelper(object):
             else:
                 return aggs_as_list
         else:
-            if len(aggs_as_list) == len(self.aggs):
+            if len(aggs_as_list) == len(self.aggs) and not isinstance(
+                list(self.original_aggs.values())[0], collections.abc.Sequence
+            ):
                 return value_names
             else:
                 return MultiIndex.from_tuples(zip(value_names, aggs_as_list))

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -538,27 +538,6 @@ class _GroupbyHelper(object):
                 return MultiIndex.from_tuples(zip(value_names, aggs_as_list))
             else:
                 return value_names
-            """
-            if (
-                isinstance(self.original_aggs, collections.abc.Mapping)
-                and len(self.original_aggs) == 1
-            ):
-                if not isinstance(list(self.original_aggs.values())[0], str):
-                    return MultiIndex.from_tuples(
-                        zip(value_names, aggs_as_list)
-                    )
-                else:
-                    return value_names
-            else:
-                if len(aggs_as_list) == len(self.aggs) or isinstance(
-                    self.original_aggs, str
-                ):
-                    return value_names
-                else:
-                    return MultiIndex.from_tuples(
-                        zip(value_names, aggs_as_list)
-                    )
-            """
 
     def get_aggs_as_list(self):
         """

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -1025,7 +1025,9 @@ def as_index(arbitrary, **kwargs):
 
     kwargs = _setdefault_name(arbitrary, kwargs)
 
-    if isinstance(arbitrary, Index):
+    if isinstance(arbitrary, cudf.MultiIndex):
+        return arbitrary
+    elif isinstance(arbitrary, Index):
         idx = arbitrary.copy(deep=False)
         idx.rename(**kwargs, inplace=True)
         return idx
@@ -1043,8 +1045,6 @@ def as_index(arbitrary, **kwargs):
         return RangeIndex(
             start=arbitrary._start, stop=arbitrary._stop, **kwargs
         )
-    elif isinstance(arbitrary, cudf.MultiIndex):
-        return arbitrary
     elif isinstance(arbitrary, pd.MultiIndex):
         return cudf.MultiIndex.from_pandas(arbitrary)
     else:

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -712,11 +712,9 @@ class MultiIndex(Index):
         return args[0]
 
     def array_equal(*args, **kwargs):
-        breakpoint()
         return args[0] == args[1]
 
     def __array_function__(self, func, types, args, kwargs):
-        breakpoint()
         cudf_df_module = MultiIndex
 
         for submodule in func.__module__.split(".")[1:]:

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -695,10 +695,6 @@ class MultiIndex(Index):
                 n += col._memory_usage(deep=deep)
         return n
 
-    def __array__(self, dtype=None) -> np.ndarray:
-        """ the array interface, return my values """
-        return np.array(list(self), dtype="object")
-
     def difference(self, other, sort=None):
         temp_self = self
         temp_other = other

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -699,6 +699,15 @@ class MultiIndex(Index):
         """ the array interface, return my values """
         return np.array(list(self), dtype="object")
 
+    def difference(self, other, sort=None):
+        temp_self = self
+        temp_other = other
+        if hasattr(self, "to_pandas"):
+            temp_self = self.to_pandas()
+        if hasattr(other, "to_pandas"):
+            temp_other = self.to_pandas()
+        return temp_self.difference(temp_other, sort)
+
     def nan_to_num(*args, **kwargs):
         return args[0]
 
@@ -719,7 +728,7 @@ class MultiIndex(Index):
 
         fname = func.__name__
 
-        handled_types = [cudf_df_module]
+        handled_types = [cudf_df_module, np.ndarray]
 
         for t in types:
             if t not in handled_types:

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4391,3 +4391,19 @@ def test_setitem_diff_size_series(series_input, key):
     got = got.astype("float64")
 
     assert_eq(expect, got)
+
+
+def test_tupleize_cols_False_set():
+    pdf = pd.DataFrame()
+    gdf = DataFrame()
+    pdf[("a", "b")] = [1]
+    gdf[("a", "b")] = [1]
+    assert_eq(pdf, gdf)
+    assert_eq(pdf.columns, gdf.columns)
+
+
+def test_init_multiindex_from_dict():
+    pdf = pd.DataFrame({("a", "b"): [1]})
+    gdf = DataFrame({("a", "b"): [1]})
+    assert_eq(pdf, gdf)
+    assert_eq(pdf.columns, gdf.columns)

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -393,9 +393,8 @@ def test_multiindex_index_and_columns():
         levels=[["val"], ["mean", "min"]], codes=[[0, 0], [0, 1]]
     )
     gdf.columns = mc
-    pdf.index = mi
-    pdf.index.names = ["x", "y"]
-    pdf.columns = mc
+    pdf.index = mi.to_pandas()
+    pdf.columns = mc.to_pandas()
     assert_eq(pdf, gdf)
 
 

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -715,6 +715,12 @@ def test_multicolumn_reset_index():
     gdg = gdf.groupby(["x"]).agg({"y": ["count", "mean"]})
     pdg = pdf.groupby(["x"]).agg({"y": ["count", "mean"]})
     assert_eq(pdg.reset_index(), gdg.reset_index(), check_dtype=False)
+    gdg = gdf.groupby(["x"]).agg({"y": ["count"]})
+    pdg = pdf.groupby(["x"]).agg({"y": ["count"]})
+    assert_eq(pdg.reset_index(), gdg.reset_index(), check_dtype=False)
+    gdg = gdf.groupby(["x"]).agg({"y": "count"})
+    pdg = pdf.groupby(["x"]).agg({"y": "count"})
+    assert_eq(pdg.reset_index(), gdg.reset_index(), check_dtype=False)
 
 
 def test_multiindex_multicolumn_reset_index():

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -622,6 +622,7 @@ def reduction(
         meta_chunk = _emulate(apply, chunk, args, chunk_kwargs)
         meta = _emulate(apply, aggregate, [[meta_chunk]], aggregate_kwargs)
     meta = dd.core.make_meta(meta)
+    breakpoint()
 
     for arg in args:
         if isinstance(arg, _Frame):

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -622,7 +622,6 @@ def reduction(
         meta_chunk = _emulate(apply, chunk, args, chunk_kwargs)
         meta = _emulate(apply, aggregate, [[meta_chunk]], aggregate_kwargs)
     meta = dd.core.make_meta(meta)
-    breakpoint()
 
     for arg in args:
         if isinstance(arg, _Frame):

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -308,3 +308,16 @@ def test_groupby_reset_index_multiindex(groupby_keys, agg_func):
     gf = gr.compute().sort_values(groupby_keys).reset_index(drop=True)
     pf = pr.compute().sort_values(groupby_keys).reset_index(drop=True)
     dd.assert_eq(gf, pf)
+
+
+def test_groupby_reset_index_drop_True():
+    df = cudf.DataFrame(
+        {"a": np.random.randint(0, 10, 10), "b": np.random.randint(0, 5, 10)}
+    )
+    ddf = dask_cudf.from_cudf(df, 5)
+    pddf = dd.from_pandas(df.to_pandas(), 5)
+    gr = ddf.groupby(["a"]).agg({"b": ["count"]}).reset_index(drop=True)
+    pr = pddf.groupby(["a"]).agg({"b": ["count"]}).reset_index(drop=True)
+    gf = gr.compute()
+    pf = pr.compute()
+    dd.assert_eq(gf, pf)

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -280,13 +280,7 @@ def test_groupby_multiindex_reset_index():
 
 
 @pytest.mark.parametrize(
-    "groupby_keys",
-    [
-        ["a"],
-        ["a", "b"],
-        ["a", "b", "d"],
-        ["a", "d", "b"],
-    ],
+    "groupby_keys", [["a"], ["a", "b"], ["a", "b", "d"], ["a", "d", "b"],],
 )
 @pytest.mark.parametrize(
     "agg_func",

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -246,6 +246,7 @@ def test_groupby_string_index_name(myindex):
 @pytest.mark.parametrize(
     "agg_func",
     [
+        lambda gb: gb.agg({"c": ["count"]}, split_out=2),
         lambda gb: gb.agg({"c": "count"}, split_out=2),
         lambda gb: gb.agg({"c": ["count", "sum"]}, split_out=2),
         lambda gb: gb.count(split_out=2),

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -280,7 +280,7 @@ def test_groupby_multiindex_reset_index():
 
 
 @pytest.mark.parametrize(
-    "groupby_keys", [["a"], ["a", "b"], ["a", "b", "d"], ["a", "d", "b"]],
+    "groupby_keys", [["a"], ["a", "b"], ["a", "b", "dd"], ["a", "dd", "b"]],
 )
 @pytest.mark.parametrize(
     "agg_func",
@@ -298,7 +298,7 @@ def test_groupby_reset_index_multiindex(groupby_keys, agg_func):
             "a": np.random.randint(0, 10, 10),
             "b": np.random.randint(0, 5, 10),
             "c": np.random.randint(0, 5, 10),
-            "d": np.random.randint(0, 5, 10),
+            "dd": np.random.randint(0, 5, 10),
         }
     )
     ddf = dask_cudf.from_cudf(df, 5)

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -280,7 +280,7 @@ def test_groupby_multiindex_reset_index():
 
 
 @pytest.mark.parametrize(
-    "groupby_keys", [["a"], ["a", "b"], ["a", "b", "d"], ["a", "d", "b"],],
+    "groupby_keys", [["a"], ["a", "b"], ["a", "b", "d"], ["a", "d", "b"]],
 )
 @pytest.mark.parametrize(
     "agg_func",


### PR DESCRIPTION
This PR addresses three fundamental issues:

1. libcudf++ refactor breaks MultiIndex flattening

Flattening MultiIndexes into a set of tuple column names used to work implicitly with Pandas approach. Using `_data` and `OrderedColumnDict`  in the refactor affected this implicit parallel.

2. Groupby column structure varies between `.agg({'a': 'count'})` and `.agg({'a': ['count']})`.

We have been returning a single column structure for both of the above cases - This worked with implicit column flattening #1 above, but now needs to be separated to work in dask.

3. Without implicit column flattening, `MultiIndex` needs to support a series of numpy `__array_function__` protocol functions to work in dask.

When columns were being flattened, protocol functions were being called on `list` instead of `cudf.MultiColumn`. Now those functions need to be implemented.

Fixes #3904 