### PR TITLE
WIP: Use Cython's `new_build_ext`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -197,10 +197,10 @@ if buildAll || hasArg cudf; then
 
     cd ${REPODIR}/python/cudf
     if [[ ${INSTALL_TARGET} != "" ]]; then
-        PARALLEL_LEVEL=${PARALLEL_LEVEL} python setup.py build_ext --inplace
+        python setup.py build_ext --inplace -j${PARALLEL_LEVEL}
         python setup.py install --single-version-externally-managed --record=record.txt
     else
-        PARALLEL_LEVEL=${PARALLEL_LEVEL} python setup.py build_ext --inplace --library-dir=${LIBCUDF_BUILD_DIR}
+        python setup.py build_ext --inplace --library-dir=${LIBCUDF_BUILD_DIR} -j${PARALLEL_LEVEL}
     fi
 fi
 

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -6,7 +6,6 @@ from distutils.sysconfig import get_python_lib
 
 import numpy as np
 import versioneer
-from Cython.Build import cythonize
 from setuptools import find_packages, setup
 from setuptools.extension import Extension
 
@@ -39,11 +38,6 @@ if not os.path.isdir(CUDA_HOME):
 
 cuda_include_dir = os.path.join(CUDA_HOME, "include")
 
-try:
-    nthreads = int(os.environ.get("PARALLEL_LEVEL", "0") or "0")
-except Exception:
-    nthreads = 0
-
 extensions = [
     Extension(
         "*",
@@ -64,6 +58,10 @@ extensions = [
         extra_compile_args=["-std=c++14"],
     )
 ]
+for e in extensions:
+    e.cython_directives = dict(
+        profile=False, language_level=3, embedsignature=True
+    )
 
 cmdclass = dict()
 cmdclass.update(versioneer.get_cmdclass())
@@ -87,13 +85,7 @@ setup(
     ],
     # Include the separately-compiled shared library
     setup_requires=["cython"],
-    ext_modules=cythonize(
-        extensions,
-        nthreads=nthreads,
-        compiler_directives=dict(
-            profile=False, language_level=3, embedsignature=True
-        ),
-    ),
+    ext_modules=extensions,
     packages=find_packages(include=["cudf", "cudf.*"]),
     package_data=dict.fromkeys(
         find_packages(include=["cudf._lib*"]), ["*.pxd"],

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -59,6 +59,9 @@ extensions = [
     )
 ]
 
+cmdclass = dict()
+cmdclass.update(versioneer.get_cmdclass())
+
 setup(
     name="cudf",
     version=versioneer.get_version(),
@@ -88,7 +91,7 @@ setup(
     package_data=dict.fromkeys(
         find_packages(include=["cudf._lib*"]), ["*.pxd"],
     ),
-    cmdclass=versioneer.get_cmdclass(),
+    cmdclass=cmdclass,
     install_requires=install_requires,
     zip_safe=False,
 )

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -10,6 +10,12 @@ from Cython.Build import cythonize
 from setuptools import find_packages, setup
 from setuptools.extension import Extension
 
+try:
+    from Cython.Distutils.build_ext import new_build_ext as build_ext
+except ImportError:
+    from setuptools.command.build_ext import build_ext
+
+
 install_requires = ["numba", "cython"]
 
 cython_files = ["cudf/**/*.pyx"]
@@ -61,6 +67,7 @@ extensions = [
 
 cmdclass = dict()
 cmdclass.update(versioneer.get_cmdclass())
+cmdclass["build_ext"] = build_ext
 
 setup(
     name="cudf",


### PR DESCRIPTION
As pointed out by @trxcllnt yesterday, we could use Cython's `new_build_ext` to speed up compilation of Cython code. This makes that change to cuDF so we can benefit from `new_build_ext`.