### PR TITLE
[REVIEW] Fix regex infinite loop while parsing invalid quantifier pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #4633 String concatenation fix in `DataFrame.rename`
 - PR #4609 Fix to handle `Series.factorize` when index is set
 - PR #4651 Fix hashing benchmark missing includes
+- PR #4673 Fix regex infinite loop while parsing invalid quantifier pattern
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/cpp/include/cudf/utilities/error.hpp
+++ b/cpp/include/cudf/utilities/error.hpp
@@ -84,31 +84,6 @@ struct cuda_error : public std::runtime_error {
   throw cudf::logic_error("cuDF failure at: " __FILE__ \
                           ":" CUDF_STRINGIFY(__LINE__) ": " reason)
 
-/**
- * @brief Indicates that an erroneous code path has been taken.
- *
- * Should be only used in host code. This uses `std::string` to build
- * the error message.
- * 
- * This is the same as CUDF_FAIL except it does not require a string literal
- * for the `reason` parameter. This allows passing a more detailed error
- * message inside the exception.
- * 
- * Throws a `cudf::logic_error`.
- *
- * Example usage:
- * ```
- * CUDF_FAIL_STRING("invalid character at position " + std::to_string(position));
- * ```
- * 
- * @param[in] reason String description of the reason
- */
-#define CUDF_FAIL_STRING(reason)                              { \
-  std::string msg = "cuDF failure at: " + std::string(__FILE__) \
-                    + ":" + std::to_string(__LINE__) +  ": "    \
-                    + reason;                                   \
-  throw cudf::logic_error(msg); }
-
 namespace cudf {
 namespace detail {
 

--- a/cpp/include/cudf/utilities/error.hpp
+++ b/cpp/include/cudf/utilities/error.hpp
@@ -84,6 +84,31 @@ struct cuda_error : public std::runtime_error {
   throw cudf::logic_error("cuDF failure at: " __FILE__ \
                           ":" CUDF_STRINGIFY(__LINE__) ": " reason)
 
+/**
+ * @brief Indicates that an erroneous code path has been taken.
+ *
+ * Should be only used in host code. This uses `std::string` to build
+ * the error message.
+ * 
+ * This is the same as CUDF_FAIL except it does not require a string literal
+ * for the `reason` parameter. This allows passing a more detailed error
+ * message inside the exception.
+ * 
+ * Throws a `cudf::logic_error`.
+ *
+ * Example usage:
+ * ```
+ * CUDF_FAIL_STRING("invalid character at position " + std::to_string(position));
+ * ```
+ * 
+ * @param[in] reason String description of the reason
+ */
+#define CUDF_FAIL_STRING(reason)                              { \
+  std::string msg = "cuDF failure at: " + std::string(__FILE__) \
+                    + ":" + std::to_string(__LINE__) +  ": "    \
+                    + reason;                                   \
+  throw cudf::logic_error(msg); }
+
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/strings/contains.cu
+++ b/cpp/src/strings/contains.cu
@@ -63,7 +63,8 @@ struct contains_fn
         prog.set_stack_mem(data1,data2);
         string_view d_str = d_strings.element<string_view>(idx);
         int32_t begin = 0;
-        int32_t end = bmatch ? 1 : d_str.length(); // 1=match only the beginning of the string
+        int32_t end = bmatch ? 1    // match only the beginning of the string;
+                             : -1;  // this handles empty strings too
         return static_cast<experimental::bool8>(prog.find(idx,d_str,begin,end));
     }
 };

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+* Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -454,7 +454,8 @@ class regex_parser
                          != escapable_chars.end()) )
                         break;
                     // anything else is a bad escape so throw an error
-                    CUDF_FAIL("invalid regex pattern: bad escape character at position " + std::to_string(exprp-pattern-1));
+                    CUDF_FAIL("invalid regex pattern: bad escape character at position "
+                              + std::to_string(exprp-pattern-1));
                 }
                 } // end-switch
                 return CHAR;
@@ -499,7 +500,8 @@ class regex_parser
 
         if( std::find(valid_preceding_inst_types.begin(), valid_preceding_inst_types.end(), m_items.back().t)
             == valid_preceding_inst_types.end() )
-            CUDF_FAIL("invalid regex pattern: nothing to repeat at position " + std::to_string(exprp-pattern-1));
+            CUDF_FAIL("invalid regex pattern: nothing to repeat at position " 
+                      + std::to_string(exprp-pattern-1));
 
         // handle quantifiers
         switch(yy)

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -454,10 +454,7 @@ class regex_parser
                          != escapable_chars.end()) )
                         break;
                     // anything else is a bad escape so throw an error
