### PR TITLE
Update Java bindings to reflect removal of CATEGORY data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,10 @@
 - PR #4065 Parquet writer: fix for out-of-range dictionary indices
 - PR #4066 Fixed mismatch with dtype enums
 - PR #4080 Fix multi-index dask test with sort issue
+- PR #4084 Update Java for removal of CATEGORY type
 
-# cuDF 0.12.0 (Date TBD)
+
+# cuDF 0.12.0 (04 Feb 2020)
 
 ## New Features
 

--- a/java/src/main/java/ai/rapids/cudf/DType.java
+++ b/java/src/main/java/ai/rapids/cudf/DType.java
@@ -49,9 +49,8 @@ public enum DType {
    * ns since the UNIX epoch
    */
   TIMESTAMP_NANOSECONDS(8, 12, "timestamp[ns]"),
-  CATEGORY(4, 13, "category"),
-  //DICTIONARY32(4, 14, "NO IDEA"),
-  STRING(0, 15, "str");
+  //DICTIONARY32(4, 13, "NO IDEA"),
+  STRING(0, 14, "str");
 
   private static final DType[] D_TYPES = DType.values();
   final int sizeInBytes;

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -422,7 +422,6 @@ public class ColumnVectorTest extends CudfTestBase {
           s = Scalar.fromString("hello, world!");
           break;
         case EMPTY:
-        case CATEGORY:
           continue;
         default:
           throw new IllegalArgumentException("Unexpected type: " + type);
@@ -527,7 +526,6 @@ public class ColumnVectorTest extends CudfTestBase {
           break;
         }
         case EMPTY:
-        case CATEGORY:
           continue;
         default:
           throw new IllegalArgumentException("Unexpected type: " + type);
@@ -553,7 +551,7 @@ public class ColumnVectorTest extends CudfTestBase {
   void testFromScalarNull() {
     final int rowCount = 4;
     for (DType type : DType.values()) {
-      if (type == DType.EMPTY || type == DType.CATEGORY) {
+      if (type == DType.EMPTY) {
         continue;
       }
       try (Scalar s = Scalar.fromNull(type);

--- a/java/src/test/java/ai/rapids/cudf/ScalarTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ScalarTest.java
@@ -46,13 +46,9 @@ public class ScalarTest extends CudfTestBase {
   @Test
   public void testNull() {
     for (DType type : DType.values()) {
-      if (type == DType.CATEGORY) {
-        assertThrows(IllegalArgumentException.class, () -> Scalar.fromNull(type));
-      } else {
-        try (Scalar s = Scalar.fromNull(type)) {
-          assertEquals(type, s.getType());
-          assertFalse(s.isValid(), "null validity for " + type);
-        }
+      try (Scalar s = Scalar.fromNull(type)) {
+        assertEquals(type, s.getType());
+        assertFalse(s.isValid(), "null validity for " + type);
       }
     }
   }


### PR DESCRIPTION
Fixing the Java build that was still referencing the recently removed CATEGORY data type.