### PR TITLE
[REVIEW] Fix misaligned error when computing regex device structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## New Features
 - PR #4472 Add new `partition` API to replace `scatter_to_tables`.
-
 - PR #4626 LogBase binops
 
 ## Improvements
@@ -31,6 +30,7 @@
 - PR #4617 Fix memory leak in aggregation object destructor
 - PR #4633 String concatenation fix in `DataFrame.rename`
 - PR #4609 Fix to handle `Series.factorize` when index is set
+- PR #4652 Fix misaligned error when computing regex device structs
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/cpp/tests/strings/contains_tests.cpp
+++ b/cpp/tests/strings/contains_tests.cpp
@@ -76,6 +76,7 @@ TEST_F(StringsContainsTests, ContainsTest)
         "[1-5]+",
         "[a-h]+",
         "[A-H]+",
+        "[a-h]*",
         "\n",
         "b.\\s*\n",
         ".*c",
@@ -93,6 +94,7 @@ TEST_F(StringsContainsTests, ContainsTest)
         true, false, false, true, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, true, true, false, false, false, false, false, false, false, false, false, false,
         false, true, false, false, false, true, true, false, true, false, false, false, false, false, false, false, false, true, true, true, false, false, true, true, false, true, true, true, true, true, false, false,
         false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, true, true, true, false, true, false, false, true, false, false, false, false, false, false, false,
+        true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false,
         false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, false, false, false,
         false, false, false, false, false, false, true, false, true, false, false, false, false, false, false, false, false, false, false, true, false, false, false, true, false, true, true, true, true, true, false, false,
@@ -112,7 +114,6 @@ TEST_F(StringsContainsTests, ContainsTest)
         cudf::test::expect_columns_equal(*results,expected);
     }
 }
-
 
 TEST_F(StringsContainsTests, MatchesTest)
 {


### PR DESCRIPTION
Closes #4636 
The regex pattern is converted into an set of structs and then copied into a single buffer of device memory. This means the structs must be aligned correctly in the memory in order to deference them in device code.
The "[a-z]*" pattern created a circumstance where the reclass struct was copied into a misaligned section of the device buffer. This PR adds logic to ensure each section of structs are copied to an aligned location.
Also added a test case for this pattern.