### PR TITLE
[WIP] Generalize Table._from_unique_ptr 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - PR #4136 Add `Index.names` property
 - PR #4144 Release GIL when calling libcudf++ functions
 - PR #4149 Use "type-serialized" for pickled types like Dask
+- PR #4170 Generalize table construction from unique pointer
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/_libxx/stream_compaction.pyx
+++ b/python/cudf/cudf/_libxx/stream_compaction.pyx
@@ -71,7 +71,7 @@ def drop_nulls(Table source_table, how="any", keys=None, thresh=None):
         move(c_result),
         column_names=source_table._column_names,
         index_names=(
-            None if source_table._index is None
+            [] if source_table._index is None
             else source_table._index_names)
     )
 

--- a/python/cudf/cudf/_libxx/stream_compaction.pyx
+++ b/python/cudf/cudf/_libxx/stream_compaction.pyx
@@ -71,7 +71,7 @@ def drop_nulls(Table source_table, how="any", keys=None, thresh=None):
         move(c_result),
         column_names=source_table._column_names,
         index_names=(
-            [] if source_table._index is None
+            None if source_table._index is None
             else source_table._index_names)
     )
 

--- a/python/cudf/cudf/_libxx/table.pxd
+++ b/python/cudf/cudf/_libxx/table.pxd
@@ -29,4 +29,8 @@ cdef class Table:
         index_names=*
     )
     @staticmethod
-    cdef Table from_unique_ptr(unique_ptr[table] c_tbl, column_names, index_names=*, index_pos=*)
+    cdef Table from_unique_ptr(
+        unique_ptr[table] c_tbl, 
+        column_names, 
+        index_names=*, 
+        index_pos=*)

--- a/python/cudf/cudf/_libxx/table.pxd
+++ b/python/cudf/cudf/_libxx/table.pxd
@@ -22,16 +22,11 @@ cdef class Table:
     cdef mutable_table_view mutable_index_view(self) except *
 
     @staticmethod
-    cdef Table from_unique_ptr(
-        unique_ptr[table] c_tbl,
-        column_names,
-        index_names=*
-    )
-
-    @staticmethod
     cdef Table from_table_view(
         table_view,
         owner,
         column_names,
         index_names=*
     )
+    @staticmethod
+    cdef Table from_unique_ptr(unique_ptr[table] c_tbl, column_names, index_names=*, index_pos=*)

--- a/python/cudf/cudf/_libxx/table.pyx
+++ b/python/cudf/cudf/_libxx/table.pyx
@@ -15,7 +15,7 @@ from libc.stdint cimport uintptr_t
 from cudf._libxx.lib cimport *
 from cudf._libxx.column cimport Column
 from cudf.utils.utils import OrderedColumnDict
-
+from collections import OrderedDict
 
 cdef class Table:
     def __init__(self, data=None, index=None):
@@ -88,13 +88,12 @@ cdef class Table:
         cdef vector[unique_ptr[column]].iterator it = columns.begin()
 
         num_cols_input = len(column_names) + len(index_names)
-        all_cols_py = []
-        for _ in range(num_cols_input):
-            all_cols_py.append(Column.from_unique_ptr(
+        all_cols_py = OrderedDict()
+        for i in range(num_cols_input):
+            all_cols_py[i] =(Column.from_unique_ptr(
                 move(dereference(it))
             ))
             it += 1 
-
         index = None
         if index_names is not None:
             index_columns = []
@@ -104,7 +103,8 @@ cdef class Table:
                 for idx in index_pos:
                     index_columns.append(all_cols_py.pop(idx))
                 index = Table(OrderedColumnDict(zip(index_names, index_columns)))
-        data = OrderedColumnDict(zip(column_names, all_cols_py))
+
+        data = OrderedColumnDict(zip(column_names, all_cols_py.values()))
 
         return Table(data=data, index=index)
 

--- a/python/cudf/cudf/_libxx/table.pyx
+++ b/python/cudf/cudf/_libxx/table.pyx
@@ -77,6 +77,11 @@ cdef class Table:
         index_names : iterable
         column_names : iterable
         """
+
+        if column_names is None:
+            column_names = []
+        if index_names is None:
+            index_names = []
         cdef vector[unique_ptr[column]] columns
         columns = c_tbl.get()[0].release()
 
@@ -89,9 +94,11 @@ cdef class Table:
                 move(dereference(it))
             ))
             it += 1 
-
-        result_index = all_cols_py.pop(index_pos)
-        index = Table(OrderedColumnDict(zip(index_names, [result_index])))
+        index = None
+        if index_names is not None:
+            if len(index_names) > 0:
+                result_index = all_cols_py.pop(index_pos)
+                index = Table(OrderedColumnDict(zip(index_names, [result_index])))
         data = OrderedColumnDict(zip(column_names, all_cols_py))
 
         return Table(data=data, index=index)

--- a/python/cudf/cudf/_libxx/table.pyx
+++ b/python/cudf/cudf/_libxx/table.pyx
@@ -76,6 +76,7 @@ cdef class Table:
         c_tbl : unique_ptr[cudf::table]
         index_names : iterable
         column_names : iterable
+        index_pos : iterable, column indices corresponding to column_names
         """
 
         cdef vector[unique_ptr[column]] columns

--- a/python/cudf/cudf/_libxx/table.pyx
+++ b/python/cudf/cudf/_libxx/table.pyx
@@ -93,7 +93,7 @@ cdef class Table:
             cols_py[i] =(Column.from_unique_ptr(
                 move(dereference(it))
             ))
-            it += 1 
+            it += 1
 
         index = None
         if index_names not in [None, []]:

--- a/python/cudf/cudf/_libxx/table.pyx
+++ b/python/cudf/cudf/_libxx/table.pyx
@@ -67,7 +67,7 @@ cdef class Table:
         unique_ptr[table] c_tbl,
         object column_names,
         object index_names=[],
-        object index_pos=0
+        object index_pos=None
     ):
         """
         Construct a Table from a unique_ptr to a cudf::table.
@@ -94,11 +94,16 @@ cdef class Table:
                 move(dereference(it))
             ))
             it += 1 
+
         index = None
         if index_names is not None:
+            index_columns = []
             if len(index_names) > 0:
-                result_index = all_cols_py.pop(index_pos)
-                index = Table(OrderedColumnDict(zip(index_names, [result_index])))
+                if index_pos is None:
+                    index_pos = range(len(index_names))
+                for idx in index_pos:
+                    index_columns.append(all_cols_py.pop(idx))
+                index = Table(OrderedColumnDict(zip(index_names, index_columns)))
         data = OrderedColumnDict(zip(column_names, all_cols_py))
 
         return Table(data=data, index=index)

--- a/python/cudf/cudf/_libxx/table.pyx
+++ b/python/cudf/cudf/_libxx/table.pyx
@@ -96,7 +96,7 @@ cdef class Table:
             it += 1
 
         index = None
-        if index_names not in [None, []]:
+        if index_names is not None and len(index_names) > 0:
             index_columns = []
             if index_pos is None:
                 index_pos = range(len(index_names))


### PR DESCRIPTION
Adds an `index_pos` argument to `Table._from_unique_ptr` allowing for cases where the desired index columns are not the leftmost columns returned by libcudf. 