### PR TITLE
[REVIEW] Add numeric/timestamp binop add/subtract overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - PR #4225 Remove stale notebooks
 - PR #4223 Fix a few of the Cython warnings
 - PR #4234 Add BUILD_LEGACY_TESTS cmake option
+- PR #4256 Add numeric/timestamp binop add/subtract overloads
 
 ## Bug Fixes
 

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -256,8 +256,8 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
   CUDF_EXPECTS(is_fixed_width(rhs.type()), "Invalid/Unsupported rhs datatype");
 
   auto new_mask = binops::detail::scalar_col_valid_mask_and(rhs, lhs, stream, mr);
-  auto out = make_numeric_column(output_type, rhs.size(), new_mask,
-                                 cudf::UNKNOWN_NULL_COUNT, stream, mr);
+  auto out = make_fixed_width_column(output_type, rhs.size(), new_mask,
+                                     cudf::UNKNOWN_NULL_COUNT, stream, mr);
 
   if (rhs.size() == 0) {
     return out;
@@ -288,8 +288,8 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
   CUDF_EXPECTS(is_fixed_width(rhs.type()), "Invalid/Unsupported rhs datatype");
 
   auto new_mask = binops::detail::scalar_col_valid_mask_and(lhs, rhs, stream, mr);
-  auto out = make_numeric_column(output_type, lhs.size(), new_mask,
-                                 cudf::UNKNOWN_NULL_COUNT, stream, mr);
+  auto out = make_fixed_width_column(output_type, lhs.size(), new_mask,
+                                     cudf::UNKNOWN_NULL_COUNT, stream, mr);
 
   if (lhs.size() == 0) {
     return out;

--- a/cpp/src/binaryop/jit/code/operation.cpp
+++ b/cpp/src/binaryop/jit/code/operation.cpp
@@ -30,25 +30,106 @@ R"***(
     using namespace simt::std;
 
     struct Add {
-        template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_numeric_v<TypeLhs> and is_numeric_v<TypeRhs>)>* = nullptr>
         static TypeOut operate(TypeLhs x, TypeRhs y) {
-            return (static_cast<TypeOut>(x) + static_cast<TypeOut>(y));
+            return static_cast<TypeOut>(x + y);
+        }
+
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_timestamp_v<TypeLhs> and is_numeric_v<TypeRhs>)>* = nullptr>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return static_cast<TypeOut>(x.time_since_epoch().count() + y);
+        }
+
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_numeric_v<TypeLhs> and is_timestamp_v<TypeRhs>)>* = nullptr>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return static_cast<TypeOut>(x + y.time_since_epoch().count());
+        }
+
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_timestamp_v<TypeLhs> and is_timestamp_v<TypeRhs>)>* = nullptr>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return static_cast<TypeOut>(x.time_since_epoch().count() + y.time_since_epoch().count());
         }
     };
 
     using RAdd = Add;
 
     struct Sub {
-        template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_numeric_v<TypeLhs> and is_numeric_v<TypeRhs>)>* = nullptr>
         static TypeOut operate(TypeLhs x, TypeRhs y) {
-            return (static_cast<TypeOut>(x) - static_cast<TypeOut>(y));
+            return static_cast<TypeOut>(x - y);
+        }
+
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_timestamp_v<TypeLhs> and is_numeric_v<TypeRhs>)>* = nullptr>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return static_cast<TypeOut>(x.time_since_epoch().count() - y);
+        }
+
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_numeric_v<TypeLhs> and is_timestamp_v<TypeRhs>)>* = nullptr>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return static_cast<TypeOut>(x - y.time_since_epoch().count());
+        }
+
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_timestamp_v<TypeLhs> and is_timestamp_v<TypeRhs>)>* = nullptr>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return static_cast<TypeOut>(x.time_since_epoch().count() - y.time_since_epoch().count());
         }
     };
 
     struct RSub {
-        template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_numeric_v<TypeLhs> and is_numeric_v<TypeRhs>)>* = nullptr>
         static TypeOut operate(TypeLhs x, TypeRhs y) {
-            return (static_cast<TypeOut>(y) - static_cast<TypeOut>(x));
+            return static_cast<TypeOut>(y - x);
+        }
+
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_timestamp_v<TypeLhs> and is_numeric_v<TypeRhs>)>* = nullptr>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return static_cast<TypeOut>(y - x.time_since_epoch().count());
+        }
+
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_numeric_v<TypeLhs> and is_timestamp_v<TypeRhs>)>* = nullptr>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return static_cast<TypeOut>(y.time_since_epoch().count() - x);
+        }
+
+        template <typename TypeOut,
+                  typename TypeLhs,
+                  typename TypeRhs,
+                  enable_if_t<(is_timestamp_v<TypeLhs> and is_timestamp_v<TypeRhs>)>* = nullptr>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return static_cast<TypeOut>(y.time_since_epoch().count() - x.time_since_epoch().count());
         }
     };
 

