### PR TITLE
[REVIEW] Update _is_local_filesystem logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@
 - PR #4285 Add init files for cython pkgs and fix `setup.py`
 - PR #4287 Parquet reader: fix empty string potentially read as null
 - PR #4297 Fix specification of package_data in setup.py
+- PR #4302 Fix `_is_local_filesystem` check
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -6,6 +6,7 @@ import warnings
 from io import BytesIO, TextIOWrapper
 
 import fsspec
+import fsspec.implementations.local
 
 from cudf.utils.docutils import docfmt_partial
 
@@ -873,11 +874,9 @@ def is_file_like(obj):
 
 
 def _is_local_filesystem(fs):
-    local_filesystem_protocols = ["file"]
 
-    if hasattr(fs, "protocol"):
-        if fs.protocol in local_filesystem_protocols:
-            return True
+    if isinstance(fs, fsspec.implementations.local.LocalFileSystem):
+        return True
     else:
         return False
 

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -874,11 +874,7 @@ def is_file_like(obj):
 
 
 def _is_local_filesystem(fs):
-
-    if isinstance(fs, fsspec.implementations.local.LocalFileSystem):
-        return True
-    else:
-        return False
+    return isinstance(fs, fsspec.implementations.local.LocalFileSystem)
 
 
 def get_filepath_or_buffer(


### PR DESCRIPTION
This Pr updates the logic used to check if the filesystem being used while reading is local or not.

1. Previous implementation checked if the `protocol` was `file` based on the information here: https://github.com/intake/filesystem_spec/blob/master/fsspec/registry.py

2. When using cudf or dask (not distributed) this is not an issue since all fs objects being checked have `protocol="file"`.

3. In dask distributed setting, the fs being passed down is of the type `fsspec.implementations.local.LocalFileSystem` but has `protocol="abstract"` which is the default protocol of it's parent class. (Not sure why the protocol name is lost in the distributed setting).

Due to the points mentioned above the `local_filesystem` check was failing in a distributed setting and cudf was going via the `BytesIO` route (which is slower).


cc: @vuule Thanks for pointing out that read_parquet was going via `BytesIO`!


<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
