### PR TITLE
[REVIEW] Move a bunch of internal nvstrings code to use native StringColumns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@
 - PR #4305 Move gpuarrow.pyx and related libarrow_cuda files into `_libxx`
 - PR #4244 Port nvstrings Substring Gather/Scatter functions to cuDF Python/Cython
 - PR #4280 Port nvstrings Numeric Handling functions to cuDF Python/Cython
+- PR #XXXX Move a bunch of internal nvstrings code to use native StringColumns
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@
 - PR #4305 Move gpuarrow.pyx and related libarrow_cuda files into `_libxx`
 - PR #4244 Port nvstrings Substring Gather/Scatter functions to cuDF Python/Cython
 - PR #4280 Port nvstrings Numeric Handling functions to cuDF Python/Cython
-- PR #XXXX Move a bunch of internal nvstrings code to use native StringColumns
+- PR #4336 Move a bunch of internal nvstrings code to use native StringColumns
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/_sort.py
+++ b/python/cudf/cudf/core/_sort.py
@@ -6,8 +6,7 @@ import logging
 import numpy as np
 
 import cudf
-import cudf._libxx as libcudf
-from cudf.core.column import ColumnBase, as_column
+import cudf._libxx as libcudfxx
 
 logging.basicConfig(format="%(levelname)s:%(message)s")
 
@@ -34,6 +33,8 @@ def get_sorted_inds(by, ascending=True, na_position="last"):
           * Not supporting: inplace, kind
           * Ascending can be a list of bools to control per column
     """
+    from cudf.core.column import ColumnBase
+
     number_of_columns = 1
     if isinstance(by, (ColumnBase)):
         by = by.as_frame()
@@ -63,6 +64,4 @@ def get_sorted_inds(by, ascending=True, na_position="last"):
     if np.isscalar(ascending):
         ascending = [ascending] * number_of_columns
 
-    out_inds_column = libcudf.sort.order_by(by, ascending, na_position)
-
-    return as_column(out_inds_column)
+    return libcudfxx.sort.order_by(by, ascending, na_position)

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -439,8 +439,8 @@ class CategoricalColumn(column.ColumnBase):
             dictionary=self.categories.to_arrow(),
         )
 
-    def unique(self, method="sort"):
-        codes = self.as_numerical.unique(method=method)
+    def unique(self):
+        codes = self.as_numerical.unique()
         return column.build_categorical_column(
             categories=self.categories,
             codes=codes,

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -726,7 +726,7 @@ class ColumnBase(Column):
         sr = cudf.Series(self)
         labels, cats = sr.factorize()
 
-        # string columns include null index in factorization; remove:
+        # columns include null index in factorization; remove:
         if self.has_nulls:
             cats = cats.dropna()
             labels = labels - 1
@@ -798,8 +798,6 @@ class ColumnBase(Column):
         """
         Get unique values in the data
         """
-        if self.null_count == len(self):
-            return column_empty_like(self, newsize=0)
         return self.as_frame().drop_duplicates(keep="first")._as_column()
 
     def serialize(self):

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -23,6 +23,7 @@ from cudf._libxx.null_mask import (
 )
 from cudf._libxx.stream_compaction import unique_count as cpp_unique_count
 from cudf._libxx.transform import bools_to_mask
+from cudf.core._sort import get_sorted_inds
 from cudf.core.buffer import Buffer
 from cudf.core.dtypes import CategoricalDtype
 from cudf.utils import cudautils, ioutils, utils
@@ -74,10 +75,12 @@ class ColumnBase(Column):
     @property
     def data_array_view(self):
         """
