### PR TITLE
[REVIEW] Port nvstrings (Sub)string Comparisons functions to cuDF Python/Cython

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
 - PR #4339 Port libcudf strings `wrap` api to cython/python
 - PR #4311 Port nvstrings String Manipulations functions to cuDF Python/Cython
 - PR #4373 Port nvstrings Regular Expressions functions to cuDF Python/Cython
+- PR #4405 Port nvstrings (Sub)string Comparisons functions to cuDF Python/Cython
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/_libxx/cpp/strings/contains.pxd
+++ b/python/cudf/cudf/_libxx/cpp/strings/contains.pxd
@@ -15,3 +15,7 @@ cdef extern from "cudf/strings/contains.hpp" namespace "cudf::strings" nogil:
     cdef unique_ptr[column] count_re(
         column_view source_strings,
         string pattern) except +
+
+    cdef unique_ptr[column] matches_re(
+        column_view source_strings,
+        string pattern) except +

--- a/python/cudf/cudf/_libxx/cpp/strings/find.pxd
+++ b/python/cudf/cudf/_libxx/cpp/strings/find.pxd
@@ -5,10 +5,30 @@ from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
 from cudf._libxx.cpp.column.column cimport column
 from cudf._libxx.cpp.scalar.scalar cimport string_scalar
-
+from cudf._libxx.cpp.types cimport size_type
 
 cdef extern from "cudf/strings/find.hpp" namespace "cudf::strings" nogil:
 
     cdef unique_ptr[column] contains(
         column_view source_strings,
         string_scalar target) except +
+
+    cdef unique_ptr[column] ends_with(
+        column_view source_strings,
+        string_scalar target) except +
+
+    cdef unique_ptr[column] starts_with(
+        column_view source_strings,
+        string_scalar target) except +
+
+    cdef unique_ptr[column] find(
+        column_view source_strings,
+        string_scalar target,
+        size_type start,
+        size_type stop) except +
+
+    cdef unique_ptr[column] rfind(
+        column_view source_strings,
+        string_scalar target,
+        size_type start,
+        size_type stop) except +

--- a/python/cudf/cudf/_libxx/cpp/strings/find_multiple.pxd
+++ b/python/cudf/cudf/_libxx/cpp/strings/find_multiple.pxd
@@ -1,0 +1,12 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+from cudf._libxx.cpp.column.column_view cimport column_view
+from libcpp.memory cimport unique_ptr
+from cudf._libxx.cpp.column.column cimport column
+
+cdef extern from "cudf/strings/find_multiple.hpp" namespace "cudf::strings" \
+        nogil:
+
+    cdef unique_ptr[column] find_multiple(
+        column_view source_strings,
+        column_view targets) except +

--- a/python/cudf/cudf/_libxx/strings/char_types.pyx
+++ b/python/cudf/cudf/_libxx/strings/char_types.pyx
@@ -133,3 +133,20 @@ def is_lower(Column source_strings):
         ))
 
     return Column.from_unique_ptr(move(c_result))
+
+
+def is_space(Column source_strings):
+    """
+    Returns a Column of boolean values with True for `source_strings`
+    that contains all characters which are spaces only.
+    """
+    cdef unique_ptr[column] c_result
+    cdef column_view source_view = source_strings.view()
+
+    with nogil:
+        c_result = move(cpp_all_characters_of_type(
+            source_view,
+            string_character_types.SPACE
+        ))
+
+    return Column.from_unique_ptr(move(c_result))

--- a/python/cudf/cudf/_libxx/strings/contains.pyx
+++ b/python/cudf/cudf/_libxx/strings/contains.pyx
@@ -55,8 +55,8 @@ def count_re(Column source_strings, object reg_ex):
 
 def match_re(Column source_strings, object reg_ex):
     """
-    Returns a Column with count of occurrences of `reg_ex` in
-    each string of `source_strings`
+    Returns a Column with each value True if the string matches `reg_ex`
+    regular expression with each record of `source_strings`
     """
     cdef unique_ptr[column] c_result
     cdef column_view source_view = source_strings.view()

