### PR TITLE
[REVIEW] Support empty index case in DataFrame._from_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - PR #4086 ORC reader: fix potentially incorrect timestamp decoding in the last rowgroup
 - PR #4089 Fix dask groupby mutliindex test case issues in join
 - PR #4076 All null string entries should have null data buffer
+- PR #4145 Support empty index case in DataFrame._from_table
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -265,7 +265,11 @@ class DataFrame(Frame):
 
     @classmethod
     def _from_table(cls, table):
-        return cls(data=table._data, index=Index._from_table(table._index))
+        if table._index is None:
+            index = None
+        else:
+            index = Index._from_table(table._index)
+        return cls(data=table._data, index=index)
 
     @staticmethod
     def _align_input_series_indices(data, index):

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4407,3 +4407,12 @@ def test_init_multiindex_from_dict():
     gdf = DataFrame({("a", "b"): [1]})
     assert_eq(pdf, gdf)
     assert_eq(pdf.columns, gdf.columns)
+
+def test_dataframe_from_table_empty_index():
+    from cudf._libxx.table import Table
+    
+    df = DataFrame({'a':[1,2,3], 'b':[4,5,6]})
+    odict = df._data
+    tbl = Table(odict)
+
+    result = DataFrame._from_table(tbl)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4408,10 +4408,11 @@ def test_init_multiindex_from_dict():
     assert_eq(pdf, gdf)
     assert_eq(pdf.columns, gdf.columns)
 
+
 def test_dataframe_from_table_empty_index():
     from cudf._libxx.table import Table
-    
-    df = DataFrame({'a':[1,2,3], 'b':[4,5,6]})
+
+    df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     odict = df._data
     tbl = Table(odict)
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4416,4 +4416,4 @@ def test_dataframe_from_table_empty_index():
     odict = df._data
     tbl = Table(odict)
 
-    result = DataFrame._from_table(tbl)
+    result = DataFrame._from_table(tbl) # noqa: F841

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4416,4 +4416,4 @@ def test_dataframe_from_table_empty_index():
     odict = df._data
     tbl = Table(odict)
 
-    result = DataFrame._from_table(tbl) # noqa: F841
+    result = DataFrame._from_table(tbl)  # noqa: F841


### PR DESCRIPTION
Fix an edge case where no index names are passed to `DataFrame._from_unique_ptr` which propagates a `None` index to `DataFrame._from_table`. 