-        View the data as a device array or nvstrings object
+        View the data as a device array object
         """
         if self.dtype == "object":
+            # TODO: Change this to raise exception once copying.pyx is ported
             return self.nvstrings
+            # raise ValueError("Cannot get an array view of a StringColumn")
 
         if is_categorical_dtype(self.dtype):
             return self.codes.data_array_view
@@ -235,6 +238,7 @@ class ColumnBase(Column):
                         libcudfxx.MAX_STRING_COLUMN_BYTES_STR
                     )
                 )
+            # TODO: remove nvstrings when concat.pyx is ported
             objs = [o.nvstrings for o in objs]
             return as_column(nvstrings.from_strings(*objs))
 
@@ -380,6 +384,7 @@ class ColumnBase(Column):
             index = len(self) + index
         if index > len(self) - 1:
             raise IndexError
+        # TODO: Remove this when copying.pyx is ported
         val = self.data_array_view[index]  # this can raise IndexError
         if isinstance(val, nvstrings.nvstrings):
             val = val.to_host()[0]
@@ -671,19 +676,10 @@ class ColumnBase(Column):
         if side == "right":
             return self.find_last_value(label, closest=True) + 1
 
-    def sort_by_values(self):
-        raise NotImplementedError
-
-    def _unique_segments(self):
-        """ Common code for unique, unique_count and value_counts"""
-        # make dense column
-        densecol = self.dropna()
-        # sort the column
-        sortcol, _ = densecol.sort_by_values()
-        # find segments
-        sortedvals = sortcol.data_array_view
-        segs, begins = cudautils.find_segments(sortedvals)
-        return segs, sortedvals
+    def sort_by_values(self, ascending=True, na_position="last"):
+        col_inds = get_sorted_inds(self, ascending, na_position)
+        col_keys = self[col_inds]
+        return col_keys, col_inds
 
     def unique_count(self, method="sort", dropna=True):
         if method != "sort":
@@ -717,14 +713,12 @@ class ColumnBase(Column):
         labels, cats = sr.factorize()
 
         # string columns include null index in factorization; remove:
-        if (
-            pd.api.types.pandas_dtype(self.dtype).type in (np.str_, np.object_)
-        ) and self.has_nulls:
+        if self.has_nulls:
             cats = cats.dropna()
             labels = labels - 1
 
         return build_categorical_column(
-            categories=cats,
+            categories=cats._column,
             codes=labels._column,
             mask=self.mask,
             ordered=ordered,
@@ -785,6 +779,14 @@ class ColumnBase(Column):
         return self.as_frame().searchsorted(
             values, side, ascending=ascending, na_position=na_position
         )
+
+    def unique(self):
+        """
+        Get unique values in the data
+        """
+        if self.null_count == len(self):
+            return column_empty_like(self, newsize=0)
+        return self.as_frame().drop_duplicates(keep="first")._as_column()
 
     def serialize(self):
         header = {}
@@ -1018,6 +1020,7 @@ def as_column(arbitrary, nan_as_null=True, dtype=None, length=None):
         data = arbitrary._values
         if dtype is not None:
             data = data.astype(dtype)
+    # TODO: Remove nvstrings here when nvstrings is fully removed
     elif isinstance(arbitrary, nvstrings.nvstrings):
         byte_count = arbitrary.byte_count()
         if byte_count > libcudfxx.MAX_STRING_COLUMN_BYTES:

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -7,7 +7,6 @@ import pyarrow as pa
 import cudf
 import cudf._lib as libcudf
 import cudf._libxx as libcudfxx
-from cudf.core._sort import get_sorted_inds
 from cudf.core.buffer import Buffer
 from cudf.core.column import as_column, column
 from cudf.utils import utils
@@ -225,11 +224,6 @@ class DatetimeColumn(column.ColumnBase):
 
         return result
 
-    def sort_by_values(self, ascending=True, na_position="last"):
-        col_inds = get_sorted_inds(self, ascending, na_position)
-        col_keys = self[col_inds]
-        return col_keys, col_inds
-
     def min(self, dtype=None):
         return libcudf.reduce.reduce("min", self, dtype=dtype)
 
@@ -251,17 +245,6 @@ class DatetimeColumn(column.ColumnBase):
         value = pd.to_datetime(value)
         value = column.as_column(value).as_numerical[0]
         return self.as_numerical.find_last_value(value, closest=closest)
-
-    def unique(self, method="sort"):
-        # method variable will indicate what algorithm to use to
-        # calculate unique, not used right now
-        if method != "sort":
-            msg = "non sort based unique() not implemented yet"
-            raise NotImplementedError(msg)
-        segs, sortedvals = self._unique_segments()
-        # gather result
-        out_col = column.as_column(sortedvals)[segs]
-        return out_col
 
     @property
     def is_unique(self):

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -9,7 +9,6 @@ import rmm
 
 import cudf._lib as libcudf
 import cudf._libxx as libcudfxx
-from cudf.core._sort import get_sorted_inds
 from cudf.core.buffer import Buffer
 from cudf.core.column import as_column, column
 from cudf.utils import cudautils, utils
@@ -147,14 +146,6 @@ class NumericalColumn(column.ColumnBase):
             return self
         return libcudfxx.unary.cast(self, dtype)
 
-    def sort_by_values(self, ascending=True, na_position="last"):
-        sort_inds = get_sorted_inds(self, ascending, na_position)
-        col_keys = self[sort_inds]
-        col_inds = column.build_column(
-            sort_inds.data, dtype=sort_inds.dtype, mask=sort_inds.mask
-        )
-        return col_keys, col_inds
-
     def to_pandas(self, index=None):
         if self.has_nulls and self.dtype == np.bool:
             # Boolean series in Pandas that contains None/NaN is of dtype
@@ -184,17 +175,6 @@ class NumericalColumn(column.ColumnBase):
             return out.cast(pa.bool_())
         else:
             return out
-
-    def unique(self, method="sort"):
-        # method variable will indicate what algorithm to use to
-        # calculate unique, not used right now
-        if method != "sort":
-            msg = "non sort based unique() not implemented yet"
-            raise NotImplementedError(msg)
-        segs, sortedvals = self._unique_segments()
-        # gather result
-        out_col = column.as_column(sortedvals)[segs]
-        return out_col
 
     def all(self):
         return bool(libcudfxx.reduce.reduce("all", self, dtype=np.bool_))

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -3,6 +3,7 @@
 import functools
 import pickle
 import warnings
+from codecs import decode
 
 import numpy as np
 import pandas as pd
@@ -15,7 +16,6 @@ import cudf._lib as libcudf
 import cudf._libxx as libcudfxx
 import cudf._libxx.string_casting as str_cast
 from cudf._lib.nvtx import nvtx_range_pop, nvtx_range_push
-from cudf._libxx.null_mask import bitmask_allocation_size_bytes
 from cudf._libxx.strings.char_types import (
     is_alnum as cpp_is_alnum,
     is_alpha as cpp_is_alpha,
@@ -31,7 +31,7 @@ from cudf._libxx.strings.substring import slice_from as cpp_slice_from
 from cudf.core.buffer import Buffer
 from cudf.core.column import column
 from cudf.utils import utils
-from cudf.utils.dtypes import is_list_like
+from cudf.utils.dtypes import is_list_like, is_scalar
 
 _str_to_numeric_typecast_functions = {
     np.dtype("int8"): str_cast.stoi8,
@@ -42,7 +42,7 @@ _str_to_numeric_typecast_functions = {
     np.dtype("float64"): str_cast.stod,
     np.dtype("bool"): str_cast.to_booleans,
     # TODO: support Date32 UNIX days
-    # np.dtype("datetime64[D]"): nvstrings.nvstrings.timestamp2int,
+    # np.dtype("datetime64[D]"): str_cast.timestamp2int,
     np.dtype("datetime64[s]"): str_cast.timestamp2int,
     np.dtype("datetime64[ms]"): str_cast.timestamp2int,
     np.dtype("datetime64[us]"): str_cast.timestamp2int,
@@ -58,7 +58,7 @@ _numeric_to_str_typecast_functions = {
     np.dtype("float64"): str_cast.dtos,
     np.dtype("bool"): str_cast.from_booleans,
     # TODO: support Date32 UNIX days
-    # np.dtype("datetime64[D]"): nvstrings.int2timestamp,
+    # np.dtype("datetime64[D]"): str_cast.int2timestamp,
     np.dtype("datetime64[s]"): str_cast.int2timestamp,
     np.dtype("datetime64[ms]"): str_cast.int2timestamp,
     np.dtype("datetime64[us]"): str_cast.int2timestamp,
@@ -78,6 +78,7 @@ class StringMethods(object):
     def __getattr__(self, attr, *args, **kwargs):
         from cudf.core.series import Series
 
+        # TODO: Remove when all needed string compute APIs are ported
         if hasattr(self._column.nvstrings, attr):
             passed_attr = getattr(self._column.nvstrings, attr)
             if callable(passed_attr):
@@ -135,6 +136,7 @@ class StringMethods(object):
 
     def __dir__(self):
         keys = dir(type(self))
+        # TODO: Remove along with `__getattr__` above when all is ported
         return set(keys + dir(self._column.nvstrings))
 
     def len(self, **kwargs):
@@ -201,7 +203,9 @@ class StringMethods(object):
         """
         from cudf.core import Series, Index
 
