### PR TITLE
[Bugfix] Fix hash-based repartitionbug in dask_cudf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,7 @@
 - PR #4591 Fix issue when reading consecutive rowgroups
 - PR #4600 Fix missing include in benchmark_fixture.hpp
 - PR #4588 Fix ordering issue in `MultiIndex`
+- PR #4625 Fix hash-based repartition bug in dask_cudf
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -144,7 +144,7 @@ def rearrange_by_hash(
     graph = HighLevelGraph.from_collections(
         "shuffle-" + token, dsk, dependencies=[df]
     )
-    df2 = DataFrame(graph, "shuffle-" + token, df, df.divisions)
+    df2 = df.__class__(graph, "shuffle-" + token, df, df.divisions)
     df2.divisions = (None,) * (df.npartitions + 1)
 
     return df2

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -383,16 +383,19 @@ def test_repartition_simple_divisions(start, stop):
 
 def test_repartition_hash_staged():
     by = ["b"]
-    datarange = 350
-    size = 1_000
+    datarange = 35
+    size = 100
     gdf = cudf.DataFrame(
         {
             "a": np.arange(size, dtype="int64"),
             "b": np.random.randint(datarange, size=size),
         }
     )
-    ddf = dgd.from_cudf(gdf, npartitions=35)
-    ddf_new = ddf.repartition(columns=by, max_branch=32)
+    ddf = dgd.from_cudf(gdf, npartitions=5)
+    ddf_new = ddf.repartition(columns=by, max_branch=4)
+
+    # Make sure we are getting a dask_cudf dataframe
+    assert type(ddf_new) == type(ddf)
 
     # Check that the length was preserved
     assert len(ddf_new) == len(ddf)


### PR DESCRIPTION
Closes [#4621](https://github.com/rapidsai/cudf/issues/4621)

Small fix to make sure we generate a dask_cudf DataFrame object as the output to `rearrange_by_hash` (rather than a dask.dataframe object).  I also made some small changes to `test_repartition_hash_staged` to assert that the type is correct (and to make it run a bit faster).

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
