### PR TITLE
Cleanup dask_cudf rearrange_by_hash and implement edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - PR #4888 Handle dropping of nan's & nulls using `skipna` parameter in Statistical reduction ops
 - PR #4905 Get decorated function name as message when annotating
 - PR #4907 Reuse EventAttributes across NVTX annotations
+- PR #4924 Properly handle npartition argument in rearrange_by_hash
 
 ## Bug Fixes
 

--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -9,7 +9,7 @@ import tlz as toolz
 
 from dask.base import tokenize
 from dask.dataframe.core import DataFrame, Index, Series, _concat
-from dask.dataframe.shuffle import rearrange_by_column
+from dask.dataframe.shuffle import rearrange_by_column, shuffle_group_get
 from dask.dataframe.utils import group_split_dispatch, hash_object_dispatch
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import M, digit, insert
@@ -23,8 +23,13 @@ def set_partitions_hash(df, columns, npartitions):
     return np.mod(c, npartitions)
 
 
-def _shuffle_group(df, columns, stage, k, npartitions, ignore_index):
-    c = hash_object_dispatch(df[columns], index=False).values
+def _shuffle_group(df, columns, stage, k, npartitions, ignore_index, nfinal):
+    ind = hash_object_dispatch(df[columns], index=False)
+    if nfinal and nfinal != npartitions:
+        # Want to start with final mapping here
+        ind = ind % int(nfinal)
+
+    c = ind.values
     typ = np.min_scalar_type(npartitions * 2)
     c = np.mod(c, npartitions).astype(typ, copy=False)
     if stage > 0:
@@ -36,25 +41,26 @@ def _shuffle_group(df, columns, stage, k, npartitions, ignore_index):
     )
 
 
+def _shuffle_group_2(df, cols, ignore_index, nparts):
+    if not len(df):
+        return {}, df
+
+    ind = (
+        hash_object_dispatch(df[cols] if cols else df, index=False)
+        % int(nparts)
+    ).astype(np.int32)
+
+    n = ind.max() + 1
+
+    result2 = group_split_dispatch(
+        df, ind.values, n, ignore_index=ignore_index
+    )
+    return result2, df.iloc[:0]
+
+
 def rearrange_by_hash(
     df, columns, npartitions, max_branch=None, ignore_index=True
 ):
-    if npartitions and npartitions != df.npartitions:
-        # Use main-line dask for new npartitions
-        meta = df._meta._constructor_sliced([0])
-        partitions = df.map_partitions(
-            set_partitions_hash, columns, npartitions, meta=meta
-        )
-        # Note: Dask will use a shallow copy for assign
-        df2 = df.assign(_partitions=partitions)
-        return rearrange_by_column(
-            df2,
-            "_partitions",
-            shuffle="tasks",
-            max_branch=max_branch,
-            npartitions=npartitions,
-            ignore_index=ignore_index,
-        )
 
     n = df.npartitions
     if max_branch is False:
@@ -101,6 +107,7 @@ def rearrange_by_hash(
                 k,
                 n,
                 ignore_index,
+                npartitions,
             )
             for inp in inputs
         }
@@ -145,9 +152,39 @@ def rearrange_by_hash(
         "shuffle-" + token, dsk, dependencies=[df]
     )
     df2 = df.__class__(graph, "shuffle-" + token, df, df.divisions)
-    df2.divisions = (None,) * (df.npartitions + 1)
 
-    return df2
+    if npartitions is not None and npartitions != df.npartitions:
+        parts = [i % df.npartitions for i in range(npartitions)]
+        token = tokenize(df2, npartitions)
+
+        dsk = {
+            ("repartition-group-" + token, i): (
+                _shuffle_group_2,
+                k,
+                columns,
+                ignore_index,
+                npartitions,
+            )
+            for i, k in enumerate(df2.__dask_keys__())
+        }
+        for p in range(npartitions):
+            dsk[("repartition-get-" + token, p)] = (
+                shuffle_group_get,
+                ("repartition-group-" + token, parts[p]),
+                p,
+            )
+
+        graph2 = HighLevelGraph.from_collections(
+            "repartition-get-" + token, dsk, dependencies=[df2]
+        )
+        df3 = df2.__class__(
+            graph2, "repartition-get-" + token, df2, [None] * (npartitions + 1)
+        )
+    else:
+        df3 = df2
+        df3.divisions = (None,) * (df.npartitions + 1)
+
+    return df3
 
 
 def set_index_post(df, index_name, drop, column_dtype):
