### PR TITLE
[REVIEW] Fix strings concatenate logic with column offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - PR #4080 Fix multi-index dask test with sort issue
 - PR #4084 Update Java for removal of CATEGORY type
 - PR #4089 Fix dask groupby mutliindex test case issues in join
+- PR #4097 Fix strings concatenate logic with column offsets
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/strings/detail/concatenate.hpp>
 #include <cudf/strings/strings_column_view.hpp>
-#include "../utilities.hpp"
+#include <strings/utilities.hpp>
 
 #include <thrust/for_each.h>
 #include <thrust/transform_reduce.h>
@@ -41,14 +41,33 @@ std::unique_ptr<column> concatenate( std::vector<strings_column_view> const& str
     CUDF_EXPECTS( strings_count < std::numeric_limits<size_type>::max(), "total number of strings is too large for cudf column" );
     if( strings_count == 0 )
         return make_empty_strings_column(mr,stream);
-    size_t total_bytes = thrust::transform_reduce( strings_columns.begin(), strings_columns.end(),
-        [] (auto scv) { return scv.chars_size(); }, static_cast<size_t>(0), thrust::plus<size_t>());
+
+    // build vector of column_device_views
+    std::vector<std::unique_ptr<column_device_view,std::function<void(column_device_view*)> > > device_cols(strings_columns.size());
+    thrust::host_vector<column_device_view> h_device_views;
+    for( auto &scv : strings_columns )
+    {
+        device_cols.emplace_back(column_device_view::create(scv.parent(),stream));
+        h_device_views.push_back(*(device_cols.back()));
+    }
+    rmm::device_vector<column_device_view> device_views(h_device_views);
+    auto execpol = rmm::exec_policy(stream);
+    auto d_views = device_views.data().get();
+    // compute size of the output chars column
+    size_t total_bytes = thrust::transform_reduce( execpol->on(stream),
+        d_views, d_views + device_views.size(),
+        [] __device__ (auto d_view) {
+            if( d_view.size()==0 )
+                return static_cast<size_t>(0);
+            auto d_offsets = d_view.child(strings_column_view::offsets_column_index).template data<int32_t>();
+            size_t size = d_offsets[d_view.size()+d_view.offset()] - d_offsets[d_view.offset()];
+            return size;
+        }, static_cast<size_t>(0), thrust::plus<size_t>());
     CUDF_EXPECTS( total_bytes < std::numeric_limits<size_type>::max(), "total size of strings is too large for cudf column" );
 
     // create chars column
     auto chars_column = make_numeric_column( data_type{INT8}, total_bytes, mask_state::UNALLOCATED, stream, mr);
-    auto chars_view = chars_column->mutable_view();
-    auto d_new_chars = chars_view.data<char>();
+    auto d_new_chars = chars_column->mutable_view().data<char>();
 
     // create offsets column
     auto offsets_column = make_numeric_column( data_type{INT32}, strings_count + 1, mask_state::UNALLOCATED, stream, mr);
@@ -56,35 +75,32 @@ std::unique_ptr<column> concatenate( std::vector<strings_column_view> const& str
     auto d_new_offsets = offsets_view.data<int32_t>();
 
     // copy over the data for all the columns
-    ++d_new_offsets;
-    size_type offset_adjust = 0;
-    size_type null_count = 0;
+    ++d_new_offsets; // skip the first element which will be set to 0 after the for-loop
+    int32_t offset_adjust = 0; // each section of offsets must be adjusted
+    size_type null_count = 0;  // add up the null counts
     for( auto column = strings_columns.begin(); column != strings_columns.end(); ++column )
     {
-        size_type size = column->size();
-        if( size==0 )
-            continue;
+        size_type column_size = column->size();
+        if( column_size==0 ) // nothing to do
+            continue; // empty column may not have children
+        size_type column_offset = column->offset();
         column_view offsets_child = column->offsets();
         column_view chars_child = column->chars();
-
         // copy the offsets column
         auto d_offsets = offsets_child.data<int32_t>();
-        CUDA_TRY(cudaMemcpyAsync( d_new_offsets, d_offsets+1+column->offset(), size*sizeof(int32_t), cudaMemcpyDeviceToDevice, stream ));
-
+        CUDA_TRY(cudaMemcpyAsync( d_new_offsets, d_offsets+1+column_offset, column_size*sizeof(int32_t), cudaMemcpyDeviceToDevice, stream ));
         // adjust offsets
-        thrust::for_each_n( rmm::exec_policy(stream)->on(stream), thrust::make_counting_iterator<size_type>(0), size,
-            [d_new_offsets, offset_adjust] __device__ (size_type idx) { d_new_offsets[idx] += offset_adjust; });
-
-        // copy the chars column
-        auto d_chars = chars_child.data<char*>();
-        size_type bytes_offset = thrust::device_pointer_cast(d_offsets)[column->offset()];
+        int32_t bytes_offset = thrust::device_pointer_cast(d_offsets)[column_offset];
+        thrust::for_each_n( rmm::exec_policy(stream)->on(stream), thrust::make_counting_iterator<size_type>(0), column_size,
+            [d_new_offsets, bytes_offset, offset_adjust] __device__ (size_type idx) { d_new_offsets[idx] += offset_adjust - bytes_offset; });
+        // copy the chars column data
+        auto d_chars = chars_child.data<char>();
         size_type bytes = chars_child.size() - bytes_offset;
         CUDA_TRY(cudaMemcpyAsync( d_new_chars, d_chars+bytes_offset, bytes, cudaMemcpyDeviceToDevice, stream ));
-
         // get ready for the next column
         offset_adjust += bytes;
         d_new_chars += bytes;
-        d_new_offsets += size;
+        d_new_offsets += column_size;
         null_count += column->null_count();
     }
     CUDA_TRY(cudaMemsetAsync( offsets_view.data<int32_t>(), 0, sizeof(int32_t), stream));
@@ -93,9 +109,10 @@ std::unique_ptr<column> concatenate( std::vector<strings_column_view> const& str
     rmm::device_buffer null_mask;
     if( null_count > 0 )
         null_mask = create_null_mask( strings_count, UNINITIALIZED, stream,mr );
-
+    offsets_column->set_null_count(0);  // reset the null counts
+    chars_column->set_null_count(0);    // for children columns
     return make_strings_column(strings_count, std::move(offsets_column), std::move(chars_column),
-                               0, std::move(null_mask), stream, mr);
+                               null_count, std::move(null_mask), stream, mr);
 }
 
 } // namespace detail

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -38,12 +38,14 @@ std::unique_ptr<column> concatenate( std::vector<strings_column_view> const& str
     // calculate the size of the output column
     size_t strings_count = thrust::transform_reduce( strings_columns.begin(), strings_columns.end(),
         [] (auto scv) { return scv.size(); }, static_cast<size_t>(0), thrust::plus<size_t>());
-    CUDF_EXPECTS( strings_count < std::numeric_limits<size_type>::max(), "total number of strings is too large for cudf column" );
+    CUDF_EXPECTS( strings_count < std::numeric_limits<size_type>::max(), 
+        "total number of strings is too large for cudf column" );
     if( strings_count == 0 )
         return make_empty_strings_column(mr,stream);
 
     // build vector of column_device_views
-    std::vector<std::unique_ptr<column_device_view,std::function<void(column_device_view*)> > > device_cols(strings_columns.size());
+    std::vector<std::unique_ptr<column_device_view,std::function<void(column_device_view*)> > > 
+        device_cols(strings_columns.size());
     thrust::host_vector<column_device_view> h_device_views;
     for( auto&& scv : strings_columns )
     {

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -45,7 +45,7 @@ std::unique_ptr<column> concatenate( std::vector<strings_column_view> const& str
     // build vector of column_device_views
     std::vector<std::unique_ptr<column_device_view,std::function<void(column_device_view*)> > > device_cols(strings_columns.size());
     thrust::host_vector<column_device_view> h_device_views;
-    for( auto &scv : strings_columns )
+    for( auto&& scv : strings_columns )
     {
         device_cols.emplace_back(column_device_view::create(scv.parent(),stream));
         h_device_views.push_back(*(device_cols.back()));

--- a/cpp/tests/table/table_tests.cpp
+++ b/cpp/tests/table/table_tests.cpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/copying.hpp>
 
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/column_utilities.hpp>
@@ -166,4 +167,40 @@ TEST_F(TableTest, ConcatenateTables)
   auto concat_table = cudf::experimental::concatenate({t1.view(), t2.view()});
 
   cudf::test::expect_tables_equal(*concat_table, gold_table);
+}
+
+TEST_F(TableTest, ConcatenateTablesWithOffsets)
+{
+  column_wrapper<int32_t> col1_1{{5, 4, 3, 5, 8, 5, 6}};
+  cudf::test::strings_column_wrapper col2_1({"dada", "egg", "avocado", "dada", "kite", "dog", "ln"});
+  cudf::table_view table_view_in1 {{col1_1, col2_1}};
+
+  column_wrapper<int32_t> col1_2{{5, 8, 5, 6, 15, 14, 13}};
+  cudf::test::strings_column_wrapper col2_2({"dada", "kite", "dog", "ln", "dado", "greg", "spinach"});
+  cudf::table_view table_view_in2 {{col1_2, col2_2}};
+
+  std::vector<cudf::size_type> split_indexes1{3};
+  std::vector<cudf::table_view> partitioned1 =
+    cudf::experimental::split( table_view_in1, split_indexes1);
+
+  std::vector<cudf::size_type> split_indexes2{3};
+  std::vector<cudf::table_view> partitioned2 =
+    cudf::experimental::split( table_view_in2, split_indexes2);
+
+  std::vector<cudf::table_view> table_views_to_concat;
+  table_views_to_concat.push_back(partitioned1[1]);
+  table_views_to_concat.push_back(partitioned2[1]);
+  std::unique_ptr<cudf::experimental::table> concatenated_tables =
+    cudf::experimental::concatenate(table_views_to_concat);
+
+  //cudf::test::print( concatenated_tables->view().column(0) );
+  //std::cout << std::endl;
+  //cudf::test::print( concatenated_tables->view().column(1) );
+  //std::cout << std::endl;
+
+  column_wrapper<int32_t> exp1_1{{5, 8, 5, 6, 6, 15, 14, 13}};
+  cudf::test::strings_column_wrapper exp2_1({"dada", "kite", "dog", "ln", "ln", "dado", "greg", "spinach"});
+  cudf::table_view table_view_exp1 {{exp1_1, exp2_1}};
+
+  cudf::test::expect_tables_equal( concatenated_tables->view(), table_view_exp1);
 }

--- a/cpp/tests/table/table_tests.cpp
+++ b/cpp/tests/table/table_tests.cpp
@@ -193,13 +193,39 @@ TEST_F(TableTest, ConcatenateTablesWithOffsets)
   std::unique_ptr<cudf::experimental::table> concatenated_tables =
     cudf::experimental::concatenate(table_views_to_concat);
 
-  //cudf::test::print( concatenated_tables->view().column(0) );
-  //std::cout << std::endl;
-  //cudf::test::print( concatenated_tables->view().column(1) );
-  //std::cout << std::endl;
-
   column_wrapper<int32_t> exp1_1{{5, 8, 5, 6, 6, 15, 14, 13}};
   cudf::test::strings_column_wrapper exp2_1({"dada", "kite", "dog", "ln", "ln", "dado", "greg", "spinach"});
+  cudf::table_view table_view_exp1 {{exp1_1, exp2_1}};
+
+  cudf::test::expect_tables_equal( concatenated_tables->view(), table_view_exp1);
+}
+
+TEST_F(TableTest, ConcatenateTablesWithOffsetsAndNulls)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> col1_1{{5, 4, 3, 5, 8, 5, 6},{0,1,1,1,1,1,1}};
+  cudf::test::strings_column_wrapper col2_1({"dada", "egg", "avocado", "dada", "kite", "dog", "ln"},{1,1,1,0,1,1,1});
+  cudf::table_view table_view_in1 {{col1_1, col2_1}};
+
+  cudf::test::fixed_width_column_wrapper<int32_t> col1_2{{5, 8, 5, 6, 15, 14, 13},{1,1,1,1,1,1,0}};
+  cudf::test::strings_column_wrapper col2_2({"dada", "kite", "dog", "ln", "dado", "greg", "spinach"},{1,0,1,1,1,1,1});
+  cudf::table_view table_view_in2 {{col1_2, col2_2}};
+
+  std::vector<cudf::size_type> split_indexes1{3};
+  std::vector<cudf::table_view> partitioned1 =
+    cudf::experimental::split( table_view_in1, split_indexes1);
+
+  std::vector<cudf::size_type> split_indexes2{3};
+  std::vector<cudf::table_view> partitioned2 =
+    cudf::experimental::split( table_view_in2, split_indexes2);
+
+  std::vector<cudf::table_view> table_views_to_concat;
+  table_views_to_concat.push_back(partitioned1[1]);
+  table_views_to_concat.push_back(partitioned2[1]);
+  std::unique_ptr<cudf::experimental::table> concatenated_tables =
+    cudf::experimental::concatenate(table_views_to_concat);
+
+  cudf::test::fixed_width_column_wrapper<int32_t> exp1_1{{5, 8, 5, 6, 6, 15, 14, 13},{1,1,1,1,1,1,1,0}};
+  cudf::test::strings_column_wrapper exp2_1({"dada", "kite", "dog", "ln", "ln", "dado", "greg", "spinach"},{0,1,1,1,1,1,1,1});
   cudf::table_view table_view_exp1 {{exp1_1, exp2_1}};
 
   cudf::test::expect_tables_equal( concatenated_tables->view(), table_view_exp1);


### PR DESCRIPTION
The `strings::detail::concatenate(columns)` code error causes invalid-argument in `cudaMemcpy` call.
Closes #4055 
Problems found in the code logic:
- The computed size of the output column is larger than needed.
- The offset adjustment logic was computing incorrect values.
- Typo in the child column `data<>()` call.

The last one specifically produced the invalid argument error but was sometimes hidden because of the first error. 