### PR TITLE
Use stack for memory in `deviceGetName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - PR #4918 Adding support for `cupy.ndarray` in `series.loc`
 - PR #4909 Added ability to transform a column using cuda method in Java bindings 
 - PR #4917 Add support for casting unsupported `dtypes` of same kind
+- PR #4927 Use stack for memory in `deviceGetName`
 - PR #4929 Java methods ensure calling thread's CUDA device matches RMM device
 
 ## Bug Fixes

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -341,7 +341,7 @@ def deviceGetName(int device):
     """
 
     cdef char* device_name = <char*> malloc(256 * sizeof(char))
-    status = cuDeviceGetName(device_name, 256, device)
+    cdef int status = cuDeviceGetName(device_name, 256, device)
     if status != 0:
         raise CUDARuntimeError(status)
     return device_name

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -347,4 +347,4 @@ def deviceGetName(int device):
     )
     if status != 0:
         raise CUDARuntimeError(status)
-    return <bytes>device_name
+    return device_name.decode()

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -14,7 +14,6 @@ from cudf._cuda.gpu cimport (
     cuDeviceGetName
 )
 from enum import IntEnum
-from libc.stdlib cimport malloc
 from cudf._cuda.gpu cimport underlying_type_attribute as c_attr
 
 
@@ -340,8 +339,8 @@ def deviceGetName(int device):
     and status code.
     """
 
-    cdef char* device_name = <char*> malloc(256 * sizeof(char))
-    cdef int status = cuDeviceGetName(device_name, 256, device)
+    cdef char[256] device_name
+    cdef int status = cuDeviceGetName(device_name, sizeof(device_name), device)
     if status != 0:
         raise CUDARuntimeError(status)
-    return device_name
+    return <bytes>device_name

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -340,7 +340,11 @@ def deviceGetName(int device):
     """
 
     cdef char[256] device_name
-    cdef int status = cuDeviceGetName(device_name, sizeof(device_name), device)
+    cdef int status = cuDeviceGetName(
+        device_name,
+        sizeof(device_name),
+        device
+    )
     if status != 0:
         raise CUDARuntimeError(status)
     return <bytes>device_name

--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -51,7 +51,7 @@ def validate_setup(check_dask=True):
             )
             warnings.warn(
                 "You will need a GPU with NVIDIA Pascal™ or newer architecture"
-                "\nDetected GPU 0: " + str(device_name.decode()) + "\n"
+                "\nDetected GPU 0: " + device_name + "\n"
                 "Detected Compute Capability: "
                 + str(major_version)
                 + "."


### PR DESCRIPTION
Instead of calling `malloc` on memory we don't call `free` on in `deviceGetName`, just allocate memory on the stack and let C clean it up when we scope out. Plus this is a bit more DRY friendly when working with object sizes. Go ahead and convert the result to a Python `str` to simplify working with it in Python code later.