### PR TITLE
Allow round_robin_partition to single partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PR #4062 Improve how java classifiers are produced
 - PR #4038 JNI and Java support for is_nan and is_not_nan
 - PR #3891 Port NVStrings (r)split_record to contiguous_(r)split_record
+- PR #4072 Allow round_robin_partition to single partition
 
 ## Bug Fixes
 

--- a/cpp/src/round_robin/round_robin.cu
+++ b/cpp/src/round_robin/round_robin.cu
@@ -174,7 +174,7 @@ round_robin_partition(table_view const& input,
 {
   auto nrows = input.num_rows();
   
-  CUDF_EXPECTS( num_partitions > 1, "Incorrect number of partitions. Must be greater than 1." );
+  CUDF_EXPECTS( num_partitions > 0, "Incorrect number of partitions. Must be greater than 0." );
   CUDF_EXPECTS( start_partition < num_partitions, "Incorrect start_partition index. Must be less than number of partitions." );
   CUDF_EXPECTS( start_partition >= 0, "Incorrect start_partition index. Must be positive." );//since cudf::size_type is an alias for int32_t, it _can_ be negative
 

--- a/cpp/tests/round_robin/round_robin_test.cpp
+++ b/cpp/tests/round_robin/round_robin_test.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <cudf/types.hpp>
 #include <tests/utilities/base_fixture.hpp>
 #include <cudf/table/table.hpp>
@@ -610,6 +626,60 @@ TYPED_TEST(RoundRobinTest, RoundRobinNPartitionsDivideNRows) {
   }
 }
 
+TYPED_TEST(RoundRobinTest, RoundRobinSinglePartition) {
+  strings_column_wrapper rrColWrap1({"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"}, {1,1,1,1,1,1,1,1,1,1,0});
+
+  cudf::size_type inputRows = static_cast<cudf::column_view const&>(rrColWrap1).size();
+
+  auto sequence_l = cudf::test::make_counting_transform_iterator(0, [](auto row) {
+      if (cudf::experimental::type_to_id<TypeParam>() == cudf::BOOL8) {
+        cudf::experimental::bool8 ret = (row % 2 == 0);
+        return static_cast<TypeParam>(ret);
+      }
+      else
+        return static_cast<TypeParam>(row); });
+
+  fixed_width_column_wrapper<TypeParam> rrColWrap2(sequence_l, sequence_l + inputRows);
+
+  cudf::table_view rr_view{{rrColWrap1, rrColWrap2}};
+
+  cudf::size_type num_partitions = 1;
+  cudf::size_type start_partition = 0;
+  std::pair<std::unique_ptr<cudf::experimental::table>, std::vector<cudf::size_type>> result;
+  EXPECT_NO_THROW(result = cudf::experimental::round_robin_partition(rr_view,
+                                                                     num_partitions,
+                                                                     start_partition));
+
+  auto p_outputTable = std::move(result.first);
+
+  auto output_column_view1{p_outputTable->view().column(0)};
+  auto output_column_view2{p_outputTable->view().column(1)};
+
+  strings_column_wrapper expectedDataWrap1({"a","b","c","d","e","f","g","h","i","j","k"},
+                                           {1,1,1,1,1,1,1,1,1,1,0});
+
+  auto expected_column_view1{static_cast<cudf::column_view const&>(expectedDataWrap1)};
+  cudf::test::expect_columns_equal(expected_column_view1, output_column_view1);
+
+  if (cudf::experimental::type_to_id<TypeParam>() == cudf::BOOL8) {
+    fixed_width_column_wrapper<TypeParam> expectedDataWrap2({1,0,1,0,1,0,1,0,1,0,1});
+    auto expected_column_view2{static_cast<cudf::column_view const&>(expectedDataWrap2)};
+
+    EXPECT_EQ(inputRows, expected_column_view2.size());
+    EXPECT_EQ(inputRows, output_column_view2.size());
+
+    cudf::test::expect_columns_equal(expected_column_view2, output_column_view2);
+  } else {
+    fixed_width_column_wrapper<TypeParam> expectedDataWrap2({0,1,2,3,4,5,6,7,8,9,10});
+    auto expected_column_view2{static_cast<cudf::column_view const&>(expectedDataWrap2)};
+    cudf::test::expect_columns_equal(expected_column_view2, output_column_view2);
+  }
+
+  std::vector<cudf::size_type> expected_partition_offsets{0};
+  EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+  EXPECT_EQ(expected_partition_offsets, result.second);
+}
+
 TYPED_TEST(RoundRobinTest, RoundRobinIncorrectNumPartitions) {
   strings_column_wrapper rrColWrap1({"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"}, {1,1,1,1,1,1,1,1,1,1,0});
   
@@ -627,7 +697,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinIncorrectNumPartitions) {
 
   cudf::table_view rr_view{{rrColWrap1, rrColWrap2}};
 
-  cudf::size_type num_partitions = 1;  
+  cudf::size_type num_partitions = 0;
   cudf::size_type start_partition = 0;
     
   EXPECT_THROW(cudf::experimental::round_robin_partition(rr_view,


### PR DESCRIPTION
Currently `round_robin_partition` explicitly checks for and prevents partitioning to a single partition.  While this is a degenerate partitioning that is equivalent to copying the input table, the code does perform this degenerate partitioning correctly.

Removing this restriction can simplify calling code that would otherwise need to check for this degenerate case and reference-count the input or perform a separate copy instead.
