### PR TITLE
Fixed mismatch with dtype enums again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - PR #4054 Fixed JNI to deal with reduction API changes
 - PR #4052 Fix for round-robin when num_partitions divides nrows.
 - PR #4049 Fix `cudf::split` issue returning one less than expected column vectors
+- PR #4066 Fixed mismatch with dtype enums
 
 
 # cuDF 0.12.0 (Date TBD)

--- a/java/src/main/java/ai/rapids/cudf/DType.java
+++ b/java/src/main/java/ai/rapids/cudf/DType.java
@@ -50,7 +50,8 @@ public enum DType {
    */
   TIMESTAMP_NANOSECONDS(8, 12, "timestamp[ns]"),
   CATEGORY(4, 13, "category"),
-  STRING(0, 14, "str");
+  //DICTIONARY32(4, 14, "NO IDEA"),
+  STRING(0, 15, "str");
 
   private static final DType[] D_TYPES = DType.values();
   final int sizeInBytes;


### PR DESCRIPTION
Quick fix for when DICTIONARY32 type went in.