--- a/python/cudf/cudf/_libxx/strings/contains.pyx
+++ b/python/cudf/cudf/_libxx/strings/contains.pyx
@@ -9,7 +9,8 @@ from cudf._libxx.cpp.column.column cimport column
 
 from cudf._libxx.cpp.strings.contains cimport (
     contains_re as cpp_contains_re,
-    count_re as cpp_count_re
+    count_re as cpp_count_re,
+    matches_re as cpp_matches_re
 )
 from libcpp.string cimport string
 
@@ -45,6 +46,25 @@ def count_re(Column source_strings, object reg_ex):
 
     with nogil:
         c_result = move(cpp_count_re(
+            source_view,
+            reg_ex_string
+        ))
+
+    return Column.from_unique_ptr(move(c_result))
+
+
+def match_re(Column source_strings, object reg_ex):
+    """
+    Returns a Column with count of occurrences of `reg_ex` in
+    each string of `source_strings`
+    """
+    cdef unique_ptr[column] c_result
+    cdef column_view source_view = source_strings.view()
+
+    cdef string reg_ex_string = <string>str(reg_ex).encode()
+
+    with nogil:
+        c_result = move(cpp_matches_re(
             source_view,
             reg_ex_string
         ))

--- a/python/cudf/cudf/_libxx/strings/find.pyx
+++ b/python/cudf/cudf/_libxx/strings/find.pyx
@@ -7,9 +7,14 @@ from cudf._libxx.column cimport Column
 from cudf._libxx.scalar cimport Scalar
 from cudf._libxx.cpp.column.column cimport column
 from cudf._libxx.cpp.scalar.scalar cimport string_scalar
+from cudf._libxx.cpp.types cimport size_type
 
 from cudf._libxx.cpp.strings.find cimport (
-    contains as cpp_contains
+    contains as cpp_contains,
+    ends_with as cpp_ends_with,
+    starts_with as cpp_starts_with,
+    find as cpp_find,
+    rfind as cpp_rfind
 )
 
 
@@ -27,6 +32,90 @@ def contains(Column source_strings, Scalar target):
         c_result = move(cpp_contains(
             source_view,
             scalar_str[0]
+        ))
+
+    return Column.from_unique_ptr(move(c_result))
+
+
+def endswith(Column source_strings, Scalar target):
+    """
+    Returns a Column of boolean values with True for `source_strings`
+    that contain strings that end with the pattern given in `target`.
+    """
+    cdef unique_ptr[column] c_result
+    cdef column_view source_view = source_strings.view()
+
+    cdef string_scalar* scalar_str = <string_scalar*>(target.c_value.get())
+
+    with nogil:
+        c_result = move(cpp_ends_with(
+            source_view,
+            scalar_str[0]
+        ))
+
+    return Column.from_unique_ptr(move(c_result))
+
+
+def startswith(Column source_strings, Scalar target):
+    """
+    Returns a Column of boolean values with True for `source_strings`
+    that contain strings that start with the pattern given in `target`.
+    """
+    cdef unique_ptr[column] c_result
+    cdef column_view source_view = source_strings.view()
+
+    cdef string_scalar* scalar_str = <string_scalar*>(target.c_value.get())
+
+    with nogil:
+        c_result = move(cpp_starts_with(
+            source_view,
+            scalar_str[0]
+        ))
+
+    return Column.from_unique_ptr(move(c_result))
+
+
+def find(Column source_strings,
+         Scalar target,
+         size_type start,
+         size_type end):
+    """
+
+    """
+    cdef unique_ptr[column] c_result
+    cdef column_view source_view = source_strings.view()
+
+    cdef string_scalar* scalar_str = <string_scalar*>(target.c_value.get())
+
+    with nogil:
+        c_result = move(cpp_find(
+            source_view,
+            scalar_str[0],
+            start,
+            end
+        ))
+
+    return Column.from_unique_ptr(move(c_result))
+
+
+def rfind(Column source_strings,
+          Scalar target,
+          size_type start,
+          size_type end):
+    """
+
+    """
+    cdef unique_ptr[column] c_result
+    cdef column_view source_view = source_strings.view()
+
+    cdef string_scalar* scalar_str = <string_scalar*>(target.c_value.get())
+
+    with nogil:
+        c_result = move(cpp_rfind(
+            source_view,
+            scalar_str[0],
+            start,
+            end
         ))
 
     return Column.from_unique_ptr(move(c_result))

