### PR TITLE
[REVIEW] Rename in-place fill to fill_in_place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - PR #4098 Remove legacy calls from libcudf strings column code
 - PR #4111 Use `Buffer`'s to serialize `StringColumn`
 - PR #4113 Get `len` of `StringColumn`s without `nvstrings`
+- PR #4130 Renames in-place `cudf::experimental::fill` to `cudf::experimental::fill_in_place`
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/filling.hpp
+++ b/cpp/include/cudf/filling.hpp
@@ -50,8 +50,8 @@ namespace experimental {
  * @param value The scalar value to fill
  * @return void
  *---------------------------------------------------------------------------**/
-void fill(mutable_column_view& destination, size_type begin, size_type end,
-          scalar const& value);
+void fill_in_place(mutable_column_view& destination, size_type begin,
+                   size_type end, scalar const& value);
 
 /**---------------------------------------------------------------------------*
  * @brief Fills a range of elements in a column out-of-place with a scalar

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -123,11 +123,11 @@ namespace experimental {
 
 namespace detail {
 
-void fill(mutable_column_view& destination,
-          size_type begin,
-          size_type end,
-          scalar const& value,
-          cudaStream_t stream) {
+void fill_in_place(mutable_column_view& destination,
+                   size_type begin,
+                   size_type end,
+                   scalar const& value,
+                   cudaStream_t stream) {
   CUDF_EXPECTS(cudf::is_fixed_width(destination.type()) == true,
                "In-place fill does not support variable-sized types.");
   CUDF_EXPECTS((begin >= 0) &&
@@ -170,11 +170,11 @@ std::unique_ptr<column> fill(column_view const& input,
 
 }  // namespace detail
 
-void fill(mutable_column_view& destination,
-          size_type begin,
-          size_type end,
-          scalar const& value) {
-  return detail::fill(destination, begin, end, value, 0);
+void fill_in_place(mutable_column_view& destination,
+                   size_type begin,
+                   size_type end,
+                   scalar const& value) {
+  return detail::fill_in_place(destination, begin, end, value, 0);
 }
 
 std::unique_ptr<column> fill(column_view const& input,

--- a/cpp/tests/filling/fill_tests.cu
+++ b/cpp/tests/filling/fill_tests.cu
@@ -95,7 +95,7 @@ public:
     // test in-place version second
 
     cudf::mutable_column_view mutable_view{destination};
-    EXPECT_NO_THROW(cudf::experimental::fill(mutable_view, begin, end, *p_val));
+    EXPECT_NO_THROW(cudf::experimental::fill_in_place(mutable_view, begin, end, *p_val));
     cudf::test::expect_columns_equal(mutable_view, expected);
   }
 };
@@ -302,7 +302,7 @@ TEST_F(FillErrorTestFixture, InvalidInplaceCall)
       thrust::make_counting_iterator(0) + 100);
 
   auto destination_view = cudf::mutable_column_view{destination};
-  EXPECT_THROW(cudf::experimental::fill(destination_view, 0, 100, *p_val_int),
+  EXPECT_THROW(cudf::experimental::fill_in_place(destination_view, 0, 100, *p_val_int),
                cudf::logic_error);
 
   auto p_val_str = cudf::make_string_scalar("five");
@@ -313,7 +313,7 @@ TEST_F(FillErrorTestFixture, InvalidInplaceCall)
     cudf::test::strings_column_wrapper(strings.begin(), strings.end());
 
   cudf::mutable_column_view destination_view_string{destination_string};
-  EXPECT_THROW(cudf::experimental::fill(
+  EXPECT_THROW(cudf::experimental::fill_in_place(
                  destination_view_string, 0, 100, *p_val_str),
                cudf::logic_error);
 }
@@ -334,33 +334,33 @@ TEST_F(FillErrorTestFixture, InvalidRange)
   cudf::mutable_column_view destination_view{destination};
 
   // empty range == no-op, this is valid
-  EXPECT_NO_THROW(cudf::experimental::fill(destination_view, 0, 0, *p_val));
+  EXPECT_NO_THROW(cudf::experimental::fill_in_place(destination_view, 0, 0, *p_val));
   EXPECT_NO_THROW(auto p_ret =
                     cudf::experimental::fill(destination, 0, 0, *p_val));
 
   // out_begin is negative
-  EXPECT_THROW(cudf::experimental::fill(destination_view, -10, 0, *p_val),
+  EXPECT_THROW(cudf::experimental::fill_in_place(destination_view, -10, 0, *p_val),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::fill(destination, -10, 0,
                  *p_val),
                cudf::logic_error);
 
   // out_begin > out_end
-  EXPECT_THROW(cudf::experimental::fill(destination_view, 10, 5, *p_val),
+  EXPECT_THROW(cudf::experimental::fill_in_place(destination_view, 10, 5, *p_val),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::fill(destination, 10, 5,
                  *p_val),
                cudf::logic_error);
 
   // out_begin >= destination.size()
-  EXPECT_THROW(cudf::experimental::fill(destination_view, 100, 100, *p_val),
+  EXPECT_THROW(cudf::experimental::fill_in_place(destination_view, 100, 100, *p_val),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::fill(destination, 100, 100,
                  *p_val),
                cudf::logic_error);
 
   // out_end > destination.size()
-  EXPECT_THROW(cudf::experimental::fill(destination_view, 99, 101, *p_val),
+  EXPECT_THROW(cudf::experimental::fill_in_place(destination_view, 99, 101, *p_val),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::fill(destination, 99, 101,
                  *p_val),
@@ -382,7 +382,7 @@ TEST_F(FillErrorTestFixture, DTypeMismatch)
 
   auto destination_view = cudf::mutable_column_view{destination};
 
-  EXPECT_THROW(cudf::experimental::fill(
+  EXPECT_THROW(cudf::experimental::fill_in_place(
                  destination_view, 0, 10, *p_val),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::fill(


### PR DESCRIPTION
Fixes #4112

Renames in-place `fill` to `fill_in_place`