### PR TITLE
Use `cudaDeviceAttr` in `getDeviceAttribute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 - PR #4927 Use stack for memory in `deviceGetName`
 - P# #4933 Enable nop annotate
 - PR #4929 Java methods ensure calling thread's CUDA device matches RMM device
+- PR #4963 Use `cudaDeviceAttr` in `getDeviceAttribute`
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -312,13 +312,13 @@ def getDeviceCount():
     return count
 
 
-def getDeviceAttribute(object attr, int device):
+def getDeviceAttribute(cudaDeviceAttr attr, int device):
     """
     Returns information about the device.
 
     Parameters
     ----------
-        attr : object (CudaDeviceAttr)
+        attr : cudaDeviceAttr
             Device attribute to query
         device : int
             Device number to query


### PR DESCRIPTION
Should limit Python to C++ object conversion to the function declaration and allow use of `attr` in C++ contexts within the function.