### PR TITLE
[REVIEW] Added in an option to statically link against cudart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PR #4626 LogBase binops
 - PR #4750 Normalize NANs and Zeroes (JNI Bindings)
 - PR #4689 Compute last day of the month for a given date
+- PR #4771 Added in an option to statically link against cudart
 
 ## Improvements
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -143,12 +143,14 @@ option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 # - cudart options --------------------------------------------------------------------------------
 # cudart can be statically linked or dynamically linked. The python ecosystem wants dynamic linking
 
-if(CUDA_RUNTIME_LIBRARY AND CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
+option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
+
+if(CUDA_STATIC_RUNTIME)
     message(STATUS "Enabling static linking of cudart")
     set(CUDART_LIBRARY "cudart_static")
 else()
     set(CUDART_LIBRARY "cudart")
-endif(CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
+endif(CUDA_STATIC_RUNTIME)
 
 ###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -140,6 +140,17 @@ option(BUILD_TESTS "Configure CMake to build tests" ON)
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 
 ###################################################################################################
+# - cudart options --------------------------------------------------------------------------------
+# cudart can be statically linked or dynamically linked. The python ecosystem wants dynamic linking
+
+if(CUDA_RUNTIME_LIBRARY AND CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
+    message(STATUS "Enabling static linking of cudart")
+    set(CUDART_LIBRARY "cudart_static")
+else()
+    set(CUDART_LIBRARY "cudart")
+endif(CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
+
+###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
@@ -797,12 +808,12 @@ endif(HT_DEFAULT_ALLOCATOR)
 set(ARROW_CUDA_LIB_LINK -Wl,--whole-archive ${ARROW_CUDA_LIB} -Wl,--no-whole-archive)
 
 # link targets for NVStrings
-target_link_libraries(libNVStrings rmm cudart cuda)
-target_link_libraries(libNVCategory libNVStrings rmm cudart cuda)
-target_link_libraries(libNVText libNVStrings rmm cudart cuda)
+target_link_libraries(libNVStrings rmm ${CUDART_LIBRARY} cuda)
+target_link_libraries(libNVCategory libNVStrings rmm ${CUDART_LIBRARY} cuda)
+target_link_libraries(libNVText libNVStrings rmm ${CUDART_LIBRARY} cuda)
 
 # link targets for cuDF
-target_link_libraries(cudf NVCategory NVStrings rmm ${ARROW_CUDA_LIB_LINK} ${ARROW_LIB} nvrtc cudart cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(cudf NVCategory NVStrings rmm ${ARROW_CUDA_LIB_LINK} ${ARROW_LIB} nvrtc ${CUDART_LIBRARY} cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------

--- a/java/README.md
+++ b/java/README.md
@@ -8,14 +8,9 @@ a GPU. This is still a work in progress so some APIs may change until the 1.0 re
 This is a fat jar with the binary dependencies packaged in the jar.  This means the jar will only
 run on platforms the jar was compiled for.  When this is in an official maven repository we will
 list the platforms that it is compiled and tested for.  In the mean time you will need to build it
-yourself.
+yourself. In official releases there should be no classifier on the jar and it should run against
+most modern cuda drivers.
 
-For the time being instead of auto-detecting the version of cuda installed on the system at
-run-time we use maven classifiers.  The java API remains the same, the difference is the native
-runtime it is compiled and linked against.
-
-
-CUDA 9.2:
 ```xml
 <dependency>
     <groupId>ai.rapids</groupId>
@@ -23,6 +18,10 @@ CUDA 9.2:
     <version>${cudf.version}</version>
 </dependency>
 ```
+
+In some cases there may be a classifier to indicate the version of cuda required. See the 
+Build From Source section below for more information about when this can happen. No official
+release of the jar will have a classifier on it.
 
 CUDA 10.0:
 ```xml
@@ -39,10 +38,10 @@ CUDA 10.0:
 Build the native code first, and make sure the a JDK is installed and available. 
 If you use the default cmake options libcudart will be dynamically linked to libcudf and librmm
 which are included.  If you do this the resulting jar will have a classifier associated with it
-because that jar can only be used with a single version of the cuda runtime.  If you want
-to remove that requirement you can build RMM and cuDF with `-DCUDA_RUNTIME_LIBRARY=Static` when
-running cmake.  This will statically link in the cuda runtime and result in a jar with no
-classifier that should run on any host that has a version of the diriver new enough to support
+because that jar can only be used with a single version of the CUDA runtime.  If you want
+to remove that requirement you can build RMM and cuDF with `-DCUDA_STATIC_RUNTIME=ON` when
+running cmake.  This will statically link in the CUDA runtime and result in a jar with no
+classifier that should run on any host that has a version of the driver new enough to support
 the runtime that this was built with.  Official releases will indicate in the release notes
 the minimum driver version required.
 

--- a/java/README.md
+++ b/java/README.md
@@ -36,8 +36,17 @@ CUDA 10.0:
 
 ## Build From Source
 
-Build the native code first, and make sure the a JDK is installed and available. Then run maven
-as you would expect.
+Build the native code first, and make sure the a JDK is installed and available. 
+If you use the default cmake options libcudart will be dynamically linked to libcudf and librmm
+which are included.  If you do this the resulting jar will have a classifier associated with it
+because that jar can only be used with a single version of the cuda runtime.  If you want
+to remove that requirement you can build RMM and cuDF with `-DCUDA_RUNTIME_LIBRARY=Static` when
+running cmake.  This will statically link in the cuda runtime and result in a jar with no
+classifier that should run on any host that has a version of the diriver new enough to support
+the runtime that this was built with.  Official releases will indicate in the release notes
+the minimum driver version required.
+
+Then run maven as you would expect.
 
 ```
 mvn clean install

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -382,8 +382,9 @@
                                   .replaceAll(/\\..*$/, '') // Drop all of the subversions from cuda
                                   .replaceAll(/-0$/, '') // If it is a X.0 version, like 10.0 drop the .0
                                 pom.properties['cuda.classifier'] = classifier
+                                println 'WARNING FOUND libcudart this means your jar will only work against a single version of the cuda runtime ' + classifier
                             } else {
-                                fail("Could not find cudart as a dependency of libcudfjni out> $sout err> $serr")
+                                pom.properties['cuda.classifier'] = ''
                             }
                             </source>
                         </configuration>

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -224,7 +224,7 @@ endif(USE_NVTX)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(cudfjni cudf rmm cudart cuda nvrtc)
+target_link_libraries(cudfjni cudf rmm cudart_static cuda nvrtc)
 
 
 


### PR DESCRIPTION
This fixes #4759 

This provides changes similar to those in https://github.com/rapidsai/rmm/pull/343

The default is kept the same to dynamically link against libcudart but static linking can be enabled.  I have manually tested this. I am not really sure that we want to have automated tests for this as it would require us to relink and rerun at least some of the tests, and python wants dynamic linking.