### PR TITLE
[REVIEW] Fix broken column wrapper in benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 - PR #4846 Fix CSV parsing with byte_range parameter and string columns
 - PR #4860 Fix issues in HostMemoryBufferTest, and testNormalizeNANsAndZeros
 - PR #4859 JSON reader: fix data type inference for string columns
+- PR #4872 Fix broken column wrapper constructors in merge benchmark
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/cpp/benchmarks/merge/merge_benchmark.cpp
+++ b/cpp/benchmarks/merge/merge_benchmark.cpp
@@ -19,9 +19,9 @@
 #include <cudf/table/table.hpp>
 #include <cudf/column/column.hpp>
 #include <cudf/table/table_view.hpp>
- 
+
 #include <cudf/merge.hpp>
- 
+
 #include <benchmarks/fixture/benchmark_fixture.hpp>
 #include <benchmarks/synchronization/synchronization.hpp>
 #include <tests/utilities/column_wrapper.hpp>
@@ -29,24 +29,24 @@
 #include <thrust/iterator/constant_iterator.h>
 
 #include <random>
- 
+
 // to enable, run cmake with -DBUILD_BENCHMARKS=ON
 
 // Fixture that enables RMM pool mode
 class Merge: public cudf::benchmark {};
- 
+
 using IntColWrap = cudf::test::fixed_width_column_wrapper<int32_t>;
 
-void BM_merge(benchmark::State& state) {   
+void BM_merge(benchmark::State& state) {
    cudf::size_type const avg_rows = 1 << 19; // 512K rows
    int const num_tables = state.range(0);
 
    // Content is irrelevant for the benchmark
    auto data_sequence = thrust::make_constant_iterator(0);
-  
+
    // Using 0 seed to ensure consistent pseudo-numbers on each run
    std::mt19937 rand_gen(0);
-   // Gaussian distribution with 98% of elements are in range [0, avg_rows*2] 
+   // Gaussian distribution with 98% of elements are in range [0, avg_rows*2]
    std::normal_distribution<> table_size_dist(avg_rows, avg_rows/2);
    // Used to generate a random monotonic sequence for each table key column
    std::uniform_int_distribution<> key_dist(0, 10);
@@ -65,8 +65,8 @@ void BM_merge(benchmark::State& state) {
          return prev_key; });
 
       columns.emplace_back(std::pair<IntColWrap, IntColWrap>{
-         IntColWrap{key_sequence, key_sequence + clamped_rows}, 
-         IntColWrap{data_sequence, data_sequence + clamped_rows}
+         IntColWrap(key_sequence, key_sequence + clamped_rows),
+         IntColWrap(data_sequence, data_sequence + clamped_rows)
       });
       tables.push_back(cudf::table_view{{columns.back().first, columns.back().second}});
       total_rows += clamped_rows;
@@ -74,24 +74,24 @@ void BM_merge(benchmark::State& state) {
    std::vector<cudf::size_type> const key_cols{0};
    std::vector<cudf::order> const column_order {cudf::order::ASCENDING};
    std::vector<cudf::null_order> const null_precedence{};
-  
+
    for(auto _ : state){
       cuda_event_timer raii(state, true); // flush_l2_cache = true, stream = 0
       auto result = cudf::experimental::merge(tables,
                                               key_cols,
                                               column_order,
-                                              null_precedence);    
-    }   
- 
+                                              null_precedence);
+    }
+
    state.SetBytesProcessed(state.iterations()*2*sizeof(int32_t)*total_rows);
 }
- 
- 
+
+
 #define MBM_BENCHMARK_DEFINE(name)                                                \
 BENCHMARK_DEFINE_F(Merge, name)(::benchmark::State& state) {                      \
    BM_merge(state);                                                               \
 }                                                                                 \
 BENCHMARK_REGISTER_F(Merge, name)->Unit(benchmark::kNanosecond)->UseManualTime()  \
                                       ->RangeMultiplier(2)->Ranges({{2, 128}});
-                                                                       
+
 MBM_BENCHMARK_DEFINE(pow2tables);


### PR DESCRIPTION
Changes to column wrapper from PR https://github.com/rapidsai/cudf/pull/3581 require that range constructors use parentheses rather than braces, which broke one of the benchmarks.