### PR TITLE
Include frame lengths in Dask serialized header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,7 @@
 - PR #4445 Fix string issue for parquet reader and support `keep_index` for `scatter_to_tables`
 - PR #4423 Tighten up Dask serialization checks
 - PR #4537 Use `elif` in Dask deserialize check
+- PR #4682 Include frame lengths in Dask serialized header
 - PR #4438 Fix repl-template error for replace_with_backrefs
 - PR #4434 Fix join_strings logic with all-null strings and non-null narep
 - PR #4465 Fix use_pandas_index having no effect in libcudf++ parquet reader

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -27,6 +27,7 @@ try:
         with log_errors():
             header, frames = x.serialize()
             assert all((type(f) is cudf.core.buffer.Buffer) for f in frames)
+            header["lengths"] = [f.nbytes for f in frames]
             return header, frames
 
     # all (de-)serializtion are attached to cudf Objects:


### PR DESCRIPTION
As going through `"dask"` serialization can result in data being split for better compression, ensure the original number of bytes in the frame is stored in `header["lengths"]`. That way on `"dask"` deserialization the frames can be merged back into their original sizes before `"cuda"` serialization is performed.