### PR TITLE
Update Java for mutating fill and rolling window changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - PR #4116 Fix a bug in contiguous_split() where tables with mixed column types could corrupt string output
 - PR #4119 Fix binary ops slowdown using jitify -remove-unused-globals
 - PR #4125 Fix type enum to account for added Dictionary type in `types.hpp`
+- PR #4137 Update Java for mutating fill and rolling window changes
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -99,7 +99,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromScalar(JNIEnv *env,
     } else if (cudf::is_fixed_width(dtype)) {
       col = cudf::make_fixed_width_column(dtype, row_count, mask_state);
       auto mut_view = col->mutable_view();
-      cudf::experimental::fill(mut_view, 0, row_count, *scalar_val);
+      cudf::experimental::fill_in_place(mut_view, 0, row_count, *scalar_val);
     } else if (dtype.id() == cudf::type_id::STRING) {
       // create a string column of all empty strings to fill (cheapest string column to create)
       auto offsets = cudf::make_numeric_column(cudf::data_type{cudf::INT32}, row_count + 1, cudf::mask_state::UNALLOCATED);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -1057,7 +1057,7 @@ public class ColumnVectorTest extends CudfTestBase {
     WindowOptions options = WindowOptions.builder().window(1, 1)
         .minPeriods(2).build();
     try (ColumnVector v1 = ColumnVector.fromInts(5, 4, 7, 6, 8)) {
-      try (ColumnVector expected = ColumnVector.fromInts(9, 16, 17, 21, 14);
+      try (ColumnVector expected = ColumnVector.fromLongs(9, 16, 17, 21, 14);
            ColumnVector result = v1.rollingWindow(AggregateOp.SUM, options)) {
         assertColumnsAreEqual(expected, result);
       }
@@ -1073,7 +1073,7 @@ public class ColumnVectorTest extends CudfTestBase {
       }
 
       // The rolling window produces the same result type as the input
-      try (ColumnVector expected = ColumnVector.fromInts(4, 5, 5, 7, 7);
+      try (ColumnVector expected = ColumnVector.fromDoubles(4.5, 16.0 / 3, 17.0 / 3, 7, 7);
            ColumnVector result = v1.rollingWindow(AggregateOp.MEAN, options)) {
         assertColumnsAreEqual(expected, result);
       }
@@ -1092,7 +1092,7 @@ public class ColumnVectorTest extends CudfTestBase {
       WindowOptions window = WindowOptions.builder()
           .minPeriods(2).window(precedingCol, followingCol).build();
       try (ColumnVector v1 = ColumnVector.fromInts(5, 4, 7, 6, 8);
-           ColumnVector expected = ColumnVector.fromBoxedInts(null, null, 9, 16, 25);
+           ColumnVector expected = ColumnVector.fromBoxedLongs(null, null, 9L, 16L, 25L);
            ColumnVector result = v1.rollingWindow(AggregateOp.SUM, window)) {
         assertColumnsAreEqual(expected, result);
       }
@@ -1122,7 +1122,7 @@ public class ColumnVectorTest extends CudfTestBase {
       WindowOptions window = WindowOptions.builder().minPeriods(2)
           .window(precedingCol, followingCol).build();
       try (ColumnVector v1 = ColumnVector.fromInts(5, 4, 7, 6, 8);
-           ColumnVector expected = ColumnVector.fromInts(16, 22, 30, 14, 14);
+           ColumnVector expected = ColumnVector.fromLongs(16, 22, 30, 14, 14);
            ColumnVector result = v1.rollingWindow(AggregateOp.SUM, window)) {
         assertColumnsAreEqual(expected, result);
       }


### PR DESCRIPTION
This fixes two issues in the Java bindings:
- libcudf's mutating `fill` is now `fill_in_place`.
- rolling window aggregations for SUM on INT32 now return INT64 and MEAN returns FLOAT64.

The former is a simple change in the JNI code to call the correct method, and the latter is a straightforward update to the unit tests to expect the new result types.