### PR TITLE
[REVIEW] Use two partitions in test_groupby_multiindex_reset_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - PR #4067 Removed unused `CATEGORY` type ID.
 - PR #3891 Port NVStrings (r)split_record to contiguous_(r)split_record
 - PR #4064 Add cudaGetDeviceCount to JNI layer
+- PR #4083 Use two partitions in test_groupby_multiindex_reset_index
 
 ## Bug Fixes
 

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -272,8 +272,8 @@ def test_groupby_multiindex_reset_index():
     df = cudf.DataFrame(
         {"a": [1, 1, 2, 3, 4], "b": [5, 2, 1, 2, 5], "c": [1, 2, 2, 3, 5]}
     )
-    ddf = dask_cudf.from_cudf(df, npartitions=1)
-    pddf = dd.from_pandas(df.to_pandas(), npartitions=1)
+    ddf = dask_cudf.from_cudf(df, npartitions=2)
+    pddf = dd.from_pandas(df.to_pandas(), npartitions=2)
     gr = ddf.groupby(["a", "c"]).agg({"b": ["count"]}).reset_index()
     pr = pddf.groupby(["a", "c"]).agg({"b": ["count"]}).reset_index()
     dd.assert_eq(
@@ -283,7 +283,7 @@ def test_groupby_multiindex_reset_index():
 
 
 @pytest.mark.parametrize(
-    "groupby_keys", [["a"], ["a", "b"], ["a", "b", "dd"], ["a", "dd", "b"]],
+    "groupby_keys", [["a"], ["a", "b"], ["a", "b", "dd"], ["a", "dd", "b"]]
 )
 @pytest.mark.parametrize(
     "agg_func",

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -268,12 +268,13 @@ def test_groupby_split_out_multiindex(agg_func):
     dd.assert_eq(gr.compute(), pr.compute())
 
 
-def test_groupby_multiindex_reset_index():
+@pytest.mark.parametrize("npartitions", [1, 2])
+def test_groupby_multiindex_reset_index(npartitions):
     df = cudf.DataFrame(
         {"a": [1, 1, 2, 3, 4], "b": [5, 2, 1, 2, 5], "c": [1, 2, 2, 3, 5]}
     )
-    ddf = dask_cudf.from_cudf(df, npartitions=2)
-    pddf = dd.from_pandas(df.to_pandas(), npartitions=2)
+    ddf = dask_cudf.from_cudf(df, npartitions=npartitions)
+    pddf = dd.from_pandas(df.to_pandas(), npartitions=npartitions)
     gr = ddf.groupby(["a", "c"]).agg({"b": ["count"]}).reset_index()
     pr = pddf.groupby(["a", "c"]).agg({"b": ["count"]}).reset_index()
     dd.assert_eq(


### PR DESCRIPTION
This PR sets `npartitions=2` to cover the multi-partition codepath in `test_groupby_multiindex_reset_index`.

Apparently black also made a tiny change to a comma.