### PR TITLE
[REVIEW] Add doc note on conda channel_priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Improvements
 
+- PR #4531 Add doc note on conda channel_priority
 - PR #4479 Adding cuda 10.2 support via conda environment file addition
 - PR #4486 Remove explicit template parameter from detail::scatter.
 - PR #4471 Consolidate partitioning functionality into a single header.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,7 @@ git submodule update --init --remote --recursive
 - Create the conda development environment `cudf_dev`:
 ```bash
 # create the conda environment (assuming in base `cudf` directory)
+# note: strict channel_priority should be disabled
 conda env create --name cudf_dev --file conda/environments/cudf_dev_cuda10.0.yml
 # activate the environment
 conda activate cudf_dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ git submodule update --init --remote --recursive
 - Create the conda development environment `cudf_dev`:
 ```bash
 # create the conda environment (assuming in base `cudf` directory)
-# note: strict channel_priority should be disabled
+# note: `channel_priority` cannot be set to `strict`; use `flexible` instead
 conda env create --name cudf_dev --file conda/environments/cudf_dev_cuda10.0.yml
 # activate the environment
 conda activate cudf_dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ git submodule update --init --remote --recursive
 - Create the conda development environment `cudf_dev`:
 ```bash
 # create the conda environment (assuming in base `cudf` directory)
-# note: `channel_priority` cannot be set to `strict`; use `flexible` instead
+# note: RAPIDS currently doesn't support `channel_priority: strict`; use `channel_priority: flexible` instead
 conda env create --name cudf_dev --file conda/environments/cudf_dev_cuda10.0.yml
 # activate the environment
 conda activate cudf_dev


### PR DESCRIPTION
Add a note that `channel_priority` should be disabled when creating conda environment from the yml file. Otherwise will get package conflicts.