### PR TITLE
[REVIEW] Protect against shutting down RMM with memory pending [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -2467,6 +2467,11 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
       return neededCleanup;
     }
 
+    @Override
+    public boolean isClean() {
+      return viewHandle == 0 && columnHandle == 0 && data == null && valid == null && offsets == null;
+    }
+
     /**
      * This returns total memory allocated in device for the ColumnVector.
      * @return number of device bytes allocated for this column

--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -50,6 +50,11 @@ public class Cuda {
       }
       return neededCleanup;
     }
+
+    @Override
+    public boolean isClean() {
+      return stream == 0;
+    }
   }
 
   /** A class representing a CUDA stream */
@@ -140,6 +145,11 @@ public class Cuda {
         logRefCountDebug("Leaked event");
       }
       return neededCleanup;
+    }
+
+    @Override
+    public boolean isClean() {
+      return event == 0;
     }
   }
 

--- a/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
@@ -51,6 +51,11 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
       }
       return neededCleanup;
     }
+
+    @Override
+    public boolean isClean() {
+      return address == 0;
+    }
   }
 
   private static final class RmmDeviceBufferCleaner extends MemoryBufferCleaner {
@@ -73,6 +78,11 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
         logRefCountDebug("Leaked device buffer");
       }
       return neededCleanup;
+    }
+
+    @Override
+    public boolean isClean() {
+      return rmmBufferAddress == 0;
     }
   }
 

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -519,6 +519,11 @@ public final class HostColumnVector implements AutoCloseable {
       }
     }
 
+    @Override
+    public boolean isClean() {
+      return data == null && valid == null && offsets == null;
+    }
+
     /**
      * This returns total memory allocated on the host for the ColumnVector.
      */

--- a/java/src/main/java/ai/rapids/cudf/HostMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/HostMemoryBuffer.java
@@ -85,6 +85,11 @@ public class HostMemoryBuffer extends MemoryBuffer {
       }
       return neededCleanup;
     }
+
+    @Override
+    public boolean isClean() {
+      return address == 0;
+    }
   }
 
   private static final class MmapCleaner extends MemoryBufferCleaner {
@@ -109,6 +114,11 @@ public class HostMemoryBuffer extends MemoryBuffer {
         logRefCountDebug("Leaked mmap buffer");
       }
       return neededCleanup;
+    }
+
+    @Override
+    public boolean isClean() {
+      return address == 0;
     }
   }
 

--- a/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
@@ -58,6 +58,11 @@ abstract public class MemoryBuffer implements AutoCloseable {
       }
       return false;
     }
+
+    @Override
+    public boolean isClean() {
+      return parent == null;
+    }
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -120,6 +120,12 @@ final class MemoryCleaner {
     public void noWarnLeakExpected() {
       leakExpected = true;
     }
+
+    /**
+     * Check if the underlying memory has been cleaned up or not.
+     * @return true this is clean else false.
+     */
+    public abstract boolean isClean();
   }
 
   static final AtomicLong leakCount = new AtomicLong();
