### PR TITLE
[REVIEW] Fix performance regression in strings::detail::concatenate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@
 - PR #4198 Fix constructing `RangeIndex` from `range`
 - PR #4192 Parquet writer: fix OOB read when computing string hash
 - PR #4199 Fix potential race condition in memcpy_block
+- PR #4215 Fix performance regression in strings::detail::concatenate
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
+#include <bitmask/legacy/valid_if.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/strings/detail/concatenate.hpp>
 #include <cudf/strings/strings_column_view.hpp>
-#include <cudf/strings/detail/utilities.hpp>
 #include <strings/utilities.hpp>
 
 #include <thrust/for_each.h>
-#include <thrust/transform_scan.h>
+#include <thrust/transform_reduce.h>
 
 namespace cudf
 {
@@ -30,124 +30,85 @@ namespace strings
 {
 namespace detail
 {
-namespace
-{
-
-// these hold offsets for offsets column and offsets for chars column
-using offset_pair = thrust::pair<size_t,size_t>;
-
-/**
- * @brief Concatenates multiple strings columns into a single column.
- *
- * The child columns are copied here for each strings column.
- * This will honor the strings column `offset` and `size` members appropriately.
- * The `d_columns_offsets` must be provided and include the output offsets
- * for each of the child columns. The `.first` member is the offset for the
- * output offsets column and the `.second` member is the offset for the
- * output chars column.
- *
- * The values in the child columns are copied directly while the output
- * offsets values must be updated according to where their new strings are placed.
- */
-struct concatenate_fn
-{
-    column_device_view const* d_strings_columns; // strings columns to copy
-    offset_pair const* d_columns_offsets;        // computed offsets for each input child columns
-    int32_t* d_new_offsets;   // offsets for the output offsets column
-    char* d_new_chars;        // chars for the output chars column
-
-    /**
-     * @brief Copy the strings child columns to the output child columns.
-     *
-     * @param idx Index of the strings column to process.
-     */
-    __device__ void operator()(size_type idx)
-    {
-        auto d_view = d_strings_columns[idx];
-        if( d_view.size()==0 )
-            return;
-        auto column_offsets = d_columns_offsets[idx];
-        // copy and adjust the offsets to the output
-        auto d_input_offsets = d_view.child(strings_column_view::offsets_column_index).data<int32_t>() + d_view.offset();
-        auto d_output_offsets = d_new_offsets + column_offsets.first;
-        auto byte_offset = column_offsets.second; // add this to input offsets values
-        auto first_offset = d_input_offsets[0];   // normalize input offsets values
-        thrust::transform( thrust::seq, d_input_offsets + 1, d_input_offsets + d_view.size()+1, d_output_offsets,
-            [first_offset, byte_offset] __device__ (int32_t old_offset) {
-                return old_offset - first_offset + byte_offset;
-            } );
-        // copy the chars to the output
-        auto byte_size = d_input_offsets[d_view.size()] - first_offset; // number of bytes to copy
-        auto d_input_chars = d_view.child(strings_column_view::chars_column_index).data<char>() + first_offset;
-        auto d_output_chars = d_new_chars + byte_offset; // point to the output memory slot
-        thrust::copy( thrust::seq, d_input_chars, d_input_chars + byte_size, d_output_chars );
-    }
-};
-
-}
 
 std::unique_ptr<column> concatenate( std::vector<strings_column_view> const& strings_columns,
                                      rmm::mr::device_memory_resource* mr,
                                      cudaStream_t stream )
 {
+    // calculate the size of the output column
+    size_t strings_count = thrust::transform_reduce( strings_columns.begin(), strings_columns.end(),
+        [] (auto scv) { return scv.size(); }, static_cast<size_t>(0), thrust::plus<size_t>());
+    CUDF_EXPECTS( strings_count < std::numeric_limits<size_type>::max(), 
+        "total number of strings is too large for cudf column" );
+    if( strings_count == 0 )
+        return make_empty_strings_column(mr,stream);
+
     // build vector of column_device_views
-    std::vector<std::unique_ptr<column_device_view,std::function<void(column_device_view*)> > >
+    std::vector<std::unique_ptr<column_device_view,std::function<void(column_device_view*)> > > 
         device_cols(strings_columns.size());
-    size_type null_count = 0;  // add up the null counts too
     thrust::host_vector<column_device_view> h_device_views;
     for( auto&& scv : strings_columns )
     {
         device_cols.emplace_back(column_device_view::create(scv.parent(),stream));
         h_device_views.push_back(*(device_cols.back()));
-        null_count += scv.null_count();
     }
     rmm::device_vector<column_device_view> device_views(h_device_views);
-    auto d_views = device_views.data().get();
     auto execpol = rmm::exec_policy(stream);
-    rmm::device_vector<offset_pair> columns_offsets(strings_columns.size()+1);
-    // compute the offsets for the output columns
-    thrust::transform_inclusive_scan( execpol->on(stream),
-        d_views, d_views + device_views.size(), columns_offsets.data().get()+1,
+    auto d_views = device_views.data().get();
+    // compute size of the output chars column
+    size_t total_bytes = thrust::transform_reduce( execpol->on(stream),
+        d_views, d_views + device_views.size(),
         [] __device__ (auto d_view) {
-            size_t bytes = 0;
-            if( d_view.size()>0 )
-            {
-                auto d_offsets =
-                    d_view.child(strings_column_view::offsets_column_index).template data<int32_t>()
-                    + d_view.offset();
-                bytes = d_offsets[d_view.size()] - d_offsets[0];
-            }
-            return offset_pair{d_view.size(),bytes};
-        },
-        [] __device__ (offset_pair const& lhs, offset_pair const& rhs) {
-            return offset_pair{ lhs.first + rhs.first, lhs.second + rhs.second};
-        });
-    offset_pair last = columns_offsets.back();
-    CUDF_EXPECTS( last.first < std::numeric_limits<size_type>::max(),
-        "total number of strings is too large for a cudf column" );
-    size_type strings_count = static_cast<size_type>(last.first);
-    if( strings_count == 0 )
-        return make_empty_strings_column(mr,stream);
-
-    CUDF_EXPECTS( last.second < std::numeric_limits<size_type>::max(),
-        "total size of strings is too large for a cudf column" );
-    size_type total_bytes = static_cast<size_type>(last.second);
-
-    // set the first set of offsets to 0
-    CUDA_TRY(cudaMemsetAsync( columns_offsets.data().get(), 0, sizeof(offset_pair)));
+            if( d_view.size()==0 )
+                return static_cast<size_t>(0);
+            auto d_offsets = d_view.child(strings_column_view::offsets_column_index).template data<int32_t>();
+            size_t size = d_offsets[d_view.size()+d_view.offset()] - d_offsets[d_view.offset()];
+            return size;
+        }, static_cast<size_t>(0), thrust::plus<size_t>());
+    CUDF_EXPECTS( total_bytes < std::numeric_limits<size_type>::max(), "total size of strings is too large for cudf column" );
 
     // create chars column
-    auto chars_column = create_chars_child_column( strings_count, null_count, total_bytes, mr, stream );
+    auto chars_column = make_numeric_column( data_type{INT8}, total_bytes, mask_state::UNALLOCATED, stream, mr);
     auto d_new_chars = chars_column->mutable_view().data<char>();
+
     // create offsets column
-    auto offsets_column = make_numeric_column( data_type{INT32}, strings_count + 1,
-                                               mask_state::UNALLOCATED, stream, mr);
-    auto d_new_offsets = offsets_column->mutable_view().data<int32_t>();
+    auto offsets_column = make_numeric_column( data_type{INT32}, strings_count + 1, mask_state::UNALLOCATED, stream, mr);
+    auto offsets_view = offsets_column->mutable_view();
+    auto d_new_offsets = offsets_view.data<int32_t>();
 
     // copy over the data for all the columns
-    thrust::for_each_n( execpol->on(stream), thrust::make_counting_iterator<size_type>(0), strings_columns.size(),
-        concatenate_fn{d_views, columns_offsets.data().get(), d_new_offsets+1, d_new_chars} );
-    CUDA_TRY(cudaMemsetAsync(d_new_offsets,0,sizeof(int32_t)));
+    ++d_new_offsets; // skip the first element which will be set to 0 after the for-loop
+    int32_t offset_adjust = 0; // each section of offsets must be adjusted
+    size_type null_count = 0;  // add up the null counts
+    for( auto column = strings_columns.begin(); column != strings_columns.end(); ++column )
+    {
+        size_type column_size = column->size();
+        if( column_size==0 ) // nothing to do
+            continue; // empty column may not have children
+        size_type column_offset = column->offset();
+        column_view offsets_child = column->offsets();
+        column_view chars_child = column->chars();
+
+        // copy the offsets column
+        auto d_offsets = offsets_child.data<int32_t>() + column_offset;
+        int32_t bytes_offset = thrust::device_pointer_cast(d_offsets)[0];
+        
+        thrust::transform( rmm::exec_policy(stream)->on(stream), d_offsets + 1, d_offsets + column_size + 1, d_new_offsets,
+            [offset_adjust, bytes_offset] __device__ (int32_t old_offset) {
+                return old_offset - bytes_offset + offset_adjust;
+            } );
+
+        // copy the chars column data
+        auto d_chars = chars_child.data<char>() + bytes_offset;
+        size_type bytes = thrust::device_pointer_cast(d_offsets)[column_size] - bytes_offset;
+        CUDA_TRY(cudaMemcpyAsync( d_new_chars, d_chars, bytes, cudaMemcpyDeviceToDevice, stream ));
+        // get ready for the next column
+        offset_adjust += bytes;
+        d_new_chars += bytes;
+        d_new_offsets += column_size;
+        null_count += column->null_count();
+    }
+    CUDA_TRY(cudaMemsetAsync( offsets_view.data<int32_t>(), 0, sizeof(int32_t), stream));
 
     // create blank null mask -- caller will be setting this
     rmm::device_buffer null_mask;


### PR DESCRIPTION
Some details in #4202 on the regression.

In the process of fixing the offsets/size calculation errors in `strings::detail::concatenate` the CPU for-loop over the table-view columns was replaced with a `thrust::for_each` to process each column in parallel. Each column thread would copy their section of offsets and chars to the output memory blocks. Using `thrust::transform` and `thrust::copy` and even `memcpy` inside the kernel was much slower than doing cudaMemcpy on each section in the CPU for-loop.
This PR reverts the code to reinstate the original for-loop but also fix the offsets/size calculations.

Closes #4202 