### PR TITLE
[REVIEW] Drop old `valid` check in `element_indexing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - PR #4888 Handle dropping of nan's & nulls using `skipna` parameter in Statistical reduction ops
 - PR #4905 Get decorated function name as message when annotating
 - PR #4907 Reuse EventAttributes across NVTX annotations
+- PR #4912 Drop old `valid` check in `element_indexing`
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -416,12 +416,7 @@ class ColumnBase(Column):
         else:
             val = val.to_array()[0]
 
-        valid = (
-            cudautils.mask_get.py_func(self.mask_array_view, index)
-            if self.mask
-            else True
-        )
-        return val if valid else None
+        return val
 
     def __getitem__(self, arg):
         from cudf.core.column import column


### PR DESCRIPTION
This is a holdover from old nvstrings code. Since we no longer needed it (and is already handled above), go ahead and drop it.