### PR TITLE
[WIP] Use rapids-build-env pkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - PR #4165 List serializable classes once
 - PR #4177 Use `uint8` type for host array copy of `Buffer`
 - PR #4182 Rename cuDF serialize functions to be more generic
+- PR #4194 Update GPU build/test script to use new conda meta-pkg for RAPIDS build environment
 
 ## Bug Fixes
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -57,12 +57,7 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
-conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
-              "dask>=2.1.0" "distributed>=2.1.0" "numpy>=1.16" "double-conversion" \
-              "rapidjson" "flatbuffers" "boost-cpp" "fsspec>=0.3.3" "dlpack" \
-              "feather-format" "cupy>=6.6.0,<8.0.0a0,!=7.1.0" "arrow-cpp=0.15.0" "pyarrow=0.15.0" \
-              "fastavro>=0.22.0" "pandas>=0.25,<0.26" "hypothesis" "s3fs" "gcsfs" \
-              "boto3" "moto" "httpretty" "streamz"
+conda install "rmm=$MINOR_VERSION.*" "rapids-build-env=$MINOR_VERSION.*"
 
 # Install the master version of dask, distributed, and streamz
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"


### PR DESCRIPTION
Remove long list of custom conda installs in `gpu/build.sh` to use the new `rapids-build-env` meta-pkg

Going forward updates can be tested in the build script but need to be pushed to the meta-pkg

This will change again with the new build process but this is to fill that gap until then