### PR TITLE
[REVIEW] Get decorated function name as message when annotating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - PR #4884 Add more NVTX annotations in cuDF Python
 - PR #4902 Use ContextDecorator instead of contextmanager for nvtx.annotate
 - PR #4894 Add annotations for the `.columns` property and setter
+- PR #4905 Get decorated function name as message when annotating
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/_lib/nvtx/nvtx.py
+++ b/python/cudf/cudf/_lib/nvtx/nvtx.py
@@ -19,12 +19,16 @@ class annotate(ContextDecorator):
 
         Parameters
         ----------
-        message : str
+        message : str, optional
             A message associated with the annotated code range.
-        color : str, color
+            When used as a decorator, the default value of message
+            is the name of the function being decorated.
+            When used as a context manager, the default value
+            is the empty string.
+        color : str or color, optional
             A color associated with the annotated code range.
             Supports `matplotlib` colors if it is available.
-        domain : str
+        domain : str, optional
             Name of a domain under which the code range is scoped.
             The default domain is called "NVTX".
 
@@ -56,6 +60,11 @@ class annotate(ContextDecorator):
     def __exit__(self, *exc):
         pop_range(self.domain)
         return False
+
+    def __call__(self, func):
+        if self.message is None:
+            self.message = func.__name__
+        return super().__call__(func)
 
 
 def push_range(message=None, color="blue", domain=None):


### PR DESCRIPTION
Automatically get the decorated function's name and use it as the `message` when annotating with NVTX. Thus, following are equivalent:

```python
@annotate("my_func", color="red")
def my_func(x):
     pass
```

```python
@annotate(color="red")
def my_func(x):
    pass
```