### PR TITLE
Update Java bindings to use new NVTX API [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - PR #4543 Add `inplace` parameter support for `Series.replace` & `DataFrame.replace`
 - PR #4817 Fix `fixed_point` documentation
 - PR #4842 Added Java bindings for titlizing a String column
+- PR #4849 Update Java bindings to use new NVTX API
 
 ## Bug Fixes
 

--- a/java/src/main/native/src/NvtxRangeJni.cpp
+++ b/java/src/main/native/src/NvtxRangeJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <cudf/utilities/nvtx_utils.hpp>
+#include <cudf/detail/nvtx/nvtx3.hpp>
 
 #include "jni_utils.hpp"
 
@@ -25,7 +25,9 @@ Java_ai_rapids_cudf_NvtxRange_push(JNIEnv *env, jclass clazz,
     jstring name, jint color_bits) {
   try {
     cudf::jni::native_jstring range_name(env, name);
-    cudf::nvtx::range_push_hex(range_name.get(), color_bits);
+    nvtx3::color range_color(static_cast<nvtx3::color::value_type>(color_bits));
+    nvtx3::event_attributes attr{range_color, range_name.get()};
+    nvtxDomainRangePushEx(nvtx3::domain::get<nvtx3::domain::global>(), attr.get());
   }
   CATCH_STD(env, );
 }
@@ -33,7 +35,7 @@ Java_ai_rapids_cudf_NvtxRange_push(JNIEnv *env, jclass clazz,
 JNIEXPORT void JNICALL
 Java_ai_rapids_cudf_NvtxRange_pop(JNIEnv *env, jclass clazz) {
   try {
-    cudf::nvtx::range_pop();
+    nvtxDomainRangePop(nvtx3::domain::get<nvtx3::domain::global>());
   }
   CATCH_STD(env, );
 }

--- a/java/src/main/native/src/NvtxRangeJni.cpp
+++ b/java/src/main/native/src/NvtxRangeJni.cpp
@@ -18,6 +18,14 @@
 
 #include "jni_utils.hpp"
 
+namespace {
+
+struct java_domain {
+  static constexpr char const* name{"Java"};
+};
+
+} // anonymous namespace
+
 extern "C" {
 
 JNIEXPORT void JNICALL
@@ -27,7 +35,7 @@ Java_ai_rapids_cudf_NvtxRange_push(JNIEnv *env, jclass clazz,
     cudf::jni::native_jstring range_name(env, name);
     nvtx3::color range_color(static_cast<nvtx3::color::value_type>(color_bits));
     nvtx3::event_attributes attr{range_color, range_name.get()};
-    nvtxDomainRangePushEx(nvtx3::domain::get<nvtx3::domain::global>(), attr.get());
+    nvtxDomainRangePushEx(nvtx3::domain::get<java_domain>(), attr.get());
   }
   CATCH_STD(env, );
 }
@@ -35,7 +43,7 @@ Java_ai_rapids_cudf_NvtxRange_push(JNIEnv *env, jclass clazz,
 JNIEXPORT void JNICALL
 Java_ai_rapids_cudf_NvtxRange_pop(JNIEnv *env, jclass clazz) {
   try {
-    nvtxDomainRangePop(nvtx3::domain::get<nvtx3::domain::global>());
+    nvtxDomainRangePop(nvtx3::domain::get<java_domain>());
   }
   CATCH_STD(env, );
 }


### PR DESCRIPTION
The old cudf NVTX APIs will be removed soon, so this updates the cudf Java bindings to use the new nvtx3 APIs.