@@ -264,7 +301,7 @@ def _approximate_quantile(df, q):
     def finalize_tsk(tsk):
         return (final_type, tsk, q)
 
-    return_type = DataFrame
+    return_type = df.__class__
 
     # pandas/cudf uses quantile in [0, 1]
     # numpy / cupy uses [0, 100]

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -421,7 +421,8 @@ def test_repartition_hash_staged(npartitions):
 
 @pytest.mark.parametrize("by", [["b"], ["c"], ["d"], ["b", "c"]])
 @pytest.mark.parametrize("npartitions", [3, 4, 5])
-def test_repartition_hash(by, npartitions):
+@pytest.mark.parametrize("max_branch", [3, 32])
+def test_repartition_hash(by, npartitions, max_branch):
     npartitions_i = 4
     datarange = 26
     size = 100
@@ -435,7 +436,9 @@ def test_repartition_hash(by, npartitions):
     )
     gdf.d = gdf.d.astype("datetime64[ms]")
     ddf = dgd.from_cudf(gdf, npartitions=npartitions_i)
-    ddf_new = ddf.repartition(columns=by, npartitions=npartitions)
+    ddf_new = ddf.repartition(
+        columns=by, npartitions=npartitions, max_branch=max_branch
+    )
 
     # Check that the length was preserved
     assert len(ddf_new) == len(ddf)

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -381,7 +381,8 @@ def test_repartition_simple_divisions(start, stop):
     dd.utils.assert_eq(a, b)
 
 
-def test_repartition_hash_staged():
+@pytest.mark.parametrize("npartitions", [2, 17, 20])
+def test_repartition_hash_staged(npartitions):
     by = ["b"]
     datarange = 35
     size = 100
@@ -393,8 +394,11 @@ def test_repartition_hash_staged():
     )
     # WARNING: Specific npartitions-max_branch combination
     # was specifically chosen to cover changes in #4676
-    ddf = dgd.from_cudf(gdf, npartitions=17)
-    ddf_new = ddf.repartition(columns=by, max_branch=4)
+    npartitions_initial = 17
+    ddf = dgd.from_cudf(gdf, npartitions=npartitions_initial)
+    ddf_new = ddf.repartition(
+        columns=by, npartitions=npartitions, max_branch=4
+    )
 
     # Make sure we are getting a dask_cudf dataframe
     assert type(ddf_new) == type(ddf)
@@ -416,7 +420,7 @@ def test_repartition_hash_staged():
 
 
 @pytest.mark.parametrize("by", [["b"], ["c"], ["d"], ["b", "c"]])
-@pytest.mark.parametrize("npartitions", [4, 5])
+@pytest.mark.parametrize("npartitions", [3, 4, 5])
 def test_repartition_hash(by, npartitions):
     npartitions_i = 4
     datarange = 26


### PR DESCRIPTION
This PR is intended to fill in some gaps in the existing `rearrange_by_hash` implementation (used for hash-based repartitioning in `dask_cudf`). The changes include:

1. **Handle `npartitions` argument without falling back to the upstream-Dask shuffle routine**.  Eventually we want to use upstream dask for the shuffle in all cases (e.g. after changes like [dask#6066](https://github.com/dask/dask/pull/6066) are fiinished/accepted).  However, the hash-based shuffle routine in `dask_cudf` is currently less memory intensive.  This PR allows the `dask_cudf` routine to be used when the number of output partitions (`npartitions`) does **not** match the orginal partition count.  Before this PR, the dask_cudf algorithm could only handle an N-to-N shuffle.

2.  **Add `_simple_shuffle` routine for the case that the number of output partitions is `<=max_branch`**.   The usual `rearrange_by_hash` algorithm is designed around a "multi-staged" shuffle.  No matter the number of output partitions, the algorithm will first perform a staged N-to-N shuffle, and then repartition according to the `npartitions` argument.  This approach requires unnecessary communication if the number of output partitions is small.  The  `_simple_shuffle` routine provides a simple single-staged shuffle from the original DataFrame directly into `npartitions` output partitions.

3. Other miscellaneous cleanup.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
