### PR TITLE
[REVIEW] Move memory resource from RmmTestEnvironment to the custom gtest main() scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - PR #4813 Fix `GenericIndex` printing
 - PR #4804 Fix issue related `repartition` during hash based repartition
 - PR #4814 Raise error if `to_csv` does not get `filename/path`
+- PR #4826 Move memory resource from RmmTestEnvironment to the custom gtest main() scope
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -169,7 +169,7 @@ class TempDirTestEnvironment : public ::testing::Environment {
  * @brief Creates and sets the default memory resource for the
  * unit test environment.
  * 
- * The resource instance must be kept alive for the duration of
+ * The returned resource instance must be kept alive for the duration of
  * the tests. Attaching the resource to a TestEnvironment causes
  * issues since the environment objects are not destroyed until
  * after the runtime is shutdown.

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <tests/utilities/cudf_gtest.hpp>
-#include "cxxopts.hpp"
+#include <tests/utilities/cxxopts.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/mr/device/default_memory_resource.hpp>
@@ -31,22 +31,22 @@
 namespace cudf {
 namespace test {
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Base test fixture class from which all libcudf tests should inherit.
  *
  * Example:
  * ```
  * class MyTestFixture : public cudf::test::BaseFixture {};
  * ```
- *---------------------------------------------------------------------------**/
+ */
 class BaseFixture : public ::testing::Test {
   rmm::mr::device_memory_resource* _mr{rmm::mr::get_default_resource()};
 
  public:
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Returns pointer to `device_memory_resource` that should be used for
    * all tests inheritng from this fixture
-   *---------------------------------------------------------------------------**/
+   */
   rmm::mr::device_memory_resource* mr() { return _mr; }
 };
 
@@ -76,7 +76,7 @@ struct uniform_distribution_impl<T, std::enable_if_t<cudf::is_timestamp<T>() > >
 template <typename T>
 using uniform_distribution_t = typename uniform_distribution_impl<T>::type;
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Provides uniform random number generation.
  *
  * It is often useful in testing to have a convenient source of random numbers.
@@ -91,7 +91,7 @@ using uniform_distribution_t = typename uniform_distribution_impl<T>::type;
  * ```
  *
  * @tparam T The type of values that will be generated.
- *---------------------------------------------------------------------------**/
+ */
 template <typename T = cudf::size_type,
           typename Engine = std::default_random_engine>
 class UniformRandomGenerator {
@@ -100,18 +100,18 @@ class UniformRandomGenerator {
 
   UniformRandomGenerator() = default;
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Construct a new Uniform Random Generator to generate uniformly
    * random numbers in the range `[upper,lower]`
    *
    * @param lower Lower bound of the range
    * @param upper Upper bound of the desired range
-   *---------------------------------------------------------------------------**/
+   */
   UniformRandomGenerator(T lower, T upper) : dist{lower, upper} {}
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Returns the next random number.
-   *---------------------------------------------------------------------------**/
+   */
   T generate() { return T{dist(rng)}; }
 
  private:
@@ -119,7 +119,7 @@ class UniformRandomGenerator {
   Engine rng{std::random_device{}()};  ///< Random generator
 };
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Provides temporary directory for temporary test files.
  *
  * Example:
@@ -127,7 +127,7 @@ class UniformRandomGenerator {
  * ::testing::Environment* const temp_env =
  *    ::testing::AddGlobalTestEnvironment(new TempDirTestEnvironment);
  * ```
- *---------------------------------------------------------------------------**/
+ */
 class TempDirTestEnvironment : public ::testing::Environment {
  public:
   std::string tmpdir;
@@ -165,43 +165,36 @@ class TempDirTestEnvironment : public ::testing::Environment {
   }
 };
 
-
-/**---------------------------------------------------------------------------*
- * @brief Test environment that initializes the default rmm memory resource.
+/**
+ * @brief Creates and sets the default memory resource for the
+ * unit test environment.
  * 
- * Required for tests programs that use rmm. It is recommended to include
- * `CUDF_TEST_PROGRAM_MAIN()` in a code file instead of directly instantiating 
- * an object of this type.
- *---------------------------------------------------------------------------**/
-class RmmTestEnvironment : public ::testing::Environment {
-/**---------------------------------------------------------------------------*
- * @brief String representing which RMM allocation mode is to be used.
+ * The resource instance must be kept alive for the duration of
+ * the tests. Attaching the resource to a TestEnvironment causes
+ * issues since the environment objects are not destroyed until
+ * after the runtime is shutdown.
+ * 
+ * @throw cudf::logic_error if the `allocation_mode` is unsupported.
  *
- * 
- *---------------------------------------------------------------------------**/
-  std::unique_ptr<rmm::mr::device_memory_resource> rmm_resource{};
-public:
-  /**
-   * @brief Sets the default RMM memory resource based on the input string.
-   * 
-   * @param allocation_mode Represents the type of the memory resource to be 
-   * used as a default resource. Valid values are 'cuda', 'pool' and 'managed'.
-   * 
-   * @throws cudf::logic_error if passed mode value is invalid.
-   */
-  RmmTestEnvironment(std::string const& allocation_mode) {
+ * @param allocation_mode String identifies which resource type.
+ *        Accepted types are "pool", "cuda", and "managed" only.
+ * @return Memory resource instance
+ */
+inline auto create_memory_resource(std::string const& allocation_mode)
+{
+    std::unique_ptr<rmm::mr::device_memory_resource> rmm_resource{};
     if (allocation_mode == "cuda")
       rmm_resource.reset(new rmm::mr::cuda_memory_resource());
     else if (allocation_mode == "pool")
       rmm_resource.reset(new rmm::mr::cnmem_memory_resource());
     else if (allocation_mode == "managed")
       rmm_resource.reset(new rmm::mr::managed_memory_resource());
-    else 
+    else
       CUDF_FAIL("Invalid RMM allocation mode");
 
     rmm::mr::set_default_resource(rmm_resource.get());
-    }
-};
+    return rmm_resource;
+}
 
 }  // namespace test
 }  // namespace cudf
@@ -233,17 +226,18 @@ inline auto parse_cudf_test_opts(int argc, char **argv) {
 /**
  * @brief Macro that defines main function for gtest programs that use rmm
  * 
- * Should be included in every test program that uses rmm allocators.The `main`
- * function is a wrapper around the google test generated `main`, mantaining
- * the original functionality. In addition, the custom `main` function parses
- * the command line to customize test behavior, like allocation mode.
- *
+ * Should be included in every test program that uses rmm allocators since
+ * it maintains the lifespane of the rmm default memory resource.
+ * This `main` function is a wrapper around the google test generated `main`,
+ * mantaining the original functionality. In addition, this custom `main`
+ * function parses the command line to customize test behavior, like the
+ * allocation mode used for creating the default memory resource.
+ * 
  */
 #define CUDF_TEST_PROGRAM_MAIN() int main(int argc, char **argv) {  \
   ::testing::InitGoogleTest(&argc, argv);                           \
   auto const cmd_opts = parse_cudf_test_opts(argc, argv);           \
   auto const rmm_mode = cmd_opts["rmm_mode"].as<std::string>();     \
-  auto const rmm_env = ::testing::AddGlobalTestEnvironment(         \
-    new cudf::test::RmmTestEnvironment(rmm_mode));                  \
+  auto resource = cudf::test::create_memory_resource(rmm_mode);     \
   return RUN_ALL_TESTS();                                           \
 }

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -182,7 +182,6 @@ class TempDirTestEnvironment : public ::testing::Environment {
  */
 inline std::unique_ptr<rmm::mr::device_memory_resource> create_memory_resource(std::string const& allocation_mode)
 {
-    std::unique_ptr<rmm::mr::device_memory_resource> rmm_resource{};
     if( allocation_mode == "cuda" )
         return std::make_unique<rmm::mr::cuda_memory_resource>();
     if( allocation_mode == "pool" )
@@ -190,7 +189,6 @@ inline std::unique_ptr<rmm::mr::device_memory_resource> create_memory_resource(s
     if( allocation_mode == "managed" )
         return std::make_unique<rmm::mr::managed_memory_resource>();
     CUDF_FAIL("Invalid RMM allocation mode: " + allocation_mode);
-    return rmm_resource;
 }
 
 }  // namespace test
@@ -224,9 +222,9 @@ inline auto parse_cudf_test_opts(int argc, char **argv) {
  * @brief Macro that defines main function for gtest programs that use rmm
  * 
  * Should be included in every test program that uses rmm allocators since
- * it maintains the lifespane of the rmm default memory resource.
+ * it maintains the lifespan of the rmm default memory resource.
  * This `main` function is a wrapper around the google test generated `main`,
- * mantaining the original functionality. In addition, this custom `main`
+ * maintaining the original functionality. In addition, this custom `main`
  * function parses the command line to customize test behavior, like the
  * allocation mode used for creating the default memory resource.
  * 


### PR DESCRIPTION
Executing `cuda-memcheck` against any gtests program results in errors reported after the tests complete.
```
Program hit cudaErrorCudartUnloading (error 4) due to "driver shutting down" on CUDA API call to cudaGetDevice.
=========     Saved host backtrace up to driver entry point at error
=========     Host Frame:/usr/lib/x86_64-linux-gnu/libcuda.so.1 [0x3c43a3]
=========     Host Frame:/usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.10.2 (cudaGetDevice + 0x186) [0x4c306]
=========     Host Frame:/conda/envs/rapids/lib/librmm.so (_ZN5cnmem7ContextD2Ev + 0x2b) [0x10f9b]
=========     Host Frame:/conda/envs/rapids/lib/librmm.so (_ZN5cnmem7Context7releaseEv + 0x56) [0x111f6]
```
This only happens if `rmm_mode=pool` which is now the default.
The problem occurs because the default memory resource is attached to an `RmmTestEnvironment` object that is then added to a global singleton via `testing::AddGlobalTestEnvironment`
This singleton does not destroy the environments until after the `main()` exits and after the CUDA runtime is shutdown causing these errors.

This PR moves the scope of the default memory resource to the custom `main()` function so that it is cleaned up before the CUDA runtime is shutdown. This also means there is no reason to have an `RmmTestEnvironment` and so this is removed as well.
