### PR TITLE
[REVIEW] Remove legacy calls from libcudf strings column code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - PR #4079 Simply use `mask.size` to create the array view
 - PR #4092 Keep mask on GPU for bit unpacking
 - PR #4081 Copy from `Buffer`'s pointer directly to host
+- PR #4098 Remove legacy calls from libcudf strings column code
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/strings/copying.hpp
+++ b/cpp/include/cudf/strings/copying.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/strings/copying.hpp
+++ b/cpp/include/cudf/strings/copying.hpp
@@ -55,29 +55,6 @@ std::unique_ptr<cudf::column> slice( strings_column_view const& strings,
                                      cudaStream_t stream=0,
                                      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource() );
 
-/**
- * @brief Returns a new strings column using the specified indices to select
- * elements from the `strings` column.
- *
- * ```
- * s1 = ["a", "b", "c", "d", "e", "f"]
- * map = [0, 2]
- * s2 = gather( s1, map )
- * s2 is ["a", "c"]
- * ```
- *
- * @param strings Strings instance for this operation.
- * @param gather_map The indices with which to select strings for the new column.
- *        Values must be within [0,size()) range.
- * @param stream CUDA stream to use kernels in this method.
- * @param mr Resource for allocating device memory.
- * @return New strings column of size indices.size()
- */
-std::unique_ptr<cudf::column> gather( strings_column_view const& strings,
-                                      cudf::column_view gather_map,
-                                      cudaStream_t stream=0,
-                                      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource() );
-
 
 } // namespace detail
 } // namespace strings

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -56,7 +56,10 @@ std::unique_ptr<cudf::column> slice( strings_column_view const& strings,
     column_view indices_view( data_type{INT32}, strings_count, indices.data().get(), nullptr, 0 );
     // build a new strings column from the indices
     auto sliced_table = experimental::detail::gather( table_view{{strings.parent()}}, indices_view, stream, mr)->release();
-    return std::move(sliced_table.front());
+    std::unique_ptr<column> output_column( std::move(sliced_table.front()) );
+    if( output_column->null_count()==0 )
+        output_column->set_null_mask(rmm::device_buffer{},0);
+    return output_column;
 }
 
 } // namespace detail

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-#include <bitmask/legacy/valid_if.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_device_view.cuh>
+#include <cudf/detail/utilities/integer_utils.hpp>
+#include <cudf/detail/gather.hpp>
 #include <cudf/strings/copying.hpp>
 #include <cudf/strings/strings_column_view.hpp>
-#include <cudf/strings/string_view.cuh>
-#include "../utilities.hpp"
-#include "../utilities.cuh"
+#include <strings/utilities.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
-#include <thrust/for_each.h>
 #include <thrust/sequence.h>
