### PR TITLE
[gpuCI] Auto-merge branch-0.12 to branch-0.13 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuDF 0.12.0 (Date TBD)
+# cuDF 0.12.0 (04 Feb 2020)
 
 ## New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@
 - PR #3673 Parquet reader: improve rounding of timestamp conversion to seconds 
 - PR #3699 Stringify libcudacxx headers for binary op JIT
 - PR #3697 Improve column insert performance for wide frames
-- PR #3616 Add aggregation infrastructure for argmax/argmin.
 - PR #3653 Make `gather_bitmask_kernel` more reusable.
 - PR #3710 Remove multiple CMake configuration steps from root build script
 - PR #3657 Define and implement compiled binops for string column comparisons


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.12` that creates a PR to keep `branch-0.13` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.