### PR TITLE
[REVIEW] Fix hash partition null mask allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - PR #4113 Use `.nvstrings` in `StringColumn.sum(...)`
 - PR #4116 Fix a bug in contiguous_split() where tables with mixed column types could corrupt string output
 - PR #4125 Fix type enum to account for added Dictionary type in `types.hpp`
+- PR #4132 Fix `hash_partition` null mask allocation
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/include/cudf/detail/copy_if.cuh
+++ b/cpp/include/cudf/detail/copy_if.cuh
@@ -228,7 +228,7 @@ struct scatter_gather_functor
 
       auto output_table = cudf::experimental::detail::gather(cudf::table_view{{input}}, 
                                          indices.begin(), indices.end(), 
-                                         false, false, false, mr, stream);
+                                         false, mr, stream);
 
       // There will be only one column
       return std::make_unique<cudf::column>(std::move(output_table->get_column(0)));

--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -348,6 +348,10 @@ void gather_bitmask(table_view const& source, MapIterator gather_map,
     std::vector<std::unique_ptr<column>>& target, gather_bitmask_op op,
     rmm::mr::device_memory_resource* mr, cudaStream_t stream)
 {
+  if (target.empty()) {
+    return;
+  }
+
   // Validate that all target columns have the same size
   auto const target_rows = target.front()->size();
   CUDF_EXPECTS(std::all_of(target.begin(), target.end(), [target_rows](auto const& col)

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -158,7 +158,8 @@ scatter(table_view const& source, MapIterator scatter_map_begin,
 
     auto gather_map = scatter_to_gather<T>(updated_scatter_map_begin, updated_scatter_map_end,
       target.num_rows(), stream);
-    gather_bitmask(source, gather_map.begin(), result, mr, stream);
+    // TODO this should be nullify_out_of_bounds, not ignore_out_of_bounds
+    gather_bitmask(source, gather_map.begin(), result, true, mr, stream);
 
     return std::make_unique<table>(std::move(result));
 }

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -158,8 +158,8 @@ scatter(table_view const& source, MapIterator scatter_map_begin,
 
     auto gather_map = scatter_to_gather<T>(updated_scatter_map_begin, updated_scatter_map_end,
       target.num_rows(), stream);
-    // TODO this should be nullify_out_of_bounds, not ignore_out_of_bounds
-    gather_bitmask(source, gather_map.begin(), result, true, mr, stream);
+    gather_bitmask(source, gather_map.begin(), result,
+      gather_bitmask_op::PASSTHROUGH, mr, stream);
 
     return std::make_unique<table>(std::move(result));
 }

--- a/cpp/src/copying/gather.cu
+++ b/cpp/src/copying/gather.cu
@@ -52,9 +52,7 @@ struct dispatch_map_type {
 	       thrust::make_transform_iterator(
 					       gather_map.end<map_type>(),
 					       index_converter<map_type>{source_table.num_rows()}),
-	       check_bounds,
 	       ignore_out_of_bounds,
-	       allow_negative_indices,
 	       mr,
 	       stream
 	     );
@@ -64,9 +62,7 @@ struct dispatch_map_type {
 	gather(source_table,
 	       gather_map.begin<map_type>(),
 	       gather_map.end<map_type>(),
-	       check_bounds,
 	       ignore_out_of_bounds,
-	       allow_negative_indices,
 	       mr,
 	       stream
 	       );

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -142,7 +142,7 @@ std::unique_ptr<table> repeat(table_view const& input_table,
                       indices.begin());
 
   return gather(input_table, indices.begin(), indices.end(),
-                false, false, false, mr, stream);
+                false, mr, stream);
 }
 
 std::unique_ptr<table> repeat(table_view const& input_table,
@@ -170,7 +170,7 @@ std::unique_ptr<table> repeat(table_view const& input_table,
   auto map_end = map_begin + output_size;
 
   return gather(input_table, map_begin, map_end,
-                false, false, false, mr, stream);
+                false, mr, stream);
 }
 
 }  // namespace detail

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -299,7 +299,7 @@ std::unique_ptr<table> sort_groupby_helper::unique_keys(
 
   return cudf::experimental::detail::gather(_keys, gather_map_it,
                                             gather_map_it + num_groups(),
-                                            false, false, false, mr, stream);
+                                            false, mr, stream);
 }
 
 

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -21,8 +21,8 @@
 #include <cudf/detail/utilities/hash_functions.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/table/row_operators.cuh>
-#include <cudf/detail/scatter.hpp>
 #include <cudf/detail/scatter.cuh>
+#include <cudf/detail/gather.cuh>
 
 #include <thrust/tabulate.h>
 

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -562,7 +562,8 @@ hash_partition_table(table_view const& input,
           grid_size, stream);
 
       // Handle bitmask using gather to take advantage of ballot_sync
