### PR TITLE
Backport scalar destructor fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,7 @@
 - PR #4494 Update Java memory event handler for new RMM resource API
 - PR #4505 Fix 0 length buffers during serialization
 - PR #4482 Fix `.str.rsplit`, `.str.split`, `.str.find`, `.str.rfind`, `.str.index`, `.str.rindex` and enable related tests
+- PR #4513 Backport scalar virtual destructor fix
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -40,7 +40,7 @@ namespace cudf {
  */
 class scalar {
  public:
-  ~scalar() = default;
+  virtual ~scalar() = default;
   scalar(scalar&& other) = default;
   scalar(scalar const& other) = default;
   scalar& operator=(scalar const& other) = delete;


### PR DESCRIPTION
The scalar destructor fix in #4399 is crucial to avoiding device memory fragmentation, but that PR was merged only into 0.14.  This backports the fix to branch-0.13.
