### PR TITLE
Use rmm::device_vector instead of thrust::device_vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - PR #4086 ORC reader: fix potentially incorrect timestamp decoding in the last rowgroup
 - PR #4089 Fix dask groupby mutliindex test case issues in join
 - PR #4076 All null string entries should have null data buffer
+- PR #4109 Use rmm::device_vector instead of thrust::device_vector
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -367,7 +367,7 @@ struct column_preprocess_info {
  * - avoiding reaching into gpu memory on the cpu to retrieve offsets to compute string sizes.
  * - creating column_device_views on the base string_column_view itself as that causes gpu memory allocation.
  */
-thrust::host_vector<column_split_info> preprocess_string_column_info(cudf::table_view const& t, thrust::device_vector<column_split_info>& device_split_info, cudaStream_t stream)
+thrust::host_vector<column_split_info> preprocess_string_column_info(cudf::table_view const& t, rmm::device_vector<column_split_info>& device_split_info, cudaStream_t stream)
 {          
    // build a list of all the offset columns and their indices for all input string columns and put them on the gpu   
    thrust::host_vector<column_preprocess_info> offset_columns;
@@ -382,10 +382,10 @@ thrust::host_vector<column_split_info> preprocess_string_column_info(cudf::table
       }
       column_index++;
    });   
-   thrust::device_vector<column_preprocess_info> device_offset_columns = offset_columns;
+   rmm::device_vector<column_preprocess_info> device_offset_columns = offset_columns;
     
    // compute column split information
-   thrust::device_vector<thrust::pair<size_type, size_type>> device_offsets(t.num_columns());
+   rmm::device_vector<thrust::pair<size_type, size_type>> device_offsets(t.num_columns());
    thrust::transform(rmm::exec_policy(stream)->on(stream), device_offset_columns.begin(), device_offset_columns.end(), device_offsets.begin(), 
       [] __device__ (column_preprocess_info const& cpi){
          return thrust::make_pair(cpi.offsets.head<int32_t>()[cpi.offset], cpi.offsets.head<int32_t>()[cpi.offset + cpi.size]);
@@ -416,7 +416,7 @@ thrust::host_vector<column_split_info> preprocess_string_column_info(cudf::table
  * call with the input table.  The memory referenced by the table_view and its internal column_views
  * is entirely contained in single block of memory.
  */
-contiguous_split_result alloc_and_copy(cudf::table_view const& t, thrust::device_vector<column_split_info>& device_split_info, rmm::mr::device_memory_resource* mr, cudaStream_t stream)
+contiguous_split_result alloc_and_copy(cudf::table_view const& t, rmm::device_vector<column_split_info>& device_split_info, rmm::mr::device_memory_resource* mr, cudaStream_t stream)
 {           
    // preprocess column split information for string columns.
    thrust::host_vector<column_split_info> split_info = preprocess_string_column_info(t, device_split_info, stream);
@@ -462,7 +462,7 @@ std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& in
    //                benchmark:        1 GB data, 10 columns, 256 splits.
    //                no optimization:  106 ms (8 GB/s)
    //                optimization:     20 ms (48 GB/s)
-   thrust::device_vector<column_split_info> device_split_info(input.num_columns());
+   rmm::device_vector<column_split_info> device_split_info(input.num_columns());
 
    std::vector<contiguous_split_result> result;
    std::transform(subtables.begin(), subtables.end(), std::back_inserter(result), [mr, stream, &device_split_info](table_view const& t) { 

--- a/cpp/src/io/json/reader_impl.hpp
+++ b/cpp/src/io/json/reader_impl.hpp
@@ -62,7 +62,7 @@ private:
   // Used when the input data is compressed, to ensure the allocated uncompressed data is freed
   std::vector<char> uncomp_data_owner_;
   rmm::device_buffer data_;
-  thrust::device_vector<uint64_t> rec_starts_;
+  rmm::device_vector<uint64_t> rec_starts_;
 
   size_t byte_range_offset_ = 0;
   size_t byte_range_size_ = 0;
@@ -74,9 +74,9 @@ private:
   // parsing options
   const bool allow_newlines_in_strings_ = false;
   ParseOptions opts_{',', '\n', '\"', '.'};
-  thrust::device_vector<SerialTrieNode> d_true_trie_;
-  thrust::device_vector<SerialTrieNode> d_false_trie_;
-  thrust::device_vector<SerialTrieNode> d_na_trie_;
+  rmm::device_vector<SerialTrieNode> d_true_trie_;
+  rmm::device_vector<SerialTrieNode> d_false_trie_;
+  rmm::device_vector<SerialTrieNode> d_na_trie_;
 
   /**
    * @brief Ingest input JSON file/buffer, without decompression

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -50,7 +50,7 @@ std::unique_ptr<cudf::column> slice( strings_column_view const& strings,
     //
     auto execpol = rmm::exec_policy(stream);
     // build indices
-    thrust::device_vector<size_type> indices(strings_count);
+    rmm::device_vector<size_type> indices(strings_count);
     thrust::sequence( execpol->on(stream), indices.begin(), indices.end(), start, step );
     // create a column_view as a wrapper of these indices
     column_view indices_view( data_type{INT32}, strings_count, indices.data().get(), nullptr, 0 );

--- a/cpp/src/strings/sorting/sorting.cu
+++ b/cpp/src/strings/sorting/sorting.cu
@@ -45,7 +45,7 @@ std::unique_ptr<cudf::column> sort( strings_column_view strings,
 
     // sort the indices of the strings
     size_type num_strings = strings.size();
-    thrust::device_vector<size_type> indices(num_strings);
+    rmm::device_vector<size_type> indices(num_strings);
     thrust::sequence( execpol->on(stream), indices.begin(), indices.end() );
     thrust::sort( execpol->on(stream), indices.begin(), indices.end(),
         [d_column, stype, order, null_order] __device__ (size_type lhs, size_type rhs) {


### PR DESCRIPTION
While working with `contiguous_split`, I noticed in the Nsight traces that `cudaMalloc` and `cudaFree` were being called quite a bit by this function.  Digging into the code, I saw `thrust::device_vector` being used instead of `rmm::device_vector`.  That bypasses RMM and loses the performance benefit of memory pooling.

This PR updates places in non-test code to use `rmm::device_vector` instead of `thrust::device_vector`.