### PR TITLE
[REVIEW] Replace the use of deprecated rmm APIs in the test environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - PR #4767 Remove linking against `gtest_main` and `gmock_main` in unit tests
 - PR #4660 Port `cudf::partition` api to python/cython
 - PR #4778 Remove `scatter_to_tables` from libcudf, cython and python
+- PR #4790 Replace the use of deprecated rmm APIs in the test environment
 
 ## Bug Fixes
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -555,7 +555,7 @@ ConfigureTest(LEGACY_TYPES_TEST "${LEGACY_TYPES_TEST_SRC}")
 set(NVCATEGORY_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/nvcategory/nvcategory_test.cu")
 
-ConfigureTest(NVCATEGORY_TEST "${NVCATEGORY_TEST_SRC}")
+ConfigureTest(LEGACY_NVCATEGORY_TEST "${NVCATEGORY_TEST_SRC}")
 
 ###################################################################################################
 # - DLPack tests ----------------------------------------------------------------------------------
@@ -700,7 +700,7 @@ ConfigureTest(LEGACY_TABLE_TEST "${LEGACY_TABLE_TEST_SRC}")
 set(DEVICE_TABLE_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/device_table/device_table_tests.cu")
 
-ConfigureTest(DEVICE_TABLE_TEST "${DEVICE_TABLE_TEST_SRC}")
+ConfigureTest(LEGACY_DEVICE_TABLE_TEST "${DEVICE_TABLE_TEST_SRC}")
 
 ###################################################################################################
 # - sorted-merge tests ----------------------------------------------------------------------------

--- a/cpp/tests/device_table/device_table_tests.cu
+++ b/cpp/tests/device_table/device_table_tests.cu
@@ -18,9 +18,9 @@
 #include <bitmask/legacy/bitmask_ops.hpp>
 #include <table/legacy/device_table.cuh>
 #include <table/legacy/device_table_row_operators.cuh>
-#include <tests/utilities/base_fixture.hpp>
 #include <gmock/gmock.h>
 #include <tests/utilities/legacy/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 #include <tests/utilities/legacy/cudf_test_utils.cuh>
 #include <cudf/types.hpp>
 
@@ -31,7 +31,7 @@
 #include <numeric>
 #include <random>
 
-struct DeviceTableTest : cudf::test::BaseFixture {
+struct DeviceTableTest : GdfTest {
   cudf::size_type const size{2000};
 };
 
@@ -564,5 +564,3 @@ TEST_F(DeviceTableTest, CopyRowsSourceNoBitmaskTargetNull) {
       thrust::make_counting_iterator(target_host_table.num_rows()),
       verify_bitmask{row_bitmask.data().get()}));
 }
-
-CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/nvcategory/nvcategory_test.cu
+++ b/cpp/tests/nvcategory/nvcategory_test.cu
@@ -36,8 +36,8 @@
 #include <cstring>
 
 #include <tests/utilities/cudf_gtest.hpp>
-#include <tests/utilities/base_fixture.hpp>
 
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 #include <tests/utilities/legacy/cudf_test_utils.cuh>
 #include <tests/utilities/legacy/nvcategory_utils.cuh>
 #include <bitmask/legacy/bit_mask.cuh>
@@ -95,7 +95,7 @@ int32_t* generate_int_data(cudf::size_type num_rows, size_t max_value, bool prin
 	return host_data;
 }
 
-struct NVCategoryTest : public cudf::test::BaseFixture
+struct NVCategoryTest : public GdfTest
 {
 	gdf_column * create_boolean_column(cudf::size_type num_rows){
 		gdf_column * column = new gdf_column{};
@@ -299,7 +299,7 @@ TEST_F(NVCategoryTest, TEST_NVCATEGORY_COMPARISON)
 	delete data;
 }
 
-struct NVCategoryConcatTest : public cudf::test::BaseFixture
+struct NVCategoryConcatTest : public GdfTest
 {
 	std::vector<gdf_column *> concat_columns;
 	gdf_column * concat_out;
@@ -403,7 +403,7 @@ namespace std{
 	}
   }
 
-struct NVCategoryJoinTest : public cudf::test::BaseFixture
+struct NVCategoryJoinTest : public GdfTest
 {
   // Containers for the raw pointers to the gdf_columns that will be used as
   // input to the gdf_join functions
@@ -859,5 +859,3 @@ TEST_F(NVCategoryJoinTest, join_test_bug){
   }
 
 }
-
-CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -22,7 +22,9 @@
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/managed_memory_resource.hpp>
 
 #include <ftw.h>
 #include <random>
@@ -176,50 +178,30 @@ class RmmTestEnvironment : public ::testing::Environment {
 /**---------------------------------------------------------------------------*
  * @brief String representing which RMM allocation mode is to be used.
  *
- * Valid values are 'cuda', 'pool' and 'managed'. 
+ * 
  *---------------------------------------------------------------------------**/
-  std::string mode;
+  std::unique_ptr<rmm::mr::device_memory_resource> rmm_resource{};
 public:
   /**
-   * @brief Constructor where the only argument is a string `mode`.
-   *
-   * Mode repesents the rmm allocation mode, @ref mode.
-   */
-  RmmTestEnvironment(std::string const& mode):mode(mode){}
-
-  /**
-   * @brief Initializes the default RMM memory resource.
-   *
-   * Sets different allocation mode based on the value passed to the constructor.
+   * @brief Sets the default RMM memory resource based on the input string.
    * 
-   * @throws cudf::logic_error if mode value is invalid.
+   * @param allocation_mode Represents the type of the memory resource to be 
+   * used as a default resource. Valid values are 'cuda', 'pool' and 'managed'.
    * 
-   * @return void
+   * @throws cudf::logic_error if passed mode value is invalid.
    */
-  void SetUp() {
-    rmmOptions_t opts{};
-    if (mode == "cuda")
-      opts.allocation_mode = CudaDefaultAllocation;
-    else if (mode == "pool")
-      opts.allocation_mode = PoolAllocation;
-    else if (mode == "managed")
-      opts.allocation_mode = CudaManagedMemory;
+  RmmTestEnvironment(std::string const& allocation_mode) {
+    if (allocation_mode == "cuda")
+      rmm_resource.reset(new rmm::mr::cuda_memory_resource());
+    else if (allocation_mode == "pool")
+      rmm_resource.reset(new rmm::mr::cnmem_memory_resource());
+    else if (allocation_mode == "managed")
+      rmm_resource.reset(new rmm::mr::managed_memory_resource());
     else 
       CUDF_FAIL("Invalid RMM allocation mode");
 
-    ASSERT_EQ(rmmInitialize(&opts), RMM_SUCCESS);
-  }
-
-  /**
-   * @brief Shuts down the rmm memory manager.
-   * 
-   * @throws cudf::logic_error if rmmFinalize is unsuccessful 
-   * 
-   * @return void
-   */
-  void TearDown() {
-    ASSERT_EQ(rmmFinalize(), RMM_SUCCESS);
-  }
+    rmm::mr::set_default_resource(rmm_resource.get());
+    }
 };
 
 }  // namespace test


### PR DESCRIPTION
Issue #797 

- Replace deprecated `rmmInitialize` and `rmmFinalize` with `rmm::mr::set_default_resource`.
- Move the test environment set up to its constructor, no need to use `SetUp`/`TearDown` any more.
- Code tested with non-legacy tests **cannot** use RMM_ALLOC any more, as it requires `rmmInitialize`. 
- Rename `nvcategory` and `device_table` tests so CMake treats them as legacy.