### PR TITLE
[REVIEW] Cythonize in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - PR #4165 List serializable classes once
 - PR #4177 Use `uint8` type for host array copy of `Buffer`
 - PR #4182 Rename cuDF serialize functions to be more generic
+- PR #4176 Add option to parallelize setup.py's cythonize
 
 ## Bug Fixes
 

--- a/build.sh
+++ b/build.sh
@@ -178,10 +178,10 @@ if buildAll || hasArg cudf; then
 
     cd ${REPODIR}/python/cudf
     if [[ ${INSTALL_TARGET} != "" ]]; then
-        python setup.py build_ext --inplace
+        python setup.py build_ext -j${PARALLEL_LEVEL} --inplace
         python setup.py install --single-version-externally-managed --record=record.txt
     else
-        python setup.py build_ext --inplace --library-dir=${LIBCUDF_BUILD_DIR}
+        python setup.py build_ext -j${PARALLEL_LEVEL} --inplace --library-dir=${LIBCUDF_BUILD_DIR}
     fi
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -178,10 +178,10 @@ if buildAll || hasArg cudf; then
 
     cd ${REPODIR}/python/cudf
     if [[ ${INSTALL_TARGET} != "" ]]; then
-        python setup.py build_ext -j${PARALLEL_LEVEL} --inplace
+        env PARALLEL_LEVEL=${PARALLEL_LEVEL} python setup.py build_ext --inplace
         python setup.py install --single-version-externally-managed --record=record.txt
     else
-        python setup.py build_ext -j${PARALLEL_LEVEL} --inplace --library-dir=${LIBCUDF_BUILD_DIR}
+        env PARALLEL_LEVEL=${PARALLEL_LEVEL} python setup.py build_ext --inplace --library-dir=${LIBCUDF_BUILD_DIR}
     fi
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -178,10 +178,10 @@ if buildAll || hasArg cudf; then
 
     cd ${REPODIR}/python/cudf
     if [[ ${INSTALL_TARGET} != "" ]]; then
-        env PARALLEL_LEVEL=${PARALLEL_LEVEL} python setup.py build_ext --inplace
+        PARALLEL_LEVEL=${PARALLEL_LEVEL} python setup.py build_ext --inplace
         python setup.py install --single-version-externally-managed --record=record.txt
     else
-        env PARALLEL_LEVEL=${PARALLEL_LEVEL} python setup.py build_ext --inplace --library-dir=${LIBCUDF_BUILD_DIR}
+        PARALLEL_LEVEL=${PARALLEL_LEVEL} python setup.py build_ext --inplace --library-dir=${LIBCUDF_BUILD_DIR}
     fi
 fi
 

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 import os
 import shutil
-import argparse
 import sysconfig
 from distutils.sysconfig import get_python_lib
 
@@ -34,16 +33,7 @@ if not os.path.isdir(CUDA_HOME):
 
 cuda_include_dir = os.path.join(CUDA_HOME, "include")
 
