### PR TITLE
[REVIEW] JNI and Java support for is_nan and is_not_nan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #4008 Eliminate extra copy in column constructor
 - PR #4013 Add cython definition for io readers cudf/io/io_types.hpp
 - PR #4014 ORC/Parquet: add count parameter to stripe/rowgroup-based reader API
+- PR #4038 JNI and Java support for is_nan and is_not_nan
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -779,6 +779,30 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
     }
   }
 
+  /**
+   * Returns a Boolean vector with the same number of rows as this instance, that has
+   * TRUE for any entry that is Nan, and FALSE otherwise
+   *
+   * @return - Boolean vector
+   */
+  public ColumnVector isNan() {
+    try (DevicePrediction prediction = new DevicePrediction(predictSizeFor(DType.BOOL8),"isNan")) {
+      return new ColumnVector(isNanNative(offHeap.cudfColumnHandle.getViewHandle()));
+    }
+  }
+
+  /**
+   * Returns a Boolean vector with the same number of rows as this instance, that has
+   * TRUE for any entry that is not Nan, and FALSE otherwise
+   *
+   * @return - Boolean vector
+   */
+  public ColumnVector isNotNan() {
+    try (DevicePrediction prediction = new DevicePrediction(predictSizeFor(DType.BOOL8),"isNan")) {
+      return new ColumnVector(isNotNanNative(offHeap.cudfColumnHandle.getViewHandle()));
+    }
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Replacement
   /////////////////////////////////////////////////////////////////////////////
@@ -2172,6 +2196,10 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
   private static native long reduce(long viewHandle, int reduceOp, int dtype) throws CudfException;
 
   private static native long isNullNative(long viewHandle);
+
+  private static native long isNanNative(long viewHandle);
+
+  private static native long isNotNanNative(long viewHandle);
 
   private static native long isNotNullNative(long viewHandle);
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -781,8 +781,7 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
 
   /**
    * Returns a Boolean vector with the same number of rows as this instance, that has
-   * TRUE for any entry that is Nan, and FALSE otherwise
-   *
+   * TRUE for any entry that is NaN, and FALSE if null or a valid floating point value
    * @return - Boolean vector
    */
   public ColumnVector isNan() {
@@ -793,8 +792,7 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
 
   /**
    * Returns a Boolean vector with the same number of rows as this instance, that has
-   * TRUE for any entry that is not Nan, and FALSE otherwise
-   *
+   * TRUE for any entry that is null or a valid floating point value, FALSE otherwise
    * @return - Boolean vector
    */
   public ColumnVector isNotNan() {

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -370,6 +370,26 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNotNullNative(JNIEnv 
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNanNative(JNIEnv *env, jclass, jlong handle) {
+  JNI_NULL_CHECK(env, handle, "input column is null", 0);
+  try {
+    const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(handle);
+    std::unique_ptr<cudf::column> ret = cudf::experimental::is_nan(*input);
+    return reinterpret_cast<jlong>(ret.release());
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNotNanNative(JNIEnv *env, jclass, jlong handle) {
+  JNI_NULL_CHECK(env, handle, "input column is null", 0);
+  try {
+    const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(handle);
+    std::unique_ptr<cudf::column> ret = cudf::experimental::is_not_nan(*input);
+    return reinterpret_cast<jlong>(ret.release());
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_unaryOperation(JNIEnv *env, jclass,
         jlong input_ptr, jint int_op) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -229,6 +229,78 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void isNanTest() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.0, 2.0, Double.NaN, 4.0, Double.NaN, 6.0);
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, true, false, true, false);
+         ColumnVector result = v.isNan()) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void isNanTestEmptyColumn() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles();
+         ColumnVector expected = ColumnVector.fromBoxedBooleans();
+         ColumnVector result = v.isNan()) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void isNanTestAllNotNans() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, false, false, false, false);
+         ColumnVector result = v.isNan()) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void isNanTestAllNans() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, true, true, true, true);
+         ColumnVector result = v.isNan()) {
+      assertColumnsAreEqual(result, expected);
+    }
+  }
+
+  @Test
+  void isNotNanTest() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.0, 2.0, Double.NaN, 4.0, Double.NaN, 6.0);
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, false, true);
+         ColumnVector result = v.isNotNan()) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void isNotNanTestEmptyColumn() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles();
+         ColumnVector expected = ColumnVector.fromBoxedBooleans();
+         ColumnVector result = v.isNotNan()) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void isNotNanTestAllNotNans() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, true, true, true, true);
+         ColumnVector result = v.isNotNan()) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void isNotNanTestAllNans() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, false, false, false, false);
+         ColumnVector result = v.isNotNan()) {
+      assertColumnsAreEqual(result, expected);
+    }
+  }
+
+  @Test
   void testGetDeviceMemorySizeNonStrings() {
     try (ColumnVector v0 = ColumnVector.fromBoxedInts(1, 2, 3, 4, 5, 6);
          ColumnVector v1 = ColumnVector.fromBoxedInts(1, 2, 3, null, null, 4, 5, 6)) {

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -228,75 +228,139 @@ public class ColumnVectorTest extends CudfTestBase {
     }
   }
 
+   @Test
+  void isNanTestWithNulls() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(null, null, Double.NaN, null, Double.NaN, null);
+         ColumnVector vF = ColumnVector.fromBoxedFloats(null, null, Float.NaN, null, Float.NaN, null);
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, true, false, true, false);
+         ColumnVector result = v.isNan();
+         ColumnVector resultF = vF.isNan()) {
+      assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
+    }
+  }
+
+  @Test
+  void isNanForTypeMismatch() {
+    assertThrows(CudfException.class, () -> {
+      try (ColumnVector v = ColumnVector.fromStrings("foo", "bar", "baz");
+           ColumnVector result = v.isNan()) {}
+    });
+  }
+
   @Test
   void isNanTest() {
     try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.0, 2.0, Double.NaN, 4.0, Double.NaN, 6.0);
