### PR TITLE
Java methods ensure calling thread's CUDA device matches RMM device [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - PR #4912 Drop old `valid` check in `element_indexing`
 - PR #4909 Added ability to transform a column using cuda method in Java bindings 
 - PR #4917 Add support for casting unsupported `dtypes` of same kind
+- PR #4929 Java methods ensure calling thread's CUDA device matches RMM device
 
 ## Bug Fixes
 

--- a/java/README.md
+++ b/java/README.md
@@ -3,6 +3,19 @@
 This project provides java bindings for cudf, to be able to process large amounts of data on
 a GPU. This is still a work in progress so some APIs may change until the 1.0 release.
 
+## Behavior on Systems with Multiple GPUs
+
+The cudf project currently operates with a single GPU per process.  The CUDA runtime will
+automatically search for a GPU to use if a thread has not specifically requested a device,
+and Java processes tend to run with many threads.  If one of the Java threads using cudf
+does not use the same device being used by other cudf threads then this will lead to an
+invalid state that can trigger application crashes.
+
+To avoid these crashes, cudf will remember which CUDA device was used to initialize the
+Rapids Memory Manager (RMM) via cudf.  cudf methods will automatically set the thread's
+CUDA device to this initial device if necessary.  Note that mixing cudf calls with other
+CUDA libraries that could change the thread's current CUDA device will be problematic.
+
 ## Dependency
 
 This is a fat jar with the binary dependencies packaged in the jar.  This means the jar will only

--- a/java/README.md
+++ b/java/README.md
@@ -5,16 +5,18 @@ a GPU. This is still a work in progress so some APIs may change until the 1.0 re
 
 ## Behavior on Systems with Multiple GPUs
 
-The cudf project currently operates with a single GPU per process.  The CUDA runtime will
-automatically search for a GPU to use if a thread has not specifically requested a device,
-and Java processes tend to run with many threads.  If one of the Java threads using cudf
-does not use the same device being used by other cudf threads then this will lead to an
-invalid state that can trigger application crashes.
+The cudf project currently works with a single GPU per process. The CUDA runtime
+assigns the default GPU to all new operating system threads when they start to
+interact with CUDA. This means that if you use a multi-threaded environment,
+like Java processes tend to be, and try to use a non-default GPU for cudf you
+can run into hard to debug issues including resource leaks, invalid states,
+application crashes, and poor performance.
 
-To avoid these crashes, cudf will remember which CUDA device was used to initialize the
-Rapids Memory Manager (RMM) via cudf.  cudf methods will automatically set the thread's
-CUDA device to this initial device if necessary.  Note that mixing cudf calls with other
-CUDA libraries that could change the thread's current CUDA device will be problematic.
+To prevent this the Java cudf API will remember the device used to initialize
+the Rapids Memory Manager (RMM), and automatically set the thread's active
+device to it, if needed. It will not set the device back when the cudf call
+completes. This is different from most CUDA libraries and can result in
+unexpected behavior if you try to mix these libraries using the same thread.
 
 ## Dependency
 