-                    std::ostringstream message;
-                    message << "invalid regex pattern: bad escape ";
-                    message << "at position " << (exprp-pattern-1);
-                    throw cudf::logic_error(message.str());
+                    CUDF_FAIL("invalid regex pattern: bad escape character at position " + std::to_string(exprp-pattern-1));
                 }
                 } // end-switch
                 return CHAR;
@@ -502,12 +499,7 @@ class regex_parser
 
         if( std::find(valid_preceding_inst_types.begin(), valid_preceding_inst_types.end(), m_items.back().t)
             == valid_preceding_inst_types.end() )
-        {
-            std::ostringstream message;
-            message << "invalid regex pattern: ";
-            message << "nothing to repeat at position " << (exprp-pattern-1);
-            throw cudf::logic_error(message.str());
-        }
+            CUDF_FAIL("invalid regex pattern: nothing to repeat at position " + std::to_string(exprp-pattern-1));
 
         // handle quantifiers
         switch(yy)

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -476,7 +476,12 @@ class regex_parser
         if( quantifiers.find(static_cast<char>(yy)) == quantifiers.end() )
             return CHAR;
 
-        // the quantifiers require at least one "real" previous item
+        // The quantifiers require at least one "real" previous item.
+        // We are throwing an error in these two if checks for invalid quantifiers.
+        // Another option is to just return CHAR silently here which effectively
+        // treats the yy character as a literal instead as a quantifier.
+        // This could lead to confusion where sometimes unescaped special characters
+        // are treated as regex expressions and sometimes they are not.
         if( m_items.empty() )
             CUDF_FAIL("invalid regex pattern: nothing to repeat at position 0");
 
@@ -1068,9 +1073,9 @@ void reprog::optimize2()
         const reinst& inst = _insts[id];
         if(inst.type == OR)
         {
-            if( inst.u2.left_id!=id )
+            if( inst.u2.left_id!=id ) // prevents infinite while-loop here
                 stack.push_back(inst.u2.left_id);
-            if( inst.u1.right_id!=id )
+            if( inst.u1.right_id!=id ) // prevents infinite while-loop here
                 stack.push_back(inst.u1.right_id);
         }
         else

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -489,10 +489,10 @@ class regex_parser
             return CHAR;
 
         // The quantifiers require at least one "real" previous item.
-        // We are throwing an error in these two if checks for invalid quantifiers.
+        // We are throwing an error in these two if-checks for invalid quantifiers.
         // Another option is to just return CHAR silently here which effectively
         // treats the yy character as a literal instead as a quantifier.
-        // This could lead to confusion where sometimes unescaped special characters
+        // This could lead to confusion where sometimes unescaped quantifier characters
         // are treated as regex expressions and sometimes they are not.
         if( m_items.empty() )
             CUDF_FAIL("invalid regex pattern: nothing to repeat at position 0");

--- a/cpp/tests/strings/contains_tests.cpp
+++ b/cpp/tests/strings/contains_tests.cpp
@@ -83,7 +83,8 @@ TEST_F(StringsContainsTests, ContainsTest)
         "\\d\\d:\\d\\d:\\d\\d",
         "\\d\\d?:\\d\\d?:\\d\\d?",
         "[Hh]ello [Ww]orld",
-        "\\bworld\\b" };
+        "\\bworld\\b",
+        ".*" };
 
     std::vector<cudf::experimental::bool8> h_expecteds{ // strings.size x patterns.size
         true, false, false, true, false, false, false, true, true, true, true, true, true, true, true, true, true, false, false, false, true, true, false, false, false, false, false, false, false, false, false, false,
@@ -94,14 +95,15 @@ TEST_F(StringsContainsTests, ContainsTest)
         true, false, false, true, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, true, true, false, false, false, false, false, false, false, false, false, false,
         false, true, false, false, false, true, true, false, true, false, false, false, false, false, false, false, false, true, true, true, false, false, true, true, false, true, true, true, true, true, false, false,
         false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, true, true, true, false, true, false, false, true, false, false, false, false, false, false, false,
-        true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false,
+        true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, true,
         false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, false, false, false,
         false, false, false, false, false, false, true, false, true, false, false, false, false, false, false, false, false, false, false, true, false, false, false, true, false, true, true, true, true, true, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false,
-        false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false
+        false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false,
+        true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, true
     };
 
     for( int idx=0; idx < static_cast<int>(patterns.size()); ++idx )
