### PR TITLE
[REVIEW] Fix sorted merge issue with null values and ascending=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,7 @@
 - PR #4358 Fix strings::concat where narep is an empty string
 - PR #4369 Fix race condition in gpuinflate
 - PR #4390 Disable ScatterValid and ScatterNull legacy tests
+- PR #4406 Fix sorted merge issue with null values and ascending=False
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/python/cudf/cudf/_libxx/merge.pyx
+++ b/python/cudf/cudf/_libxx/merge.pyx
@@ -44,6 +44,12 @@ def merge_sorted(
     column_order = (libcudf_types.order.ASCENDING
                     if ascending
                     else libcudf_types.order.DESCENDING)
+
+    if ascending == False:
+        if na_position == "last":
+            na_position = "first"
+        else:
+            na_position = "last"
     null_precedence = (
         libcudf_types.null_order.BEFORE if na_position == "first"
         else libcudf_types.null_order.AFTER

--- a/python/cudf/cudf/_libxx/merge.pyx
+++ b/python/cudf/cudf/_libxx/merge.pyx
@@ -45,7 +45,7 @@ def merge_sorted(
                     if ascending
                     else libcudf_types.order.DESCENDING)
 
-    if ascending == False:
+    if ascending is False:
         if na_position == "last":
             na_position = "first"
         else:

--- a/python/cudf/cudf/tests/test_reshape.py
+++ b/python/cudf/cudf/tests/test_reshape.py
@@ -266,7 +266,7 @@ def test_df_merge_sorted(nparts, keys, na_position, ascending):
     keys_1 = keys or ["timestamp"]
     # Null values NOT currently supported with Categorical data
     # or when `ascending=False`
-    add_null = ascending and keys_1[0] not in ("name")
+    add_null = keys_1[0] not in ("name")
     df, dfs = _prepare_merge_sorted_test(
         size,
         nparts,
@@ -314,7 +314,7 @@ def test_df_merge_sorted_ignore_index(keys, na_position, ascending):
     keys_1 = keys or ["timestamp"]
     # Null values NOT currently supported with Categorical data
     # or when `ascending=False`
-    add_null = ascending and keys_1[0] not in ("name")
+    add_null = keys_1[0] not in ("name")
     df, dfs = _prepare_merge_sorted_test(
         size,
         nparts,


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
libucdf++ follows the following rule,
```
Ascending, null_order::AFTER
1, 2, 3, NULL
Descending, null_order::AFTER
NULL, 3, 2, 1
Ascending, null_order::BEFORE
NULL, 1, 2, 3
Descending, null_order::BEFORE
3, 2, 1, NULL
```
and python/cython had to handle situation where `ascending=False` to reverse na_postion from "first" to "last" and vice-versa. 

closes #4246 