### PR TITLE
Optimize `__reduce__` in `StringColumn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - PR #4098 Remove legacy calls from libcudf strings column code
 - PR #4044 Port join.pyx to use libcudf++ APIs
 - PR #4111 Use `Buffer`'s to serialize `StringColumn`
+- PR #4567 Optimize `__reduce__` in `StringColumn`
 - PR #4113 Get `len` of `StringColumn`s without `nvstrings`
 - PR #4147 Remove workaround for UNKNOWN_NULL_COUNT in contiguous_split.
 - PR #4130 Renames in-place `cudf::experimental::fill` to `cudf::experimental::fill_in_place`

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -2011,8 +2011,11 @@ class StringColumn(column.ColumnBase):
         return True in self.str().contains(f"^{item}$")
 
     def __reduce__(self):
-        cpumem = self.to_arrow()
-        return column.as_column, (cpumem, False, np.dtype("object"))
+        mask = None
+        if self.null_count > 0:
+            mask = self.mask
+
+        return column.build_column, (None, "str", mask, None, 0, self.children)
 
     def str(self, parent=None):
         return StringMethods(self, parent=parent)


### PR DESCRIPTION
Instead of converting the data to arrow in `__reduce__`, simply follow the same pattern we are using serialize. This should allow for a pretty efficient pickling method when pickling of `StringColumn`s is required.