### PR TITLE
Expose contiguous table when deserializing from Java [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - PR #4849 Update Java bindings to use new NVTX API
 - PR #4845 Add CUDF_FUNC_RANGE to top-level cuIO function APIs
 - PR #4848 Side step `unique_count` calculation in `scatter_by_map`
+- PR #4869 Expose contiguous table when deserializing from Java
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
+++ b/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public final class ContiguousTable implements AutoCloseable {
     }
   }
 
-  private ContiguousTable(Table table, DeviceMemoryBuffer buffer) {
+  ContiguousTable(Table table, DeviceMemoryBuffer buffer) {
     this.table = table;
     this.buffer = buffer;
   }

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -48,6 +48,7 @@ import static ai.rapids.cudf.Table.sum;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1237,6 +1238,8 @@ public class TableTest extends CudfTestBase {
       DataInputStream din = new DataInputStream(bin);
       try (JCudfSerialization.TableAndRowCountPair result = JCudfSerialization.readTableFrom(din)) {
         assertTablesAreEqual(t, result.getTable());
+        assertEquals(result.getTable(), result.getContiguousTable().getTable());
+        assertNotNull(result.getContiguousTable().getBuffer());
       }
     }
   }
@@ -1248,6 +1251,7 @@ public class TableTest extends CudfTestBase {
     ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
     try (JCudfSerialization.TableAndRowCountPair result = JCudfSerialization.readTableFrom(bin)) {
       assertNull(result.getTable());
+      assertNull(result.getContiguousTable());
       assertEquals(10, result.getNumRows());
     }
   }
@@ -1259,6 +1263,7 @@ public class TableTest extends CudfTestBase {
     ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
     try (JCudfSerialization.TableAndRowCountPair result = JCudfSerialization.readTableFrom(bin)) {
       assertNull(result.getTable());
+      assertNull(result.getContiguousTable());
       assertEquals(0, result.getNumRows());
     }
   }
@@ -1534,8 +1539,12 @@ public class TableTest extends CudfTestBase {
           ByteArrayInputStream bin2 = new ByteArrayInputStream(bout2.toByteArray());
           try (JCudfSerialization.TableAndRowCountPair found = JCudfSerialization.readTableFrom(bin2)) {
             assertPartialTablesAreEqual(t, 0, t.getRowCount(), found.getTable(), false);
+            assertEquals(found.getTable(), found.getContiguousTable().getTable());
+            assertNotNull(found.getContiguousTable().getBuffer());
           }
-          assertNull(JCudfSerialization.readTableFrom(bin2).getTable());
+          JCudfSerialization.TableAndRowCountPair tp = JCudfSerialization.readTableFrom(bin2);
+          assertNull(tp.getTable());
+          assertNull(tp.getContiguousTable());
         } finally {
           for (HostMemoryBuffer buff: buffers) {
             buff.close();
@@ -1569,8 +1578,12 @@ public class TableTest extends CudfTestBase {
           ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
           try (JCudfSerialization.TableAndRowCountPair found = JCudfSerialization.readTableFrom(bin)) {
             assertPartialTablesAreEqual(t, i, len, found.getTable(), i == 0 && len == t.getRowCount());
+            assertEquals(found.getTable(), found.getContiguousTable().getTable());
+            assertNotNull(found.getContiguousTable().getBuffer());
           }
-          assertNull(JCudfSerialization.readTableFrom(bin).getTable());
+          JCudfSerialization.TableAndRowCountPair tp = JCudfSerialization.readTableFrom(bin);
+          assertNull(tp.getTable());
+          assertNull(tp.getContiguousTable());
         }
       }
     }


### PR DESCRIPTION
The Java bindings currently deserialize a table into a contiguous buffer, but the caller cannot access the underlying device buffer that encompasses the entire table.  The Java bindings already have a `ContiguousTable` class to describe contiguous tables, and it would be nice to expose this for use-cases that could take advantage of contiguous table buffers.