### PR TITLE
[REVIEW] All null string entries should have null data buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - PR #4049 Fix `cudf::split` issue returning one less than expected column vectors
 - PR #4065 Parquet writer: fix for out-of-range dictionary indices
 - PR #4066 Fixed mismatch with dtype enums
+- PR #4076 All null string entries should have null data buffer
 
 # cuDF 0.12.0 (Date TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - PR #4089 Fix dask groupby mutliindex test case issues in join
 - PR #4076 All null string entries should have null data buffer
 
+
 # cuDF 0.12.0 (04 Feb 2020)
 
 ## New Features

--- a/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
+++ b/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
@@ -1037,10 +1037,7 @@ public class JCudfSerialization {
       // Don't copy anything, there are no rows
       return 0;
     }
-    long bytesToCopy = 0;
-    if (column.getHostBufferFor(ColumnVector.BufferType.DATA) != null) {
-      bytesToCopy = (numRows + 1) * 4;
-    }
+    long bytesToCopy = (numRows + 1) * 4;
 
     long srcOffset = rowOffset * 4;
     if (rowOffset == 0) {

--- a/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
+++ b/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
@@ -1037,7 +1037,11 @@ public class JCudfSerialization {
       // Don't copy anything, there are no rows
       return 0;
     }
-    long bytesToCopy = (numRows + 1) * 4;
+    long bytesToCopy = 0;
+    if (column.getHostBufferFor(ColumnVector.BufferType.DATA) != null) {
+      bytesToCopy = (numRows + 1) * 4;
+    }
+
     long srcOffset = rowOffset * 4;
     if (rowOffset == 0) {
       return copySlicedAndPad(out, column, ColumnVector.BufferType.OFFSET, srcOffset, bytesToCopy);
@@ -1294,11 +1298,7 @@ public class JCudfSerialization {
             offsets = combinedBuffer.slice(offsetInfo.offsets, offsetInfo.offsetsLen);
           }
 
-          if (offsetInfo.dataLen == 0) {
-            // The vector is possibly full of null strings. This is a rare corner case, but here is the
-            // simplest place to work around it.
-            data = DeviceMemoryBuffer.allocate(1);
-          } else {
+          if (offsetInfo.dataLen > 0) {
             data = combinedBuffer.slice(offsetInfo.data, offsetInfo.dataLen);
           }
 

--- a/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
+++ b/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
@@ -1038,7 +1038,6 @@ public class JCudfSerialization {
       return 0;
     }
     long bytesToCopy = (numRows + 1) * 4;
-
     long srcOffset = rowOffset * 4;
     if (rowOffset == 0) {
       return copySlicedAndPad(out, column, ColumnVector.BufferType.OFFSET, srcOffset, bytesToCopy);
@@ -1295,6 +1294,8 @@ public class JCudfSerialization {
             offsets = combinedBuffer.slice(offsetInfo.offsets, offsetInfo.offsetsLen);
           }
 
+          // The vector is possibly full of null strings. This is a rare corner case, but we let
+          // data buffer stay null.
           if (offsetInfo.dataLen > 0) {
             data = combinedBuffer.slice(offsetInfo.data, offsetInfo.dataLen);
           }

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -646,7 +646,6 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeCudfColumnView(
     jlong j_offset, jlong j_valid, jint j_null_count, jint size) {
 
   JNI_ARG_CHECK(env, (size != 0), "size is 0", 0);
-  JNI_NULL_CHECK(env, j_data, "char data is null", 0);
 
   cudf::type_id n_type = static_cast<cudf::type_id>(j_type);
   cudf::data_type n_data_type(n_type);


### PR DESCRIPTION
Passing a one byte data buffer for all null strings case can cause corruption given that the cudf layer can handle null data buffers. This PR address this issue by letting the buffer be null if there is no data.