### PR TITLE
Add Dask serializers for cuDF objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #4040 Add support for n-way merge of sorted tables
 - PR #4053 Multi-column quantiles.
 - PR #4107 Add groupby nunique aggregation
+- PR #4153 Support Dask serialization protocol on cuDF objects
 
 ## Improvements
 

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -4,6 +4,7 @@ import cudf
 import cudf.core.groupby.groupby
 
 try:
+    from distributed.protocol import dask_deserialize, dask_serialize
     from distributed.protocol.cuda import cuda_deserialize, cuda_serialize
     from distributed.utils import log_errors
 
@@ -19,12 +20,41 @@ try:
             cudf.core.buffer.Buffer,
         )
     )
-    def serialize_cudf_dataframe(x):
+    def cuda_serialize_cudf_dataframe(x):
         with log_errors():
             header, frames = x.serialize()
             return header, frames
 
+    # all (de-)serializtion are attached to cudf Objects:
+    # Series/DataFrame/Index/Column/Buffer/etc
+    @dask_serialize.register(
+        (
+            cudf.DataFrame,
+            cudf.Series,
+            cudf.core.series.Series,
+            cudf.core.groupby.groupby._Groupby,
+            cudf.core.column.column.Column,
+            cudf.core.buffer.Buffer,
+        )
+    )
+    def dask_serialize_cudf_dataframe(x):
+        with log_errors():
+            header, frames = x.serialize()
+            assert all(isinstance(f, cudf.core.buffer.Buffer) for f in frames)
+            frames = [f.to_host_array().data for f in frames]
+            return header, frames
+
     @cuda_deserialize.register(
+        (
+            cudf.DataFrame,
+            cudf.Series,
+            cudf.core.series.Series,
+            cudf.core.groupby.groupby._Groupby,
+            cudf.core.column.column.Column,
+            cudf.core.buffer.Buffer,
+        )
+    )
+    @dask_deserialize.register(
         (
             cudf.DataFrame,
             cudf.Series,


### PR DESCRIPTION
In the event that serializing CUDA objects directly is not possible, this performs the next best thing, which is to serialize objects using Dask's serialization protocol. The protocol requires that data be on the host in 1-D contiguous `memoryviews`. So we perform serialization as we otherwise would. As a last step we perform a device-to-host transfer of the frames. Then we hand this off to Dask to serialize. When deserializing the data, all of the deserializers already work as frames are turned into `Buffer`s, which perform a host-to-device transfer if needed. This provides us an option that avoids pickling. As a result we are able to serialize things with Dask more efficiently using this protocol.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
