### PR TITLE
Correct doxygen version [skip-ci]

### DIFF
--- a/cpp/custrings/doxygen/Doxyfile
+++ b/cpp/custrings/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "NVStrings"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.10
+PROJECT_NUMBER         = 0.13
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "libcudf"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.12
+PROJECT_NUMBER         = 0.13
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
This should be updated with each release. This results in the doxygen files showing the wrong version for the correct release.