### PR TITLE
Fix dependencies of libcudf.so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,7 @@
 - PR #4538 Fix cudf::strings::slice_strings(step=-1) for empty strings
 - PR #4557 Disable compile-errors on deprecation warnings, for JNI
 - PR #4571 Load JNI native dependencies for Scalar class
+- PR #4577 Fix libcudf.so dependencies
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -805,7 +805,7 @@ target_link_libraries(libNVCategory libNVStrings rmm cudart cuda)
 target_link_libraries(libNVText libNVStrings rmm cudart cuda)
 
 # link targets for cuDF
-target_link_libraries(cudf NVCategory NVStrings rmm ${ARROW_CUDA_LIB_LINK} ${ARROW_LIB} nvrtc cudart cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(cudf libNVCategory libNVStrings rmm ${ARROW_CUDA_LIB_LINK} ${ARROW_LIB} nvrtc cudart cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------


### PR DESCRIPTION
Occasionally I have CI builds fail with errors complaining that NVCategory and NVStrings libraries cannot be found when trying to link libcudf.  Usually a re-run fixes it.  libcudf is not explicitly depending upon the targets that build the NVCategory and NVStrings libraries.  That can lead to a failure to link libcudf.so if the build system dedicates more resources to building the libcudf side of the dependency tree vs. NVStrings.

This fixes CMakeLists.txt to have libcudf depend on the builds of libNVCategory and libNVStrings rather than assuming those libs are already available.