### PR TITLE
Use Dask to serialize `Buffer`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PR #4038 JNI and Java support for is_nan and is_not_nan
 - PR #3891 Port NVStrings (r)split_record to contiguous_(r)split_record
 - PR #4064 Add cudaGetDeviceCount to JNI layer
+- PR #4077 Use Dask to serialize `Buffer`s
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -16,6 +16,7 @@ try:
             cudf.core.series.Series,
             cudf.core.groupby.groupby._Groupby,
             cudf.core.column.column.Column,
+            cudf.core.buffer.Buffer,
         )
     )
     def serialize_cudf_dataframe(x):
@@ -30,6 +31,7 @@ try:
             cudf.core.series.Series,
             cudf.core.groupby.groupby._Groupby,
             cudf.core.column.column.Column,
+            cudf.core.buffer.Buffer,
         )
     )
     def deserialize_cudf_dataframe(header, frames):

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -105,8 +105,8 @@ class Buffer:
 
         # Patch header to load data with `Buffer`
         header["original-type-serialized"] = header["type-serialized"]
-        header["type"] = pickle.dumps(type(self))
         header["type-serialized"] = pickle.dumps(type(self))
+        header["type"] = pickle.dumps(type(self))
 
         return header, frames
 
@@ -116,8 +116,8 @@ class Buffer:
 
         # Revert patch to load data with owner's type
         header = dict(header)
-        del header["type"]
         header["type-serialized"] = header.pop("original-type-serialized")
+        del header["type"]
 
         return cls(data=cuda_loads(header, frames))
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -105,7 +105,7 @@ class Buffer:
 
         # Patch header to load data with `Buffer`
         header["original-type-serialized"] = header["type-serialized"]
-        header["type"] = pickle.dumps(self.__class__)
+        header["type"] = pickle.dumps(type(self))
         header["type-serialized"] = pickle.dumps(self.__class__)
 
         return header, frames

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -104,7 +104,9 @@ class Buffer:
             )
 
         # Patch header to load data with `Buffer`
+        header["original-type"] = header["type"]
         header["original-type-serialized"] = header["type-serialized"]
+        header["type"] = pickle.dumps(self.__class__)
         header["type-serialized"] = pickle.dumps(self.__class__)
 
         return header, frames
@@ -115,6 +117,7 @@ class Buffer:
 
         # Revert patch to load data with owner's type
         header = dict(header)
+        header["type"] = header.pop("original-type")
         header["type-serialized"] = header.pop("original-type-serialized")
 
         return cls(data=cuda_loads(header, frames))

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -106,7 +106,7 @@ class Buffer:
         # Patch header to load data with `Buffer`
         header["original-type-serialized"] = header["type-serialized"]
         header["type"] = pickle.dumps(type(self))
-        header["type-serialized"] = pickle.dumps(self.__class__)
+        header["type-serialized"] = pickle.dumps(type(self))
 
         return header, frames
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -104,7 +104,6 @@ class Buffer:
             )
 
         # Patch header to load data with `Buffer`
-        header["original-type"] = header["type"]
         header["original-type-serialized"] = header["type-serialized"]
         header["type"] = pickle.dumps(self.__class__)
         header["type-serialized"] = pickle.dumps(self.__class__)
@@ -117,7 +116,7 @@ class Buffer:
 
         # Revert patch to load data with owner's type
         header = dict(header)
-        header["type"] = header.pop("original-type")
+        del header["type"]
         header["type-serialized"] = header.pop("original-type-serialized")
 
         return cls(data=cuda_loads(header, frames))


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

Adds Dask serialization support of `Buffer`s directly. This is done by leveraging Dask's support for serializing the underlying data pointed to by the `Buffer`. If that fails, we fallback to building a Numba `DeviceNDArray` for Dask to serialize. Lightly touches `Column`s serialization to offload serialization of `Buffer`s it hold. Should avoid some overhead in constructing Numba `DeviceNDArray`s when that isn't needed.

Note: Currently a Numba `DeviceNDArray` will be used for RMM `DeviceBuffer`s, but that should be fixed with native Dask support for those provided by PR ( https://github.com/dask/distributed/pull/3442 )

cc @quasiben @kkraus14