### PR TITLE
[HOTFIX] FIX Update fsspec version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,7 @@
 - PR #4683 Fix Slicing issue with categorical column in DataFrame
 - PR #4676 Fix bug in `_shuffle_group` for repartition
 - PR #4681 Fix `test_repr` tests that were generating a `RangeIndex` for column names
+- PR #4729 Fix `fsspec` versioning to prevent dask test failures
 
 
 # cuDF 0.12.0 (04 Feb 2020)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,7 +59,7 @@ logger "Activate conda env..."
 source activate gdf
 conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
               "dask>=2.1.0" "distributed>=2.1.0" "numpy>=1.16" "double-conversion" \
-              "rapidjson" "flatbuffers" "boost-cpp" "fsspec>=0.3.3" "dlpack" \
+              "rapidjson" "flatbuffers" "boost-cpp" "fsspec>=0.3.3,<0.7.0a0" "dlpack" \
               "feather-format" "cupy>=6.6.0,<8.0.0a0,!=7.1.0" "arrow-cpp=0.15.0" "pyarrow=0.15.0" \
               "fastavro>=0.22.0" "pandas>=0.25,<0.26" "hypothesis" "s3fs" "gcsfs" \
               "boto3" "moto" "httpretty" "streamz" "ipython=7.3*" "jupyterlab"

--- a/conda/environments/cudf_dev_cuda10.0.yml
+++ b/conda/environments/cudf_dev_cuda10.0.yml
@@ -17,7 +17,7 @@ dependencies:
   - fastavro>=0.22.9
   - notebook>=0.5.0
   - cython>=0.29,<0.30
-  - fsspec>=0.3.3
+  - fsspec>=0.3.3,<0.7.0a0
   - pytest
   - sphinx
   - sphinx_rtd_theme

--- a/conda/environments/cudf_dev_cuda10.1.yml
+++ b/conda/environments/cudf_dev_cuda10.1.yml
@@ -17,7 +17,7 @@ dependencies:
   - fastavro>=0.22.9
   - notebook>=0.5.0
   - cython>=0.29,<0.30
-  - fsspec>=0.3.3
+  - fsspec>=0.3.3,<0.7.0a0
   - pytest
   - sphinx
   - sphinx_rtd_theme

--- a/conda/environments/cudf_dev_cuda10.2.yml
+++ b/conda/environments/cudf_dev_cuda10.2.yml
@@ -17,7 +17,7 @@ dependencies:
   - fastavro>=0.22.9
   - notebook>=0.5.0
   - cython>=0.29,<0.30
-  - fsspec>=0.3.3
+  - fsspec>=0.3.3,<0.7.0a0
   - pytest
   - sphinx
   - sphinx_rtd_theme
@@ -27,7 +27,7 @@ dependencies:
   - ipython
   - recommonmark
   - pandoc=<2.0.0
-  - cudatoolkit=9.2
+  - cudatoolkit=10.2
   - pip
   - partd
   - flake8

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - rmm {{ minor_version }}.*
     - nvstrings {{ minor_version }}.*
     - dlpack
-    - fsspec>=0.3.3
+    - fsspec>=0.3.3,<0.7.0a0
 
 test:
   commands:


### PR DESCRIPTION
`fsspec` 0.7.0 was released ~7hrs ago and is breaking dask tests due to recent changes. This is to update the allowed versions to prevent the failures.

Follows updates made in rapidsai/integration#17