### PR TITLE
[REVIEW] Add ShiftLeft (<<), ShiftRight (>>) and ShiftRightUnsigned (>>>) binops.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PR #4276 Port avro.pyx to libcudf++
 - PR #4259 Ability to create Java host buffers from memory-mapped files
 - PR #4240 Add groupby::groups()
+- PR #4315 ShiftLeft, ShiftRight, ShiftRightUnsigned binops
 
 ## Improvements
 

--- a/cpp/include/cudf/binaryop.hpp
+++ b/cpp/include/cudf/binaryop.hpp
@@ -28,31 +28,35 @@ namespace experimental {
  * @brief Types of binary operations that can be performed on data.
  */
 enum class binary_operator {
-  ADD,             ///< operator +
-  SUB,             ///< operator -
-  MUL,             ///< operator *
-  DIV,             ///< operator / using common type of lhs and rhs
-  TRUE_DIV,        ///< operator / after promoting type to floating point
-  FLOOR_DIV,       ///< operator / after promoting to 64 bit floating point and then
-                   ///< flooring the result
-  MOD,             ///< operator %
-  PYMOD,           ///< operator % but following python's sign rules for negatives
-  POW,             ///< lhs ^ rhs
-  EQUAL,           ///< operator ==
-  NOT_EQUAL,       ///< operator !=
-  LESS,            ///< operator <
-  GREATER,         ///< operator >
-  LESS_EQUAL,      ///< operator <=
-  GREATER_EQUAL,   ///< operator >=
-  BITWISE_AND,     ///< operator &
-  BITWISE_OR,      ///< operator |
-  BITWISE_XOR,     ///< operator ^
-  LOGICAL_AND,     ///< operator &&
-  LOGICAL_OR,      ///< operator ||
-  COALESCE,        ///< operator x,y  x is null ? y : x
-  GENERIC_BINARY,  ///< generic binary operator to be generated with input
-                   ///< ptx code
-  INVALID_BINARY   ///< invalid operation
+  ADD,                    ///< operator +
+  SUB,                    ///< operator -
+  MUL,                    ///< operator *
+  DIV,                    ///< operator / using common type of lhs and rhs
+  TRUE_DIV,               ///< operator / after promoting type to floating point
+  FLOOR_DIV,              ///< operator / after promoting to 64 bit floating point and then
+                          ///< flooring the result
+  MOD,                    ///< operator %
+  PYMOD,                  ///< operator % but following python's sign rules for negatives
+  POW,                    ///< lhs ^ rhs
+  EQUAL,                  ///< operator ==
+  NOT_EQUAL,              ///< operator !=
+  LESS,                   ///< operator <
+  GREATER,                ///< operator >
+  LESS_EQUAL,             ///< operator <=
+  GREATER_EQUAL,          ///< operator >=
+  BITWISE_AND,            ///< operator &
+  BITWISE_OR,             ///< operator |
+  BITWISE_XOR,            ///< operator ^
+  LOGICAL_AND,            ///< operator &&
+  LOGICAL_OR,             ///< operator ||
+  COALESCE,               ///< operator x,y  x is null ? y : x
+  GENERIC_BINARY,         ///< generic binary operator to be generated with input
+                          ///< ptx code
+  SHIFT_LEFT,             ///< operator <<
+  SHIFT_RIGHT,            ///< operator >>
+  SHIFT_RIGHT_UNSIGNED,   ///< operator >>> (from Java)
+  
+  INVALID_BINARY          ///< invalid operation
 };
 
 /**

--- a/cpp/include/cudf/binaryop.hpp
+++ b/cpp/include/cudf/binaryop.hpp
@@ -54,7 +54,10 @@ enum class binary_operator {
                           ///< ptx code
   SHIFT_LEFT,             ///< operator <<
   SHIFT_RIGHT,            ///< operator >>
-  SHIFT_RIGHT_UNSIGNED,   ///< operator >>> (from Java)
+
+  // Logical right shift. Casts to an unsigned value before shifing.
+  // approximates >>> from Java.
+  SHIFT_RIGHT_UNSIGNED,   ///< operator >>> 
   
   INVALID_BINARY          ///< invalid operation
 };

--- a/cpp/src/binaryop/jit/code/operation.cpp
+++ b/cpp/src/binaryop/jit/code/operation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Copyright 2018-2019 BlazingDB, Inc.
  *     Copyright 2018 Christian Noboa Mardini <christian@blazingdb.com>
@@ -25,7 +25,7 @@ namespace code {
 
 const char* operation =
 R"***(
-#pragma once
+    #pragma once
     #include "traits.h"
     using namespace simt::std;
 
@@ -335,8 +335,49 @@ R"***(
             GENERIC_BINARY_OP(&output, x, y);
             return output;
         }
+    };    
+    
+    struct ShiftLeft {
+        template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return (x << y);
+        }
     };
 
+    struct RShiftLeft {
+        template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return (y << x);
+        }
+    };
+
+    struct ShiftRight {
+        template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return (x >> y);
+        }
+    };    
+
+    struct RShiftRight {
+        template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return (y >> x);
+        }
+    };
+
+    struct ShiftRightUnsigned {
+        template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return (static_cast<make_unsigned_t<TypeLhs>>(x) >> y);            
+        }
+    };    
+
+    struct RShiftRightUnsigned {
+        template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+        static TypeOut operate(TypeLhs x, TypeRhs y) {
+            return (static_cast<make_unsigned_t<TypeLhs>>(y) >> x);            
+        }
+    };    
 )***";
 
 } // namespace code

--- a/cpp/src/binaryop/jit/util.hpp
+++ b/cpp/src/binaryop/jit/util.hpp
@@ -83,6 +83,12 @@ namespace jit {
         operator_name = "LogicalOr"; break;
       case binary_operator::GENERIC_BINARY:
         operator_name = "UserDefinedOp"; break;
+      case binary_operator::SHIFT_LEFT:
+        operator_name = "ShiftLeft"; break;
+      case binary_operator::SHIFT_RIGHT:
+        operator_name = "ShiftRight"; break;        
+      case binary_operator::SHIFT_RIGHT_UNSIGNED:
+        operator_name = "ShiftRightUnsigned"; break;
       default:
         operator_name = "None"; break;
     }

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -500,6 +500,217 @@ TEST_F(BinaryOperationIntegrationTest, GreaterEqual_Vector_Vector_B8_STR_STR) {
   ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, GREATER_EQUAL());
 }
 
+TEST_F(BinaryOperationIntegrationTest, ShiftLeft_Vector_Vector_SI32) {
+  using TypeOut = int;
+  using TypeLhs = int;
+  using TypeRhs = int;
+
+  using SHIFT_LEFT = cudf::library::operation::ShiftLeft<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_column<TypeRhs>(100);
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_LEFT,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_LEFT());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftLeft_Vector_Vector_SI32_SI16_SI64) {
+  using TypeOut = int;
+  using TypeLhs = int16_t;
+  using TypeRhs = int64_t;
+
+  using SHIFT_LEFT = cudf::library::operation::ShiftLeft<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_column<TypeRhs>(100);
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_LEFT,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_LEFT());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftLeft_Scalar_Vector_SI32) {
+  using TypeOut = int;
+  using TypeLhs = int;
+  using TypeRhs = int;
+
+  using SHIFT_LEFT = cudf::library::operation::ShiftLeft<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_scalar<TypeLhs>();
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_column<TypeRhs>(100);
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_LEFT,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_LEFT());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftLeft_Vector_Scalar_SI32) {
+  using TypeOut = int;
+  using TypeLhs = int;
+  using TypeRhs = int;
+
+  using SHIFT_LEFT = cudf::library::operation::ShiftLeft<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_scalar<TypeRhs>();
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_LEFT,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_LEFT());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftRight_Vector_Vector_SI32) {
+  using TypeOut = int;
+  using TypeLhs = int;
+  using TypeRhs = int;
+
+  using SHIFT_RIGHT = cudf::library::operation::ShiftRight<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_column<TypeRhs>(100);
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_RIGHT,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_RIGHT());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftRight_Vector_Vector_SI32_SI16_SI64) {
+  using TypeOut = int;
+  using TypeLhs = int16_t;
+  using TypeRhs = int64_t;
+
+  using SHIFT_RIGHT = cudf::library::operation::ShiftRight<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_column<TypeRhs>(100);
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_RIGHT,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_RIGHT());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftRight_Scalar_Vector_SI32) {
+  using TypeOut = int;
+  using TypeLhs = int;
+  using TypeRhs = int;
+
+  using SHIFT_RIGHT = cudf::library::operation::ShiftRight<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_scalar<TypeLhs>();
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_column<TypeRhs>(100);
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_RIGHT,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_RIGHT());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftRight_Vector_Scalar_SI32) {
+  using TypeOut = int;
+  using TypeLhs = int;
+  using TypeRhs = int;
+
+  using SHIFT_RIGHT = cudf::library::operation::ShiftRight<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_scalar<TypeRhs>();
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_RIGHT,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_RIGHT());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftRightUnsigned_Vector_Vector_SI32) {
+  using TypeOut = int;
+  using TypeLhs = int;
+  using TypeRhs = int;
+
+  using SHIFT_RIGHT_UNSIGNED = cudf::library::operation::ShiftRightUnsigned<TypeOut, TypeLhs, TypeRhs>;
+
+  int num_els = 4;
+
+  TypeLhs lhs[]   = { -8, 78, -93, 0, -INT_MAX };  
+  cudf::test::fixed_width_column_wrapper<TypeLhs> lhs_w(lhs, lhs + num_els);
+
+  TypeRhs shift[]   = { 1, 1, 3, 2, 16 };  
+  cudf::test::fixed_width_column_wrapper<TypeRhs> shift_w(shift, shift + num_els);
+  
+  TypeOut expected[]   = { 2147483644, 39, 536870900, 0, 32768 };  
+  cudf::test::fixed_width_column_wrapper<TypeOut> expected_w(expected, expected + num_els);
+  
+  auto out = cudf::experimental::binary_operation(
+      lhs_w, shift_w, cudf::experimental::binary_operator::SHIFT_RIGHT_UNSIGNED,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  cudf::test::expect_columns_equal(*out, expected_w);
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftRightUnsigned_Vector_Vector_SI32_SI16_SI64) {
+  using TypeOut = int;
+  using TypeLhs = int16_t;
+  using TypeRhs = int64_t;
+
+  using SHIFT_RIGHT_UNSIGNED = cudf::library::operation::ShiftRightUnsigned<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_column<TypeRhs>(100);
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_RIGHT_UNSIGNED,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_RIGHT_UNSIGNED());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftRightUnsigned_Scalar_Vector_SI32) {
+  using TypeOut = int;
+  using TypeLhs = int;
+  using TypeRhs = int;
+
+  using SHIFT_RIGHT_UNSIGNED = cudf::library::operation::ShiftRightUnsigned<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_scalar<TypeLhs>();
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_column<TypeRhs>(100);
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_RIGHT_UNSIGNED,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_RIGHT_UNSIGNED());
+}
+
+TEST_F(BinaryOperationIntegrationTest, ShiftRightUnsigned_Vector_Scalar_SI32) {
+  using TypeOut = int;
+  using TypeLhs = int;
+  using TypeRhs = int;
+
+  using SHIFT_RIGHT_UNSIGNED = cudf::library::operation::ShiftRightUnsigned<TypeOut, TypeLhs, TypeRhs>;
+
+  auto lhs = make_random_wrapped_column<TypeLhs>(100);
+  // this generates values in the range 1-10 which should be reasonable for the shift
+  auto rhs = make_random_wrapped_scalar<TypeRhs>();
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::SHIFT_RIGHT_UNSIGNED,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, SHIFT_RIGHT_UNSIGNED());
+}
 
 }  // namespace binop
 }  // namespace test

--- a/cpp/tests/binaryop/util/operation.h
+++ b/cpp/tests/binaryop/util/operation.h
@@ -177,6 +177,27 @@ namespace operation {
         }
     };
 
+    template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+    struct ShiftLeft {
+        TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
+            return TypeOut(lhs << rhs);
+        }
+    };
+
+    template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+    struct ShiftRight {
+        TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
+            return TypeOut(lhs >> rhs);
+        }
+    };
+
+    template <typename TypeOut, typename TypeLhs, typename TypeRhs>
+    struct ShiftRightUnsigned {
+        TypeOut operator()(TypeLhs lhs, TypeRhs rhs) {
+            return TypeOut(static_cast<std::make_unsigned_t<TypeLhs>>(lhs) >> rhs);
+        }
+    };
+
 }  // namespace operation
 }  // namespace library
 }  // namespace cudf


### PR DESCRIPTION

Closes  https://github.com/rapidsai/cudf/issues/3791

Note : ShiftRightUnsigned is the closest C++ equivalent to Java's  >>>