### PR TITLE
[REVIEW] Use jitify -remove-unused-globals to fix binops slowdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 - PR #4097 Fix strings concatenate logic with column offsets
 - PR #4076 All null string entries should have null data buffer
 - PR #4109 Use rmm::device_vector instead of thrust::device_vector
-
+- PR #4119 Fix binary ops slowdown using jitify -remove-unused-globals
 
 # cuDF 0.12.0 (04 Feb 2020)
 

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -87,6 +87,8 @@ const std::string hash = "prog_binop.experimental";
 
 const std::vector<std::string> compiler_flags{
     "-std=c++14",
+    // Have jitify prune unused global variables
+    "-remove-unused-globals",
     // suppress all NVRTC warnings
     "-w",
     // force libcudacxx to not include system headers

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -337,11 +337,19 @@ std::unique_ptr<column> rolling_window_udf(column_view const &input,
   auto output_view = output->mutable_view();
   rmm::device_scalar<size_type> device_valid_count{0, stream};
 
+  const std::vector<std::string> compiler_flags{
+    "-std=c++14",
+    // Have jitify prune unused global variables
+    "-remove-unused-globals",
+    // suppress all NVRTC warnings
+    "-w"
+  };
+
   // Launch the jitify kernel
   cudf::jit::launcher(hash, cuda_source,
                       { cudf_types_hpp, cudf_utilities_bit_hpp,
                         cudf::experimental::rolling::jit::code::operation_h },
-                      { "-std=c++14", "-w" }, nullptr, stream)
+                      compiler_flags, nullptr, stream)
     .set_kernel_inst("gpu_rolling_new", // name of the kernel we are launching
                       { cudf::jit::get_type_name(input.type()), // list of template arguments
                         cudf::jit::get_type_name(output->type()),

--- a/cpp/src/transform/transform.cpp
+++ b/cpp/src/transform/transform.cpp
@@ -53,12 +53,18 @@ void unary_operation(mutable_column_view output, column_view input,
       cudf::jit::parse_single_function_cuda(
           udf, "GENERIC_UNARY_OP") + code::kernel;
   }
+
+  const std::vector<std::string> compiler_flags{
+    "-std=c++14",
+    // Have jitify prune unused global variables
+    "-remove-unused-globals",
+    // suppress all NVRTC warnings
+    "-w"
+  };
   
   // Launch the jitify kernel
-  cudf::jit::launcher(
-    hash, cuda_source,
-    { cudf_types_hpp },
-    { "-std=c++14" }, nullptr, stream
+  cudf::jit::launcher(hash, cuda_source, { cudf_types_hpp },
+                      compiler_flags, nullptr, stream
   ).set_kernel_inst(
     "kernel", // name of the kernel we are launching
     { cudf::jit::get_type_name(output.type()), // list of template arguments


### PR DESCRIPTION
Fixes #3659 

Uses new jitify option `-remove-unused-globals` to remove unnecessary unused globals that were introduced into RAPIDS PTX when including libcu++ headers. This should solve the performance regression in #3659. 

Depends on NVIDIA/jitify#40 (merged), and rapidsai/jitify#7 (which merges the former into rapidsai fork of jitify). This PR updates the libcudf jitify submodule.