### PR TITLE
skip-multi-gpu-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,7 +232,7 @@
 - PR #4279 Fix converting `np.float64` to Scalar
 - PR #4285 Add init files for cython pkgs and fix `setup.py`
 - PR #4287 Parquet reader: fix empty string potentially read as null
-- PR #4310 Fix empty values case in groupby 
+- PR #4310 Fix empty values case in groupby
 - PR #4297 Fix specification of package_data in setup.py
 - PR #4302 Fix `_is_local_filesystem` check
 - PR #4303 Parquet reader: fix empty columns missing from table
@@ -255,6 +255,7 @@
 - PR #4467 Fix dropna issue for a DataFrame having np.nan
 - PR #4480 Fix string_scalar.value to return an empty string_view for empty string-scalar
 - PR #4474 Fix to not materialize RangeIndex in copy_categories
+- PR #4496 Skip tests which require 2+ GPUs
 
 
 # cuDF 0.12.0 (04 Feb 2020)
@@ -269,7 +270,7 @@
 - PR #3555 Add column names support to libcudf++ io readers and writers
 - PR #3527 Add string functionality for merge API
 - PR #3610 Add memory_usage to DataFrame and Series APIs
-- PR #3557 Add contiguous_split() function. 
+- PR #3557 Add contiguous_split() function.
 - PR #3619 Support CuPy 7
 - PR #3604 Add nvtext ngrams-tokenize function
 - PR #3403 Define and implement new stack + tile APIs

--- a/python/dask_cudf/dask_cudf/tests/test_distributed.py
+++ b/python/dask_cudf/dask_cudf/tests/test_distributed.py
@@ -1,3 +1,4 @@
+import numba.cuda
 import pytest
 
 import dask
@@ -10,6 +11,11 @@ import cudf
 import dask_cudf
 
 dask_cuda = pytest.importorskip("dask_cuda")
+
+
+def more_than_two_gpus():
+    ngpus = len(numba.cuda.gpus)
+    return ngpus >= 2
 
 
 @pytest.mark.parametrize("delayed", [True, False])
@@ -44,6 +50,9 @@ def test_merge():
             assert len(res) == 4
 
 
+@pytest.mark.skipif(
+    not more_than_two_gpus(), reason="Machine does not have more than two GPUs"
+)
 def test_ucx_seriesgroupby():
     pytest.importorskip("ucp")
 


### PR DESCRIPTION
PR skips tests which requires 2+ GPUs

cc @dillon-cullinan 