### PR TITLE
Redux serialize `Buffer` directly with `__cuda_array_interface__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - PR #4079 Simply use `mask.size` to create the array view
 - PR #4092 Keep mask on GPU for bit unpacking
 - PR #4081 Copy from `Buffer`'s pointer directly to host
+- PR #4101 Redux serialize `Buffer` directly with `__cuda_array_interface__`
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -16,6 +16,7 @@ try:
             cudf.core.series.Series,
             cudf.core.groupby.groupby._Groupby,
             cudf.core.column.column.Column,
+            cudf.core.buffer.Buffer,
         )
     )
     def serialize_cudf_dataframe(x):
@@ -30,6 +31,7 @@ try:
             cudf.core.series.Series,
             cudf.core.groupby.groupby._Groupby,
             cudf.core.column.column.Column,
+            cudf.core.buffer.Buffer,
         )
     )
     def deserialize_cudf_dataframe(header, frames):

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -109,7 +109,17 @@ class Buffer:
 
     @classmethod
     def deserialize(cls, header, frames):
-        return Buffer(frames[0])
+        buf = Buffer(frames[0])
+
+        if header["shape"] != buf.__cuda_array_interface__["shape"]:
+            raise ValueError(
+                "Recieved a `Buffer` with the wrong size."
+                " Expected {0}, but got {1}".format(
+                    header["shape"], buf.__cuda_array_interface__["shape"]
+                )
+            )
+
+        return buf
 
     @classmethod
     def empty(cls, size):

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -60,6 +60,13 @@ class Buffer:
     def __reduce__(self):
         return self.__class__, (self.to_host_array(),)
 
+    def __len__(self):
+        return self.size
+
+    @property
+    def nbytes(self):
+        return self.size
+
     @property
     def __cuda_array_interface__(self):
         intf = {

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -1,5 +1,6 @@
 import functools
 import operator
+import pickle
 
 import numpy as np
 
@@ -103,7 +104,9 @@ class Buffer:
             )
 
     def serialize(self):
-        header = self.__cuda_array_interface__.copy()
+        header = {}
+        header["type"] = pickle.dumps(type(self))
+        header["desc"] = self.__cuda_array_interface__.copy()
         frames = [self]
         return header, frames
 
@@ -111,11 +114,12 @@ class Buffer:
     def deserialize(cls, header, frames):
         buf = cls(frames[0])
 
-        if header["shape"] != buf.__cuda_array_interface__["shape"]:
+        if header["desc"]["shape"] != buf.__cuda_array_interface__["shape"]:
             raise ValueError(
                 "Recieved a `Buffer` with the wrong size."
                 " Expected {0}, but got {1}".format(
-                    header["shape"], buf.__cuda_array_interface__["shape"]
+                    header["desc"]["shape"],
+                    buf.__cuda_array_interface__["shape"],
                 )
             )
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -109,7 +109,7 @@ class Buffer:
 
     @classmethod
     def deserialize(cls, header, frames):
-        buf = Buffer(frames[0])
+        buf = cls(frames[0])
 
         if header["shape"] != buf.__cuda_array_interface__["shape"]:
             raise ValueError(

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -95,6 +95,15 @@ class Buffer:
                 f"Cannot construct Buffer from {data.__class__.__name__}"
             )
 
+    def serialize(self):
+        header = self.__cuda_array_interface__.copy()
+        frames = [self]
+        return header, frames
+
+    @classmethod
+    def deserialize(cls, header, frames):
+        return Buffer(frames[0])
+
     @classmethod
     def empty(cls, size):
         dbuf = DeviceBuffer(size=size)

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -60,6 +60,17 @@ class Buffer:
     def __reduce__(self):
         return self.__class__, (self.to_host_array(),)
 
+    @property
+    def __cuda_array_interface__(self):
+        intf = {
+            "data": (self.ptr, False),
+            "shape": (self.size,),
+            "strides": (1,),
+            "typestr": "|u1",
+            "version": 0,
+        }
+        return intf
+
     def to_host_array(self):
         data = np.empty((self.size,), "i1")
         rmm._lib.device_buffer.copy_ptr_to_host(self.ptr, data.view("u1"))

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -267,10 +267,9 @@ class CategoricalColumn(column.ColumnBase):
         header["data_frames_count"] = len(data_frames)
         frames.extend(data_frames)
         if self.nullable:
-            mask_frames = [self.mask_array_view]
-        else:
-            mask_frames = []
-        frames.extend(mask_frames)
+            mask_header, mask_frames = self.mask.serialize()
+            header["mask"] = mask_header
+            frames.extend(mask_frames)
         header["frame_count"] = len(frames)
         return header, frames
 
@@ -288,8 +287,10 @@ class CategoricalColumn(column.ColumnBase):
             frames[n_dtype_frames : n_dtype_frames + n_data_frames],
         )
         mask = None
-        if header["frame_count"] > n_dtype_frames + n_data_frames:
-            mask = Buffer(frames[n_dtype_frames + n_data_frames])
+        if "mask" in header:
+            mask = Buffer.deserialize(
+                header["mask"], [frames[n_dtype_frames + n_data_frames]]
+            )
         return column.build_column(
             data=None, dtype=dtype, mask=mask, children=(data,)
         )


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

This is a combination and simplification of the approaches in PR ( https://github.com/rapidsai/cudf/pull/4023 ) and PR ( https://github.com/rapidsai/cudf/pull/4077 ). Though it's worth noting the former remains valuable beyond this context.

Namely this PR adds `__cuda_array_interface__` to the `Buffer` class. Also it adds serialization methods that leverage this for direct `Buffer` serialization. This is then leveraged by other cuDF serialization methods to allow `Buffer`s to ship themselves as frames. This all thanks to Distributed and ucx-py's ability to leverage `__cuda_array_interface__` when shipping objects over the wire. Should cut out some overhead added by building Numba representations of `Buffer`s, which is now no longer needed.