### PR TITLE
Mark Java cleaner objects as being cleaned even if exception is thrown [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
 - PR #4859 JSON reader: fix data type inference for string columns
 - PR #4868 Temporary fix to skip validation on Dask related runs
 - PR #4872 Fix broken column wrapper constructors in merge benchmark
+- PR #4876 Mark Java cleaner objects as being cleaned even if exception is thrown
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -2060,6 +2060,46 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
   /////////////////////////////////////////////////////////////////////////////
 
   /**
+   * Close all non-null buffers. Exceptions that occur during the process will
+   * be aggregated into a single exception thrown at the end.
+   */
+  static void closeBuffers(MemoryBuffer data, MemoryBuffer valid, MemoryBuffer offsets) {
+    Throwable toThrow = null;
+    if (data != null) {
+      try {
+        data.close();
+      } catch (Throwable t) {
+        toThrow = t;
+      }
+    }
+    if (valid != null) {
+      try {
+        valid.close();
+      } catch (Throwable t) {
+        if (toThrow != null) {
+          toThrow.addSuppressed(t);
+        } else {
+          toThrow = t;
+        }
+      }
+    }
+    if (offsets != null) {
+      try {
+        offsets.close();
+      } catch (Throwable t) {
+        if (toThrow != null) {
+          toThrow.addSuppressed(t);
+        } else {
+          toThrow = t;
+        }
+      }
+    }
+    if (toThrow != null) {
+      throw new RuntimeException(toThrow);
+    }
+  }
+
+  /**
    * USE WITH CAUTION: This method exposes the address of the native cudf::column_view.  This allows
    * writing custom kernels or other cuda operations on the data.  DO NOT close this column
    * vector until you are completely done using the native column_view.  DO NOT modify the column in
@@ -2513,34 +2553,57 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
       long size = getDeviceMemorySize();
       boolean neededCleanup = false;
       long address = 0;
+
+      // Always mark the resource as freed even if an exception is thrown.
+      // We cannot know how far it progressed before the exception, and
+      // therefore it is unsafe to retry.
+      Throwable toThrow = null;
       if (viewHandle != 0) {
         address = viewHandle;
-        deleteColumnView(viewHandle);
-        viewHandle = 0;
+        try {
+          deleteColumnView(viewHandle);
+        } catch (Throwable t) {
+          toThrow = t;
+        } finally {
+          viewHandle = 0;
+        }
         neededCleanup = true;
       }
       if (columnHandle != 0) {
         if (address != 0) {
           address = columnHandle;
         }
-        deleteCudfColumn(columnHandle);
-        columnHandle = 0;
+        try {
+          deleteCudfColumn(columnHandle);
+        } catch (Throwable t) {
+          if (toThrow != null) {
+            toThrow.addSuppressed(t);
+          } else {
+            toThrow = t;
+          }
+        } finally {
+          columnHandle = 0;
+        }
         neededCleanup = true;
       }
-      if (data != null) {
-        data.close();
-        data = null;
+      if (data != null || valid != null || offsets != null) {
+        try {
+          closeBuffers(data, valid, offsets);
+        } catch (Throwable t) {
+          if (toThrow != null) {
+            toThrow.addSuppressed(t);
+          } else {
+            toThrow = t;
+          }
+        } finally {
+          data = null;
+          valid = null;
+          offsets = null;
+        }
         neededCleanup = true;
       }
-      if (valid != null) {
-        valid.close();
-        valid = null;
-        neededCleanup = true;
-      }
-      if (offsets != null) {
-        offsets.close();
-        offsets = null;
-        neededCleanup = true;
+      if (toThrow != null) {
+        throw new RuntimeException(toThrow);
       }
       if (neededCleanup) {
         if (logErrorIfNotClean) {

--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -136,8 +136,14 @@ public class Cuda {
       boolean neededCleanup = false;
       long origAddress = event;
       if (event != 0) {
-        destroyEvent(event);
-        event = 0;
+        try {
+          destroyEvent(event);
+        } finally {
+          // Always mark the resource as freed even if an exception is thrown.
+          // We cannot know how far it progressed before the exception, and
+          // therefore it is unsafe to retry.
+          event = 0;
+        }
         neededCleanup = true;
       }
       if (neededCleanup && logErrorIfNotClean) {

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -483,19 +483,17 @@ public final class HostColumnVector implements AutoCloseable {
     @Override
     protected boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
-      if (data != null) {
-        data.close();
-        data = null;
-        neededCleanup = true;
-      }
-      if (valid != null) {
-        valid.close();
-        valid = null;
-        neededCleanup = true;
-      }
-      if (offsets != null) {
-        offsets.close();
-        offsets = null;
+      if (data != null || valid != null || offsets != null) {
+        try {
+          ColumnVector.closeBuffers(data, valid, offsets);
+        } finally {
+          // Always mark the resource as freed even if an exception is thrown.
+          // We cannot know how far it progressed before the exception, and
+          // therefore it is unsafe to retry.
+          data = null;
+          valid = null;
+          offsets = null;
+        }
         neededCleanup = true;
       }
       if (neededCleanup && logErrorIfNotClean) {

--- a/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
@@ -52,8 +52,14 @@ abstract public class MemoryBuffer implements AutoCloseable {
           log.error("A SLICED BUFFER WAS LEAKED(ID: " + id + " parent: " + parent + ")");
           logRefCountDebug("Leaked sliced buffer");
         }
-        parent.close();
-        parent = null;
+        try {
+          parent.close();
+        } finally {
+          // Always mark the resource as freed even if an exception is thrown.
+          // We cannot know how far it progressed before the exception, and
+          // therefore it is unsafe to retry.
+          parent = null;
+        }
         return true;
       }
       return false;

--- a/java/src/main/java/ai/rapids/cudf/RmmEventHandler.java
+++ b/java/src/main/java/ai/rapids/cudf/RmmEventHandler.java
@@ -49,6 +49,9 @@ public interface RmmEventHandler {
   /**
    * Invoked after an RMM memory allocate operation when an allocate threshold is crossed.
    * See {@link #getAllocThresholds()} for details on allocate threshold crossing.
+   * <p>NOTE: Any exception thrown by this method will cause the corresponding allocation
+   * that triggered the threshold callback to be released before the exception is
+   * propagated to the application.
    * @param totalAllocSize total amount of memory allocated after the crossing
    */
   void onAllocThreshold(long totalAllocSize);
@@ -56,6 +59,8 @@ public interface RmmEventHandler {
   /**
    * Invoked after an RMM memory deallocation operation when a deallocate threshold is crossed.
    * See {@link #getDeallocThresholds()} for details on deallocate threshold crossing.
+   * <p>NOTE: Any exception thrown by this method will be propagated to the application
+   * after the resource that triggered the threshold was released.
    * @param totalAllocSize total amount of memory allocated after the crossing
    */
   void onDeallocThreshold(long totalAllocSize);

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -489,8 +489,14 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
           LOG.error("A SCALAR WAS LEAKED(ID: " + id + " " + Long.toHexString(scalarHandle) + ")");
           logRefCountDebug("Leaked scalar");
         }
-        closeScalar(scalarHandle);
-        scalarHandle = 0;
+        try {
+          closeScalar(scalarHandle);
+        } finally {
+          // Always mark the resource as freed even if an exception is thrown.
+          // We cannot know how far it progressed before the exception, and
+          // therefore it is unsafe to retry.
+          scalarHandle = 0;
+        }
         return true;
       }
       return false;


### PR DESCRIPTION
The RmmTest unit test can occasionally fail because it tests a scenario where closing a device buffer throws an exception.  This can leave the cleaner tracking object in a state where the resource has been released but the tracking object thinks it still needs to be released, causing the Rmm shutdown code to throw an exception on the "leaked" resource.

This updates the `cleanImpl` methods to always mark the resource as being cleaned even if the cleanup throws.  An exception at this point means we cannot retry the cleanup, so the resource is always marked as cleaned to prevent retry later (e.g.: at shutdown) before the exception is propagated to the application.