### PR TITLE
[REVIEW] Fix `test_repr` tests that generated RangeIndex column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,7 @@
 - PR #4625 Fix hash-based repartition bug in dask_cudf
 - PR #4662 Fix to handle `keep_index` in `partition_by_hash`
 - PR #4676 Fix bug in `_shuffle_group` for repartition
+- PR #XXXX Fix `test_repr` tests that were generating a `RangeIndex` for column names
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,7 +294,7 @@
 - PR #4625 Fix hash-based repartition bug in dask_cudf
 - PR #4662 Fix to handle `keep_index` in `partition_by_hash`
 - PR #4676 Fix bug in `_shuffle_group` for repartition
-- PR #XXXX Fix `test_repr` tests that were generating a `RangeIndex` for column names
+- PR #4681 Fix `test_repr` tests that were generating a `RangeIndex` for column names
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/python/cudf/cudf/tests/test_repr.py
+++ b/python/cudf/cudf/tests/test_repr.py
@@ -77,8 +77,11 @@ def test_full_series(nrows, dtype):
 @pytest.mark.parametrize("ncols", [0, 1, 2, 9, 20 / 2, 11, 20 - 1, 20, 20 + 1])
 def test_full_dataframe_20(dtype, nrows, ncols):
     size = 20
-    pdf = pd.DataFrame(np.random.randint(0, 100, (size, size))).astype(dtype)
+    pdf = pd.DataFrame(
+        {idx: np.random.randint(0, 100, size) for idx in range(size)}
+    ).astype(dtype)
     gdf = cudf.from_pandas(pdf)
+
     ncols, nrows = gdf._repr_pandas025_formatting(ncols, nrows, dtype)
     pd.options.display.max_rows = int(nrows)
     pd.options.display.max_columns = int(ncols)
@@ -93,7 +96,9 @@ def test_full_dataframe_20(dtype, nrows, ncols):
 @pytest.mark.parametrize("ncols", [9, 21 / 2, 11, 21 - 1])
 def test_full_dataframe_21(dtype, nrows, ncols):
     size = 21
-    pdf = pd.DataFrame(np.random.randint(0, 100, (size, size))).astype(dtype)
+    pdf = pd.DataFrame(
+        {idx: np.random.randint(0, 100, size) for idx in range(size)}
+    ).astype(dtype)
     gdf = cudf.from_pandas(pdf)
     pd.options.display.max_rows = int(nrows)
     pd.options.display.max_columns = int(ncols)

--- a/python/cudf/cudf/tests/test_repr.py
+++ b/python/cudf/cudf/tests/test_repr.py
@@ -100,6 +100,7 @@ def test_full_dataframe_21(dtype, nrows, ncols):
         {idx: np.random.randint(0, 100, size) for idx in range(size)}
     ).astype(dtype)
     gdf = cudf.from_pandas(pdf)
+
     pd.options.display.max_rows = int(nrows)
     pd.options.display.max_columns = int(ncols)
     assert pdf.__repr__() == gdf.__repr__()


### PR DESCRIPTION
Fixes #4677 

The tests were generating a column name index backed by a `RangeIndex` which is something cudf just doesn't support for column names. Pandas seems to actually format these differently which then causes failures since when cuDF converts to Pandas for printing it materializes the column names into an `Int64Index`.