### PR TITLE
Fix column leaks in Java unit test [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,13 @@
 - PR #4613 Fix issue related to downcasting in `.loc`
 - PR #4615 Fix potential OOB write in ORC writer compression stage
 - PR #4587 Fix non-regex libcudf contains methods to return true when target is an empty string
-
 - PR #4617 Fix memory leak in aggregation object destructor
 - PR #4633 String concatenation fix in `DataFrame.rename`
 - PR #4609 Fix to handle `Series.factorize` when index is set
 - PR #4652 Fix misaligned error when computing regex device structs
 - PR #4651 Fix hashing benchmark missing includes
 - PR #4679 Fix comments for make_dictionary_column factory functions
+- PR #4711 Fix column leaks in Java unit test
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/java/src/test/java/ai/rapids/cudf/BinaryOpTest.java
+++ b/java/src/test/java/ai/rapids/cudf/BinaryOpTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -1088,11 +1088,11 @@ public class BinaryOpTest extends CudfTestBase {
   @Test
   public void testLogBase10() {
     try (ColumnVector dcv1 = ColumnVector.fromBoxedDoubles(DOUBLES_2);
-         Scalar base = Scalar.fromInt(10)) {
-      ColumnVector answer = dcv1.log(base);
-      ColumnVector expected = ColumnVector.fromBoxedDoubles(Arrays.stream(DOUBLES_2)
-        .map(Math::log10)
-        .toArray(Double[]::new));
+         Scalar base = Scalar.fromInt(10);
+         ColumnVector answer = dcv1.log(base);
+         ColumnVector expected = ColumnVector.fromBoxedDoubles(Arrays.stream(DOUBLES_2)
+            .map(Math::log10)
+            .toArray(Double[]::new))) {
       assertColumnsAreEqual(expected, answer, "log10");
     }
   }
@@ -1100,11 +1100,11 @@ public class BinaryOpTest extends CudfTestBase {
   @Test
   public void testLogBase2() {
     try (ColumnVector dcv1 = ColumnVector.fromBoxedDoubles(DOUBLES_2);
-         Scalar base = Scalar.fromInt(2)) {
-      ColumnVector answer = dcv1.log(base);
-      ColumnVector expected = ColumnVector.fromBoxedDoubles(Arrays.stream(DOUBLES_2)
-        .map(n -> Math.log(n) / Math.log(2))
-        .toArray(Double[]::new));
+         Scalar base = Scalar.fromInt(2);
+         ColumnVector answer = dcv1.log(base);
+         ColumnVector expected = ColumnVector.fromBoxedDoubles(Arrays.stream(DOUBLES_2)
+             .map(n -> Math.log(n) / Math.log(2))
+             .toArray(Double[]::new))) {
       assertColumnsAreEqual(expected, answer, "log2");
     }
   }


### PR DESCRIPTION
This fixes a couple of columns that can be leaked in a unit test.  These leaks can cause issues if later unit tests in the same JVM process reinitializes RMM, invalidating the memory resource allocators associated with the columns that were leaked.