--- a/cpp/src/binaryop/jit/code/traits.cpp
+++ b/cpp/src/binaryop/jit/code/traits.cpp
@@ -38,6 +38,17 @@ R"***(
     template <typename T>
     constexpr bool is_floating_point_v = simt::std::is_floating_point<T>::value;
 
+    // Simplifying is_integral_v or is_floating_point_v
+    template <typename T>
+    constexpr bool is_numeric_v = (is_integral_v<T> or is_floating_point_v<T>);
+
+    template <typename T>
+    constexpr bool is_timestamp_v = (simt::std::is_same<cudf::timestamp_D, T>::value  or
+                                     simt::std::is_same<cudf::timestamp_s, T>::value  or
+                                     simt::std::is_same<cudf::timestamp_ms, T>::value or
+                                     simt::std::is_same<cudf::timestamp_us, T>::value or
+                                     simt::std::is_same<cudf::timestamp_ns, T>::value );
+
     // -------------------------------------------------------------------------
     // type_traits cannot tell the difference between float and double
     template <typename Type>

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -319,6 +319,105 @@ TEST_F(BinaryOperationIntegrationTest, Logical_Or_Vector_Vector_B8_SI16_SI64) {
   ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, OR());
 }
 
+TEST_F(BinaryOperationIntegrationTest, Sub_Scalar_Vector_SI32_SI32_TSD) {
+  using TypeOut = int32_t;
+  using TypeLhs = int32_t;
+  using TypeRhs = cudf::timestamp_D;
+
+  using SUB = cudf::library::operation::Sub<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_scalar<TypeLhs>();
+  auto rhs = make_random_wrapped_column<TypeRhs>(10000);
+
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SUB,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SUB());
+}
+
+TEST_F(BinaryOperationIntegrationTest, Sub_Scalar_Vector_TSD_SI32_TSD) {
+  using TypeOut = cudf::timestamp_D;
+  using TypeLhs = int32_t;
+  using TypeRhs = cudf::timestamp_D;
+
+  using SUB = cudf::library::operation::Sub<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_scalar<TypeLhs>();
+  auto rhs = make_random_wrapped_column<TypeRhs>(10000);
+
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SUB,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SUB());
+}
+
+TEST_F(BinaryOperationIntegrationTest, Sub_Vector_Vector_TSD_SI32_TSD) {
+  using TypeOut = cudf::timestamp_D;
+  using TypeLhs = int32_t;
+  using TypeRhs = cudf::timestamp_D;
+
+  using SUB = cudf::library::operation::Sub<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(10000);
+  auto rhs = make_random_wrapped_column<TypeRhs>(10000);
+
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SUB,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SUB());
+}
+
+TEST_F(BinaryOperationIntegrationTest, Add_Vector_Scalar_SI32_TSD_SI32) {
+  using TypeOut = int32_t;
+  using TypeLhs = cudf::timestamp_D;
+  using TypeRhs = int32_t;
+
+  using ADD = cudf::library::operation::Add<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  auto rhs = make_random_wrapped_scalar<TypeRhs>();
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::ADD,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, ADD());
+}
+
+TEST_F(BinaryOperationIntegrationTest, Add_Vector_Scalar_TSD_TSD_SI32) {
+  using TypeOut = cudf::timestamp_D;
+  using TypeLhs = cudf::timestamp_D;
+  using TypeRhs = int32_t;
+
+  using ADD = cudf::library::operation::Add<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  auto rhs = make_random_wrapped_scalar<TypeRhs>();
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::ADD,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, ADD());
+}
+
+TEST_F(BinaryOperationIntegrationTest, Add_Vector_Vector_TSD_TSD_SI32) {
+  using TypeOut = cudf::timestamp_D;
+  using TypeLhs = cudf::timestamp_D;
+  using TypeRhs = int32_t;
+
+  using ADD = cudf::library::operation::Add<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  auto rhs = make_random_wrapped_column<TypeRhs>(100);
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::ADD,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, ADD());
+}
+
 TEST_F(BinaryOperationIntegrationTest, Less_Scalar_Vector_B8_TSS_TSS) {
   using TypeOut = cudf::experimental::bool8;
   using TypeLhs = cudf::timestamp_s;

--- a/cpp/tests/binaryop/util/operation.h
+++ b/cpp/tests/binaryop/util/operation.h
@@ -23,23 +23,83 @@
 #include <type_traits>
 #include <cstdint>
 
+#include <cudf/utilities/traits.hpp>
+
 namespace cudf {
 namespace library {
 namespace operation {
 
     template <typename TypeOut, typename TypeLhs, typename TypeRhs>
     struct Add {
+        template <typename O = TypeOut,
+                  typename L = TypeLhs,
+                  typename R = TypeRhs,
+                  typename std::enable_if_t<cudf::is_numeric<L>() and
+                                            cudf::is_numeric<R>()>* = nullptr>
         TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
-            using TypeCommon = typename std::common_type<TypeLhs, TypeRhs>::type;
-            return (TypeOut)((TypeCommon)lhs + (TypeCommon)rhs);
+            return static_cast<TypeOut>(lhs + rhs);
+        }
+        template <typename O = TypeOut,
+                  typename L = TypeLhs,
+                  typename R = TypeRhs,
+                  typename std::enable_if_t<cudf::is_timestamp<L>() and
+                                            cudf::is_numeric<R>()>* = nullptr>
+        TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
+            return static_cast<TypeOut>(lhs.time_since_epoch().count() + rhs);
+        }
+        template <typename O = TypeOut,
+                  typename L = TypeLhs,
+                  typename R = TypeRhs,
+                  typename std::enable_if_t<cudf::is_numeric<L>() and
+                                            cudf::is_timestamp<R>()>* = nullptr>
+        TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
+            return static_cast<TypeOut>(lhs + rhs.time_since_epoch().count());
+        }
+        template <typename O = TypeOut,
+                  typename L = TypeLhs,
+                  typename R = TypeRhs,
+                  typename std::enable_if_t<cudf::is_timestamp<L>() and
+                                            cudf::is_timestamp<R>()>* = nullptr>
+        TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
+            return static_cast<TypeOut>(lhs.time_since_epoch().count() +
+                                        rhs.time_since_epoch().count());
         }
     };
 
     template <typename TypeOut, typename TypeLhs, typename TypeRhs>
     struct Sub {
+        template <typename O = TypeOut,
+                  typename L = TypeLhs,
+                  typename R = TypeRhs,
+                  typename std::enable_if_t<cudf::is_numeric<L>() and
+                                            cudf::is_numeric<R>()>* = nullptr>
         TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
-            using TypeCommon = typename std::common_type<TypeLhs, TypeRhs>::type;
-            return (TypeOut)((TypeCommon)lhs - (TypeCommon)rhs);
+            return static_cast<TypeOut>(lhs - rhs);
+        }
+        template <typename O = TypeOut,
+                  typename L = TypeLhs,
+                  typename R = TypeRhs,
+                  typename std::enable_if_t<cudf::is_timestamp<L>() and
+                                            cudf::is_numeric<R>()>* = nullptr>
+        TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
+            return static_cast<TypeOut>(lhs.time_since_epoch().count() - rhs);
+        }
+        template <typename O = TypeOut,
+                  typename L = TypeLhs,
+                  typename R = TypeRhs,
+                  typename std::enable_if_t<cudf::is_numeric<L>() and
+                                            cudf::is_timestamp<R>()>* = nullptr>
+        TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
+            return static_cast<TypeOut>(lhs - rhs.time_since_epoch().count());
+        }
+        template <typename O = TypeOut,
+                  typename L = TypeLhs,
+                  typename R = TypeRhs,
+                  typename std::enable_if_t<cudf::is_timestamp<L>() and
+                                            cudf::is_timestamp<R>()>* = nullptr>
+        TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
+            return static_cast<TypeOut>(lhs.time_since_epoch().count() -
+                                        rhs.time_since_epoch().count());
         }
     };
 


### PR DESCRIPTION
Add numeric and timestamp binop add/subtract overloads.

This change allows adding and subtracting numeric and timestamp scalars/columns, where the numeric side is implicitly assumed to be a `std::chrono::duration`.

Closes #4180, #4181
