### PR TITLE
[REVIEW] Fix join_strings logic with all-null strings and non-null narep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Bug Fixes
 - PR #4386 Update Java package to 0.14
+- PR #4402 Fix cudf::strings::join_strings logic with all-null strings and null narep
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/cpp/src/strings/combine.cu
+++ b/cpp/src/strings/combine.cu
@@ -197,7 +197,7 @@ std::unique_ptr<column> join_strings( strings_column_view const& strings,
     // only one entry so it is either all valid or all null
     size_type null_count = 0;
     rmm::device_buffer null_mask; // init to null null-mask
-    if( strings.null_count()==strings_count )
+    if( strings.null_count()==strings_count && d_narep.is_null() )
     {
         null_mask = create_null_mask(1,cudf::mask_state::ALL_NULL,stream,mr);
         null_count = 1;

--- a/cpp/tests/strings/combine_tests.cu
+++ b/cpp/tests/strings/combine_tests.cu
@@ -125,3 +125,20 @@ TEST_F(StringsCombineTest, JoinZeroSizeStringsColumn)
     auto results = cudf::strings::join_strings(strings_view);
     cudf::test::expect_strings_empty(results->view());
 }
+
+TEST_F(StringsCombineTest, JoinAllNullStringsColumn)
+{
+    cudf::test::strings_column_wrapper strings( {"","",""}, {0,0,0} );
+
+    auto results = cudf::strings::join_strings(cudf::strings_column_view(strings));
+    cudf::test::strings_column_wrapper expected1( {""}, {0} );
+    cudf::test::expect_columns_equal(*results,expected1);
+
+    results = cudf::strings::join_strings(cudf::strings_column_view(strings),cudf::string_scalar(""),cudf::string_scalar("3"));
+    cudf::test::strings_column_wrapper expected2( {"333"} );
+    cudf::test::expect_columns_equal(*results,expected2);
+
+    results = cudf::strings::join_strings(cudf::strings_column_view(strings),cudf::string_scalar("-"),cudf::string_scalar("*"));
+    cudf::test::strings_column_wrapper expected3( {"*-*-*"} );
+    cudf::test::expect_columns_equal(*results,expected3);
+}


### PR DESCRIPTION
The `join_strings()` function returns a column with a single string concatenating all the strings from the input column. In the case where all the strings in the input column are null, the logic was incorrectly setting the null-mask for the output column.
Added several tests for this case as well.
Closes #4395 