-        if isinstance(others, Series):
+        if isinstance(others, StringColumn):
+            others = others.nvstrings
+        elif isinstance(others, Series):
             assert others.dtype == np.dtype("object")
             others = others._column.nvstrings
         elif isinstance(others, Index):
@@ -326,7 +330,7 @@ class StringMethods(object):
 
         out = self._column.nvstrings.extract(pat)
         if len(out) == 1 and expand is False:
-            return self._return_or_inplace(out[0], **kwargs,)
+            return self._return_or_inplace(out[0], **kwargs)
         else:
             kwargs.setdefault("expand", expand)
             return self._return_or_inplace(out, **kwargs)
@@ -723,6 +727,7 @@ class StringColumn(column.ColumnBase):
             None, size, dtype, mask=mask, offset=offset, children=children
         )
 
+        # TODO: Remove these once NVStrings is fully deprecated / removed
         self._nvstrings = None
         self._nvcategory = None
         self._indices = None
@@ -748,6 +753,8 @@ class StringColumn(column.ColumnBase):
 
     def set_base_mask(self, value):
         super().set_base_mask(value)
+
+        # TODO: Remove these once NVStrings is fully deprecated / removed
         self._indices = None
         self._nvcategory = None
         self._nvstrings = None
@@ -755,6 +762,8 @@ class StringColumn(column.ColumnBase):
     def set_base_children(self, value):
         # TODO: Implement dtype validation of the children here somehow
         super().set_base_children(value)
