### PR TITLE
[REVIEW] Explicit mutable_column_view to column_view conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - PR #4076 All null string entries should have null data buffer
 - PR #4109 Use rmm::device_vector instead of thrust::device_vector
 - PR #4116 Fix a bug in contiguous_split() where tables with mixed column types could corrupt string output
+- PR #4126 Make mutable_column_view to column_view conversion explicit
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -496,7 +496,7 @@ class mutable_column_view : public detail::column_view_base {
    *
    * @return column_view An immutable view of the mutable view's elements
    *---------------------------------------------------------------------------**/
-  operator column_view() const;
+  explicit operator column_view() const;
 
  private:
   std::vector<mutable_column_view> mutable_children;

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -161,7 +161,7 @@ void binary_operation(mutable_column_view& out,
            cudf::jit::get_type_name(rhs.type()),
            cudf::jit::get_type_name(lhs.type()),
            get_operator_name(op, OperatorType::Reverse)})
-      .launch(out.size(), cudf::jit::get_data_ptr(out),
+      .launch(out.size(), cudf::jit::get_data_ptr(column_view{out}),
               cudf::jit::get_data_ptr(rhs), cudf::jit::get_data_ptr(lhs));
 }
 
@@ -179,7 +179,7 @@ void binary_operation(mutable_column_view& out,
            cudf::jit::get_type_name(lhs.type()),
            cudf::jit::get_type_name(rhs.type()),
            get_operator_name(op, OperatorType::Direct)})
-      .launch(out.size(), cudf::jit::get_data_ptr(out),
+      .launch(out.size(), cudf::jit::get_data_ptr(column_view{out}),
               cudf::jit::get_data_ptr(lhs), cudf::jit::get_data_ptr(rhs));
 }
 
@@ -197,7 +197,7 @@ void binary_operation(mutable_column_view& out,
            cudf::jit::get_type_name(lhs.type()),
            cudf::jit::get_type_name(rhs.type()),
            get_operator_name(op, OperatorType::Direct)})
-      .launch(out.size(), cudf::jit::get_data_ptr(out),
+      .launch(out.size(), cudf::jit::get_data_ptr(column_view{out}),
               cudf::jit::get_data_ptr(lhs), cudf::jit::get_data_ptr(rhs));
 }
 
@@ -225,7 +225,7 @@ void binary_operation(mutable_column_view& out,
                         cudf::jit::get_type_name(rhs.type()),
                         get_operator_name(binary_operator::GENERIC_BINARY,
                                           OperatorType::Direct)})
-      .launch(out.size(), cudf::jit::get_data_ptr(out),
+      .launch(out.size(), cudf::jit::get_data_ptr(column_view{out}),
               cudf::jit::get_data_ptr(lhs), cudf::jit::get_data_ptr(rhs));
 }
 

--- a/cpp/src/column/column_view.cpp
+++ b/cpp/src/column/column_view.cpp
@@ -22,6 +22,7 @@
 
 #include <exception>
 #include <vector>
+#include <algorithm>
 
 namespace cudf {
 
@@ -111,8 +112,9 @@ void mutable_column_view::set_null_count(size_type new_null_count) {
 mutable_column_view::operator column_view() const {
   // Convert children to immutable views
   std::vector<column_view> child_views(num_children());
-  std::copy(std::cbegin(mutable_children), std::cend(mutable_children),
-            std::begin(child_views));
+  std::transform(std::cbegin(mutable_children), std::cend(mutable_children),
+                 std::begin(child_views),
+                 [](auto const& mut_child) { return column_view{mut_child}; });
   return column_view{_type,
                      _size,
                      _data,

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -274,7 +274,7 @@ struct column_copy_functor {
       }
       mcv.set_null_count(cudf::UNKNOWN_NULL_COUNT);
 
-      out_cols.push_back(mcv);
+      out_cols.push_back(column_view{mcv});
    }
 };
 template <>

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -976,7 +976,7 @@ void normalize_nans_and_zeros(mutable_column_view in_out,
 
   // wrapping the in_out data in a column_view so we can call the same lower level code.
   // that we use for the non in-place version.
-  column_view input = in_out;
+  column_view input{in_out};
 
   // to device. unique_ptr which gets automatically cleaned up when we leave
   auto device_in = column_device_view::create(input);

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -348,7 +348,7 @@ std::unique_ptr<column> rolling_window_udf(column_view const &input,
                         udf_agg->_operator_name,
                         static_window ? "cudf::size_type" : "cudf::size_type*"})
     .launch(input.size(), cudf::jit::get_data_ptr(input), input.null_mask(),
-            cudf::jit::get_data_ptr(output_view), output_view.null_mask(),
+            cudf::jit::get_data_ptr(column_view{output_view}), output_view.null_mask(),
             device_valid_count.data(), preceding_window, following_window, min_periods);
 
   output->set_null_count(output->size() - device_valid_count.value(stream));

--- a/cpp/src/strings/strings_scalar_factories.cpp
+++ b/cpp/src/strings/strings_scalar_factories.cpp
@@ -24,7 +24,7 @@ std::unique_ptr<scalar> make_string_scalar(
     cudaStream_t stream,
     rmm::mr::device_memory_resource* mr)
 {
-    auto s = new string_scalar(string, false, stream, mr);
+    auto s = new string_scalar(string, true, stream, mr);
     return std::unique_ptr<scalar>(s);
 }
 

--- a/cpp/src/strings/strings_scalar_factories.cpp
+++ b/cpp/src/strings/strings_scalar_factories.cpp
@@ -24,7 +24,7 @@ std::unique_ptr<scalar> make_string_scalar(
     cudaStream_t stream,
     rmm::mr::device_memory_resource* mr)
 {
-    auto s = new string_scalar(string, true, stream, mr);
+    auto s = new string_scalar(string, false, stream, mr);
     return std::unique_ptr<scalar>(s);
 }
 

--- a/cpp/src/transform/transform.cpp
+++ b/cpp/src/transform/transform.cpp
@@ -65,7 +65,7 @@ void unary_operation(mutable_column_view output, column_view input,
       cudf::jit::get_type_name(input.type()) }
   ).launch(
     output.size(),
-    cudf::jit::get_data_ptr(output),
+    cudf::jit::get_data_ptr(column_view{output}),
     cudf::jit::get_data_ptr(input)
   );
 


### PR DESCRIPTION
Fixes #4112 

Make the mutable_column_view to column_view conversion explicit to avoid unexpected overload resolution, e.g.:
```
auto column = cudf::make_numeric_column(...);
cudf::experimental::fill(column->mutable_view(), 0, column->size(), scalar);
```