@@ -130,10 +136,12 @@ final class MemoryCleaner {
   private static class CleanerWeakReference<T> extends WeakReference<T> {
 
     private final Cleaner cleaner;
+    final boolean isRmmBlocker;
 
-    public CleanerWeakReference(T orig, Cleaner cleaner, ReferenceQueue collected) {
+    public CleanerWeakReference(T orig, Cleaner cleaner, ReferenceQueue collected, boolean isRmmBlocker) {
       super(orig, collected);
       this.cleaner = cleaner;
+      this.isRmmBlocker = isRmmBlocker;
     }
 
     public void clean() {
@@ -208,27 +216,36 @@ final class MemoryCleaner {
 
   static void register(ColumnVector vec, Cleaner cleaner) {
     // It is now registered...
-    all.add(new CleanerWeakReference(vec, cleaner, collected));
+    all.add(new CleanerWeakReference(vec, cleaner, collected, true));
   }
 
   static void register(HostColumnVector vec, Cleaner cleaner) {
     // It is now registered...
-    all.add(new CleanerWeakReference(vec, cleaner, collected));
+    all.add(new CleanerWeakReference(vec, cleaner, collected, false));
   }
 
   static void register(MemoryBuffer buf, Cleaner cleaner) {
     // It is now registered...
-    all.add(new CleanerWeakReference(buf, cleaner, collected));
+    all.add(new CleanerWeakReference(buf, cleaner, collected, buf instanceof BaseDeviceMemoryBuffer));
   }
 
   static void register(Cuda.Stream stream, Cleaner cleaner) {
     // It is now registered...
-    all.add(new CleanerWeakReference(stream, cleaner, collected));
+    all.add(new CleanerWeakReference(stream, cleaner, collected, false));
   }
 
   static void register(Cuda.Event event, Cleaner cleaner) {
     // It is now registered...
-    all.add(new CleanerWeakReference(event, cleaner, collected));
+    all.add(new CleanerWeakReference(event, cleaner, collected, false));
+  }
+
+  /**
+   * This is not 100% perfect and we can still run into situations where RMM buffers were not
+   * collected and this returns true because of thread race conditions. This is just a best effort.
+   * @return true if there are no rmm blockers else false.
+   */
+  static boolean bestEffortNoRmmBlockers() {
+    return !all.stream().anyMatch(cwr -> cwr.isRmmBlocker && !cwr.cleaner.isClean());
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -241,11 +241,11 @@ final class MemoryCleaner {
 
   /**
    * This is not 100% perfect and we can still run into situations where RMM buffers were not
-   * collected and this returns true because of thread race conditions. This is just a best effort.
-   * @return true if there are no rmm blockers else false.
+   * collected and this returns false because of thread race conditions. This is just a best effort.
+   * @return true if there are rmm blockers else false.
    */
-  static boolean bestEffortNoRmmBlockers() {
-    return !all.stream().anyMatch(cwr -> cwr.isRmmBlocker && !cwr.cleaner.isClean());
+  static boolean bestEffortHasRmmBlockers() {
+    return all.stream().anyMatch(cwr -> cwr.isRmmBlocker && !cwr.cleaner.isClean());
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
+++ b/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
@@ -110,8 +110,9 @@ public final class PinnedMemoryPool implements AutoCloseable {
     @Override
     protected boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
-      long origAddress = section.baseAddress;
+      long origAddress = 0;
       if (section != null) {
+        origAddress = section.baseAddress;
         PinnedMemoryPool.freeInternal(section);
         if (origLength > 0) {
           MemoryListener.hostDeallocation(origLength, id);
@@ -124,6 +125,11 @@ public final class PinnedMemoryPool implements AutoCloseable {
         logRefCountDebug("Leaked pinned host buffer");
       }
       return neededCleanup;
+    }
+
+    @Override
+    public boolean isClean() {
+      return section == null;
     }
   }
 

--- a/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
+++ b/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -119,7 +119,25 @@ public class Rmm {
   /**
    * Shut down any initialized rmm.
    */
-  public static native void shutdown() throws RmmException;
+  public static void shutdown() throws RmmException {
+    final int MAX_ATTEMPTS = 4;
+    int attempts = 0;
+    try {
+      while (!MemoryCleaner.bestEffortNoRmmBlockers() && attempts < MAX_ATTEMPTS) {
+        System.gc();
+        attempts++;
+        Thread.sleep(500);
+      }
+    } catch (InterruptedException e) {
+      // Ignored
+    }
+    if (attempts >= MAX_ATTEMPTS) {
+      throw new RmmException("Could not shut down RMM there appear to be outstanding allocations");
+    }
+    shutdownInternal();
+  }
+
+  private native static void shutdownInternal() throws RmmException;
 
   /**
    * ---------------------------------------------------------------------------*

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -16,6 +16,7 @@
 package ai.rapids.cudf;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This is the binding class for rmm lib.
@@ -117,21 +118,57 @@ public class Rmm {
   private static native boolean isInitializedInternal() throws RmmException;
 
   /**
-   * Shut down any initialized rmm.
+   * Shut down any initialized RMM instance.  This should be used very rarely.  It does not need to
+   * be used when shutting down your process because CUDA will handle releasing all of the
+   * resources when your process exits.  This really should only be used if you want to turn off the
+   * memory pool for some reasons.  As such we make an effort to be sure no resources have been
+   * leaked before shutting down.  This may involve forcing a JVM GC to collect any leaked java
+   * objects that still point to CUDA memory.  By default this will do a gc every 2 seconds and
+   * wait for up to 4 seconds before throwing an RmmException if not all of the resources are freed.
+   * @throws RmmException on any error. This includes if there are outstanding allocations that
+   * could not be collected.
    */
   public static void shutdown() throws RmmException {
-    final int MAX_ATTEMPTS = 4;
-    int attempts = 0;
+    shutdown(2, 4, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Shut down any initialized RMM instance.  This should be used very rarely.  It does not need to
+   * be used when shutting down your process because CUDA will handle releasing all of the
+   * resources when your process exits.  This really should only be used if you want to turn off the
+   * memory pool for some reasons.  As such we make an effort to be sure no resources have been
+   * leaked before shutting down.  This may involve forcing a JVM GC to collect any leaked java
+   * objects that still point to CUDA memory.
+   *
+   * @param forceGCInterval how frequently should we force a JVM GC. This is just a recommendation
+   *                        to the JVM to do a gc.
+   * @param maxWaitTime the maximum amount of time to wait for all objects to be collected before
+   *                    throwing an exception.
+   * @param units the units for forceGcInterval and maxWaitTime.
+   * @throws RmmException on any error. This includes if there are outstanding allocations that
+   * could not be collected before maxWaitTime.
+   */
+  public static void shutdown(long forceGCInterval, long maxWaitTime, TimeUnit units)
+      throws RmmException{
+    long now = System.currentTimeMillis();
+    final long endTime = now + units.toMillis(maxWaitTime);
+    long nextGcTime = now;
     try {
-      while (!MemoryCleaner.bestEffortNoRmmBlockers() && attempts < MAX_ATTEMPTS) {
-        System.gc();
-        attempts++;
-        Thread.sleep(500);
+      if (MemoryCleaner.bestEffortHasRmmBlockers()) {
+        do {
+          if (nextGcTime <= now) {
+            System.gc();
+            nextGcTime = nextGcTime + units.toMillis(forceGCInterval);
+          }
+          // Check if everything is ready about every 10 ms
+          Thread.sleep(10);
+          now = System.currentTimeMillis();
+        } while (endTime > now && MemoryCleaner.bestEffortHasRmmBlockers());
       }
     } catch (InterruptedException e) {
       // Ignored
     }
-    if (attempts >= MAX_ATTEMPTS) {
+    if (MemoryCleaner.bestEffortHasRmmBlockers()) {
       throw new RmmException("Could not shut down RMM there appear to be outstanding allocations");
     }
     shutdownInternal();

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -495,5 +495,10 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
       }
       return false;
     }
+
+    @Override
+    public boolean isClean() {
+      return scalarHandle == 0;
+    }
   }
 }

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -292,7 +292,7 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Rmm_isInitializedInternal(JNIEnv 
   } CATCH_STD(env, false)
 }
 
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_shutdown(JNIEnv *env, jclass clazz) {
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_shutdownInternal(JNIEnv *env, jclass clazz) {
   try {
     set_java_device_memory_resource(env, nullptr, nullptr, nullptr);
     JNI_RMM_TRY(env, , rmmFinalize());

--- a/java/src/test/java/ai/rapids/cudf/RmmMemoryAccessorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/RmmMemoryAccessorTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 package ai.rapids.cudf;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -64,7 +66,7 @@ class RmmMemoryAccessorTest extends CudfTestBase {
     }
     Rmm.initialize(RmmAllocationMode.POOL, false, 2048);
     try (DeviceMemoryBuffer buffer = DeviceMemoryBuffer.allocate(1024)) {
-      assertThrows(RmmException.class, () -> Rmm.shutdown());
+      assertThrows(RmmException.class, () -> Rmm.shutdown(500, 2000, TimeUnit.MILLISECONDS));
     }
     Rmm.shutdown();
   }

--- a/java/src/test/java/ai/rapids/cudf/RmmMemoryAccessorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/RmmMemoryAccessorTest.java
@@ -58,6 +58,18 @@ class RmmMemoryAccessorTest extends CudfTestBase {
   }
 
   @Test
+  public void shutdown() {
+    if (Rmm.isInitialized()) {
+      Rmm.shutdown();
+    }
+    Rmm.initialize(RmmAllocationMode.POOL, false, 2048);
+    try (DeviceMemoryBuffer buffer = DeviceMemoryBuffer.allocate(1024)) {
+      assertThrows(RmmException.class, () -> Rmm.shutdown());
+    }
+    Rmm.shutdown();
+  }
+
+  @Test
   public void allocate() {
     long address = Rmm.alloc(10, 0);
     try {


### PR DESCRIPTION
For the second time we spent way too long debugging a seg fault when RMM was shut down in a unit test after another test leaked some device memory.  This adds in a best effort guard against that happening.
