### PR TITLE
[REVIEW] Fixes bug in transform in handling single line UDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - PR #4813 Fix `GenericIndex` printing
 - PR #4804 Fix issue related `repartition` during hash based repartition
 - PR #4814 Raise error if `to_csv` does not get `filename/path`
+- PR #4834 Fix bug in transform in handling single line UDFs
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/cpp/src/transform/transform.cpp
+++ b/cpp/src/transform/transform.cpp
@@ -50,7 +50,7 @@ void unary_operation(mutable_column_view output, column_view input,
           cudf::jit::get_type_name(output_type), {0}
           ) + code::kernel;
   }else{  
-    cuda_source = 
+    cuda_source = "\n" +
       cudf::jit::parse_single_function_cuda(
           udf, "GENERIC_UNARY_OP") + code::kernel;
   }

--- a/cpp/tests/transform/integration/unary-transform-test.cu
+++ b/cpp/tests/transform/integration/unary-transform-test.cu
@@ -119,15 +119,7 @@ R"***(
 TEST_F(UnaryOperationIntegrationTest, Transform_INT32_INT32) {
 
 // c = a * a - a
-const char cuda[] =
-R"***(
-__device__ inline void f(
-  int* output, 
-  int input
-){
-  *output = input*input - input;
-}
-)***";
+const char cuda[] = "__device__ inline void f(int* output,int input){*output = input*input - input;}";
 
 const char* ptx =
 R"***(


### PR DESCRIPTION
Fixes #4835

Transform was unable to handle CUDA UDFs passed as a single line of string. This was because Jitify expects the first line of the string source to be the name of the source. So it discards it.

This problem is specific to Transform as all other JIT enabled functionalities already prepend and empty new line to their string code. `rolling` happened to include it by chance.
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
