### PR TITLE
[REVIEW] Adds in support for chunked writers to java [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Improvements
 - PR #4471 Consolidate partitioning functionality into a single header.
+- PR #4498 Adds in support for chunked writers to java
 
 ## Bug Fixes
 - PR #4386 Update Java package to 0.14

--- a/java/src/main/java/ai/rapids/cudf/HostBufferConsumer.java
+++ b/java/src/main/java/ai/rapids/cudf/HostBufferConsumer.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package ai.rapids.cudf;
+
+/**
+ * Provides a set of APIs for consuming host buffers.  This is typically used
+ * when writing out Tables in various file formats.
+ */
+public interface HostBufferConsumer {
+  /**
+   * Consume a buffer.
+   * @param buffer the buffer.  Be sure to close this buffer when you are done
+   *               with it or it will leak.
+   * @param len the length of the buffer that is valid.  The valid data will be 0 until len.
+   */
+  void handleBuffer(HostMemoryBuffer buffer, long len);
+
+  /**
+   * Indicates that no more buffers will be supplied.
+   */
+  default void done() {}
+}

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -221,6 +221,7 @@ public final class Table implements AutoCloseable {
   /**
    * Setup everything to write parquet formatted data to a file.
    * @param columnNames     names that correspond to the table columns
+   * @param nullable        true if the column can have nulls else false
    * @param metadataKeys    Metadata key names to place in the Parquet file
    * @param metadataValues  Metadata values corresponding to metadataKeys
    * @param compression     native compression codec ID
@@ -239,6 +240,7 @@ public final class Table implements AutoCloseable {
   /**
    * Setup everything to write parquet formatted data to a buffer.
    * @param columnNames     names that correspond to the table columns
+   * @param nullable        true if the column can have nulls else false
    * @param metadataKeys    Metadata key names to place in the Parquet file
    * @param metadataValues  Metadata values corresponding to metadataKeys
    * @param compression     native compression codec ID
@@ -286,6 +288,7 @@ public final class Table implements AutoCloseable {
   /**
    * Setup everything to write ORC formatted data to a file.
    * @param columnNames     names that correspond to the table columns
+   * @param nullable        true if the column can have nulls else false
    * @param metadataKeys    Metadata key names to place in the Parquet file
    * @param metadataValues  Metadata values corresponding to metadataKeys
    * @param compression     native compression codec ID
@@ -302,6 +305,7 @@ public final class Table implements AutoCloseable {
   /**
    * Setup everything to write ORC formatted data to a buffer.
    * @param columnNames     names that correspond to the table columns
+   * @param nullable        true if the column can have nulls else false
    * @param metadataKeys    Metadata key names to place in the Parquet file
    * @param metadataValues  Metadata values corresponding to metadataKeys
    * @param compression     native compression codec ID
@@ -689,6 +693,7 @@ public final class Table implements AutoCloseable {
       handle = 0;
       if (consumer != null) {
         consumer.done();
+        consumer = null;
       }
     }
   }
@@ -780,6 +785,7 @@ public final class Table implements AutoCloseable {
       handle = 0;
       if (consumer != null) {
         consumer.done();
+        consumer = null;
       }
     }
   }

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -180,10 +180,6 @@ public final class Table implements AutoCloseable {
   private static native long bound(long inputTable, long valueTable,
                                    boolean[] descFlags, boolean[] areNullsSmallest, boolean isUpperBound) throws CudfException;
 
-  private static native void writeORC(int compressionType, String[] colNames, String[] metadataKeys,
-                                      String[] metadataValues, String outputFileName, long buffer,
-                                      long bufferLength, long tableToWrite) throws CudfException;
-
   /**
    * Ugly long function to read CSV.  This is a long function to avoid the overhead of reaching
    * into a java
@@ -223,18 +219,54 @@ public final class Table implements AutoCloseable {
                                            long address, long length, int timeUnit) throws CudfException;
 
   /**
-   * Write Parquet formatted data.
-   * @param table           handle to the native table
+   * Setup everything to write parquet formatted data to a file.
    * @param columnNames     names that correspond to the table columns
    * @param metadataKeys    Metadata key names to place in the Parquet file
    * @param metadataValues  Metadata values corresponding to metadataKeys
    * @param compression     native compression codec ID
    * @param statsFreq       native statistics frequency ID
    * @param filename        local output path
+   * @return a handle that is used in later calls to writeParquetChunk and writeParquetEnd.
    */
-  private static native void writeParquet(long table, String[] columnNames,
-      String[] metadataKeys, String[] metadataValues,
-      int compression, int statsFreq, String filename) throws CudfException;
+  private static native long writeParquetFileBegin(String[] columnNames,
+                                               boolean[] nullable,
+                                               String[] metadataKeys,
+                                               String[] metadataValues,
+                                               int compression,
+                                               int statsFreq,
+                                               String filename) throws CudfException;
+
+  /**
+   * Setup everything to write parquet formatted data to a buffer.
+   * @param columnNames     names that correspond to the table columns
+   * @param metadataKeys    Metadata key names to place in the Parquet file
+   * @param metadataValues  Metadata values corresponding to metadataKeys
+   * @param compression     native compression codec ID
+   * @param statsFreq       native statistics frequency ID
+   * @param consumer        consumer of host buffers produced.
+   * @return a handle that is used in later calls to writeParquetChunk and writeParquetEnd.
+   */
+  private static native long writeParquetBufferBegin(String[] columnNames,
+                                                   boolean[] nullable,
+                                                   String[] metadataKeys,
+                                                   String[] metadataValues,
+                                                   int compression,
+                                                   int statsFreq,
+                                                   HostBufferConsumer consumer) throws CudfException;
+
+  /**
+   * Write out a table to an open handle.
+   * @param handle the handle to the writer.
+   * @param table the table to write out.
+   * @param tableMemSize the size of the table in bytes to help with memory allocation.
+   */
+  private static native void writeParquetChunk(long handle, long table, long tableMemSize);
+
+  /**
+   * Finish writing out parquet.
+   * @param handle the handle.  Do not use again once this returns.
+   */
+  private static native void writeParquetEnd(long handle);
 
   /**
    * Read in ORC formatted data.
@@ -250,6 +282,52 @@ public final class Table implements AutoCloseable {
   private static native long[] readORC(String[] filterColumnNames,
                                        String filePath, long address, long length,
                                        boolean usingNumPyTypes, int timeUnit) throws CudfException;
+
+  /**
+   * Setup everything to write ORC formatted data to a file.
+   * @param columnNames     names that correspond to the table columns
+   * @param metadataKeys    Metadata key names to place in the Parquet file
+   * @param metadataValues  Metadata values corresponding to metadataKeys
+   * @param compression     native compression codec ID
+   * @param filename        local output path
+   * @return a handle that is used in later calls to writeORCChunk and writeORCEnd.
+   */
+  private static native long writeORCFileBegin(String[] columnNames,
+                                                   boolean[] nullable,
+                                                   String[] metadataKeys,
+                                                   String[] metadataValues,
+                                                   int compression,
+                                                   String filename) throws CudfException;
+
+  /**
+   * Setup everything to write ORC formatted data to a buffer.
+   * @param columnNames     names that correspond to the table columns
+   * @param metadataKeys    Metadata key names to place in the Parquet file
+   * @param metadataValues  Metadata values corresponding to metadataKeys
+   * @param compression     native compression codec ID
+   * @param consumer        consumer of host buffers produced.
+   * @return a handle that is used in later calls to writeORCChunk and writeORCEnd.
+   */
+  private static native long writeORCBufferBegin(String[] columnNames,
+                                                     boolean[] nullable,
+                                                     String[] metadataKeys,
+                                                     String[] metadataValues,
+                                                     int compression,
+                                                     HostBufferConsumer consumer) throws CudfException;
+
+  /**
+   * Write out a table to an open handle.
+   * @param handle the handle to the writer.
+   * @param table the table to write out.
+   * @param tableMemSize the size of the table in bytes to help with memory allocation.
+   */
+  private static native void writeORCChunk(long handle, long table, long tableMemSize);
+
+  /**
+   * Finish writing out ORC.
+   * @param handle the handle.  Do not use again once this returns.
+   */
+  private static native void writeORCEnd(long handle);
 
   private static native long[] groupByAggregate(long inputTable, int[] keyIndices, int[] aggColumnsIndices,
                                                 int[] aggTypes, boolean ignoreNullKeys) throws CudfException;
@@ -569,11 +647,81 @@ public final class Table implements AutoCloseable {
     }
   }
 
+  private static class ParquetTableWriter implements TableWriter {
+    private long handle;
+    HostBufferConsumer consumer;
+
+    private ParquetTableWriter(ParquetWriterOptions options, File outputFile) {
+      this.consumer = null;
+      this.handle = writeParquetFileBegin(options.getColumnNames(),
+          options.getColumnNullability(),
+          options.getMetadataKeys(),
+          options.getMetadataValues(),
+          options.getCompressionType().nativeId,
+          options.getStatisticsFrequency().nativeId,
+          outputFile.getAbsolutePath());
+    }
+
+    private ParquetTableWriter(ParquetWriterOptions options, HostBufferConsumer consumer) {
+      this.handle = writeParquetBufferBegin(options.getColumnNames(),
+          options.getColumnNullability(),
+          options.getMetadataKeys(),
+          options.getMetadataValues(),
+          options.getCompressionType().nativeId,
+          options.getStatisticsFrequency().nativeId,
+          consumer);
+      this.consumer = consumer;
+    }
+
+    @Override
+    public void write(Table table) {
+      if (handle == 0) {
+        throw new IllegalStateException("Writer was already closed");
+      }
+      writeParquetChunk(handle, table.nativeHandle, table.getDeviceMemorySize());
+    }
+
+    @Override
+    public void close() throws CudfException {
+      if (handle != 0) {
+        writeParquetEnd(handle);
+      }
+      handle = 0;
+      if (consumer != null) {
+        consumer.done();
+      }
+    }
+  }
+
+  /**
+   * Get a table writer to write parquet data to a file.
+   * @param options the parquet writer options.
+   * @param outputFile where to write the file.
+   * @return a table writer to use for writing out multiple tables.
+   */
+  public static TableWriter writeParquetChunked(ParquetWriterOptions options, File outputFile) {
+    return new ParquetTableWriter(options, outputFile);
+  }
+
+  /**
+   * Get a table writer to write parquet data and handle each chunk with a callback.
+   * @param options the parquet writer options.
+   * @param consumer a class that will be called when host buffers are ready with parquet
+   *                 formatted data in them.
+   * @return a table writer to use for writing out multiple tables.
+   */
+  public static TableWriter writeParquetChunked(ParquetWriterOptions options,
+                                                HostBufferConsumer consumer) {
+    return new ParquetTableWriter(options, consumer);
+  }
+
   /**
    * Writes this table to a Parquet file on the host
    *
    * @param outputFile file to write the table to
+   * @deprecated please use writeParquetChunked instead
    */
+  @Deprecated
   public void writeParquet(File outputFile) {
     writeParquet(ParquetWriterOptions.DEFAULT, outputFile);
   }
@@ -583,35 +731,100 @@ public final class Table implements AutoCloseable {
    *
    * @param options parameters for the writer
    * @param outputFile file to write the table to
+   * @deprecated please use writeParquetChunked instead
    */
+  @Deprecated
   public void writeParquet(ParquetWriterOptions options, File outputFile) {
-    writeParquet(this.nativeHandle,
-        options.getColumnNames(),
-        options.getMetadataKeys(),
-        options.getMetadataValues(),
-        options.getCompressionType().nativeId,
-        options.getStatisticsFrequency().nativeId,
-        outputFile.getAbsolutePath());
+    try (TableWriter writer = writeParquetChunked(options, outputFile)) {
+      writer.write(this);
+    }
+  }
+
+  private static class ORCTableWriter implements TableWriter {
+    private long handle;
+    HostBufferConsumer consumer;
+
+    private ORCTableWriter(ORCWriterOptions options, File outputFile) {
+      this.handle = writeORCFileBegin(options.getColumnNames(),
+          options.getColumnNullability(),
+          options.getMetadataKeys(),
+          options.getMetadataValues(),
+          options.getCompressionType().nativeId,
+          outputFile.getAbsolutePath());
+      this.consumer = null;
+    }
+
+    private ORCTableWriter(ORCWriterOptions options, HostBufferConsumer consumer) {
+      this.handle = writeORCBufferBegin(options.getColumnNames(),
+          options.getColumnNullability(),
+          options.getMetadataKeys(),
+          options.getMetadataValues(),
+          options.getCompressionType().nativeId,
+          consumer);
+      this.consumer = consumer;
+    }
+
+    @Override
+    public void write(Table table) {
+      if (handle == 0) {
+        throw new IllegalStateException("Writer was already closed");
+      }
+      writeORCChunk(handle, table.nativeHandle, table.getDeviceMemorySize());
+    }
+
+    @Override
+    public void close() throws CudfException {
+      if (handle != 0) {
+        writeORCEnd(handle);
+      }
+      handle = 0;
+      if (consumer != null) {
+        consumer.done();
+      }
+    }
   }
 
   /**
-   * Writes this table to a file on the host
-   *
-   * @param outputFile - File to write the table to
+   * Get a table writer to write ORC data to a file.
+   * @param options the ORC writer options.
+   * @param outputFile where to write the file.
+   * @return a table writer to use for writing out multiple tables.
    */
+  public static TableWriter writeORCChunked(ORCWriterOptions options, File outputFile) {
+    return new ORCTableWriter(options, outputFile);
+  }
+
+  /**
+   * Get a table writer to write ORC data and handle each chunk with a callback.
+   * @param options the ORC writer options.
+   * @param consumer a class that will be called when host buffers are ready with ORC
+   *                 formatted data in them.
+   * @return a table writer to use for writing out multiple tables.
+   */
+  public static TableWriter writeORCChunked(ORCWriterOptions options, HostBufferConsumer consumer) {
+    return new ORCTableWriter(options, consumer);
+  }
+
+  /**
+   * Writes this table to a file on the host.
+   * @param outputFile - File to write the table to
+   * @deprecated please use writeORCChunked instead
+   */
+  @Deprecated
   public void writeORC(File outputFile) {
     writeORC(ORCWriterOptions.DEFAULT, outputFile);
   }
 
   /**
-   * Writes this table to a file on the host
-   *
+   * Writes this table to a file on the host.
    * @param outputFile - File to write the table to
+   * @deprecated please use writeORCChunked instead
    */
+  @Deprecated
   public void writeORC(ORCWriterOptions options, File outputFile) {
-    writeORC(options.getCompressionType().nativeId, options.getColumnNames(),
-        options.getMetadataKeys(), options.getMetadataValues(), outputFile.getAbsolutePath(),
-        0, 0, this.nativeHandle);
+    try (TableWriter writer = Table.writeORCChunked(options, outputFile)) {
+      writer.write(this);
+    }
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/TableWriter.java
+++ b/java/src/main/java/ai/rapids/cudf/TableWriter.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package ai.rapids.cudf;
+
+/**
+ * Provides an interface for writing out Table information in multiple steps.
+ * A TableWriter will be returned from one of various factory functions in Table that
+ * let you set the format of the data and its destination.  After that write can be called one or
+ * more times.  When you are done writing call close to finish.
+ */
+public interface TableWriter extends AutoCloseable {
+  /**
+   * Write out a table.  Note that all columns must be in the same order each time this is called
+   * and the format of each table cannot change.
+   * @param table what to write out.
+   */
+  void write(Table table);
+
+  @Override
+  void close() throws CudfException;
+}

--- a/java/src/main/java/ai/rapids/cudf/TableWriter.java
+++ b/java/src/main/java/ai/rapids/cudf/TableWriter.java
@@ -30,7 +30,7 @@ public interface TableWriter extends AutoCloseable {
    * and the format of each table cannot change.
    * @param table what to write out.
    */
-  void write(Table table);
+  void write(Table table) throws CudfException;
 
   @Override
   void close() throws CudfException;

--- a/java/src/main/java/ai/rapids/cudf/WriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/WriterOptions.java
@@ -22,11 +22,16 @@ class WriterOptions {
 
   private final CompressionType compressionType;
   private final String[] columnNames;
+  private final boolean[] columnNullability;
   private final Map<String, String> metadata;
 
   <T extends WriterBuilder> WriterOptions(T builder) {
     compressionType = builder.compressionType;
     columnNames = (String[]) builder.columnNames.toArray(new String[builder.columnNames.size()]);
+    columnNullability = new boolean[builder.columnNullability.size()];
+    for (int i = 0; i < builder.columnNullability.size(); i++) {
+      columnNullability[i] = (boolean)builder.columnNullability.get(i);
+    }
     metadata = Collections.unmodifiableMap(builder.metadata);
   }
 
@@ -50,8 +55,13 @@ class WriterOptions {
     return metadata.values().toArray(new String[metadata.size()]);
   }
 
+  public boolean[] getColumnNullability() {
+    return columnNullability;
+  }
+
   protected static class WriterBuilder<T extends WriterBuilder> {
     final List<String> columnNames = new ArrayList<>();
+    final List<Boolean> columnNullability = new ArrayList<>();
     final Map<String, String> metadata = new LinkedHashMap<>();
     CompressionType compressionType = CompressionType.AUTO;
 
@@ -61,6 +71,21 @@ class WriterOptions {
      */
     public T withColumnNames(String... columnNames) {
       this.columnNames.addAll(Arrays.asList(columnNames));
+      for (int i = 0; i < columnNames.length; i++) {
+        this.columnNullability.add(true);
+      }
+      return (T) this;
+    }
+
+    /**
+     * Add column name that is not nullable
+     * @param columnNames
+     */
+    public T withNotNullableColumnNames(String... columnNames) {
+      this.columnNames.addAll(Arrays.asList(columnNames));
+      for (int i = 0; i < columnNames.length; i++) {
+        this.columnNullability.add(false);
+      }
       return (T) this;
     }
 

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -742,6 +742,21 @@ native_jobjectArray<jobject> contiguous_table_array(JNIEnv* env, jsize length);
 
 std::unique_ptr<cudf::experimental::aggregation> map_jni_aggregation(jint op);
 
+/**
+ * Allocate a HostMemoryBuffer
+ */
+jobject allocate_host_buffer(JNIEnv* env, jlong amount, jboolean prefer_pinned);
+
+/**
+ * Get the address of a HostMemoryBuffer
+ */
+jlong get_host_buffer_address(JNIEnv* env, jobject buffer);
+
+/**
+ * Get the length of a HostMemoryBuffer
+ */
+jlong get_host_buffer_length(JNIEnv* env, jobject buffer);
+
 // Get the JNI environment, attaching the current thread to the JVM if necessary. If the thread
 // needs to be attached, the thread will automatically detach when the thread terminates.
 JNIEnv* get_jni_env(JavaVM* jvm);

--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -106,9 +106,9 @@ native_jobjectArray<jobject> contiguous_table_array(JNIEnv* env, jsize length) {
 }
 
 static jclass host_memory_buffer_jclass;
-static jmethodID host_buffer_allocate;
-static jfieldID host_buffer_address;
-static jfieldID host_buffer_length;
+static jmethodID Host_buffer_allocate;
+static jfieldID Host_buffer_address;
+static jfieldID Host_buffer_length;
 
 #define HOST_MEMORY_BUFFER_CLASS "ai/rapids/cudf/HostMemoryBuffer"
 #define HOST_MEMORY_BUFFER_SIG(param_sig) "(" param_sig ")L" HOST_MEMORY_BUFFER_CLASS ";"
@@ -119,19 +119,19 @@ static bool cache_host_memory_buffer_jni(JNIEnv *env) {
     return false;
   }
 
-  host_buffer_allocate = env->GetStaticMethodID(cls,
+  Host_buffer_allocate = env->GetStaticMethodID(cls,
           "allocate", HOST_MEMORY_BUFFER_SIG("JZ"));
-  if (host_buffer_allocate == nullptr) {
+  if (Host_buffer_allocate == nullptr) {
     return false;
   }
 
-  host_buffer_address = env->GetFieldID(cls, "address", "J");
-  if (host_buffer_address == nullptr) {
+  Host_buffer_address = env->GetFieldID(cls, "address", "J");
+  if (Host_buffer_address == nullptr) {
     return false;
   }
 
-  host_buffer_length = env->GetFieldID(cls, "length", "J");
-  if (host_buffer_length == nullptr) {
+  Host_buffer_length = env->GetFieldID(cls, "length", "J");
+  if (Host_buffer_length == nullptr) {
     return false;
   }
 
@@ -151,7 +151,7 @@ static void release_host_memory_buffer_jni(JNIEnv *env) {
 }
 
 jobject allocate_host_buffer(JNIEnv* env, jlong amount, jboolean prefer_pinned) {
-  jobject ret = env->CallStaticObjectMethod(host_memory_buffer_jclass, host_buffer_allocate,
+  jobject ret = env->CallStaticObjectMethod(host_memory_buffer_jclass, Host_buffer_allocate,
           amount, prefer_pinned);
 
   if (env->ExceptionCheck()) {
@@ -161,11 +161,11 @@ jobject allocate_host_buffer(JNIEnv* env, jlong amount, jboolean prefer_pinned) 
 }
 
 jlong get_host_buffer_address(JNIEnv* env, jobject buffer) {
-  return env->GetLongField(buffer, host_buffer_address);
+  return env->GetLongField(buffer, Host_buffer_address);
 }
 
 jlong get_host_buffer_length(JNIEnv* env, jobject buffer) {
-  return env->GetLongField(buffer, host_buffer_length);
+  return env->GetLongField(buffer, Host_buffer_length);
 }
 
 // Get the JNI environment, attaching the current thread to the JVM if necessary. If the thread

--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -37,8 +37,8 @@ private:
 namespace cudf {
 namespace jni {
 
-static jclass contiguous_table_jclass;
-static jmethodID from_contiguous_column_views;
+static jclass Contiguous_table_jclass;
+static jmethodID From_contiguous_column_views;
 
 #define CONTIGUOUS_TABLE_CLASS "ai/rapids/cudf/ContiguousTable"
 #define CONTIGUOUS_TABLE_FACTORY_SIG(param_sig) "(" param_sig ")L" CONTIGUOUS_TABLE_CLASS ";"
@@ -49,24 +49,24 @@ static bool cache_contiguous_table_jni(JNIEnv *env) {
     return false;
   }
 
-  from_contiguous_column_views = env->GetStaticMethodID(cls, 
+  From_contiguous_column_views = env->GetStaticMethodID(cls, 
           "fromContiguousColumnViews", CONTIGUOUS_TABLE_FACTORY_SIG("[JJJJ"));
-  if (from_contiguous_column_views == nullptr) {
+  if (From_contiguous_column_views == nullptr) {
     return false;
   }
 
   // Convert local reference to global so it cannot be garbage collected.
-  contiguous_table_jclass = static_cast<jclass>(env->NewGlobalRef(cls));
-  if (contiguous_table_jclass == nullptr) {
+  Contiguous_table_jclass = static_cast<jclass>(env->NewGlobalRef(cls));
+  if (Contiguous_table_jclass == nullptr) {
     return false;
   }
   return true;
 }
 
 static void release_contiguous_table_jni(JNIEnv *env) {
-  if (contiguous_table_jclass != nullptr) {
-    env->DeleteGlobalRef(contiguous_table_jclass);
-    contiguous_table_jclass = nullptr;
+  if (Contiguous_table_jclass != nullptr) {
+    env->DeleteGlobalRef(Contiguous_table_jclass);
+    Contiguous_table_jclass = nullptr;
   }
 }
 
@@ -91,7 +91,7 @@ jobject contiguous_table_from(JNIEnv* env, cudf::experimental::contiguous_split_
   }
 
   views.commit();
-  jobject ret = env->CallStaticObjectMethod(contiguous_table_jclass, from_contiguous_column_views,
+  jobject ret = env->CallStaticObjectMethod(Contiguous_table_jclass, From_contiguous_column_views,
           views.get_jArray(),
           address, size, buff_address);
 
@@ -102,10 +102,10 @@ jobject contiguous_table_from(JNIEnv* env, cudf::experimental::contiguous_split_
 }
 
 native_jobjectArray<jobject> contiguous_table_array(JNIEnv* env, jsize length) {
-  return native_jobjectArray<jobject>(env, env->NewObjectArray(length, contiguous_table_jclass, nullptr));
+  return native_jobjectArray<jobject>(env, env->NewObjectArray(length, Contiguous_table_jclass, nullptr));
 }
 
-static jclass host_memory_buffer_jclass;
+static jclass Host_memory_buffer_jclass;
 static jmethodID Host_buffer_allocate;
 static jfieldID Host_buffer_address;
 static jfieldID Host_buffer_length;
@@ -136,22 +136,22 @@ static bool cache_host_memory_buffer_jni(JNIEnv *env) {
   }
 
   // Convert local reference to global so it cannot be garbage collected.
-  host_memory_buffer_jclass = static_cast<jclass>(env->NewGlobalRef(cls));
-  if (host_memory_buffer_jclass == nullptr) {
+  Host_memory_buffer_jclass = static_cast<jclass>(env->NewGlobalRef(cls));
+  if (Host_memory_buffer_jclass == nullptr) {
     return false;
   }
   return true;
 }
 
 static void release_host_memory_buffer_jni(JNIEnv *env) {
-  if (host_memory_buffer_jclass != nullptr) {
-    env->DeleteGlobalRef(host_memory_buffer_jclass);
-    host_memory_buffer_jclass = nullptr;
+  if (Host_memory_buffer_jclass != nullptr) {
+    env->DeleteGlobalRef(Host_memory_buffer_jclass);
+    Host_memory_buffer_jclass = nullptr;
   }
 }
 
 jobject allocate_host_buffer(JNIEnv* env, jlong amount, jboolean prefer_pinned) {
-  jobject ret = env->CallStaticObjectMethod(host_memory_buffer_jclass, Host_buffer_allocate,
+  jobject ret = env->CallStaticObjectMethod(Host_memory_buffer_jclass, Host_buffer_allocate,
           amount, prefer_pinned);
 
   if (env->ExceptionCheck()) {

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -219,6 +219,10 @@ private:
         on_dealloc_threshold_method, "onDeallocThreshold", total_after);
   }
 
+  bool supports_get_mem_info() const noexcept override {
+    return resource->supports_get_mem_info();
+  }
+
   std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override {
     return resource->get_mem_info(stream);
   }

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -2142,11 +2142,6 @@ public class TableTest extends CudfTestBase {
     }
 
     @Override
-    public void done() {
-      // NOOP
-    }
-
-    @Override
     public void close() {
       buffer.close();
     }

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -38,10 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
 
 import static ai.rapids.cudf.Aggregate.max;
 import static ai.rapids.cudf.Table.TestBuilder;
@@ -2126,16 +2123,63 @@ public class TableTest extends CudfTestBase {
     }
   }
 
+  private final class MyBufferConsumer implements HostBufferConsumer, AutoCloseable {
+    public final HostMemoryBuffer buffer;
+    long offset = 0;
+
+    public MyBufferConsumer() {
+      buffer = HostMemoryBuffer.allocate(10 * 1024 * 1024);
+    }
+
+    @Override
+    public void handleBuffer(HostMemoryBuffer src, long len) {
+      try {
+        this.buffer.copyFromHostBuffer(offset, src, 0, len);
+        offset += len;
+      } finally {
+        src.close();
+      }
+    }
+
+    @Override
+    public void done() {
+      // NOOP
+    }
+
+    @Override
+    public void close() {
+      buffer.close();
+    }
+  }
+
+  @Test
+  void testParquetWriteToBufferChunked() {
+    try (Table table0 = getExpectedFileTable();
+         MyBufferConsumer consumer = new MyBufferConsumer()) {
+         try (TableWriter writer = Table.writeParquetChunked(ParquetWriterOptions.DEFAULT, consumer)) {
+           writer.write(table0);
+           writer.write(table0);
+           writer.write(table0);
+         }
+      try (Table table1 = Table.readParquet(ParquetOptions.DEFAULT, consumer.buffer, 0, consumer.offset);
+           Table concat = Table.concatenate(table0, table0, table0)) {
+        assertTablesAreEqual(concat, table1);
+      }
+    }
+  }
+
   @Test
   void testParquetWriteToFileWithNames() throws IOException {
     File tempFile = File.createTempFile("test-names", ".parquet");
     try (Table table0 = getExpectedFileTable()) {
       ParquetWriterOptions options = ParquetWriterOptions.builder()
-          .withColumnNames("first", "second", "third", "fourth", "fifth", "sixth")
+          .withColumnNames("first", "second", "third", "fourth", "fifth", "sixth", "seventh")
           .withCompressionType(CompressionType.NONE)
           .withStatisticsFrequency(ParquetWriterOptions.StatisticsFrequency.NONE)
           .build();
-      table0.writeParquet(options, tempFile.getAbsoluteFile());
+      try (TableWriter writer = Table.writeParquetChunked(options, tempFile.getAbsoluteFile())) {
+        writer.write(table0);
+      }
       try (Table table2 = Table.readParquet(tempFile.getAbsoluteFile())) {
         assertTablesAreEqual(table0, table2);
       }
@@ -2149,12 +2193,14 @@ public class TableTest extends CudfTestBase {
     File tempFile = File.createTempFile("test-names-metadata", ".parquet");
     try (Table table0 = getExpectedFileTable()) {
       ParquetWriterOptions options = ParquetWriterOptions.builder()
-          .withColumnNames("first", "second", "third", "fourth", "fifth", "sixth")
+          .withColumnNames("first", "second", "third", "fourth", "fifth", "sixth", "seventh")
           .withMetadata("somekey", "somevalue")
           .withCompressionType(CompressionType.NONE)
           .withStatisticsFrequency(ParquetWriterOptions.StatisticsFrequency.NONE)
           .build();
-      table0.writeParquet(options, tempFile.getAbsoluteFile());
+      try (TableWriter writer = Table.writeParquetChunked(options, tempFile.getAbsoluteFile())) {
+        writer.write(table0);
+      }
       try (Table table2 = Table.readParquet(tempFile.getAbsoluteFile())) {
         assertTablesAreEqual(table0, table2);
       }
@@ -2171,12 +2217,30 @@ public class TableTest extends CudfTestBase {
           .withCompressionType(CompressionType.NONE)
           .withStatisticsFrequency(ParquetWriterOptions.StatisticsFrequency.NONE)
           .build();
-      table0.writeParquet(options, tempFile.getAbsoluteFile());
+      try (TableWriter writer = Table.writeParquetChunked(options, tempFile.getAbsoluteFile())) {
+        writer.write(table0);
+      }
       try (Table table2 = Table.readParquet(tempFile.getAbsoluteFile())) {
         assertTablesAreEqual(table0, table2);
       }
     } finally {
       tempFile.delete();
+    }
+  }
+
+  @Test
+  void testORCWriteToBufferChunked() {
+    try (Table table0 = getExpectedFileTable();
+         MyBufferConsumer consumer = new MyBufferConsumer()) {
+      try (TableWriter writer = Table.writeORCChunked(ORCWriterOptions.DEFAULT, consumer)) {
+        writer.write(table0);
+        writer.write(table0);
+        writer.write(table0);
+      }
+      try (Table table1 = Table.readORC(ORCOptions.DEFAULT, consumer.buffer, 0, consumer.offset);
+           Table concat = Table.concatenate(table0, table0, table0)) {
+        assertTablesAreEqual(concat, table1);
+      }
     }
   }
 


### PR DESCRIPTION
Adds in support so when writing to Parquet or Orc we can do it one table at a time, instead of all at once.  It also lets us write the data into a memory buffer instead of a local file.