### PR TITLE
[WIP] Define and implement extract_record API.

### DIFF
--- a/cpp/include/cudf/strings/extract_record.hpp
+++ b/cpp/include/cudf/strings/extract_record.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/table/table.hpp>
+
+namespace cudf
+{
+namespace strings
+{
+
+/**
+ * @brief Returns a table of string columns for each matching group specified in the given regular expression pattern.
+ *
+ * All the strings for the first group will go in the first output column; the second group
+ * go in the second column and so on. Null entries are added if the string does match.
+ *
+ * Any null string entries return corresponding null output column entries.
+ * The number of output columns coincides with the number groups defined in the regex pattern parameter.
+ *
+ * ```
+ * s = ["a1","b2","c3"]
+ * r = extract(s,"([ab])(\\d)")
+ * r is now [["a","1"],
+ *           ["b","2"],
+ *           [null,null]]
+ * ```
+ *
+ * @param strings String column to search for regex patterns.
+ * @param pattern The regular expression pattern with group indicators.
+ * @param mr Resource for allocating device memory.
+ * @return Table of string columns extracted from the input column.
+ */
+std::unique_ptr<experimental::table> extract_record( strings_column_view const& strings,
+                                                     std::string const& pattern,
+                                                     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+
+} // namespace strings
+} // namespace cudf


### PR DESCRIPTION
This tracks porting work for https://github.com/rapidsai/cudf/issues/3826, for porting `extract_record()` functionality (more here: https://rapidsai.github.io/projects/nvstrings/en/0.11.0/api.html#nvstrings.nvstrings.extract_record)