-#include <thrust/scatter.h>
-#include <thrust/transform_scan.h>
 
 namespace cudf
 {
@@ -60,120 +55,8 @@ std::unique_ptr<cudf::column> slice( strings_column_view const& strings,
     // create a column_view as a wrapper of these indices
     column_view indices_view( data_type{INT32}, strings_count, indices.data().get(), nullptr, 0 );
     // build a new strings column from the indices
-    return gather(strings, indices_view, stream, mr);
-}
-
-// return new strings column with strings from this instance as specified by the indices
-std::unique_ptr<cudf::column> gather( strings_column_view const& strings,
-                                      column_view gather_map, cudaStream_t stream,
-                                      rmm::mr::device_memory_resource* mr  )
-{
-    auto strings_count = gather_map.size();
-    if( strings_count == 0 )
-        return make_empty_strings_column(mr,stream);
-    // TODO use index-normalizing iterator to allow any numeric type for gather_map
-    CUDF_EXPECTS( gather_map.type().id()==cudf::INT32, "strings gather method only supports int32 indices right now");
-    auto d_indices = gather_map.data<int32_t>();
-    auto sliced_offset = strings.offset(); // account for a sliced column view
-
-    auto execpol = rmm::exec_policy(stream);
-    auto strings_column = column_device_view::create(strings.parent(),stream);
-    auto d_column = *strings_column;
-    auto d_offsets = strings.offsets().data<int32_t>();
-
-    // build offsets column
-    auto offsets_transformer = [d_column, d_offsets, sliced_offset] __device__ (size_type idx) {
-            if( d_column.is_null(idx) ) // handles offset
-                return 0;
-            auto index = sliced_offset + idx;
-            return d_offsets[index+1] - d_offsets[index];
-        };
-    auto offsets_transformer_itr = thrust::make_transform_iterator( d_indices, offsets_transformer );
-    auto offsets_column = detail::make_offsets_child_column(offsets_transformer_itr,
-                                               offsets_transformer_itr+strings_count,
-                                               mr, stream);
-    auto offsets_view = offsets_column->view();
-    auto d_new_offsets = offsets_view.data<int32_t>();
-
-    // build null mask
-    auto valid_mask = strings::detail::make_null_mask(strings_count,
-        [d_column, d_indices] __device__ (size_type idx) { return !d_column.is_null(d_indices[idx]);},
-        mr, stream);
-    auto null_count = valid_mask.second;
-    rmm::device_buffer null_mask = valid_mask.first;
-
-    // build chars column
-    size_type bytes = thrust::device_pointer_cast(d_new_offsets)[strings_count];
-    auto chars_column = strings::detail::create_chars_child_column( strings_count, null_count, bytes, mr, stream );
-    auto chars_view = chars_column->mutable_view();
-    auto d_chars = chars_view.data<int8_t>();
-    thrust::for_each_n(execpol->on(stream), thrust::make_counting_iterator<size_type>(0), strings_count,
-        [d_column, d_indices, d_new_offsets, d_chars] __device__(size_type idx){
-            size_type index = d_indices[idx];
-            if( d_column.is_null(index) )
-                return;
-            string_view d_str = d_column.element<string_view>(index);
-            memcpy(d_chars + d_new_offsets[idx], d_str.data(), d_str.size_bytes() );
-        });
-
-    return make_strings_column(strings_count, std::move(offsets_column), std::move(chars_column),
-                               null_count, std::move(null_mask), stream, mr);
-}
-
-
-//
-// s1 = ['a','b,'c','d']
-// pos = [1,3]
-// s3 = s1.scatter('e',pos,2)
-// ['a','e','c','e']
-//
-std::unique_ptr<cudf::column> scatter( strings_column_view strings,
-                                       const char* string,
-                                       cudf::column_view scatter_map,
-                                       cudaStream_t stream,
-                                       rmm::mr::device_memory_resource* mr )
-{
-    size_type strings_count = strings.size();
-    if( strings_count == 0 )
-        return make_empty_strings_column(mr,stream);
-    size_type elements = scatter_map.size();
-    auto execpol = rmm::exec_policy(0);
-    // TODO use index-normalizing iterator to allow any numeric type for gather_map
-    CUDF_EXPECTS( scatter_map.type().id()==cudf::INT32, "strings scatter method only supports int32 indices right now");
-    auto d_indices = scatter_map.data<int32_t>();
-    // copy string to device
-    auto replace = detail::string_from_host(string, stream);
-    auto d_replace = *replace;
-    // create strings vector
-    rmm::device_vector<string_view> strings_vector =
-        detail::create_string_vector_from_column(strings, stream);
-    auto d_strings = strings_vector.data().get();
-    // replace specific elements
-    thrust::for_each_n(execpol->on(0),
-        thrust::make_counting_iterator<unsigned int>(0), elements,
-        [d_indices, d_replace, d_strings] __device__ (unsigned int idx) {
-            d_strings[d_indices[idx]] = d_replace;
-        });
-
-    auto valid_mask = strings::detail::make_null_mask(strings_count,
-        [d_strings] __device__ (size_type idx) { return !d_strings[idx].is_null(); },
-        mr, stream);
-    auto null_count = valid_mask.second;
-    rmm::device_buffer null_mask = valid_mask.first;
-
-    // build offsets column
-    auto offsets_column = child_offsets_from_string_vector(strings_vector,mr,stream);
-    auto offsets_view = offsets_column->view();
-    auto d_offsets = offsets_view.data<int32_t>();
-
-    // build chars column
-    size_type bytes = thrust::device_pointer_cast(d_offsets)[strings_count];
-    if( (bytes==0) && (null_count < strings_count) )
-        bytes = 1; // all entries are empty strings
-    auto chars_column = child_chars_from_string_vector(strings_vector,d_offsets,null_count,mr,stream);
-
-    return make_strings_column(strings_count, std::move(offsets_column), std::move(chars_column),
-                               null_count, std::move(null_mask), stream, mr);
+    auto sliced_table = experimental::detail::gather( table_view{{strings.parent()}}, indices_view, stream, mr)->release();
+    return std::move(sliced_table.front());
 }
 
 } // namespace detail

