### PR TITLE
[REVIEW] Make scalar destructor virtual.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,7 @@
 - PR #4358 Fix strings::concat where narep is an empty string
 - PR #4369 Fix race condition in gpuinflate
 - PR #4390 Disable ScatterValid and ScatterNull legacy tests
+- PR #4399 Make scalar destructor virtual.
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -40,7 +40,7 @@ namespace cudf {
  */
 class scalar {
  public:
-  ~scalar() = default;
+  virtual ~scalar() = default;
   scalar(scalar&& other) = default;
   scalar(scalar const& other) = default;
   scalar& operator=(scalar const& other) = delete;


### PR DESCRIPTION

Ensures derived class destructors get called in all circumstances.

Closes https://github.com/rapidsai/cudf/issues/4396