### PR TITLE
[REVIEW] Fix handling of empty inputs for concatenate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,6 +287,7 @@
 - PR #4591 Fix issue when reading consecutive rowgroups
 - PR #4600 Fix missing include in benchmark_fixture.hpp
 - PR #4588 Fix ordering issue in `MultiIndex`
+- PR #4632 Fix handling of empty inputs to concatenate
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -87,7 +87,7 @@ TYPED_TEST(TypedColumnTest, ConcatenateEmptyColumns){
 }
 
 TYPED_TEST(TypedColumnTest, ConcatenateNoColumns){
-    std::vector<column_view> columns_to_concat();
+    std::vector<column_view> columns_to_concat{};
     EXPECT_THROW(cudf::concatenate(columns_to_concat), cudf::logic_error);
 }
 

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -73,6 +73,24 @@ struct TypedColumnTest : public cudf::test::BaseFixture {
 
 TYPED_TEST_CASE(TypedColumnTest, cudf::test::Types<int32_t>);
 
+TYPED_TEST(TypedColumnTest, ConcatenateEmptyColumns){
+    cudf::test::fixed_width_column_wrapper<TypeParam> empty_first{};
+    cudf::test::fixed_width_column_wrapper<TypeParam> empty_second{};
+    cudf::test::fixed_width_column_wrapper<TypeParam> empty_third{};
+    std::vector<column_view> columns_to_concat({empty_first, empty_second, empty_third});
+
+    auto concat = cudf::concatenate(columns_to_concat);
+
+    auto expected_type = cudf::column_view(empty_first)->type();
+    EXPECT_EQ(concat->size(), 0);
+    EXPECT_EQ(concat->type(), expected_type);
+}
+
+TYPED_TEST(TypedColumnTest, ConcatenateNoColumns){
+    std::vector<column_view> columns_to_concat();
+    EXPECT_THROW(cudf::concatenate(columns_to_concat), cudf::logic_error);
+}
+
 TYPED_TEST(TypedColumnTest, ConcatenateColumnView) {
   cudf::column original{this->type(), this->num_elements(), this->data,
                         this->mask};

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -81,7 +81,7 @@ TYPED_TEST(TypedColumnTest, ConcatenateEmptyColumns){
 
     auto concat = cudf::concatenate(columns_to_concat);
 
-    auto expected_type = cudf::column_view(empty_first)->type();
+    auto expected_type = cudf::column_view(empty_first).type();
     EXPECT_EQ(concat->size(), 0);
     EXPECT_EQ(concat->type(), expected_type);
 }


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/4629

- Throw if no columns were passed to concatenate
- Return empty column if all columns to concat are empty