### PR TITLE
[REVIEW] Fix strings::concat when narep parameter is an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@
 - PR #4303 Parquet reader: fix empty columns missing from table
 - PR #4115 Serialize an empty column table with non zero rows
 - PR #4327 Preemptive dispatch fix for changes in dask#5973
+- PR #4358 Fix strings::concat where narep is an empty string
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/src/strings/combine.cu
+++ b/cpp/src/strings/combine.cu
@@ -58,7 +58,7 @@ std::unique_ptr<column> concatenate( table_view const& strings_columns,
 
     CUDF_EXPECTS( separator.is_valid(), "Parameter separator must be a valid string_scalar");
     string_view d_separator(separator.data(),separator.size());
-    string_view const d_narep = [&] {
+    string_view const d_narep = [&narep] {
         if( !narep.is_valid() )
             return string_view(nullptr,0);
         return narep.size()==0 ? string_view("",0) : string_view(narep.data(),narep.size());
@@ -146,9 +146,11 @@ std::unique_ptr<column> join_strings( strings_column_view const& strings,
 
     auto execpol = rmm::exec_policy(stream);
     string_view d_separator(separator.data(),separator.size());
-    string_view d_narep(nullptr,0);
-    if( narep.is_valid() ) // narep is allowed to be invalid
-        d_narep = string_view(narep.data(),narep.size());
+    string_view const d_narep = [&narep] {
+        if( !narep.is_valid() )
+            return string_view(nullptr,0);
+        return narep.size()==0 ? string_view("",0) : string_view(narep.data(),narep.size());
+    } ();
 
     auto strings_column = column_device_view::create(strings.parent(),stream);
     auto d_strings = *strings_column;

--- a/cpp/tests/strings/combine_tests.cu
+++ b/cpp/tests/strings/combine_tests.cu
@@ -24,10 +24,9 @@
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/column_wrapper.hpp>
 #include <tests/utilities/column_utilities.hpp>
-#include "./utilities.h"
+#include <tests/strings/utilities.h>
 
 #include <vector>
-#include <gmock/gmock.h>
 
 
 struct StringsCombineTest : public cudf::test::BaseFixture {};

--- a/cpp/tests/strings/combine_tests.cu
+++ b/cpp/tests/strings/combine_tests.cu
@@ -71,6 +71,14 @@ TEST_F(StringsCombineTest, Concatenate)
         auto results = cudf::strings::concatenate(table,cudf::string_scalar(":"),cudf::string_scalar("_"));
         cudf::test::expect_columns_equal(*results,expected);
     }
+    {
+        std::vector<const char*> h_expected{ "eeexyz", "bbabc", "d", "éa", "aa", "bbb", "éééf" };
+        cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end(),
+            thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
+
+        auto results = cudf::strings::concatenate(table,cudf::string_scalar(""),cudf::string_scalar(""));
+        cudf::test::expect_columns_equal(*results,expected);
+    }
 }
 
 TEST_F(StringsCombineTest, ConcatZeroSizeStringsColumns)


### PR DESCRIPTION
Closes #4349 
This is similar to #4307 where the empty string parameter was being incorrectly interpreted as a null string. This caused the result where nulls were not being properly replaced during the concat.
The logic has been fixed for this. Also, some of the logic was updated to use the more current libcudf++ style.
Also added a test case for empty string narep.