-      experimental::detail::gather_bitmask(input, gather_map.begin(), output_cols, false, mr, stream);
+      experimental::detail::gather_bitmask(input, gather_map.begin(), output_cols,
+        experimental::detail::gather_bitmask_op::DONT_CHECK, mr, stream);
     }
 
     auto output {std::make_unique<experimental::table>(std::move(output_cols))};

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -562,7 +562,7 @@ hash_partition_table(table_view const& input,
           grid_size, stream);
 
       // Handle bitmask using gather to take advantage of ballot_sync
-      experimental::detail::gather_bitmask(input, gather_map.begin(), output_cols, mr, stream);
+      experimental::detail::gather_bitmask(input, gather_map.begin(), output_cols, false, mr, stream);
     }
 
     auto output {std::make_unique<experimental::table>(std::move(output_cols))};

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -340,12 +340,12 @@ construct_join_output_df(
           right.select(right_common_col),
           complement_indices.second.begin(),
           complement_indices.second.end(),
-          false, nullify_out_of_bounds);
+          nullify_out_of_bounds);
       auto common_from_left = experimental::detail::gather(
           left.select(left_common_col),
           joined_indices.first.begin(),
           joined_indices.first.end(),
-          false, nullify_out_of_bounds);
+          nullify_out_of_bounds);
       common_table = experimental::concatenate(
           {common_from_right->view(), common_from_left->view()});
     } 
@@ -357,7 +357,7 @@ construct_join_output_df(
           left.select(left_common_col),
           joined_indices.first.begin(),
           joined_indices.first.end(),
-          false, nullify_out_of_bounds);
+          nullify_out_of_bounds);
       }
   }
 
@@ -367,14 +367,14 @@ construct_join_output_df(
         left.select(left_noncommon_col),
         joined_indices.first.begin(),
         joined_indices.first.end(),
-        false, nullify_out_of_bounds);
+        nullify_out_of_bounds);
 
   std::unique_ptr<experimental::table> right_table =
     experimental::detail::gather(
         right.select(right_noncommon_col),
         joined_indices.second.begin(),
         joined_indices.second.end(),
-        false, nullify_out_of_bounds);
+        nullify_out_of_bounds);
 
   return std::make_unique<experimental::table>(
       combine_join_columns(

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -130,7 +130,7 @@ std::unique_ptr<cudf::experimental::table> left_semi_anti_join(cudf::table_view 
                                         });
 
   return cudf::experimental::detail::gather(left.select(return_columns), gather_map.begin(), gather_map_end,
-                                            false, false, true, mr);
+                                            false, mr);
 }
 } // detail
 

--- a/cpp/src/quantiles/quantiles.cu
+++ b/cpp/src/quantiles/quantiles.cu
@@ -56,8 +56,6 @@ quantiles(table_view const& input,
                           quantile_idx_iter,
                           quantile_idx_iter + q.size(),
                           false,
-                          false,
-                          false,
                           mr);
 }
 

--- a/cpp/src/reshape/tile.cu
+++ b/cpp/src/reshape/tile.cu
@@ -57,7 +57,7 @@ tile(const table_view &in, size_type count, rmm::mr::device_memory_resource *mr)
     auto tiled_it = thrust::make_transform_iterator(counting_it,
                                                     tile_functor{in_num_rows});
 
-    return detail::gather(in, tiled_it, tiled_it + out_num_rows, mr);
+    return detail::gather(in, tiled_it, tiled_it + out_num_rows, false, mr);
 }
 
 } // namespace experimental