--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -298,11 +298,13 @@ public class Cuda {
 
   /**
    * Set the id of the current device.
-   * Note this is relative to CUDA_SET_VISIBLE_DEVICES, e.g. if
+   * <p>Note this is relative to CUDA_SET_VISIBLE_DEVICES, e.g. if
    * CUDA_SET_VISIBLE_DEVICES=1,0, and you call setDevice(0), you will get device 1.
+   * <p>Note if RMM has been initialized and the requested device ID does not
+   * match the device used to initialize RMM then this will throw an error.
    * @throws CudaException on any error
    */
-  public static native void setDevice(int device) throws CudaException;
+  public static native void setDevice(int device) throws CudaException, CudfException;
 
   /**
    * Calls cudaFree(0). This can be used to initialize the GPU after a setDevice()

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -679,6 +679,16 @@ jlong get_host_buffer_length(JNIEnv* env, jobject buffer);
 // needs to be attached, the thread will automatically detach when the thread terminates.
 JNIEnv* get_jni_env(JavaVM* jvm);
 
+/** Set the device to use for cudf */
+void set_cudf_device(int device);
+
+/**
+ * If the current thread has not set the CUDA device via Cuda.setDevice then this could
+ * set the device, throw an exception, or do nothing depending on how the application has
+ * configured it via Cuda.setAutoSetDeviceMode.
+ */
+void auto_set_device(JNIEnv* env);
+
 } // namespace jni
 } // namespace cudf
 

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -51,6 +51,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_upperStrings(JNIEnv *en
   JNI_NULL_CHECK(env, handle, "column is null", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     cudf::strings_column_view strings_column(*column);
 
@@ -65,6 +66,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_lowerStrings(JNIEnv *en
   JNI_NULL_CHECK(env, handle, "column is null", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     cudf::strings_column_view strings_column(*column);
 
@@ -80,6 +82,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_concatenate(JNIEnv *env
   using cudf::column;
   using cudf::column_view;
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<column_view> columns(env, column_handles);
     std::vector<column_view> columns_vector(columns.size());
     for (int i = 0; i < columns.size(); ++i) {
@@ -96,6 +99,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_sequence(JNIEnv *env, j
     jlong j_initial_val, jlong j_step, jint row_count) {
   JNI_NULL_CHECK(env, j_initial_val, "scalar is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     auto initial_val = reinterpret_cast<cudf::scalar const*>(j_initial_val);
     auto step = reinterpret_cast<cudf::scalar const*>(j_step);
     std::unique_ptr<cudf::column> col;
@@ -113,6 +117,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromScalar(JNIEnv *env,
     jlong j_scalar, jint row_count) {
   JNI_NULL_CHECK(env, j_scalar, "scalar is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     auto scalar_val = reinterpret_cast<cudf::scalar const*>(j_scalar);
     auto dtype = scalar_val->type();
     cudf::mask_state mask_state = scalar_val->is_valid() ? cudf::mask_state::UNALLOCATED : cudf::mask_state::ALL_NULL;
@@ -144,6 +149,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_replaceNulls(JNIEnv *en
   JNI_NULL_CHECK(env, j_col, "column is null", 0);
   JNI_NULL_CHECK(env, j_scalar, "scalar is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view col = *reinterpret_cast<cudf::column_view*>(j_col);
     auto val = reinterpret_cast<cudf::scalar*>(j_scalar);
     std::unique_ptr<cudf::column> result = cudf::experimental::replace_nulls(col, *val);
@@ -158,6 +164,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_ifElseVV(JNIEnv *env, j
   JNI_NULL_CHECK(env, j_true_vec, "true column is null", 0);
   JNI_NULL_CHECK(env, j_false_vec, "false column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     auto pred_vec = reinterpret_cast<cudf::column_view*>(j_pred_vec);
     auto true_vec = reinterpret_cast<cudf::column_view*>(j_true_vec);
     auto false_vec = reinterpret_cast<cudf::column_view*>(j_false_vec);
@@ -173,6 +180,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_ifElseVS(JNIEnv *env, j
   JNI_NULL_CHECK(env, j_true_vec, "true column is null", 0);
   JNI_NULL_CHECK(env, j_false_scalar, "false scalar is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     auto pred_vec = reinterpret_cast<cudf::column_view*>(j_pred_vec);
     auto true_vec = reinterpret_cast<cudf::column_view*>(j_true_vec);
     auto false_scalar = reinterpret_cast<cudf::scalar*>(j_false_scalar);
@@ -188,6 +196,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_ifElseSV(JNIEnv *env, j
   JNI_NULL_CHECK(env, j_true_scalar, "true scalar is null", 0);
   JNI_NULL_CHECK(env, j_false_vec, "false column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     auto pred_vec = reinterpret_cast<cudf::column_view*>(j_pred_vec);
     auto true_scalar = reinterpret_cast<cudf::scalar*>(j_true_scalar);
     auto false_vec = reinterpret_cast<cudf::column_view*>(j_false_vec);
@@ -203,6 +212,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_ifElseSS(JNIEnv *env, j
   JNI_NULL_CHECK(env, j_true_scalar, "true scalar is null", 0);
   JNI_NULL_CHECK(env, j_false_scalar, "false scalar is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     auto pred_vec = reinterpret_cast<cudf::column_view*>(j_pred_vec);
     auto true_scalar = reinterpret_cast<cudf::scalar*>(j_true_scalar);
     auto false_scalar = reinterpret_cast<cudf::scalar*>(j_false_scalar);
@@ -216,6 +226,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_reduce(JNIEnv *env, jcl
     jlong j_col_view, jint agg_type, jint j_dtype) {
   JNI_NULL_CHECK(env, j_col_view, "column view is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     auto col = reinterpret_cast<cudf::column_view*>(j_col_view);
     auto agg = cudf::jni::map_jni_aggregation(agg_type);
     cudf::data_type out_dtype{static_cast<cudf::type_id>(j_dtype)};
@@ -231,6 +242,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_quantile(JNIEnv *env, j
                                                                          jdoubleArray jquantiles) {
   JNI_NULL_CHECK(env, input_column, "native handle is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jdoubleArray native_quantiles(env, jquantiles);
     std::vector<double> quantiles(native_quantiles.data(), native_quantiles.data() + native_quantiles.size()); 
     cudf::column_view *n_input_column = reinterpret_cast<cudf::column_view *>(input_column);
@@ -249,6 +261,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_rollingWindow(
 
   JNI_NULL_CHECK(env, input_col, "native handle is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *n_input_col = reinterpret_cast<cudf::column_view *>(input_col);
     cudf::column_view *n_preceding_col = reinterpret_cast<cudf::column_view *>(preceding_col);
     cudf::column_view *n_following_col = reinterpret_cast<cudf::column_view *>(following_col);
@@ -274,6 +287,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnVector_slice(JNIEnv *env,
   JNI_NULL_CHECK(env, slice_indices, "slice indices are null", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *n_column = reinterpret_cast<cudf::column_view *>(input_column);
     cudf::jni::native_jintArray n_slice_indices(env, slice_indices);
 
@@ -304,6 +318,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnVector_split(JNIEnv *env,
   JNI_NULL_CHECK(env, split_indices, "split indices are null", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *n_column = reinterpret_cast<cudf::column_view *>(input_column);
     cudf::jni::native_jintArray n_split_indices(env, split_indices);
 
@@ -331,6 +346,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_lengths(JNIEnv *env, jc
                                                                  jlong view_handle) {
   JNI_NULL_CHECK(env, view_handle, "input column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *n_column = reinterpret_cast<cudf::column_view *>(view_handle);
     std::unique_ptr<cudf::column> result = cudf::strings::count_characters(cudf::strings_column_view(*n_column));
     return reinterpret_cast<jlong>(result.release());
@@ -342,6 +358,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_byteCount(JNIEnv *env, 
                                                                    jlong view_handle) {
   JNI_NULL_CHECK(env, view_handle, "input column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *n_column = reinterpret_cast<cudf::column_view *>(view_handle);
     std::unique_ptr<cudf::column> result = cudf::strings::count_bytes(cudf::strings_column_view(*n_column));
     return reinterpret_cast<jlong>(result.release());
@@ -362,6 +379,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_findAndReplaceAll(JNIEn
   using cudf::column;
 
   try {
+    cudf::jni::auto_set_device(env);
     column_view *input_column = reinterpret_cast<column_view *>(input_handle);
     column_view *old_values_column = reinterpret_cast<column_view *>(old_values_handle);
     column_view *new_values_column = reinterpret_cast<column_view *>(new_values_handle);
@@ -377,6 +395,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_findAndReplaceAll(JNIEn
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNullNative(JNIEnv *env, jclass, jlong handle) {
   JNI_NULL_CHECK(env, handle, "input column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(handle);
     std::unique_ptr<cudf::column> ret = cudf::experimental::is_null(*input);
     return reinterpret_cast<jlong>(ret.release());
@@ -387,6 +406,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNullNative(JNIEnv *en
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNotNullNative(JNIEnv *env, jclass, jlong handle) {
   JNI_NULL_CHECK(env, handle, "input column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(handle);
     std::unique_ptr<cudf::column> ret = cudf::experimental::is_valid(*input);
     return reinterpret_cast<jlong>(ret.release());
@@ -397,6 +417,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNotNullNative(JNIEnv 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNanNative(JNIEnv *env, jclass, jlong handle) {
   JNI_NULL_CHECK(env, handle, "input column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(handle);
     std::unique_ptr<cudf::column> ret = cudf::experimental::is_nan(*input);
     return reinterpret_cast<jlong>(ret.release());
@@ -407,6 +428,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNanNative(JNIEnv *env
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isNotNanNative(JNIEnv *env, jclass, jlong handle) {
   JNI_NULL_CHECK(env, handle, "input column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(handle);
     std::unique_ptr<cudf::column> ret = cudf::experimental::is_not_nan(*input);
     return reinterpret_cast<jlong>(ret.release());
@@ -418,6 +440,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_unaryOperation(JNIEnv *
         jlong input_ptr, jint int_op) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
     cudf::experimental::unary_op op = static_cast<cudf::experimental::unary_op>(int_op);
     std::unique_ptr<cudf::column> ret = cudf::experimental::unary_operation(*input, op);
@@ -430,6 +453,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_year(JNIEnv *env, jclas
                                                               jlong input_ptr) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
     std::unique_ptr<cudf::column> output = cudf::datetime::extract_year(*input);
     return reinterpret_cast<jlong>(output.release());
@@ -441,6 +465,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_month(JNIEnv *env, jcla
                                                                jlong input_ptr) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
     std::unique_ptr<cudf::column> output = cudf::datetime::extract_month(*input);
     return reinterpret_cast<jlong>(output.release());
@@ -452,6 +477,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_day(JNIEnv *env, jclass
                                                              jlong input_ptr) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
     std::unique_ptr<cudf::column> output = cudf::datetime::extract_day(*input);
     return reinterpret_cast<jlong>(output.release());
@@ -463,6 +489,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_hour(JNIEnv *env, jclas
                                                               jlong input_ptr) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
     std::unique_ptr<cudf::column> output = cudf::datetime::extract_hour(*input);
     return reinterpret_cast<jlong>(output.release());
@@ -474,6 +501,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_minute(JNIEnv *env, jcl
                                                                 jlong input_ptr) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
     std::unique_ptr<cudf::column> output = cudf::datetime::extract_minute(*input);
     return reinterpret_cast<jlong>(output.release());
@@ -485,6 +513,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_second(JNIEnv *env, jcl
                                                                 jlong input_ptr) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
     std::unique_ptr<cudf::column> output = cudf::datetime::extract_second(*input);
     return reinterpret_cast<jlong>(output.release());
@@ -497,6 +526,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_castTo(JNIEnv *env,
                                                                 jlong handle, jint type) {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     cudf::data_type n_data_type(static_cast<cudf::type_id>(type));
     std::unique_ptr<cudf::column> result;
@@ -558,6 +588,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringTimestampToTimest
   JNI_NULL_CHECK(env, formatObj, "format is null", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring format(env, formatObj);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     cudf::strings_column_view strings_column(*column);
@@ -574,6 +605,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_timestampToStringTimest
   JNI_NULL_CHECK(env, j_format, "format is null", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring format(env, j_format);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
 
@@ -588,6 +620,7 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_ColumnVector_containsScalar(JNIEn
   JNI_NULL_CHECK(env, j_view_handle, "haystack vector is null", false);
   JNI_NULL_CHECK(env, j_scalar_handle, "scalar needle is null", false);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::scalar* scalar = reinterpret_cast<cudf::scalar*>(j_scalar_handle);
 
@@ -601,6 +634,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_containsVector(JNIEnv *
   JNI_NULL_CHECK(env, j_haystack_handle, "haystack vector is null", false);
   JNI_NULL_CHECK(env, j_needle_handle, "needle vector is null", false);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* haystack = reinterpret_cast<cudf::column_view*>(j_haystack_handle);
     cudf::column_view* needle = reinterpret_cast<cudf::column_view*>(j_needle_handle);
 
@@ -614,6 +648,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_transform(JNIEnv *env, 
                                                                  jlong handle, jstring j_udf,
                                                                  jboolean j_is_ptx) {
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     cudf::jni::native_jstring n_j_udf(env, j_udf);
     std::string n_udf(n_j_udf.get());
@@ -630,6 +665,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringStartWith(JNIEnv 
   JNI_NULL_CHECK(env, comp_string, "comparison string scalar is null", false);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_column(*column_view);
     cudf::string_scalar* comp_scalar = reinterpret_cast<cudf::string_scalar*>(comp_string);
@@ -646,6 +682,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringEndWith(JNIEnv *e
   JNI_NULL_CHECK(env, comp_string, "comparison string scalar is null", false);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_column(*column_view);
     cudf::string_scalar* comp_scalar = reinterpret_cast<cudf::string_scalar*>(comp_string);
@@ -662,6 +699,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringContains(JNIEnv *
     JNI_NULL_CHECK(env, comp_string, "comparison string scalar is null", false);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_column(*column_view);
     cudf::string_scalar* comp_scalar = reinterpret_cast<cudf::string_scalar*>(comp_string);
@@ -678,6 +716,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_matchesRe(JNIEnv *env, 
     JNI_NULL_CHECK(env, patternObj, "pattern is null", false);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_column(*column_view);
     cudf::jni::native_jstring pattern(env, patternObj);
@@ -694,6 +733,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_containsRe(JNIEnv *env,
     JNI_NULL_CHECK(env, patternObj, "pattern is null", false);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_column(*column_view);
     cudf::jni::native_jstring pattern(env, patternObj);
@@ -711,6 +751,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringConcatenation(JNI
   JNI_NULL_CHECK(env, separator, "separator string scalar object is null", 0);
   JNI_NULL_CHECK(env, narep, "narep string scalar object is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::string_scalar* separator_scalar = reinterpret_cast<cudf::string_scalar*>(separator);
     cudf::string_scalar* narep_scalar = reinterpret_cast<cudf::string_scalar*>(narep);
     cudf::jni::native_jpointerArray<cudf::column_view> n_cudf_columns(env, column_handles);
@@ -732,6 +773,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_binaryOpVV(JNIEnv *env,
   JNI_NULL_CHECK(env, lhs_view, "lhs is null", 0);
   JNI_NULL_CHECK(env, rhs_view, "rhs is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     auto lhs = reinterpret_cast<cudf::column_view *>(lhs_view);
     auto rhs = reinterpret_cast<cudf::column_view *>(rhs_view);
 
@@ -748,6 +790,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_binaryOpVS(JNIEnv *env,
   JNI_NULL_CHECK(env, lhs_view, "lhs is null", 0);
   JNI_NULL_CHECK(env, rhs_ptr, "rhs is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     auto lhs = reinterpret_cast<cudf::column_view *>(lhs_view);
     cudf::scalar *rhs = reinterpret_cast<cudf::scalar *>(rhs_ptr);
 
@@ -762,6 +805,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_substring(JNIEnv *env, 
                                                                 jint start, jint end) {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
 
@@ -777,6 +821,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_substringColumn(JNIEnv 
   JNI_NULL_CHECK(env, start_column, "column is null", 0);
   JNI_NULL_CHECK(env, end_column, "column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
     cudf::column_view *sc = reinterpret_cast<cudf::column_view *>(start_column);
@@ -793,6 +838,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_substringLocate(JNIEnv 
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, substring, "target string scalar is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
     cudf::string_scalar* ss_scalar = reinterpret_cast<cudf::string_scalar*>(substring);
@@ -809,6 +855,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringReplace(JNIEnv *e
   JNI_NULL_CHECK(env, target, "target string scalar is null", 0);
   JNI_NULL_CHECK(env, replace, "replace string scalar is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
     cudf::string_scalar* ss_target = reinterpret_cast<cudf::string_scalar*>(target);
@@ -823,15 +870,16 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringReplace(JNIEnv *e
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_normalizeNANsAndZeros(JNIEnv *env,
                                                                                 jclass clazz,
                                                                                 jlong input_column) {
-    using cudf::column_view;
+  using cudf::column_view;
 
-    JNI_NULL_CHECK(env, input_column, "Input column is null", 0);
-    try {
-       return reinterpret_cast<jlong>(
-         cudf::normalize_nans_and_zeros(*reinterpret_cast<column_view*>(input_column)).release()
-       );
-    }
-    CATCH_STD(env, 0);
+  JNI_NULL_CHECK(env, input_column, "Input column is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    return reinterpret_cast<jlong>(
+      cudf::normalize_nans_and_zeros(*reinterpret_cast<column_view*>(input_column)).release()
+    );
+  }
+  CATCH_STD(env, 0);
 }
 
 ////////
@@ -845,39 +893,43 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeCudfColumnView(
     jlong j_offset, jlong j_valid, jint j_null_count, jint size) {
 
   JNI_ARG_CHECK(env, (size != 0), "size is 0", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::type_id n_type = static_cast<cudf::type_id>(j_type);
+    cudf::data_type n_data_type(n_type);
 
-  cudf::type_id n_type = static_cast<cudf::type_id>(j_type);
-  cudf::data_type n_data_type(n_type);
+    std::unique_ptr<cudf::column_view> ret;
+    void * data = reinterpret_cast<void *>(j_data);
+    cudf::bitmask_type * valid = reinterpret_cast<cudf::bitmask_type *>(j_valid);
+    if (valid == nullptr) {
+      j_null_count = 0;
+    }
 
-  std::unique_ptr<cudf::column_view> ret;
-  void * data = reinterpret_cast<void *>(j_data);
-  cudf::bitmask_type * valid = reinterpret_cast<cudf::bitmask_type *>(j_valid);
-  if (valid == nullptr) {
-    j_null_count = 0;
+    if (n_type == cudf::STRING) {
+      JNI_NULL_CHECK(env, j_offset, "offset is null", 0);
+      // This must be kept in sync with how string columns are created
+      // offsets are always the first child
+      // data is the second child
+
+      cudf::size_type * offsets = reinterpret_cast<cudf::size_type *>(j_offset);
+      cudf::column_view offsets_column(cudf::data_type{cudf::INT32}, size + 1, offsets);
+      cudf::column_view data_column(cudf::data_type{cudf::INT8}, j_data_size, data);
+      ret.reset(new cudf::column_view(cudf::data_type{cudf::STRING}, size, nullptr,
+                  valid, j_null_count, 0, {offsets_column, data_column}));
+    } else {
+      ret.reset(new cudf::column_view(n_data_type, size, data, valid, j_null_count));
+    }
+
+    return reinterpret_cast<jlong>(ret.release());
   }
-
-  if (n_type == cudf::STRING) {
-    JNI_NULL_CHECK(env, j_offset, "offset is null", 0);
-    // This must be kept in sync with how string columns are created
-    // offsets are always the first child
-    // data is the second child
-
-    cudf::size_type * offsets = reinterpret_cast<cudf::size_type *>(j_offset);
-    cudf::column_view offsets_column(cudf::data_type{cudf::INT32}, size + 1, offsets);
-    cudf::column_view data_column(cudf::data_type{cudf::INT8}, j_data_size, data);
-    ret.reset(new cudf::column_view(cudf::data_type{cudf::STRING}, size, nullptr,
-                valid, j_null_count, 0, {offsets_column, data_column}));
-  } else {
-    ret.reset(new cudf::column_view(n_data_type, size, data, valid, j_null_count));
-  }
-
-  return reinterpret_cast<jlong>(ret.release());
+  CATCH_STD(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeTypeId(JNIEnv *env, jobject j_object,
                                                                       jlong handle) {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     return column->type().id();
   }
@@ -889,6 +941,7 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeRowCount(JNIEnv
                                                                         jlong handle) {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     return static_cast<jint>(column->size());
   }
@@ -900,6 +953,7 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeNullCount(JNIEn
                                                                              jlong handle) {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     return static_cast<jint>(column->null_count());
   }
@@ -910,6 +964,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_ColumnVector_deleteColumnView(JNIEnv 
                                                                        jobject j_object,
                                                                        jlong handle) {
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *view = reinterpret_cast<cudf::column_view *>(handle);
     delete view;
   }
@@ -920,6 +975,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeDataPoint
                                                                                  jobject j_object,
                                                                                  jlong handle) {
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jlongArray ret(env, 2);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     if (column->type().id() == cudf::STRING) {
@@ -945,6 +1001,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeOffsetsPo
                                                                                     jobject j_object,
                                                                                     jlong handle) {
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jlongArray ret(env, 2);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     if (column->type().id() == cudf::STRING) {
@@ -970,6 +1027,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeValidPoin
                                                                                   jobject j_object,
                                                                                   jlong handle) {
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jlongArray ret(env, 2);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     ret[0] = reinterpret_cast<jlong>(column->null_mask());
@@ -987,6 +1045,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeValidPointerSi
                                                                                  jobject j_object,
                                                                                  jint size) {
   try {
+    cudf::jni::auto_set_device(env);
     return static_cast<jlong>(cudf::bitmask_allocation_size_bytes(size));
   }
   CATCH_STD(env, 0);
@@ -1004,7 +1063,11 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_ColumnVector_deleteCudfColumn(JNIEnv 
                                                                        jobject j_object,
                                                                        jlong handle) {
   JNI_NULL_CHECK(env, handle, "column handle is null", );
-  delete reinterpret_cast<cudf::column *>(handle);
+  try {
+    cudf::jni::auto_set_device(env);
+    delete reinterpret_cast<cudf::column *>(handle);
+  }
+  CATCH_STD(env, )
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_ColumnVector_setNativeNullCountColumn(JNIEnv *env,
@@ -1013,6 +1076,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_ColumnVector_setNativeNullCountColumn
                                                                                jint null_count) {
   JNI_NULL_CHECK(env, handle, "native handle is null", );
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column *column = reinterpret_cast<cudf::column *>(handle);
     column->set_null_count(null_count);
   }
@@ -1023,6 +1087,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeColumnView(JNI
                                                                            jobject j_object,
                                                                            jlong handle) {
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column *column = reinterpret_cast<cudf::column *>(handle);
     std::unique_ptr<cudf::column_view> view(new cudf::column_view());
     *view.get() = column->view();
@@ -1035,6 +1100,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeEmptyCudfColumn(
     JNIEnv *env, jobject j_object, jint j_type) {
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::type_id n_type = static_cast<cudf::type_id>(j_type);
     cudf::data_type n_data_type(n_type);
     std::unique_ptr<cudf::column> column(
@@ -1050,6 +1116,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeNumericCudfColumn(
   JNI_ARG_CHECK(env, (j_size != 0), "size is 0", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::type_id n_type = static_cast<cudf::type_id>(j_type);
     cudf::data_type n_data_type(n_type);
     cudf::size_type n_size = static_cast<cudf::size_type>(j_size);
@@ -1068,6 +1135,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeTimestampCudfColumn
   JNI_NULL_CHECK(env, j_size, "size is null", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::type_id n_type = static_cast<cudf::type_id>(j_type);
     std::unique_ptr<cudf::data_type> n_data_type(new cudf::data_type(n_type));
     cudf::size_type n_size = static_cast<cudf::size_type>(j_size);
@@ -1088,6 +1156,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeStringCudfColumnHos
   JNI_NULL_CHECK(env, j_offset_data, "offset is null", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::size_type *host_offsets = reinterpret_cast<cudf::size_type *>(j_offset_data);
     char *n_char_data = reinterpret_cast<char *>(j_char_data);
     cudf::size_type n_data_size = host_offsets[size];
@@ -1146,6 +1215,7 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeNullCountColumn
                                                                                jlong handle) {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column *column = reinterpret_cast<cudf::column *>(handle);
     return static_cast<jint>(column->null_count());
   }
@@ -1156,35 +1226,38 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_clamper(JNIEnv *env, jo
                                                             jlong j_lo_scalar, jlong j_lo_replace_scalar,
                                                             jlong j_hi_scalar, jlong j_hi_replace_scalar) {
 
-    JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
-    JNI_NULL_CHECK(env, j_lo_scalar, "lo scalar is null", 0)
-    JNI_NULL_CHECK(env, j_lo_replace_scalar, "lo scalar replace value is null", 0)
-    JNI_NULL_CHECK(env, j_hi_scalar, "lo scalar is null", 0)
-    JNI_NULL_CHECK(env, j_hi_replace_scalar, "lo scalar replace value is null", 0)
-    using cudf::experimental::clamp;
-    try {
-      cudf::column_view *column_view = reinterpret_cast<cudf::column_view *>(handle);
-      cudf::scalar *lo_scalar = reinterpret_cast<cudf::scalar *>(j_lo_scalar);
-      cudf::scalar *lo_replace_scalar = reinterpret_cast<cudf::scalar *>(j_lo_replace_scalar);
-      cudf::scalar *hi_scalar = reinterpret_cast<cudf::scalar *>(j_hi_scalar);
-      cudf::scalar *hi_replace_scalar = reinterpret_cast<cudf::scalar *>(j_hi_replace_scalar);
+  JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
+  JNI_NULL_CHECK(env, j_lo_scalar, "lo scalar is null", 0)
+  JNI_NULL_CHECK(env, j_lo_replace_scalar, "lo scalar replace value is null", 0)
+  JNI_NULL_CHECK(env, j_hi_scalar, "lo scalar is null", 0)
+  JNI_NULL_CHECK(env, j_hi_replace_scalar, "lo scalar replace value is null", 0)
+  using cudf::experimental::clamp;
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::column_view *column_view = reinterpret_cast<cudf::column_view *>(handle);
+    cudf::scalar *lo_scalar = reinterpret_cast<cudf::scalar *>(j_lo_scalar);
+    cudf::scalar *lo_replace_scalar = reinterpret_cast<cudf::scalar *>(j_lo_replace_scalar);
+    cudf::scalar *hi_scalar = reinterpret_cast<cudf::scalar *>(j_hi_scalar);
+    cudf::scalar *hi_replace_scalar = reinterpret_cast<cudf::scalar *>(j_hi_replace_scalar);
 
-      std::unique_ptr<cudf::column> result = clamp(*column_view, *lo_scalar, *lo_replace_scalar, *hi_scalar, *hi_replace_scalar);
+    std::unique_ptr<cudf::column> result = clamp(*column_view, *lo_scalar, *lo_replace_scalar, *hi_scalar, *hi_replace_scalar);
 
-     return reinterpret_cast<jlong>(result.release());
-    }
-    CATCH_STD(env, 0);
+   return reinterpret_cast<jlong>(result.release());
+  }
+  CATCH_STD(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_title(JNIEnv *env, jobject j_object, jlong handle) {
 
-    JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
+  JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
 
-    try {
-        cudf::column_view *view = reinterpret_cast<cudf::column_view *>(handle);
-        std::unique_ptr<cudf::column> result = cudf::strings::title(*view);
-        return reinterpret_cast<jlong>(result.release());
-    }
-    CATCH_STD(env, 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::column_view *view = reinterpret_cast<cudf::column_view *>(handle);
+    std::unique_ptr<cudf::column> result = cudf::strings::title(*view);
+    return reinterpret_cast<jlong>(result.release());
+  }
+  CATCH_STD(env, 0);
 }
+
 } // extern "C"

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -16,36 +16,80 @@
 
 #include "jni_utils.hpp"
 
+namespace {
+
+/** The CUDA device that should be used by all threads using cudf */
+int Cudf_device{cudaInvalidDeviceId};
+
+} // anonymous namespace
+
+namespace cudf {
+namespace jni {
+
+/** Set the device to use for cudf */
+void set_cudf_device(int device) {
+  Cudf_device = device;
+}
+
+/**
+ * If a cudf device has been specified then this ensures the calling thread
+ * is using the same device.
+ */
+void auto_set_device(JNIEnv* env) {
+  if (Cudf_device != cudaInvalidDeviceId) {
+    int device;
+    cudaError_t cuda_status = cudaGetDevice(&device);
+    jni_cuda_check(env, cuda_status);
+    if (device != Cudf_device) {
+      cuda_status = cudaSetDevice(Cudf_device);
+      jni_cuda_check(env, cuda_status);
+    }
+  }
+}
+
+} // namespace jni
+} // namespace cudf
+
 extern "C" {
 
 JNIEXPORT jobject JNICALL Java_ai_rapids_cudf_Cuda_memGetInfo(JNIEnv *env, jclass clazz) {
-  size_t free, total;
-  JNI_CUDA_TRY(env, NULL, cudaMemGetInfo(&free, &total));
+  try {
+    cudf::jni::auto_set_device(env);
 
-  jclass info_class = env->FindClass("Lai/rapids/cudf/CudaMemInfo;");
-  if (info_class == NULL) {
-    return NULL;
-  }
+    size_t free, total;
+    JNI_CUDA_TRY(env, NULL, cudaMemGetInfo(&free, &total));
 
-  jmethodID ctor_id = env->GetMethodID(info_class, "<init>", "(JJ)V");
-  if (ctor_id == NULL) {
-    return NULL;
-  }
+    jclass info_class = env->FindClass("Lai/rapids/cudf/CudaMemInfo;");
+    if (info_class == NULL) {
+      return NULL;
+    }
 
-  jobject info_obj = env->NewObject(info_class, ctor_id, (jlong)free, (jlong)total);
-  // No need to check for exceptions of null return value as we are just handing the object back to
-  // the JVM. which will handle throwing any exceptions that happened in the constructor.
-  return info_obj;
+    jmethodID ctor_id = env->GetMethodID(info_class, "<init>", "(JJ)V");
+    if (ctor_id == NULL) {
+      return NULL;
+    }
+
+    jobject info_obj = env->NewObject(info_class, ctor_id, (jlong)free, (jlong)total);
+    // No need to check for exceptions of null return value as we are just handing the object back to
+    // the JVM. which will handle throwing any exceptions that happened in the constructor.
+    return info_obj;
+  } CATCH_STD(env, nullptr);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Cuda_hostAllocPinned(JNIEnv *env, jclass, jlong size) {
-  void * ret = nullptr;
-  JNI_CUDA_TRY(env, 0, cudaMallocHost(&ret, size));
-  return reinterpret_cast<jlong>(ret);
+  try {
+    cudf::jni::auto_set_device(env);
+    void * ret = nullptr;
+    JNI_CUDA_TRY(env, 0, cudaMallocHost(&ret, size));
+    return reinterpret_cast<jlong>(ret);
+  } CATCH_STD(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_freePinned(JNIEnv *env, jclass, jlong ptr) {
-  JNI_CUDA_TRY(env, , cudaFreeHost(reinterpret_cast<void *>(ptr)));
+  try {
+    cudf::jni::auto_set_device(env);
+    JNI_CUDA_TRY(env, , cudaFreeHost(reinterpret_cast<void *>(ptr)));
+  } CATCH_STD(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_memcpy(JNIEnv *env, jclass, jlong jdst, jlong jsrc,
@@ -55,108 +99,170 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_memcpy(JNIEnv *env, jclass, jlon
   }
   JNI_ARG_CHECK(env, jdst != 0, "dst memory pointer is null", );
   JNI_ARG_CHECK(env, jsrc != 0, "src memory pointer is null", );
-  auto dst = reinterpret_cast<void*>(jdst);
-  auto src = reinterpret_cast<void*>(jsrc);
-  auto kind = static_cast<cudaMemcpyKind>(jkind);
-  JNI_CUDA_TRY(env, , cudaMemcpy(dst, src, count, kind));
+  try {
+    cudf::jni::auto_set_device(env);
+    auto dst = reinterpret_cast<void*>(jdst);
+    auto src = reinterpret_cast<void*>(jsrc);
+    auto kind = static_cast<cudaMemcpyKind>(jkind);
+    JNI_CUDA_TRY(env, , cudaMemcpy(dst, src, count, kind));
+  } CATCH_STD(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_memset(JNIEnv *env, jclass, jlong dst, jbyte value,
                                                        jlong count, jint kind) {
   JNI_NULL_CHECK(env, dst, "dst memory pointer is null", );
-  JNI_CUDA_TRY(env, , cudaMemset((void *)dst, value, count));
+  try {
+    cudf::jni::auto_set_device(env);
+    JNI_CUDA_TRY(env, , cudaMemset((void *)dst, value, count));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getDevice(JNIEnv *env, jclass) {
-  jint dev;
-  JNI_CUDA_TRY(env, -2, cudaGetDevice(&dev));
-  return dev;
+  try {
+    cudf::jni::auto_set_device(env);
+    jint dev;
+    JNI_CUDA_TRY(env, -2, cudaGetDevice(&dev));
+    return dev;
+  }
+  CATCH_STD(env, -2);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getDeviceCount(JNIEnv *env, jclass) {
-  jint count;
-  JNI_CUDA_TRY(env, -2, cudaGetDeviceCount(&count));
-  return count;
+  try {
+    cudf::jni::auto_set_device(env);
+    jint count;
+    JNI_CUDA_TRY(env, -2, cudaGetDeviceCount(&count));
+    return count;
+  }
+  CATCH_STD(env, -2);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_setDevice(JNIEnv *env, jclass, jint dev) {
-  JNI_CUDA_TRY(env, , cudaSetDevice(dev));
+  try {
+    if (Cudf_device != cudaInvalidDeviceId && dev != Cudf_device) {
+      cudf::jni::throw_java_exception(env, cudf::jni::CUDF_ERROR_CLASS,
+          "Cannot change device after RMM init");
+    }
+    JNI_CUDA_TRY(env, , cudaSetDevice(dev));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_freeZero(JNIEnv *env, jclass) {
-  JNI_CUDA_TRY(env, , cudaFree(0));
+  try {
+    cudf::jni::auto_set_device(env);
+    JNI_CUDA_TRY(env, , cudaFree(0));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Cuda_createStream(JNIEnv* env, jclass,
     jboolean isNonBlocking) {
-  cudaStream_t stream = nullptr;
-  auto flags = isNonBlocking ? cudaStreamNonBlocking : cudaStreamDefault;
-  JNI_CUDA_TRY(env, 0, cudaStreamCreateWithFlags(&stream, flags));
-  return reinterpret_cast<jlong>(stream);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudaStream_t stream = nullptr;
+    auto flags = isNonBlocking ? cudaStreamNonBlocking : cudaStreamDefault;
+    JNI_CUDA_TRY(env, 0, cudaStreamCreateWithFlags(&stream, flags));
+    return reinterpret_cast<jlong>(stream);
+  }
+  CATCH_STD(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_destroyStream(JNIEnv* env, jclass,
     jlong jstream) {
-  auto stream = reinterpret_cast<cudaStream_t>(jstream);
-  JNI_CUDA_TRY(env, , cudaStreamDestroy(stream));
+  try {
+    cudf::jni::auto_set_device(env);
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    JNI_CUDA_TRY(env, , cudaStreamDestroy(stream));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_streamWaitEvent(JNIEnv* env, jclass,
     jlong jstream, jlong jevent) {
-  auto stream = reinterpret_cast<cudaStream_t>(jstream);
-  auto event = reinterpret_cast<cudaEvent_t>(jevent);
-  JNI_CUDA_TRY(env, , cudaStreamWaitEvent(stream, event, 0));
+  try {
+    cudf::jni::auto_set_device(env);
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    auto event = reinterpret_cast<cudaEvent_t>(jevent);
+    JNI_CUDA_TRY(env, , cudaStreamWaitEvent(stream, event, 0));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_streamSynchronize(JNIEnv* env, jclass,
     jlong jstream) {
-  auto stream = reinterpret_cast<cudaStream_t>(jstream);
-  JNI_CUDA_TRY(env, , cudaStreamSynchronize(stream));
+  try {
+    cudf::jni::auto_set_device(env);
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    JNI_CUDA_TRY(env, , cudaStreamSynchronize(stream));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Cuda_createEvent(JNIEnv* env, jclass,
     jboolean enableTiming, jboolean blockingSync) {
-  cudaEvent_t event = nullptr;
-  unsigned int flags = 0;
-  if (!enableTiming) {
-    flags = flags | cudaEventDisableTiming;
+  try {
+    cudf::jni::auto_set_device(env);
+    cudaEvent_t event = nullptr;
+    unsigned int flags = 0;
+    if (!enableTiming) {
+      flags = flags | cudaEventDisableTiming;
+    }
+    if (blockingSync) {
+      flags = flags | cudaEventBlockingSync;
+    }
+    JNI_CUDA_TRY(env, 0, cudaEventCreateWithFlags(&event, flags));
+    return reinterpret_cast<jlong>(event);
   }
-  if (blockingSync) {
-    flags = flags | cudaEventBlockingSync;
-  }
-  JNI_CUDA_TRY(env, 0, cudaEventCreateWithFlags(&event, flags));
-  return reinterpret_cast<jlong>(event);
+  CATCH_STD(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_destroyEvent(JNIEnv* env, jclass,
     jlong jevent) {
-  auto event = reinterpret_cast<cudaEvent_t>(jevent);
-  JNI_CUDA_TRY(env, , cudaEventDestroy(event));
+  try {
+    cudf::jni::auto_set_device(env);
+    auto event = reinterpret_cast<cudaEvent_t>(jevent);
+    JNI_CUDA_TRY(env, , cudaEventDestroy(event));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Cuda_eventQuery(JNIEnv* env, jclass,
     jlong jevent) {
-  auto event = reinterpret_cast<cudaEvent_t>(jevent);
-  auto result = cudaEventQuery(event);
-  if (result == cudaSuccess) {
-     return true;
-  } else if (result == cudaErrorNotReady) {
-     return false;
-  } // else
-  JNI_CUDA_TRY(env, false, result);
+  try {
+    cudf::jni::auto_set_device(env);
+    auto event = reinterpret_cast<cudaEvent_t>(jevent);
+    auto result = cudaEventQuery(event);
+    if (result == cudaSuccess) {
+       return true;
+    } else if (result == cudaErrorNotReady) {
+       return false;
+    } // else
+    JNI_CUDA_TRY(env, false, result);
+  }
+  CATCH_STD(env, false);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_eventRecord(JNIEnv* env, jclass,
     jlong jevent, jlong jstream) {
-  auto event = reinterpret_cast<cudaEvent_t>(jevent);
-  auto stream = reinterpret_cast<cudaStream_t>(jstream);
-  JNI_CUDA_TRY(env, , cudaEventRecord(event, stream));
+  try {
+    cudf::jni::auto_set_device(env);
+    auto event = reinterpret_cast<cudaEvent_t>(jevent);
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    JNI_CUDA_TRY(env, , cudaEventRecord(event, stream));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_eventSynchronize(JNIEnv* env, jclass,
     jlong jevent) {
-  auto event = reinterpret_cast<cudaEvent_t>(jevent);
-  JNI_CUDA_TRY(env, , cudaEventSynchronize(event));
+  try {
+    cudf::jni::auto_set_device(env);
+    auto event = reinterpret_cast<cudaEvent_t>(jevent);
+    JNI_CUDA_TRY(env, , cudaEventSynchronize(event));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_memcpyOnStream(JNIEnv* env, jclass,
@@ -166,12 +272,16 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_memcpyOnStream(JNIEnv* env, jcla
   }
   JNI_ARG_CHECK(env, jdst != 0, "dst memory pointer is null", );
   JNI_ARG_CHECK(env, jsrc != 0, "src memory pointer is null", );
-  auto dst = reinterpret_cast<void*>(jdst);
-  auto src = reinterpret_cast<void*>(jsrc);
-  auto kind = static_cast<cudaMemcpyKind>(jkind);
-  auto stream = reinterpret_cast<cudaStream_t>(jstream);
-  JNI_CUDA_TRY(env, , cudaMemcpyAsync(dst, src, count, kind, stream));
-  JNI_CUDA_TRY(env, , cudaStreamSynchronize(stream));
+  try {
+    cudf::jni::auto_set_device(env);
+    auto dst = reinterpret_cast<void*>(jdst);
+    auto src = reinterpret_cast<void*>(jsrc);
+    auto kind = static_cast<cudaMemcpyKind>(jkind);
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    JNI_CUDA_TRY(env, , cudaMemcpyAsync(dst, src, count, kind, stream));
+    JNI_CUDA_TRY(env, , cudaStreamSynchronize(stream));
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_asyncMemcpyOnStream(JNIEnv* env, jclass,
@@ -181,11 +291,15 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_asyncMemcpyOnStream(JNIEnv* env,
   }
   JNI_ARG_CHECK(env, jdst != 0, "dst memory pointer is null", );
   JNI_ARG_CHECK(env, jsrc != 0, "src memory pointer is null", );
-  auto dst = reinterpret_cast<void*>(jdst);
-  auto src = reinterpret_cast<void*>(jsrc);
-  auto kind = static_cast<cudaMemcpyKind>(jkind);
-  auto stream = reinterpret_cast<cudaStream_t>(jstream);
-  JNI_CUDA_TRY(env, , cudaMemcpyAsync(dst, src, count, kind, stream));
+  try {
+    cudf::jni::auto_set_device(env);
+    auto dst = reinterpret_cast<void*>(jdst);
+    auto src = reinterpret_cast<void*>(jsrc);
+    auto kind = static_cast<cudaMemcpyKind>(jkind);
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    JNI_CUDA_TRY(env, , cudaMemcpyAsync(dst, src, count, kind, stream));
+  }
+  CATCH_STD(env, );
 }
 
 } // extern "C"

--- a/java/src/main/native/src/ScalarJni.cpp
+++ b/java/src/main/native/src/ScalarJni.cpp
@@ -23,6 +23,7 @@ extern "C" {
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Scalar_closeScalar(JNIEnv* env, jclass, jlong scalar_handle) {
   try {
+    cudf::jni::auto_set_device(env);
     cudf::scalar* s = reinterpret_cast<cudf::scalar*>(scalar_handle);
     delete s;
   }
@@ -31,6 +32,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Scalar_closeScalar(JNIEnv* env, jclas
 
 JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Scalar_isScalarValid(JNIEnv* env, jclass, jlong scalar_handle) {
   try {
+    cudf::jni::auto_set_device(env);
     cudf::scalar* s = reinterpret_cast<cudf::scalar*>(scalar_handle);
     return static_cast<jboolean>(s->is_valid());
   }
@@ -39,6 +41,7 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Scalar_isScalarValid(JNIEnv* env,
 
 JNIEXPORT jbyte JNICALL Java_ai_rapids_cudf_Scalar_getByte(JNIEnv* env, jclass, jlong scalar_handle) {
   try {
+    cudf::jni::auto_set_device(env);
     using ScalarType = cudf::experimental::scalar_type_t<int8_t>;
     auto s = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jbyte>(s->value());
@@ -48,6 +51,7 @@ JNIEXPORT jbyte JNICALL Java_ai_rapids_cudf_Scalar_getByte(JNIEnv* env, jclass, 
 
 JNIEXPORT jshort JNICALL Java_ai_rapids_cudf_Scalar_getShort(JNIEnv* env, jclass, jlong scalar_handle) {
   try {
+    cudf::jni::auto_set_device(env);
     using ScalarType = cudf::experimental::scalar_type_t<int16_t>;
     auto s = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jshort>(s->value());
@@ -57,6 +61,7 @@ JNIEXPORT jshort JNICALL Java_ai_rapids_cudf_Scalar_getShort(JNIEnv* env, jclass
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Scalar_getInt(JNIEnv* env, jclass, jlong scalar_handle) {
   try {
+    cudf::jni::auto_set_device(env);
     using ScalarType = cudf::experimental::scalar_type_t<int32_t>;
     auto s = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jint>(s->value());
@@ -66,6 +71,7 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Scalar_getInt(JNIEnv* env, jclass, jl
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_getLong(JNIEnv* env, jclass, jlong scalar_handle) {
   try {
+    cudf::jni::auto_set_device(env);
     using ScalarType = cudf::experimental::scalar_type_t<int64_t>;
     auto s = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jlong>(s->value());
@@ -75,6 +81,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_getLong(JNIEnv* env, jclass, 
 
 JNIEXPORT jfloat JNICALL Java_ai_rapids_cudf_Scalar_getFloat(JNIEnv* env, jclass, jlong scalar_handle) {
   try {
+    cudf::jni::auto_set_device(env);
     using ScalarType = cudf::experimental::scalar_type_t<float>;
     auto s = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jfloat>(s->value());
@@ -84,6 +91,7 @@ JNIEXPORT jfloat JNICALL Java_ai_rapids_cudf_Scalar_getFloat(JNIEnv* env, jclass
 
 JNIEXPORT jdouble JNICALL Java_ai_rapids_cudf_Scalar_getDouble(JNIEnv* env, jclass, jlong scalar_handle) {
   try {
+    cudf::jni::auto_set_device(env);
     using ScalarType = cudf::experimental::scalar_type_t<double>;
     auto s = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jdouble>(s->value());
@@ -93,6 +101,7 @@ JNIEXPORT jdouble JNICALL Java_ai_rapids_cudf_Scalar_getDouble(JNIEnv* env, jcla
 
 JNIEXPORT jbyteArray JNICALL Java_ai_rapids_cudf_Scalar_getUTF8(JNIEnv* env, jclass, jlong scalar_handle) {
   try {
+    cudf::jni::auto_set_device(env);
     auto s = reinterpret_cast<cudf::string_scalar*>(scalar_handle);
     std::string val{s->to_string()};
     if (val.size() > 0x7FFFFFFF) {
@@ -107,6 +116,7 @@ JNIEXPORT jbyteArray JNICALL Java_ai_rapids_cudf_Scalar_getUTF8(JNIEnv* env, jcl
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeBool8Scalar(JNIEnv* env, jclass,
     jboolean value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s = cudf::make_numeric_scalar(cudf::data_type(cudf::BOOL8));
     s->set_valid(is_valid);
     if (is_valid) {
@@ -122,6 +132,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeBool8Scalar(JNIEnv* env, 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt8Scalar(JNIEnv* env, jclass,
     jbyte value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s = cudf::make_numeric_scalar(cudf::data_type(cudf::INT8));
     s->set_valid(is_valid);
     if (is_valid) {
@@ -136,6 +147,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt8Scalar(JNIEnv* env, j
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt16Scalar(JNIEnv* env, jclass,
     jshort value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s = cudf::make_numeric_scalar(cudf::data_type(cudf::INT16));
     s->set_valid(is_valid);
     if (is_valid) {
@@ -150,6 +162,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt16Scalar(JNIEnv* env, 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt32Scalar(JNIEnv* env, jclass,
     jint value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s = cudf::make_numeric_scalar(cudf::data_type(cudf::INT32));
     s->set_valid(is_valid);
     if (is_valid) {
@@ -164,6 +177,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt32Scalar(JNIEnv* env, 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt64Scalar(JNIEnv* env, jclass,
     jlong value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s = cudf::make_numeric_scalar(cudf::data_type(cudf::INT64));
     s->set_valid(is_valid);
     if (is_valid) {
@@ -178,6 +192,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt64Scalar(JNIEnv* env, 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat32Scalar(JNIEnv* env, jclass,
     jfloat value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s = cudf::make_numeric_scalar(cudf::data_type(cudf::FLOAT32));
     s->set_valid(is_valid);
     if (is_valid) {
@@ -192,6 +207,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat32Scalar(JNIEnv* env
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat64Scalar(JNIEnv* env, jclass,
     jdouble value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s = cudf::make_numeric_scalar(cudf::data_type(cudf::FLOAT64));
     s->set_valid(is_valid);
     if (is_valid) {
@@ -206,6 +222,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat64Scalar(JNIEnv* env
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeStringScalar(JNIEnv* env, jclass,
     jbyteArray value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     std::string strval;
     if (is_valid) {
       cudf::jni::native_jbyteArray jbytes{env, value};
@@ -221,6 +238,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeStringScalar(JNIEnv* env,
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeTimestampDaysScalar(JNIEnv* env, jclass,
     jint value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s = cudf::make_timestamp_scalar(cudf::data_type(cudf::TIMESTAMP_DAYS));
     s->set_valid(is_valid);
     if (is_valid) {
@@ -235,6 +253,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeTimestampDaysScalar(JNIEn
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeTimestampTimeScalar(JNIEnv* env, jclass,
     jint jdtype_id, jlong value, jboolean is_valid) {
   try {
+    cudf::jni::auto_set_device(env);
     auto dtype_id = static_cast<cudf::type_id>(jdtype_id);
     std::unique_ptr<cudf::scalar> s = cudf::make_timestamp_scalar(cudf::data_type(dtype_id));
     s->set_valid(is_valid);
@@ -253,6 +272,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_binaryOpSV(JNIEnv *env, jclas
   JNI_NULL_CHECK(env, lhs_ptr, "lhs is null", 0);
   JNI_NULL_CHECK(env, rhs_view, "rhs is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::scalar *lhs = reinterpret_cast<cudf::scalar *>(lhs_ptr);
     auto rhs = reinterpret_cast<cudf::column_view *>(rhs_view);
 

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -291,7 +291,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_createCudfTableView(JNIEnv *en
   JNI_NULL_CHECK(env, j_cudf_columns, "columns are null", 0);
 
   try {
-      cudf::jni::native_jpointerArray<cudf::column_view> n_cudf_columns(env, j_cudf_columns);
+    cudf::jni::auto_set_device(env);
+    cudf::jni::native_jpointerArray<cudf::column_view> n_cudf_columns(env, j_cudf_columns);
 
     std::vector<cudf::column_view> column_views(n_cudf_columns.size());
     for (int i = 0 ; i < n_cudf_columns.size() ; i++) {
@@ -306,7 +307,11 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_createCudfTableView(JNIEnv *en
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_deleteCudfTable(JNIEnv *env, jclass class_object,
                                                                jlong j_cudf_table_view) {
   JNI_NULL_CHECK(env, j_cudf_table_view, "table view handle is null", );
-  delete reinterpret_cast<cudf::table_view*>(j_cudf_table_view);
+  try {
+    cudf::jni::auto_set_device(env);
+    delete reinterpret_cast<cudf::table_view*>(j_cudf_table_view);
+  }
+  CATCH_STD(env, );
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(
@@ -320,6 +325,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(
   JNI_NULL_CHECK(env, j_are_nulls_smallest, "null order array is null", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<cudf::column_view> n_sort_keys_columns(env, j_sort_keys_columns);
     jsize num_columns = n_sort_keys_columns.size();
     const cudf::jni::native_jbooleanArray n_is_descending(env, j_is_descending);
@@ -384,6 +390,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
   }
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jstringArray n_col_names(env, col_names);
     cudf::jni::native_jstringArray n_data_types(env, data_types);
 
@@ -458,6 +465,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readParquet(
   }
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
       JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "inputfilepath can't be empty",
@@ -503,6 +511,7 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeParquetBufferBegin(JNIEnv*
   JNI_NULL_CHECK(env, j_metadata_values, "null metadata values", 0);
   JNI_NULL_CHECK(env, consumer, "null consumer", 0);
   try {
+    cudf::jni::auto_set_device(env);
     using namespace cudf::experimental::io;
     cudf::jni::native_jstringArray col_names(env, j_col_names);
     cudf::jni::native_jbooleanArray col_nullability(env, j_col_nullability);
@@ -547,6 +556,7 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeParquetFileBegin(JNIEnv* e
   JNI_NULL_CHECK(env, j_metadata_values, "null metadata values", 0);
   JNI_NULL_CHECK(env, j_output_path, "null output path", 0);
   try {
+    cudf::jni::auto_set_device(env);
     using namespace cudf::experimental::io;
     cudf::jni::native_jstringArray col_names(env, j_col_names);
     cudf::jni::native_jbooleanArray col_nullability(env, j_col_nullability);
@@ -590,6 +600,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeParquetChunk(JNIEnv* env, 
     state->sink->set_alloc_size(alloc_size);
   }
   try {
+    cudf::jni::auto_set_device(env);
     write_parquet_chunked(*tview, state->state);
   } CATCH_STD(env, )
 }
@@ -603,6 +614,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeParquetEnd(JNIEnv* env, jc
       reinterpret_cast<cudf::jni::native_parquet_writer_handle *>(j_state);
   std::unique_ptr<cudf::jni::native_parquet_writer_handle> make_sure_we_delete(state);
   try {
+    cudf::jni::auto_set_device(env);
     write_parquet_chunked_end(state->state);
   } CATCH_STD(env, )
 }
@@ -623,6 +635,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readORC(
   }
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
       JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "inputfilepath can't be empty",
@@ -666,6 +679,7 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeORCBufferBegin(JNIEnv* env
   JNI_NULL_CHECK(env, j_metadata_values, "null metadata values", 0);
   JNI_NULL_CHECK(env, consumer, "null consumer", 0);
   try {
+    cudf::jni::auto_set_device(env);
     using namespace cudf::experimental::io;
     cudf::jni::native_jstringArray col_names(env, j_col_names);
     cudf::jni::native_jbooleanArray col_nullability(env, j_col_nullability);
@@ -708,6 +722,7 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeORCFileBegin(JNIEnv* env, 
   JNI_NULL_CHECK(env, j_metadata_values, "null metadata values", 0);
   JNI_NULL_CHECK(env, j_output_path, "null output path", 0);
   try {
+    cudf::jni::auto_set_device(env);
     using namespace cudf::experimental::io;
     cudf::jni::native_jstringArray col_names(env, j_col_names);
     cudf::jni::native_jbooleanArray col_nullability(env, j_col_nullability);
@@ -750,6 +765,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeORCChunk(JNIEnv* env, jcla
     state->sink->set_alloc_size(alloc_size);
   }
   try {
+    cudf::jni::auto_set_device(env);
     write_orc_chunked(*tview, state->state);
   } CATCH_STD(env, )
 }
@@ -763,6 +779,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeORCEnd(JNIEnv* env, jclass
       reinterpret_cast<cudf::jni::native_orc_writer_handle *>(j_state);
   std::unique_ptr<cudf::jni::native_orc_writer_handle> make_sure_we_delete(state);
   try {
+    cudf::jni::auto_set_device(env);
     write_orc_chunked_end(state->state);
   } CATCH_STD(env, )
 }
@@ -776,6 +793,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftJoin(
   JNI_NULL_CHECK(env, right_col_join_indices, "right_col_join_indices is null", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::table_view *n_left_table = reinterpret_cast<cudf::table_view *>(left_table);
     cudf::table_view *n_right_table = reinterpret_cast<cudf::table_view *>(right_table);
     cudf::jni::native_jintArray left_join_cols_arr(env, left_col_join_indices);
@@ -809,6 +827,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerJoin(
   JNI_NULL_CHECK(env, right_col_join_indices, "right_col_join_indices is null", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::table_view *n_left_table = reinterpret_cast<cudf::table_view *>(left_table);
     cudf::table_view *n_right_table = reinterpret_cast<cudf::table_view *>(right_table);
     cudf::jni::native_jintArray left_join_cols_arr(env, left_col_join_indices);
@@ -842,6 +861,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftSemiJoin(JNIEnv *env,
   JNI_NULL_CHECK(env, right_col_join_indices, "right_col_join_indices is null", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::table_view *n_left_table = reinterpret_cast<cudf::table_view *>(left_table);
     cudf::table_view *n_right_table = reinterpret_cast<cudf::table_view *>(right_table);
     cudf::jni::native_jintArray left_join_cols_arr(env, left_col_join_indices);
@@ -872,6 +892,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftAntiJoin(JNIEnv *env,
   JNI_NULL_CHECK(env, right_col_join_indices, "right_col_join_indices is null", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::table_view *n_left_table = reinterpret_cast<cudf::table_view *>(left_table);
     cudf::table_view *n_right_table = reinterpret_cast<cudf::table_view *>(right_table);
     cudf::jni::native_jintArray left_join_cols_arr(env, left_col_join_indices);
@@ -898,6 +919,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_interleaveColumns(JNIEnv *env,
 
   JNI_NULL_CHECK(env, j_cudf_table_view, "table is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::table_view *table_view = reinterpret_cast<cudf::table_view *>(j_cudf_table_view);
     std::unique_ptr<cudf::column> result = cudf::experimental::interleave_columns(*table_view);
     return reinterpret_cast<jlong>(result.release());
@@ -909,6 +931,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_concatenate(JNIEnv *env, 
                                                                    jlongArray table_handles) {
   JNI_NULL_CHECK(env, table_handles, "input tables are null", NULL);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<cudf::table_view> tables(env, table_handles);
 
     long unsigned int num_tables = tables.size();
@@ -936,6 +959,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_hashPartition(
   JNI_ARG_CHECK(env, number_of_partitions > 0, "number_of_partitions is zero", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::table_view *n_input_table = reinterpret_cast<cudf::table_view *>(input_table);
     cudf::jni::native_jintArray n_columns_to_hash(env, columns_to_hash);
     int n_number_of_partitions = static_cast<int>(number_of_partitions);
@@ -970,6 +994,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_roundRobinPartition(
   JNI_ARG_CHECK(env, start_partition >= 0, "start_partition is negative", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
     auto n_input_table = reinterpret_cast<cudf::table_view *>(input_table);
     int n_num_partitions = static_cast<int>(num_partitions);
     cudf::jni::native_jintArray n_output_offsets(env, output_offsets);
@@ -994,6 +1019,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_groupByAggregate(
   JNI_NULL_CHECK(env, agg_types, "agg_types are null", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::table_view *n_input_table = reinterpret_cast<cudf::table_view *>(input_table);
     cudf::jni::native_jintArray n_keys(env, keys);
     cudf::jni::native_jintArray n_values(env, aggregate_column_indices);
@@ -1047,6 +1073,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_filter(JNIEnv *env, jclas
   JNI_NULL_CHECK(env, input_jtable, "input table is null", 0);
   JNI_NULL_CHECK(env, mask_jcol, "mask column is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::table_view *input = reinterpret_cast<cudf::table_view *>(input_jtable);
     cudf::column_view *mask = reinterpret_cast<cudf::column_view *>(mask_jcol);
     std::unique_ptr<cudf::experimental::table> result = cudf::experimental::apply_boolean_mask(*input, *mask);
@@ -1063,6 +1090,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_bound(JNIEnv *env, jclass,
   using cudf::table_view;
   using cudf::column;
   try {
+    cudf::jni::auto_set_device(env);
     table_view *input = reinterpret_cast<table_view *>(input_jtable);
     table_view *values = reinterpret_cast<table_view *>(values_jtable);
     cudf::jni::native_jbooleanArray const n_desc_flags(env, desc_flags);
@@ -1096,6 +1124,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplit(JNIEnv 
   JNI_NULL_CHECK(env, split_indices, "split indices are null", 0);
 
   try {
+    cudf::jni::auto_set_device(env);
     cudf::table_view *n_table = reinterpret_cast<cudf::table_view *>(input_table);
     cudf::jni::native_jintArray n_split_indices(env, split_indices);
 
@@ -1129,6 +1158,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_rollingWindowAggregate(
   JNI_NULL_CHECK(env, j_agg_types, "agg_types are null", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
 
     using cudf::jni::valid_window_parameters;
 
@@ -1195,6 +1225,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_timeRangeRollingWindowAgg
   JNI_NULL_CHECK(env, j_agg_types, "agg_types are null", NULL);
 
   try {
+    cudf::jni::auto_set_device(env);
 
     using cudf::jni::valid_window_parameters;
 

--- a/java/src/test/java/ai/rapids/cudf/RmmMemoryAccessorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/RmmMemoryAccessorTest.java
@@ -41,7 +41,7 @@ class RmmMemoryAccessorTest extends CudfTestBase {
     }
     File f = File.createTempFile("ALL_LOG",".csv");
     f.deleteOnExit();
-    Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, Rmm.logTo(f), 1024*1024*1024, -1);
+    Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, Rmm.logTo(f), 1024*1024*1024);
     try (DeviceMemoryBuffer address = Rmm.alloc(10, Cuda.DEFAULT_STREAM)) {
       assertNotEquals(0, address);
     }


### PR DESCRIPTION
The CUDA runtime will automatically search for a GPU to use if a thread has not specifically requested a device, and Java processes tend to run with many threads.  If one of the Java threads using cudf does not use the same device being used by other cudf threads then this will lead to an invalid state that can trigger application crashes.

To avoid these crashes, this changes the Java cudf bindings tol remember which CUDA device was used to initialize the Rapids Memory Manager (RMM) via cudf.  Java cudf methods will automatically update the thread's CUDA device to match the RMM device if necessary.