### PR TITLE
Change stringConcatenate to use array argument [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -1622,10 +1622,10 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * Concatenate columns of strings together, combining a corresponding row from each column
    * into a single string row of a new column with no separator string inserted between each
    * combined string and maintaining null values in combined rows.
-   * @param columns indefinite number of columns containing strings.
+   * @param columns array of columns containing strings.
    * @return A new java column vector containing the concatenated strings.
    */
-  public ColumnVector stringConcatenate(ColumnVector... columns) {
+  public ColumnVector stringConcatenate(ColumnVector[] columns) {
     try (Scalar emptyString = Scalar.fromString("");
          Scalar nullString = Scalar.fromString(null)) {
       return stringConcatenate(emptyString, nullString, columns);
@@ -1639,10 +1639,10 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * @param narep string scalar indicating null behavior. If set to null and any string in the row
    *              is null the resulting string will be null. If not null, null values in any column
    *              will be replaced by the specified string.
-   * @param columns indefinite number of columns containing strings, must be more than 2 columns
+   * @param columns array of columns containing strings, must be more than 2 columns
    * @return A new java column vector containing the concatenated strings.
    */
-  public static ColumnVector stringConcatenate(Scalar separator, Scalar narep, ColumnVector... columns) {
+  public static ColumnVector stringConcatenate(Scalar separator, Scalar narep, ColumnVector[] columns) {
     assert columns.length >= 2 : ".stringConcatenate() operation requires at least 2 columns";
     assert separator != null : "separator scalar provided may not be null";
     assert separator.getType() == DType.STRING : "separator scalar must be a string scalar";

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -992,55 +992,78 @@ public class ColumnVectorTest extends CudfTestBase {
                                                    "IJ\"\u0100\u0101\u0500\u0501IJ\"\u0100\u0101\u0500\u0501",
                                                    "kl mkl m", "Nop1Nop1", "\\qRs2\\qRs2", "3tuV\'3tuV\'",
                                                    "wX4YzwX4Yz", "\ud720\ud721\ud720\ud721");
-         Scalar emptyString = Scalar.fromString("");
-         ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
-                                                              v, v)) {
-      assertColumnsAreEqual(concat, e_concat);
+         Scalar emptyString = Scalar.fromString("")) {
+      ColumnVector[] arr = new ColumnVector[2];
+      arr[0] = v;
+      arr[1] = v;
+      try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {
+        assertColumnsAreEqual(concat, e_concat);
+      }
     }
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("B", "cd", "\u0480\u0481", "E\tf");
            ColumnVector cv = ColumnVector.fromInts(1, 2, 3, 4);
-           Scalar emptyString = Scalar.fromString("");
-           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
-                                                                sv, cv)) {}
+           Scalar emptyString = Scalar.fromString("")) {
+        ColumnVector[] arr = new ColumnVector[2];
+        arr[0] = sv;
+        arr[1] = cv;
+        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {}
+      }
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv1 = ColumnVector.fromStrings("a", "B", "cd");
            ColumnVector sv2 = ColumnVector.fromStrings("a", "B");
-           Scalar emptyString = Scalar.fromString("");
-           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
-                                                                sv1, sv2)) {}
+           Scalar emptyString = Scalar.fromString("")) {
+        ColumnVector[] arr = new ColumnVector[2];
+        arr[0] = sv1;
+        arr[1] = sv2;
+        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {}
+      }
+    });
+    assertThrows(AssertionError.class, () -> {
+      try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
+           Scalar emptyString = Scalar.fromString("")) {
+        ColumnVector[] arr = new ColumnVector[1];
+        arr[0] = sv;
+        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {}
+      }
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
            Scalar emptyString = Scalar.fromString("");
-           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
-                                                                sv)) {}
+           Scalar nullString = Scalar.fromString(null)) {
+        ColumnVector[] arr = new ColumnVector[2];
+        arr[0] = sv;
+        arr[1] = sv;
+        try (ColumnVector concat = ColumnVector.stringConcatenate(nullString, emptyString, arr)) {}
+      }
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
-           Scalar emptyString = Scalar.fromString("");
-           Scalar nullString = Scalar.fromString(null);
-           ColumnVector concat = ColumnVector.stringConcatenate(nullString, emptyString,
-                                                                sv, sv)) {}
+           Scalar emptyString = Scalar.fromString("")) {
+        ColumnVector[] arr = new ColumnVector[2];
+        arr[0] = sv;
+        arr[1] = sv;
+        try (ColumnVector concat = ColumnVector.stringConcatenate(null, emptyString, arr)) {}
+      }
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
-           Scalar emptyString = Scalar.fromString("");
-           ColumnVector concat = ColumnVector.stringConcatenate(null, emptyString,
-                                                                sv, sv)) {}
+           Scalar emptyString = Scalar.fromString("")) {
+        ColumnVector[] arr = new ColumnVector[2];
+        arr[0] = sv;
+        arr[1] = sv;
+        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, null, arr)) {}
+      }
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
-           Scalar emptyString = Scalar.fromString("");
-           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, null,
-                                                                sv, sv)) {}
-    });
-    assertThrows(AssertionError.class, () -> {
-      try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
-           Scalar emptyString = Scalar.fromString("");
-           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
-                                                                sv, null)) {}
+           Scalar emptyString = Scalar.fromString("")) {
+        ColumnVector[] arr = new ColumnVector[2];
+        arr[0] = sv;
+        arr[1] = null;
+        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {}
+      }
     });
   }
 
