### PR TITLE
quantiles: rename and adjust signature for clarity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #3910 Adding sinh, cosh, tanh, asinh, acosh, atanh cube root and rint unary support.
 - PR #3972 Add Java bindings for left_semi_join and left_anti_join
 - PR #3975 Simplify and generalize data handling in `Buffer`
+- PR #---- Change quantiles signature for clarity.
 - PR #3911 Adding null boolean handling for copy_if_else
 - PR #4002 Adding to_frame and fix for categorical column issue
 - PR #4009 build script update to enable cudf build without installing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - PR #3910 Adding sinh, cosh, tanh, asinh, acosh, atanh cube root and rint unary support.
 - PR #3972 Add Java bindings for left_semi_join and left_anti_join
 - PR #3975 Simplify and generalize data handling in `Buffer`
-- PR #---- Change quantiles signature for clarity.
+- PR #4021 Change quantiles signature for clarity.
 - PR #3911 Adding null boolean handling for copy_if_else
 - PR #4002 Adding to_frame and fix for categorical column issue
 - PR #4009 build script update to enable cudf build without installing

--- a/cpp/include/cudf/quantiles.hpp
+++ b/cpp/include/cudf/quantiles.hpp
@@ -26,7 +26,7 @@ namespace experimental {
 /* @brief Computes a value for a quantile by interpolating between the values on
  *        either side of the desired quantile.
  *
- * @param[in] input        Columns used to compute quantile values.
+ * @param[in] input        Column used to compute quantile values.
  * @param[in] q            Desired quantile in range [0, 1].
  * @param[in] interp       Strategy used to interpolate between the two values
  *                         on either side of the desired quantile.

--- a/cpp/include/cudf/quantiles.hpp
+++ b/cpp/include/cudf/quantiles.hpp
@@ -23,25 +23,24 @@
 namespace cudf {
 namespace experimental {
 
-/* @brief For each column, computes a value for a quantile by interpolating
- *        between the values on either side of the desired quantile.
+/* @brief Computes a value for a quantile by interpolating between the values on
+ *        either side of the desired quantile.
  *
- * @param[in] input        Table containing columns used to compute quantile
- *                         values.
+ * @param[in] input        Columns used to compute quantile values.
  * @param[in] q            Desired quantile in range [0, 1].
  * @param[in] interp       Strategy used to interpolate between the two values
  *                         on either side of the desired quantile.
- * @param[in] column_order Indicates the sortedness of columns.
+ * @param[in] column_order Indicates the sortedness of the column.
  *
- * @returns Value of the desired quantile for each column, or null if the column
- *          has no valid elements.
+ * @returns Value of the desired quantile, or null if the column has no valid
+ *          elements.
  */
 
-std::vector<std::unique_ptr<scalar>>
-quantiles(table_view const& input,
-          double q,
-          interpolation interp = interpolation::LINEAR,
-          std::vector<order_info> column_order = {});
+std::unique_ptr<scalar>
+quantile(column_view const& input,
+         double q,
+         interpolation interp = interpolation::LINEAR,
+         order_info column_order = {});
 
 } // namespace experimental
 } // namespace cudf

--- a/cpp/src/quantiles/quantiles.cu
+++ b/cpp/src/quantiles/quantiles.cu
@@ -93,40 +93,16 @@ struct quantile_functor
 };
 
 } // anonymous namespace
+} // namespace detail
 
 std::unique_ptr<scalar>
 quantile(column_view const& input,
-         double percent,
+         double q,
          interpolation interp,
          order_info column_order)
 {
         return type_dispatcher(input.type(), detail::quantile_functor{},
-                               input, percent, interp, column_order);
-}
-
-} // namspace detail
-
-std::vector<std::unique_ptr<scalar>>
-quantiles(table_view const& input,
-          double percent,
-          interpolation interp,
-          std::vector<order_info> column_order)
-{
-    if (column_order.size() == 0) {
-        column_order = std::vector<order_info>(input.num_columns(), { false });
-    } else {
-        CUDF_EXPECTS(column_order.size() == static_cast<uint32_t>(input.num_columns()),
-                     "Must provide order_info for each column.");
-    }
-
-    std::vector<std::unique_ptr<scalar>> out(input.num_columns());
-    for (size_type i = 0; i < input.num_columns(); i++) {
-        out[i] = detail::quantile(input.column(i),
-                                  percent,
-                                  interp,
-                                  column_order[i]);
-    }
-    return out;
+                               input, q, interp, column_order);
 }
 
 } // namespace experimental


### PR DESCRIPTION
Related to #4011.

Changing `cudf::experimental::quantiles` name/signature in preparation for multi-column API to reduce confusion.