### PR TITLE
[REVIEW] implemented fix for joins for column_in_common is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - PR #4049 Fix `cudf::split` issue returning one less than expected column vectors
 - PR #4065 Parquet writer: fix for out-of-range dictionary indices
 - PR #4066 Fixed mismatch with dtype enums
+- PR #4078 Fix joins for when column_in_common input parameter is empty
 
 # cuDF 0.12.0 (Date TBD)
 

--- a/cpp/include/cudf/strings/detail/gather.cuh
+++ b/cpp/include/cudf/strings/detail/gather.cuh
@@ -61,7 +61,7 @@ std::unique_ptr<cudf::column> gather( strings_column_view const& strings,
 {
     auto output_count = std::distance(begin, end);
     auto strings_count = strings.size();
-    if( output_count == 0 || strings_count == 0 )
+    if( output_count == 0 )
         return make_empty_strings_column(mr,stream);
 
     auto execpol = rmm::exec_policy(stream);

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -357,6 +357,8 @@ construct_join_output_df(
           joined_indices.first.end(),
           false, nullify_out_of_bounds);
     }
+  } else {
+      common_table = std::make_unique<experimental::table>();
   }
 
   // Construct the left non common columns

--- a/cpp/tests/join/join_tests.cu
+++ b/cpp/tests/join/join_tests.cu
@@ -58,6 +58,53 @@ TEST_F(JoinTest, InvalidCommonColumnIndices)
       cudf::logic_error);
 }
 
+
+TEST_F(JoinTest, LeftJoinNoNullsWithNoCommon)
+{
+  column_wrapper <int32_t> col0_0{{3, 1, 2, 0, 3}};
+  strcol_wrapper           col0_1({"s0", "s1", "s2", "s4", "s1"});
+  column_wrapper <int32_t> col0_2{{0, 1, 2, 4, 1}};
+
+  column_wrapper <int32_t> col1_0{{2, 2, 0, 4, 3}};
+  strcol_wrapper           col1_1{{"s1", "s0", "s1", "s2", "s1"}};
+  column_wrapper <int32_t> col1_2{{1, 0, 1, 2, 1}};
+
+  CVector cols0, cols1;
+  cols0.push_back(col0_0.release());
+  cols0.push_back(col0_1.release());
+  cols0.push_back(col0_2.release());
+  cols1.push_back(col1_0.release());
+  cols1.push_back(col1_1.release());
+  cols1.push_back(col1_2.release());
+
+  Table t0(std::move(cols0));
+  Table t1(std::move(cols1));
+
+  auto result = cudf::experimental::left_join(t0, t1, {0}, {0}, {});
+  auto result_sort_order = cudf::experimental::sorted_order(result->view());
+  auto sorted_result = cudf::experimental::gather(result->view(), *result_sort_order);
+
+  column_wrapper <int32_t> col_gold_0{{3, 1, 2, 2, 0, 3}, {1, 1, 1, 1, 1, 1}};
+  strcol_wrapper           col_gold_1({"s0", "s1", "s2", "s2", "s4", "s1"}, {1, 1, 1, 1, 1, 1});
+  column_wrapper <int32_t> col_gold_2{{0, 1, 2, 2, 4, 1}, {1, 1, 1, 1, 1, 1}};
+  column_wrapper <int32_t> col_gold_3{{3, -1, 2, 2, 0, 3}, {1, 0, 1, 1, 1, 1}};
+  strcol_wrapper           col_gold_4({"s1", "", "s1", "s0", "s1", "s1"}, {1, 0, 1, 1, 1, 1});
+  column_wrapper <int32_t> col_gold_5{{1, -1, 1, 0, 1, 1}, {1, 0, 1, 1, 1, 1}};
+  CVector cols_gold;
+  cols_gold.push_back(col_gold_0.release());
+  cols_gold.push_back(col_gold_1.release());
+  cols_gold.push_back(col_gold_2.release());
+  cols_gold.push_back(col_gold_3.release());
+  cols_gold.push_back(col_gold_4.release());
+  cols_gold.push_back(col_gold_5.release());
+  Table gold(std::move(cols_gold));
+
+  auto gold_sort_order = cudf::experimental::sorted_order(gold.view());
+  auto sorted_gold = cudf::experimental::gather(gold.view(), *gold_sort_order);
+
+  cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
+}
+
 TEST_F(JoinTest, FullJoinNoNulls)
 {
   column_wrapper <int32_t> col0_0{{3, 1, 2, 0, 3}};


### PR DESCRIPTION
This PR implements a fix to joins that allows for input parameter `column_in_common` to be empty. The fix is simply copied from PR #4044 from brandon-b-miller. I believe that PR #4044 will also be containing a lot more for the python side, but having this fix would help resolves #3974 faster.
