### PR TITLE
[REVIEW] Fix for copy_bitmask issue with uninitialized device_buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #3970 Fix for Series Pickle
 - PR #3964 Restore legacy NVStrings and NVCategory dependencies in Java jar
 - PR #3982 Fix java unary op enum and add missing ops
+- PR #4007 Fix for copy_bitmask issue with uninitialized device_buffer
 
 
 # cuDF 0.12.0 (Date TBD)

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -287,7 +287,7 @@ __global__ void copy_offset_bitmask(bitmask_type *__restrict__ destination,
        destination_word_index < number_of_mask_words;
        destination_word_index += blockDim.x * gridDim.x) {
     destination[destination_word_index] =
-        get_mask_offset_word(source, destination_word_index, source_begin_bit, source_end_bit);
+      get_mask_offset_word(source, destination_word_index, source_begin_bit, source_end_bit);
   }
 }
 

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -275,19 +275,25 @@ __global__ void subtract_set_bits_range_boundaries_kerenel(
  * @param source The mask to copy from
  * @param source_begin_bit The offset into `source` from which to begin the copy
  * @param source_end_bit   The offset into `source` till which copying is done
- * @param number_of_mask_words The number of `cudf::bitmask_type` words to copy
+ * @param number_of_mask_words The number of `cudf::bitmask_type` words to copy,
+ *        these are the words with actual masking bits, this number may not be
+ *        equal to actual size of the mask which includes padding.
+ * @param number_of_words The number of `cudf::bitmask_type` words including
+ *        padding
  *---------------------------------------------------------------------------**/
 // TODO: Also make binops test that uses offset in column_view
 __global__ void copy_offset_bitmask(bitmask_type *__restrict__ destination,
                                     bitmask_type const *__restrict__ source,
                                     size_type source_begin_bit,
                                     size_type source_end_bit,
-                                    size_type number_of_mask_words) {
+                                    size_type number_of_mask_words,
+                                    size_type number_of_words) {
   for (size_type destination_word_index = threadIdx.x + blockIdx.x * blockDim.x;
-       destination_word_index < number_of_mask_words;
+       destination_word_index < number_of_words;
        destination_word_index += blockDim.x * gridDim.x) {
     destination[destination_word_index] =
-      get_mask_offset_word(source, destination_word_index, source_begin_bit, source_end_bit);
+        (destination_word_index< number_of_mask_words)?
+        get_mask_offset_word(source, destination_word_index, source_begin_bit, source_end_bit) : 0;
   }
 }
 
@@ -675,7 +681,7 @@ rmm::device_buffer copy_bitmask(bitmask_type const *mask, size_type begin_bit,
     copy_offset_bitmask<<<config.num_blocks, config.num_threads_per_block, 0,
                           stream>>>(
         static_cast<bitmask_type *>(dest_mask.data()), mask, begin_bit, end_bit,
-        number_of_mask_words);
+        number_of_mask_words, num_bytes/sizeof(bitmask_type));
     CHECK_CUDA(stream);
   }
   return dest_mask;

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -271,7 +271,7 @@ void expect_equal_buffers(void const* lhs, void const* rhs,
                             typed_rhs));
 }
 
-// copy column bitbitmask to host (used by to_host())
+// copy column bitmask to host (used by to_host())
 std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c) {
   if (c.nullable()) {
     auto num_bitmasks = bitmask_allocation_size_bytes(c.size()) / sizeof(bitmask_type);

--- a/cpp/tests/utilities/column_utilities.hpp
+++ b/cpp/tests/utilities/column_utilities.hpp
@@ -113,6 +113,21 @@ void print(cudf::column_view const& col, std:: ostream &os = std::cout, std::str
  *---------------------------------------------------------------------------**/
 std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c);
 
+/**---------------------------------------------------------------------------*
+ * @brief Validates bitmask situated in host as per `number_of_elements`
+ *
+ * This takes care of padded bits
+ *
+ * @param        expected_mask A vector representing expected mask
+ * @param        got_mask A vector representing mask obtained from column
+ * @param        number_of_elements number of elements the mask represent
+ *
+ * @returns      true if both vector match till the `number_of_elements`
+ *---------------------------------------------------------------------------**/
+bool validate_host_masks(std::vector<bitmask_type> const& expected_mask,
+                         std::vector<bitmask_type> const& got_mask_begin,
+                         size_type number_of_elements);
+
 /**
  * @brief Copies the data and bitmask of a `column_view` to the host.
  *

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -100,7 +100,7 @@ TYPED_TEST(ColumnUtilitiesTest, NullableToHostWithOffset) {
 
   auto masks = cudf::test::detail::make_null_mask_vector(valid + split, valid + size);
 
-  EXPECT_TRUE(std::equal(masks.begin(), masks.end(), host_data.second.begin()));
+  EXPECT_TRUE(cudf::test::validate_host_masks(masks, host_data.second, expected_data.size()));
 }
 
 TYPED_TEST(ColumnUtilitiesTest, NullableToHostAllValid) {


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
The device_buffer being created for mask is bigger due to padding and kernel is not updating these padded bytes, so there are chances these bytes have some residual values. Which caused issue in one of the test cases. The test case has been updated to just check bits equivalent to number of elements.