### PR TITLE
[REVIEW] Make MemoryBuffer public, and add MemoryBuffer.slice [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #4645 Add Alias for `kurtosis` as `kurt`
 - PR #4668 Add Java bindings for log2/log10 unary ops and log_base binary op
 - PR #4616 Enable different RMM allocation modes in unit tests
+- PR #4699 Make Java's MemoryBuffer public and add MemoryBuffer.slice
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/BaseDeviceMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/BaseDeviceMemoryBuffer.java
@@ -21,7 +21,7 @@ package ai.rapids.cudf;
 /**
  * Base class for all MemoryBuffers that are in device memory.
  */
-public class BaseDeviceMemoryBuffer extends MemoryBuffer {
+public abstract class BaseDeviceMemoryBuffer extends MemoryBuffer {
   protected BaseDeviceMemoryBuffer(long address, long length, MemoryBuffer parent) {
     super(address, length, parent);
   }

--- a/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
@@ -88,7 +88,7 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
     super(address, lengthInBytes, new DeviceBufferCleaner(address));
   }
 
-  private DeviceMemoryBuffer(long address, long lengthInBytes, BaseDeviceMemoryBuffer parent) {
+  private DeviceMemoryBuffer(long address, long lengthInBytes, DeviceMemoryBuffer parent) {
     super(address, lengthInBytes, parent);
   }
 

--- a/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
     super(address, lengthInBytes, new DeviceBufferCleaner(address));
   }
 
-  private DeviceMemoryBuffer(long address, long lengthInBytes, DeviceMemoryBuffer parent) {
+  private DeviceMemoryBuffer(long address, long lengthInBytes, BaseDeviceMemoryBuffer parent) {
     super(address, lengthInBytes, parent);
   }
 
@@ -109,6 +109,7 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
    * @param len how many bytes to slice
    * @return a device buffer that will need to be closed independently from this buffer.
    */
+  @Override
   public synchronized final DeviceMemoryBuffer slice(long offset, long len) {
     addressOutOfBoundsCheck(address + offset, len, "slice");
     refCount++;

--- a/java/src/main/java/ai/rapids/cudf/DeviceMemoryBufferView.java
+++ b/java/src/main/java/ai/rapids/cudf/DeviceMemoryBufferView.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -27,5 +27,13 @@ public class DeviceMemoryBufferView extends BaseDeviceMemoryBuffer {
   DeviceMemoryBufferView(long address, long lengthInBytes) {
     // Set the cleaner to null so we don't end up releasing anything
     super(address, lengthInBytes, (MemoryBufferCleaner) null);
+  }
+
+  /**
+   * At the moment we don't have use for slicing a view.
+   */
+  @Override
+  public synchronized final DeviceMemoryBufferView slice(long offset, long len) {
+    throw new UnsupportedOperationException("Slice on view is not supported");
   }
 }

--- a/java/src/main/java/ai/rapids/cudf/HostMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/HostMemoryBuffer.java
@@ -549,6 +549,7 @@ public class HostMemoryBuffer extends MemoryBuffer {
    * @param len how many bytes to slice
    * @return a host buffer that will need to be closed independently from this buffer.
    */
+  @Override
   public final synchronized HostMemoryBuffer slice(long offset, long len) {
     addressOutOfBoundsCheck(address + offset, len, "slice");
     refCount++;

--- a/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,8 +25,11 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Abstract class for representing the Memory Buffer
+ *
+ * NOTE: MemoryBuffer is public to make it easier to work with the class hierarchy,
+ * subclassing beyond what is included in CUDF is not recommended and not supported.
  */
-abstract class MemoryBuffer implements AutoCloseable {
+abstract public class MemoryBuffer implements AutoCloseable {
   private static final Logger log = LoggerFactory.getLogger(MemoryBuffer.class);
   private static final AtomicLong idGen = new AtomicLong(0);
   protected final long address;
@@ -145,6 +148,20 @@ abstract class MemoryBuffer implements AutoCloseable {
   public final long getAddress() {
     return address;
   }
+
+  /**
+   * Slice off a part of the buffer. Note that this is a zero copy operation and all
+   * slices must be closed along with the original buffer before the memory is released.
+   * So use this with some caution.
+   *
+   * Note that [[DeviceMemoryBuffer]] and [[HostMemoryBuffer]] support slicing, and override this
+   * function.
+   *
+   * @param offset where to start the slice at.
+   * @param len how many bytes to slice
+   * @return a slice of the original buffer that will need to be closed independently
+   */
+  public abstract MemoryBuffer slice(long offset, long len);
 
   /**
    * Close this buffer and free memory


### PR DESCRIPTION
This PR exposes `MemoryBuffer` and `MemoryBuffer.slice`, so that it is easier for callers to work with `MemoryBuffer` as opposed to specializing everything for `HostMemoryBuffer`, `DeviceMemoryBuffer`, etc.