### PR TITLE
[REVIEW] Fix NVStrings test_convert failure in 10.2 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - PR #4119 Fix binary ops slowdown using jitify -remove-unused-globals
 - PR #4125 Fix type enum to account for added Dictionary type in `types.hpp`
 - PR #4137 Update Java for mutating fill and rolling window changes
+- PR #4141 Fix NVStrings test_convert failure in 10.2 build
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/custrings/tests/test_convert.cu
+++ b/cpp/custrings/tests/test_convert.cu
@@ -96,7 +96,7 @@ TEST_F(TestConvert, ToFloat)
     std::vector<const char*> hstrs{"1234", nullptr, 
             "-876", "543.2", "-0.12", ".25", "-.002",
             "", "NaN", "abc123", "123abc", "456e", "-1.78e+5",
-            "-122.99609375", "12e+309" };
+            "-122.33644782123456789", "12e+309" };
     NVStrings* strs = NVStrings::create_from_array(hstrs.data(),hstrs.size());
 
     {    
@@ -107,7 +107,7 @@ TEST_F(TestConvert, ToFloat)
         float expected[] = { 1234.0, 0,
             -876.0, 543.2, -0.12, 0.25, -0.002,
             0, nanval, 0, 123.0, 456.0, -178000.0,
-            -122.99609, infval };
+            -122.33645, infval };
         for( int idx = 0; idx < (int) hstrs.size(); ++idx )
         {
             float fval1 = results[idx];
@@ -129,7 +129,7 @@ TEST_F(TestConvert, ToFloat)
         double expected[] = { 1234.0, 0,
             -876.0, 543.2, -0.12, 0.25, -0.002,
             0, nanval, 0, 123.0, 456.0, -178000.0,
-            -122.99609375, infval };
+            -122.3364478212345, infval };
         for( int idx = 0; idx < (int) hstrs.size(); ++idx )
         {
             double fval1 = results[idx];

--- a/cpp/custrings/tests/test_convert.cu
+++ b/cpp/custrings/tests/test_convert.cu
@@ -129,7 +129,7 @@ TEST_F(TestConvert, ToFloat)
         double expected[] = { 1234.0, 0,
             -876.0, 543.2, -0.12, 0.25, -0.002,
             0, nanval, 0, 123.0, 456.0, -178000.0,
-            -122.3364478212345, infval };
+            -122.33644782123469, infval };
         for( int idx = 0; idx < (int) hstrs.size(); ++idx )
         {
             double fval1 = results[idx];
@@ -139,7 +139,7 @@ TEST_F(TestConvert, ToFloat)
             else if( std::isinf(fval1) )
                 EXPECT_TRUE( std::isinf(fval2) );
             else
-                EXPECT_NEAR(fval1,fval2,1e-10);
+                EXPECT_DOUBLE_EQ(fval1,fval2);
         }
     }
 

--- a/cpp/custrings/tests/test_convert.cu
+++ b/cpp/custrings/tests/test_convert.cu
@@ -139,7 +139,7 @@ TEST_F(TestConvert, ToFloat)
             else if( std::isinf(fval1) )
                 EXPECT_TRUE( std::isinf(fval2) );
             else
-                EXPECT_DOUBLE_EQ(fval1,fval2);
+                EXPECT_NEAR(fval1,fval2,1e-10);
         }
     }
 

--- a/cpp/custrings/tests/test_convert.cu
+++ b/cpp/custrings/tests/test_convert.cu
@@ -96,7 +96,7 @@ TEST_F(TestConvert, ToFloat)
     std::vector<const char*> hstrs{"1234", nullptr, 
             "-876", "543.2", "-0.12", ".25", "-.002",
             "", "NaN", "abc123", "123abc", "456e", "-1.78e+5",
-            "-122.33644782123456789", "12e+309" };
+            "-122.99609375", "12e+309" };
     NVStrings* strs = NVStrings::create_from_array(hstrs.data(),hstrs.size());
 
     {    
@@ -107,15 +107,17 @@ TEST_F(TestConvert, ToFloat)
         float expected[] = { 1234.0, 0,
             -876.0, 543.2, -0.12, 0.25, -0.002,
             0, nanval, 0, 123.0, 456.0, -178000.0,
-            -122.3364486694336, infval };
+            -122.99609, infval };
         for( int idx = 0; idx < (int) hstrs.size(); ++idx )
         {
             float fval1 = results[idx];
             float fval2 = expected[idx];
             if( std::isnan(fval1) )
                 EXPECT_TRUE( std::isnan(fval2) );
+            else if( std::isinf(fval1) )
+                EXPECT_TRUE( std::isinf(fval2) );
             else
-                EXPECT_EQ(fval1,fval2);
+                EXPECT_FLOAT_EQ(fval1,fval2);
         }
     }
 
@@ -127,15 +129,17 @@ TEST_F(TestConvert, ToFloat)
         double expected[] = { 1234.0, 0,
             -876.0, 543.2, -0.12, 0.25, -0.002,
             0, nanval, 0, 123.0, 456.0, -178000.0,
-            -122.3364478212345, infval };
+            -122.99609375, infval };
         for( int idx = 0; idx < (int) hstrs.size(); ++idx )
         {
             double fval1 = results[idx];
             double fval2 = expected[idx];
             if( std::isnan(fval1) )
                 EXPECT_TRUE( std::isnan(fval2) );
+            else if( std::isinf(fval1) )
+                EXPECT_TRUE( std::isinf(fval2) );
             else
-                EXPECT_EQ(fval1,fval2);
+                EXPECT_NEAR(fval1,fval2,1e-10);
         }
     }
 

--- a/python/nvstrings/tests/test_convert.py
+++ b/python/nvstrings/tests/test_convert.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
 import numpy as np
+from pytest import approx
 from utils import assert_eq
 
 import nvstrings
@@ -365,7 +366,12 @@ def test_stof():
         456.0,
         -178000.0,
     ]
-    assert_eq(got, expected)
+    # assert_eq(got, expected)
+    for idx in range(len(expected)):
+        if expected[idx] is None:
+            assert_eq(got[idx], expected[idx])
+        else:
+            assert got[idx] == approx(expected[idx])
 
 
 def test_stod():
@@ -408,7 +414,12 @@ def test_stod():
         -178000.0,
         -122.33644781999999,
     ]
-    assert_eq(got, expected)
+    # assert_eq(got, expected)
+    for idx in range(len(expected)):
+        if expected[idx] is None:
+            assert_eq(got[idx], expected[idx])
+        else:
+            assert got[idx] == approx(expected[idx])
 
 
 def test_htoi():

--- a/python/nvstrings/tests/test_convert.py
+++ b/python/nvstrings/tests/test_convert.py
@@ -366,7 +366,6 @@ def test_stof():
         456.0,
         -178000.0,
     ]
-    # assert_eq(got, expected)
     for idx in range(len(expected)):
         if expected[idx] is None:
             assert_eq(got[idx], expected[idx])
@@ -414,7 +413,6 @@ def test_stod():
         -178000.0,
         -122.33644781999999,
     ]
-    # assert_eq(got, expected)
     for idx in range(len(expected)):
         if expected[idx] is None:
             assert_eq(got[idx], expected[idx])


### PR DESCRIPTION
The `test_convert` module was using `EXPECT_EQ` for checking float and double values.
Changed the code to use `EXPECT_NEAR` instead.