### PR TITLE
Import `tlz` for optional `cytoolz` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@
 - PR #4461 Port nvstrings Miscellaneous functions to cuDF Python/Cython
 - PR #4503 Port binaryop.pyx to libcudf++ API
 - PR #4499 Adding changes to handle include `keep_index` and `RangeIndex`
+- PR #4533 Import `tlz` for optional `cytoolz` support
 - PR #4493 Skip legacy testing in CI
 
 ## Bug Fixes

--- a/python/dask_cudf/dask_cudf/accessor.py
+++ b/python/dask_cudf/dask_cudf/accessor.py
@@ -12,7 +12,7 @@ accessor properties.
 
 """
 
-from toolz import partial
+from tlz import partial
 
 import cudf
 from cudf.core.column.categorical import (

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -5,7 +5,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
-from toolz import partition_all
+from tlz import partition_all
 
 import dask
 import dask.dataframe as dd


### PR DESCRIPTION
`cytoolz` has some more performant implementations of the same things in `toolz`. By importing `tlz` instead of `toolz`, we will pick up the `cytoolz` implementations when they are available. Otherwise we fallback to the `toolz` implementations.