### PR TITLE
Add memory threshold callbacks for Java RMM event handler [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@
 - PR #4305 Move gpuarrow.pyx and related libarrow_cuda files into `_libxx`
 - PR #4244 Port nvstrings Substring Gather/Scatter functions to cuDF Python/Cython
 - PR #4280 Port nvstrings Numeric Handling functions to cuDF Python/Cython
+- PR #4328 Add memory threshold callbacks for Java RMM event handler 
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/RmmEventHandler.java
+++ b/java/src/main/java/ai/rapids/cudf/RmmEventHandler.java
@@ -25,4 +25,38 @@ public interface RmmEventHandler {
    * @return true if the memory allocation should be retried or false if it should fail
    */
   boolean onAllocFailure(long sizeRequested);
+
+  /**
+   * Get the memory thresholds that will trigger {@link #onAllocThreshold(long)}
+   * to be called when one or more of the thresholds is crossed during a memory allocation.
+   * A threshold is crossed when the total memory allocated before the RMM allocate operation
+   * is less than a threshold value and the threshold value is less than or equal to the
+   * total memory allocated after the RMM memory allocate operation.
+   * @return allocate memory thresholds or null for no thresholds.
+   */
+  long[] getAllocThresholds();
+
+  /**
+   * Get the memory thresholds that will trigger {@link #onDeallocThreshold(long)}
+   * to be called when one or more of the thresholds is crossed during a memory deallocation.
+   * A threshold is crossed when the total memory allocated before the RMM deallocate operation
+   * is greater than or equal to a threshold value and the threshold value is greater than the
+   * total memory allocated after the RMM memory deallocate operation.
+   * @return deallocate memory thresholds or null for no thresholds.
+   */
+  long[] getDeallocThresholds();
+
+  /**
+   * Invoked after an RMM memory allocate operation when an allocate threshold is crossed.
+   * See {@link #getAllocThresholds()} for details on allocate threshold crossing.
+   * @param totalAllocSize total amount of memory allocated after the crossing
+   */
+  void onAllocThreshold(long totalAllocSize);
+
+  /**
+   * Invoked after an RMM memory deallocation operation when a deallocate threshold is crossed.
+   * See {@link #getDeallocThresholds()} for details on deallocate threshold crossing.
+   * @param totalAllocSize total amount of memory allocated after the crossing
+   */
+  void onDeallocThreshold(long totalAllocSize);
 }

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -790,9 +790,11 @@ JNIEnv* get_jni_env(JavaVM* jvm);
       if (RMM_ERROR_CUDA_ERROR == internal_rmmStatus) {                                            \
         cuda_e = cudf::jni::cuda_exception(env, cudaGetLastError());                               \
       }                                                                                            \
-      jthrowable jt = cudf::jni::rmmException(env, internal_rmmStatus, cuda_e);                    \
-      if (jt != NULL) {                                                                            \
-        env->Throw(jt);                                                                            \
+      if (!env->ExceptionCheck()) {                                                                \
+        jthrowable jt = cudf::jni::rmmException(env, internal_rmmStatus, cuda_e);                  \
+        if (jt != NULL) {                                                                          \
+          env->Throw(jt);                                                                          \
+        }                                                                                          \
       }                                                                                            \
       return ret_val;                                                                              \
     }                                                                                              \

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -26,6 +26,8 @@
 namespace cudf {
 namespace jni {
 
+constexpr jint MINIMUM_JNI_VERSION = JNI_VERSION_1_6;
+
 /**
  * @brief indicates that a JNI error of some kind was thrown and the main
  * function should return.

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -28,6 +28,13 @@ namespace jni {
 
 constexpr jint MINIMUM_JNI_VERSION = JNI_VERSION_1_6;
 
+constexpr char const* CUDA_ERROR_CLASS = "ai/rapids/cudf/CudaException";
+constexpr char const* CUDF_ERROR_CLASS = "ai/rapids/cudf/CudfException";
+constexpr char const* INDEX_OOB_CLASS = "java/lang/ArrayIndexOutOfBoundsException";
+constexpr char const* ILLEGAL_ARG_CLASS = "java/lang/IllegalArgumentException";
+constexpr char const* NPE_CLASS = "java/lang/NullPointerException";
+constexpr char const* OOM_CLASS = "java/lang/OutOfMemoryError";
+
 /**
  * @brief indicates that a JNI error of some kind was thrown and the main
  * function should return.
@@ -54,7 +61,7 @@ inline void throw_java_exception(JNIEnv *const env, const char *class_name, cons
  * exception so the flow control stop processing.
  */
 inline void check_java_exception(JNIEnv *const env) {
-  if (env->ExceptionOccurred()) {
+  if (env->ExceptionCheck()) {
     // Not going to try to get the message out of the Exception, too complex and
     // might fail.
     throw jni_exception("JNI Exception...");
@@ -188,20 +195,20 @@ public:
 
   N_TYPE operator[](int index) const {
     if (orig == NULL) {
-      throw_java_exception(env, "java/lang/NullPointerException", "pointer is NULL");
+      throw_java_exception(env, NPE_CLASS, "pointer is NULL");
     }
     if (index < 0 || index >= len) {
-      throw_java_exception(env, "java/lang/ArrayIndexOutOfBoundsException", "NOT IN BOUNDS");
+      throw_java_exception(env, INDEX_OOB_CLASS, "NOT IN BOUNDS");
     }
     return data()[index];
   }
 
   N_TYPE &operator[](int index) {
     if (orig == NULL) {
-      throw_java_exception(env, "java/lang/NullPointerException", "pointer is NULL");
+      throw_java_exception(env, NPE_CLASS, "pointer is NULL");
     }
     if (index < 0 || index >= len) {
-      throw_java_exception(env, "java/lang/ArrayIndexOutOfBoundsException", "NOT IN BOUNDS");
+      throw_java_exception(env, INDEX_OOB_CLASS, "NOT IN BOUNDS");
     }
     return data()[index];
   }
@@ -471,7 +478,7 @@ public:
 
   T get(int index) const {
     if (orig == NULL) {
-      throw_java_exception(env, "java/lang/NullPointerException", "jobjectArray pointer is NULL");
+      throw_java_exception(env, NPE_CLASS, "jobjectArray pointer is NULL");
     }
     T ret = static_cast<T>(env->GetObjectArrayElement(orig, index));
     check_java_exception(env);
@@ -480,7 +487,7 @@ public:
 
   void set(int index, const T &val) {
     if (orig == NULL) {
-      throw_java_exception(env, "java/lang/NullPointerException", "jobjectArray pointer is NULL");
+      throw_java_exception(env, NPE_CLASS, "jobjectArray pointer is NULL");
     }
     env->SetObjectArrayElement(orig, index, val);
     check_java_exception(env);
@@ -562,7 +569,7 @@ public:
 
   native_jstring &get(int index) const {
     if (arr.is_null()) {
-      throw_java_exception(env, "java/lang/NullPointerException", "jstringArray pointer is NULL");
+      throw_java_exception(env, cudf::jni::NPE_CLASS, "jstringArray pointer is NULL");
     }
     init_cache();
     return cache[index];
@@ -600,7 +607,7 @@ public:
  * @brief create a cuda exception from a given cudaError_t
  */
 inline jthrowable cuda_exception(JNIEnv *const env, cudaError_t status, jthrowable cause = NULL) {
-  jclass ex_class = env->FindClass("ai/rapids/cudf/CudaException");
+  jclass ex_class = env->FindClass(cudf::jni::CUDA_ERROR_CLASS);
   if (ex_class == NULL) {
     return NULL;
   }
@@ -752,6 +759,15 @@ JNIEnv* get_jni_env(JavaVM* jvm);
     return ret_val;                                                                                \
   }
 
+// Throw a new exception only if one is not pending then always return with the specified value
+#define JNI_CHECK_THROW_NEW(env, class_name, message, ret_val)                                     \
+  {                                                                                                \
+    if (env->ExceptionOccurred()) {                                                                \
+      return ret_val;                                                                              \
+    }                                                                                              \
+    JNI_THROW_NEW(env, class_name, message, ret_val)                                               \
+  }
+
 #define JNI_CUDA_TRY(env, ret_val, call)                                                           \
   {                                                                                                \
     cudaError_t internal_cuda_status = (call);                                                     \
@@ -785,14 +801,14 @@ JNIEnv* get_jni_env(JavaVM* jvm);
 #define JNI_NULL_CHECK(env, obj, error_msg, ret_val)                                               \
   {                                                                                                \
     if ((obj) == 0) {                                                                              \
-      JNI_THROW_NEW(env, "java/lang/NullPointerException", error_msg, ret_val);                    \
+      JNI_THROW_NEW(env, cudf::jni::NPE_CLASS, error_msg, ret_val);                                \
     }                                                                                              \
   }
 
 #define JNI_ARG_CHECK(env, obj, error_msg, ret_val)                                                \
   {                                                                                                \
     if (!(obj)) {                                                                                  \
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", error_msg, ret_val);                \
+      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, error_msg, ret_val);                        \
     }                                                                                              \
   }
 
@@ -805,16 +821,8 @@ JNIEnv* get_jni_env(JavaVM* jvm);
 
 #define CATCH_STD(env, ret_val)                                                                    \
   catch (const std::bad_alloc &e) {                                                                \
-    JNI_THROW_NEW(env, "java/lang/OutOfMemoryError", "Could not allocate native memory", ret_val); \
-  }                                                                                                \
-  catch (const cudf::jni::jni_exception &e) {                                                      \
-    /* indicates that a java exception happened, just return so java can throw                     \
-     * it. */                                                                                      \
-    return ret_val;                                                                                \
-  }                                                                                                \
-  catch (const cudf::cuda_error &e) {                                                              \
-    JNI_THROW_NEW(env, "ai/rapids/cudf/CudaException", e.what(), ret_val);                         \
+    JNI_CHECK_THROW_NEW(env, cudf::jni::OOM_CLASS, "Could not allocate native memory", ret_val);   \
   }                                                                                                \
   catch (const std::exception &e) {                                                                \
-    JNI_THROW_NEW(env, "ai/rapids/cudf/CudfException", e.what(), ret_val);                         \
+    JNI_CHECK_THROW_NEW(env, cudf::jni::CUDF_ERROR_CLASS, e.what(), ret_val);                      \
   }

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -826,5 +826,6 @@ JNIEnv* get_jni_env(JavaVM* jvm);
     JNI_CHECK_THROW_NEW(env, cudf::jni::OOM_CLASS, "Could not allocate native memory", ret_val);   \
   }                                                                                                \
   catch (const std::exception &e) {                                                                \
+    /* If jni_exception caught then a Java exception is pending and this will not overwrite it. */ \
     JNI_CHECK_THROW_NEW(env, cudf::jni::CUDF_ERROR_CLASS, e.what(), ret_val);                      \
   }

--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -37,8 +37,6 @@ private:
 namespace cudf {
 namespace jni {
 
-static const jint MINIMUM_JNI_VERSION = JNI_VERSION_1_6;
-
 static jclass contiguous_table_jclass;
 static jmethodID from_contiguous_column_views;
 
@@ -121,7 +119,7 @@ JNIEnv* get_jni_env(JavaVM* jvm) {
     attach_args.name = const_cast<char*>("cudf thread");
     attach_args.group = NULL;
 
-    if (jvm->AttachCurrentThreadAsDaemon(reinterpret_cast<void**>(env), &attach_args) == JNI_OK) {
+    if (jvm->AttachCurrentThreadAsDaemon(reinterpret_cast<void**>(&env), &attach_args) == JNI_OK) {
       // use thread_local object to detach the thread from the JVM when thread terminates.
       thread_local jvm_detach_on_destruct detacher(jvm);
     } else {

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -73,7 +73,7 @@ public:
   virtual ~java_event_handler_memory_resource() {
     // This should normally be called by a JVM thread. If the JVM environment is missing then this
     // is likely being triggered by the C++ runtime during shutdown. In that case the JVM may
-    // already be destroyed and should not be called.
+    // already be destroyed and this thread should not try to attach to get an environment.
     JNIEnv* env = nullptr;
     if (jvm->GetEnv(reinterpret_cast<void**>(&env), cudf::jni::MINIMUM_JNI_VERSION) == JNI_OK) {
       env->DeleteGlobalRef(handler_obj);

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#include <atomic>
+#include <limits>
+#include <mutex>
+#include <unordered_map>
 #include <rmm/mr/device/default_memory_resource.hpp>
 
 #include "jni_utils.hpp"
@@ -33,10 +37,13 @@ public:
   java_event_handler_memory_resource(
       JNIEnv* env,
       jobject jhandler,
+      jlongArray jalloc_thresholds,
+      jlongArray jdealloc_thresholds,
       device_memory_resource* resource_to_wrap) : resource(resource_to_wrap) {
     if (env->GetJavaVM(&jvm) < 0) {
-      throw cudf::jni::jni_exception("GetJavaVM failed");
+      throw std::runtime_error("GetJavaVM failed");
     }
+
     jclass cls = env->GetObjectClass(jhandler);
     if (cls == nullptr) {
       throw cudf::jni::jni_exception("class not found");
@@ -45,6 +52,18 @@ public:
     if (on_alloc_fail_method == nullptr) {
       throw cudf::jni::jni_exception("onAllocFailure method");
     }
+    on_alloc_threshold_method = env->GetMethodID(cls, "onAllocThreshold", "(J)V");
+    if (on_alloc_threshold_method == nullptr) {
+      throw cudf::jni::jni_exception("onAllocThreshold method");
+    }
+    on_dealloc_threshold_method = env->GetMethodID(cls, "onDeallocThreshold", "(J)V");
+    if (on_dealloc_threshold_method == nullptr) {
+      throw cudf::jni::jni_exception("onDeallocThreshold method");
+    }
+
+    update_thresholds(env, alloc_thresholds, jalloc_thresholds);
+    update_thresholds(env, dealloc_thresholds, jdealloc_thresholds);
+
     handler_obj = env->NewGlobalRef(jhandler);
     if (handler_obj == nullptr) {
       throw cudf::jni::jni_exception("global ref");
@@ -66,8 +85,42 @@ private:
   JavaVM* jvm;
   jobject handler_obj;
   jmethodID on_alloc_fail_method;
+  jmethodID on_alloc_threshold_method;
+  jmethodID on_dealloc_threshold_method;
 
-  bool on_alloc_fail(std::size_t bytes) {
+  // sorted memory thresholds to trigger callbacks
+  std::vector<std::size_t> alloc_thresholds{};
+  std::vector<std::size_t> dealloc_thresholds{};
+
+  std::size_t total_allocated{0};
+
+  // map nd associated lock to track memory sizes by address
+  // TODO: This should be removed when rmm::alloc and rmm::free are removed and the size parameter
+  //       for do_deallocate can be trusted. If map and mutex are removed then total_allocated
+  //       should be updated to be atomic.
+  std::unordered_map<void*, std::size_t> size_map{};
+  std::mutex size_map_mutex{};
+
+
+  static void update_thresholds(JNIEnv* env, std::vector<std::size_t>& thresholds, jlongArray from_java) {
+    thresholds.clear();
+    if (from_java != nullptr) {
+      cudf::jni::native_jlongArray jvalues(env, from_java);
+      thresholds.insert(thresholds.end(), jvalues.data(), jvalues.data() + jvalues.size());
+    } else {
+      // use a single, maximum-threshold value so we don't have to always check for the corner case.
+      thresholds.push_back(std::numeric_limits<std::size_t>::max());
+    }
+  }
+
+  static void log_callback_exception(JNIEnv* env, char const* callback_name, jthrowable throwable) {
+    std::cerr << callback_name << "  threw a Java exception: ";
+    env->ExceptionDescribe();
+    // describe clears the exception so re-throw it
+    env->Throw(throwable);
+  }
+
+  bool on_alloc_fail(std::size_t num_bytes) {
     cudaError_t err = cudaPeekAtLastError();
     if (err != cudaSuccess) {
       // workaround for RMM pooled mode (CNMEM backend) leaving a CUDA error pending
@@ -82,32 +135,91 @@ private:
     JNIEnv* env = cudf::jni::get_jni_env(jvm);
     jboolean result = env->CallBooleanMethod(handler_obj,
                                              on_alloc_fail_method,
-                                             static_cast<jlong>(bytes));
+                                             static_cast<jlong>(num_bytes));
     auto throwable = env->ExceptionOccurred();
     if (throwable != NULL) {
-      std::cerr << "Allocator callback threw a Java exception: ";
-      env->ExceptionDescribe();
-      // describe clears the exception so re-throw it
-      env->Throw(throwable);
-      throw std::runtime_error("Java RMM event handler threw an exception");
+      log_callback_exception(env, "onAllocFailure", throwable);
+      throw std::runtime_error("onAllocFailure handler threw an exception");
     }
     return result;
   }
 
-  void* do_allocate(std::size_t bytes, cudaStream_t stream) override {
-    while (true) {
-      try {
-        return resource->allocate(bytes, stream);
-      } catch (std::bad_alloc const& e) {
-        if (!on_alloc_fail(bytes)) {
-          throw e;
+  void check_for_threshold_callback(
+      std::size_t low,
+      std::size_t high,
+      std::vector<std::size_t> const& thresholds,
+      jmethodID callback_method,
+      char const* callback_name,
+      std::size_t current_total) {
+    if (high >= thresholds.front() && low < thresholds.back()) {
+      // could use binary search, but assumption is threshold count is very small
+      auto it = std::find_if(thresholds.begin(), thresholds.end(),
+          [=](std::size_t t) -> bool { return low < t && high >= t; });
+      if (it != thresholds.end()) {
+        JNIEnv* env = cudf::jni::get_jni_env(jvm);
+        env->CallVoidMethod(handler_obj, callback_method, current_total);
+        auto throwable = env->ExceptionOccurred();
+        if (throwable != nullptr) {
+          log_callback_exception(env, callback_name, throwable);
+          throw std::runtime_error("onAllocThreshold handler threw an exception");
         }
       }
     }
   }
 
+  void* do_allocate(std::size_t num_bytes, cudaStream_t stream) override {
+    std::size_t total_before;
+    std::size_t total_after;
+    void* result;
+    while (true) {
+      try {
+        std::lock_guard<std::mutex> lock(size_map_mutex);
+        total_before = total_allocated;
+        result = resource->allocate(num_bytes, stream);
+        total_allocated += num_bytes;
+        total_after = total_allocated;
+        size_map[result] = num_bytes;
+        break;
+      } catch (std::bad_alloc const& e) {
+        if (!on_alloc_fail(num_bytes)) {
+          throw e;
+        }
+      }
+    }
+
+    try {
+      check_for_threshold_callback(total_before, total_after, alloc_thresholds,
+          on_alloc_threshold_method, "onAllocThreshold", total_after);
+    } catch (std::exception e) {
+      // Free the allocation as app will think the exception means the memory was not allocated.
+      resource->deallocate(result, num_bytes, stream);
+      throw e;
+    }
+
+    return result;
+  }
+
   void do_deallocate(void* p, std::size_t size, cudaStream_t stream) override {
-    resource->deallocate(p, size, stream);
+    std::size_t total_before;
+    std::size_t total_after;
+    {
+      std::lock_guard<std::mutex> lock(size_map_mutex);
+      total_before = total_allocated;
+      resource->deallocate(p, size, stream);
+      // TODO: size can't be trusted until rmm::alloc and rmm::free are removed,
+      //       see https://github.com/rapidsai/rmm/issues/302
+      auto it = size_map.find(p);
+      if (it != size_map.end()) {
+        total_allocated -= it->second;
+        size_map.erase(it);
+      } else {
+        // Untracked size, may be due to allocation that occurred before handler was installed.
+      }
+      total_after = total_allocated;
+    }
+
+    check_for_threshold_callback(total_after, total_before, dealloc_thresholds,
+        on_dealloc_threshold_method, "onDeallocThreshold", total_after);
   }
 
   std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override {
@@ -121,7 +233,11 @@ private:
 
 std::unique_ptr<java_event_handler_memory_resource> Java_memory_resource{};
 
-void set_java_device_memory_resource(JNIEnv* env, jobject handler_obj) {
+void set_java_device_memory_resource(
+    JNIEnv* env,
+    jobject handler_obj,
+    jlongArray jalloc_thresholds,
+    jlongArray jdealloc_thresholds) {
   if (Java_memory_resource && handler_obj != nullptr) {
     JNI_THROW_NEW(env, RMM_EXCEPTION_CLASS, "Another event handler is already set", )
   }
@@ -137,7 +253,8 @@ void set_java_device_memory_resource(JNIEnv* env, jobject handler_obj) {
   }
   if (handler_obj != nullptr) {
     auto resource = rmm::mr::get_default_resource();
-    Java_memory_resource.reset(new java_event_handler_memory_resource(env, handler_obj, resource));
+    Java_memory_resource.reset(new java_event_handler_memory_resource(
+        env, handler_obj, jalloc_thresholds, jdealloc_thresholds, resource));
     auto replaced_resource = rmm::mr::set_default_resource(Java_memory_resource.get());
     if (resource != replaced_resource) {
       rmm::mr::set_default_resource(replaced_resource);
@@ -155,41 +272,49 @@ extern "C" {
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(JNIEnv *env, jclass clazz,
                                                                   jint allocation_mode,
                                                                   jboolean enable_logging,
-                                                                  jlong pool_size,
-                                                                  jobject handler_obj) {
-  if (rmmIsInitialized(nullptr)) {
-    JNI_THROW_NEW(env, "java/lang/IllegalStateException", "RMM already initialized", );
-  }
-  rmmOptions_t opts;
-  opts.allocation_mode = static_cast<rmmAllocationMode_t>(allocation_mode);
-  opts.enable_logging = enable_logging == JNI_TRUE;
-  opts.initial_pool_size = pool_size;
-  JNI_RMM_TRY(env, , rmmInitialize(&opts));
-  set_java_device_memory_resource(env, handler_obj);
+                                                                  jlong pool_size) {
+  try {
+    if (rmmIsInitialized(nullptr)) {
+      JNI_THROW_NEW(env, "java/lang/IllegalStateException", "RMM already initialized", );
+    }
+    rmmOptions_t opts;
+    opts.allocation_mode = static_cast<rmmAllocationMode_t>(allocation_mode);
+    opts.enable_logging = enable_logging == JNI_TRUE;
+    opts.initial_pool_size = pool_size;
+    JNI_RMM_TRY(env, , rmmInitialize(&opts));
+  } CATCH_STD(env, )
 }
 
 JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Rmm_isInitializedInternal(JNIEnv *env, jclass clazz) {
-  return rmmIsInitialized(nullptr);
+  try {
+    return rmmIsInitialized(nullptr);
+  } CATCH_STD(env, false)
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_shutdown(JNIEnv *env, jclass clazz) {
-  set_java_device_memory_resource(env, nullptr);
-  JNI_RMM_TRY(env, , rmmFinalize());
+  try {
+    set_java_device_memory_resource(env, nullptr, nullptr, nullptr);
+    JNI_RMM_TRY(env, , rmmFinalize());
+  } CATCH_STD(env, )
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_alloc(JNIEnv *env, jclass clazz, jlong size,
                                                       jlong stream) {
-  void *ret = 0;
-  cudaStream_t c_stream = reinterpret_cast<cudaStream_t>(stream);
-  JNI_RMM_TRY(env, 0, RMM_ALLOC(&ret, size, c_stream));
-  return (jlong)ret;
+  try {
+    void *ret = 0;
+    cudaStream_t c_stream = reinterpret_cast<cudaStream_t>(stream);
+    JNI_RMM_TRY(env, 0, RMM_ALLOC(&ret, size, c_stream));
+    return (jlong)ret;
+  } CATCH_STD(env, 0)
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_free(JNIEnv *env, jclass clazz, jlong ptr,
                                                     jlong stream) {
-  void *cptr = reinterpret_cast<void *>(ptr);
-  cudaStream_t c_stream = reinterpret_cast<cudaStream_t>(stream);
-  JNI_RMM_TRY(env, , RMM_FREE(cptr, c_stream));
+  try {
+    void *cptr = reinterpret_cast<void *>(ptr);
+    cudaStream_t c_stream = reinterpret_cast<cudaStream_t>(stream);
+    JNI_RMM_TRY(env, , RMM_FREE(cptr, c_stream));
+  } CATCH_STD(env, )
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_freeDeviceBuffer(JNIEnv *env, jclass clazz,
@@ -198,17 +323,25 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_freeDeviceBuffer(JNIEnv *env, jcl
   delete cptr;
 }
 
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_setEventHandlerInternal(JNIEnv* env, jclass,
-                                                                       jobject handler_obj) {
-  set_java_device_memory_resource(env, handler_obj);
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_setEventHandlerInternal(
+    JNIEnv* env,
+    jclass,
+    jobject handler_obj,
+    jlongArray jalloc_thresholds,
+    jlongArray jdealloc_thresholds) {
+  try {
+    set_java_device_memory_resource(env, handler_obj, jalloc_thresholds, jdealloc_thresholds);
+  } CATCH_STD(env, )
 }
 
 JNIEXPORT jstring JNICALL Java_ai_rapids_cudf_Rmm_getLog(JNIEnv *env, jclass clazz, jlong size,
-                                                      jlong stream) {
-  size_t amount = rmmLogSize();
-  std::unique_ptr<char> buffer(new char[amount]);
-  JNI_RMM_TRY(env, nullptr, rmmGetLog(buffer.get(), amount));
-  return env->NewStringUTF(buffer.get());
+                                                         jlong stream) {
+  try {
+    size_t amount = rmmLogSize();
+    std::unique_ptr<char> buffer(new char[amount]);
+    JNI_RMM_TRY(env, nullptr, rmmGetLog(buffer.get(), amount));
+    return env->NewStringUTF(buffer.get());
+  } CATCH_STD(env, nullptr)
 }
 
 }


### PR DESCRIPTION
This adds the ability for the Java RMM event handler to be called when total allocation thresholds are crossed during allocation and deallocation.  Calling back into the JVM from native code is relatively expensive.  This provides a way for a Java application to be informed when certain RMM memory thresholds are crossed without resorting to calling Java on every RMM allocation and deallocation.