### PR TITLE
[REVIEW] Removed bogus backwards include in cuIO code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@
 - PR #4244 Port nvstrings Substring Gather/Scatter functions to cuDF Python/Cython
 - PR #4280 Port nvstrings Numeric Handling functions to cuDF Python/Cython
 - PR #4166 Port `is_sorted.pyx` to use libcudf++ APIs
+- PR #4345 Removed an undesirable backwards include from /include to /src in cuIO writers.hpp
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/io/writers.hpp
+++ b/cpp/include/cudf/io/writers.hpp
@@ -25,7 +25,6 @@
 
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
-#include <io/parquet/parquet.h>
 
 #include <memory>
 #include <utility>
@@ -221,29 +220,6 @@ class writer {
    * @param[in] pq_chunked_state State information that crosses _begin() / write_chunked() / _end() boundaries.   
    */
   void write_chunked_end(struct pq_chunked_state& state);    
-};
-
-/**
- * @brief Chunked writer state struct. Contains various pieces of information
- *        needed that span the begin() / write() / end() call process.
- */
-struct pq_chunked_state {
-  /// The writer to be used
-  std::unique_ptr<writer>             wp;  
-  /// Cuda stream to be used
-  cudaStream_t                        stream;  
-  /// Overall file metadata.  Filled in during the process and written during write_chunked_end()
-  cudf::io::parquet::FileMetaData     md;  
-  /// current write position for rowgroups/chunks
-  size_t                              current_chunk_offset;
-  /// optional user metadata
-  table_metadata const*               user_metadata = nullptr;
-  /// only used in the write_chunked() case. copied from the (optionally) user supplied
-  /// argument to write_parquet_chunked_begin()
-  table_metadata_with_nullability     user_metadata_with_nullability;  
-  /// special parameter only used by detail::write() to indicate that we are guaranteeing 
-  /// a single table write.  this enables some internal optimizations.
-  bool                                single_write_mode = false;
 };
 
 }  // namespace parquet

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -20,6 +20,8 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/error.hpp>
 
+#include <io/parquet/parquet.h>
+
 
 namespace cudf {
 namespace experimental {

--- a/cpp/src/io/parquet/parquet.h
+++ b/cpp/src/io/parquet/parquet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@
 #define __IO_PARQUET_H__
 
 #include "parquet_common.h"
+
+#include <cudf/io/types.hpp>
+#include <cudf/io/writers.hpp>
 
 #include <stdint.h>
 #include <stddef.h>
@@ -297,10 +300,41 @@ protected:
     std::vector<uint8_t> *m_buf;
 };
 
-
-
 } // namespace parquet
 } // namespace io
+
+namespace experimental {
+namespace io {
+namespace detail {
+namespace parquet {
+   /**
+    * @brief Chunked writer state struct. Contains various pieces of information
+    *        needed that span the begin() / write() / end() call process.
+    */
+   struct pq_chunked_state {
+      /// The writer to be used
+      std::unique_ptr<writer>             wp;  
+      /// Cuda stream to be used
+      cudaStream_t                        stream;  
+      /// Overall file metadata.  Filled in during the process and written during write_chunked_end()
+      cudf::io::parquet::FileMetaData     md;  
+      /// current write position for rowgroups/chunks
+      size_t                              current_chunk_offset;
+      /// optional user metadata
+      table_metadata const*               user_metadata = nullptr;
+      /// only used in the write_chunked() case. copied from the (optionally) user supplied
+      /// argument to write_parquet_chunked_begin()
+      table_metadata_with_nullability     user_metadata_with_nullability;  
+      /// special parameter only used by detail::write() to indicate that we are guaranteeing 
+      /// a single table write.  this enables some internal optimizations.
+      bool                                single_write_mode = false;
+   };
+
+}  // parquet
+}  // detail
+}  // experimental
+}  // io
+
 } // namespace cudf
 
 #endif // __IO_PARQUET_H__


### PR DESCRIPTION

`/include/io/writers.hpp` was including `/src/cudf/io/parquet/parquet.h` to get at types needed for the `pq_chunked_state struct`.  Since this struct itself is intended to be anonymous, it can be buried further down in the parquet writer code (`/src/cudf/io/parquet/parquet.h`), removing the bad include.