### PR TITLE
[REVIEW] Update Google Test Execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - PR #4149 Use "type-serialized" for pickled types like Dask
 - PR #4163 Assert Dask CUDA serializers have `Buffer` frames
 - PR #4177 Use `uint8` type for host array copy of `Buffer`
+- PR #4183 Update Google Test Execution
 
 ## Bug Fixes
 

--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ INSTALL_TARGET=install
 BENCHMARKS=OFF
 BUILD_ALL_GPU_ARCH=0
 BUILD_NVTX=ON
-BUILD_TESTS=OFF
+BUILD_TESTS="OFF"
 
 # Set defaults for vars that may not have been defined externally
 #  FIXME: if INSTALL_PREFIX is not set, check PREFIX, then check
@@ -99,7 +99,7 @@ if hasArg --allgpuarch; then
     BUILD_ALL_GPU_ARCH=1
 fi
 if hasArg benchmarks; then
-    BENCHMARKS=ON
+    BENCHMARKS="ON"
 fi
 if hasArg tests; then
     BUILD_TESTS=ON
@@ -154,7 +154,7 @@ if buildAll || hasArg libnvstrings; then
         make -j${PARALLEL_LEVEL} nvstrings VERBOSE=${VERBOSE}
     fi
 
-    if [[ ${BUILD_TEST} == "ON" ]]; then
+    if [[ ${BUILD_TESTS} == "ON" ]]; then
         make -j${PARALLEL_LEVEL} build_tests_nvstrings VERBOSE=${VERBOSE}
     fi
 fi
@@ -181,7 +181,7 @@ if buildAll || hasArg libcudf; then
         make -j${PARALLEL_LEVEL} cudf VERBOSE=${VERBOSE}
     fi
 
-    if [[ ${BUILD_TEST} == "ON" ]]; then
+    if [[ ${BUILD_TESTS} == "ON" ]]; then
         make -j${PARALLEL_LEVEL} build_tests_cudf VERBOSE=${VERBOSE}
     fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,8 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean libnvstrings nvstrings libcudf cudf dask_cudf benchmarks -v -g -n -x --allgpuarch --disable_nvtx -h"
-HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [-v] [-g] [-n] [-h] [-x]
+VALIDARGS="clean libnvstrings nvstrings libcudf cudf dask_cudf benchmarks tests -v -g -n -x --allgpuarch --disable_nvtx -h"
+HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [tests] [-v] [-g] [-n] [-h] [-x]
    clean            - remove all existing build artifacts and configuration (start
                       over)
    libnvstrings     - build the nvstrings C++ code only
