### PR TITLE
Update RMM include files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #3910 Adding sinh, cosh, tanh, asinh, acosh, atanh cube root and rint unary support.
 - PR #3972 Add Java bindings for left_semi_join and left_anti_join
 - PR #3975 Simplify and generalize data handling in `Buffer`
+- PR #3985 Update RMM include files and remove extraneously included header files.
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 - PR #3880 Add aggregation infrastructure support for reduction
 - PR #4021 Change quantiles signature for clarity.
 
-
 ## Bug Fixes
 
 - PR #3888 Drop `ptr=None` from `DeviceBuffer` call

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -20,7 +20,7 @@
 #include "column_view.hpp"
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <memory>
 #include <type_traits>

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -20,7 +20,6 @@
 #include "column_view.hpp"
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <memory>
 #include <type_traits>

--- a/cpp/include/cudf/datetime.hpp
+++ b/cpp/include/cudf/datetime.hpp
@@ -18,6 +18,8 @@
 
 #include <cudf/types.hpp>
 
+#include <memory>
+
 namespace cudf {
 namespace datetime {
 namespace detail {

--- a/cpp/include/cudf/datetime.hpp
+++ b/cpp/include/cudf/datetime.hpp
@@ -16,9 +16,7 @@
 
 #pragma once
 
-#include <cudf/column/column.hpp>
-#include <cudf/column/column_view.hpp>
-#include <rmm/mr/default_memory_resource.hpp>
+#include <cudf/types.hpp>
 
 namespace cudf {
 namespace datetime {

--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -23,7 +23,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <rmm/device_scalar.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cub/cub.cuh>
 

--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -23,7 +23,6 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <rmm/device_scalar.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cub/cub.cuh>
 

--- a/cpp/include/cudf/detail/fill.hpp
+++ b/cpp/include/cudf/detail/fill.hpp
@@ -18,9 +18,6 @@
 
 #include <cudf/filling.hpp>
 #include <cudf/types.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
-
-#include <cuda_runtime.h>
 
 #include <memory>
 

--- a/cpp/include/cudf/detail/fill.hpp
+++ b/cpp/include/cudf/detail/fill.hpp
@@ -18,7 +18,7 @@
 
 #include <cudf/filling.hpp>
 #include <cudf/types.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cuda_runtime.h>
 

--- a/cpp/include/cudf/detail/repeat.hpp
+++ b/cpp/include/cudf/detail/repeat.hpp
@@ -16,11 +16,7 @@
 
 #pragma once
 
-#include <cudf/filling.hpp>
 #include <cudf/types.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
-
-#include <cuda_runtime.h>
 
 #include <memory>
 

--- a/cpp/include/cudf/detail/repeat.hpp
+++ b/cpp/include/cudf/detail/repeat.hpp
@@ -18,7 +18,7 @@
 
 #include <cudf/filling.hpp>
 #include <cudf/types.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cuda_runtime.h>
 

--- a/cpp/include/cudf/filling.hpp
+++ b/cpp/include/cudf/filling.hpp
@@ -17,8 +17,6 @@
 #pragma once
 
 #include <cudf/types.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <memory>
 

--- a/cpp/include/cudf/filling.hpp
+++ b/cpp/include/cudf/filling.hpp
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <cudf/types.hpp>
-#include <rmm/mr/default_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <memory>
 

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -15,11 +15,11 @@
  */
 #pragma once
 
-#include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <vector>
 
 namespace cudf {
 

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -19,7 +19,7 @@
 #include <cudf/types.hpp>
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 namespace cudf {
 

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -22,7 +22,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/thrust_rmm_allocator.h>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <memory>
 #include <type_traits>

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -22,7 +22,6 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/thrust_rmm_allocator.h>
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <memory>
 #include <type_traits>

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -32,7 +32,7 @@
 #include <cub/cub.cuh>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/thrust_rmm_allocator.h>
 
 #include <algorithm>

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -32,7 +32,6 @@
 #include <cub/cub.cuh>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/thrust_rmm_allocator.h>
 
 #include <algorithm>

--- a/cpp/src/column/column.cu
+++ b/cpp/src/column/column.cu
@@ -26,7 +26,7 @@
 #include <cudf/copying.hpp>
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <algorithm>
 #include <numeric>

--- a/cpp/src/column/column.cu
+++ b/cpp/src/column/column.cu
@@ -26,7 +26,6 @@
 #include <cudf/copying.hpp>
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <algorithm>
 #include <numeric>

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -26,7 +26,6 @@
 #include <cudf/strings/detail/copy_range.cuh>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -26,7 +26,7 @@
 #include <cudf/strings/detail/copy_range.cuh>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -18,6 +18,8 @@
 #include <cudf/datetime.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/utilities/traits.hpp>
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
 
 #include <rmm/thrust_rmm_allocator.h>
 

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -25,7 +25,6 @@
 #include <cudf/strings/detail/fill.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cuda_runtime.h>
 

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -25,7 +25,7 @@
 #include <cudf/strings/detail/fill.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cuda_runtime.h>
 

--- a/cpp/src/filling/legacy/tile.cu
+++ b/cpp/src/filling/legacy/tile.cu
@@ -17,7 +17,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/legacy/copying.hpp>
 #include "cudf/types.hpp"
-#include "rmm/mr/device_memory_resource.hpp"
+#include "rmm/mr/device/device_memory_resource.hpp"
 
 #include <cudf/cudf.h>
 #include <cudf/types.h>

--- a/cpp/src/filling/legacy/tile.cu
+++ b/cpp/src/filling/legacy/tile.cu
@@ -17,7 +17,6 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/legacy/copying.hpp>
 #include "cudf/types.hpp"
-#include "rmm/mr/device/device_memory_resource.hpp"
 
 #include <cudf/cudf.h>
 #include <cudf/types.h>

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -27,7 +27,6 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <rmm/thrust_rmm_allocator.h>
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/constant_iterator.h>

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -27,7 +27,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <rmm/thrust_rmm_allocator.h>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/constant_iterator.h>

--- a/cpp/src/hash/hash_allocator.cuh
+++ b/cpp/src/hash/hash_allocator.cuh
@@ -20,9 +20,9 @@
 #include <new>
 
 #include <rmm/rmm.h>
-#include <rmm/mr/device_memory_resource.hpp>
-#include <rmm/mr/managed_memory_resource.hpp>
-#include <rmm/mr/default_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/managed_memory_resource.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
 
 template <class T>
 struct managed_allocator {

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -20,7 +20,6 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 namespace cudf {
 namespace experimental {

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -20,7 +20,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 namespace cudf {
 namespace experimental {

--- a/cpp/src/table/table.cpp
+++ b/cpp/src/table/table.cpp
@@ -16,7 +16,6 @@
 
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <cudf/utilities/error.hpp>
 
 namespace cudf {

--- a/cpp/src/table/table.cpp
+++ b/cpp/src/table/table.cpp
@@ -16,7 +16,7 @@
 
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 #include <cudf/utilities/error.hpp>
 
 namespace cudf {

--- a/cpp/tests/column/factories_test.cpp
+++ b/cpp/tests/column/factories_test.cpp
@@ -21,8 +21,6 @@
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/type_lists.hpp>
 
-#include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <gmock/gmock.h>
 

--- a/cpp/tests/column/factories_test.cpp
+++ b/cpp/tests/column/factories_test.cpp
@@ -21,8 +21,8 @@
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/type_lists.hpp>
 
-#include <rmm/mr/default_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <gmock/gmock.h>
 

--- a/cpp/tests/scalar/factories_test.cpp
+++ b/cpp/tests/scalar/factories_test.cpp
@@ -20,8 +20,8 @@
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/type_lists.hpp>
 
-#include <rmm/mr/default_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <gmock/gmock.h>
 

--- a/cpp/tests/scalar/factories_test.cpp
+++ b/cpp/tests/scalar/factories_test.cpp
@@ -20,9 +20,6 @@
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/type_lists.hpp>
 
-#include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
-
 #include <gmock/gmock.h>
 
 class ScalarFactoryTest : public cudf::test::BaseFixture {

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -20,8 +20,8 @@
 #include <cudf/wrappers/bool.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/mr/default_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <ftw.h>
 #include <random>


### PR DESCRIPTION
Corresponds to https://github.com/rapidsai/rmm/pull/262

- [x] Updates libcudf includes of RMM files to reflect changes in https://github.com/rapidsai/rmm/pull/262
- [x] Removes extraneous includes of RMM headers
