### PR TITLE
[REVIEW] Fix strings::pad when using pad::both with odd width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - PR #4651 Fix hashing benchmark missing includes
 - PR #4679 Fix comments for make_dictionary_column factory functions
 - PR #4711 Fix column leaks in Java unit test
+- PR #4722 Fix strings::pad when using pad::both with odd width
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/cpp/src/strings/padding.cu
+++ b/cpp/src/strings/padding.cu
@@ -124,8 +124,8 @@ std::unique_ptr<column> pad( strings_column_view const& strings,
                 string_view d_str = d_strings.element<string_view>(idx);
                 char* ptr = d_chars + d_offsets[idx];
                 int32_t pad = static_cast<int32_t>(width - d_str.length());
-                auto right_pad = pad/2;
-                auto left_pad = pad - right_pad;
+                auto right_pad = (width & 1) ? pad/2 : (pad-pad/2); // odd width = right-justify
+                auto left_pad = pad - right_pad; // e.g. width=7 gives "++foxx+" while width=6 gives "+fox++"
                 while( left_pad-- > 0 )
                     ptr += from_char_utf8(d_fill_char,ptr);
                 ptr = copy_string(ptr, d_str);

--- a/cpp/src/strings/padding.cu
+++ b/cpp/src/strings/padding.cu
@@ -124,7 +124,7 @@ std::unique_ptr<column> pad( strings_column_view const& strings,
                 string_view d_str = d_strings.element<string_view>(idx);
                 char* ptr = d_chars + d_offsets[idx];
                 int32_t pad = static_cast<int32_t>(width - d_str.length());
-                auto right_pad = (width & 1) ? pad/2 : (pad-pad/2); // odd width = right-justify
+                auto right_pad = (width & 1) ? pad/2 : (pad - pad/2); // odd width = right-justify
                 auto left_pad = pad - right_pad; // e.g. width=7 gives "++foxx+" while width=6 gives "+fox++"
                 while( left_pad-- > 0 )
                     ptr += from_char_utf8(d_fill_char,ptr);

--- a/cpp/tests/strings/pad_tests.cu
+++ b/cpp/tests/strings/pad_tests.cu
@@ -59,9 +59,27 @@ TEST_F(StringsPadTest, Padding)
     {
         auto results = cudf::strings::pad(strings_view, width, cudf::strings::pad_side::BOTH, phil);
 
-        std::vector<const char*> h_expected{ "eee ddd", "+bb cc", nullptr, "++++++", "++aa++", "++bbb+", "++ééé+", "+++o++" };
+        std::vector<const char*> h_expected{ "eee ddd", "bb cc+", nullptr, "++++++", "++aa++", "+bbb++", "+ééé++", "++o+++" };
         cudf::test::strings_column_wrapper expected( h_expected.begin(), h_expected.end(),
              thrust::make_transform_iterator( h_expected.begin(), [] (auto str) { return str!=nullptr; }));
+        cudf::test::expect_columns_equal(*results,expected);
+    }
+}
+
+TEST_F(StringsPadTest, PaddingBoth)
+{
+    cudf::test::strings_column_wrapper strings( {"koala", "foxx", "fox", "chameleon"} );
+    std::string phil = "+";
+    auto strings_view = cudf::strings_column_view(strings);
+
+    {   // even width left justify
+        auto results = cudf::strings::pad(strings_view, 6, cudf::strings::pad_side::BOTH, phil);
+        cudf::test::strings_column_wrapper expected( {"koala+", "+foxx+", "+fox++", "chameleon"} );
+        cudf::test::expect_columns_equal(*results,expected);
+    }
+    {   // odd width right justify
+        auto results = cudf::strings::pad(strings_view, 7, cudf::strings::pad_side::BOTH, phil);
+        cudf::test::strings_column_wrapper expected( {"+koala+", "++foxx+", "++fox++", "chameleon"} );
         cudf::test::expect_columns_equal(*results,expected);
     }
 }


### PR DESCRIPTION
Closes #4354 
Passing pad widths in Pandas `center()` results in different behavior if the width parameter is an odd vs even value. If the width is odd and the resulting pad is also odd (string width is even), then the extra padding character goes on the _left_ of the resulting string. If the width is even and the resulting pad is odd (string width is odd), then the extra padding character goes on the _right_ of the resulting string.

```
ps = pd.Series(["fox","foxx"])
ps.str.center(6,"+")
0    +fox++
1    +foxx+

ps.str.center(7,"+")
0    ++fox++
1    ++foxx+
```
Using width=6 and odd-lengthed string 'fox' the extra padding char '+' goes on the right.
Using width=7 and even-lengthed string 'foxx' the extra padding char '+" goes on the left.

More examples are in the #4354 description and comments.
Also added more tests that include more pad::BOTH cases.
