### PR TITLE
[REVIEW] Fix missing include in partition header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PR #4617 Fix memory leak in aggregation object destructor
 - PR #4633 String concatenation fix in `DataFrame.rename`
 - PR #4609 Fix to handle `Series.factorize` when index is set
+- PR #4651 Fix `partition.hpp` missing includes
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - PR #4617 Fix memory leak in aggregation object destructor
 - PR #4633 String concatenation fix in `DataFrame.rename`
 - PR #4609 Fix to handle `Series.factorize` when index is set
-- PR #4651 Fix `partition.hpp` missing includes
+- PR #4651 Fix hashing benchmark missing includes
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/cpp/benchmarks/hashing/hashing_benchmark.cpp
+++ b/cpp/benchmarks/hashing/hashing_benchmark.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <cudf/partitioning.hpp>
+#include <cudf/table/table.hpp>
 
 #include <tests/utilities/column_wrapper.hpp>
 #include <benchmarks/fixture/benchmark_fixture.hpp>

--- a/cpp/include/cudf/partitioning.hpp
+++ b/cpp/include/cudf/partitioning.hpp
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cudf/types.hpp>
-#include <cudf/table/table.hpp>
 #include <memory>
 #include <vector>
 

--- a/cpp/include/cudf/partitioning.hpp
+++ b/cpp/include/cudf/partitioning.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/table/table.hpp>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
The hashing benchmark is failing to build on branch-0.14 because the table.hpp header doesn't get included with partition.hpp.