### PR TITLE
[REVIEW] Improve how java classifiers are produced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - PR #4014 ORC/Parquet: add count parameter to stripe/rowgroup-based reader API
 - PR #3880 Add aggregation infrastructure support for reduction
 - PR #4021 Change quantiles signature for clarity.
+- PR #4062 Improve how java classifiers are produced
 
 ## Bug Fixes
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -377,14 +377,11 @@
                             def libcudart = ~/libcudart\\.so\\.(.*)\\s+=>.*/
                             def cm = libcudart.matcher(sout)
                             if (cm.find()) {
-                                switch(cm.group(1)) {
-                                    case ~/10\\.0.*/:
-                                        pom.properties['cuda.classifier'] = 'cuda10'
-                                        break
-                                    default:
-                                        pom.properties['cuda.classifier'] = ''
-                                        break
-                                }
+                                def classifier = 'cuda' + cm.group(1)
+                                  .replaceFirst(/\\./, '-') // First . becomes a -
+                                  .replaceAll(/\\..*$/, '') // Drop all of the subversions from cuda
+                                  .replaceAll(/-0$/, '') // If it is a X.0 version, like 10.0 drop the .0
+                                pom.properties['cuda.classifier'] = classifier
                             } else {
                                 fail("Could not find cudart as a dependency of libcudfjni out> $sout err> $serr")
                             }


### PR DESCRIPTION
This makes it so that the classifier comes from the cuda version without hard coded mapping rules.