### PR TITLE
Tighten up Dask serialization checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,7 @@
 - PR #4369 Fix race condition in gpuinflate
 - PR #4390 Disable ScatterValid and ScatterNull legacy tests
 - PR #4406 Fix sorted merge issue with null values and ascending=False
+- PR #4423 Tighten up Dask serialization checks
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -23,7 +23,7 @@ try:
     def cuda_serialize_cudf_object(x):
         with log_errors():
             header, frames = x.serialize()
-            assert all(isinstance(f, cudf.core.buffer.Buffer) for f in frames)
+            assert all((type(f) is cudf.core.buffer.Buffer) for f in frames)
             return header, frames
 
     # all (de-)serializtion are attached to cudf Objects:

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -39,6 +39,11 @@ try:
     @dask_deserialize.register(serializable_classes)
     def deserialize_cudf_object(header, frames):
         with log_errors():
+            if header["serializer"] == "cuda":
+                assert all(hasattr(f, "__cuda_array_interface__") for f in frames)
+            if header["serializer"] == "dask":
+                frames = [memoryview(f) for f in frames]
+
             cudf_typ = pickle.loads(header["type-serialized"])
             cudf_obj = cudf_typ.deserialize(header, frames)
             return cudf_obj

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -40,7 +40,9 @@ try:
     def deserialize_cudf_object(header, frames):
         with log_errors():
             if header["serializer"] == "cuda":
-                assert all(hasattr(f, "__cuda_array_interface__") for f in frames)
+                assert all(
+                    hasattr(f, "__cuda_array_interface__") for f in frames
+                )
             if header["serializer"] == "dask":
                 frames = [memoryview(f) for f in frames]
 

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -30,8 +30,8 @@ try:
     # Series/DataFrame/Index/Column/Buffer/etc
     @dask_serialize.register(serializable_classes)
     def dask_serialize_cudf_object(x):
+        header, frames = cuda_serialize_cudf_object(x)
         with log_errors():
-            header, frames = x.serialize()
             frames = [f.to_host_array().data for f in frames]
             return header, frames
 


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/4421

Adds a few checks around serialization. Some of these are safe-guards. Some of these will raise errors to catch problematic behavior we have seen. Hopefully this will make sure we are getting top-performance when serializing. Also should make it easier to catch the cases where we are not.

cc @cjnolet (who raised this point offline)
cc @dantegd (for awareness)