### PR TITLE
[REVIEW] Fix issue with not setting GPU on background thread [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - PR #4651 Fix hashing benchmark missing includes
 - PR #4679 Fix comments for make_dictionary_column factory functions
 - PR #4711 Fix column leaks in Java unit test
+- PR #4725 Fix issue java with not setting GPU on background thread
 
 
 # cuDF 0.13.0 (Date TBD)

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -147,10 +147,6 @@ final class MemoryCleaner {
    * The default GPU as set by user threads.
    */
   private static volatile int defaultGpu = -1;
-  /**
-   * The default GPU as set by the cleaner thread.
-   */
-  private static volatile int currentGpuId = -1;
 
   /**
    * This should be called from RMM when it is initialized.
@@ -161,6 +157,7 @@ final class MemoryCleaner {
 
   private static final Thread t = new Thread(() -> {
     try {
+      int currentGpuId = -1;
       while (true) {
         CleanerWeakReference next = (CleanerWeakReference)collected.remove(100);
         if (next != null) {

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -37,7 +37,7 @@ public class Rmm {
    * @throws IllegalStateException if RMM has already been initialized
    */
   public static void initialize(int allocationMode, boolean enableLogging, long poolSize) {
-    initialize(allocationMode, enableLogging, poolSize, -1);
+    initialize(allocationMode, enableLogging, poolSize, Cuda.getDevice());
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -36,7 +36,24 @@ public class Rmm {
    * @param poolSize       The initial pool size in bytes
    * @throws IllegalStateException if RMM has already been initialized
    */
-  public static void initialize(int allocationMode, boolean enableLogging, long poolSize)
+  public static void initialize(int allocationMode, boolean enableLogging, long poolSize) {
+    initialize(allocationMode, enableLogging, poolSize, -1);
+  }
+
+  /**
+   * Initialize memory manager state and storage.
+   * @param allocationMode Allocation strategy to use. Bit set using
+   *                       {@link RmmAllocationMode#CUDA_DEFAULT},
+   *                       {@link RmmAllocationMode#POOL} and
+   *                       {@link RmmAllocationMode#CUDA_MANAGED_MEMORY}
+   * @param enableLogging  Enable logging memory manager events
+   * @param poolSize       The initial pool size in bytes
+   * @param gpuId          The GPU that RMM should use.  You are still responsible for
+   *                       setting this GPU yourself on each thread before calling RMM
+   *                       this just sets it for any internal threads used.
+   * @throws IllegalStateException if RMM has already been initialized
+   */
+  public static void initialize(int allocationMode, boolean enableLogging, long poolSize, int gpuId)
       throws RmmException {
     if (defaultInitialized) {
       synchronized(Rmm.class) {
@@ -47,6 +64,9 @@ public class Rmm {
       }
     }
     initializeInternal(allocationMode, enableLogging, poolSize);
+    if (gpuId >= 0) {
+      MemoryCleaner.setDefaultGpu(gpuId);
+    }
   }
 
   /**


### PR DESCRIPTION
If a non-default GPU is used the memory cleaner thread was still on the default GPU so they were not being collected, even though all of the code indicated that it was a success.
