### PR TITLE
[REVIEW] Remove dangling pointer to RMM exec policy in drop duplicates test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,6 +287,7 @@
 - PR #4591 Fix issue when reading consecutive rowgroups
 - PR #4600 Fix missing include in benchmark_fixture.hpp
 - PR #4588 Fix ordering issue in `MultiIndex`
+- PR #4630 Remove dangling reference to RMM exec policy in drop duplicates tests.
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/tests/stream_compaction/legacy/drop_duplicates_tests.cu
+++ b/cpp/tests/stream_compaction/legacy/drop_duplicates_tests.cu
@@ -146,9 +146,8 @@ bool compare_columns_indexed(
   cudf::size_type* index_ptr = ((cudf::size_type*)index_col.data);
 
   rmm::device_vector<cudf::size_type> ordered(rows);
-  auto exec = rmm::exec_policy(0)->on(0);
-  thrust::sequence(exec, ordered.begin(), ordered.end());
-  thrust::sort_by_key(exec, index_ptr , index_ptr + rows, ordered.data().get());
+  thrust::sequence(rmm::exec_policy(0)->on(0), ordered.begin(), ordered.end());
+  thrust::sort_by_key(rmm::exec_policy(0)->on(0), index_ptr , index_ptr + rows, ordered.data().get());
 
   cudf::table destination_table(rows,
                                 cudf::column_dtypes(out_table),


### PR DESCRIPTION
Fixes segfault in CI testing for legacy tests. 

CC @raydouglass 