### PR TITLE
[REVIEW] Use ContextDecorator instead of contextmanager for nvtx.annotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - PR #4869 Expose contiguous table when deserializing from Java
 - PR #4873 Prevent mutable_view() from invoking null count
 - PR #4884 Add more NVTX annotations in cuDF Python
+- PR #4902 Use ContextDecorator instead of contextmanager for nvtx.annotate
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/_lib/nvtx/nvtx.py
+++ b/python/cudf/cudf/_lib/nvtx/nvtx.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
-from contextlib import contextmanager
+from contextlib import ContextDecorator
 
 from cudf._lib.nvtx._lib import (
     pop_range as libnvtx_pop_range,
@@ -8,44 +8,54 @@ from cudf._lib.nvtx._lib import (
 )
 
 
-@contextmanager
-def annotate(message=None, color="blue", domain=None):
+class annotate(ContextDecorator):
     """
-    Annotate a function or a code range.
-
-    Parameters
-    ----------
-    message : str
-        A message associated with the annotated code range.
-    color : str, color
-        A color associated with the annotated code range.
-        Supports `matplotlib` colors if it is available.
-    domain : str
-        Name of a domain under which the code range is scoped.
-        The default domain is called "NVTX".
-
-    Examples
-    --------
-    >>> import nvtx
-    >>> import time
-
-    Using a decorator:
-
-    >>> @nvtx.annotate("my_func", color="red", domain="cudf")
-    ... def func():
-    ...     time.sleep(0.1)
-
-    Using a context manager:
-
-    >>> with nvtx.annotate("my_code_range", color="blue"):
-    ...    time.sleep(10)
-    ...
+    Annotate code ranges using a context manager or a decorator.
     """
-    push_range(message, color, domain)
-    try:
-        yield
-    finally:
-        pop_range(domain)
+
+    def __init__(self, message=None, color="blue", domain=None):
+        """
+        Annotate a function or a code range.
+
+        Parameters
+        ----------
+        message : str
+            A message associated with the annotated code range.
+        color : str, color
+            A color associated with the annotated code range.
+            Supports `matplotlib` colors if it is available.
+        domain : str
+            Name of a domain under which the code range is scoped.
+            The default domain is called "NVTX".
+
+        Examples
+        --------
+        >>> import nvtx
+        >>> import time
+
+        Using a decorator:
+
+        >>> @nvtx.annotate("my_func", color="red", domain="cudf")
+       ... def func():
+        ...     time.sleep(0.1)
+
+        Using a context manager:
+
+        >>> with nvtx.annotate("my_code_range", color="blue"):
+        ...    time.sleep(10)
+        ...
+        """
+        self.message = message
+        self.color = color
+        self.domain = domain
+
+    def __enter__(self):
+        push_range(self.message, self.color, self.domain)
+        return self
+
+    def __exit__(self, *exc):
+        pop_range(self.domain)
+        return False
 
 
 def push_range(message=None, color="blue", domain=None):

--- a/python/cudf/cudf/_lib/nvtx/nvtx.py
+++ b/python/cudf/cudf/_lib/nvtx/nvtx.py
@@ -36,7 +36,7 @@ class annotate(ContextDecorator):
         Using a decorator:
 
         >>> @nvtx.annotate("my_func", color="red", domain="cudf")
-       ... def func():
+        ... def func():
         ...     time.sleep(0.1)
 
         Using a context manager:


### PR DESCRIPTION
This should enable using `@annotate` with functions that need to be pickled/serialized by Dask. cc: @jrhemstad 