+
+        # TODO: Remove these once NVStrings is fully deprecated / removed
         self._indices = None
         self._nvcategory = None
         self._nvstrings = None
@@ -834,6 +843,7 @@ class StringColumn(column.ColumnBase):
     def __len__(self):
         return self.size
 
+    # TODO: Remove this once NVStrings is fully deprecated / removed
     @property
     def nvstrings(self):
         if self._nvstrings is None:
@@ -854,6 +864,7 @@ class StringColumn(column.ColumnBase):
                 )
         return self._nvstrings
 
+    # TODO: Remove these once NVStrings is fully deprecated / removed
     @property
     def nvcategory(self):
         if self._nvcategory is None:
@@ -867,9 +878,11 @@ class StringColumn(column.ColumnBase):
         self._nvcategory = nvc
 
     def _set_mask(self, value):
+        # TODO: Remove these once NVStrings is fully deprecated / removed
         self._nvstrings = None
         self._nvcategory = None
         self._indices = None
+
         super()._set_mask(value)
 
     @property
@@ -898,7 +911,7 @@ class StringColumn(column.ColumnBase):
 
         if mem_dtype.type is np.datetime64:
             if "format" not in kwargs:
-                if len(self.nvstrings) > 0:
+                if len(self) > 0:
                     # infer on host from the first not na element
                     fmt = pd.core.tools.datetimes._guess_datetime_format(
                         self[self.notna()][0]
@@ -915,27 +928,28 @@ class StringColumn(column.ColumnBase):
         return self
 
     def to_arrow(self):
-        sbuf = np.empty(self.nvstrings.byte_count(), dtype="int8")
-        obuf = np.empty(len(self.nvstrings) + 1, dtype="int32")
+        if len(self) == 0:
+            sbuf = np.empty(0, dtype="int8")
+            obuf = np.empty(0, dtype="int32")
+            nbuf = None
+        else:
+            sbuf = self.children[1].data.to_host_array().view("int8")
+            obuf = self.children[0].data.to_host_array().view("int32")
+            nbuf = None
+            if self.null_count > 0:
+                nbuf = self.mask.to_host_array().view("int8")
+                nbuf = pa.py_buffer(nbuf)
 
-        mask_size = bitmask_allocation_size_bytes(len(self.nvstrings))
-        nbuf = np.empty(mask_size, dtype="i1")
-
-        self.str().to_offsets(sbuf, obuf, nbuf=nbuf)
         sbuf = pa.py_buffer(sbuf)
         obuf = pa.py_buffer(obuf)
-        nbuf = pa.py_buffer(nbuf)
+
         if self.null_count == len(self):
             return pa.NullArray.from_buffers(
                 pa.null(), len(self), [pa.py_buffer((b""))], self.null_count
             )
         else:
             return pa.StringArray.from_buffers(
-                len(self.nvstrings),
-                obuf,
-                sbuf,
-                nbuf,
-                self.nvstrings.null_count(),
+                len(self), obuf, sbuf, nbuf, self.null_count
             )
 
     def to_pandas(self, index=None):
@@ -1000,29 +1014,6 @@ class StringColumn(column.ColumnBase):
         )
         return col
 
