### PR TITLE
[REVIEW] Fix string_scalar.value to return an empty string_view for empty string-scalar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,7 @@
 - PR #4465 Fix use_pandas_index having no effect in libcudf++ parquet reader
 - PR #4464 Update Cmake to always link in libnvToolsExt
 - PR #4467 Fix dropna issue for a DataFrame having np.nan
+- PR #4480 Fix string_scalar.value to return an empty string_view for empty string-scalar
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -304,7 +304,9 @@ class string_scalar : public scalar {
    * 
    * @param stream The CUDA stream to do the operation in
    */
-  value_type value(cudaStream_t stream = 0) const { return value_type{data(), size()}; }
+  value_type value(cudaStream_t stream = 0) const {
+    return (is_valid(stream) && size()==0) ? value_type{"",0} : value_type{data(), size()};
+  }
   
   /**
    * @brief Returns the size of the string in bytes

--- a/cpp/include/cudf/scalar/scalar_device_view.cuh
+++ b/cpp/include/cudf/scalar/scalar_device_view.cuh
@@ -159,7 +159,8 @@ class string_scalar_device_view
    * @brief Returns string_view of the value of this scalar.
    */
   __device__ string_view value() const noexcept {
-    return string_view(this->data(), _size);
+    return (is_valid() && _size==0) ? string_view{"",0} :
+              string_view(this->data(), _size);
   }
 
   /**

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -468,6 +468,22 @@ TEST_F(BinaryOperationIntegrationTest, Equal_Vector_Vector_B8_STR_STR) {
   ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, EQUAL());
 }
 
+TEST_F(BinaryOperationIntegrationTest, Equal_Vector_Scalar_B8_STR_STR) {
+  using TypeOut = cudf::experimental::bool8;
+  using TypeLhs = std::string;
+  using TypeRhs = std::string;
+
+  using EQUAL = cudf::library::operation::Equal<TypeOut, TypeLhs, TypeRhs>;
+
+  auto rhs = cudf::test::strings_column_wrapper( {"eee", "bb", "<null>", "", "aa", "bbb", "ééé"} );
+  auto lhs = cudf::string_scalar("");
+  auto out = cudf::experimental::binary_operation(
+      lhs, rhs, cudf::experimental::binary_operator::EQUAL,
+      data_type(experimental::type_to_id<TypeOut>()));
+
+  ASSERT_BINOP<TypeOut, TypeLhs, TypeRhs>(*out, lhs, rhs, EQUAL());
+}
+
 TEST_F(BinaryOperationIntegrationTest, LessEqual_Vector_Vector_B8_STR_STR) {
   using TypeOut = cudf::experimental::bool8;
   using TypeLhs = std::string;


### PR DESCRIPTION
Reference #4477 
The `string_scalar` and `string_scalar_device_view` both create `string_view` instances from their `_data` and `_size` elements. Unfortunately, when these are created with empty strings the `_data` member variable is nullptr. When this is used to create the `string_view` it identifies the string as a null-string instead of an empty string.
This means that comparing empty strings from a strings column for example with a `string_view` created from an empty `string_scalar` will not match since `null != empty`.
This PR fixes the `value()` method for `string_scalar` and `string_scalar_device_view` to return the correct `string_view` for a valid, empty string.

Also, added binary-operation test for the EQUAL operator for this case as described in #4477 