### PR TITLE
Update Java memory resource handler for new supports_get_mem_info API [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,7 @@
 - PR #4467 Fix dropna issue for a DataFrame having np.nan
 - PR #4480 Fix string_scalar.value to return an empty string_view for empty string-scalar
 - PR #4474 Fix to not materialize RangeIndex in copy_categories
+- PR #4494 Update Java memory event handler for new RMM resource API
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -219,6 +219,10 @@ private:
         on_dealloc_threshold_method, "onDeallocThreshold", total_after);
   }
 
+  bool supports_get_mem_info() const noexcept override {
+    return resource->supports_get_mem_info();
+  }
+
   std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override {
     return resource->get_mem_info(stream);
   }


### PR DESCRIPTION
RMM 0.13 added a new `supports_get_mem_info` API for `device_memory_resource`.  This updates the Java RMM event handler resource wrapper to fix the JNI build.