### PR TITLE
Restore legacy NVStrings and NVCategory dependencies in Java jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - PR #3888 Drop `ptr=None` from `DeviceBuffer` call
 - PR #3953 Fix overflow in column_buffer when computing the device buffer size
+- PR #3964 Restore legacy NVStrings and NVCategory dependencies in Java jar
 
 
 # cuDF 0.12.0 (Date TBD)

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -454,6 +454,8 @@
                                     <directory>${native.cudf.path}</directory>
                                     <includes>
                                         <include>libcudf.so</include>
+                                        <include>libNVCategory.so</include>
+                                        <include>libNVStrings.so</include>
                                     </includes>
                                 </resource>
                                 <resource>

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -34,6 +34,8 @@ public class NativeDepsLoader {
   private static final String[] loadOrder = new String[] {
       "boost_filesystem",
       "rmm",
+      "NVStrings",
+      "NVCategory",
       "cudf",
       "cudfjni"
   };

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -135,6 +135,35 @@ if (RMM_INCLUDE AND RMM_LIBRARY)
 endif (RMM_INCLUDE AND RMM_LIBRARY)
 
 ###################################################################################################
+# - NVStrings -------------------------------------------------------------------------------------
+
+# NVSTRING_INCLUDE is the same as CUDF_INCLUDE
+
+find_library(NVSTRINGS_LIBRARY "NVStrings"
+             HINTS "$ENV{NVSTRINGS_ROOT}/lib"
+                   "$ENV{CONDA_PREFIX}/lib"
+                   "../../../../cpp/build")
+
+find_library(NVCATEGORY_LIBRARY "NVCategory"
+             HINTS "$ENV{NVSTRINGS_ROOT}/lib"
+                   "$ENV{CONDA_PREFIX}/lib"
+                   "../../../../cpp/build")
+
+message(STATUS "NVSTRINGS: NVSTRINGS_LIBRARY set to ${NVSTRINGS_LIBRARY}")
+message(STATUS "NVSTRINGS: NVCATEGORY_LIBRARY set to ${NVCATEGORY_LIBRARY}")
+
+add_library(NVStrings SHARED IMPORTED ${NVSTRINGS_LIBRARY})
+if (NVSTRINGS_LIBRARY)
+    set_target_properties(NVStrings PROPERTIES IMPORTED_LOCATION ${NVSTRINGS_LIBRARY})
+endif (NVSTRINGS_LIBRARY)
+
+add_library(NVCategory SHARED IMPORTED ${NVCATEGORY_LIBRARY})
+if (NVCATEGORY_LIBRARY)
+    set_target_properties(NVCategory PROPERTIES IMPORTED_LOCATION ${NVCATEGORY_LIBRARY})
+endif (NVCATEGORY_LIBRARY)
+
+
+###################################################################################################
 # - find JNI -------------------------------------------------------------------------------------
 find_package(JNI REQUIRED)
 if(JNI_FOUND)


### PR DESCRIPTION
The new JNI has moved to libcudf++ and no longer uses NVCategory and NVStrings, but libcudf.so still links against those libraries for its legacy code and therefore they must be available in order for libcudf.so to successfully load.  This PR restores the code that places those two dependency libs in the cudf jar and dynamically loads them before attempting to load libcudf.so.

These two libraries can be removed from the jar and load table when libcudf.so stops dynamically linking against them.
