### PR TITLE
[REVIEW] Change threshold of optimized code for hash partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - PR #4079 Simply use `mask.size` to create the array view
 - PR #4092 Keep mask on GPU for bit unpacking
 - PR #4081 Copy from `Buffer`'s pointer directly to host
+- PR #4105 Change threshold of using optimized hash partition code
 
 ## Bug Fixes
 

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -34,7 +34,7 @@ namespace {
 constexpr size_type OPTIMIZED_BLOCK_SIZE = 512;
 constexpr size_type OPTIMIZED_ROWS_PER_THREAD = 8;
 constexpr size_type ELEMENTS_PER_THREAD = 2;
-constexpr size_type THRESHOLD_FOR_OPTIMIZED_PARTITION_KERNEL = 512; 
+constexpr size_type THRESHOLD_FOR_OPTIMIZED_PARTITION_KERNEL = 1024; 
 
 // Launch configuration for fallback hash partition
 constexpr size_type FALLBACK_BLOCK_SIZE = 256;


### PR DESCRIPTION
This PR is a quick change based on PR #3808 

- Change threshold for using optimized hash partition code (based on shared memory output cache + cub block scan #3808) from 512 partitions to 1024 partitions 
- Tested on V100, seeing up to 2X speedup on 1024-partition cases

@harrism @trevorsm7 

```
Before using optimized code for 1024 partitions: 
Benchmark                                                    Time             CPU   Iterations
Hashing/hash_partition/131072/1/1024/manual_time         0.238 ms        0.261 ms         2919
Hashing/hash_partition/262144/1/1024/manual_time         0.293 ms        0.317 ms         2365
Hashing/hash_partition/524288/1/1024/manual_time         0.406 ms        0.430 ms         1720
Hashing/hash_partition/1048576/1/1024/manual_time        0.641 ms        0.667 ms         1071
Hashing/hash_partition/2097152/1/1024/manual_time         1.10 ms         1.13 ms          633
Hashing/hash_partition/131072/16/1024/manual_time        0.581 ms        0.605 ms         1144
Hashing/hash_partition/262144/16/1024/manual_time        0.779 ms        0.803 ms          883
Hashing/hash_partition/524288/16/1024/manual_time         1.20 ms         1.22 ms          578
Hashing/hash_partition/1048576/16/1024/manual_time        2.05 ms         2.08 ms          341
Hashing/hash_partition/2097152/16/1024/manual_time        3.89 ms         3.92 ms          180
Hashing/hash_partition/131072/256/1024/manual_time        6.56 ms         6.59 ms          105
Hashing/hash_partition/262144/256/1024/manual_time        8.69 ms         8.71 ms           80
Hashing/hash_partition/524288/256/1024/manual_time        14.2 ms         14.2 ms           49
Hashing/hash_partition/1048576/256/1024/manual_time       26.0 ms         26.1 ms           27
Hashing/hash_partition/2097152/256/1024/manual_time       51.9 ms         51.9 ms           12

After using optimized code for 1024 partitions: 
Benchmark                                                    Time             CPU   Iterations
Hashing/hash_partition/131072/1/1024/manual_time         0.133 ms        0.153 ms         5095
Hashing/hash_partition/262144/1/1024/manual_time         0.136 ms        0.157 ms         5071
Hashing/hash_partition/524288/1/1024/manual_time         0.163 ms        0.186 ms         4215
Hashing/hash_partition/1048576/1/1024/manual_time        0.218 ms        0.242 ms         3182
Hashing/hash_partition/2097152/1/1024/manual_time        0.319 ms        0.343 ms         2192
Hashing/hash_partition/131072/16/1024/manual_time        0.518 ms        0.541 ms         1331
Hashing/hash_partition/262144/16/1024/manual_time        0.610 ms        0.634 ms         1132
Hashing/hash_partition/524288/16/1024/manual_time        0.823 ms        0.846 ms          844
Hashing/hash_partition/1048576/16/1024/manual_time        1.44 ms         1.46 ms          487
Hashing/hash_partition/2097152/16/1024/manual_time        2.58 ms         2.61 ms          271
Hashing/hash_partition/131072/256/1024/manual_time        6.59 ms         6.62 ms          106
Hashing/hash_partition/262144/256/1024/manual_time        8.02 ms         8.04 ms           87
Hashing/hash_partition/524288/256/1024/manual_time        11.3 ms         11.3 ms           62
Hashing/hash_partition/1048576/256/1024/manual_time       20.7 ms         20.8 ms           34
Hashing/hash_partition/2097152/256/1024/manual_time       38.3 ms         38.3 ms           18
```
