### PR TITLE
[REVIEW] Fix comments for make_dictionary_column factory functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - PR #4609 Fix to handle `Series.factorize` when index is set
 - PR #4652 Fix misaligned error when computing regex device structs
 - PR #4651 Fix hashing benchmark missing includes
+- PR #4679 Fix comments for make_dictionary_column factory functions
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -344,13 +344,13 @@ std::unique_ptr<column> make_strings_column(
  * resulting strings column.
  *
  * @param num_strings The number of strings the column represents.
- * @param offsets The column of offset values for this column.
- *                The number of elements is one more than the total number
- *                of strings so the offset[last] - offset[0] is the total
- *                number of bytes in the strings vector.
- * @param chars The column of char bytes for all the strings for this column.
- *              Individual strings are identified by the offsets and the
- * nullmask.
+ * @param offsets_column The column of offset values for this column.
+ *                       The number of elements is one more than the total number
+ *                       of strings so the offset[last] - offset[0] is the total
+ *                       number of bytes in the strings vector.
+ * @param chars_column The column of char bytes for all the strings for this column.
+ *                     Individual strings are identified by the offsets and the
+ *                     nullmask.
  * @param null_count The number of null string entries.
  * @param null_mask The bits specifying the null strings in device memory.
  *                  Arrow format for nulls is used for interpeting this bitmask.

--- a/cpp/include/cudf/dictionary/dictionary_column_view.hpp
+++ b/cpp/include/cudf/dictionary/dictionary_column_view.hpp
@@ -71,8 +71,6 @@ public:
      */
     size_type keys_size() const noexcept;
 
-private:
-    column_view _dictionary;
 };
 
 } // namespace cudf

--- a/cpp/include/cudf/dictionary/dictionary_factories.hpp
+++ b/cpp/include/cudf/dictionary/dictionary_factories.hpp
@@ -43,6 +43,8 @@ namespace cudf
  * d is now {["a","c","d"],[1,0,0,2,2]}
  * ```
  *
+ * The null_mask and null count for the output column are copied from the indices column.
+ *
  * @throw cudf::logic_error if keys_column contains nulls
  * @throw cudf::logic_error if indices_column type is not INT32
  *
@@ -68,8 +70,6 @@ std::unique_ptr<column> make_dictionary_column( column_view const& keys_column,
  * `keys_column[i+1]` for all `i in [0,n-1)` where `n` is the number of keys.
  *
  * The indices values must be in the range [0,keys_column.size()).
- *
- * The null_mask and null count for the output column are copied from the indices column.
  *
  * @throw cudf::logic_error if keys_column or indices_column contains nulls
  * @throw cudf::logic_error if indices_column type is not INT32

--- a/cpp/include/cudf/dictionary/dictionary_factories.hpp
+++ b/cpp/include/cudf/dictionary/dictionary_factories.hpp
@@ -38,9 +38,9 @@ namespace cudf
  *
  * ```
  * k = ["a","c","d"]
- * i = [1,0,0,2,2]
+ * i = [1,0,null,2,2]
  * d = make_dictionary_column(k,i)