-    def sort_by_values(self, ascending=True, na_position="last"):
-        if na_position == "last":
-            nullfirst = False
-        elif na_position == "first":
-            nullfirst = True
-
-        idx_dev_arr = rmm.device_array(len(self), dtype="int32")
-        dev_ptr = libcudf.cudf.get_ctype_ptr(idx_dev_arr)
-        self.nvstrings.order(
-            2, asc=ascending, nullfirst=nullfirst, devptr=dev_ptr
-        )
-
-        col_inds = column.build_column(
-            Buffer(idx_dev_arr), idx_dev_arr.dtype, mask=None
-        )
-
-        col_keys = self[col_inds.data_array_view]
-
-        return col_keys, col_inds
-
-    def copy(self, deep=True):
-        return column.as_column(self.nvstrings.copy())
-
     def unordered_compare(self, cmpop, rhs):
         return _string_column_binop(self, rhs, op=cmpop)
 
@@ -1030,48 +1021,14 @@ class StringColumn(column.ColumnBase):
         """
         Return col with *to_replace* replaced with *value*
         """
-        to_replace = column.as_column(to_replace)
-        replacement = column.as_column(replacement)
-        if len(to_replace) == 1 and len(replacement) == 1:
-            to_replace = to_replace.nvstrings.to_host()[0]
-            replacement = replacement.nvstrings.to_host()[0]
-            result = self.nvstrings.replace(to_replace, replacement)
-            return column.as_column(result)
-        else:
-            raise NotImplementedError(
-                "StringColumn currently only supports replacing"
-                " single values"
-            )
+        to_replace = column.as_column(to_replace, dtype=self.dtype)
+        replacement = column.as_column(replacement, dtype=self.dtype)
+        return libcudfxx.replace.replace(self, to_replace, replacement)
 
     def fillna(self, fill_value):
-        """
-        Fill null values with * fill_value *
-        """
-        from cudf.core.series import Series
-
-        if not isinstance(fill_value, str) and not (
-            isinstance(fill_value, Series)
-            and isinstance(fill_value._column, StringColumn)
-        ):
-            raise TypeError("fill_value must be a string or a string series")
-
-        # replace fill_value with nvstrings
-        # if it is a column
-
-        if isinstance(fill_value, Series):
-            if len(fill_value) < len(self):
-                raise ValueError(
-                    "fill value series must be of same or "
-                    "greater length than the series to be filled"
-                )
-
-            fill_value = fill_value[: len(self)]._column.nvstrings
-
-        filled_data = self.nvstrings.fillna(fill_value)
-        result = column.as_column(filled_data)
-        result = result.set_mask(None)
-
-        return result
+        if not is_scalar(fill_value):
+            fill_value = column.as_column(fill_value, dtype=self.dtype)
+        return libcudfxx.replace.replace_nulls(self, fill_value)
 
     def _find_first_and_last(self, value):
         found_indices = self.str().contains(f"^{value}$")
