### PR TITLE
[REVIEW] Fix CSV parsing with byte_range parameter and string columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 - PR #4804 Fix issue related `repartition` during hash based repartition
 - PR #4814 Raise error if `to_csv` does not get `filename/path`
 - PR #4797 Fix string timestamp to datetime conversion with `ms` and `ns`
+- PR #4846 Fix CSV parsing with byte_range parameter and string columns
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/cpp/src/io/csv/legacy/csv_reader_impl.cu
+++ b/cpp/src/io/csv/legacy/csv_reader_impl.cu
@@ -447,17 +447,31 @@ std::pair<uint64_t, uint64_t> reader::Impl::select_rows(
   // or a linetermination within a quotechar pair.
   if (opts.quotechar != '\0') {
     auto count = std::distance(it_begin, it_end) - 1;
-
+    // First element is zero if reading from start of file, skip it in that case
+    // Check the first element otherwise, it could be a quotation
+    const int start = (h_row_offsets[0] == 0) ? 1 : 0;
+    // Starting in the incomplete first row (before first line terminator in the byte range)?
+    bool is_partial_row = (h_row_offsets[0] != 0);
     auto filtered_count = count;
     bool quotation = false;
-    for (int i = 1; i < count; ++i) {
-      if (h_data[h_row_offsets[i] - 1] == opts.quotechar) {
-        quotation = !quotation;
-        h_row_offsets[i] = static_cast<uint64_t>(-1);
+    for (int i = start; i < count; ++i) {
+      auto& offset = h_row_offsets[i];
+      if (h_data[offset - 1] == opts.quotechar) {
+        // Don't update the quotation state before hitting the first line terminator 
+        if (!is_partial_row) {
+          quotation = !quotation;
+        }
+        offset = static_cast<uint64_t>(-1);
         filtered_count--;
-      } else if (quotation) {
-        h_row_offsets[i] = static_cast<uint64_t>(-1);
-        filtered_count--;
+      } else if (h_data[offset - 1] == opts.terminator) {
+        if (quotation){
+          offset = static_cast<uint64_t>(-1);
+          filtered_count--;
+        }
+        else if (is_partial_row){
+          // Hit the the first line terminator, reset the is_partial_row flag
+          is_partial_row = false;
+        }
       }
     }
     if (filtered_count != count) {

--- a/cpp/tests/io/csv_test.cu
+++ b/cpp/tests/io/csv_test.cu
@@ -518,6 +518,23 @@ TEST_F(CsvReaderTest, ByteRange) {
                            view.column(0));
 }
 
+TEST_F(CsvReaderTest, ByteRangeStrings) {
+  std::string input = "\"a\"\n\"b\"\n\"c\"";
+  cudf_io::read_csv_args in_args{cudf_io::source_info{input.c_str(), input.size()}};
+  in_args.names = {"A"};
+  in_args.dtype = {"str"};
+  in_args.header = -1;
+  in_args.byte_range_offset = 4;
+  auto result = cudf_io::read_csv(in_args);
+
+  const auto view = result.tbl->view();
+  EXPECT_EQ(1, view.num_columns());
+  ASSERT_EQ(cudf::type_id::STRING, view.column(0).type().id());
+
+  expect_column_data_equal(std::vector<std::string>{"c"},
+                           view.column(0));
+}
+
 TEST_F(CsvReaderTest, BlanksAndComments) {
   auto filepath = temp_env->get_temp_dir() + "BlanksAndComments.csv";
   {

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -957,7 +957,7 @@ def test_csv_reader_byte_range(tmpdir, segment_bytes):
 @pytest.mark.parametrize("segment_bytes", [10, 19, 31, 36])
 def test_csv_reader_byte_range_strings(segment_bytes):
     names = ["strings"]
-    buffer = '\n'.join('\"' + str(x) + '\"' for x in range(1, 100))
+    buffer = "\n".join('"' + str(x) + '"' for x in range(1, 100))
     file_size = len(buffer)
 
     ref_df = read_csv(StringIO(buffer), names=names).to_pandas()

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -953,6 +953,26 @@ def test_csv_reader_byte_range(tmpdir, segment_bytes):
     assert list(df["int1"]) == list(ref_df["int1"])
     assert list(df["int2"]) == list(ref_df["int2"])
 
+@pytest.mark.parametrize("segment_bytes", [10, 19, 31, 36])
+def test_csv_reader_byte_range_strings(segment_bytes):
+    names = ["strings"]
+    buffer = '\n'.join('\"' + str(x) + '\"' for x in range(1, 100))
+    file_size = len(buffer)
+
+    ref_df = read_csv(StringIO(buffer), names=names).to_pandas()
+
+    dfs = []
+    for segment in range((file_size + segment_bytes - 1) // segment_bytes):
+        dfs.append(
+            read_csv(
+                StringIO(buffer),
+                names=names,
+                byte_range=(segment * segment_bytes, segment_bytes),
+            )
+        )
+    df = cudf.concat(dfs).to_pandas()
+
+    assert list(df["strings"]) == list(ref_df["strings"])
 
 @pytest.mark.parametrize(
     "header_row, skip_rows, skip_blanks",

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -953,6 +953,7 @@ def test_csv_reader_byte_range(tmpdir, segment_bytes):
     assert list(df["int1"]) == list(ref_df["int1"])
     assert list(df["int2"]) == list(ref_df["int2"])
 
+
 @pytest.mark.parametrize("segment_bytes", [10, 19, 31, 36])
 def test_csv_reader_byte_range_strings(segment_bytes):
     names = ["strings"]
@@ -973,6 +974,7 @@ def test_csv_reader_byte_range_strings(segment_bytes):
     df = cudf.concat(dfs).to_pandas()
 
     assert list(df["strings"]) == list(ref_df["strings"])
+
 
 @pytest.mark.parametrize(
     "header_row, skip_rows, skip_blanks",


### PR DESCRIPTION
Closes #3156 

Fix `select_rows` in CSV reader:
- Enable filtering of the first element when `byte_offset` is used. When parsing from the start of the file, a zero entry is added to mark the start of the first row. `select_row` used to skip filtering of this entry, but it should not be skipped when parsing with `byte_offset` (the first entry could be a quotation character, which need to be filtered out).
- When filtering rows and `byte_offset` is used, avoid updating the quotation state before hitting the first line terminator. This is important for cases where the byte range starts within a string, so quotation state get inverted in the entire filtering of the byte range.
- Add C++ and Python tests that fail when either of the fixes above is not present.