+         ColumnVector vF = ColumnVector.fromBoxedFloats(1.1f, 2.2f, Float.NaN, 4.4f, Float.NaN, 6.6f);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, true, false, true, false);
-         ColumnVector result = v.isNan()) {
+         ColumnVector result = v.isNan();
+         ColumnVector resultF = vF.isNan()) {
       assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
     }
   }
 
   @Test
   void isNanTestEmptyColumn() {
     try (ColumnVector v = ColumnVector.fromBoxedDoubles();
+         ColumnVector vF = ColumnVector.fromBoxedFloats();
          ColumnVector expected = ColumnVector.fromBoxedBooleans();
-         ColumnVector result = v.isNan()) {
+         ColumnVector result = v.isNan();
+         ColumnVector resultF = vF.isNan()) {
       assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
     }
   }
 
   @Test
   void isNanTestAllNotNans() {
     try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+         ColumnVector vF = ColumnVector.fromBoxedFloats(1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, false, false, false, false);
-         ColumnVector result = v.isNan()) {
+         ColumnVector result = v.isNan();
+         ColumnVector resultF = vF.isNan()) {
       assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
     }
   }
 
   @Test
   void isNanTestAllNans() {
     try (ColumnVector v = ColumnVector.fromBoxedDoubles(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+         ColumnVector vF = ColumnVector.fromBoxedFloats(Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, true, true, true, true);
-         ColumnVector result = v.isNan()) {
+         ColumnVector result = v.isNan();
+         ColumnVector resultF = vF.isNan()) {
       assertColumnsAreEqual(result, expected);
+      assertColumnsAreEqual(resultF, expected);
     }
+  }
+
+  @Test
+  void isNotNanTestWithNulls() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(null, null, Double.NaN, null, Double.NaN, null);
+         ColumnVector vF = ColumnVector.fromBoxedFloats(null, null, Float.NaN, null, Float.NaN, null);
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, false, true);
+         ColumnVector result = v.isNotNan();
+         ColumnVector resultF = vF.isNotNan()) {
+      assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
+    }
+  }
+
+  @Test
+  void isNotNanForTypeMismatch() {
+    assertThrows(CudfException.class, () -> {
+      try (ColumnVector v = ColumnVector.fromStrings("foo", "bar", "baz");
+           ColumnVector result = v.isNotNan()) {}
+    });
   }
 
   @Test
   void isNotNanTest() {
     try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.0, 2.0, Double.NaN, 4.0, Double.NaN, 6.0);
+         ColumnVector vF = ColumnVector.fromBoxedFloats(1.1f, 2.2f, Float.NaN, 4.4f, Float.NaN, 6.6f);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, false, true);
-         ColumnVector result = v.isNotNan()) {
+         ColumnVector result = v.isNotNan();
+         ColumnVector resultF = vF.isNotNan()) {
       assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
     }
   }
 
   @Test
   void isNotNanTestEmptyColumn() {
     try (ColumnVector v = ColumnVector.fromBoxedDoubles();
+         ColumnVector vF = ColumnVector.fromBoxedFloats();
          ColumnVector expected = ColumnVector.fromBoxedBooleans();
-         ColumnVector result = v.isNotNan()) {
+         ColumnVector result = v.isNotNan();
+         ColumnVector resultF = vF.isNotNan()) {
       assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
     }
   }
 
   @Test
   void isNotNanTestAllNotNans() {
     try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+         ColumnVector vF = ColumnVector.fromBoxedFloats(1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, true, true, true, true);
-         ColumnVector result = v.isNotNan()) {
+         ColumnVector result = v.isNotNan();
+         ColumnVector resultF = vF.isNotNan()) {
       assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
     }
   }
 
   @Test
   void isNotNanTestAllNans() {
     try (ColumnVector v = ColumnVector.fromBoxedDoubles(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+         ColumnVector vF = ColumnVector.fromBoxedFloats(Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN);
          ColumnVector expected = ColumnVector.fromBoxedBooleans(false, false, false, false, false, false);
-         ColumnVector result = v.isNotNan()) {
-      assertColumnsAreEqual(result, expected);
+         ColumnVector result = v.isNotNan();
+         ColumnVector resultF = vF.isNotNan()) {
+      assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
     }
   }
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -291,8 +291,8 @@ public class ColumnVectorTest extends CudfTestBase {
          ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, true, true, true, true);
          ColumnVector result = v.isNan();
          ColumnVector resultF = vF.isNan()) {
-      assertColumnsAreEqual(result, expected);
-      assertColumnsAreEqual(resultF, expected);
+      assertColumnsAreEqual(expected, result);
+      assertColumnsAreEqual(expected, resultF);
     }
   }
 


### PR DESCRIPTION
Add JNI bindings and java api for is_nan and is_not_nan. Currently needs the compile fix per : https://github.com/rapidsai/cudf/pull/4037 to compile and test. 