### PR TITLE
Load JNI native dependencies for Scalar class [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,7 @@
 - PR #4519 Remove `n` validation for `nlargest` & `nsmallest` and add negative support for `n`
 - PR #4526 Fix index slicing issue for index incase of an empty dataframe
 - PR #4557 Disable compile-errors on deprecation warnings, for JNI
+- PR #4571 Load JNI native dependencies for Scalar class
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -29,6 +29,10 @@ import java.util.Objects;
  * A single scalar value.
  */
 public final class Scalar implements AutoCloseable, BinaryOperable {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(Scalar.class);
 
   private final DType type;


### PR DESCRIPTION
The Scalar class in the Java bindings has native methods but was not ensuring the native dependencies were loaded before calling those methods.  This adds a static block to the class to make sure the native dependencies are loaded when the Scalar class is loaded.