### PR TITLE
[REVIEW] Change NVTX to always be linked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,7 @@
 - PR #4445 Fix string issue for parquet reader and support `keep_index` for `scatter_to_tables`
 - PR #4423 Tighten up Dask serialization checks
 - PR #4434 Fix join_strings logic with all-null strings and non-null narep
+- PR #4464 Update Cmake to always link in libnvToolsExt
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -764,12 +764,19 @@ add_dependencies(cudf stringify_run)
 ###################################################################################################
 # - build options ---------------------------------------------------------------------------------
 
+
+# Link NVTX library
+find_library(NVTX_LIBRARY nvToolsExt PATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+target_link_libraries(cudf ${NVTX_LIBRARY})
+
 option(USE_NVTX "Build with NVTX support" ON)
 if(USE_NVTX)
     message(STATUS "Using Nvidia Tools Extension")
-    find_library(NVTX_LIBRARY nvToolsExt PATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
-    target_link_libraries(cudf ${NVTX_LIBRARY})
+    # The `USE_NVTX` macro is deprecated
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_NVTX")
+else()
+    # Makes NVTX APIs no-ops
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDISABLE_NVTX")
 endif(USE_NVTX)
 
 option(HT_DEFAULT_ALLOCATOR "Use the default allocator for hash tables" ON)


### PR DESCRIPTION
The previous `USE_NVTX` cmake configuration was based on the old libcudf NVTX APIs that would completely avoid the need to link `libnvToolsExt` into the library. That wasn't the best way to do things. Now that https://github.com/rapidsai/cudf/pull/4304  was merged, using `USE_NVTX=OFF` will break builds. 

Instead, we should always link `libnvToolsExt` and instead make use of the `DISABLE_NVTX` macro to make calls to NVTX APIs be no-ops. 

- [x] Updates the cmake config so that libnvToolsExt is always linked.
- [x] Adds using the `DISALBE_NVTX` macro to make NVTX APIs no-ops.
