### PR TITLE
[REVIEW] Add Java bindings for strip [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #4789 Disallow timestamp sum and diffs via binary ops
 - PR #4815 Add JNI total memory allocated API
 - PR #4906 Add Java bindings for interleave_columns
+- PR #4938 Add Java bindings for strip
 
 ## Improvements
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -1909,6 +1909,17 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
   }
 
   /**
+   * Removes whitespace from the beginning and end of a string.
+   * @return A new java column vector containing the stripped strings.
+   */
+  public ColumnVector strip() {
+    assert type == DType.STRING : "column type must be a String";
+    try (DevicePrediction prediction = new DevicePrediction(predictSizeFor(DType.INT32), "strip")) {
+      return new ColumnVector(stringStrip(getNativeView()));
+    }
+  }
+
+  /**
    * Checks if each string in a column contains a specified comparison string, resulting in a
    * parallel column of the boolean results.
    * @param compString scalar containing the string being searched for.
@@ -2217,6 +2228,12 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * @return native handle of the resulting cudf column containing the boolean results.
    */
   private static native long stringEndWith(long cudfViewHandle, long compString) throws CudfException;
+
+  /**
+   * Native method to strip whitespace from the start and end of a string.
+   * @param columnView native handle of the cudf::column_view being operated on.
+   */
+  private static native long stringStrip(long columnView) throws CudfException;
 
   /**
    * Native method for checking if strings match the passed in regex pattern from the

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -34,6 +34,7 @@
 #include <cudf/strings/contains.hpp>
 #include <cudf/strings/find.hpp>
 #include <cudf/strings/replace.hpp>
+#include <cudf/strings/strip.hpp>
 #include <cudf/strings/substring.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/unary.hpp>
@@ -862,6 +863,19 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringReplace(JNIEnv *e
     cudf::string_scalar* ss_replace = reinterpret_cast<cudf::string_scalar*>(replace);
 
     std::unique_ptr<cudf::column> result = cudf::strings::replace(scv, *ss_target, *ss_replace);
+    return reinterpret_cast<jlong>(result.release());
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringStrip(JNIEnv *env, jclass, jlong column_view) {
+  JNI_NULL_CHECK(env, column_view, "column is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
+    cudf::strings_column_view scv(*cv);
+
+    std::unique_ptr<cudf::column> result = cudf::strings::strip(scv);
     return reinterpret_cast<jlong>(result.release());
   }
   CATCH_STD(env, 0);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -996,6 +996,15 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testTrimStrings() {
+    try (ColumnVector cv = ColumnVector.fromStrings(" 123", "123 ", null, " 123 ", "\t\t123\n\n");
+         ColumnVector trimmed = cv.strip();
+         ColumnVector expected = ColumnVector.fromStrings("123", "123", null, "123", "123")) {
+      TableTest.assertColumnsAreEqual(expected, trimmed);
+    }
+  }
+
+  @Test
   void testAppendStrings() {
     try (HostColumnVector cv = HostColumnVector.build(10, 0, (b) -> {
       b.append("123456789");


### PR DESCRIPTION
Adds Java binding for `strip` method to remove leading and trailing whitespace.

I was unsure about the correct code for predicting device size and based it on the implementation for `stringReplace` since that seemed roughly equivalent.