### PR TITLE
Fix __sizeof__ calculation in string column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 - PR #4137 Update Java for mutating fill and rolling window changes
 - PR #4141 Fix NVStrings test_convert failure in 10.2 build
 - PR #4158 Fix merge issue with empty table return if one of the two tables are empty
+- PR #4175 Fix `__sizeof__` calculation in `StringColumn`
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -550,10 +550,12 @@ class StringColumn(column.ColumnBase):
         return StringMethods(self, index=index, name=name)
 
     def __sizeof__(self):
-        n = (
-            self.base_children[0].__sizeof__()
-            + self.base_children[1].__sizeof__()
-        )
+        n = 0
+        if self.base_children is not None and len(self.base_children) == 2:
+            n += (
+                self.base_children[0].__sizeof__()
+                + self.base_children[1].__sizeof__()
+            )
         if self.base_mask:
             n += self.base_mask.size
         return n


### PR DESCRIPTION
Fixes #4173

When a string column is empty, it does not have `self.base_children` so just I'm just adding a check against that case.