### PR TITLE
[REVIEW] Rename in-place copy_range to copy_range_in_place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - PR #4111 Use `Buffer`'s to serialize `StringColumn`
 - PR #4113 Get `len` of `StringColumn`s without `nvstrings`
 - PR #4130 Renames in-place `cudf::experimental::fill` to `cudf::experimental::fill_in_place`
+- PR #4143 Renames in-place `cudf::experimental::copy_range` to `cudf::experimental::copy_range_in_place`
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/copying.hpp
+++ b/cpp/include/cudf/copying.hpp
@@ -258,10 +258,10 @@ std::unique_ptr<table> empty_like(table_view const& input_table);
  * @param target_begin The starting index of the target range (inclusive)
  * @return void
  */
-void copy_range(column_view const& source,
-                mutable_column_view& target,
-                size_type source_begin, size_type source_end,
-                size_type target_begin);
+void copy_range_in_place(column_view const& source,
+                         mutable_column_view& target,
+                         size_type source_begin, size_type source_end,
+                         size_type target_begin);
 
 /**
  * @brief Copies a range of elements out-of-place from one column to another.

--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -225,10 +225,10 @@ void copy_range(SourceValueIterator source_value_begin,
  * @param target_begin The starting index of the target range (inclusive)
  * @return void
  */
-void copy_range(column_view const& source, mutable_column_view& target,
-                size_type source_begin, size_type source_end,
-                size_type target_begin,
-                cudaStream_t stream = 0);
+void copy_range_in_place(column_view const& source, mutable_column_view& target,
+                         size_type source_begin, size_type source_end,
+                         size_type target_begin,
+                         cudaStream_t stream = 0);
 
 /**
  * @brief Internal API to copy a range of elements out-of-place from one column

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -156,10 +156,10 @@ namespace experimental {
 
 namespace detail {
 
-void copy_range(column_view const& source, mutable_column_view& target,
-                size_type source_begin, size_type source_end,
-                size_type target_begin,
-                cudaStream_t stream) {
+void copy_range_in_place(column_view const& source, mutable_column_view& target,
+                         size_type source_begin, size_type source_end,
+                         size_type target_begin,
+                         cudaStream_t stream) {
   CUDF_EXPECTS(cudf::is_fixed_width(target.type()) == true,
                "In-place copy_range does not support variable-sized types.");
   CUDF_EXPECTS((source_begin <= source_end) &&
@@ -212,11 +212,11 @@ std::unique_ptr<column> copy_range(column_view const& source,
 
 }  // namespace detail
 
-void copy_range(column_view const& source, mutable_column_view& target,
-                size_type source_begin, size_type source_end,
-                size_type target_begin) {
-  return detail::copy_range(source, target, source_begin, source_end,
-                            target_begin, 0);
+void copy_range_in_place(column_view const& source, mutable_column_view& target,
+                         size_type source_begin, size_type source_end,
+                         size_type target_begin) {
+  return detail::copy_range_in_place(source, target, source_begin, source_end,
+                                     target_begin, 0);
 }
 
 std::unique_ptr<column> copy_range(column_view const& source,

--- a/cpp/tests/copying/copy_range_tests.cpp
+++ b/cpp/tests/copying/copy_range_tests.cpp
@@ -52,8 +52,8 @@ public:
 
     // test the in-place version second
 
-    EXPECT_NO_THROW(cudf::experimental::copy_range(source, target,
-                      source_begin, source_end, target_begin));
+    EXPECT_NO_THROW(cudf::experimental::copy_range_in_place(
+      source, target, source_begin, source_end, target_begin));
     cudf::test::expect_columns_equal(target, expected);
   }
 };
@@ -392,8 +392,8 @@ TEST_F(CopyRangeErrorTestFixture, InvalidInplaceCall)
 
   cudf::mutable_column_view target_view{target};
   // source has null values but target is not nullable.
-  EXPECT_THROW(cudf::experimental::copy_range(source, target_view,
-                                              0, size, 0),
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
+                source, target_view, 0, size, 0),
                cudf::logic_error);
 
   std::vector<std::string>
@@ -404,7 +404,7 @@ TEST_F(CopyRangeErrorTestFixture, InvalidInplaceCall)
     cudf::test::strings_column_wrapper(strings.begin(), strings.end());
 
   cudf::mutable_column_view target_view_string{target_string};
-  EXPECT_THROW(cudf::experimental::copy_range(
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
                  source_string, target_view_string, 0, size, 0),
                cudf::logic_error);
 }
@@ -424,13 +424,13 @@ TEST_F(CopyRangeErrorTestFixture, InvalidRange)
   cudf::mutable_column_view target_view{target};
 
   // empty_range == no-op, this is valid
-  EXPECT_NO_THROW(cudf::experimental::copy_range(
+  EXPECT_NO_THROW(cudf::experimental::copy_range_in_place(
                     source, target_view, 0, 0, 0));
   EXPECT_NO_THROW(auto p_ret = cudf::experimental::copy_range(
                     source, target, 0, 0, 0));
 
   // source_begin is negative
-  EXPECT_THROW(cudf::experimental::copy_range(
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
                  source, target_view, -1, size, 0),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::copy_range(
@@ -438,7 +438,7 @@ TEST_F(CopyRangeErrorTestFixture, InvalidRange)
                cudf::logic_error);
 
   // source_begin > source_end
-  EXPECT_THROW(cudf::experimental::copy_range(
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
                  source, target_view, 10, 5, 0),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::copy_range(
@@ -446,7 +446,7 @@ TEST_F(CopyRangeErrorTestFixture, InvalidRange)
                cudf::logic_error);
 
   // source_begin >= source.size()
-  EXPECT_THROW(cudf::experimental::copy_range(
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
                  source, target_view, 100, 100, 0),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::copy_range(
@@ -454,7 +454,7 @@ TEST_F(CopyRangeErrorTestFixture, InvalidRange)
                cudf::logic_error);
 
   // source_end > source.size()
-  EXPECT_THROW(cudf::experimental::copy_range(
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
                  source, target_view, 99, 101, 0),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::copy_range(
@@ -462,7 +462,7 @@ TEST_F(CopyRangeErrorTestFixture, InvalidRange)
                cudf::logic_error);
 
   // target_begin < 0
-  EXPECT_THROW(cudf::experimental::copy_range(
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
                  source, target_view, 50, 100, -5),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::copy_range(
@@ -470,7 +470,7 @@ TEST_F(CopyRangeErrorTestFixture, InvalidRange)
                cudf::logic_error);
 
   // target_begin >= target.size()
-  EXPECT_THROW(cudf::experimental::copy_range(
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
                  source, target_view, 50, 100, 100),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::copy_range(
@@ -478,7 +478,7 @@ TEST_F(CopyRangeErrorTestFixture, InvalidRange)
                cudf::logic_error);
 
   // target_begin + (source_end - source_begin) > target.size()
-  EXPECT_THROW(cudf::experimental::copy_range(
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
                  source, target_view, 50, 100, 80),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::copy_range(
@@ -500,7 +500,7 @@ TEST_F(CopyRangeErrorTestFixture, DTypeMismatch)
 
   cudf::mutable_column_view target_view{target};
 
-  EXPECT_THROW(cudf::experimental::copy_range(
+  EXPECT_THROW(cudf::experimental::copy_range_in_place(
                  source, target_view, 0, 100, 0),
                cudf::logic_error);
   EXPECT_THROW(auto p_ret = cudf::experimental::copy_range(


### PR DESCRIPTION
Related to #4112 

Renames in-place `copy_range` to `copy_range_in_place`