### PR TITLE
[REVIEW] HostMemoryBufferTest should tear down the pinned memory pool [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - PR #4797 Fix string timestamp to datetime conversion with `ms` and `ns`
 - PR #4834 Fix bug in transform in handling single line UDFs
 - PR #4846 Fix CSV parsing with byte_range parameter and string columns
+- PR #4860 Tear down PinnedMemoryPool in the HostMemoryBufferTest on exit
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@
 - PR #4797 Fix string timestamp to datetime conversion with `ms` and `ns`
 - PR #4834 Fix bug in transform in handling single line UDFs
 - PR #4846 Fix CSV parsing with byte_range parameter and string columns
-- PR #4860 Tear down PinnedMemoryPool in the HostMemoryBufferTest on exit
+- PR #4860 Fix issues in HostMemoryBufferTest, and testNormalizeNANsAndZeros, set surefire.runOrder=hourly
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@
 - PR #4797 Fix string timestamp to datetime conversion with `ms` and `ns`
 - PR #4834 Fix bug in transform in handling single line UDFs
 - PR #4846 Fix CSV parsing with byte_range parameter and string columns
-- PR #4860 Fix issues in HostMemoryBufferTest, and testNormalizeNANsAndZeros, set surefire.runOrder=hourly
+- PR #4860 Fix issues in HostMemoryBufferTest, and testNormalizeNANsAndZeros
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -271,10 +271,6 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.0</version>
-                    <configuration>
-                      <!-- hourly (alphabetical on even hours, reverse alphabetical on odd hours) -->
-                      <runOrder>hourly</runOrder>
-                    </configuration>
                     <dependencies>
                         <dependency>
                             <groupId>org.junit.platform</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -271,6 +271,10 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.0</version>
+                    <configuration>
+                      <!-- hourly (alphabetical on even hours, reverse alphabetical on odd hours) -->
+                      <runOrder>hourly</runOrder>
+                    </configuration>
                     <dependencies>
                         <dependency>
                             <groupId>org.junit.platform</groupId>

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -140,7 +140,7 @@ public class ColumnVectorTest extends CudfTestBase {
       TableTest.assertColumnsAreEqual(cv, backAgain);
     }
   }
-
+/*
   @Test
   void testRefCountLeak() throws InterruptedException {
     assumeTrue(Boolean.getBoolean("ai.rapids.cudf.flaky-tests-enabled"));
@@ -155,6 +155,7 @@ public class ColumnVectorTest extends CudfTestBase {
     } while (leakNow != expectedLeakCount && System.currentTimeMillis() < maxTime);
     assertEquals(expectedLeakCount, MemoryCleaner.leakCount.get());
   }
+  */
 
   @Test
   void testConcatTypeError() {
@@ -226,18 +227,21 @@ public class ColumnVectorTest extends CudfTestBase {
     Double[]  ins = new Double[] {0.0, -0.0, Double.NaN, MIN_PLUS_NaN, MAX_PLUS_NaN, MIN_MINUS_NaN, MAX_MINUS_NaN, null};
     Double[] outs = new Double[] {0.0,  0.0, Double.NaN,   Double.NaN,   Double.NaN,    Double.NaN,    Double.NaN, null};
 
-    try (ColumnVector     input      = ColumnVector.fromBoxedDoubles(ins);
-         HostColumnVector expected   = ColumnVector.fromBoxedDoubles(outs).copyToHost();
-         HostColumnVector normalized = input.normalizeNANsAndZeros().copyToHost()) {
-      for (int i = 0; i<input.getRowCount(); ++i) {
-        if (expected.isNull(i)) {
-          assertTrue(normalized.isNull(i));
-        }
-        else {
-          assertEquals(
-                  Double.doubleToRawLongBits(expected.getDouble(i)),
-                  Double.doubleToRawLongBits(normalized.getDouble(i))
-          );
+    try (ColumnVector input = ColumnVector.fromBoxedDoubles(ins);
+         ColumnVector expectedColumn = ColumnVector.fromBoxedDoubles(outs);
+         ColumnVector normalizedColumn = input.normalizeNANsAndZeros()) {
+      try (HostColumnVector expected = expectedColumn.copyToHost();
+           HostColumnVector normalized = normalizedColumn.copyToHost()) {
+        for (int i = 0; i<input.getRowCount(); ++i) {
+          if (expected.isNull(i)) {
+            assertTrue(normalized.isNull(i));
+          }
+          else {
+            assertEquals(
+                    Double.doubleToRawLongBits(expected.getDouble(i)),
+                    Double.doubleToRawLongBits(normalized.getDouble(i))
+            );
+          }
         }
       }
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -140,7 +140,7 @@ public class ColumnVectorTest extends CudfTestBase {
       TableTest.assertColumnsAreEqual(cv, backAgain);
     }
   }
-/*
+
   @Test
   void testRefCountLeak() throws InterruptedException {
     assumeTrue(Boolean.getBoolean("ai.rapids.cudf.flaky-tests-enabled"));
@@ -155,7 +155,7 @@ public class ColumnVectorTest extends CudfTestBase {
     } while (leakNow != expectedLeakCount && System.currentTimeMillis() < maxTime);
     assertEquals(expectedLeakCount, MemoryCleaner.leakCount.get());
   }
-  */
+ 
 
   @Test
   void testConcatTypeError() {

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -155,7 +155,6 @@ public class ColumnVectorTest extends CudfTestBase {
     } while (leakNow != expectedLeakCount && System.currentTimeMillis() < maxTime);
     assertEquals(expectedLeakCount, MemoryCleaner.leakCount.get());
   }
- 
 
   @Test
   void testConcatTypeError() {

--- a/java/src/test/java/ai/rapids/cudf/HostMemoryBufferTest.java
+++ b/java/src/test/java/ai/rapids/cudf/HostMemoryBufferTest.java
@@ -28,12 +28,20 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Random;
 
+import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class HostMemoryBufferTest extends CudfTestBase {
+  @AfterEach
+  void teardown() {
+    if (PinnedMemoryPool.isInitialized()) {
+      PinnedMemoryPool.shutdown();
+    }
+  }
+
   @Test
   void testRefCountLeak() throws InterruptedException {
     assumeTrue(Boolean.getBoolean("ai.rapids.cudf.flaky-tests-enabled"));


### PR DESCRIPTION
I started seeing a failure in the `PinnedMemoryPoolTest` due to the pinned pool being initialized in the `HostMemoryBufferTest` and not being shutdown after it exists.