### PR TITLE
Disable compile-errors on deprecation warnings, for JNI [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@
 - PR #4513 Backport scalar virtual destructor fix
 - PR #4519 Remove `n` validation for `nlargest` & `nsmallest` and add negative support for `n`
 - PR #4526 Fix index slicing issue for index incase of an empty dataframe
+- PR #4557 Disable compile-errors on deprecation warnings, for JNI
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=deprecated-declarations")
 
     option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" ON)
     if(CMAKE_CXX11_ABI)
@@ -65,7 +65,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-
 
 # set warnings as errors
 # TODO: remove `no-maybe-unitialized` used to suppress warnings in rmm::exec_policy
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-error=deprecated-declarations")
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling / memchecking
 option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler" OFF)


### PR DESCRIPTION
Disabled compilation failures on JNI native code, for deprecation warnings.
E.g.
```
../src/strings/utilities.cuh:82:48:   required from ‘auto cudf::strings::detail::make_strings_children(SizeAndExecuteFunction, cudf::size_type, cudf::size_type, rmm::mr::device_memory_resource*, cudaStream_t) [with SizeAndExecuteFunction = cudf::strings::detail::_GLOBAL__N__56_tmpxft_00006cba_00000000_8_backref_re_compute_75_cpp1_ii_c02a6011::backrefs_fn<112>; cudf::size_type = int; cudaStream_t = CUstream_st*]’
../src/strings/replace/backref_re.cu:205:173:   required from here
/home/mithunr/workspace/anaconda2/envs/cudf_dev/include/rmm/thrust_rmm_allocator.h:61:10: warning: ‘rmmError_t rmm::free(void*, cudaStream_t, const char*, unsigned int)’ is deprecated [-Wdeprecated-declarations]
       RMM_FREE(thrust::raw_pointer_cast(ptr), stream);
       ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/mithunr/workspace/anaconda2/envs/cudf_dev/include/rmm/rmm.hpp:192:34: note: declared here
```