- * d is now {["a","c","d"],[1,0,0,2,2]}
+ * d is now {["a","c","d"],[1,0,undefined,2,2]} bitmask={1,1,0,1,1}
  * ```
  *
  * The null_mask and null count for the output column are copied from the indices column.
@@ -61,8 +61,8 @@ std::unique_ptr<column> make_dictionary_column( column_view const& keys_column,
                                                 cudaStream_t stream = 0);
 
 /**
- * @brief Construct a dictionary column by using the provided keys
- * and indices.
+ * @brief Construct a dictionary column by taking ownership of the provided keys
+ * and indices columns.
  *
  * The keys_column and indices columns must contain no nulls.
  * It is assumed the elements in `keys_column` are unique and

--- a/cpp/include/cudf/dictionary/encode.hpp
+++ b/cpp/include/cudf/dictionary/encode.hpp
@@ -19,9 +19,14 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 
+/**
+ * @file encode.hpp
+ * @brief Dictionary encode and decode APIs.
+ */
 
 namespace cudf
 {
+//! Dictionary column APIs.
 namespace dictionary
 {
 

--- a/cpp/include/cudf/strings/attributes.hpp
+++ b/cpp/include/cudf/strings/attributes.hpp
@@ -20,6 +20,7 @@
 
 namespace cudf
 {
+//! Strings column APIs.
 namespace strings
 {
 

--- a/cpp/include/cudf/strings/convert/convert_booleans.hpp
+++ b/cpp/include/cudf/strings/convert/convert_booleans.hpp
@@ -47,7 +47,7 @@ std::unique_ptr<column> to_booleans( strings_column_view const& strings,
  *
  * @throw cudf::logic_error if the input column is not BOOL8 type.
  *
- * @param column Boolean column to convert.
+ * @param booleans Boolean column to convert.
  * @param true_string String to use for true in the output column.
  * @param false_string String to use for false in the output column.
  * @param mr Resource for allocating device memory.

--- a/cpp/include/cudf/strings/convert/convert_floats.hpp
+++ b/cpp/include/cudf/strings/convert/convert_floats.hpp
@@ -56,9 +56,8 @@ std::unique_ptr<column> to_floats( strings_column_view const& strings,
  *
  * @throw cudf::logic_error if floats column is not float type.
  *
- * @param column Numeric column to convert.
+ * @param floats Numeric column to convert.
  * @param mr Resource for allocating device memory.
- * @param stream Stream to use for any kernels in this function.
  * @return New strings column with floats as strings.
  */
 std::unique_ptr<column> from_floats( column_view const& floats,

--- a/cpp/include/cudf/strings/convert/convert_integers.hpp
+++ b/cpp/include/cudf/strings/convert/convert_integers.hpp
@@ -61,9 +61,8 @@ std::unique_ptr<column> to_integers( strings_column_view const& strings,
  *
  * @throw cudf::logic_error if integers column is not integral type.
  *
- * @param column Numeric column to convert.
+ * @param integers Numeric column to convert.
  * @param mr Resource for allocating device memory.
- * @param stream Stream to use for any kernels in this function.
  * @return New strings column with integers as strings.
  */
 std::unique_ptr<column> from_integers( column_view const& integers,

--- a/cpp/include/cudf/strings/convert/convert_ipv4.hpp
+++ b/cpp/include/cudf/strings/convert/convert_ipv4.hpp
@@ -65,7 +65,7 @@ std::unique_ptr<column> ipv4_to_integers( strings_column_view const& strings,
  *
  * @throw cudf::logic_error if the input column is not INT64 type.
  *
- * @param column Integer (INT64) column to convert.
+ * @param integers Integer (INT64) column to convert.
  * @param mr Resource for allocating device memory.
  * @return New strings column.
  */

--- a/cpp/include/cudf/strings/padding.hpp
+++ b/cpp/include/cudf/strings/padding.hpp
@@ -54,6 +54,7 @@ enum class pad_side {
  *        Default is pad right (left justify).
  * @param fill_char Single UTF-8 character to use for padding.
  *        Default is the space character.
+ * @param mr Resource for allocating device memory.
  * @return New column with padded strings.
  */
 std::unique_ptr<column> pad( strings_column_view const& strings,
@@ -79,6 +80,7 @@ std::unique_ptr<column> pad( strings_column_view const& strings,
  *
  * @param strings Strings instance for this operation.
  * @param width The minimum number of characters for each string.
+ * @param mr Resource for allocating device memory.
  * @return New column of strings.
  */
 std::unique_ptr<column> zfill( strings_column_view const& strings,


### PR DESCRIPTION
Closes #4658 
Comment about the null-mask was on the wrong on both dictionary factory functions.
Also corrected some doxygen warnings and added comment to `strings` and `dictionary` namespaces so they appear nicely in the generated docs.