### PR TITLE
Type `status` variables as `cudaError_t`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@
 - PR #4907 Reuse EventAttributes across NVTX annotations
 - PR #4912 Drop old `valid` check in `element_indexing`
 - PR #4909 Added ability to transform a column using cuda method in Java bindings 
-- PR #4925 Type `status` variables as `int`
+- PR #4925 Type `status` variables as `cudaError_t`
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - PR #4907 Reuse EventAttributes across NVTX annotations
 - PR #4912 Drop old `valid` check in `element_indexing`
 - PR #4909 Added ability to transform a column using cuda method in Java bindings 
+- PR #4925 Type `status` variables as `int`
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/_cuda/gpu.pxd
+++ b/python/cudf/cudf/_cuda/gpu.pxd
@@ -305,7 +305,9 @@ cdef extern from "cuda_runtime_api.h" nogil:
     cudaError_t cudaDriverGetVersion(int* driverVersion)
     cudaError_t cudaRuntimeGetVersion(int* runtimeVersion)
     cudaError_t cudaGetDeviceCount(int* count)
-    cudaError_t cudaDeviceGetAttribute(int* value, cudaDeviceAttr attr, int device)
+    cudaError_t cudaDeviceGetAttribute(int* value,
+                                       cudaDeviceAttr attr,
+                                       int device)
     cudaError_t cudaGetDeviceProperties(cudaDeviceProp* prop, int device)
 
     const char* cudaGetErrorName(cudaError_t error)

--- a/python/cudf/cudf/_cuda/gpu.pxd
+++ b/python/cudf/cudf/_cuda/gpu.pxd
@@ -302,11 +302,11 @@ cdef extern from "cuda.h" nogil:
 
 cdef extern from "cuda_runtime_api.h" nogil:
 
-    int cudaDriverGetVersion(int* driverVersion)
-    int cudaRuntimeGetVersion(int* runtimeVersion)
-    int cudaGetDeviceCount(int* count)
-    int cudaDeviceGetAttribute(int* value, cudaDeviceAttr attr, int device)
-    int cudaGetDeviceProperties(cudaDeviceProp* prop, int device)
+    cudaError_t cudaDriverGetVersion(int* driverVersion)
+    cudaError_t cudaRuntimeGetVersion(int* runtimeVersion)
+    cudaError_t cudaGetDeviceCount(int* count)
+    cudaError_t cudaDeviceGetAttribute(int* value, cudaDeviceAttr attr, int device)
+    cudaError_t cudaGetDeviceProperties(cudaDeviceProp* prop, int device)
 
     const char* cudaGetErrorName(cudaError_t error)
     const char* cudaGetErrorString(cudaError_t error)

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -246,7 +246,7 @@ def driverGetVersion():
     and status code.
     """
     cdef int version
-    status = cudaDriverGetVersion(&version)
+    cdef int status = cudaDriverGetVersion(&version)
     if status != 0:
         raise CUDARuntimeError(status)
     return version
@@ -263,7 +263,7 @@ def runtimeGetVersion():
     """
 
     cdef int version
-    status = cudaRuntimeGetVersion(&version)
+    cdef int status = cudaRuntimeGetVersion(&version)
     if status != 0:
         raise CUDARuntimeError(status)
     return version
@@ -279,7 +279,7 @@ def getDeviceCount():
     """
 
     cdef int count
-    status = cudaGetDeviceCount(&count)
+    cdef int status = cudaGetDeviceCount(&count)
     if status != 0:
         raise CUDARuntimeError(status)
     return count
@@ -301,7 +301,7 @@ def getDeviceAttribute(object attr, int device):
     """
 
     cdef int value
-    status = cudaDeviceGetAttribute(&value, attr, device)
+    cdef int status = cudaDeviceGetAttribute(&value, attr, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return value
@@ -321,7 +321,7 @@ def getDeviceProperties(int device):
     """
 
     cdef cudaDeviceProp prop
-    status = cudaGetDeviceProperties(&prop, device)
+    cdef int status = cudaGetDeviceProperties(&prop, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return prop
@@ -341,7 +341,7 @@ def deviceGetName(int device):
     """
 
     cdef char* device_name = <char*> malloc(256 * sizeof(char))
-    status = cuDeviceGetName(device_name, 256, device)
+    cdef int status = cuDeviceGetName(device_name, 256, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return device_name

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -22,10 +22,10 @@ class CUDARuntimeError(RuntimeError):
 
     def __init__(self, cudaError_t status):
         self.status = status
-        cdef bytes name = cudaGetErrorName(status)
-        cdef bytes msg = cudaGetErrorString(status)
+        cdef str name = cudaGetErrorName(status).decode()
+        cdef str msg = cudaGetErrorString(status).decode()
         super(CUDARuntimeError, self).__init__(
-            '%s: %s' % (name.decode(), msg.decode()))
+            '%s: %s' % (name, msg))
 
     def __reduce__(self):
         return (type(self), (self.status,))

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -20,10 +20,10 @@ from cudf._cuda.gpu cimport underlying_type_attribute as c_attr
 
 class CUDARuntimeError(RuntimeError):
 
-    def __init__(self, status):
+    def __init__(self, cudaError_t status):
         self.status = status
-        cdef bytes name = cudaGetErrorName(<cudaError_t>status)
-        cdef bytes msg = cudaGetErrorString(<cudaError_t>status)
+        cdef bytes name = cudaGetErrorName(status)
+        cdef bytes msg = cudaGetErrorString(status)
         super(CUDARuntimeError, self).__init__(
             '%s: %s' % (name.decode(), msg.decode()))
 

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -246,7 +246,7 @@ def driverGetVersion():
     and status code.
     """
     cdef int version
-    cdef int status = cudaDriverGetVersion(&version)
+    cdef cudaError_t status = cudaDriverGetVersion(&version)
     if status != 0:
         raise CUDARuntimeError(status)
     return version
@@ -263,7 +263,7 @@ def runtimeGetVersion():
     """
 
     cdef int version
-    cdef int status = cudaRuntimeGetVersion(&version)
+    cdef cudaError_t status = cudaRuntimeGetVersion(&version)
     if status != 0:
         raise CUDARuntimeError(status)
     return version
@@ -279,7 +279,7 @@ def getDeviceCount():
     """
 
     cdef int count
-    cdef int status = cudaGetDeviceCount(&count)
+    cdef cudaError_t status = cudaGetDeviceCount(&count)
     if status != 0:
         raise CUDARuntimeError(status)
     return count
@@ -301,7 +301,7 @@ def getDeviceAttribute(object attr, int device):
     """
 
     cdef int value
-    cdef int status = cudaDeviceGetAttribute(&value, attr, device)
+    cdef cudaError_t status = cudaDeviceGetAttribute(&value, attr, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return value
@@ -321,7 +321,7 @@ def getDeviceProperties(int device):
     """
 
     cdef cudaDeviceProp prop
-    cdef int status = cudaGetDeviceProperties(&prop, device)
+    cdef cudaError_t status = cudaGetDeviceProperties(&prop, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return prop
@@ -341,7 +341,7 @@ def deviceGetName(int device):
     """
 
     cdef char* device_name = <char*> malloc(256 * sizeof(char))
-    cdef int status = cuDeviceGetName(device_name, 256, device)
+    cdef cudaError_t status = cuDeviceGetName(device_name, 256, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return device_name


### PR DESCRIPTION
Possibly related to issue ( https://github.com/rapidsai/cudf/issues/627 )

Since these are C typed variables, make sure they are typed when assigned to avoid casting them to Python objects (at least until that is needed). Will at least delay this to the error handling section of code where we can accept the conversion cost.