@@ -1056,9 +1079,13 @@ public class ColumnVectorTest extends CudfTestBase {
                                                    "kl mkl m", "Nop1Nop1", "\\qRs2\\qRs2", "NULLNULL",
                                                    "3tuV\'3tuV\'", "wX4YzwX4Yz", "\ud720\ud721\ud720\ud721");
           Scalar emptyString = Scalar.fromString("");
-          Scalar nullSubstitute = Scalar.fromString("NULL");
-         ColumnVector concat = ColumnVector.stringConcatenate(emptyString, nullSubstitute, v, v)) {
-      assertColumnsAreEqual(concat, e_concat);
+          Scalar nullSubstitute = Scalar.fromString("NULL")) {
+      ColumnVector[] arr = new ColumnVector[2];
+      arr[0] = v;
+      arr[1] = v;
+      try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, nullSubstitute, arr)) {
+        assertColumnsAreEqual(concat, e_concat);
+      }
     }
   }
 
@@ -1069,10 +1096,13 @@ public class ColumnVectorTest extends CudfTestBase {
          ColumnVector e_concat = ColumnVector.fromStrings("aA1\t\ud721b", "BA1\t\ud721C", "cdA1\t\ud721\u0500\u0501",
                                                           "\u0480\u0481A1\t\ud721x\nYz", null, null, null, null);
          Scalar separatorString = Scalar.fromString("A1\t\ud721");
-         Scalar nullString = Scalar.fromString(null);
-         ColumnVector concat = ColumnVector.stringConcatenate(separatorString, nullString,
-                                                              sv1, sv2)) {
-      assertColumnsAreEqual(concat, e_concat);
+         Scalar nullString = Scalar.fromString(null)) {
+      ColumnVector[] arr = new ColumnVector[2];
+      arr[0] = sv1;
+      arr[1] = sv2;
+      try (ColumnVector concat = ColumnVector.stringConcatenate(separatorString, nullString, arr)) {
+        assertColumnsAreEqual(concat, e_concat);
+      }
     }
   }
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -992,78 +992,55 @@ public class ColumnVectorTest extends CudfTestBase {
                                                    "IJ\"\u0100\u0101\u0500\u0501IJ\"\u0100\u0101\u0500\u0501",
                                                    "kl mkl m", "Nop1Nop1", "\\qRs2\\qRs2", "3tuV\'3tuV\'",
                                                    "wX4YzwX4Yz", "\ud720\ud721\ud720\ud721");
-         Scalar emptyString = Scalar.fromString("")) {
-      ColumnVector[] arr = new ColumnVector[2];
-      arr[0] = v;
-      arr[1] = v;
-      try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {
-        assertColumnsAreEqual(concat, e_concat);
-      }
+         Scalar emptyString = Scalar.fromString("");
+         ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
+                                                              new ColumnVector[]{v, v})) {
+      assertColumnsAreEqual(concat, e_concat);
     }
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("B", "cd", "\u0480\u0481", "E\tf");
            ColumnVector cv = ColumnVector.fromInts(1, 2, 3, 4);
-           Scalar emptyString = Scalar.fromString("")) {
-        ColumnVector[] arr = new ColumnVector[2];
-        arr[0] = sv;
-        arr[1] = cv;
-        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {}
-      }
+           Scalar emptyString = Scalar.fromString("");
+           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
+                                                                new ColumnVector[]{sv, cv})) {}
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv1 = ColumnVector.fromStrings("a", "B", "cd");
            ColumnVector sv2 = ColumnVector.fromStrings("a", "B");
-           Scalar emptyString = Scalar.fromString("")) {
-        ColumnVector[] arr = new ColumnVector[2];
-        arr[0] = sv1;
-        arr[1] = sv2;
-        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {}
-      }
-    });
-    assertThrows(AssertionError.class, () -> {
-      try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
-           Scalar emptyString = Scalar.fromString("")) {
-        ColumnVector[] arr = new ColumnVector[1];
-        arr[0] = sv;
-        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {}
-      }
+           Scalar emptyString = Scalar.fromString("");
+           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
+                                                                new ColumnVector[]{sv1, sv2})) {}
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
            Scalar emptyString = Scalar.fromString("");