--- a/cpp/src/strings/sorting/sorting.cu
+++ b/cpp/src/strings/sorting/sorting.cu
@@ -15,7 +15,7 @@
  */
 
 #include <cudf/column/column_device_view.cuh>
-#include <cudf/strings/copying.hpp>
+#include <cudf/detail/gather.hpp>
 #include <cudf/strings/sorting.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/string_view.cuh>
@@ -66,7 +66,8 @@ std::unique_ptr<cudf::column> sort( strings_column_view strings,
     // create a column_view as a wrapper of these indices
     column_view indices_view( data_type{INT32}, num_strings, indices.data().get(), nullptr, 0 );
     // now build a new strings column from the indices
-    return gather( strings, indices_view, stream, mr );
+    auto table_sorted = experimental::detail::gather( table_view{{strings.parent()}}, indices_view, stream, mr )->release();
+    return std::move(table_sorted.front());
 }
 
 } // namespace detail

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/null_mask.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/detail/valid_if.cuh>
 #include <strings/utilities.hpp>
@@ -24,7 +23,6 @@
 
 #include <rmm/thrust_rmm_allocator.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/transform_scan.h>
 #include <thrust/for_each.h>
 
 

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-#include <bitmask/legacy/valid_if.cuh>
-#include <cudf/column/column_factories.hpp>
 #include <cudf/column/column.hpp>
-#include <cudf/legacy/functions.h>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/utilities/error.hpp>
-#include "./utilities.hpp"
-#include "./utilities.cuh"
+#include <cudf/detail/valid_if.cuh>
+#include <strings/utilities.hpp>
+#include <strings/utilities.cuh>
 
 #include <rmm/thrust_rmm_allocator.h>
 #include <thrust/transform_reduce.h>
