### PR TITLE
[REVIEW] Fixed a bug in contiguous_split() involving tables of mixed types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - PR #4089 Fix dask groupby mutliindex test case issues in join
 - PR #4076 All null string entries should have null data buffer
 - PR #4109 Use rmm::device_vector instead of thrust::device_vector
+- PR #4116 Fix a bug in contiguous_split() where tables with mixed column types could corrupt string output
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/tests/copying/split_tests.cu
+++ b/cpp/tests/copying/split_tests.cu
@@ -574,3 +574,42 @@ TEST_F(ContiguousSplitTableCornerCases, EmptyOutputColumn) {
         }
     );
 }
+
+TEST_F(ContiguousSplitTableCornerCases, MixedColumnTypes) {
+  cudf::size_type start = 0;    
+  auto valids = cudf::test::make_counting_transform_iterator(start, [](auto i) { return true; });    
+  
+  std::vector<std::string> strings[2]     = { {"", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"}, 
+                                              {"", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"} };
+  
+  std::vector<std::unique_ptr<cudf::column>> cols;   
+  
+  auto iter0 = cudf::test::make_counting_transform_iterator(0, [](auto i) { return (i);});
+  auto c0 = cudf::test::fixed_width_column_wrapper<int>(iter0, iter0 + 10, valids);
+  cols.push_back(c0.release());
+  
+  auto iter1 = cudf::test::make_counting_transform_iterator(10, [](auto i) { return (i);});
+  auto c1 = cudf::test::fixed_width_column_wrapper<int>(iter1, iter1 + 10, valids);
+  cols.push_back(c1.release());
+
+  auto c2 = cudf::test::strings_column_wrapper(strings[0].begin(), strings[0].end(), valids);
+  cols.push_back(c2.release());
+
+  auto c3 = cudf::test::strings_column_wrapper(strings[1].begin(), strings[1].end(), valids);
+  cols.push_back(c3.release());
+
+  auto iter4 = cudf::test::make_counting_transform_iterator(20, [](auto i) { return (i);});
+  auto c4 = cudf::test::fixed_width_column_wrapper<int>(iter4, iter4 + 10, valids);
+  cols.push_back(c4.release());
+
+  auto tbl = cudf::experimental::table(std::move(cols));
+  
+  std::vector<cudf::size_type> splits{5};
+
+  auto result = cudf::experimental::contiguous_split(tbl, splits);
+  auto expected = cudf::experimental::split(tbl, splits);
+  
+  for (unsigned long index = 0; index < expected.size(); index++) {      
+    cudf::test::expect_tables_equal(expected[index], result[index].table);
+  }
+}


### PR DESCRIPTION
Fixes #4114

Tables with mixed column types including strings could cause some internal indexing issues that resulted in corrupted output/split columns.   Core issue was a thrust::transform() that was storing offset values in an output array just pushing the elements on to the end instead of respecting their expected column indices.