### PR TITLE
[REVIEW] Fix merge issue with empty table return if one of the two tables are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - PR #4125 Fix type enum to account for added Dictionary type in `types.hpp`
 - PR #4137 Update Java for mutating fill and rolling window changes
 - PR #4141 Fix NVStrings test_convert failure in 10.2 build
+- PR #4158 Fix merge issue with empty table return if one of the two tables are empty
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/src/table/table.cpp
+++ b/cpp/src/table/table.cpp
@@ -45,7 +45,7 @@ table::table(std::vector<std::unique_ptr<column>>&& columns)
 
 // Copy the contents of a `table_view`
 table::table(table_view view, cudaStream_t stream,
-             rmm::mr::device_memory_resource* mr) {
+             rmm::mr::device_memory_resource* mr) : _num_rows{view.num_rows()} {
   _columns.reserve(view.num_columns());
   for (auto const& c : view) {
     _columns.emplace_back(std::make_unique<column>(c, stream, mr));

--- a/cpp/tests/merge/merge_test.cpp
+++ b/cpp/tests/merge/merge_test.cpp
@@ -46,6 +46,31 @@ class MergeTest_ : public cudf::test::BaseFixture {};
 
 TYPED_TEST_CASE(MergeTest_, cudf::test::FixedWidthTypes);
 
+TYPED_TEST(MergeTest_, MergeIsZeroWhenShouldNotBeZero) {
+    using columnFactoryT = cudf::test::fixed_width_column_wrapper<TypeParam>;
+
+    columnFactoryT leftColWrap1{1,2,3,4,5};
+    columnFactoryT rightColWrap1{};
+
+    std::vector<cudf::size_type> key_cols{0};
+    std::vector<cudf::order> column_order;
+    column_order.push_back(cudf::order::ASCENDING);
+    std::vector<cudf::null_order> null_precedence(column_order.size(), cudf::null_order::AFTER);
+
+    cudf::table_view left_view{{leftColWrap1}};
+    cudf::table_view right_view{{rightColWrap1}};
+    cudf::table_view expected{{leftColWrap1}};
+
+    auto result = cudf::experimental::merge({left_view, right_view},
+                                           key_cols,
+                                           column_order,
+                                           null_precedence);
+
+    int expected_len = 5;
+    ASSERT_EQ(result->num_rows(), expected_len);
+    cudf::test::expect_tables_equal(expected, result->view());
+}
+
 TYPED_TEST(MergeTest_, MismatchedNumColumns) {
     using columnFactoryT = cudf::test::fixed_width_column_wrapper<TypeParam>;
     

--- a/cpp/tests/table/table_tests.cpp
+++ b/cpp/tests/table/table_tests.cpp
@@ -51,6 +51,22 @@ TEST_F(TableTest, EmptyColumnedTable)
     EXPECT_EQ(input.num_columns(), expected);
 }
 
+TEST_F(TableTest, ValidateConstructorTableViewToTable)
+{
+    column_wrapper <int8_t>  col1{{1,2,3,4}};
+    column_wrapper <int8_t>  col2{{1,2,3,4}};
+
+    CVector cols;
+    cols.push_back(col1.release());
+    cols.push_back(col2.release());
+
+    Table input_table(std::move(cols));
+
+    Table out_table(input_table.view());
+
+    cudf::test::expect_tables_equal(out_table, input_table);
+}
+
 TEST_F(TableTest, GetTableWithSelectedColumns)
 {
   column_wrapper <int8_t>  col1{{1,2,3,4}};

--- a/cpp/tests/table/table_tests.cpp
+++ b/cpp/tests/table/table_tests.cpp
@@ -64,7 +64,8 @@ TEST_F(TableTest, ValidateConstructorTableViewToTable)
 
     Table out_table(input_table.view());
 
-    cudf::test::expect_tables_equal(out_table, input_table);
+    EXPECT_EQ(input_table.num_columns(), out_table.num_columns());
+    EXPECT_EQ(input_table.num_rows(), out_table.num_rows());
 }
 
 TEST_F(TableTest, GetTableWithSelectedColumns)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
constructor was not updating number of rows while creating table from table_view which created the issue.

close #4152 