@@ -68,11 +67,14 @@ std::unique_ptr<column> make_strings_column(
     auto d_offsets = offsets_view.data<int32_t>();
 
     // create null mask
-    auto valid_mask = strings::detail::make_null_mask(strings_count,
-        [d_strings] __device__ (size_type idx) { return d_strings[idx].first!=nullptr; },
-        mr, stream);
-    auto null_count = valid_mask.second;
-    rmm::device_buffer null_mask = valid_mask.first;
+    auto new_nulls = experimental::detail::valid_if( thrust::make_counting_iterator<size_type>(0),
+                    thrust::make_counting_iterator<size_type>(strings_count),
+                    [d_strings] __device__ (size_type idx) { return d_strings[idx].first!=nullptr; },
+                    stream, mr);
+    auto null_count = new_nulls.second;
+    rmm::device_buffer null_mask;
+    if( null_count > 0 )
+        null_mask = std::move(new_nulls.first);
 
     // build chars column
     auto chars_column = strings::detail::create_chars_child_column( strings_count, null_count, bytes, mr, stream );

--- a/cpp/src/strings/utilities.cuh
+++ b/cpp/src/strings/utilities.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <bitmask/legacy/valid_if.cuh>
+//#include <bitmask/legacy/valid_if.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/detail/utilities.cuh>
 
@@ -86,35 +86,6 @@ auto make_strings_children( SizeAndExecuteFunction size_and_exec_fn, size_type s
     size_and_exec_fn.d_chars = chars_column->mutable_view().template data<char>(); // fill in the chars
     thrust::for_each_n(rmm::exec_policy(stream)->on(stream), thrust::make_counting_iterator<size_type>(0), strings_count, size_and_exec_fn);
     return std::make_pair(std::move(offsets_column),std::move(chars_column));
-}
-
-
-/**
- * @brief Utility to create a null mask for a strings column using a custom function.
- *
- * @tparam BoolFn Function should return true/false given index for a strings column.
- * @param strings_count Number of strings for the column.
- * @param bfn The custom function used for identifying null string entries.
- * @param mr Memory resource to use.
- * @param stream Stream to use for any kernel calls.
- * @return Pair including null mask and null count
- */
-template <typename BoolFn>
-std::pair<rmm::device_buffer,cudf::size_type> make_null_mask( cudf::size_type strings_count,
-    BoolFn bfn,
-    rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-    cudaStream_t stream = 0)
-{
-    auto valid_mask = valid_if( static_cast<const bit_mask_t*>(nullptr),
-                                bfn, strings_count, stream );
-    auto null_count = valid_mask.second;
-    rmm::device_buffer null_mask;
-    if( null_count > 0 )
-        null_mask = rmm::device_buffer(valid_mask.first,
-                                       gdf_valid_allocation_size(strings_count),
-                                       stream,mr); // does deep copy
-    RMM_TRY( RMM_FREE(valid_mask.first,stream) ); // TODO valid_if to return device_buffer in future
-    return std::make_pair(std::move(null_mask), null_count);
 }
 
 /**

--- a/cpp/tests/strings/array_tests.cu
+++ b/cpp/tests/strings/array_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/strings/array_tests.cu
+++ b/cpp/tests/strings/array_tests.cu
@@ -77,8 +77,8 @@ TEST_P(SliceParmsTest, Slice)
     auto strings_view = cudf::strings_column_view(strings);
     auto results = cudf::strings::detail::slice(strings_view,start,end);
 
-    cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end(),
-         thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
+    cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end() );
+        // thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
     cudf::test::expect_columns_equal(*results,expected);
 }
 
@@ -117,8 +117,8 @@ TEST_P(SliceParmsTest, SliceAllEmpty)
     }
     auto strings_view = cudf::strings_column_view(strings);
     auto results = cudf::strings::detail::slice(strings_view,start,end);
-    cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end(),
-         thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
+    cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end() );
+        // thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
     cudf::test::expect_columns_equal(*results,expected);
 }
 

--- a/cpp/tests/strings/array_tests.cu
+++ b/cpp/tests/strings/array_tests.cu
@@ -78,7 +78,7 @@ TEST_P(SliceParmsTest, Slice)
     auto results = cudf::strings::detail::slice(strings_view,start,end);
 
     cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end() );
-        // thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
+         //thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
     cudf::test::expect_columns_equal(*results,expected);
 }
 
@@ -118,7 +118,7 @@ TEST_P(SliceParmsTest, SliceAllEmpty)
     auto strings_view = cudf::strings_column_view(strings);
     auto results = cudf::strings::detail::slice(strings_view,start,end);
     cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end() );
-        // thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
+         //thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
     cudf::test::expect_columns_equal(*results,expected);
 }
 


### PR DESCRIPTION
Before starting on #4050 
When porting NVStrings to libcudf++, some needed cudf functions had not yet been ported.
Early ported code relied on legacy `valid_if` function and needed to be moved to the newer `valid_if` libcudf++ ported version.
Also, now that cudf `gather` and `scatter` support strings columns, the strings-only versions of these API can be removed. This will ripple into fixing up other code (e.g. slice) and some test code.
