### PR TITLE
[REVIEW] Python / Cython mask updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 - PR #4101 Redux serialize `Buffer` directly with `__cuda_array_interface__`
 - PR #4098 Remove legacy calls from libcudf strings column code
 - PR #4111 Use `Buffer`'s to serialize `StringColumn`
-- PR #XXXX Mask cleanup and fixes: use `int32` dtype, ensure 64 byte padding, handle offsets
+- PR #4133 Mask cleanup and fixes: use `int32` dtype, ensure 64 byte padding, handle offsets
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - PR #4101 Redux serialize `Buffer` directly with `__cuda_array_interface__`
 - PR #4098 Remove legacy calls from libcudf strings column code
 - PR #4111 Use `Buffer`'s to serialize `StringColumn`
+- PR #XXXX Mask cleanup and fixes: use `int32` dtype, ensure 64 byte padding, handle offsets
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -55,7 +55,7 @@ std::unique_ptr<column> make_empty_column(data_type type);
  * allocation of the column's `data` and `null_mask`.
  */
 std::unique_ptr<column> make_numeric_column(
-    data_type type, size_type size, mask_state state = UNALLOCATED,
+    data_type type, size_type size, mask_state state = mask_state::UNALLOCATED,
     cudaStream_t stream = 0,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
@@ -109,7 +109,7 @@ std::unique_ptr<column> make_numeric_column(
  * allocation of the column's `data` and `null_mask`.
  */
 std::unique_ptr<column> make_timestamp_column(
-    data_type type, size_type size, mask_state state = UNALLOCATED,
+    data_type type, size_type size, mask_state state = mask_state::UNALLOCATED,
     cudaStream_t stream = 0,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
@@ -163,7 +163,7 @@ std::unique_ptr<column> make_timestamp_column(
  * allocation of the column's `data` and `null_mask`.
  */
 std::unique_ptr<column> make_fixed_width_column(
-    data_type type, size_type size, mask_state state = UNALLOCATED,
+    data_type type, size_type size, mask_state state = mask_state::UNALLOCATED,
     cudaStream_t stream = 0,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 

--- a/cpp/include/cudf/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/detail/copy_if_else.cuh
@@ -128,7 +128,7 @@ std::unique_ptr<column> copy_if_else(data_type type, bool nullable,
    constexpr int block_size = 256;
    cudf::experimental::detail::grid_1d grid{num_els, block_size, 1};
 
-   std::unique_ptr<column> out = make_fixed_width_column(type, size, nullable ? UNINITIALIZED : UNALLOCATED, stream, mr);
+   std::unique_ptr<column> out = make_fixed_width_column(type, size, nullable ? mask_state::UNINITIALIZED : mask_state::UNALLOCATED, stream, mr);
    
    auto out_v = mutable_column_device_view::create(*out);
 

--- a/cpp/include/cudf/detail/unary.hpp
+++ b/cpp/include/cudf/detail/unary.hpp
@@ -44,7 +44,7 @@ std::unique_ptr<column> true_if(InputIterator begin, InputIterator end,
                            rmm::mr::device_memory_resource * mr =
                                rmm::mr::get_default_resource(),
                            cudaStream_t stream = 0) {
-    auto output = make_numeric_column(data_type(BOOL8), size, UNALLOCATED, stream, mr);
+    auto output = make_numeric_column(data_type(BOOL8), size, mask_state::UNALLOCATED, stream, mr);
     auto output_mutable_view = output->mutable_view();
     auto output_data = output_mutable_view.data<cudf::experimental::bool8>();
 

--- a/cpp/include/cudf/strings/detail/merge.cuh
+++ b/cpp/include/cudf/strings/detail/merge.cuh
@@ -66,7 +66,7 @@ std::unique_ptr<column> merge( strings_column_view const& lhs, strings_column_vi
   rmm::device_buffer null_mask;
   size_type null_count = lhs.null_count() + rhs.null_count();
   if( null_count > 0 )
-    null_mask = create_null_mask(strings_count,ALL_VALID,stream,mr);
+    null_mask = create_null_mask(strings_count,mask_state::ALL_VALID,stream,mr);
 
   // build offsets column
   auto offsets_transformer = [d_lhs, d_rhs] __device__ (auto index_pair) {

--- a/cpp/include/cudf/types.hpp
+++ b/cpp/include/cudf/types.hpp
@@ -126,7 +126,7 @@ struct order_info {
 /**---------------------------------------------------------------------------*
  * @brief Controls the allocation/initialization of a null mask.
  *---------------------------------------------------------------------------**/
-enum class mask_state : int {
+enum class mask_state : int32_t {
   UNALLOCATED,    ///< Null mask not allocated, (all elements are valid)
   UNINITIALIZED,  ///< Null mask allocated, but not initialized
   ALL_VALID,      ///< Null mask allocated, initialized to all elements valid

--- a/cpp/include/cudf/types.hpp
+++ b/cpp/include/cudf/types.hpp
@@ -126,7 +126,7 @@ struct order_info {
 /**---------------------------------------------------------------------------*
  * @brief Controls the allocation/initialization of a null mask.
  *---------------------------------------------------------------------------**/
-enum mask_state {
+enum class mask_state : int {
   UNALLOCATED,    ///< Null mask not allocated, (all elements are valid)
   UNINITIALIZED,  ///< Null mask allocated, but not initialized
   ALL_VALID,      ///< Null mask allocated, initialized to all elements valid

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -42,13 +42,13 @@ namespace cudf {
 
 size_type state_null_count(mask_state state, size_type size) {
   switch (state) {
-    case UNALLOCATED:
+    case mask_state::UNALLOCATED:
       return 0;
-    case UNINITIALIZED:
+    case mask_state::UNINITIALIZED:
       return UNKNOWN_NULL_COUNT;
-    case ALL_NULL:
+    case mask_state::ALL_NULL:
       return size;
-    case ALL_VALID:
+    case mask_state::ALL_VALID:
       return 0;
     default:
       CUDF_FAIL("Invalid null mask state.");
@@ -80,14 +80,14 @@ rmm::device_buffer create_null_mask(size_type size, mask_state state,
                                     rmm::mr::device_memory_resource *mr) {
   size_type mask_size{0};
 
-  if (state != UNALLOCATED) {
+  if (state != mask_state::UNALLOCATED) {
     mask_size = bitmask_allocation_size_bytes(size);
   }
 
   rmm::device_buffer mask(mask_size, stream, mr);
 
-  if (state != UNINITIALIZED) {
-    uint8_t fill_value = (state == ALL_VALID) ? 0xff : 0x00;
+  if (state != mask_state::UNINITIALIZED) {
+    uint8_t fill_value = (state == mask_state::ALL_VALID) ? 0xff : 0x00;
     CUDA_TRY(cudaMemsetAsync(static_cast<bitmask_type *>(mask.data()),
                              fill_value, mask_size, stream));
   }
@@ -731,7 +731,7 @@ rmm::device_buffer concatenate_masks(std::vector<column_view> const &views,
    size_type total_element_count =
      std::accumulate(views.begin(), views.end(), 0,
          [](auto accumulator, auto const& v) { return accumulator + v.size(); });
-    null_mask = create_null_mask(total_element_count, UNINITIALIZED, stream, mr);
+    null_mask = create_null_mask(total_element_count, mask_state::UNINITIALIZED, stream, mr);
 
     detail::concatenate_masks(
         views, static_cast<bitmask_type *>(null_mask.data()), stream);

--- a/cpp/src/copying/copy.cpp
+++ b/cpp/src/copying/copy.cpp
@@ -34,9 +34,9 @@ inline mask_state should_allocate_mask(mask_allocation_policy mask_alloc,
                                        bool mask_exists) {
   if ((mask_alloc == mask_allocation_policy::ALWAYS) ||
       (mask_alloc == mask_allocation_policy::RETAIN && mask_exists)) {
-    return UNINITIALIZED;
+    return mask_state::UNINITIALIZED;
   } else {
-    return UNALLOCATED;
+    return mask_state::UNALLOCATED;
   }
 }
 

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -95,7 +95,7 @@ struct out_of_place_copy_range_dispatch {
     auto p_ret = std::make_unique<cudf::column>(target, stream, mr);
     if ((!p_ret->nullable()) && source.has_nulls(source_begin, source_end)) {
       p_ret->set_null_mask(
-        cudf::create_null_mask(p_ret->size(), cudf::ALL_VALID, stream, mr), 0);
+        cudf::create_null_mask(p_ret->size(), cudf::mask_state::ALL_VALID, stream, mr), 0);
     }
 
     if (source_end != source_begin) {  // otherwise no-op

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -339,7 +339,7 @@ std::unique_ptr<column> boolean_mask_scatter(
     cudaStream_t stream) {
 
     auto indices = cudf::make_numeric_column(data_type{INT32},
-                                  target.size(), UNALLOCATED, stream, mr);
+                                  target.size(), mask_state::UNALLOCATED, stream, mr);
     auto mutable_indices = indices->mutable_view();
 
     thrust::sequence(rmm::exec_policy(stream)->on(stream),

--- a/cpp/src/dlpack/dlpack.cpp
+++ b/cpp/src/dlpack/dlpack.cpp
@@ -163,7 +163,7 @@ std::unique_ptr<experimental::table> from_dlpack(
   // Allocate columns and copy data from tensor
   std::vector<std::unique_ptr<column>> columns(num_columns);
   for (auto& col : columns) {
-    col = make_numeric_column(dtype, num_rows, UNALLOCATED, stream, mr);
+    col = make_numeric_column(dtype, num_rows, mask_state::UNALLOCATED, stream, mr);
 
     CUDA_TRY(cudaMemcpyAsync(col->mutable_view().head<void>(),
       reinterpret_cast<void*>(tensor_data), bytes, cudaMemcpyDefault, stream));

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -82,7 +82,7 @@ struct out_of_place_fill_range_dispatch {
     if (end != begin) {  // otherwise no fill
       if (!p_ret->nullable() && !value.is_valid()) {
         p_ret->set_null_mask(
-          cudf::create_null_mask(p_ret->size(), cudf::ALL_VALID, stream, mr), 0);
+          cudf::create_null_mask(p_ret->size(), cudf::mask_state::ALL_VALID, stream, mr), 0);
       }
 
       auto ret_view = p_ret->mutable_view();

--- a/cpp/src/io/utilities/column_buffer.hpp
+++ b/cpp/src/io/utilities/column_buffer.hpp
@@ -71,7 +71,7 @@ struct column_buffer {
     } else {
       _data = create_data(type, size, stream, mr);
     }
-    _null_mask = create_null_mask(size, ALL_NULL, stream, mr);
+    _null_mask = create_null_mask(size, mask_state::ALL_NULL, stream, mr);
     _null_count = 0;
   }
 

--- a/cpp/src/reductions/scan.cu
+++ b/cpp/src/reductions/scan.cu
@@ -90,7 +90,7 @@ struct ScanDispatcher {
                                          cudaStream_t stream)
   {
     rmm::device_buffer mask =
-        create_null_mask(input_view.size(), UNINITIALIZED, stream, mr);
+        create_null_mask(input_view.size(), mask_state::UNINITIALIZED, stream, mr);
     auto d_input = column_device_view::create(input_view, stream);
     auto v = experimental::detail::make_validity_iterator(*d_input);
     auto first_null_position = thrust::find_if_not(

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -305,7 +305,7 @@ struct rolling_window_launcher
       if (input.is_empty()) return empty_like(input);
 
       auto output = make_fixed_width_column(target_type(input.type(), op), input.size(),
-              UNINITIALIZED, stream, mr);
+              mask_state::UNINITIALIZED, stream, mr);
 
       cudf::mutable_column_view output_view = output->mutable_view();
       auto valid_count = kernel_launcher<T, agg_op, op, WindowIterator>(input, output_view, preceding_window_begin,
@@ -333,7 +333,7 @@ struct rolling_window_launcher
       if (input.is_empty()) return empty_like(input);
 
       auto output = make_numeric_column(cudf::data_type{cudf::experimental::type_to_id<size_type>()},
-            input.size(), cudf::UNINITIALIZED, stream, mr);
+            input.size(), cudf::mask_state::UNINITIALIZED, stream, mr);
 
       cudf::mutable_column_view output_view = output->mutable_view();
 
@@ -486,7 +486,7 @@ std::unique_ptr<column> rolling_window_udf(column_view const &input,
   }
 
   std::unique_ptr<column> output = make_numeric_column(udf_agg->_output_type, input.size(),
-                                                       cudf::UNINITIALIZED, stream, mr);
+                                                       cudf::mask_state::UNINITIALIZED, stream, mr);
 
   auto output_view = output->mutable_view();
   rmm::device_scalar<size_type> device_valid_count{0, stream};

--- a/cpp/src/stream_compaction/drop_duplicates.cu
+++ b/cpp/src/stream_compaction/drop_duplicates.cu
@@ -210,7 +210,7 @@ std::unique_ptr<experimental::table>
   // The values will be filled into this column
   auto unique_indices = 
         cudf::make_numeric_column(data_type{INT32}, 
-                                  keys_view.num_rows(), UNALLOCATED, stream, mr);
+                                  keys_view.num_rows(), mask_state::UNALLOCATED, stream, mr);
   auto mutable_unique_indices_view = unique_indices->mutable_view();
   // This is just slice of `unique_indices` but with different size as per the
   // keys_view has been processed in `get_unique_ordered_indices`

--- a/cpp/src/strings/combine.cu
+++ b/cpp/src/strings/combine.cu
@@ -209,7 +209,7 @@ std::unique_ptr<column> join_strings( strings_column_view const& strings,
     rmm::device_buffer null_mask; // init to null null-mask
     if( strings.null_count()==strings_count )
     {
-        null_mask = create_null_mask(1,cudf::ALL_NULL,stream,mr);
+        null_mask = create_null_mask(1,cudf::mask_state::ALL_NULL,stream,mr);
         null_count = 1;
     }
     auto chars_column = detail::create_chars_child_column( strings_count, null_count, bytes, mr, stream );

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -152,7 +152,7 @@ std::unique_ptr<column> concatenate( std::vector<strings_column_view> const& str
     // create blank null mask -- caller will be setting this
     rmm::device_buffer null_mask;
     if( null_count > 0 )
-        null_mask = create_null_mask( strings_count, UNINITIALIZED, stream,mr );
+        null_mask = create_null_mask( strings_count, mask_state::UNINITIALIZED, stream,mr );
     offsets_column->set_null_count(0);  // reset the null counts
     chars_column->set_null_count(0);    // for children columns
     return make_strings_column(strings_count, std::move(offsets_column), std::move(chars_column),

--- a/cpp/src/strings/findall.cu
+++ b/cpp/src/strings/findall.cu
@@ -161,7 +161,7 @@ std::unique_ptr<experimental::table> findall_re( strings_column_view const& stri
     if( columns==0 )
         results.push_back(std::make_unique<column>( data_type{STRING}, strings_count,
                           rmm::device_buffer{0,stream,mr}, // no data
-                          create_null_mask(strings_count,ALL_NULL,stream,mr), strings_count ));
+                          create_null_mask(strings_count,mask_state::ALL_NULL,stream,mr), strings_count ));
 
     for( int32_t column_index=0; column_index < columns; ++column_index )
     {

--- a/cpp/src/strings/split/split.cu
+++ b/cpp/src/strings/split/split.cu
@@ -828,7 +828,7 @@ std::unique_ptr<experimental::table> split_fn( size_type strings_count,
     {
         results.push_back(std::make_unique<column>( data_type{STRING}, strings_count,
                           rmm::device_buffer{0,stream,mr}, // no data
-                          create_null_mask(strings_count, ALL_NULL, stream, mr), strings_count ));
+                          create_null_mask(strings_count, mask_state::ALL_NULL, stream, mr), strings_count ));
     }
 
     // Create each column.

--- a/cpp/tests/copying/utility_tests.cu
+++ b/cpp/tests/copying/utility_tests.cu
@@ -33,7 +33,7 @@ TYPED_TEST_CASE(EmptyLikeTest, numeric_types);
 
 TYPED_TEST(EmptyLikeTest, ColumnNumericTests) {
     cudf::size_type size = 10;
-    cudf::mask_state state = cudf::ALL_VALID;
+    cudf::mask_state state = cudf::mask_state::ALL_VALID;
     auto input = make_numeric_column(cudf::data_type{cudf::experimental::type_to_id<TypeParam>()}, size, state);
     auto expected = make_numeric_column(cudf::data_type{cudf::experimental::type_to_id<TypeParam>()}, 0);
     auto got = cudf::experimental::empty_like(input->view());
@@ -125,10 +125,10 @@ void expect_tables_prop_equal(cudf::table_view lhs, cudf::table_view rhs)
 struct EmptyLikeTableTest : public cudf::test::BaseFixture {};
 
 TEST_F(EmptyLikeTableTest, TableTest) {
-    cudf::mask_state state = cudf::ALL_VALID;
+    cudf::mask_state state = cudf::mask_state::ALL_VALID;
     cudf::size_type size = 10;
     auto input = create_table(size, state);
-    auto expected = create_table(0, cudf::UNINITIALIZED);
+    auto expected = create_table(0, cudf::mask_state::UNINITIALIZED);
     auto got = cudf::experimental::empty_like(input->view());
 
     expect_tables_prop_equal(got->view(), expected->view()); 
@@ -142,9 +142,9 @@ TYPED_TEST_CASE(AllocateLikeTest, numeric_types);
 TYPED_TEST(AllocateLikeTest, ColumnNumericTestSameSize) {
     // For same size as input
     cudf::size_type size = 10;
-    cudf::mask_state state = cudf::ALL_VALID;
+    cudf::mask_state state = cudf::mask_state::ALL_VALID;
     auto input = make_numeric_column(cudf::data_type{cudf::experimental::type_to_id<TypeParam>()}, size, state);
-    auto expected = make_numeric_column(cudf::data_type{cudf::experimental::type_to_id<TypeParam>()}, size, cudf::UNINITIALIZED);
+    auto expected = make_numeric_column(cudf::data_type{cudf::experimental::type_to_id<TypeParam>()}, size, cudf::mask_state::UNINITIALIZED);
     auto got = cudf::experimental::allocate_like(input->view());
     cudf::test::expect_column_properties_equal(*expected, *got);
 }
@@ -153,9 +153,9 @@ TYPED_TEST(AllocateLikeTest, ColumnNumericTestSpecifiedSize) {
     // For same size as input
     cudf::size_type size = 10;
     cudf::size_type specified_size = 5;
-    cudf::mask_state state = cudf::ALL_VALID;
+    cudf::mask_state state = cudf::mask_state::ALL_VALID;
     auto input = make_numeric_column(cudf::data_type{cudf::experimental::type_to_id<TypeParam>()}, size, state);
-    auto expected = make_numeric_column(cudf::data_type{cudf::experimental::type_to_id<TypeParam>()}, specified_size, cudf::UNINITIALIZED);
+    auto expected = make_numeric_column(cudf::data_type{cudf::experimental::type_to_id<TypeParam>()}, specified_size, cudf::mask_state::UNINITIALIZED);
     auto got = cudf::experimental::allocate_like(input->view(), specified_size);
     cudf::test::expect_column_properties_equal(*expected, *got);
 }

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -63,7 +63,7 @@ TEST_F(TableViewTest, TestLexicographicalComparatorTwoTableCase)
     cudf::table_view input_table_1 {{col1}};
     cudf::table_view input_table_2 {{col2}};
 
-    auto got = cudf::make_numeric_column(cudf::data_type(cudf::INT8), input_table_1.num_rows(), cudf::UNALLOCATED);
+    auto got = cudf::make_numeric_column(cudf::data_type(cudf::INT8), input_table_1.num_rows(), cudf::mask_state::UNALLOCATED);
     cudf::test::fixed_width_column_wrapper<int8_t> expected {{1, 1, 0, 1}};
     row_comparison(input_table_1, input_table_2, got->mutable_view(), column_order);
 
@@ -77,7 +77,7 @@ TEST_F(TableViewTest, TestLexicographicalComparatorSameTable)
 
     cudf::table_view input_table_1 {{col1}};
 
-    auto got = cudf::make_numeric_column(cudf::data_type(cudf::INT8), input_table_1.num_rows(), cudf::UNALLOCATED);
+    auto got = cudf::make_numeric_column(cudf::data_type(cudf::INT8), input_table_1.num_rows(), cudf::mask_state::UNALLOCATED);
     cudf::test::fixed_width_column_wrapper<int8_t> expected {{0, 0, 0, 0}};
     row_comparison(input_table_1, input_table_1, got->mutable_view(), column_order);
 

--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -212,14 +212,12 @@ def copy_range(out_col, in_col, int out_begin, int out_end,
         return out_col
 
     if not out_col.has_nulls and in_col.nullable:
-        mask = create_null_mask(len(out_col))
-        cudautils.fill_value(mask, 0xff)
-        out_col = out_col.set_mask(Buffer(mask))
+        mask = create_null_mask(len(out_col), state="all_valid")
+        out_col = out_col.set_mask(mask)
 
     if not in_col.has_nulls and out_col.nullable:
-        mask = create_null_mask(len(in_col))
-        cudautils.fill_value(mask, 0xff)
-        in_col = in_col.set_mask(Buffer(mask))
+        mask = create_null_mask(len(in_col), state="all_valid")
+        in_col = in_col.set_mask(mask)
 
     cdef gdf_column* c_out_col = column_view_from_column(out_col)
     cdef gdf_column* c_in_col = column_view_from_column(in_col)

--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -17,7 +17,6 @@ from cudf._lib.utils cimport (
     table_from_columns,
     table_to_dataframe
 )
-import rmm
 from cudf._lib.includes.copying cimport (
     copy as cpp_copy,
     copy_range as cpp_copy_range,
@@ -25,6 +24,7 @@ from cudf._lib.includes.copying cimport (
     scatter as cpp_scatter,
     scatter_to_tables as cpp_scatter_to_tables
 )
+from cudf._libxx.null_mask import create_null_mask
 
 import numba
 import numpy as np
@@ -212,12 +212,12 @@ def copy_range(out_col, in_col, int out_begin, int out_end,
         return out_col
 
     if not out_col.has_nulls and in_col.nullable:
-        mask = utils.make_mask(len(out_col))
+        mask = create_null_mask(len(out_col))
         cudautils.fill_value(mask, 0xff)
         out_col = out_col.set_mask(Buffer(mask))
 
     if not in_col.has_nulls and out_col.nullable:
-        mask = utils.make_mask(len(in_col))
+        mask = create_null_mask(len(in_col))
         cudautils.fill_value(mask, 0xff)
         in_col = in_col.set_mask(Buffer(mask))
 

--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -24,7 +24,7 @@ from cudf._lib.includes.copying cimport (
     scatter as cpp_scatter,
     scatter_to_tables as cpp_scatter_to_tables
 )
-from cudf._libxx.null_mask import create_null_mask
+from cudf._libxx.null_mask import create_null_mask, MaskState
 
 import numba
 import numpy as np
@@ -212,11 +212,11 @@ def copy_range(out_col, in_col, int out_begin, int out_end,
         return out_col
 
     if not out_col.has_nulls and in_col.nullable:
-        mask = create_null_mask(len(out_col), state="all_valid")
+        mask = create_null_mask(len(out_col), state=MaskState.ALL_VALID)
         out_col = out_col.set_mask(mask)
 
     if not in_col.has_nulls and out_col.nullable:
-        mask = create_null_mask(len(in_col), state="all_valid")
+        mask = create_null_mask(len(in_col), state=MaskState.ALL_VALID)
         in_col = in_col.set_mask(mask)
 
     cdef gdf_column* c_out_col = column_view_from_column(out_col)

--- a/python/cudf/cudf/_lib/cudf.pyx
+++ b/python/cudf/cudf/_lib/cudf.pyx
@@ -23,7 +23,7 @@ import pyarrow as pa
 
 from cudf.utils import cudautils
 from cudf.utils.dtypes import is_categorical_dtype
-from cudf.utils.utils import calc_chunk_size, mask_dtype, mask_bitsize
+from cudf.utils.utils import calc_mask_bytes, mask_bitsize
 import rmm
 import nvstrings
 import nvcategory
@@ -329,7 +329,6 @@ cdef Column gdf_column_to_column(gdf_column* c_col):
     """
     from cudf.core.buffer import Buffer
     from cudf.core.column import build_column, as_column
-    from cudf.utils.utils import mask_bitsize, calc_chunk_size
 
     gdf_dtype = c_col.dtype
     data_ptr = int(<uintptr_t>c_col.data)
@@ -359,7 +358,7 @@ cdef Column gdf_column_to_column(gdf_column* c_col):
         mask = None
         if mask_ptr != 0:
             mptr = rmm._DevicePointer(mask_ptr)
-            mask = Buffer(mptr, size=calc_chunk_size(c_col.size, mask_bitsize))
+            mask = Buffer(mptr, size=calc_mask_bytes(c_col.size))
 
         result = build_column(data=data,
                               dtype=dtype,

--- a/python/cudf/cudf/_lib/cudf.pyx
+++ b/python/cudf/cudf/_lib/cudf.pyx
@@ -23,7 +23,7 @@ import pyarrow as pa
 
 from cudf.utils import cudautils
 from cudf.utils.dtypes import is_categorical_dtype
-from cudf.utils.utils import calc_mask_bytes, mask_bitsize
+from cudf._libxx.null_mask import bitmask_allocation_size_bytes
 import rmm
 import nvstrings
 import nvcategory
@@ -358,7 +358,7 @@ cdef Column gdf_column_to_column(gdf_column* c_col):
         mask = None
         if mask_ptr != 0:
             mptr = rmm._DevicePointer(mask_ptr)
-            mask = Buffer(mptr, size=calc_mask_bytes(c_col.size))
+            mask = Buffer(mptr, size=bitmask_allocation_size_bytes(c_col.size))
 
         result = build_column(data=data,
                               dtype=dtype,
@@ -510,25 +510,6 @@ cpdef check_gdf_error(errcode):
             msg = errname
 
         raise GDFError(errname, msg)
-
-
-cpdef count_nonzero_mask(mask, size):
-    """ Counts the number of null bits in a given validity mask
-    """
-    assert mask.size * mask_bitsize >= size
-    cdef int nnz = 0
-    cdef uintptr_t mask_ptr = get_ctype_ptr(mask)
-    cdef int c_size = size
-
-    if mask_ptr:
-        with nogil:
-            gdf_count_nonzero_mask(
-                <valid_type*>mask_ptr,
-                c_size,
-                &nnz
-            )
-
-    return nnz
 
 
 cdef char* py_to_c_str(object py_str) except? NULL:

--- a/python/cudf/cudf/_lib/dlpack.pyx
+++ b/python/cudf/cudf/_lib/dlpack.pyx
@@ -21,6 +21,7 @@ import pyarrow as pa
 import warnings
 
 from cudf._lib.includes.dlpack cimport *
+from cudf._libxx.null_mask import bitmask_allocation_size_bytes
 from cudf.utils.utils import mask_dtype
 
 
@@ -75,10 +76,12 @@ cpdef from_dlpack(dlpack_capsule):
 
         valid_ptr = <uintptr_t>result_cols[idx].valid
         if valid_ptr:
+            nbytes = bitmask_allocation_size_bytes(result_cols[idx].size)
+            nelem = int(nbytes / mask_dtype.itemsize)
             valids.append(
                 rmm.device_array_from_ptr(
                     ptr=valid_ptr,
-                    nelem=calc_chunk_size(result_cols[idx].size, mask_bitsize),
+                    nelem=nelem,
                     dtype=mask_dtype,
                     finalizer=rmm._make_finalizer(valid_ptr, 0)
                 )

--- a/python/cudf/cudf/_lib/dlpack.pyx
+++ b/python/cudf/cudf/_lib/dlpack.pyx
@@ -21,6 +21,7 @@ import pyarrow as pa
 import warnings
 
 from cudf._lib.includes.dlpack cimport *
+from cudf.utils.utils import mask_dtype
 
 
 cpdef from_dlpack(dlpack_capsule):

--- a/python/cudf/cudf/_lib/rolling.pyx
+++ b/python/cudf/cudf/_lib/rolling.pyx
@@ -15,6 +15,7 @@ from cudf.utils import cudautils
 
 from cudf._lib.cudf cimport *
 from cudf._lib.cudf import *
+from cudf._libxx.null_mask import create_null_mask
 cimport cudf._lib.includes.rolling as cpp_rolling
 
 
@@ -71,14 +72,14 @@ def rolling(inp, window, min_periods, center, op):
         if op not in ["count", "sum"]:
             null_count = len(inp)
             fill_value = inp.default_na_value()
-            mask = cudautils.make_empty_mask(null_count)
+            mask = create_null_mask(null_count, state="all_null")
         data = cudautils.full(
             inp.data_array_view.size, fill_value, inp.data_array_view.dtype
         )
 
         out_col = build_column(Buffer(data),
                                dtype=data.dtype,
-                               mask=Buffer(mask))
+                               mask=mask)
     else:
         if callable(op):
             nb_type = numba.numpy_support.from_dtype(inp.dtype)

--- a/python/cudf/cudf/_lib/rolling.pyx
+++ b/python/cudf/cudf/_lib/rolling.pyx
@@ -15,7 +15,7 @@ from cudf.utils import cudautils
 
 from cudf._lib.cudf cimport *
 from cudf._lib.cudf import *
-from cudf._libxx.null_mask import create_null_mask
+from cudf._libxx.null_mask import create_null_mask, MaskState
 cimport cudf._lib.includes.rolling as cpp_rolling
 
 
@@ -72,7 +72,7 @@ def rolling(inp, window, min_periods, center, op):
         if op not in ["count", "sum"]:
             null_count = len(inp)
             fill_value = inp.default_na_value()
-            mask = create_null_mask(null_count, state="all_null")
+            mask = create_null_mask(null_count, state=MaskState.ALL_NULL)
         data = cudautils.full(
             inp.data_array_view.size, fill_value, inp.data_array_view.dtype
         )

--- a/python/cudf/cudf/_lib/unaryops.pyx
+++ b/python/cudf/cudf/_lib/unaryops.pyx
@@ -143,7 +143,7 @@ def apply_dt_extract_op(Column incol, Column outcol, op):
 def nans_to_nulls(Column py_col):
     from cudf.core.column import as_column
     from cudf.core.buffer import Buffer
-    from cudf.utils.utils import mask_bitsize, calc_chunk_size
+    from cudf.utils.utils import mask_bitsize, calc_mask_bytes
 
     cdef gdf_column* c_col = column_view_from_column(py_col)
     cdef pair[cpp_unaryops.bit_mask_t_ptr, size_type] result
@@ -157,7 +157,7 @@ def nans_to_nulls(Column py_col):
         mask_ptr = rmm._DevicePointer(int(<uintptr_t>result.first))
         mask_buf = Buffer(
             mask_ptr,
-            calc_chunk_size(len(py_col), mask_bitsize)
+            calc_mask_bytes(len(py_col))
         )
     else:
         c_free(<void*><uintptr_t>result.first, <cudaStream_t><uintptr_t>0)

--- a/python/cudf/cudf/_libxx/column.pyx
+++ b/python/cudf/cudf/_libxx/column.pyx
@@ -18,10 +18,10 @@ from libcpp.memory cimport unique_ptr, make_unique
 
 import cudf._libxx as libcudfxx
 from cudf._libxx.lib cimport *
+from cudf._libxx.null_mask import bitmask_allocation_size_bytes
 
 from cudf.core.buffer import Buffer
 from cudf.utils.dtypes import is_categorical_dtype
-from cudf.utils.utils import calc_mask_bytes, mask_bitsize
 
 
 np_to_cudf_types = {
@@ -191,7 +191,7 @@ cdef class Column:
                             type(value).__name__)
 
         if value is not None:
-            required_size = calc_mask_bytes(self.base_size)
+            required_size = bitmask_allocation_size_bytes(self.base_size)
             if value.size < required_size:
                 error_msg = (
                     "The Buffer for mask is smaller than expected, got " +
@@ -218,7 +218,7 @@ cdef class Column:
         and compute new data Buffers zero-copy that use pointer arithmetic to
         properly adjust the pointer.
         """
-        mask_size = calc_mask_bytes(self.size)
+        mask_size = bitmask_allocation_size_bytes(self.size)
         required_num_bytes = -(-self.size // 8)  # ceiling divide
         error_msg = (
             "The value for mask is smaller than expected, got {}  bytes, "
@@ -475,13 +475,13 @@ cdef class Column:
                 mask = Buffer(
                     rmm.DeviceBuffer(
                         ptr=mask_ptr,
-                        size=calc_mask_bytes(size)
+                        size=bitmask_allocation_size_bytes(size)
                     )
                 )
             else:
                 mask = Buffer(
                     mask=mask_ptr,
-                    size=calc_mask_bytes(size),
+                    size=bitmask_allocation_size_bytes(size),
                     owner=mask_owner
                 )
 

--- a/python/cudf/cudf/_libxx/column.pyx
+++ b/python/cudf/cudf/_libxx/column.pyx
@@ -162,13 +162,7 @@ cdef class Column:
     @property
     def mask(self):
         if self._mask is None:
-            if self.base_mask is None or (
-                self.offset == 0
-                and self.base_mask.size == calc_chunk_size(
-                    self.size,
-                    mask_bitsize
-                )
-            ):
+            if self.base_mask is None or self.offset == 0:
                 self._mask = self.base_mask
             else:
                 self._mask = libcudfxx.null_mask.copy_bitmask(self)

--- a/python/cudf/cudf/_libxx/column.pyx
+++ b/python/cudf/cudf/_libxx/column.pyx
@@ -219,16 +219,16 @@ cdef class Column:
         properly adjust the pointer.
         """
         mask_size = calc_mask_bytes(self.size)
-        required_num_bits = -(-self.size // 8)  # ceiling divide
+        required_num_bytes = -(-self.size // 8)  # ceiling divide
         error_msg = (
-            "The value for mask is smaller than expected, got {}  bits, "
-            "expected " + str(required_num_bits) + " bits."
+            "The value for mask is smaller than expected, got {}  bytes, "
+            "expected " + str(required_num_bytes) + " bytes."
         )
         if value is None:
             mask = None
         elif hasattr(value, "__cuda_array_interface__"):
             mask = Buffer(value)
-            if mask.size < required_num_bits:
+            if mask.size < required_num_bytes:
                 raise ValueError(error_msg.format(str(value.size)))
             if mask.size < mask_size:
                 dbuf = rmm.DeviceBuffer(size=mask_size)
@@ -236,14 +236,14 @@ cdef class Column:
                 mask = Buffer(dbuf)
         elif hasattr(value, "__array_interface__"):
             value = np.asarray(value).view("u1")[:mask_size]
-            if value.size < required_num_bits:
+            if value.size < required_num_bytes:
                 raise ValueError(error_msg.format(str(value.size)))
             dbuf = rmm.DeviceBuffer(size=mask_size)
             dbuf.copy_from_host(value)
             mask = Buffer(dbuf)
         elif PyObject_CheckBuffer(value):
             value = np.asarray(value).view("u1")[:mask_size]
-            if value.size < required_num_bits:
+            if value.size < required_num_bytes:
                 raise ValueError(error_msg.format(str(value.size)))
             dbuf = rmm.DeviceBuffer(size=mask_size)
             dbuf.copy_from_host()

--- a/python/cudf/cudf/_libxx/column.pyx
+++ b/python/cudf/cudf/_libxx/column.pyx
@@ -246,7 +246,7 @@ cdef class Column:
             if value.size < required_num_bytes:
                 raise ValueError(error_msg.format(str(value.size)))
             dbuf = rmm.DeviceBuffer(size=mask_size)
-            dbuf.copy_from_host()
+            dbuf.copy_from_host(value)
             mask = Buffer(dbuf)
         else:
             raise TypeError(

--- a/python/cudf/cudf/_libxx/includes/null_mask.pxd
+++ b/python/cudf/cudf/_libxx/includes/null_mask.pxd
@@ -8,6 +8,8 @@
 from cudf._libxx.lib cimport *
 
 
+ctypedef int mask_state_underlying_type
+
 cdef extern from "cudf/null_mask.hpp" namespace "cudf" nogil:
     cdef device_buffer copy_bitmask "cudf::copy_bitmask" (
         column_view view

--- a/python/cudf/cudf/_libxx/includes/null_mask.pxd
+++ b/python/cudf/cudf/_libxx/includes/null_mask.pxd
@@ -12,3 +12,17 @@ cdef extern from "cudf/null_mask.hpp" namespace "cudf" nogil:
     cdef device_buffer copy_bitmask "cudf::copy_bitmask" (
         column_view view
     ) except +
+
+    cdef size_t bitmask_allocation_size_bytes (
+        size_type number_of_bits,
+        size_t padding_boundary
+    ) except +
+
+    cdef size_t bitmask_allocation_size_bytes (
+        size_type number_of_bits
+    ) except +
+
+    cdef device_buffer create_null_mask (
+        size_type size,
+        mask_state state
+    ) except +

--- a/python/cudf/cudf/_libxx/includes/null_mask.pxd
+++ b/python/cudf/cudf/_libxx/includes/null_mask.pxd
@@ -5,10 +5,12 @@
 # cython: embedsignature = True
 # cython: language_level = 3
 
+from libc.stdint cimport int32_t
+
 from cudf._libxx.lib cimport *
 
 
-ctypedef int mask_state_underlying_type
+ctypedef int32_t mask_state_underlying_type
 
 cdef extern from "cudf/null_mask.hpp" namespace "cudf" nogil:
     cdef device_buffer copy_bitmask "cudf::copy_bitmask" (

--- a/python/cudf/cudf/_libxx/includes/transform.pxd
+++ b/python/cudf/cudf/_libxx/includes/transform.pxd
@@ -1,0 +1,16 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+from libcpp.pair cimport pair
+
+from cudf._libxx.lib cimport *
+
+
+cdef extern from "cudf/transform.hpp" namespace "cudf::experimental" nogil:
+    cdef pair[unique_ptr[device_buffer], size_type] bools_to_mask (
+        column_view input
+    ) except +

--- a/python/cudf/cudf/_libxx/lib.pxd
+++ b/python/cudf/cudf/_libxx/lib.pxd
@@ -20,11 +20,11 @@ cdef extern from "cudf/types.hpp" namespace "cudf" nogil:
     cdef enum:
         UNKNOWN_NULL_COUNT = -1
 
-    cdef enum mask_state:
-        UNALLOCATED,
-        UNINITIALIZED,
-        ALL_VALID,
-        ALL_NULL
+    ctypedef enum mask_state:
+        UNALLOCATED "cudf::mask_state::UNALLOCATED"
+        UNINITIALIZED "cudf::mask_state::UNINITIALIZED"
+        ALL_VALID "cudf::mask_state::ALL_VALID"
+        ALL_NULL "cudf::mask_state::ALL_NULL"
 
     cdef enum type_id:
         EMPTY = 0

--- a/python/cudf/cudf/_libxx/lib.pxd
+++ b/python/cudf/cudf/_libxx/lib.pxd
@@ -9,6 +9,7 @@ from libc.stdint cimport int32_t, uint32_t
 from libcpp cimport bool
 from libcpp.vector cimport vector
 from libcpp.memory cimport unique_ptr
+from libcpp.pair cimport pair
 
 from rmm._lib.device_buffer cimport device_buffer, DeviceBuffer, move
 
@@ -18,6 +19,12 @@ cdef extern from "cudf/types.hpp" namespace "cudf" nogil:
 
     cdef enum:
         UNKNOWN_NULL_COUNT = -1
+
+    cdef enum mask_state:
+        UNALLOCATED,
+        UNINITIALIZED,
+        ALL_VALID,
+        ALL_NULL
 
     cdef enum type_id:
         EMPTY = 0
@@ -152,3 +159,5 @@ cdef extern from "<utility>" namespace "std" nogil:
     cdef unique_ptr[table] move(unique_ptr[table])
     cdef vector[unique_ptr[column]] move(vector[unique_ptr[column]])
     cdef device_buffer move(device_buffer)
+    cdef pair[unique_ptr[device_buffer], size_type] \
+        move(pair[unique_ptr[device_buffer], size_type])

--- a/python/cudf/cudf/_libxx/null_mask.pyx
+++ b/python/cudf/cudf/_libxx/null_mask.pyx
@@ -25,10 +25,10 @@ class MaskState(Enum):
     """
     Enum for null mask creation state
     """
-    UNALLOCATED = <int>(mask_state.UNALLOCATED)
-    UNINITIALIZED = <int>(mask_state.UNINITIALIZED)
-    ALL_VALID = <int>(mask_state.ALL_VALID)
-    ALL_NULL = <int>(mask_state.ALL_NULL)
+    UNALLOCATED = <mask_state_underlying_type>(mask_state.UNALLOCATED)
+    UNINITIALIZED = <mask_state_underlying_type>(mask_state.UNINITIALIZED)
+    ALL_VALID = <mask_state_underlying_type>(mask_state.ALL_VALID)
+    ALL_NULL = <mask_state_underlying_type>(mask_state.ALL_NULL)
 
 
 def copy_bitmask(Column col):
@@ -85,7 +85,9 @@ def create_null_mask(size_type size, state=MaskState.UNINITIALIZED):
 
     cdef device_buffer db
     cdef unique_ptr[device_buffer] up_db
-    cdef mask_state c_mask_state = <mask_state>(<int>(state.value))
+    cdef mask_state c_mask_state = <mask_state>(
+        <mask_state_underlying_type>(state.value)
+    )
 
     with nogil:
         db = cpp_create_null_mask(size, c_mask_state)

--- a/python/cudf/cudf/_libxx/null_mask.pyx
+++ b/python/cudf/cudf/_libxx/null_mask.pyx
@@ -5,6 +5,7 @@
 # cython: embedsignature = True
 # cython: language_level = 3
 
+from enum import Enum
 
 from libcpp.memory cimport unique_ptr, make_unique
 
@@ -19,12 +20,31 @@ from cudf._libxx.includes.null_mask cimport (
 
 from cudf.core.buffer import Buffer
 
-_mask_states = {
-    "unallocated": UNALLOCATED,
-    "uninitialized": UNINITIALIZED,
-    "all_valid": ALL_VALID,
-    "all_null": ALL_NULL
-}
+
+cdef class mask_state_value:
+    """
+    Wraps a ``mask_state`` enum class value in a Cython object
+    """
+    cdef mask_state c_value
+
+    def __cinit__(self):
+        pass
+
+    @staticmethod
+    cdef mask_state_value from_c_val(mask_state c_val):
+        cdef mask_state_value wrapper = mask_state_value()
+        wrapper.c_value = c_val
+        return wrapper
+
+
+class MaskState(Enum):
+    """
+    Enum for null mask creation state
+    """
+    UNALLOCATED = mask_state_value.from_c_val(mask_state.UNALLOCATED)
+    UNINITIALIZED = mask_state_value.from_c_val(mask_state.UNINITIALIZED)
+    ALL_VALID = mask_state_value.from_c_val(mask_state.ALL_VALID)
+    ALL_NULL = mask_state_value.from_c_val(mask_state.ALL_NULL)
 
 
 def copy_bitmask(Column col):
@@ -61,14 +81,28 @@ def bitmask_allocation_size_bytes(size_type num_bits):
     return output_size
 
 
-def create_null_mask(size_type size, state="uninitialized"):
+def create_null_mask(size_type size, state=MaskState.UNINITIALIZED):
     """
     Given a size and a mask state, allocate a mask that can properly represent
     the given size with the given mask state
+
+    Parameters
+    ----------
+    size : int
+        Number of elements the mask needs to be able to represent
+    state : ``MaskState``, default ``MaskState.UNINITIALIZED``
+        State the null mask should be created in
     """
+    if not isinstance(state, MaskState):
+        raise TypeError(
+            "`state` is required to be of type `MaskState`, got "
+            + (type(state).__name__)
+        )
+
     cdef device_buffer db
     cdef unique_ptr[device_buffer] up_db
-    cdef mask_state c_mask_state = _mask_states[state]
+    cdef mask_state_value cy_mask_state = state.value
+    cdef mask_state c_mask_state = cy_mask_state.c_value
 
     with nogil:
         db = cpp_create_null_mask(size, c_mask_state)

--- a/python/cudf/cudf/_libxx/null_mask.pyx
+++ b/python/cudf/cudf/_libxx/null_mask.pyx
@@ -19,6 +19,13 @@ from cudf._libxx.includes.null_mask cimport (
 
 from cudf.core.buffer import Buffer
 
+_mask_states = {
+    "unallocated": UNALLOCATED,
+    "uninitialized": UNINITIALIZED,
+    "all_valid": ALL_VALID,
+    "all_null": ALL_NULL
+}
+
 
 def copy_bitmask(Column col):
     """
@@ -54,16 +61,17 @@ def bitmask_allocation_size_bytes(size_type num_bits):
     return output_size
 
 
-def create_null_mask(size_type size, mask_state state=UNINITIALIZED):
+def create_null_mask(size_type size, state="uninitialized"):
     """
     Given a size and a mask state, allocate a mask that can properly represent
     the given size with the given mask state
     """
     cdef device_buffer db
     cdef unique_ptr[device_buffer] up_db
+    cdef mask_state c_mask_state = _mask_states[state]
 
     with nogil:
-        db = cpp_create_null_mask(size, state)
+        db = cpp_create_null_mask(size, c_mask_state)
         up_db = make_unique[device_buffer](move(db))
 
     rmm_db = DeviceBuffer.c_from_unique_ptr(move(up_db))

--- a/python/cudf/cudf/_libxx/null_mask.pyx
+++ b/python/cudf/cudf/_libxx/null_mask.pyx
@@ -21,30 +21,14 @@ from cudf._libxx.includes.null_mask cimport (
 from cudf.core.buffer import Buffer
 
 
-cdef class mask_state_value:
-    """
-    Wraps a ``mask_state`` enum class value in a Cython object
-    """
-    cdef mask_state c_value
-
-    def __cinit__(self):
-        pass
-
-    @staticmethod
-    cdef mask_state_value from_c_val(mask_state c_val):
-        cdef mask_state_value wrapper = mask_state_value()
-        wrapper.c_value = c_val
-        return wrapper
-
-
 class MaskState(Enum):
     """
     Enum for null mask creation state
     """
-    UNALLOCATED = mask_state_value.from_c_val(mask_state.UNALLOCATED)
-    UNINITIALIZED = mask_state_value.from_c_val(mask_state.UNINITIALIZED)
-    ALL_VALID = mask_state_value.from_c_val(mask_state.ALL_VALID)
-    ALL_NULL = mask_state_value.from_c_val(mask_state.ALL_NULL)
+    UNALLOCATED = <int>(mask_state.UNALLOCATED)
+    UNINITIALIZED = <int>(mask_state.UNINITIALIZED)
+    ALL_VALID = <int>(mask_state.ALL_VALID)
+    ALL_NULL = <int>(mask_state.ALL_NULL)
 
 
 def copy_bitmask(Column col):
@@ -101,8 +85,7 @@ def create_null_mask(size_type size, state=MaskState.UNINITIALIZED):
 
     cdef device_buffer db
     cdef unique_ptr[device_buffer] up_db
-    cdef mask_state_value cy_mask_state = state.value
-    cdef mask_state c_mask_state = cy_mask_state.c_value
+    cdef mask_state c_mask_state = <mask_state>(<int>(state.value))
 
     with nogil:
         db = cpp_create_null_mask(size, c_mask_state)

--- a/python/cudf/cudf/_libxx/null_mask.pyx
+++ b/python/cudf/cudf/_libxx/null_mask.pyx
@@ -11,7 +11,11 @@ from libcpp.memory cimport unique_ptr, make_unique
 import cudf._libxx as libcudfxx
 from cudf._libxx.lib cimport *
 from cudf._libxx.column cimport Column
-from cudf._libxx.includes.null_mask cimport copy_bitmask as cpp_copy_bitmask
+from cudf._libxx.includes.null_mask cimport (
+    copy_bitmask as cpp_copy_bitmask,
+    create_null_mask as cpp_create_null_mask,
+    bitmask_allocation_size_bytes as cpp_bitmask_allocation_size_bytes
+)
 
 from cudf.core.buffer import Buffer
 
@@ -25,8 +29,44 @@ def copy_bitmask(Column col):
         return None
 
     cdef column_view col_view = col.view()
-    cdef device_buffer db = cpp_copy_bitmask(col_view)
-    cdef unique_ptr[device_buffer] up_db = make_unique[device_buffer](move(db))
+    cdef device_buffer db
+    cdef unique_ptr[device_buffer] up_db
+
+    with nogil:
+        db = cpp_copy_bitmask(col_view)
+        up_db = make_unique[device_buffer](move(db))
+
+    rmm_db = DeviceBuffer.c_from_unique_ptr(move(up_db))
+    buf = Buffer(rmm_db)
+    return buf
+
+
+def bitmask_allocation_size_bytes(size_type num_bits):
+    """
+    Given a size, calculates the number of bytes that should be allocated for a
+    column validity mask
+    """
+    cdef size_t output_size
+
+    with nogil:
+        output_size = cpp_bitmask_allocation_size_bytes(num_bits)
+
+    return output_size
+
+
+def create_null_mask(size_type size, mask_state state=UNINITIALIZED):
+    """
+    Given a size and a mask state, allocate a mask that can properly represent
+    the given size with the given mask state
+    """
+    cdef mask_state state =
+    cdef device_buffer db
+    cdef unique_ptr[device_buffer] up_db
+
+    with nogil:
+        db = cpp_create_null_mask(size, state)
+        up_db = make_unique[device_buffer](move(db))
+
     rmm_db = DeviceBuffer.c_from_unique_ptr(move(up_db))
     buf = Buffer(rmm_db)
     return buf

--- a/python/cudf/cudf/_libxx/null_mask.pyx
+++ b/python/cudf/cudf/_libxx/null_mask.pyx
@@ -59,7 +59,6 @@ def create_null_mask(size_type size, mask_state state=UNINITIALIZED):
     Given a size and a mask state, allocate a mask that can properly represent
     the given size with the given mask state
     """
-    cdef mask_state state =
     cdef device_buffer db
     cdef unique_ptr[device_buffer] up_db
 

--- a/python/cudf/cudf/_libxx/null_mask.pyx
+++ b/python/cudf/cudf/_libxx/null_mask.pyx
@@ -15,7 +15,8 @@ from cudf._libxx.column cimport Column
 from cudf._libxx.includes.null_mask cimport (
     copy_bitmask as cpp_copy_bitmask,
     create_null_mask as cpp_create_null_mask,
-    bitmask_allocation_size_bytes as cpp_bitmask_allocation_size_bytes
+    bitmask_allocation_size_bytes as cpp_bitmask_allocation_size_bytes,
+    mask_state_underlying_type
 )
 
 from cudf.core.buffer import Buffer

--- a/python/cudf/cudf/_libxx/transform.pyx
+++ b/python/cudf/cudf/_libxx/transform.pyx
@@ -1,0 +1,37 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+
+from libcpp.memory cimport unique_ptr, make_unique
+from libcpp.pair cimport pair
+
+import cudf._libxx as libcudfxx
+from cudf._libxx.lib cimport *
+from cudf._libxx.column cimport Column
+from cudf._libxx.includes.transform cimport bools_to_mask as cpp_bools_to_mask
+
+from cudf.core.buffer import Buffer
+
+
+def bools_to_mask(Column col):
+    """
+    Given an int8 (boolean) column, compress the data from booleans to bits and
+    return a Buffer
+    """
+    cdef column_view col_view = col.view()
+    cdef pair[unique_ptr[device_buffer], size_type] cpp_out
+    cdef unique_ptr[device_buffer] up_db
+    cdef size_type null_count
+
+    with nogil:
+        cpp_out = move(cpp_bools_to_mask(col_view))
+        up_db = move(cpp_out.first)
+        # null_count = cpp_out.second
+
+    rmm_db = DeviceBuffer.c_from_unique_ptr(move(up_db))
+    buf = Buffer(rmm_db)
+    return buf

--- a/python/cudf/cudf/comm/gpuarrow.py
+++ b/python/cudf/cudf/comm/gpuarrow.py
@@ -3,19 +3,15 @@
 from collections import OrderedDict
 from collections.abc import Sequence
 
-import numba.cuda.cudadrv.driver
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-import rmm
-
-from cudf._lib.arrow._cuda import CudaBuffer
 from cudf._lib.gpuarrow import (
     CudaRecordBatchStreamReader as _CudaRecordBatchStreamReader,
 )
-from cudf.core import Series
-from cudf.utils.utils import calc_chunk_size, mask_bitsize, mask_dtype
+from cudf.core import Series, column
+from cudf.utils.utils import mask_bitsize, mask_dtype
 
 
 class CudaRecordBatchStreamReader(_CudaRecordBatchStreamReader):
@@ -63,7 +59,7 @@ class GpuArrowNodeReader(object):
     def __init__(self, table, index):
         self._table = table
         self._field = table.schema[index]
-        self._series = array_to_series(table.column(index))
+        self._series = Series(column.as_column(table.column(index)))
         self._series.name = self.name
 
     def __len__(self):
@@ -139,91 +135,6 @@ class GpuArrowNodeReader(object):
         """
         assert self.is_dictionary
         return self._series.copy(deep=False)
-
-
-def gpu_view_as(nbytes, buf, dtype, shape=None, strides=None):
-    ptr = numba.cuda.cudadrv.driver.device_pointer(buf.to_numba())
-    arr = rmm.device_array_from_ptr(ptr, nbytes // dtype.itemsize, dtype=dtype)
-    arr.gpu_data._obj = buf
-    return arr
-
-
-def make_device_arrays(array):
-    buffers = array.buffers()
-    dtypes = [np.dtype(np.int8), None, None]
-
-    if pa.types.is_list(array.type):
-        dtypes[1] = np.dtype(np.int32)
-    elif pa.types.is_string(array.type) or pa.types.is_binary(array.type):
-        dtypes[2] = np.dtype(np.int8)
-        dtypes[1] = np.dtype(np.int32)
-    elif not pa.types.is_dictionary(array.type):
-        dtypes[1] = arrow_to_pandas_dtype(array.type)
-    else:
-        dtypes[1] = arrow_to_pandas_dtype(array.type.index_type)
-
-    if buffers[0] is not None:
-        buf = CudaBuffer.from_buffer(buffers[0])
-        nbytes = min(buf.size, calc_chunk_size(len(array), mask_bitsize))
-        buffers[0] = gpu_view_as(nbytes, buf, dtypes[0])
-
-    for i in range(1, len(buffers)):
-        if buffers[i] is not None:
-            buf = CudaBuffer.from_buffer(buffers[i])
-            nbytes = min(buf.size, len(array) * dtypes[i].itemsize)
-            buffers[i] = gpu_view_as(nbytes, buf, dtypes[i])
-
-    return buffers
-
-
-def array_to_series(array):
-    if isinstance(array, pa.ChunkedArray):
-        return Series._concat(
-            [array_to_series(chunk) for chunk in array.chunks]
-        )
-
-    array_len = len(array)
-    null_count = array.null_count
-    buffers = make_device_arrays(array)
-    mask, data = buffers[0], buffers[1]
-    dtype = arrow_to_pandas_dtype(array.type)
-
-    if pa.types.is_dictionary(array.type):
-        from cudf.core.column import build_categorical_column
-        from cudf.core.buffer import Buffer
-
-        codes = array_to_series(array.indices)
-        categories = array_to_series(array.dictionary)
-        if mask is not None:
-            mask = Buffer(mask)
-        data = build_categorical_column(
-            categories=categories, codes=codes, mask=mask
-        )
-
-    elif pa.types.is_string(array.type):
-        import nvstrings
-
-        offs, data = buffers[1], buffers[2]
-        offs = offs[array.offset : array.offset + array_len + 1]
-        data = None if data is None else data.device_ctypes_pointer.value
-        mask = None if mask is None else mask.device_ctypes_pointer.value
-        data = nvstrings.from_offsets(
-            data,
-            offs.device_ctypes_pointer.value,
-            array_len,
-            mask,
-            null_count,
-            True,
-        )
-    elif data is not None:
-        data = data[array.offset : array.offset + len(array)]
-
-    series = Series(data, dtype=dtype)
-
-    if null_count > 0 and mask is not None and not series.nullable:
-        return series.set_mask(mask, null_count)
-
-    return series
 
 
 def arrow_to_pandas_dtype(pa_type):

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -74,7 +74,7 @@ class Buffer:
             "data": (self.ptr, False),
             "shape": (self.size,),
             "strides": (1,),
-            "typestr": "|u1",
+            "typestr": "|i1",
             "version": 0,
         }
         return intf

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -80,8 +80,8 @@ class Buffer:
         return intf
 
     def to_host_array(self):
-        data = np.empty((self.size,), "i1")
-        rmm._lib.device_buffer.copy_ptr_to_host(self.ptr, data.view("u1"))
+        data = np.empty((self.size,), "u1")
+        rmm._lib.device_buffer.copy_ptr_to_host(self.ptr, data)
         return data
 
     def _init_from_array_like(self, data):

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -244,6 +244,12 @@ class CategoricalColumn(column.ColumnBase):
 
         self._codes = None
 
+    @property
+    def base_size(self):
+        return int(
+            (self.base_children[0].size) / self.base_children[0].dtype.itemsize
+        )
+
     def __contains__(self, item):
         try:
             self._encode(item)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -16,12 +16,17 @@ import cudf
 import cudf._lib as libcudf
 import cudf._libxx as libcudfxx
 from cudf._libxx.column import Column
+from cudf._libxx.null_mask import (
+    bitmask_allocation_size_bytes,
+    create_null_mask,
+)
 from cudf._libxx.stream_compaction import unique_count as cpp_unique_count
+from cudf._libxx.transform import bools_to_mask
 from cudf.core.buffer import Buffer
 from cudf.core.dtypes import CategoricalDtype
 from cudf.utils import cudautils, ioutils, utils
 from cudf.utils.dtypes import is_categorical_dtype, is_scalar, np_to_pa_dtype
-from cudf.utils.utils import buffers_from_pyarrow, calc_mask_bytes, mask_dtype
+from cudf.utils.utils import buffers_from_pyarrow, mask_dtype
 
 
 class ColumnBase(Column):
@@ -248,7 +253,7 @@ class ColumnBase(Column):
         # Allocate output mask only if there's nulls in the input objects
         mask = None
         if nulls:
-            mask = Buffer(utils.make_mask(newsize))
+            mask = create_null_mask(newsize)
 
         col = build_column(
             data=data, dtype=head.dtype, mask=mask, children=children
@@ -279,10 +284,8 @@ class ColumnBase(Column):
         If ``all_valid`` is True, the new mask is set to all valid.
         If ``all_valid`` is False, the new mask is set to all null.
         """
-        nelem = len(self)
-        mask_sz = calc_mask_bytes(nelem)
-        mask = Buffer.empty(mask_sz)
-        if nelem > 0:
+        mask = create_null_mask(len(self))
+        if len(self) > 0:
             cudautils.fill_value(mask, 0xFF if all_valid else 0)
         return self.set_mask(mask=mask)
 
@@ -428,7 +431,8 @@ class ColumnBase(Column):
                 bytemask = cudautils.expand_mask_bits(
                     data_size, self.mask_array_view
                 )
-                slice_mask = cudautils.compact_mask_bytes(bytemask[arg])
+                bytemask = as_column(bytemask)
+                slice_mask = bools_to_mask(bytemask[arg])
             else:
                 slice_data = self.data_array_view[arg]
                 slice_mask = None
@@ -620,13 +624,13 @@ class ColumnBase(Column):
 
         Returns
         -------
-        device array
+        Buffer
         """
 
         if self.has_nulls:
             raise ValueError("Column must have no nulls.")
 
-        return cudautils.compact_mask_bytes(self.data_array_view)
+        return bools_to_mask(self)
 
     @ioutils.doc_to_dlpack()
     def to_dlpack(self):
@@ -1031,8 +1035,7 @@ def as_column(arbitrary, nan_as_null=True, dtype=None, length=None):
 
         nbuf = None
         if arbitrary.null_count() > 0:
-            mask_size = calc_mask_bytes(arbitrary.size())
-            nbuf = Buffer.empty(mask_size)
+            nbuf = create_null_mask(arbitrary.size())
             arbitrary.set_null_bitmask(nbuf.ptr, bdevmem=True)
         arbitrary.to_offsets(sbuf.ptr, obuf.ptr, None, bdevmem=True)
         children = (
@@ -1357,8 +1360,6 @@ def _data_from_cuda_array_interface_desc(obj):
 
 
 def _mask_from_cuda_array_interface_desc(obj):
-    from cudf.utils.cudautils import compact_mask_bytes
-
     desc = obj.__cuda_array_interface__
     mask = desc.get("mask", None)
 
@@ -1369,16 +1370,11 @@ def _mask_from_cuda_array_interface_desc(obj):
         typestr = desc["typestr"]
         typecode = typestr[1]
         if typecode == "t":
-            mask_size = calc_mask_bytes(nelem)
+            mask_size = bitmask_allocation_size_bytes(nelem)
             mask = Buffer(data=ptr, size=mask_size, owner=obj)
         elif typecode == "b":
-            dtype = np.dtype(typestr)
-            mask = compact_mask_bytes(
-                rmm.device_array_from_ptr(
-                    ptr, nelem=nelem, dtype=dtype, finalizer=None
-                )
-            )
-            mask = Buffer(mask)
+            col = as_column(mask)
+            mask = bools_to_mask(col)
         else:
             raise NotImplementedError(
                 f"Cannot infer mask from typestr {typestr}"

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -473,6 +473,13 @@ class StringColumn(column.ColumnBase):
         self._nvcategory = None
         self._indices = None
 
+    @property
+    def base_size(self):
+        return int(
+            (self.base_children[0].size - 1)
+            / self.base_children[0].dtype.itemsize
+        )
+
     def set_base_data(self, value):
         if value is not None:
             raise RuntimeError(

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -14,6 +14,7 @@ import rmm
 import cudf._lib as libcudf
 from cudf._lib.nvtx import nvtx_range_pop, nvtx_range_push
 from cudf._libxx.null_mask import (
+    MaskState,
     bitmask_allocation_size_bytes,
     create_null_mask,
 )
@@ -662,7 +663,9 @@ class StringColumn(column.ColumnBase):
         out_col = column.as_column(out_arr)
 
         if self.has_nulls:
-            out_mask = create_null_mask(len(self), state="uninitialized")
+            out_mask = create_null_mask(
+                len(self), state=MaskState.UNINITIALIZED
+            )
             out_mask_ptr = out_mask.ptr
             self.nvstrings.set_null_bitmask(out_mask_ptr, bdevmem=True)
             out_col = out_col.set_mask(out_mask)

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -662,7 +662,7 @@ class StringColumn(column.ColumnBase):
         out_col = column.as_column(out_arr)
 
         if self.has_nulls:
-            out_mask = create_null_mask(len(self))
+            out_mask = create_null_mask(len(self), state="uninitialized")
             out_mask_ptr = out_mask.ptr
             self.nvstrings.set_null_bitmask(out_mask_ptr, bdevmem=True)
             out_col = out_col.set_mask(out_mask)

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -651,9 +651,7 @@ class StringColumn(column.ColumnBase):
         out_col = column.as_column(out_arr)
 
         if self.has_nulls:
-            mask_size = utils.calc_chunk_size(
-                len(self.nvstrings), utils.mask_bitsize
-            )
+            mask_size = utils.calc_mask_bytes(len(self.nvstrings))
             out_mask = Buffer.empty(mask_size)
             out_mask_ptr = out_mask.ptr
             self.nvstrings.set_null_bitmask(out_mask_ptr, bdevmem=True)
@@ -671,10 +669,8 @@ class StringColumn(column.ColumnBase):
         sbuf = np.empty(self.nvstrings.byte_count(), dtype="int8")
         obuf = np.empty(len(self.nvstrings) + 1, dtype="int32")
 
-        mask_size = utils.calc_chunk_size(
-            len(self.nvstrings), utils.mask_bitsize
-        )
-        nbuf = np.empty(mask_size, dtype="int8")
+        mask_size = utils.calc_mask_bytes(len(self.nvstrings))
+        nbuf = np.empty(mask_size, dtype="u1")
 
         self.str().to_offsets(sbuf, obuf, nbuf=nbuf)
         sbuf = pa.py_buffer(sbuf)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -24,6 +24,7 @@ import rmm
 import cudf
 import cudf._lib as libcudf
 import cudf._libxx as libcudfxx
+from cudf._libxx.transform import bools_to_mask
 from cudf.core import column
 from cudf.core._sort import get_sorted_inds
 from cudf.core.buffer import Buffer
@@ -501,12 +502,11 @@ class DataFrame(Frame):
                 if other[col].has_nulls:
                     raise ValueError("Column must have no nulls.")
 
-                boolbits = cudautils.compact_mask_bytes(
-                    other[col]._column.data_array_view
-                )
+                out_mask = bools_to_mask(other[col]._column)
             else:
                 boolbits = cudautils.make_empty_mask(len(self[col]))
-            df[col] = df[col].set_mask(Buffer(boolbits))
+                out_mask = Buffer(boolbits)
+            df[col] = df[col].set_mask(out_mask)
         return df
 
     def __setitem__(self, arg, value):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -24,10 +24,10 @@ import rmm
 import cudf
 import cudf._lib as libcudf
 import cudf._libxx as libcudfxx
+from cudf._libxx.null_mask import create_null_mask
 from cudf._libxx.transform import bools_to_mask
 from cudf.core import column
 from cudf.core._sort import get_sorted_inds
-from cudf.core.buffer import Buffer
 from cudf.core.column import (
     CategoricalColumn,
     StringColumn,
@@ -504,8 +504,7 @@ class DataFrame(Frame):
 
                 out_mask = bools_to_mask(other[col]._column)
             else:
-                boolbits = cudautils.make_empty_mask(len(self[col]))
-                out_mask = Buffer(boolbits)
+                out_mask = create_null_mask(len(self[col]), state="all_null")
             df[col] = df[col].set_mask(out_mask)
         return df
 
@@ -931,7 +930,7 @@ class DataFrame(Frame):
                 if fill_value is None:
                     return Series.from_masked_array(
                         data=rmm.device_array(max_num_rows, dtype="float64"),
-                        mask=cudautils.make_empty_mask(max_num_rows),
+                        mask=create_null_mask(max_num_rows, state="all_null"),
                     ).set_index(col.index)
                 else:
                     return getattr(col, fn)(fill_value)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -26,6 +26,7 @@ import cudf._lib as libcudf
 import cudf._libxx as libcudfxx
 from cudf.core import column
 from cudf.core._sort import get_sorted_inds
+from cudf.core.buffer import Buffer
 from cudf.core.column import (
     CategoricalColumn,
     StringColumn,
@@ -505,7 +506,7 @@ class DataFrame(Frame):
                 )
             else:
                 boolbits = cudautils.make_empty_mask(len(self[col]))
-            df[col] = df[col].set_mask(boolbits)
+            df[col] = df[col].set_mask(Buffer(boolbits))
         return df
 
     def __setitem__(self, arg, value):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -24,7 +24,7 @@ import rmm
 import cudf
 import cudf._lib as libcudf
 import cudf._libxx as libcudfxx
-from cudf._libxx.null_mask import create_null_mask
+from cudf._libxx.null_mask import MaskState, create_null_mask
 from cudf._libxx.transform import bools_to_mask
 from cudf.core import column
 from cudf.core._sort import get_sorted_inds
@@ -508,7 +508,9 @@ class DataFrame(Frame):
 
                 out_mask = bools_to_mask(other[col]._column)
             else:
-                out_mask = create_null_mask(len(self[col]), state="all_null")
+                out_mask = create_null_mask(
+                    len(self[col]), state=MaskState.ALL_NULL
+                )
             df[col] = df[col].set_mask(out_mask)
         return df
 
@@ -934,7 +936,9 @@ class DataFrame(Frame):
                 if fill_value is None:
                     return Series.from_masked_array(
                         data=rmm.device_array(max_num_rows, dtype="float64"),
-                        mask=create_null_mask(max_num_rows, state="all_null"),
+                        mask=create_null_mask(
+                            max_num_rows, state=MaskState.ALL_NULL
+                        ),
                     ).set_index(col.index)
                 else:
                     return getattr(col, fn)(fill_value)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1454,9 +1454,7 @@ class Series(Frame):
         -------
         device array
         """
-        if self.has_nulls:
-            raise ValueError("Column must have no nulls.")
-        return cudautils.compact_mask_bytes(self._column.data_array_view)
+        return self._column.as_mask()
 
     def astype(self, dtype, errors="raise", **kwargs):
         """

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -13,7 +13,6 @@ import rmm
 
 import cudf
 import cudf._lib as libcudf
-from cudf.core.buffer import Buffer
 from cudf.core.column import ColumnBase, DatetimeColumn, column
 from cudf.core.frame import Frame
 from cudf.core.index import Index, RangeIndex, as_index
@@ -77,7 +76,7 @@ class Series(Frame):
         data : 1D array-like
             The values.  Null values must not be skipped.  They can appear
             as garbage values.
-        mask : 1D array-like of numpy.uint8
+        mask : 1D array-like
             The null-mask.  Valid values are marked as ``1``; otherwise ``0``.
             The mask bit given the data index ``idx`` is computed as::
 
@@ -86,7 +85,6 @@ class Series(Frame):
             The number of null values.
             If None, it is calculated automatically.
         """
-        mask = Buffer(mask)
         col = column.as_column(data).set_mask(mask)
         return cls(data=col)
 
@@ -378,7 +376,7 @@ class Series(Frame):
 
         Parameters
         ----------
-        mask : 1D array-like of numpy.uint8
+        mask : 1D array-like
             The null-mask.  Valid values are marked as ``1``; otherwise ``0``.
             The mask bit given the data index ``idx`` is computed as::
 
@@ -388,8 +386,6 @@ class Series(Frame):
             If None, it is calculated automatically.
 
         """
-        if mask is not None:
-            mask = Buffer(mask)
         col = self._column.set_mask(mask)
         return self._copy_construct(data=col)
 
@@ -479,12 +475,6 @@ class Series(Frame):
         """Return Series by taking values from the corresponding *indices*.
         """
         return self[indices]
-
-    def _get_mask_as_series(self):
-        mask = Series(cudautils.ones(len(self), dtype=np.bool))
-        if self._column.nullable:
-            mask = mask.set_mask(self._column.mask).fillna(False)
-        return mask
 
     def __bool__(self):
         """Always raise TypeError when converting a Series

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1203,8 +1203,8 @@ def test_to_from_arrow_nulls(data_type):
     # We have 64B padded buffers for nulls whereas Arrow returns a minimal
     # number of bytes, so only check the first byte in this case
     np.testing.assert_array_equal(
-        np.asarray(s1.buffers()[0])[0],
-        gs1._column.mask_array_view.copy_to_host().view("int8")[0],
+        np.asarray(s1.buffers()[0]).view("u1")[0],
+        gs1._column.mask_array_view.copy_to_host().view("u1")[0],
     )
     assert pa.Array.equals(s1, gs1.to_arrow())
 
@@ -1214,8 +1214,8 @@ def test_to_from_arrow_nulls(data_type):
     # We have 64B padded buffers for nulls whereas Arrow returns a minimal
     # number of bytes, so only check the first byte in this case
     np.testing.assert_array_equal(
-        np.array(s2.buffers()[0])[0],
-        gs2._column.mask_array_view.copy_to_host()[0],
+        np.asarray(s2.buffers()[0]).view("u1")[0],
+        gs2._column.mask_array_view.copy_to_host().view("u1")[0],
     )
     assert pa.Array.equals(s2, gs2.to_arrow())
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -444,7 +444,7 @@ def test_dataframe_to_string():
     df = DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [11, 12, 13, 14, 15, 16]})
 
     data = np.arange(6)
-    mask = np.zeros(1, dtype=np.uint8)
+    mask = np.zeros(1, dtype=gd.utils.utils.mask_dtype)
     mask[0] = 0b00101101
 
     masked = Series.from_masked_array(data, mask)
@@ -1203,8 +1203,8 @@ def test_to_from_arrow_nulls(data_type):
     # We have 64B padded buffers for nulls whereas Arrow returns a minimal
     # number of bytes, so only check the first byte in this case
     np.testing.assert_array_equal(
-        np.array(s1.buffers()[0])[0],
-        gs1._column.mask_array_view.copy_to_host()[0],
+        np.asarray(s1.buffers()[0])[0],
+        gs1._column.mask_array_view.copy_to_host().view("int8")[0],
     )
     assert pa.Array.equals(s1, gs1.to_arrow())
 

--- a/python/cudf/cudf/tests/utils.py
+++ b/python/cudf/cudf/tests/utils.py
@@ -28,9 +28,9 @@ def random_bitmask(size):
     size : int
         number of bits
     """
-    sz = utils.calc_chunk_size(size, utils.mask_bitsize)
-    data = np.random.randint(0, 255 + 1, size=sz)
-    return data.astype(utils.mask_dtype)
+    sz = utils.calc_mask_bytes(size)
+    data = np.random.randint(0, 255, dtype="u1", size=sz)
+    return data
 
 
 def expand_bits_to_bytes(arr):

--- a/python/cudf/cudf/tests/utils.py
+++ b/python/cudf/cudf/tests/utils.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 from cudf import Series
-from cudf.utils import utils
+from cudf._libxx.null_mask import bitmask_allocation_size_bytes
 
 supported_numpy_dtypes = [
     "bool",
@@ -28,9 +28,9 @@ def random_bitmask(size):
     size : int
         number of bits
     """
-    sz = utils.calc_mask_bytes(size)
+    sz = bitmask_allocation_size_bytes(size)
     data = np.random.randint(0, 255, dtype="u1", size=sz)
-    return data
+    return data.view("i1")
 
 
 def expand_bits_to_bytes(arr):

--- a/python/cudf/cudf/utils/cudautils.py
+++ b/python/cudf/cudf/utils/cudautils.py
@@ -7,7 +7,6 @@ from numba import cuda, int32, numpy_support
 
 import rmm
 
-from cudf._libxx.null_mask import create_null_mask
 from cudf.utils.utils import (
     check_equals_float,
     check_equals_int,
@@ -310,13 +309,6 @@ def copy_to_dense(data, mask, out=None):
     if out.size > 0:
         gpu_copy_to_dense.forall(data.size)(data, mask, slots, out)
     return (sz, out)
-
-
-def make_empty_mask(size):
-    bits = create_null_mask(size)
-    if bits.size > 0:
-        gpu_fill_value.forall(bits.size)(bits, 0)
-    return bits
 
 
 #

--- a/python/cudf/cudf/utils/cudautils.py
+++ b/python/cudf/cudf/utils/cudautils.py
@@ -250,7 +250,7 @@ def gpu_expand_mask_bits(bits, out):
 def expand_mask_bits(size, bits):
     """Expand bit-mask into byte-mask
     """
-    expanded_mask = full(size, 0, dtype=np.int32)
+    expanded_mask = full(size, 0, dtype=np.uint8)
     numtasks = min(1024, expanded_mask.size)
     if numtasks > 0:
         gpu_expand_mask_bits.forall(numtasks)(bits, expanded_mask)

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -146,6 +146,13 @@ def pyarrow_buffer_to_cudf_buffer(arrow_buf, mask_size=0):
     # Try creating a PyArrow CudaBuffer from the PyArrow Buffer object, it
     # fails with an ArrowTypeError if it's a host based Buffer so we catch and
     # process as expected
+    if not isinstance(arrow_buf, pa.Buffer):
+        raise TypeError(
+            "Expected type: {}, got type: {}".format(
+                pa.Buffer.__name__, type(arrow_buf).__name__
+            )
+        )
+
     try:
         arrow_cuda_buf = arrowCudaBuffer.from_buffer(arrow_buf)
         buf = Buffer(

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -76,11 +76,6 @@ def make_mask(size):
     return rmm.device_array(shape=size, dtype=mask_dtype)
 
 
-def require_writeable_array(arr):
-    # This should be fixed in numba (numba issue #2521)
-    return np.require(arr, requirements="W")
-
-
 def scalar_broadcast_to(scalar, size, dtype=None):
     from cudf.utils.cudautils import fill_value
     from cudf.utils.dtypes import to_cudf_compatible_scalar, is_string_dtype
@@ -141,8 +136,6 @@ def buffers_from_pyarrow(pa_arr, dtype=None):
         - cudf.Buffer --> string characters
     """
     from cudf.core.buffer import Buffer
-
-    # from cudf.utils.cudautils import copy_array
 
     buffers = pa_arr.buffers()
 


### PR DESCRIPTION
Things this PR does:

- Moves the mask logical type handling on the Python/Cython side to be int32 instead of int8
    - can't use uint32 as there's situations where we run binaryops with the buffers as data buffers of columns
- Guarantees that Python/Cython managed mask buffers are 64 byte padded
- Properly handles values of `offset` / `size` of Python/Cython Column objects
- Python/Cython bindings to a few different libcudf null_mask related functions
- Moves Python/Cython code for mask allocation / functions to use libcudf binded functions
- Fixes handling of Arrow buffers that can be arbitrarily backed by GPU or host memory
- Changes cpp `mask_state` from an `enum` to an `enum class`