-           Scalar nullString = Scalar.fromString(null)) {
-        ColumnVector[] arr = new ColumnVector[2];
-        arr[0] = sv;
-        arr[1] = sv;
-        try (ColumnVector concat = ColumnVector.stringConcatenate(nullString, emptyString, arr)) {}
-      }
+           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
+                                                                new ColumnVector[]{sv})) {}
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
-           Scalar emptyString = Scalar.fromString("")) {
-        ColumnVector[] arr = new ColumnVector[2];
-        arr[0] = sv;
-        arr[1] = sv;
-        try (ColumnVector concat = ColumnVector.stringConcatenate(null, emptyString, arr)) {}
-      }
+           Scalar emptyString = Scalar.fromString("");
+           Scalar nullString = Scalar.fromString(null);
+           ColumnVector concat = ColumnVector.stringConcatenate(nullString, emptyString,
+                                                                new ColumnVector[]{sv, sv})) {}
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
-           Scalar emptyString = Scalar.fromString("")) {
-        ColumnVector[] arr = new ColumnVector[2];
-        arr[0] = sv;
-        arr[1] = sv;
-        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, null, arr)) {}
-      }
+           Scalar emptyString = Scalar.fromString("");
+           ColumnVector concat = ColumnVector.stringConcatenate(null, emptyString,
+                                                                new ColumnVector[]{sv, sv})) {}
     });
     assertThrows(AssertionError.class, () -> {
       try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
-           Scalar emptyString = Scalar.fromString("")) {
-        ColumnVector[] arr = new ColumnVector[2];
-        arr[0] = sv;
-        arr[1] = null;
-        try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString, arr)) {}
-      }
+           Scalar emptyString = Scalar.fromString("");
+           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, null,
+                                                                new ColumnVector[]{sv, sv})) {}
+    });
+    assertThrows(AssertionError.class, () -> {
+      try (ColumnVector sv = ColumnVector.fromStrings("a", "B", "cd");
+           Scalar emptyString = Scalar.fromString("");
+           ColumnVector concat = ColumnVector.stringConcatenate(emptyString, emptyString,
+                                                                new ColumnVector[]{sv, null})) {}
     });
   }
 
@@ -1079,13 +1056,10 @@ public class ColumnVectorTest extends CudfTestBase {
                                                    "kl mkl m", "Nop1Nop1", "\\qRs2\\qRs2", "NULLNULL",
                                                    "3tuV\'3tuV\'", "wX4YzwX4Yz", "\ud720\ud721\ud720\ud721");
           Scalar emptyString = Scalar.fromString("");
-          Scalar nullSubstitute = Scalar.fromString("NULL")) {
-      ColumnVector[] arr = new ColumnVector[2];
-      arr[0] = v;
-      arr[1] = v;
-      try (ColumnVector concat = ColumnVector.stringConcatenate(emptyString, nullSubstitute, arr)) {
-        assertColumnsAreEqual(concat, e_concat);
-      }
+          Scalar nullSubstitute = Scalar.fromString("NULL");
+         ColumnVector concat = ColumnVector.stringConcatenate(emptyString, nullSubstitute,
+                                                              new ColumnVector[]{v, v})) {
+      assertColumnsAreEqual(concat, e_concat);
     }
   }
 
@@ -1096,13 +1070,10 @@ public class ColumnVectorTest extends CudfTestBase {
          ColumnVector e_concat = ColumnVector.fromStrings("aA1\t\ud721b", "BA1\t\ud721C", "cdA1\t\ud721\u0500\u0501",
                                                           "\u0480\u0481A1\t\ud721x\nYz", null, null, null, null);
          Scalar separatorString = Scalar.fromString("A1\t\ud721");
-         Scalar nullString = Scalar.fromString(null)) {
-      ColumnVector[] arr = new ColumnVector[2];
-      arr[0] = sv1;
-      arr[1] = sv2;
-      try (ColumnVector concat = ColumnVector.stringConcatenate(separatorString, nullString, arr)) {
-        assertColumnsAreEqual(concat, e_concat);
-      }
+         Scalar nullString = Scalar.fromString(null);
+         ColumnVector concat = ColumnVector.stringConcatenate(separatorString, nullString,
+                                                              new ColumnVector[]{sv1, sv2})) {
+      assertColumnsAreEqual(concat, e_concat);
     }
   }
 


### PR DESCRIPTION
Changes the string column concatenate function to use an array of strings rather than a variable number of arguments reinterpreted as an array. The translation of the Java variable arguments does not play well with the Scala plugin side.