@@ -1085,14 +1042,6 @@ class StringColumn(column.ColumnBase):
 
     def find_last_value(self, value, closest=False):
         return self._find_first_and_last(value)[1]
-
-    def unique(self, method="sort"):
-        """
-        Get unique strings in the data
-        """
-        import nvcategory as nvc
-
-        return column.as_column(nvc.from_strings(self.nvstrings).keys())
 
     def normalize_binop_value(self, other):
         if isinstance(other, column.Column):
@@ -1113,15 +1062,22 @@ class StringColumn(column.ColumnBase):
         if reflect:
             lhs, rhs = rhs, lhs
         if isinstance(rhs, StringColumn) and binop == "add":
-            return lhs.nvstrings.cat(others=rhs.nvstrings)
+            return lhs.str().cat(others=rhs)
         else:
             msg = "{!r} operator not supported between {} and {}"
             raise TypeError(msg.format(binop, type(self), type(rhs)))
 
     def sum(self, dtype=None):
-        # dtype is irrelevant it is needed to be in sync with
-        # the sum method for Numeric Series
-        return self.nvstrings.join().to_host()[0]
+        # Should we be raising here? Pandas can't handle the mix of strings and
+        # None and throws, but we already have a test that looks to ignore
+        # nulls and returns anyway.
+
+        # if self.null_count > 0:
+        #     raise ValueError("Cannot get sum of string column with nulls")
+
+        if len(self) == 0:
+            return ""
+        return decode(self.children[1].data.to_host_array(), encoding="utf-8")
 
     @property
     def is_unique(self):
@@ -1158,6 +1114,7 @@ class StringColumn(column.ColumnBase):
     def _mimic_inplace(self, other_col, inplace=False):
         out = super()._mimic_inplace(other_col, inplace=inplace)
         if inplace:
+            # TODO: Remove these once NVStrings is fully deprecated / removed
             self._nvstrings = other_col._nvstrings
             self._nvcategory = other_col._nvcategory
             self._indices = other_col._indices

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -10,7 +10,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-import nvstrings
 import rmm
 
 import cudf
@@ -220,7 +219,7 @@ class Index(Frame):
             return as_index(op())
 
     def unique(self):
-        return as_index(self._values.unique())
+        return as_index(self._values.unique(), name=self.name)
 
     def __add__(self, other):
         return self._apply_op("__add__", other)
@@ -983,7 +982,11 @@ class StringIndex(GenericIndex):
         elif isinstance(values, StringIndex):
             values = values._values.copy()
         else:
-            values = column.as_column(nvstrings.to_device(values))
+            values = column.as_column(values, dtype="str")
+            if not pd.api.types.is_string_dtype(values.dtype):
+                raise ValueError(
+                    "Couldn't create StringIndex from passed in object"
+                )
         super(StringIndex, self).__init__(values, **kwargs)
 
     def to_pandas(self):

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2081,20 +2081,11 @@ class Series(Frame):
         warnings.warn("Use .unique() instead", DeprecationWarning)
         return self.unique()
 
-    def unique(self, method="sort", sort=True):
-        """Returns unique values of this Series.
-        default='sort' will be changed to 'hash' when implemented.
+    def unique(self):
         """