@@ -28,6 +28,7 @@ HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [-v] [-g] [-n] [-h] [
    cudf             - build the cudf Python package
    dask_cudf        - build the dask_cudf Python package
    benchmarks       - build benchmarks
+   tests            - build tests
    -v               - verbose build mode
    -g               - build for debug
    -n               - no install step
@@ -51,6 +52,7 @@ INSTALL_TARGET=install
 BENCHMARKS=OFF
 BUILD_ALL_GPU_ARCH=0
 BUILD_NVTX=ON
+BUILD_TESTS=OFF
 
 # Set defaults for vars that may not have been defined externally
 #  FIXME: if INSTALL_PREFIX is not set, check PREFIX, then check
@@ -98,6 +100,9 @@ if hasArg --allgpuarch; then
 fi
 if hasArg benchmarks; then
     BENCHMARKS=ON
+fi
+if hasArg tests; then
+    BUILD_TESTS=ON
 fi
 if hasArg --disable_nvtx; then
     BUILD_NVTX="OFF"
@@ -148,6 +153,10 @@ if buildAll || hasArg libnvstrings; then
     else
         make -j${PARALLEL_LEVEL} nvstrings VERBOSE=${VERBOSE}
     fi
+
+    if [[ ${BUILD_TEST} == "ON" ]]; then
+        make -j${PARALLEL_LEVEL} build_tests_nvstrings VERBOSE=${VERBOSE}
+    fi
 fi
 
 # Build and install the nvstrings Python package
@@ -170,6 +179,10 @@ if buildAll || hasArg libcudf; then
         make -j${PARALLEL_LEVEL} install_cudf VERBOSE=${VERBOSE}
     else
         make -j${PARALLEL_LEVEL} cudf VERBOSE=${VERBOSE}
+    fi
+
+    if [[ ${BUILD_TEST} == "ON" ]]; then
+        make -j${PARALLEL_LEVEL} build_tests_cudf VERBOSE=${VERBOSE}
     fi
 fi
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -99,7 +99,7 @@ else
     logger "GoogleTests..."
     cd $WORKSPACE/cpp/build
 
-    for gt in gtests; do
+    for gt in gtest/*; do
         test_name=$(basename ${gt})
         echo "Running GoogleTest $test_name"
         ${gt} --gtest_output=xml:${WORKSPACE}/test-results/

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -99,7 +99,7 @@ else
     logger "GoogleTests..."
     cd $WORKSPACE/cpp/build
 
-    for gt in gtest/*; do
+    for gt in ${WORKSPACE}/cpp/build/gtests/* ; do
         test_name=$(basename ${gt})
         echo "Running GoogleTest $test_name"
         ${gt} --gtest_output=xml:${WORKSPACE}/test-results/

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -99,7 +99,7 @@ else
     logger "GoogleTests..."
     cd $WORKSPACE/cpp/build
 
-    for gt in gtests/*; do
+    for gt in gtests; do
         test_name=$(basename ${gt})
         echo "Running GoogleTest $test_name"
         ${gt} --gtest_output=xml:${WORKSPACE}/test-results/

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -83,7 +83,7 @@ conda list
 ################################################################################
 
 logger "Build libcudf..."
-$WORKSPACE/build.sh clean libnvstrings nvstrings libcudf cudf dask_cudf benchmarks
+$WORKSPACE/build.sh clean libnvstrings nvstrings libcudf cudf dask_cudf benchmarks tests
 
 ################################################################################
 # TEST - Run GoogleTest and py.tests for libnvstrings, nvstrings, libcudf, and
@@ -96,13 +96,15 @@ else
     logger "Check GPU usage..."
     nvidia-smi
 
-    logger "GoogleTest for libnvstrings..."
+    logger "GoogleTests..."
     cd $WORKSPACE/cpp/build
-    GTEST_OUTPUT="xml:${WORKSPACE}/test-results/" make -j${PARALLEL_LEVEL} test_nvstrings
 
-    logger "GoogleTest for libcudf..."
-    cd $WORKSPACE/cpp/build
-    GTEST_OUTPUT="xml:${WORKSPACE}/test-results/" make -j${PARALLEL_LEVEL} test_cudf
+    for gt in gtests/*; do
+      test_name=$(basename ${gt})
+      echo "Running GoogleTest $test_name"
+      ${gt} --gtest_output=xml:${WORKSPACE}/test-results/
+    done
+
 
     # set environment variable for numpy 1.16
     # will be enabled for later versions by default

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -100,9 +100,9 @@ else
     cd $WORKSPACE/cpp/build
 
     for gt in gtests/*; do
-      test_name=$(basename ${gt})
-      echo "Running GoogleTest $test_name"
-      ${gt} --gtest_output=xml:${WORKSPACE}/test-results/
+        test_name=$(basename ${gt})
+        echo "Running GoogleTest $test_name"
+        ${gt} --gtest_output=xml:${WORKSPACE}/test-results/
     done
 
 
@@ -110,8 +110,8 @@ else
     # will be enabled for later versions by default
     np_ver=$(python -c "import numpy; print('.'.join(numpy.__version__.split('.')[:-1]))")
     if [ "$np_ver" == "1.16" ];then
-      logger "export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1"
-      export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
+        logger "export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1"
+        export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
     fi
 
     cd $WORKSPACE/python/nvstrings


### PR DESCRIPTION
This PR runs Google Test executables directly instead of using `make`. This is to increase the output for developers when running tests.
