### PR TITLE
[WIP] Remove RMM init/finalize from cudf test fixture.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@
 - PR #4499 Adding changes to handle include `keep_index` and `RangeIndex`
 - PR #4493 Skip legacy testing in CI
 - PR #4534 Disable deprecation warnings as errors.
+- PR #4542 Remove RMM init/finalize in cudf test fixture.
 
 ## Bug Fixes
 

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -47,9 +47,6 @@ class BaseFixture : public ::testing::Test {
    *---------------------------------------------------------------------------**/
   rmm::mr::device_memory_resource* mr() { return _mr; }
 
-  static void SetUpTestCase() { ASSERT_EQ(rmmInitialize(nullptr), RMM_SUCCESS); }
-
-  static void TearDownTestCase() { ASSERT_EQ(rmmFinalize(), RMM_SUCCESS); }
 };
 
 template <typename T, typename Enable = void>


### PR DESCRIPTION
Cut down on some of the warnings after https://github.com/rapidsai/rmm/pull/331 by removing the deprecated init/finalize in the cudf test fixture. 