### PR TITLE
[REVIEW] Remove UNKNOWN_NULL_COUNT workaround from contiguous_split()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - PR #4098 Remove legacy calls from libcudf strings column code
 - PR #4111 Use `Buffer`'s to serialize `StringColumn`
 - PR #4113 Get `len` of `StringColumn`s without `nvstrings`
+- PR #4147 Remove workaround for UNKNOWN_NULL_COUNT in contiguous_split.
 
 ## Bug Fixes
 

--- a/cpp/tests/copying/split_tests.cu
+++ b/cpp/tests/copying/split_tests.cu
@@ -610,6 +610,6 @@ TEST_F(ContiguousSplitTableCornerCases, MixedColumnTypes) {
   auto expected = cudf::experimental::split(tbl, splits);
   
   for (unsigned long index = 0; index < expected.size(); index++) {      
-    cudf::test::expect_tables_equal(expected[index], result[index].table);
+    cudf::test::expect_tables_equivalent(expected[index], result[index].table);
   }
 }

--- a/cpp/tests/utilities/table_utilities.cu
+++ b/cpp/tests/utilities/table_utilities.cu
@@ -19,5 +19,15 @@ void expect_tables_equal(cudf::table_view lhs, cudf::table_view rhs) {
   }
 }
 
+/**
+ * @copydoc cudf::test::expect_tables_equivalent
+ * 
+ **/
+void expect_tables_equivalent(cudf::table_view lhs, cudf::table_view rhs) {  
+  for (auto i=0; i<lhs.num_columns(); ++i) {
+    cudf::test::expect_columns_equivalent(lhs.column(i), rhs.column(i));
+  }
+}
+
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/utilities/table_utilities.cu
+++ b/cpp/tests/utilities/table_utilities.cu
@@ -24,7 +24,8 @@ void expect_tables_equal(cudf::table_view lhs, cudf::table_view rhs) {
  * 
  **/
 void expect_tables_equivalent(cudf::table_view lhs, cudf::table_view rhs) {  
-  for (auto i=0; i<lhs.num_columns(); ++i) {
+  auto num_columns = lhs.num_columns();
+  for (auto i=0; i<num_columns; ++i) {
     cudf::test::expect_columns_equivalent(lhs.column(i), rhs.column(i));
   }
 }

--- a/cpp/tests/utilities/table_utilities.hpp
+++ b/cpp/tests/utilities/table_utilities.hpp
@@ -40,5 +40,16 @@ void expect_table_properties_equal(cudf::table_view lhs, cudf::table_view rhs);
  *---------------------------------------------------------------------------**/
 void expect_tables_equal(cudf::table_view lhs, cudf::table_view rhs);
 
+/*
+ * @brief Verifies the equivalency of two tables.
+ *
+ * Treats null elements as equivalent.  Columns that have nullability but no nulls,
+ * and columns that are not nullable are considered equivalent.
+ *
+ * @param lhs The first table
+ * @param rhs The second table
+ **/
+void expect_tables_equivalent(cudf::table_view lhs, cudf::table_view rhs);
+
 }  // namespace test
 }  // namespace cudf


### PR DESCRIPTION

contiguous_split() had a small hack in it to get around an issue with slice().  Slice was returning UNKNOWN_NULL_COUNT for all sliced columns.  This caused computation of that number silently within contiguous_split() which caused performance issues because of the scale contiguous_split runs at (ten of thousands or more columns).  

slice() has been changed to produce proper null counts (https://github.com/rapidsai/cudf/issues/3600) so the hack is no longer necessary.