-        if method != "sort":
-            msg = "non sort based unique() not implemented yet"
-            raise NotImplementedError(msg)
-        if not sort:
-            msg = "not sorted unique not implemented yet."
-            raise NotImplementedError(msg)
-        if self.null_count == len(self):
-            res = column.column_empty_like(self._column, newsize=0)
-            return self._copy_construct(data=res)
-        res = self._column.unique(method=method)
+        Returns unique values of this Series.
+        """
+        res = self._column.unique()
         return Series(res, name=self.name)
 
     def nunique(self, method="sort", dropna=True):

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4275,16 +4275,14 @@ def test_memory_usage_string():
     )
 
     # Check string column
-    assert (
-        gdf.B.memory_usage(deep=True, index=False)
-        == gdf.B._column.nvstrings.device_memory()
+    assert gdf.B.memory_usage(deep=True, index=False) == df.B.memory_usage(
+        deep=True, index=False
     )
 
     # Check string index
-    assert (
-        gdf.set_index("B").index.memory_usage(deep=True)
-        == gdf.B._column.nvstrings.device_memory()
-    )
+    assert gdf.set_index("B").index.memory_usage(
+        deep=True
+    ) == df.B.memory_usage(deep=True, index=False)
 
 
 @pytest.mark.xfail

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -56,6 +56,7 @@ def ps_gs(data, index):
     return (ps, gs)
 
 
+# TODO: Remove this once NVStrings is fully removed / deprecated
 @pytest.mark.parametrize("nbytes", [0, 2 ** 10, 2 ** 31 - 1, 2 ** 31, 2 ** 32])
 @patch.object(nvstrings.nvstrings, "byte_count")
 def test_from_nvstrings_nbytes(mock_byte_count, nbytes):
@@ -981,9 +982,7 @@ def test_string_no_children_properties():
         ["abcdefghij", "0123456789", "9876543210", None, "accénted", ""],
     ],
 )
-@pytest.mark.parametrize(
-    "index", [0, 1, 2, 3, 9, 10],
-)
+@pytest.mark.parametrize("index", [0, 1, 2, 3, 9, 10])
 def test_string_get(string, index):
     pds = pd.Series(string)
     gds = Series(string)
@@ -1028,7 +1027,7 @@ def test_string_slice_from():
     gs = Series(["hello world", "holy accéntéd", "batman", None, ""])
     d_starts = Series([2, 3, 0, -1, -1], dtype=np.int32)
     d_stops = Series([-1, -1, 0, -1, -1], dtype=np.int32)
-    got = gs.str.slice_from(starts=d_starts._column, stops=d_stops._column,)
+    got = gs.str.slice_from(starts=d_starts._column, stops=d_stops._column)
     expected = Series(["llo world", "y accéntéd", "", None, ""])
     assert_eq(got, expected)
 
@@ -1041,15 +1040,9 @@ def test_string_slice_from():
         ["koala", "fox", "chameleon"],
     ],
 )
-@pytest.mark.parametrize(
-    "number", [0, 1, 10],
-)
-@pytest.mark.parametrize(
-    "diff", [0, 2, 9],
-)
-@pytest.mark.parametrize(
-    "repr", ["2", "!!"],
-)
+@pytest.mark.parametrize("number", [0, 1, 10])
+@pytest.mark.parametrize("diff", [0, 2, 9])
+@pytest.mark.parametrize("repr", ["2", "!!"])
 def test_string_slice_replace(string, number, diff, repr):
     pds = pd.Series(string)
     gds = Series(string)

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -80,12 +80,11 @@ def scalar_broadcast_to(scalar, size, dtype=None):
         dtype = scalar.dtype
 
     if np.dtype(dtype) == np.dtype("object"):
-        import nvstrings
         from cudf.core.column import as_column
         from cudf.utils.cudautils import zeros
 
         gather_map = zeros(size, dtype="int32")
-        scalar_str_col = as_column(nvstrings.to_device([scalar]))
+        scalar_str_col = as_column([scalar], dtype="str")
         return scalar_str_col[gather_map]
     else:
         da = rmm.device_array((size,), dtype=dtype)


### PR DESCRIPTION
Related to #4334 

Moved as much of the nvstrings related code to use StringColumns directly. There's a couple notable gaps surrounding `concat` and `__getitem__` related things that can hopefully be tackled as we port `copying.pyx` and `concat.pyx`.