### PR TITLE
[REVIEW] Add cudf::sequence() for generating a column of incrementing values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PR #4321 Expose Python Semi and Anti Joins
 - PR #4291 Add Java callback support for RMM events
 - PR #4298 Port orc.pyx to libcudf++
+- PR #4338 Add cudf::sequence() for generating an incrementing list of numeric values
 
 ## Improvements
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -559,6 +559,7 @@ add_library(cudf
             src/filling/legacy/repeat.cu
             src/filling/repeat.cu
             src/filling/legacy/tile.cu
+            src/filling/sequence.cu
             src/reshape/tile.cu
             src/search/legacy/search.cu
             src/search/search.cu

--- a/cpp/include/cudf/detail/sequence.hpp
+++ b/cpp/include/cudf/detail/sequence.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/filling.hpp>
+#include <cudf/detail/sequence.hpp>
+#include <cudf/types.hpp>
+
+// #include <memory>
+
+namespace cudf {
+namespace experimental {
+namespace detail {
+
+/**
+ * @copydoc cudf::experimental::sequence
+ *
+ * @param stream CUDA stream to run this function
+ **/
+std::unique_ptr<column> sequence(size_type size, scalar const& init, scalar const& step,
+                                 rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+                                 cudaStream_t stream = 0);
+
+}  // namespace detail
+}  // namespace experimental
+}  // namespace cudf

--- a/cpp/include/cudf/detail/sequence.hpp
+++ b/cpp/include/cudf/detail/sequence.hpp
@@ -20,8 +20,6 @@
 #include <cudf/detail/sequence.hpp>
 #include <cudf/types.hpp>
 
-// #include <memory>
-
 namespace cudf {
 namespace experimental {
 namespace detail {

--- a/cpp/include/cudf/detail/sequence.hpp
+++ b/cpp/include/cudf/detail/sequence.hpp
@@ -25,11 +25,22 @@ namespace experimental {
 namespace detail {
 
 /**
- * @copydoc cudf::experimental::sequence
+ * @copydoc cudf::experimental::sequence(size_type size, scalar const& init, scalar const& step,
+ *                                       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
  *
  * @param stream CUDA stream to run this function
  **/
 std::unique_ptr<column> sequence(size_type size, scalar const& init, scalar const& step,
+                                 rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+                                 cudaStream_t stream = 0);
+
+/**
+ * @copydoc cudf::experimental::sequence(size_type size, scalar const& init,
+                                         rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
+ *
+ * @param stream CUDA stream to run this function
+ **/
+std::unique_ptr<column> sequence(size_type size, scalar const& init,
                                  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
                                  cudaStream_t stream = 0);
 

--- a/cpp/include/cudf/filling.hpp
+++ b/cpp/include/cudf/filling.hpp
@@ -140,5 +140,30 @@ std::unique_ptr<table> repeat(
     table_view const& input_table, scalar const& count,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/**
+ * @brief Fills a column with a sequence of value specified by an initial value and a step.
+ * 
+ * Creates a new column and fills with @p size values starting at @p init and 
+ * incrementing by @p step.
+ *
+ * ```
+ * size = 3
+ * init = 0
+ * step = 2 
+ * return = [0, 2, 4]
+ * ``` 
+ * @throws `cudf::logic_error` if @p init and @p @step are not the same type.
+ * @throws `cudf::logic_error` if @p size is invalid or @p size is negative.
+ * @throws `cudf::logic_error` if @p size overflows size_type.
+ * 
+ * @param size Size of the output column
+ * @param init First value in the sequence
+ * @param step Increment value
+ * @param mr Memory resource to allocate the result output column
+ * @return std::unique_ptr<column> The result table containing the sequence
+ **/
+std::unique_ptr<column> sequence(size_type size, scalar const& init, scalar const& step,
+                                 rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+
 }  // namespace experimental
 }  // namespace cudf

--- a/cpp/include/cudf/filling.hpp
+++ b/cpp/include/cudf/filling.hpp
@@ -166,5 +166,28 @@ std::unique_ptr<table> repeat(
 std::unique_ptr<column> sequence(size_type size, scalar const& init, scalar const& step,
                                  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/**
+ * @brief Fills a column with a sequence of value specified by an initial value and a step of 1.
+ * 
+ * Creates a new column and fills with @p size values starting at @p init and 
+ * incrementing by 1, generating the sequence
+ * [ init, init+1, init+2, ... init + (size - 1)]
+ *
+ * ```
+ * size = 3
+ * init = 0 
+ * return = [0, 1, 2]
+ * ```   
+ * @throws `cudf::logic_error` if @p init is not numeric.
+ * @throws `cudf::logic_error` if @p size is < 0. 
+ * 
+ * @param size Size of the output column
+ * @param init First value in the sequence 
+ * @param mr Memory resource to allocate the result output column
+ * @return std::unique_ptr<column> The result table containing the sequence
+ **/
+std::unique_ptr<column> sequence(size_type size, scalar const& init,
+                                 rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+
 }  // namespace experimental
 }  // namespace cudf

--- a/cpp/include/cudf/filling.hpp
+++ b/cpp/include/cudf/filling.hpp
@@ -144,17 +144,18 @@ std::unique_ptr<table> repeat(
  * @brief Fills a column with a sequence of value specified by an initial value and a step.
  * 
  * Creates a new column and fills with @p size values starting at @p init and 
- * incrementing by @p step.
+ * incrementing by @p step, generating the sequence
+ * [ init, init+step, init+2*step, ... init + (size - 1)*step]
  *
  * ```
  * size = 3
  * init = 0
  * step = 2 
  * return = [0, 2, 4]
- * ``` 
+ * ```  
  * @throws `cudf::logic_error` if @p init and @p @step are not the same type.
- * @throws `cudf::logic_error` if @p size is invalid or @p size is negative.
- * @throws `cudf::logic_error` if @p size overflows size_type.
+ * @throws `cudf::logic_error` if scalar types are not numeric.
+ * @throws `cudf::logic_error` if @p size is < 0. 
  * 
  * @param size Size of the output column
  * @param init First value in the sequence

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -87,7 +87,7 @@ std::unique_ptr<column> sequence(size_type size, scalar const& init, scalar cons
    CUDF_EXPECTS(size >= 0, "size must be >= 0");
    CUDF_EXPECTS(is_numeric(init.type()), "Input scalar types must be numeric");
 
-   return cudf::experimental::type_dispatcher(init.type(), sequence_functor{}, size, init, step, mr, stream);
+   return type_dispatcher(init.type(), sequence_functor{}, size, init, step, mr, stream);
 }
 
 }  // namespace detail
@@ -95,7 +95,7 @@ std::unique_ptr<column> sequence(size_type size, scalar const& init, scalar cons
 std::unique_ptr<column> sequence(size_type size, scalar const& init, scalar const& step,
                                  rmm::mr::device_memory_resource* mr)
 {
-   return cudf::experimental::detail::sequence(size, init, step, mr, 0);
+   return detail::sequence(size, init, step, mr, 0);
 }
 
 }  // namespace experimental

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -35,8 +35,8 @@ namespace {
 // __T289 link error.  This seems to be related to lambda usage within functions using SFINAE.
 template<typename T>
 struct tabulator {
-   cudf::numeric_scalar_device_view<T> n_init;
-   cudf::numeric_scalar_device_view<T> n_step;
+   cudf::numeric_scalar_device_view<T> const n_init;
+   cudf::numeric_scalar_device_view<T> const n_step;
 
    T __device__ operator()(cudf::size_type i){
       return n_init.value() + (i * n_step.value());

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -749,7 +749,7 @@ ConfigureTest(ROLLING_TEST "${ROLLING_TEST_SRC}")
 set(FILLING_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/filling/fill_tests.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/filling/repeat_tests.cu"
-    "${CMAKE_CURRENT_SOURCE_DIR}/filling/sequence_tests.cu")
+    "${CMAKE_CURRENT_SOURCE_DIR}/filling/sequence_tests.cpp")
 
 ConfigureTest(FILLING_TEST "${FILLING_TEST_SRC}")
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -748,7 +748,8 @@ ConfigureTest(ROLLING_TEST "${ROLLING_TEST_SRC}")
 
 set(FILLING_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/filling/fill_tests.cu"
-    "${CMAKE_CURRENT_SOURCE_DIR}/filling/repeat_tests.cu")
+    "${CMAKE_CURRENT_SOURCE_DIR}/filling/repeat_tests.cu"
+    "${CMAKE_CURRENT_SOURCE_DIR}/filling/sequence_tests.cu")
 
 ConfigureTest(FILLING_TEST "${FILLING_TEST_SRC}")
 

--- a/cpp/tests/filling/sequence_tests.cpp
+++ b/cpp/tests/filling/sequence_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/filling/sequence_tests.cpp
+++ b/cpp/tests/filling/sequence_tests.cpp
@@ -118,3 +118,19 @@ TEST_F(SequenceTestFixture, MismatchedInputs)
    numeric_scalar<double> step3(-5);
    EXPECT_THROW(cudf::experimental::sequence(10, init3, step3), cudf::logic_error);
 }
+
+TYPED_TEST(SequenceTypedTestFixture, DefaultStep)
+{
+   using T = TypeParam;
+
+   numeric_scalar<T> init(0);   
+   
+   size_type num_els = 10;
+   
+   T expected[]   = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };   
+   fixed_width_column_wrapper<T> expected_w(expected, expected + num_els);
+
+   auto result = cudf::experimental::sequence(num_els, init);
+        
+   expect_columns_equal(*result, expected_w);
+}

--- a/cpp/tests/filling/sequence_tests.cu
+++ b/cpp/tests/filling/sequence_tests.cu
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/cudf.h>
+
+#include <cudf/scalar/scalar.hpp>
+
+#include <tests/utilities/cudf_gtest.hpp>
+#include <tests/utilities/base_fixture.hpp>
+#include <tests/utilities/type_lists.hpp>
+#include <tests/utilities/column_utilities.hpp>
+#include <tests/utilities/column_wrapper.hpp>
+
+#include <cudf/filling.hpp>
+
+using namespace cudf;
+using namespace cudf::test;
+
+template <typename T>
+class SequenceTypedTestFixture : public cudf::test::BaseFixture {};
+
+class SequenceTestFixture : public cudf::test::BaseFixture {};
+
+using NumericTypesNoBool = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
+
+TYPED_TEST_CASE(SequenceTypedTestFixture, NumericTypesNoBool);
+
+TYPED_TEST(SequenceTypedTestFixture, Incrementing)
+{
+   using T = TypeParam;
+
+   numeric_scalar<T> init(0);
+   numeric_scalar<T> step(1);
+   
+   size_type num_els = 10;
+   
+   T expected[]   = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };   
+   fixed_width_column_wrapper<T> expected_w(expected, expected + num_els);
+
+   auto result = cudf::experimental::sequence(num_els, init, step);
+        
+   expect_columns_equal(*result, expected_w);
+}
+
+TYPED_TEST(SequenceTypedTestFixture, Decrementing)
+{
+   using T = TypeParam;
+
+   numeric_scalar<T> init(0);
+   numeric_scalar<T> step(-5);
+   
+   size_type num_els = 10;
+   
+   T expected[]   = { 0, -5, -10, -15, -20, -25, -30, -35, -40, -45 };   
+   fixed_width_column_wrapper<T> expected_w(expected, expected + num_els);
+
+   auto result = cudf::experimental::sequence(num_els, init, step);
+        
+   expect_columns_equal(*result, expected_w);
+}
+
+TYPED_TEST(SequenceTypedTestFixture, EmptyOutput)
+{
+   using T = TypeParam;
+
+   numeric_scalar<T> init(0);
+   numeric_scalar<T> step(-5);
+   
+   size_type num_els = 0;
+   
+   T expected[]   = {  };   
+   fixed_width_column_wrapper<T> expected_w(expected, expected + num_els);
+
+   auto result = cudf::experimental::sequence(num_els, init, step);
+        
+   expect_columns_equal(*result, expected_w);
+}
+
+TEST_F(SequenceTestFixture, BadTypes)
+{   
+   string_scalar string_init("zero");
+   string_scalar string_step("???");      
+   EXPECT_THROW(cudf::experimental::sequence(10, string_init, string_step), cudf::logic_error);
+
+   numeric_scalar<bool> bool_init(true);
+   numeric_scalar<bool> bool_step(false);
+   EXPECT_THROW(cudf::experimental::sequence(10, bool_init, bool_step), cudf::logic_error);
+
+   timestamp_scalar<timestamp_s> ts_init(10);
+   timestamp_scalar<timestamp_s> ts_step(10);
+   EXPECT_THROW(cudf::experimental::sequence(10, ts_init, ts_step), cudf::logic_error);
+}
+
+TEST_F(SequenceTestFixture, MismatchedInputs)
+{   
+   numeric_scalar<int> init(0);
+   numeric_scalar<float> step(-5);
+   EXPECT_THROW(cudf::experimental::sequence(10, init, step), cudf::logic_error);   
+
+   numeric_scalar<int> init2(0);
+   numeric_scalar<int8_t> step2(-5);
+   EXPECT_THROW(cudf::experimental::sequence(10, init2, step2), cudf::logic_error);
+
+   numeric_scalar<float> init3(0);
+   numeric_scalar<double> step3(-5);
+   EXPECT_THROW(cudf::experimental::sequence(10, init3, step3), cudf::logic_error);
+}


### PR DESCRIPTION

Closes https://github.com/rapidsai/cudf/issues/4325

Generate a column of values based on input numeric scalars specifying an initial value and a step.

Only issue worth calling out with the PR is in sequence.cu.   In the type dispatched functor that ultimately calls thrust,  instead of using a lambda I'm using an external functor (tabulator).  The reason for this is an obscure link error that comes up from time to time when using type dispatched functors that utilize SFINAE :  device lambdas (possibly any lambda) will sometimes cause the error.  The only way around it is to use an external functor.   For another example, see : ```normalize_nans_and_zeros_lambda``` in replace.cu

