### PR TITLE
[REVIEW] Fix strings::replace_re handling empty regex pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - PR #4617 Fix memory leak in aggregation object destructor
 - PR #4633 String concatenation fix in `DataFrame.rename`
 - PR #4609 Fix to handle `Series.factorize` when index is set
+- PR #4659 Fix strings::replace_re handling empty regex pattern
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/cpp/src/strings/regex/regex.cuh
+++ b/cpp/src/strings/regex/regex.cuh
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
+#include <strings/regex/regcomp.h>
 #include <memory>
 #include <functional>
 
@@ -85,7 +86,12 @@ public:
     /**
      * @brief Returns the number of regex instructions.
      */
-    int32_t insts_counts() const  { return _insts_count; }
+    __host__ __device__ int32_t insts_counts() const  { return _insts_count; }
+
+    /**
+     * @brief Returns true if this is an empty program.
+     */
+    __device__ bool is_empty() const  { return insts_counts()==0 || get_inst(0)->type == END; }
 
     /**
      * @brief Returns the number of regex groups found in the expression.
@@ -102,7 +108,7 @@ public:
     /**
      * @brief Returns the regex instruction object for a given index.
      */
-    __host__ __device__ inline reinst* get_inst(int32_t idx) const;
+    __device__ inline reinst* get_inst(int32_t idx) const;
 
     /**
      * @brief Returns the regex class object for a given index.

--- a/cpp/src/strings/regex/regex.inl
+++ b/cpp/src/strings/regex/regex.inl
@@ -16,7 +16,6 @@
 
 #include <cuda_runtime.h>
 #include <cudf/strings/string_view.cuh>
-#include <strings/regex/regcomp.h>
 #include <strings/char_types/is_flags.h>
 #include <strings/utilities.cuh>
 
@@ -179,7 +178,7 @@ __device__ inline void reprog_device::set_stack_mem(u_char* s1, u_char* s2)
     _stack_mem2 = s2;
 }
 
-__host__ __device__ inline reinst* reprog_device::get_inst(int32_t idx) const
+__device__ inline reinst* reprog_device::get_inst(int32_t idx) const
 {
     assert( (idx >= 0) && (idx < _insts_count) );
     return _insts + idx;

--- a/cpp/src/strings/replace/multi_re.cu
+++ b/cpp/src/strings/replace/multi_re.cu
@@ -82,7 +82,7 @@ struct replace_multi_regex_fn
                 reprog_device prog = progs[ptn_idx];
                 prog.set_stack_mem(data1,data2);
                 size_type begin = ch_pos, end = ch_pos+1;
-                if( prog.find(idx,d_str,begin,end) > 0 )
+                if( !prog.is_empty() && prog.find(idx,d_str,begin,end) > 0 )
                 {
                     string_view d_repl = d_repls.size() > 1 ?
                                          d_repls.element<string_view>(ptn_idx) :

--- a/cpp/src/strings/replace/replace_re.cu
+++ b/cpp/src/strings/replace/replace_re.cu
@@ -83,7 +83,7 @@ struct replace_regex_fn
         // copy input to output replacing strings as we go
         while( mxn-- > 0 ) // maximum number of replaces
         {
-            if( prog.find(idx,d_str,begin,end) <= 0 )
+            if( prog.is_empty() || prog.find(idx,d_str,begin,end) <= 0 )
                 break; // no more matches
             auto spos = d_str.byte_offset(begin); // get offset for these
             auto epos = d_str.byte_offset(end);   // character position values

--- a/cpp/tests/strings/replace_regex_tests.cpp
+++ b/cpp/tests/strings/replace_regex_tests.cpp
@@ -84,6 +84,21 @@ TEST_F(StringsReplaceTests, ReplaceMultiRegexTest)
     cudf::test::expect_columns_equal(*results,expected);
 }
 
+TEST_F(StringsReplaceTests, WithEmptyPattern)
+{
+    std::vector<const char*> h_strings{ "asd", "xcv" };
+    cudf::test::strings_column_wrapper strings( h_strings.begin(), h_strings.end(),
+        thrust::make_transform_iterator( h_strings.begin(), [] (auto str) { return str!=nullptr; }));
+    auto strings_view = cudf::strings_column_view(strings);
+    std::vector<std::string> patterns({""});
+    cudf::test::strings_column_wrapper repls( {"bbb"} );
+    auto repls_view = cudf::strings_column_view(repls);
+    auto results = cudf::strings::replace_re(strings_view,patterns,repls_view);
+    cudf::test::expect_columns_equal(*results,strings);
+    results = cudf::strings::replace_re(strings_view,"",cudf::string_scalar("bbb"));
+    cudf::test::expect_columns_equal(*results,strings);
+}
+
 TEST_F(StringsReplaceTests, ReplaceBackrefsRegexTest)
 {
     std::vector<const char*> h_strings{ "the quick brown fox jumps over the lazy dog",


### PR DESCRIPTION
Closes #4622 
The replace logic will increment through each string trying to match the given regex pattern. If the pattern is found, the corresponding replacement string replaces the matched bounds in the input string. The replace then continues trying to match the next occurrence of the pattern by repositioning to the end of the matched bounds. When the pattern is an empty string the width of the bounds is 0 thereby causing in an infinite loop looking for the next occurrence.

This PR corrects this logic for the multiple-pattern replace API as well as the single-pattern replace API by checking for the empty regex object.
Also, test cases were added to pass empty regex patterns.
