### PR TITLE
Use Python memory in `deviceGetName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - PR #4907 Reuse EventAttributes across NVTX annotations
 - PR #4912 Drop old `valid` check in `element_indexing`
 - PR #4909 Added ability to transform a column using cuda method in Java bindings 
+- PR #4926 Use Python memory in `deviceGetName`
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -341,7 +341,7 @@ def deviceGetName(int device):
     """
 
     cdef char* device_name = <char*> malloc(256 * sizeof(char))
-    status = cuDeviceGetName(device_name, 256, device)
+    cdef int status = cuDeviceGetName(device_name, 256, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return device_name

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -340,8 +340,9 @@ def deviceGetName(int device):
     and status code.
     """
 
-    cdef char* device_name = <char*> malloc(256 * sizeof(char))
-    cdef int status = cuDeviceGetName(device_name, 256, device)
+    cdef int size = 256
+    cdef char* device_name = <char*> malloc(size * sizeof(char))
+    cdef int status = cuDeviceGetName(device_name, size, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return device_name

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -346,4 +346,4 @@ def deviceGetName(int device):
     cdef int status = cuDeviceGetName(device_name_ptr, size, device)
     if status != 0:
         raise CUDARuntimeError(status)
-    return device_name
+    return device_name.decode()

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -1,5 +1,6 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
+from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING
 from cudf._cuda.gpu cimport (
     cudaDriverGetVersion,
     cudaRuntimeGetVersion,
@@ -14,7 +15,6 @@ from cudf._cuda.gpu cimport (
     cuDeviceGetName
 )
 from enum import IntEnum
-from libc.stdlib cimport malloc
 from cudf._cuda.gpu cimport underlying_type_attribute as c_attr
 
 
@@ -341,8 +341,9 @@ def deviceGetName(int device):
     """
 
     cdef int size = 256
-    cdef char* device_name = <char*> malloc(size * sizeof(char))
-    cdef int status = cuDeviceGetName(device_name, size, device)
+    cdef bytes device_name = PyBytes_FromStringAndSize(NULL, size)
+    cdef char* device_name_ptr = PyBytes_AS_STRING(device_name)
+    cdef int status = cuDeviceGetName(device_name_ptr, size, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return device_name

--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -51,7 +51,7 @@ def validate_setup(check_dask=True):
             )
             warnings.warn(
                 "You will need a GPU with NVIDIA Pascal™ or newer architecture"
-                "\nDetected GPU 0: " + str(device_name.decode()) + "\n"
+                "\nDetected GPU 0: " + device_name + "\n"
                 "Detected Compute Capability: "
                 + str(major_version)
                 + "."


### PR DESCRIPTION
To simplify allocation and freeing of memory used in `deviceGetName`, go ahead and just allocate a `bytes` object to hold the device name. Further convert the result to a Python `str` to make it easier to work with in other Python contexts.