--- a/cpp/src/round_robin/round_robin.cu
+++ b/cpp/src/round_robin/round_robin.cu
@@ -97,7 +97,7 @@ degenerate_partitions(cudf::table_view const& input,
 
     auto uniq_tbl = cudf::experimental::detail::gather(input,
                                                        rotated_iter_begin, rotated_iter_begin + nrows,//map
-                                                       false, false, false,
+                                                       false,
                                                        mr,
                                                        stream);
 
@@ -128,7 +128,7 @@ degenerate_partitions(cudf::table_view const& input,
     //
     auto uniq_tbl = cudf::experimental::detail::gather(input,
                                                        d_row_indices.begin(), d_row_indices.end(),//map
-                                                       false, false, false,
+                                                       false,
                                                        mr,
                                                        stream);
 
@@ -230,7 +230,7 @@ round_robin_partition(table_view const& input,
 
   auto uniq_tbl = cudf::experimental::detail::gather(input,
                                                      iter_begin, iter_begin + nrows,
-                                                     false, false, false,
+                                                     false,
                                                      mr,
                                                      stream);
   auto ret_pair =

--- a/cpp/tests/copying/gather_tests.cu
+++ b/cpp/tests/copying/gather_tests.cu
@@ -33,7 +33,7 @@ TYPED_TEST(GatherTest, GatherDetailDeviceVectorTest) {
   // test with device vector iterators
   {
     std::unique_ptr<cudf::experimental::table> result =
-      cudf::experimental::detail::gather(source_table, gather_map.begin(), gather_map.end(), true);
+      cudf::experimental::detail::gather(source_table, gather_map.begin(), gather_map.end());
 
     for (auto i=0; i<source_table.num_columns(); ++i) {
       cudf::test::expect_columns_equal(source_table.column(i), result->view().column(i));
@@ -46,8 +46,7 @@ TYPED_TEST(GatherTest, GatherDetailDeviceVectorTest) {
   {
     std::unique_ptr<cudf::experimental::table> result =
       cudf::experimental::detail::gather(source_table, gather_map.data().get(),
-                                         gather_map.data().get() + gather_map.size(),
-                                         true);
+                                         gather_map.data().get() + gather_map.size());
 
     for (auto i=0; i<source_table.num_columns(); ++i) {
       cudf::test::expect_columns_equal(source_table.column(i), result->view().column(i));
@@ -412,6 +411,6 @@ TEST_F(GatherTestStr, GatherZeroSizeStringsColumn)
 {
     cudf::column_view zero_size_strings_column( cudf::data_type{cudf::STRING}, 0, nullptr, nullptr, 0);
     rmm::device_vector<cudf::size_type> gather_map{};
-    auto results = cudf::experimental::detail::gather(cudf::table_view({zero_size_strings_column}), gather_map.begin(), gather_map.end(), false, true);
+    auto results = cudf::experimental::detail::gather(cudf::table_view({zero_size_strings_column}), gather_map.begin(), gather_map.end(), true);
     cudf::test::expect_strings_empty(results->get_column(0).view());
 }

--- a/cpp/tests/hashing/hash_partition_test.cpp
+++ b/cpp/tests/hashing/hash_partition_test.cpp
@@ -135,6 +135,22 @@ TEST_F(HashPartition, MixedColumnTypes)
   expect_tables_equal(output1->view(), output2->view());
 }
 
+TEST_F(HashPartition, NullableStrings)
+{
+  strings_column_wrapper strings({"a", "bb", "ccc", "d"}, {1, 1, 1, 1});
+  cudf::table_view input({strings});
+
+  std::vector<cudf::size_type> const columns_to_hash({0});
+  cudf::size_type const num_partitions = 3;
+
+  std::unique_ptr<cudf::experimental::table> result;
+  std::vector<cudf::size_type> offsets;
+  std::tie(result, offsets) = cudf::hash_partition(input, columns_to_hash, num_partitions);
+
+  auto const& col = result->get_column(0);
+  EXPECT_EQ(0, col.null_count());
+}
+
 TEST_F(HashPartition, ColumnsToHash)
 {
   fixed_width_column_wrapper<int32_t> to_hash({1, 2, 3, 4, 5, 6});
@@ -165,6 +181,22 @@ template <typename T>
 class HashPartitionFixedWidth : public cudf::test::BaseFixture {};
 
 TYPED_TEST_CASE(HashPartitionFixedWidth, cudf::test::FixedWidthTypes);
+
+TYPED_TEST(HashPartitionFixedWidth, NullableFixedWidth)
+{
+  fixed_width_column_wrapper<TypeParam> fixed({1, 2, 3, 4}, {1, 1, 1, 1});
+  cudf::table_view input({fixed});
+
+  std::vector<cudf::size_type> const columns_to_hash({0});
+  cudf::size_type const num_partitions = 3;
+
+  std::unique_ptr<cudf::experimental::table> result;
+  std::vector<cudf::size_type> offsets;
+  std::tie(result, offsets) = cudf::hash_partition(input, columns_to_hash, num_partitions);
+
+  auto const& col = result->get_column(0);
+  EXPECT_EQ(0, col.null_count());
+}
 
 template <typename T>
 void run_fixed_width_test(size_t cols, size_t rows, cudf::size_type num_partitions, bool has_nulls = false)


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/4103
Closes https://github.com/rapidsai/cudf/issues/4120

The `hash_partition` optimization in PR https://github.com/rapidsai/cudf/pull/3748 included a fallback for non-fixed-width columns using `column_gatherer`. When the source column contains a null mask, `column_gatherer` would allocate a mask for the output and leave it in uninitialized state. However, hash_partition only computes the null mask if the source actually contains nulls. This resulted in a bug where an input strings column with all-valid null mask would produce an output column with an uninitialized/all-nulls mask.

I added unit tests for the above case and refactored the null mask allocation outside of `column_gatherer`.