### PR TITLE
[REVIEW] Add annotations for the `.columns` property and setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - PR #4869 Expose contiguous table when deserializing from Java
 - PR #4873 Prevent mutable_view() from invoking null count
 - PR #4884 Add more NVTX annotations in cuDF Python
+- PR #4894 Add annotations for the `.columns` property and setter
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1334,12 +1334,14 @@ class DataFrame(Frame):
         return self.loc
 
     @property
+    @annotate("DATAFRAME_COLUMNS_GETTER", color="yellow", domain="cudf_python")
     def columns(self):
         """Returns a tuple of columns
         """
         return self._data.to_pandas_index()
 
     @columns.setter
+    @annotate("DATAFRAME_COLUMNS_SETTER", color="yellow", domain="cudf_python")
     def columns(self, columns):
         if isinstance(columns, (cudf.MultiIndex, cudf.Index)):
             columns = columns.to_pandas()


### PR DESCRIPTION
## Summary

Adds annotations for the `.columns` getter and setter as those seem to be extremely time consuming, e.g., within a call to `groupby.agg()`:

<img width="748" alt="Screen Shot 2020-04-14 at 9 14 04 AM" src="https://user-images.githubusercontent.com/3190405/79229563-3bccdb80-7e31-11ea-96e2-7b1e614c652e.png">

## Context:

Underneath each `DataFrame` is a `ColumnAccessor` object, a proprietary dict-like object that holds the mapping of column names to columns. It is accessible via the `._data` attribute:

```python
In [3]: a = cudf.DataFrame({'a': [1, 2, 3], 'b': ['a', 'b', 'c']})

In [4]: print(a._data)
ColumnAccessor(OrderedColumnDict([('a', <cudf.core.column.numerical.NumericalColumn object at 0x7f0e084b0730>), ('b', <cudf.core.column.string.StringColumn object at 0x7f0e084cdb90>)]), multiindex=False, lev
el_names=(None,))
```

`DataFrame.columns` returns an object of type `pandas.Index`, containing just the names of the columns. 

```python
In [5]: a.columns
Out[5]: Index(['a', 'b'], dtype='object')
```

Ordinarily, this would be just the keys of the `ColumnAccessor` object. However, because `.columns` can also be a `MultiIndex`, the logic for generating `.columns` from `._data` is more complex. It is encapsulated in the `ColumnAccessor.to_pandas_index()` method, which turns out to be what makes it so expensive.

```python
In [6]: a._data.to_pandas_index()
Out[6]: Index(['a', 'b'], dtype='object')
```

I suspect lots of other places in the `cudf` codebase use`.columns`. We can usually get away with interacting with the `ColumnAccessor` object instead, which is much more efficient. Alternatively, we should look into making `.to_pandas_index()` more efficient.

Will address in a follow-up PR.