### PR TITLE
[REVIEW] Fix losing index name in dask-cudf `reset_index`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@
 - PR #4232 Fix handling empty tuples of children in string columns
 - PR #4222 Fix no-return compile error in binop-null-test
 - PR #4245 Fix race condition in parquet reader
-- PR #XXXX Fix dask-cudf losing index name in `reset_index`
+- PR #4258 Fix dask-cudf losing index name in `reset_index`
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@
 - PR #4232 Fix handling empty tuples of children in string columns
 - PR #4222 Fix no-return compile error in binop-null-test
 - PR #4245 Fix race condition in parquet reader
+- PR #XXXX Fix dask-cudf losing index name in `reset_index`
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4431,9 +4431,10 @@ def test_dataframe_from_table_empty_index():
     result = DataFrame._from_table(tbl)  # noqa: F841
 
 
-def test_dataframe_from_dictionary_series_same_name_index():
-    pd_idx1 = pd.Index([1, 2, 0], name="test_index")
-    pd_idx2 = pd.Index([2, 0, 1], name="test_index")
+@pytest.mark.parametrize("dtype", ["int64", "str"])
+def test_dataframe_from_dictionary_series_same_name_index(dtype):
+    pd_idx1 = pd.Index([1, 2, 0], name="test_index").astype(dtype)
+    pd_idx2 = pd.Index([2, 0, 1], name="test_index").astype(dtype)
     pd_series1 = pd.Series([1, 2, 3], index=pd_idx1)
     pd_series2 = pd.Series([1, 2, 3], index=pd_idx2)
 
@@ -4444,6 +4445,10 @@ def test_dataframe_from_dictionary_series_same_name_index():
 
     expect = pd.DataFrame({"a": pd_series1, "b": pd_series2})
     got = gd.DataFrame({"a": gd_series1, "b": gd_series2})
+
+    if dtype == "str":
+        # Pandas actually loses its index name erroneously here...
+        expect.index.name = "test_index"
 
     assert_eq(expect, got)
     assert expect.index.names == got.index.names

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -179,29 +179,6 @@ class DataFrame(_Frame, dd.core.DataFrame):
             )
         return super().set_index(other, shuffle="tasks", **kwargs)
 
-    def reset_index(self, force=False, drop=False):
-        """Reset index to range based
-        """
-        if force:
-            dfs = self.to_delayed()
-            sizes = np.asarray(compute(*map(delayed(len), dfs)))
-            prefixes = np.zeros_like(sizes)
-            prefixes[1:] = np.cumsum(sizes[:-1])
-
-            @delayed
-            def fix_index(df, startpos):
-                stoppos = startpos + len(df)
-                return df.set_index(
-                    cudf.core.index.RangeIndex(start=startpos, stop=stoppos)
-                )
-
-            outdfs = [
-                fix_index(df, startpos) for df, startpos in zip(dfs, prefixes)
-            ]
-            return from_delayed(outdfs, meta=self._meta.reset_index(drop=True))
-        else:
-            return self.map_partitions(M.reset_index, drop=drop)
-
     def sort_values(self, by, ignore_index=False):
         """Sort by the given column
 


### PR DESCRIPTION
Fixes #4252 

We can just use mainline Dask code here now 😄

Also added a unit test for String index name alignment as I initially thought it could be that, but I was mistaken.