-argparser = argparse.ArgumentParser()
-argparser.add_argument("-j", "--jobs", required=False, const=None, default=None, type=int)
-try:
-    args, unknown = argparser.parse_known_args()
-except Exception:
-    args = argparse.Namespace()
-    setattr(args, 'jobs', None)
-
-nthreads=int(args.jobs if args.jobs is not None else
-             os.environ.get("JOBS", os.environ.get("PARALLEL_LEVEL", "0")))
+nthreads=int(os.environ.get("JOBS", os.environ.get("PARALLEL_LEVEL", "0")))
 
 extensions = [
     Extension(

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -33,7 +33,10 @@ if not os.path.isdir(CUDA_HOME):
 
 cuda_include_dir = os.path.join(CUDA_HOME, "include")
 
-nthreads=int(os.environ.get("JOBS", os.environ.get("PARALLEL_LEVEL", "0")))
+try:
+    nthreads = int(os.environ.get("PARALLEL_LEVEL", "0") or "0")
+except Exception:
+    nthreads = 0
 
 extensions = [
     Extension(

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -35,12 +35,15 @@ if not os.path.isdir(CUDA_HOME):
 cuda_include_dir = os.path.join(CUDA_HOME, "include")
 
 argparser = argparse.ArgumentParser()
-argparser.add_argument("-j", "--jobs", default=None, type=int)
-args, unknown = argparser.parse_known_args()
-if args.jobs is not None:
-    nthreads=int(args.jobs)
-else:
-    nthreads=int(os.environ.get("JOBS", "0"))
+argparser.add_argument("-j", "--jobs", required=False, const=None, default=None, type=int)
+try:
+    args, unknown = argparser.parse_known_args()
+except Exception:
+    args = argparse.Namespace()
+    setattr(args, 'jobs', None)
+
+nthreads=int(args.jobs if args.jobs is not None else
+             os.environ.get("JOBS", os.environ.get("PARALLEL_LEVEL", "0")))
 
 extensions = [
     Extension(

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 import os
 import shutil
+import argparse
 import sysconfig
 from distutils.sysconfig import get_python_lib
 
@@ -33,6 +34,13 @@ if not os.path.isdir(CUDA_HOME):
 
 cuda_include_dir = os.path.join(CUDA_HOME, "include")
 
+argparser = argparse.ArgumentParser()
+argparser.add_argument("-j", "--jobs", default=None, type=int)
+args, unknown = argparser.parse_known_args()
+if args.jobs is not None:
+    nthreads=int(args.jobs)
+else:
+    nthreads=int(os.environ.get("JOBS", "0"))
 
 extensions = [
     Extension(
@@ -73,7 +81,7 @@ setup(
     ],
     # Include the separately-compiled shared library
     setup_requires=["cython"],
-    ext_modules=cythonize(extensions),
+    ext_modules=cythonize(extensions, nthreads=nthreads),
     packages=find_packages(include=["cudf", "cudf.*"]),
     package_data={
         "cudf._lib": ["*.pxd"],


### PR DESCRIPTION
Filing this WIP PR to test optionally cythonizing in parallel.

In testing it seems cythonize's `nthreads` argument controls the Cython -> C++ pre-processing, so reading this from a `PARALLEL_LEVEL` env variable is a nice boost to cython re-compile times.

<details>
<summary>Click to see <code>setup.py build_ext --inplace -j22</code> output from a clean-build</summary><pre>
$ build-cudf-python 
Compiling cudf/_lib/arrow/_cuda.pyx because it changed.
Compiling cudf/_lib/avro.pyx because it changed.
Compiling cudf/_lib/binops.pyx because it changed.
Compiling cudf/_lib/concat.pyx because it changed.
Compiling cudf/_lib/copying.pyx because it changed.
Compiling cudf/_lib/csv.pyx because it changed.
Compiling cudf/_lib/cudf.pyx because it changed.
Compiling cudf/_lib/dlpack.pyx because it changed.
Compiling cudf/_lib/filling.pyx because it changed.
Compiling cudf/_lib/gpuarrow.pyx because it changed.
Compiling cudf/_lib/groupby.pyx because it changed.
Compiling cudf/_lib/hash.pyx because it changed.
Compiling cudf/_lib/issorted.pyx because it changed.
Compiling cudf/_lib/join.pyx because it changed.
Compiling cudf/_lib/json.pyx because it changed.
Compiling cudf/_lib/nvtx.pyx because it changed.
Compiling cudf/_lib/orc.pyx because it changed.
Compiling cudf/_lib/parquet.pyx because it changed.
Compiling cudf/_lib/quantile.pyx because it changed.
Compiling cudf/_lib/reduce.pyx because it changed.
Compiling cudf/_lib/replace.pyx because it changed.
Compiling cudf/_lib/reshape.pyx because it changed.
Compiling cudf/_lib/rolling.pyx because it changed.
Compiling cudf/_lib/search.pyx because it changed.
Compiling cudf/_lib/sort.pyx because it changed.
Compiling cudf/_lib/stream_compaction.pyx because it changed.
Compiling cudf/_lib/table.pyx because it changed.
Compiling cudf/_lib/transpose.pyx because it changed.
Compiling cudf/_lib/typecast.pyx because it changed.
Compiling cudf/_lib/unaryops.pyx because it changed.
Compiling cudf/_lib/utils.pyx because it changed.
Compiling cudf/_libxx/column.pyx because it changed.
Compiling cudf/_libxx/copying.pyx because it changed.
Compiling cudf/_libxx/null_mask.pyx because it changed.
Compiling cudf/_libxx/stream_compaction.pyx because it changed.
Compiling cudf/_libxx/table.pyx because it changed.
[ 1/36] Cythonizing cudf/_lib/arrow/_cuda.pyx
[ 2/36] Cythonizing cudf/_lib/avro.pyx
[ 3/36] Cythonizing cudf/_lib/binops.pyx
[ 4/36] Cythonizing cudf/_lib/concat.pyx
[ 5/36] Cythonizing cudf/_lib/copying.pyx
[ 6/36] Cythonizing cudf/_lib/csv.pyx
[ 7/36] Cythonizing cudf/_lib/cudf.pyx
[ 9/36] Cythonizing cudf/_lib/filling.pyx
[ 8/36] Cythonizing cudf/_lib/dlpack.pyx
[10/36] Cythonizing cudf/_lib/gpuarrow.pyx
[12/36] Cythonizing cudf/_lib/hash.pyx
[11/36] Cythonizing cudf/_lib/groupby.pyx
[13/36] Cythonizing cudf/_lib/issorted.pyx
[14/36] Cythonizing cudf/_lib/join.pyx
[15/36] Cythonizing cudf/_lib/json.pyx
[16/36] Cythonizing cudf/_lib/nvtx.pyx
[17/36] Cythonizing cudf/_lib/orc.pyx
[19/36] Cythonizing cudf/_lib/quantile.pyx
[20/36] Cythonizing cudf/_lib/reduce.pyx
[18/36] Cythonizing cudf/_lib/parquet.pyx
[22/36] Cythonizing cudf/_lib/reshape.pyx
[21/36] Cythonizing cudf/_lib/replace.pyx
warning: cudf/_lib/csv.pyx:96:53: Not all members given for struct 'reader_options'
warning: cudf/_lib/csv.pyx:96:53: Not all members given for struct 'reader_options'
warning: cudf/_lib/json.pyx:77:47: Use boundscheck(False) for faster access
warning: cudf/_lib/csv.pyx:273:65: Not all members given for struct 'csv_write_arg'
warning: cudf/_lib/csv.pyx:273:65: Not all members given for struct 'csv_write_arg'
[23/36] Cythonizing cudf/_lib/rolling.pyx
[24/36] Cythonizing cudf/_lib/search.pyx
warning: cudf/_lib/avro.pyx:59:47: Use boundscheck(False) for faster access
[25/36] Cythonizing cudf/_lib/sort.pyx
[26/36] Cythonizing cudf/_lib/stream_compaction.pyx
warning: cudf/_lib/csv.pyx:209:46: Use boundscheck(False) for faster access
[27/36] Cythonizing cudf/_lib/table.pyx
[28/36] Cythonizing cudf/_lib/transpose.pyx
warning: cudf/_lib/orc.pyx:86:46: Use boundscheck(False) for faster access
[29/36] Cythonizing cudf/_lib/typecast.pyx
[30/36] Cythonizing cudf/_lib/unaryops.pyx
[31/36] Cythonizing cudf/_lib/utils.pyx
[32/36] Cythonizing cudf/_libxx/column.pyx
warning: cudf/_lib/parquet.pyx:122:49: Use boundscheck(False) for faster access
[33/36] Cythonizing cudf/_libxx/copying.pyx
[34/36] Cythonizing cudf/_libxx/null_mask.pyx
[35/36] Cythonizing cudf/_libxx/stream_compaction.pyx
[36/36] Cythonizing cudf/_libxx/table.pyx
warning: cudf/_lib/typecast.pyx:33:24: local variable 'c_category' referenced before assignment
/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/setuptools/dist.py:476: UserWarning: Normalizing '0.13.0a+1870.g22fa178ba.dirty' to '0.13.0a0+1870.g22fa178ba.dirty'
  normalized_version,
running build_ext
building 'cudf._lib.arrow._cuda' extension
creating build
creating build/temp.linux-x86_64-3.7
creating build/temp.linux-x86_64-3.7/cudf
creating build/temp.linux-x86_64-3.7/cudf/_lib
creating build/temp.linux-x86_64-3.7/cudf/_lib/arrow
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/arrow/_cuda.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/arrow/_cuda.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
cudf/_lib/arrow/_cuda.cpp:3888:52: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_sparse_tensor_csr’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::SparseTensorCSR>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_sparse_tensor_csr)(PyObject *); /*proto*/
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3887:52: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_sparse_tensor_coo’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::SparseTensorCOO>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_sparse_tensor_coo)(PyObject *); /*proto*/
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3886:43: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_tensor’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Tensor>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_tensor)(PyObject *); /*proto*/
                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3885:42: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_table’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Table>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_table)(PyObject *); /*proto*/
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3883:42: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_field’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Field>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_field)(PyObject *); /*proto*/
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3882:45: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_data_type’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::DataType>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_data_type)(PyObject *); /*proto*/
                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3879:42: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_array’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Array>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_array)(PyObject *); /*proto*/
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3878:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_sparse_tensor_csr’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_sparse_tensor_csr)(std::shared_ptr< arrow::SparseTensorCSR>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3877:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_sparse_tensor_coo’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_sparse_tensor_coo)(std::shared_ptr< arrow::SparseTensorCOO>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3876:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_tensor’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_tensor)(std::shared_ptr< arrow::Tensor>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3875:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_table’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_table)(std::shared_ptr< arrow::Table>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3874:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_schema’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_schema)(std::shared_ptr< arrow::Schema>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3873:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_resizable_buffer’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_resizable_buffer)(std::shared_ptr< arrow::ResizableBuffer>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3872:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_field’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_field)(std::shared_ptr< arrow::Field>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3871:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_data_type’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_data_type)(std::shared_ptr< arrow::DataType>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3868:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_chunked_array’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_chunked_array)(std::shared_ptr< arrow::ChunkedArray>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/arrow/_cuda.cpp:3867:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_array’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_array)(std::shared_ptr< arrow::Array>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/arrow/python/platform.h:25:0,
                 from cudf/_lib/arrow/_cuda.cpp:684:
/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m/datetime.h:204:25: warning: ‘PyDateTimeAPI’ defined but not used [-Wunused-variable]
 static PyDateTime_CAPI *PyDateTimeAPI = NULL;
                         ^~~~~~~~~~~~~
creating build/lib.linux-x86_64-3.7
creating build/lib.linux-x86_64-3.7/cudf
creating build/lib.linux-x86_64-3.7/cudf/_lib
creating build/lib.linux-x86_64-3.7/cudf/_lib/arrow
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/arrow/_cuda.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/arrow/_cuda.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.avro' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/avro.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/avro.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/avro.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/avro.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.binops' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/binops.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/binops.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/binops.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/binops.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.concat' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/concat.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/concat.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/concat.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/concat.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.copying' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/copying.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/copying.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/copying.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/copying.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.csv' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/csv.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/csv.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/csv.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/csv.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.cudf' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/cudf.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/cudf.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/cudf.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/cudf.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.dlpack' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/dlpack.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/dlpack.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/dlpack.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/dlpack.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.filling' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/filling.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/filling.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/filling.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/filling.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.gpuarrow' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/gpuarrow.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/gpuarrow.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
cudf/_lib/gpuarrow.cpp:4504:52: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_sparse_tensor_csr’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::SparseTensorCSR>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_sparse_tensor_csr)(PyObject *); /*proto*/
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4503:52: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_sparse_tensor_coo’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::SparseTensorCOO>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_sparse_tensor_coo)(PyObject *); /*proto*/
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4502:43: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_tensor’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Tensor>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_tensor)(PyObject *); /*proto*/
                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4501:42: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_table’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Table>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_table)(PyObject *); /*proto*/
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4500:43: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_schema’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Schema>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_schema)(PyObject *); /*proto*/
                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4499:42: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_field’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Field>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_field)(PyObject *); /*proto*/
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4498:45: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_data_type’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::DataType>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_data_type)(PyObject *); /*proto*/
                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4497:43: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_buffer’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Buffer>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_buffer)(PyObject *); /*proto*/
                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4496:48: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_batch’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::RecordBatch>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_batch)(PyObject *); /*proto*/
                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4495:42: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_unwrap_array’ defined but not used [-Wunused-variable]
 static std::shared_ptr< arrow::Array>  (*__pyx_f_7pyarrow_3lib_pyarrow_unwrap_array)(PyObject *); /*proto*/
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4494:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_sparse_tensor_csr’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_sparse_tensor_csr)(std::shared_ptr< arrow::SparseTensorCSR>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4493:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_sparse_tensor_coo’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_sparse_tensor_coo)(std::shared_ptr< arrow::SparseTensorCOO>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4492:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_tensor’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_tensor)(std::shared_ptr< arrow::Tensor>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4491:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_table’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_table)(std::shared_ptr< arrow::Table>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4489:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_resizable_buffer’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_resizable_buffer)(std::shared_ptr< arrow::ResizableBuffer>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4488:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_field’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_field)(std::shared_ptr< arrow::Field>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4487:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_data_type’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_data_type)(std::shared_ptr< arrow::DataType>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4486:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_buffer’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_buffer)(std::shared_ptr< arrow::Buffer>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4485:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_batch’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_batch)(std::shared_ptr< arrow::RecordBatch>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4484:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_chunked_array’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_chunked_array)(std::shared_ptr< arrow::ChunkedArray>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/gpuarrow.cpp:4483:20: warning: ‘__pyx_f_7pyarrow_3lib_pyarrow_wrap_array’ defined but not used [-Wunused-variable]
 static PyObject *(*__pyx_f_7pyarrow_3lib_pyarrow_wrap_array)(std::shared_ptr< arrow::Array>  const &); /*proto*/
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/arrow/python/platform.h:25:0,
                 from cudf/_lib/gpuarrow.cpp:696:
/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m/datetime.h:204:25: warning: ‘PyDateTimeAPI’ defined but not used [-Wunused-variable]
 static PyDateTime_CAPI *PyDateTimeAPI = NULL;
                         ^~~~~~~~~~~~~
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/gpuarrow.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/gpuarrow.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.groupby' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/groupby.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/groupby.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
In file included from cudf/_lib/groupby.cpp:680:0:
../../cpp/include/cudf/legacy/groupby.hpp: In constructor ‘cudf::groupby::sort::Options::Options(bool, cudf::groupby::sort::null_order, bool)’:
../../cpp/include/cudf/legacy/groupby.hpp:156:8: warning: ‘cudf::groupby::sort::Options::input_sorted’ will be initialized after [-Wreorder]
   bool input_sorted; ///< Indicates if the input data is sorted.
        ^~~~~~~~~~~~
../../cpp/include/cudf/legacy/groupby.hpp:155:14: warning:   ‘cudf::groupby::sort::null_order cudf::groupby::sort::Options::null_sort_behavior’ [-Wreorder]
   null_order null_sort_behavior; ///< Indicates how nulls are treated
              ^~~~~~~~~~~~~~~~~~
../../cpp/include/cudf/legacy/groupby.hpp:158:3: warning:   when initialized here [-Wreorder]
   Options(bool _ignore_null_keys = true,
   ^~~~~~~
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/groupby.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/groupby.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.hash' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/hash.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/hash.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/hash.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/hash.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.issorted' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/issorted.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/issorted.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/issorted.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/issorted.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.join' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/join.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/join.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/join.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/join.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.json' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/json.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/json.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/json.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/json.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.nvtx' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/nvtx.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/nvtx.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/nvtx.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/nvtx.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.orc' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/orc.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/orc.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/orc.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/orc.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.parquet' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/parquet.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/parquet.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
In file included from cudf/_lib/parquet.cpp:680:0:
../../cpp/include/cudf/io/functions.hpp: In constructor ‘cudf::experimental::io::write_orc_args::write_orc_args(const cudf::experimental::io::sink_info&, const cudf::table_view&, const cudf::experimental::io::table_metadata*, cudf::experimental::io::compression_type, bool)’:
../../cpp/include/cudf/io/functions.hpp:307:25: warning: ‘cudf::experimental::io::write_orc_args::metadata’ will be initialized after [-Wreorder]
   const table_metadata *metadata;
                         ^~~~~~~~
../../cpp/include/cudf/io/functions.hpp:301:20: warning:   ‘cudf::experimental::io::compression_type cudf::experimental::io::write_orc_args::compression’ [-Wreorder]
   compression_type compression;
                    ^~~~~~~~~~~
../../cpp/include/cudf/io/functions.hpp:309:12: warning:   when initialized here [-Wreorder]
   explicit write_orc_args(sink_info const& snk, table_view const& table_,
            ^~~~~~~~~~~~~~
../../cpp/include/cudf/io/functions.hpp: In constructor ‘cudf::experimental::io::write_parquet_args::write_parquet_args(const cudf::experimental::io::sink_info&, const cudf::table_view&, const cudf::experimental::io::table_metadata*, cudf::experimental::io::compression_type, cudf::experimental::io::statistics_freq)’:
../../cpp/include/cudf/io/functions.hpp:399:25: warning: ‘cudf::experimental::io::write_parquet_args::metadata’ will be initialized after [-Wreorder]
   const table_metadata *metadata;
                         ^~~~~~~~
../../cpp/include/cudf/io/functions.hpp:393:20: warning:   ‘cudf::experimental::io::compression_type cudf::experimental::io::write_parquet_args::compression’ [-Wreorder]
   compression_type compression;
                    ^~~~~~~~~~~
../../cpp/include/cudf/io/functions.hpp:403:12: warning:   when initialized here [-Wreorder]
   explicit write_parquet_args(sink_info const& sink_, table_view const& table_,
            ^~~~~~~~~~~~~~~~~~
../../cpp/include/cudf/io/functions.hpp: In constructor ‘cudf::experimental::io::write_parquet_chunked_args::write_parquet_chunked_args(const cudf::experimental::io::sink_info&, const cudf::experimental::io::table_metadata_with_nullability*, cudf::experimental::io::compression_type, cudf::experimental::io::statistics_freq)’:
../../cpp/include/cudf/io/functions.hpp:441:42: warning: ‘cudf::experimental::io::write_parquet_chunked_args::metadata’ will be initialized after [-Wreorder]
   const table_metadata_with_nullability *metadata;
                                          ^~~~~~~~
../../cpp/include/cudf/io/functions.hpp:437:20: warning:   ‘cudf::experimental::io::compression_type cudf::experimental::io::write_parquet_chunked_args::compression’ [-Wreorder]
   compression_type compression;
                    ^~~~~~~~~~~
../../cpp/include/cudf/io/functions.hpp:443:12: warning:   when initialized here [-Wreorder]
   explicit write_parquet_chunked_args(sink_info const& sink_,
            ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/parquet.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/parquet.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.quantile' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/quantile.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/quantile.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/quantile.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/quantile.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.reduce' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/reduce.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/reduce.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/reduce.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/reduce.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.replace' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/replace.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/replace.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/replace.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/replace.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.reshape' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/reshape.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/reshape.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/reshape.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/reshape.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.rolling' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/rolling.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/rolling.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/rolling.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/rolling.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.search' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/search.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/search.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/search.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/search.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.sort' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/sort.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/sort.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/sort.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/sort.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.stream_compaction' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/stream_compaction.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/stream_compaction.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/stream_compaction.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/stream_compaction.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.table' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/table.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/table.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/table.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/table.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.transpose' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/transpose.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/transpose.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/transpose.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/transpose.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.typecast' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/typecast.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/typecast.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
cudf/_lib/typecast.cpp: In function ‘PyObject* __pyx_pw_4cudf_4_lib_8typecast_1cast(PyObject*, PyObject*, PyObject*)’:
cudf/_lib/typecast.cpp:2757:23: warning: ‘__pyx_v_c_category’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   __pyx_t_10.category = ((void *)__pyx_v_c_category);
   ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cudf/_lib/typecast.cpp:2566:13: note: ‘__pyx_v_c_category’ was declared here
   uintptr_t __pyx_v_c_category;
             ^~~~~~~~~~~~~~~~~~
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/typecast.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/typecast.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.unaryops' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/unaryops.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/unaryops.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/unaryops.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/unaryops.cpython-37m-x86_64-linux-gnu.so
building 'cudf._lib.utils' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_lib/utils.cpp -o build/temp.linux-x86_64-3.7/cudf/_lib/utils.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_lib/utils.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_lib/utils.cpython-37m-x86_64-linux-gnu.so
building 'cudf._libxx.column' extension
creating build/temp.linux-x86_64-3.7/cudf/_libxx
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_libxx/column.cpp -o build/temp.linux-x86_64-3.7/cudf/_libxx/column.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
creating build/lib.linux-x86_64-3.7/cudf/_libxx
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_libxx/column.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_libxx/column.cpython-37m-x86_64-linux-gnu.so
building 'cudf._libxx.copying' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_libxx/copying.cpp -o build/temp.linux-x86_64-3.7/cudf/_libxx/copying.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
In file included from ../../cpp/include/cudf/scalar/scalar.hpp:19:0,
                 from ../../cpp/include/cudf/copying.hpp:20,
                 from cudf/_libxx/copying.cpp:671:
../../cpp/include/cudf/utilities/type_dispatcher.hpp:279:0: warning: ignoring #pragma nv_exec_check_disable  [-Wunknown-pragmas]
 #pragma nv_exec_check_disable
 
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_libxx/copying.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_libxx/copying.cpython-37m-x86_64-linux-gnu.so
building 'cudf._libxx.null_mask' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_libxx/null_mask.cpp -o build/temp.linux-x86_64-3.7/cudf/_libxx/null_mask.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_libxx/null_mask.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_libxx/null_mask.cpython-37m-x86_64-linux-gnu.so
building 'cudf._libxx.stream_compaction' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_libxx/stream_compaction.cpp -o build/temp.linux-x86_64-3.7/cudf/_libxx/stream_compaction.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_libxx/stream_compaction.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_libxx/stream_compaction.cpython-37m-x86_64-linux-gnu.so
building 'cudf._libxx.table' extension
/usr/local/bin/ccache /usr/bin/gcc-7 -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../cpp/include/cudf -I../../cpp/include -I../../cpp/build/include -I../../thirdparty/cub -I../../thirdparty/libcudacxx/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages/numpy/core/include -I/usr/local/cuda-10.1/include -I/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/include/python3.7m -c cudf/_libxx/table.cpp -o build/temp.linux-x86_64-3.7/cudf/_libxx/table.o -std=c++14
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
/usr/bin/g++-7 -pthread -shared -B /home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/compiler_compat -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,-rpath=/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/cudf/_libxx/table.o -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib/python3.7/site-packages -L/home/ptaylor/dev/rapids/compose/etc/conda/envs/rapids/lib -lcudf -o build/lib.linux-x86_64-3.7/cudf/_libxx/table.cpython-37m-x86_64-linux-gnu.so
copying build/lib.linux-x86_64-3.7/cudf/_lib/arrow/_cuda.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib/arrow
copying build/lib.linux-x86_64-3.7/cudf/_lib/avro.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/binops.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/concat.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/copying.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/csv.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/cudf.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/dlpack.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/filling.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/gpuarrow.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/groupby.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/hash.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/issorted.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/join.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/json.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/nvtx.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/orc.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/parquet.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/quantile.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/reduce.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/replace.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/reshape.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/rolling.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/search.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/sort.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/stream_compaction.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/table.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/transpose.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/typecast.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/unaryops.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_lib/utils.cpython-37m-x86_64-linux-gnu.so -> cudf/_lib
copying build/lib.linux-x86_64-3.7/cudf/_libxx/column.cpython-37m-x86_64-linux-gnu.so -> cudf/_libxx
copying build/lib.linux-x86_64-3.7/cudf/_libxx/copying.cpython-37m-x86_64-linux-gnu.so -> cudf/_libxx
copying build/lib.linux-x86_64-3.7/cudf/_libxx/null_mask.cpython-37m-x86_64-linux-gnu.so -> cudf/_libxx
copying build/lib.linux-x86_64-3.7/cudf/_libxx/stream_compaction.cpython-37m-x86_64-linux-gnu.so -> cudf/_libxx
copying build/lib.linux-x86_64-3.7/cudf/_libxx/table.cpython-37m-x86_64-linux-gnu.so -> cudf/_libxx
</pre></details>
