### PR TITLE
[REVIEW] Disable ScatterValid and ScatterNull legacy tests due to recent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,7 @@
 - PR #4327 Preemptive dispatch fix for changes in dask#5973
 - PR #4358 Fix strings::concat where narep is an empty string
 - PR #4369 Fix race condition in gpuinflate
+- PR #4390 Disable ScatterValid and ScatterNull legacy tests
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/tests/copying/legacy/scalar_scatter_tests.cu
+++ b/cpp/tests/copying/legacy/scalar_scatter_tests.cu
@@ -136,7 +136,7 @@ TYPED_TEST(ScalarScatterTest, ScatterMultiColValid) {
   destination_table.destroy();
 }
 
-TYPED_TEST(ScalarScatterTest, ScatterValid) {
+TYPED_TEST(ScalarScatterTest, DISABLED_ScatterValid) {
   constexpr cudf::size_type target_size{1920};
 
   static_assert(0 == target_size % 3,
@@ -182,7 +182,7 @@ TYPED_TEST(ScalarScatterTest, ScatterValid) {
   destination_table.destroy();
 }
 
-TYPED_TEST(ScalarScatterTest, ScatterNull) {
+TYPED_TEST(ScalarScatterTest, DISABLED_ScatterNull) {
   constexpr cudf::size_type target_size{1920};
 
   static_assert(0 == target_size % 3,


### PR DESCRIPTION
Since the legacy tests will be deleted soon, disabling these intermittently failing legacy tests.