--- a/python/cudf/cudf/_libxx/strings/find.pyx
+++ b/python/cudf/cudf/_libxx/strings/find.pyx
@@ -80,7 +80,10 @@ def find(Column source_strings,
          size_type start,
          size_type end):
     """
-
+    Returns a Column containing lowest indexes in each string of
+    `source_strings` that fully contain `target` string.
+    Scan portion of strings in `source_strings` can be
+    controlled by setting `start` and `end` values.
     """
     cdef unique_ptr[column] c_result
     cdef column_view source_view = source_strings.view()
@@ -103,7 +106,10 @@ def rfind(Column source_strings,
           size_type start,
           size_type end):
     """
-
+    Returns a Column containing highest indexes in each string of
+    `source_strings` that fully contain `target` string.
+    Scan portion of strings in `source_strings` can be
+    controlled by setting `start` and `end` values.
     """
     cdef unique_ptr[column] c_result
     cdef column_view source_view = source_strings.view()

--- a/python/cudf/cudf/_libxx/strings/find_multiple.pyx
+++ b/python/cudf/cudf/_libxx/strings/find_multiple.pyx
@@ -1,0 +1,28 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+from cudf._libxx.move cimport move
+from cudf._libxx.cpp.column.column_view cimport column_view
+from libcpp.memory cimport unique_ptr
+from cudf._libxx.column cimport Column
+from cudf._libxx.cpp.column.column cimport column
+
+from cudf._libxx.cpp.strings.find_multiple cimport (
+    find_multiple as cpp_find_multiple,
+)
+
+
+def find_multiple(Column source_strings, Column target_strings):
+    """
+
+    """
+    cdef unique_ptr[column] c_result
+    cdef column_view source_view = source_strings.view()
+    cdef column_view target_view = target_strings.view()
+
+    with nogil:
+        c_result = move(cpp_find_multiple(
+            source_view,
+            target_view
+        ))
+
+    return Column.from_unique_ptr(move(c_result))