@@ -140,6 +142,13 @@ TEST_F(StringsContainsTests, MatchesTest)
     {
         auto results = cudf::strings::matches_re(strings_view,"@\\w+");
         cudf::experimental::bool8 h_expected[] = {false,false,false,false,false,false,false};
+        cudf::test::fixed_width_column_wrapper<cudf::experimental::bool8> expected( h_expected, h_expected+h_strings.size(),
+            thrust::make_transform_iterator( h_strings.begin(), [] (auto str) { return str!=nullptr; }));
+        cudf::test::expect_columns_equal(*results,expected);
+    }
+    {
+        auto results = cudf::strings::matches_re(strings_view,".*");
+        cudf::experimental::bool8 h_expected[] = {true,true,true,true,true,false,true};
         cudf::test::fixed_width_column_wrapper<cudf::experimental::bool8> expected( h_expected, h_expected+h_strings.size(),
             thrust::make_transform_iterator( h_strings.begin(), [] (auto str) { return str!=nullptr; }));
         cudf::test::expect_columns_equal(*results,expected);

--- a/cpp/tests/strings/replace_regex_tests.cpp
+++ b/cpp/tests/strings/replace_regex_tests.cpp
@@ -94,6 +94,8 @@ TEST_F(StringsReplaceTests, InvalidRegex)
     EXPECT_THROW( cudf::strings::replace_re(strings_view,"|",cudf::string_scalar("")), cudf::logic_error );
     EXPECT_THROW( cudf::strings::replace_re(strings_view,"+",cudf::string_scalar("")), cudf::logic_error );
     EXPECT_THROW( cudf::strings::replace_re(strings_view,"ab(*)",cudf::string_scalar("")), cudf::logic_error );
+    EXPECT_THROW( cudf::strings::replace_re(strings_view,"\\",cudf::string_scalar("")), cudf::logic_error );
+    EXPECT_THROW( cudf::strings::replace_re(strings_view,"\\p",cudf::string_scalar("")), cudf::logic_error );
 }
 
 

--- a/cpp/tests/strings/replace_regex_tests.cpp
+++ b/cpp/tests/strings/replace_regex_tests.cpp
@@ -84,6 +84,19 @@ TEST_F(StringsReplaceTests, ReplaceMultiRegexTest)
     cudf::test::expect_columns_equal(*results,expected);
 }
 
+TEST_F(StringsReplaceTests, InvalidRegex)
+{
+    cudf::test::strings_column_wrapper strings( {"abc*def|ghi+jkl",""} ); // these do not really matter
+    auto strings_view = cudf::strings_column_view(strings);
+
+    // these are quantifiers that do not have a preceding character/class
+    EXPECT_THROW( cudf::strings::replace_re(strings_view,"*",cudf::string_scalar("")), cudf::logic_error );
+    EXPECT_THROW( cudf::strings::replace_re(strings_view,"|",cudf::string_scalar("")), cudf::logic_error );
+    EXPECT_THROW( cudf::strings::replace_re(strings_view,"+",cudf::string_scalar("")), cudf::logic_error );
+    EXPECT_THROW( cudf::strings::replace_re(strings_view,"ab(*)",cudf::string_scalar("")), cudf::logic_error );
+}
+
+
 TEST_F(StringsReplaceTests, ReplaceBackrefsRegexTest)
 {
     std::vector<const char*> h_strings{ "the quick brown fox jumps over the lazy dog",

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -478,7 +478,7 @@ class StringMethods(object):
 
         return self._return_or_inplace(
             cpp_replace_re(self._column, pat, Scalar(repl, "str"), n)
-            if regex is True
+            if regex is True and len(pat) > 1
             else cpp_replace(
                 self._column, Scalar(pat, "str"), Scalar(repl, "str"), n
             ),

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -476,6 +476,7 @@ class StringMethods(object):
             n = -1
         from cudf._libxx.scalar import Scalar
 
+        # Pandas forces non-regex replace when pat is a single-character
         return self._return_or_inplace(
             cpp_replace_re(self._column, pat, Scalar(repl, "str"), n)
             if regex is True and len(pat) > 1


### PR DESCRIPTION
Closes #3732 
Closes #3725 
Any regex quantifier requires a previous item to repeat in the expression pattern.
For example "a*" means to match "a" zero or more times.
An invalid quantifier expression like simply "*" (no preceding char to check) was causing the regex parser to go into an infinite loop trying to resolve the previous item.
Likewise, an invalid escape sequence like "\" (single backslash) was being silently ignored.
The code logic has been fixed in this PR and errors are returned for invalid regex patterns.

Closes #4671 
The `contains()` was incorrectly returning false for empty string with regex pattern ".*"
This was due to the end-parm being set to 0 (size of empty string) on the regex find() function.
The find() allows the end-parm to be -1 to indicate to the end of the string which returns the correct result.
Adding this simple one-line fix and tests to this PR as well.