### PR TITLE
[WIP] Pack/unpack cuDF frames during serialization

### DIFF
--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -28,6 +28,7 @@ try:
             header, frames = x.serialize()
 
             assert all((type(f) is cudf.core.buffer.Buffer) for f in frames)
+            header["serializer"] = "cuda"
             header["lengths"] = [f.nbytes for f in frames]
 
             return header, frames
@@ -38,6 +39,7 @@ try:
     def dask_serialize_cudf_object(x):
         header, frames = cuda_serialize_cudf_object(x)
         with log_errors():
+            header["serializer"] = "dask"
             frames = [f.to_host_array().data for f in frames]
             return header, frames
 

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -29,6 +29,7 @@ try:
 
             assert all((type(f) is cudf.core.buffer.Buffer) for f in frames)
             header["serializer"] = "cuda"
+            header["compression"] = (False,) * len(frames)
             header["lengths"] = [f.nbytes for f in frames]
 
             return header, frames
@@ -40,6 +41,7 @@ try:
         header, frames = cuda_serialize_cudf_object(x)
         with log_errors():
             header["serializer"] = "dask"
+            header["compression"] = (None,) * len(frames)
             frames = [f.to_host_array().data for f in frames]
             return header, frames
 

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -26,8 +26,10 @@ try:
     def cuda_serialize_cudf_object(x):
         with log_errors():
             header, frames = x.serialize()
+
             assert all((type(f) is cudf.core.buffer.Buffer) for f in frames)
             header["lengths"] = [f.nbytes for f in frames]
+
             return header, frames
 
     # all (de-)serializtion are attached to cudf Objects:


### PR DESCRIPTION
Related to issue ( https://github.com/rapidsai/cudf/issues/3793 ), issue ( https://github.com/rapidsai/rmm/issues/318 ), issue ( https://github.com/rapidsai/dask-cuda/issues/250 )

To cutdown on the number of frames that need to be transmitted over the wire or transferred to/from host, pack all `Buffer`s into one `DeviceBuffer` using CuPy to facilitate. In deserialization, use CuPy to unpack them into a series of separate `DeviceBuffer` allocations.

Since cuDF already makes sure CuPy uses RMM for allocations, we need not worry about this when creating `ndarray`s. However it is worth noting we pay for a copy and a larger allocation both during serialization and deserialization. It would be nice to avoid that, but it probably requires some C++/CUDA code to do. So have held off on it for now.

cc @quasiben