--- a/python/cudf/cudf/_libxx/strings/find_multiple.pyx
+++ b/python/cudf/cudf/_libxx/strings/find_multiple.pyx
@@ -13,7 +13,8 @@ from cudf._libxx.cpp.strings.find_multiple cimport (
 
 def find_multiple(Column source_strings, Column target_strings):
     """
-
+    Returns a column with character position values where each
+    of the `target_strings` are found in each string of `source_strings`.
     """
     cdef unique_ptr[column] c_result
     cdef column_view source_view = source_strings.view()

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -38,9 +38,16 @@ from cudf._libxx.strings.char_types import (
 from cudf._libxx.strings.contains import (
     contains_re as cpp_contains_re,
     count_re as cpp_count_re,
+    match_re as cpp_match_re,
 )
 from cudf._libxx.strings.extract import extract as cpp_extract
-from cudf._libxx.strings.find import contains as cpp_contains
+from cudf._libxx.strings.find import (
+    contains as cpp_contains,
+    endswith as cpp_endswith,
+    find as cpp_find,
+    rfind as cpp_rfind,
+    startswith as cpp_startswith,
+)
 from cudf._libxx.strings.findall import findall as cpp_findall
 from cudf._libxx.strings.padding import (
     PadSide,
@@ -1548,6 +1555,87 @@ class StringMethods(object):
             the original Series/Index.
         """
         return self._return_or_inplace(cpp_isspace(self._column), **kwargs)
+
+    def endswith(self, pat, na=np.nan, **kwargs):
+        if na is not np.nan:
+            raise NotImplementedError("`na` parameter is not yet supported")
+
+        from cudf._libxx.scalar import Scalar
+
+        return self._return_or_inplace(
+            cpp_endswith(self._column, Scalar(pat, "str")), **kwargs
+        )
+
+    def startswith(self, pat, na=np.nan, **kwargs):
+        if na is not np.nan:
+            raise NotImplementedError("`na` parameter is not yet supported")
+
+        from cudf._libxx.scalar import Scalar
+
+        return self._return_or_inplace(
+            cpp_startswith(self._column, Scalar(pat, "str")), **kwargs
+        )
+
+    def find(self, sub, start=0, end=None, **kwargs):
+        from cudf._libxx.scalar import Scalar
+
+        if end is None:
+            end = -1
+
+        return self._return_or_inplace(
+            cpp_find(self._column, Scalar(sub, "str"), start, end), **kwargs
+        )
+
+    def rfind(self, sub, start=0, end=None, **kwargs):
+        from cudf._libxx.scalar import Scalar
+
+        if end is None:
+            end = -1
+        return self._return_or_inplace(
+            cpp_rfind(self._column, Scalar(sub, "str"), start, end), **kwargs
+        )
+
+    def index(self, sub, start=0, end=None, **kwargs):
+        from cudf._libxx.scalar import Scalar
+
+        if end is None:
+            end = -1
+
+        result = self._return_or_inplace(
+            cpp_find(self._column, Scalar(sub, "str"), start, end), **kwargs
+        )
+
+        if (result == -1).any():
+            raise ValueError("substring not found")
+        else:
+            return result
+
+    def rindex(self, sub, start=0, end=None, **kwargs):
+        from cudf._libxx.scalar import Scalar
+
+        if end is None:
+            end = -1
+
+        result = self._return_or_inplace(
+            cpp_rfind(self._column, Scalar(sub, "str"), start, end), **kwargs
+        )
+
+        if (result == -1).any():
+            raise ValueError("substring not found")
+        else:
+            return result
+
+    def match(self, pat, case=True, flags=0, na=np.nan, **kwargs):
+        if case is not True:
+            raise NotImplementedError("`case` parameter is not yet supported")
+        elif flags != 0:
+            raise NotImplementedError("`flags` parameter is not yet supported")
+        elif na is not np.nan:
+            raise NotImplementedError("`na` parameter is not yet supported")
+
+        return self._return_or_inplace(
+            cpp_match_re(self._column, pat), **kwargs
+        )
 
 
 class StringColumn(column.ColumnBase):

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -1574,11 +1574,10 @@ class StringMethods(object):
             pattern matches the end of each string element.
 
         """
-        na = kwargs.get("na", None)
-        if na is not None:
+        if "na" in kwargs:
             warnings.warn(
                 "`na` parameter is not yet supported, \
-                as input series is expected to have true strings"
+                as cudf uses native strings instead of Python objects"
             )
 
         from cudf._libxx.scalar import Scalar
@@ -1603,11 +1602,10 @@ class StringMethods(object):
             pattern matches the start of each string element.
 
         """
-        na = kwargs.get("na", None)
-        if na is not None:
+        if "na" in kwargs:
             warnings.warn(
                 "`na` parameter is not yet supported, \
-                as input series is expected to have true strings"
+                as cudf uses native strings instead of Python objects"
             )
 
         from cudf._libxx.scalar import Scalar
@@ -1770,11 +1768,10 @@ class StringMethods(object):
         elif flags != 0:
             raise NotImplementedError("`flags` parameter is not yet supported")
 
-        na = kwargs.get("na", None)
-        if na is not None:
+        if "na" in kwargs:
             warnings.warn(
                 "`na` parameter is not yet supported, \
-                as input series is expected to have true strings"
+                as cudf uses native strings instead of Python objects"
             )
 
         return self._return_or_inplace(

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -1558,7 +1558,7 @@ class StringMethods(object):
         """
         return self._return_or_inplace(cpp_isspace(self._column), **kwargs)
 
-    def endswith(self, pat, na=np.nan, **kwargs):
+    def endswith(self, pat, **kwargs):
         """
         Test if the end of each string element matches a pattern.
 
@@ -1574,8 +1574,12 @@ class StringMethods(object):
             pattern matches the end of each string element.
 
         """
-        if na is not np.nan:
-            raise NotImplementedError("`na` parameter is not yet supported")
+        na = kwargs.get("na", None)
+        if na is not None:
+            warnings.warn(
+                "`na` parameter is not yet supported, \
+                as input series is expected to have true strings"
+            )
 
         from cudf._libxx.scalar import Scalar
 
@@ -1583,7 +1587,7 @@ class StringMethods(object):
             cpp_endswith(self._column, Scalar(pat, "str")), **kwargs
         )
 
-    def startswith(self, pat, na=np.nan, **kwargs):
+    def startswith(self, pat, **kwargs):
         """
         Test if the start of each string element matches a pattern.
 
@@ -1599,8 +1603,12 @@ class StringMethods(object):
             pattern matches the start of each string element.
 
         """
-        if na is not np.nan:
-            raise NotImplementedError("`na` parameter is not yet supported")
+        na = kwargs.get("na", None)
+        if na is not None:
+            warnings.warn(
+                "`na` parameter is not yet supported, \
+                as input series is expected to have true strings"
+            )
 
         from cudf._libxx.scalar import Scalar
 
@@ -1743,7 +1751,7 @@ class StringMethods(object):
         else:
             return result
 
-    def match(self, pat, case=True, flags=0, na=np.nan, **kwargs):
+    def match(self, pat, case=True, flags=0, **kwargs):
         """
         Determine if each string matches a regular expression.
 
@@ -1761,8 +1769,13 @@ class StringMethods(object):
             raise NotImplementedError("`case` parameter is not yet supported")
         elif flags != 0:
             raise NotImplementedError("`flags` parameter is not yet supported")
-        elif na is not np.nan:
-            raise NotImplementedError("`na` parameter is not yet supported")
+
+        na = kwargs.get("na", None)
+        if na is not None:
+            warnings.warn(
+                "`na` parameter is not yet supported, \
+                as input series is expected to have true strings"
+            )
 
         return self._return_or_inplace(
             cpp_match_re(self._column, pat), **kwargs

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -1557,6 +1557,21 @@ class StringMethods(object):
         return self._return_or_inplace(cpp_isspace(self._column), **kwargs)
 
     def endswith(self, pat, na=np.nan, **kwargs):
+        """
+        Test if the end of each string element matches a pattern.
+
+        Parameters
+        ----------
+        pat : str
+            Character sequence. Regular expressions are not accepted.
+
+        Returns
+        -------
+        Series or Index of bool
+            A Series of booleans indicating whether the given
+            pattern matches the end of each string element.
+
+        """
         if na is not np.nan:
             raise NotImplementedError("`na` parameter is not yet supported")
 
@@ -1567,6 +1582,21 @@ class StringMethods(object):
         )
 
     def startswith(self, pat, na=np.nan, **kwargs):
+        """
+        Test if the start of each string element matches a pattern.
+
+        Parameters
+        ----------
+        pat : str
+            Character sequence. Regular expressions are not accepted.
+
+        Returns
+        -------
+        Series or Index of bool
+            A Series of booleans indicating whether the given
+            pattern matches the start of each string element.
+
+        """
         if na is not np.nan:
             raise NotImplementedError("`na` parameter is not yet supported")
 
@@ -1577,6 +1607,27 @@ class StringMethods(object):
         )
 
     def find(self, sub, start=0, end=None, **kwargs):
+        """
+        Return lowest indexes in each strings in the Series/Index
+        where the substring is fully contained between [start:end].
+        Return -1 on failure.
+
+        Parameters
+        ----------
+        sub : str
+            Substring being searched.
+
+        start : int
+            Left edge index.
+
+        end : int
+            Right edge index.
+
+        Returns
+        -------
+        Series or Index of int
+
+        """
         from cudf._libxx.scalar import Scalar
 
         if end is None:
@@ -1587,6 +1638,27 @@ class StringMethods(object):
         )
 
     def rfind(self, sub, start=0, end=None, **kwargs):
+        """
+        Return highest indexes in each strings in the Series/Index
+        where the substring is fully contained between [start:end].
+        Return -1 on failure.
+
+        Parameters
+        ----------
+        sub : str
+            Substring being searched.
+
+        start : int
+            Left edge index.
+
+        end : int
+            Right edge index.
+
+        Returns
+        -------
+        Series or Index of int
+
+        """
         from cudf._libxx.scalar import Scalar
 
         if end is None:
@@ -1596,6 +1668,28 @@ class StringMethods(object):
         )
 
     def index(self, sub, start=0, end=None, **kwargs):
+        """
+        Return lowest indexes in each strings where the substring
+        is fully contained between [start:end]. This is the same
+        as str.find except instead of returning -1, it raises a ValueError
+        when the substring is not found.
+
+        Parameters
+        ----------
+        sub : str
+            Substring being searched.
+
+        start : int
+            Left edge index.
+
+        end : int
+            Right edge index.
+
+        Returns
+        -------
+        Series or Index of object
+
+        """
         from cudf._libxx.scalar import Scalar
 
         if end is None:
@@ -1611,6 +1705,28 @@ class StringMethods(object):
             return result
 
     def rindex(self, sub, start=0, end=None, **kwargs):
+        """
+        Return highest indexes in each strings where the substring
+        is fully contained between [start:end]. This is the same
+        as str.rfind except instead of returning -1, it raises a ValueError
+        when the substring is not found.
+
+        Parameters
+        ----------
+        sub : str
+            Substring being searched.
+
+        start : int
+            Left edge index.
+
+        end : int
+            Right edge index.
+
+        Returns
+        -------
+        Series or Index of object
+
+        """
         from cudf._libxx.scalar import Scalar
 
         if end is None:
@@ -1626,6 +1742,19 @@ class StringMethods(object):
             return result
 
     def match(self, pat, case=True, flags=0, na=np.nan, **kwargs):
+        """
+        Determine if each string matches a regular expression.
+
+        Parameters
+        ----------
+        pat : str
+            Character sequence or regular expression.
+
+        Returns
+        -------
+        Series or Index of boolean values.
+
+        """
         if case is not True:
             raise NotImplementedError("`case` parameter is not yet supported")
         elif flags != 0:

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -1544,7 +1544,9 @@ class StringMethods(object):
             Series or Index of boolean values with the same length as
             the original Series/Index.
         """
-        return self._return_or_inplace(self._parent == "", **kwargs)
+        return self._return_or_inplace(
+            (self._parent == "").fillna(False), **kwargs
+        )
 
     def isspace(self, **kwargs):
         """

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -32,6 +32,7 @@ from cudf._libxx.strings.char_types import (
     is_digit as cpp_is_digit,
     is_lower as cpp_is_lower,
     is_numeric as cpp_is_numeric,
+    is_space as cpp_isspace,
     is_upper as cpp_is_upper,
 )
 from cudf._libxx.strings.contains import (
@@ -1527,6 +1528,26 @@ class StringMethods(object):
         return self._return_or_inplace(
             cpp_findall(self._column, pat), **kwargs
         )
+
+    def isempty(self, **kwargs):
+        """
+        Check whether each string is a an empty string.
+
+        Returns : Series or Index of bool
+            Series or Index of boolean values with the same length as
+            the original Series/Index.
+        """
+        return self._return_or_inplace(self._parent == "", **kwargs)
+
+    def isspace(self, **kwargs):
+        """
+        Check whether all characters in each string are whitespace.
+
+        Returns : Series or Index of bool
+            Series or Index of boolean values with the same length as
+            the original Series/Index.
+        """
+        return self._return_or_inplace(cpp_isspace(self._column), **kwargs)
 
 
 class StringColumn(column.ColumnBase):

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -1663,7 +1663,7 @@ def test_string_str_index(data, sub, er):
         assert not er
 
     try:
-        ps.str.index(sub)
+        gs.str.index(sub)
     except er:
         pass
     else:
@@ -1701,7 +1701,7 @@ def test_string_str_rindex(data, sub, er):
         assert not er
 
     try:
-        ps.str.index(sub)
+        gs.str.index(sub)
     except er:
         pass
     else:

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -1163,6 +1163,9 @@ def test_string_char_case(case_op, data):
     assert_eq(gs.str.isalpha(), ps.str.isalpha())
     assert_eq(gs.str.isdigit(), ps.str.isdigit())
     assert_eq(gs.str.isnumeric(), ps.str.isnumeric())
+    assert_eq(gs.str.isspace(), ps.str.isspace())
+
+    assert_eq(gs.str.isempty(), ps == "")
 
 
 @pytest.mark.parametrize(
@@ -1524,3 +1527,203 @@ def test_string_replace_with_backrefs(find, replace):
     got = gs.str.replace_with_backrefs(find, replace)
     expected = ps.str.replace(find, replace, regex=True)
     assert_eq(got, expected)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        ["abc", "xyz", "a", "ab", "123", "097"],
+        ["A B", "1.5", "3,000"],
+        ["23", "³", "⅕", ""],
+        [" ", "\t\r\n ", ""],
+        ["$", "B", "Aab$", "$$ca", "C$B$", "cat"],
+        ["line to be wrapped", "another line to be wrapped"],
+        ["hello", "there", "world", "+1234", "-1234", None, "accént", ""],
+        ["1. Ant.  ", "2. Bee!\n", "3. Cat?\t", None],
+    ],
+)
+@pytest.mark.parametrize(
+    "pat",
+    [
+        # TODO, PREM: Uncomment after this issue is fixed
+        # '',
+        # None,
+        " ",
+        "a",
+        "abc",
+        "cat",
+        "$",
+        "\n",
+    ],
+)
+def test_string_starts_ends(data, pat):
+    ps = pd.Series(data)
+    gs = Series(data)
+
+    assert_eq(ps.str.startswith(pat), gs.str.startswith(pat))
+    assert_eq(ps.str.endswith(pat), gs.str.endswith(pat))
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        ["abc", "xyz", "a", "ab", "123", "097"],
+        ["A B", "1.5", "3,000"],
+        ["23", "³", "⅕", ""],
+        [" ", "\t\r\n ", ""],
+        ["$", "B", "Aab$", "$$ca", "C$B$", "cat"],
+        ["line to be wrapped", "another line to be wrapped"],
+        ["hello", "there", "world", "+1234", "-1234", None, "accént", ""],
+        ["1. Ant.  ", "2. Bee!\n", "3. Cat?\t", None],
+    ],
+)
+@pytest.mark.parametrize(
+    "sub",
+    [
+        # TODO, PREM: Uncomment after this issue is fixed
+        # '',
+        # None,
+        " ",
+        "a",
+        "abc",
+        "cat",
+        "$",
+        "\n",
+    ],
+)
+def test_string_find(data, sub):
+    ps = pd.Series(data)
+    gs = Series(data)
+
+    assert_eq(ps.str.find(sub).fillna(-1), gs.str.find(sub), check_dtype=False)
+    assert_eq(
+        ps.str.find(sub, start=1).fillna(-1),
+        gs.str.find(sub, start=1),
+        check_dtype=False,
+    )
+    assert_eq(
+        ps.str.find(sub, end=10).fillna(-1),
+        gs.str.find(sub, end=10),
+        check_dtype=False,
+    )
+    assert_eq(
+        ps.str.find(sub, start=2, end=10).fillna(-1),
+        gs.str.find(sub, start=2, end=10),
+        check_dtype=False,
+    )
+
+    assert_eq(
+        ps.str.rfind(sub).fillna(-1), gs.str.rfind(sub), check_dtype=False
+    )
+    assert_eq(
+        ps.str.rfind(sub, start=1).fillna(-1),
+        gs.str.rfind(sub, start=1),
+        check_dtype=False,
+    )
+    assert_eq(
+        ps.str.rfind(sub, end=10).fillna(-1),
+        gs.str.rfind(sub, end=10),
+        check_dtype=False,
+    )
+    assert_eq(
+        ps.str.rfind(sub, start=2, end=10).fillna(-1),
+        gs.str.rfind(sub, start=2, end=10),
+        check_dtype=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "data,sub,er",
+    [
+        (["abc", "xyz", "a", "ab", "123", "097"], "a", ValueError),
+        (["A B", "1.5", "3,000"], "abc", ValueError),
+        (["23", "³", "⅕", ""], "⅕", ValueError),
+        ([" ", "\t\r\n ", ""], "\n", ValueError),
+        (["$", "B", "Aab$", "$$ca", "C$B$", "cat"], "$", ValueError),
+        (["line to be wrapped", "another line to be wrapped"], " ", None),
+        (
+            ["hello", "there", "world", "+1234", "-1234", None, "accént", ""],
+            "+",
+            ValueError,
+        ),
+    ],
+)
+def test_string_str_index(data, sub, er):
+    ps = pd.Series(data)
+    gs = Series(data)
+
+    if er is None:
+        assert_eq(ps.str.index(sub), gs.str.index(sub), check_dtype=False)
+
+    try:
+        ps.str.index(sub)
+    except er:
+        pass
+    else:
+        assert not er
+
+    try:
+        ps.str.index(sub)
+    except er:
+        pass
+    else:
+        assert not er
+
+
+@pytest.mark.parametrize(
+    "data,sub,er",
+    [
+        (["abc", "xyz", "a", "ab", "123", "097"], "a", ValueError),
+        (["A B", "1.5", "3,000"], "abc", ValueError),
+        (["23", "³", "⅕", ""], "⅕", ValueError),
+        ([" ", "\t\r\n ", ""], "\n", ValueError),
+        (["$", "B", "Aab$", "$$ca", "C$B$", "cat"], "$", ValueError),
+        (["line to be wrapped", "another line to be wrapped"], " ", None),
+        (
+            ["hello", "there", "world", "+1234", "-1234", None, "accént", ""],
+            "+",
+            ValueError,
+        ),
+    ],
+)
+def test_string_str_rindex(data, sub, er):
+    ps = pd.Series(data)
+    gs = Series(data)
+
+    if er is None:
+        assert_eq(ps.str.rindex(sub), gs.str.rindex(sub), check_dtype=False)
+
+    try:
+        ps.str.index(sub)
+    except er:
+        pass
+    else:
+        assert not er
+
+    try:
+        ps.str.index(sub)
+    except er:
+        pass
+    else:
+        assert not er
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        ["abc", "xyz", "a", "ab", "123", "097"],
+        ["A B", "1.5", "3,000"],
+        ["23", "³", "⅕", ""],
+        [" ", "\t\r\n ", ""],
+        ["$", "B", "Aab$", "$$ca", "C$B$", "cat"],
+        ["line to be wrapped", "another line to be wrapped"],
+        ["hello", "there", "world", "+1234", "-1234", None, "accént", ""],
+        ["1. Ant.  ", "2. Bee!\n", "3. Cat?\t", None],
+    ],
+)
+@pytest.mark.parametrize("pat", ["", " ", "a", "abc", "cat", "$", "\n"])
+def test_string_str_match(data, pat):
+    ps = pd.Series(data)
+    gs = Series(data)
+
+    assert_eq(ps.str.match(pat), gs.str.match(pat))


### PR DESCRIPTION
This resolves: #3990 

Ported

- [x] `nvstrings.nvstrings.is_empty` --> `Series.str.isempty` (No built-in Pandas equivalent)
- [x] `nvstrings.nvstrings.isspace` --> `Series.str.isspace` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.isspace.html#pandas.Series.str.isspace)
- [x] `nvstrings.nvstrings.endswith` --> `Series.str.endswith` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.endswith.html#pandas.Series.str.endswith)
- [x] `nvstrings.nvstrings.startswith` --> `Series.str.startswith` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.startswith.html#pandas.Series.str.startswith)
- [x] `nvstrings.nvstrings.find` --> `Series.str.find` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.find.html#pandas.Series.str.find)
- [x] `nvstrings.nvstrings.rfind` --> `Series.str.rfind` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.rfind.html#pandas.Series.str.rfind)
- [x] `nvstrings.nvstrings.index` --> `Series.str.index` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.index.html#pandas.Series.str.index)
- [x] `nvstrings.nvstrings.match` --> `Series.str.match` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.match.html#pandas.Series.str.match)
- [x] `nvstrings.nvstrings.rindex` --> `Series.str.rindex` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.rindex.html#pandas.Series.str.rindex)
- [x] `nvstrings.nvstrings.find_multiple` --> `Series.str.find` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.find.html#pandas.Series.str.find)
- [x] `nvstrings.nvstrings.find_from` --> `Series.str.find` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.find.html#pandas.Series.str.find)


~~- [ ] `nvstrings.nvstrings.match_strings` --> `Series.str.match` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.match.html#pandas.Series.str.match)~~ **Not porting this, as `match_strings` isn't implemented.**
- [x] Tests & doc.






<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
