### PR TITLE
[REVIEW] Move nvstrings standalone docs pages to libcudf doxygen pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 - PR #4985 Add null_count to Python Column ctors and use already computed null_count when possible
 - PR #5002 Fix Column.__reduce__ to accept `null_count`
 - PR #5006 Add Java bindings for strip, lstrip and rstrip
+- PR #5027 Move nvstrings standalone docs pages to libcudf doxygen pages
 
 ## Bug Fixes
 

--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "libcudf"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.13
+PROJECT_NUMBER         = 0.14
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -771,7 +771,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../src ../include
+INPUT                  = main_page.md regex.md unicode.md ../src ../include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -827,7 +827,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */nvtx/* */nvstrings/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -898,7 +898,7 @@ INPUT_FILTER           =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-FILTER_PATTERNS        =
+FILTER_PATTERNS        = 
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for
@@ -920,7 +920,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = main_page.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/cpp/doxygen/main_page.md
+++ b/cpp/doxygen/main_page.md
@@ -1,0 +1,5 @@
+# libcudf 
+
+libcudf is a C++ GPU DataFrame library for loading, joining, aggregating, filtering, and otherwise 
+manipulating data. A GPU DataFrame is a column-oriented tabular data structure, so libcudf provides
+two core data structures: cudf::column, and cudf::table.

--- a/cpp/doxygen/regex.md
+++ b/cpp/doxygen/regex.md
@@ -1,7 +1,18 @@
 # Regex Features
 
-This page specifies which regex features are currently supported by libcudf strings column APIs that accept regex patterns.
+This page specifies which regex features are currently supported by libcudf strings column APIs that accept regex patterns:
+
+- cudf::strings::contains_re()
+- cudf::strings::matches_re()
+- cudf::strings::count_re()
+- cudf::strings::extract()
+- cudf::strings::findall_re()
+- cudf::strings::replace_re()
+- cudf::strings::replace_with_backrefs()
+
 The details are based on features documented at https://www.regular-expressions.info/reference.html
+
+**Note:** The alternation character is the pipe character `|` and not the character included in the tables on this page. There is an issue including the pipe character inside the table markdown that is rendered by doxygen.
 
 ## Features Supported
 
@@ -9,9 +20,9 @@ The details are based on features documented at https://www.regular-expressions.
 
 | Feature  | Syntax | Description | Example |
 | ---------- | ------------- | ------------- | ------------- |
-| Literal character | Any character except `[\^$.&#124;?*+()` | All characters except the listed special characters match a single instance of themselves | `a` matches `a` |
+| Literal character | Any character except `[\^$.⎮?*+()` | All characters except the listed special characters match a single instance of themselves | `a` matches `a` |
 | Literal curly braces | `{` and `}` | `{` and `}` are literal characters, unless they are part of a valid regular expression token such as a quantifier `{3}` | `{` matches `{` |
-| Backslash escapes a metacharacter | `\` followed by any of `[\^$.&#124;?*+(){}` | A backslash escapes special characters to suppress their special meaning | `\*` matches `*` |
+| Backslash escapes a metacharacter | `\` followed by any of `[\^$.⎮?*+(){}` | A backslash escapes special characters to suppress their special meaning | `\*` matches `*` |
 | Hexadecimal escape | `\xFF` where `FF` are 2 hexadecimal digits | Matches the character at the specified position in the code page | `\xA9` matches `©` |
 | Character escape | `\n`, `\r` and `\t` | Match an line-feed (LF) character, carriage return (CR) character and a tab character respectively | `\r\n` matches a Windows CRLF line break |
 | Character escape | `\a` | Match the "alert" or "bell" control character (ASCII 0x07) | |
@@ -26,7 +37,6 @@ The details are based on features documented at https://www.regular-expressions.
 | Dot | . (dot) | Matches any single character except line break characters. Optionally match line break characters. | . matches x or (almost) any other character |
 | Alternation | `⎮` (pipe) | Causes the regex engine to match either the part on the left side, or the part on the right side. Can be strung together into a series of alternations. | `abc⎮def⎮xyz` matches `abc`, `def` or `xyz` |
 
-**Note** the alternation character is the pipe character `|` and not the character included in the tables on this page. There is an issue including the pipe character inside tables markdown that is rendered by doxygen.
 
 ### Character Classes
 
@@ -34,32 +44,32 @@ The details are based on features documented at https://www.regular-expressions.
 | ---------- | ------------- | ------------- | ------------- |
 | Character class | `[` | `[` begins a character class. | |
 | Literal character | Any character except `\^-]` | All characters except the listed special characters are literal characters that add themselves to the character class. | `[abc]` matches `a`, `b` or `c` |
-| Backslash escapes a metacharacter	| `\` (backslash) followed by any of `\^-]` | A backslash escapes special characters to suppress their special meaning. | `[\^\\]]` matches `^` or `]` |
+| Backslash escapes a metacharacter	| `\` (backslash) followed by any of `\^-]` | A backslash escapes special characters to suppress their special meaning. | `[\^\]]` matches `^` or `]` |
 | Range | `-` (hyphen) between two tokens that each specify a single character. | Adds a range of characters to the character class. | `[a-zA-Z0-9]` matches any ASCII letter or digit |
-| Negated character class | `^` (caret) immediately after the opening [ | Negates the character class, causing it to match a single character not listed in the character class. | `[\^a-d]` matches `x` (any character except `a`, `b`, `c` or `d`) |
+| Negated character class | `^` (caret) immediately after the opening `[` | Negates the character class, causing it to match a single character not listed in the character class. | `[^a-d]` matches `x` (any character except `a`, `b`, `c` or `d`) |
 | Literal opening bracket | `[` | An opening square bracket is a literal character that adds an opening square bracket to the character class. | `[ab[cd]ef]` matches `aef]`, `bef]`, `[ef]`, `cef]`, and `def]` |
-| Character escape | `\n`, `\r` and `\t` | Add an LF character, a CR character, or a tab character to the character class, respectively. | `[\n\r\t]` a line feed, a carriage return, or a tab. |
-| Character escape | `\a` | Add the "alert" or "bell" control character (ASCII 0x07) to the character class. | `[\a\t]` matches a bell or a tab character. |
-| Character escape | `\b` | Add the "backspace" control character (ASCII 0x08) to the character class. | `[\b\t]` matches a backspace or a tab character. |
-| Character escape | `\f` | Add the form-feed control character (ASCII 0x0C) to the character class. | `[\f\t]` matches a form-feed or a tab character. |
+| Character escape | `\n`, `\r` and `\t` | Add an LF character, a CR character, or a tab character to the character class, respectively. | `[\n\r\t]` matches a line feed, a carriage return, or a tab character |
+| Character escape | `\a` | Add the "alert" or "bell" control character (ASCII 0x07) to the character class. | `[\a\t]` matches a bell or a tab character |
+| Character escape | `\b` | Add the backspace control character (ASCII 0x08) to the character class. | `[\b\t]` matches a backspace or a tab character |
+| Character escape | `\f` | Add the form-feed control character (ASCII 0x0C) to the character class. | `[\f\t]` matches a form-feed or a tab character |
 
 ### Shorthand Character Classes
 
 | Feature  | Syntax | Description | Example |
 | ---------- | ------------- | ------------- | ------------- |
-| Shorthand | `\d` | Adds all digits to the character class. Matches a single digit if used outside character classes. | `\d` match a character that is a digit |
-| Shorthand | `\w` | Adds all word characters to the character class. Matches a single word character if used outside character classes. | `\w` match any single word character |
-| Shorthand | `\s` | Adds all whitespace to the character class. Matches a single whitespace character if used outside character classes. | `\s` match any single whitespace character |
+| Shorthand | `\d` | Adds all digits to the character class. Matches a single digit if used outside character classes. | `\d` matches a character that is a digit |
+| Shorthand | `\w` | Adds all word characters to the character class. Matches a single word character if used outside character classes. | `\w` matches any single word character |
+| Shorthand | `\s` | Adds all whitespace to the character class. Matches a single whitespace character if used outside character classes. | `\s` matches any single whitespace character |
 | Shorthand | `\D` | Adds all non-digits to the character class. Matches a single character that is not a digit character if used outside character classes. | `[\D]` matches a single character that is not a digit character |
 | Shorthand | `\W` | Adds all non-word characters to the character class. Matches a single character that is not a word character if used outside character classes. | [`\W`] matches a single character that is not a word character |
-| Shorthand | `\s` | Adds all non-whitespace to the character class. Matches a single character that is not a whitespace character if used outside character classes. | `[\S]` match a single character that is not a whitespace character |
+| Shorthand | `\s` | Adds all non-whitespace to the character class. Matches a single character that is not a whitespace character if used outside character classes. | `[\S]` matches a single character that is not a whitespace character |
 
 ### Anchors
 
 | Feature  | Syntax | Description | Example |
 | ---------- | ------------- | ------------- | ------------- |
-| String anchor | `^` (caret) | Matches at the start of the string | `^.` matches `a` in `abc\ndef` |
-| String anchor | `$` (dollar) | Matches at the end of the string | `.$` matches `f` in `abc\ndef` |
+| String anchor | `^` (caret) | Matches at the start of the string | `^.` matches `a` in `abcdef` |
+| String anchor | `$` (dollar) | Matches at the end of the string | `.$` matches `f` in `abcdef` |
 | Line anchor | `^` (caret) | Matches after each line break in addition to matching at the start of the string, thus matching at the start of each line in the string. | `^.` matches `a` and `d` in `abc\ndef` |
 | Line anchor | `$` (dollar) | Matches before each line break in addition to matching at the end of the string, thus matching at the end of each line in the string. | `.$` matches `c` and `f` in `abc\ndef`　|
 | String anchor | `\A` | Matches at the start of the string | `\A\w` matches only `a` in `abc` |
@@ -82,8 +92,8 @@ The details are based on features documented at https://www.regular-expressions.
 | Lazy quantifier | `??` | Makes the preceding item optional. Lazy, so the optional item is excluded in the match if possible. | `abc??` matches `ab` or `abc` |
 | Lazy quantifier | `*?` | Repeats the previous item zero or more times. Lazy, so the engine first attempts to skip the previous item, before trying permutations with ever increasing matches of the preceding item. | `".*?"` matches `"def"` and `"ghi"` in `abc "def" "ghi" jkl` |
 | Lazy quantifier | `+?` | Repeats the previous item once or more. Lazy, so the engine first matches the previous item only once, before trying permutations with ever increasing matches of the preceding item. | `".+?"` matches `"def"` and `"ghi"` in `abc "def" "ghi" jkl` |
-| Fixed quantifier | `{n}` where `n is an integer >= 1` | Repeats the previous item exactly `n` times. | Repeats the previous item exactly `n` times. |
-| Greedy quantifier | `{n,m}` where `n >= 0` and `m >= n` | Repeats the previous item between `n` and `m` times. Greedy, so repeating m times is tried before reducing the repetition to `n` times. | `a{2,4}` matches `aaaa`, `aaa` or `aa` |
+| Fixed quantifier | `{n}` where `n is an integer >= 1` | Repeats the previous item exactly `n` times. | `a{5}` matches `aaaaa` |
+| Greedy quantifier | `{n,m}` where `n >= 0` and `m >= n` | Repeats the previous item between `n` and `m` times. Greedy, so repeating `m` times is tried before reducing the repetition to `n` times. | `a{2,4}` matches `aaaa`, `aaa` or `aa` |
 | Greedy quantifier | `{n,}` where `n >= 0` | Repeats the previous item at least `n` times. Greedy, so as many items as possible will be matched before trying permutations with less matches of the preceding item, up to the point where the preceding item is matched only `n` times. | `a{2,}` matches `aaaaa` in `aaaaa` |
 | Lazy quantifier | `{n,m}?` where `n >= 0` and `m >= n` | Repeats the previous item between `n` and `m` times. Lazy, so repeating `n` times is tried before increasing the repetition to `m` times. | `a{2,4}?` matches `aa`, `aaa` or `aaaa` |
 | Lazy quantifier | `{n,}?` where `n >= 0` | Repeats the previous item `n` or more times. Lazy, so the engine first matches the previous item `n` times, before trying permutations with ever increasing matches of the preceding item. | `a{2,}?` matches `aa` in `aaaaa` |

--- a/cpp/doxygen/regex.md
+++ b/cpp/doxygen/regex.md
@@ -1,0 +1,96 @@
+# Regex Features
+
+This page specifies which regex features are currently supported by libcudf strings column APIs that accept regex patterns.
+The details are based on features documented at https://www.regular-expressions.info/reference.html
+
+## Features Supported
+
+### Characters
+
+| Feature  | Syntax | Description | Example |
+| ---------- | ------------- | ------------- | ------------- |
+| Literal character | Any character except `[\^$.&#124;?*+()` | All characters except the listed special characters match a single instance of themselves | `a` matches `a` |
+| Literal curly braces | `{` and `}` | `{` and `}` are literal characters, unless they are part of a valid regular expression token such as a quantifier `{3}` | `{` matches `{` |
+| Backslash escapes a metacharacter | `\` followed by any of `[\^$.&#124;?*+(){}` | A backslash escapes special characters to suppress their special meaning | `\*` matches `*` |
+| Hexadecimal escape | `\xFF` where `FF` are 2 hexadecimal digits | Matches the character at the specified position in the code page | `\xA9` matches `©` |
+| Character escape | `\n`, `\r` and `\t` | Match an line-feed (LF) character, carriage return (CR) character and a tab character respectively | `\r\n` matches a Windows CRLF line break |
+| Character escape | `\a` | Match the "alert" or "bell" control character (ASCII 0x07) | |
+| Character escape | `\f` | Match the form-feed control character (ASCII 0x0C) | |
+| NULL escape      | `\0` | Match the NULL character ||
+| Octal escape     | `\100` through `\177` <br/> `\200` through `\377` <br/> `\01` through `\07` <br/> `\010` through `\077` | Matches the character at the specified position in the ASCII table | `\100` matches `@` |
+
+### Basic Features
+
+| Feature  | Syntax | Description | Example |
+| ---------- | ------------- | ------------- | ------------- |
+| Dot | . (dot) | Matches any single character except line break characters. Optionally match line break characters. | . matches x or (almost) any other character |
+| Alternation | `⎮` (pipe) | Causes the regex engine to match either the part on the left side, or the part on the right side. Can be strung together into a series of alternations. | `abc⎮def⎮xyz` matches `abc`, `def` or `xyz` |
+
+**Note** the alternation character is the pipe character `|` and not the character included in the tables on this page. There is an issue including the pipe character inside tables markdown that is rendered by doxygen.
+
+### Character Classes
+
+| Feature  | Syntax | Description | Example |
+| ---------- | ------------- | ------------- | ------------- |
+| Character class | `[` | `[` begins a character class. | |
+| Literal character | Any character except `\^-]` | All characters except the listed special characters are literal characters that add themselves to the character class. | `[abc]` matches `a`, `b` or `c` |
+| Backslash escapes a metacharacter	| `\` (backslash) followed by any of `\^-]` | A backslash escapes special characters to suppress their special meaning. | `[\^\\]]` matches `^` or `]` |
+| Range | `-` (hyphen) between two tokens that each specify a single character. | Adds a range of characters to the character class. | `[a-zA-Z0-9]` matches any ASCII letter or digit |
+| Negated character class | `^` (caret) immediately after the opening [ | Negates the character class, causing it to match a single character not listed in the character class. | `[\^a-d]` matches `x` (any character except `a`, `b`, `c` or `d`) |
+| Literal opening bracket | `[` | An opening square bracket is a literal character that adds an opening square bracket to the character class. | `[ab[cd]ef]` matches `aef]`, `bef]`, `[ef]`, `cef]`, and `def]` |
+| Character escape | `\n`, `\r` and `\t` | Add an LF character, a CR character, or a tab character to the character class, respectively. | `[\n\r\t]` a line feed, a carriage return, or a tab. |
+| Character escape | `\a` | Add the "alert" or "bell" control character (ASCII 0x07) to the character class. | `[\a\t]` matches a bell or a tab character. |
+| Character escape | `\b` | Add the "backspace" control character (ASCII 0x08) to the character class. | `[\b\t]` matches a backspace or a tab character. |
+| Character escape | `\f` | Add the form-feed control character (ASCII 0x0C) to the character class. | `[\f\t]` matches a form-feed or a tab character. |
+
+### Shorthand Character Classes
+
+| Feature  | Syntax | Description | Example |
+| ---------- | ------------- | ------------- | ------------- |
+| Shorthand | `\d` | Adds all digits to the character class. Matches a single digit if used outside character classes. | `\d` match a character that is a digit |
+| Shorthand | `\w` | Adds all word characters to the character class. Matches a single word character if used outside character classes. | `\w` match any single word character |
+| Shorthand | `\s` | Adds all whitespace to the character class. Matches a single whitespace character if used outside character classes. | `\s` match any single whitespace character |
+| Shorthand | `\D` | Adds all non-digits to the character class. Matches a single character that is not a digit character if used outside character classes. | `[\D]` matches a single character that is not a digit character |
+| Shorthand | `\W` | Adds all non-word characters to the character class. Matches a single character that is not a word character if used outside character classes. | [`\W`] matches a single character that is not a word character |
+| Shorthand | `\s` | Adds all non-whitespace to the character class. Matches a single character that is not a whitespace character if used outside character classes. | `[\S]` match a single character that is not a whitespace character |
+
+### Anchors
+
+| Feature  | Syntax | Description | Example |
+| ---------- | ------------- | ------------- | ------------- |
+| String anchor | `^` (caret) | Matches at the start of the string | `^.` matches `a` in `abc\ndef` |
+| String anchor | `$` (dollar) | Matches at the end of the string | `.$` matches `f` in `abc\ndef` |
+| Line anchor | `^` (caret) | Matches after each line break in addition to matching at the start of the string, thus matching at the start of each line in the string. | `^.` matches `a` and `d` in `abc\ndef` |
+| Line anchor | `$` (dollar) | Matches before each line break in addition to matching at the end of the string, thus matching at the end of each line in the string. | `.$` matches `c` and `f` in `abc\ndef`　|
+| String anchor | `\A` | Matches at the start of the string | `\A\w` matches only `a` in `abc` |
+| String anchor | `\Z` | Matches at the end of the string | `\w\Z` matches `f` in `abc\ndef` but fails to match `abc\ndef\n` or `abc\ndef\n\n` |
+
+### Word Boundaries
+
+| Feature  | Syntax | Description | Example |
+| ---------- | ------------- | ------------- | ------------- |
+| Word boundary | `\b` | Matches at a position that is followed by a word character but not preceded by a word character, or that is preceded by a word character but not followed by a word character. | `\b.` matches `a`, the space, and `d` in `abc def` |
+| Word boundary | `\B`　| Matches at a position that is preceded and followed by a word character, or that is not preceded and not followed by a word character. | `\B.` matches `b`, `c`, `e`, and `f` in `abc def` |
+
+### Quantifiers
+
+| Feature  | Syntax | Description | Example |
+| ---------- | ------------- | ------------- | ------------- |
+| Greedy quantifier | `?` (question mark) | Makes the preceding item optional. Greedy, so the optional item is included in the match if possible. | `abc?` matches `abc` or `ab` |
+| Greedy quantifier | `*` (star) | Repeats the previous item zero or more times. Greedy, so as many items as possible will be matched before trying permutations with less matches of the preceding item, up to the point where the preceding item is not matched at all. | `".*"` matches `"def"` and `"ghi"` in `abc "def" "ghi" jkl` |
+| Greedy quantifier | `+` (plus)　| Repeats the previous item once or more. Greedy, so as many items as possible will be matched before trying permutations with less matches of the preceding item, up to the point where the preceding item is matched only once. | `".+"` matches `"def"` and `"ghi"` in `abc "def" "ghi" jkl` |
+| Lazy quantifier | `??` | Makes the preceding item optional. Lazy, so the optional item is excluded in the match if possible. | `abc??` matches `ab` or `abc` |
+| Lazy quantifier | `*?` | Repeats the previous item zero or more times. Lazy, so the engine first attempts to skip the previous item, before trying permutations with ever increasing matches of the preceding item. | `".*?"` matches `"def"` and `"ghi"` in `abc "def" "ghi" jkl` |
+| Lazy quantifier | `+?` | Repeats the previous item once or more. Lazy, so the engine first matches the previous item only once, before trying permutations with ever increasing matches of the preceding item. | `".+?"` matches `"def"` and `"ghi"` in `abc "def" "ghi" jkl` |
+| Fixed quantifier | `{n}` where `n is an integer >= 1` | Repeats the previous item exactly `n` times. | Repeats the previous item exactly `n` times. |
+| Greedy quantifier | `{n,m}` where `n >= 0` and `m >= n` | Repeats the previous item between `n` and `m` times. Greedy, so repeating m times is tried before reducing the repetition to `n` times. | `a{2,4}` matches `aaaa`, `aaa` or `aa` |
+| Greedy quantifier | `{n,}` where `n >= 0` | Repeats the previous item at least `n` times. Greedy, so as many items as possible will be matched before trying permutations with less matches of the preceding item, up to the point where the preceding item is matched only `n` times. | `a{2,}` matches `aaaaa` in `aaaaa` |
+| Lazy quantifier | `{n,m}?` where `n >= 0` and `m >= n` | Repeats the previous item between `n` and `m` times. Lazy, so repeating `n` times is tried before increasing the repetition to `m` times. | `a{2,4}?` matches `aa`, `aaa` or `aaaa` |
+| Lazy quantifier | `{n,}?` where `n >= 0` | Repeats the previous item `n` or more times. Lazy, so the engine first matches the previous item `n` times, before trying permutations with ever increasing matches of the preceding item. | `a{2,}?` matches `aa` in `aaaaa` |
+
+### Groups
+
+| Feature  | Syntax | Description | Example |
+| ---------- | ------------- | ------------- | ------------- |
+| Capturing group | `(`regex`)` | Parentheses group the regex between them. They capture the text matched by the regex inside them into a numbered group. They allow you to apply regex operators to the entire grouped regex. | `(abc⎮def)ghi` matches `abcghi` or `defghi` |
+| Non-capturing group | `(?:`regex`)` | Non-capturing parentheses group the regex so you can apply regex operators, but do not capture anything. | `(?:abc⎮def)ghi` matches `abcghi` or `defghi` |

--- a/cpp/doxygen/unicode.md
+++ b/cpp/doxygen/unicode.md
@@ -1,10 +1,10 @@
 # Unicode Limitations
 
 The strings column currently supports only UTF-8 characters internally.
-For functions that require character testing (e.g. all_characters_of_type()) or
-case conversion (e.g. to_upper(), to_lower(), capitalize(), etc) only the 16-bit [Unicode 13.0](http://www.unicode.org/versions/Unicode13.0.0) character code-points (0-65535) values are supported.
+For functions that require character testing (e.g. cudf::strings::all_characters_of_type()) or
+case conversion (e.g. cudf::strings::to_upper(), cudf::strings::to_lower(), cudf::strings::capitalize(), etc) only the 16-bit [Unicode 13.0](http://www.unicode.org/versions/Unicode13.0.0) character code-points (0-65535) values are supported.
 Case conversion and character testing on characters above code-point 65535 are not supported.
 
 Case conversions that are context-sensitive are not supported. Also, case conversions that result
 in multiple characters are not reversible. That is, adjacent individual characters will not be case converted
-to a single character. For example, converting character ß to upper case will result in the characters "SS". Converting "SS" to lower case will produce "ss".
+to a single character. For example, converting character ß to upper case will result in the characters "SS". But converting "SS" to lower case will produce "ss".

--- a/cpp/doxygen/unicode.md
+++ b/cpp/doxygen/unicode.md
@@ -2,9 +2,22 @@
 
 The strings column currently supports only UTF-8 characters internally.
 For functions that require character testing (e.g. cudf::strings::all_characters_of_type()) or
-case conversion (e.g. cudf::strings::to_upper(), cudf::strings::to_lower(), cudf::strings::capitalize(), etc) only the 16-bit [Unicode 13.0](http://www.unicode.org/versions/Unicode13.0.0) character code-points (0-65535) values are supported.
+case conversion (e.g. cudf::strings::capitalize(), etc) only the 16-bit [Unicode 13.0](http://www.unicode.org/versions/Unicode13.0.0) 
+character code-points (0-65535) values are supported.
 Case conversion and character testing on characters above code-point 65535 are not supported.
 
 Case conversions that are context-sensitive are not supported. Also, case conversions that result
 in multiple characters are not reversible. That is, adjacent individual characters will not be case converted
 to a single character. For example, converting character ß to upper case will result in the characters "SS". But converting "SS" to lower case will produce "ss".
+
+Strings case and type APIs:
+
+- cudf::strings::all_characters_of_type()
+- cudf::strings::to_upper()
+- cudf::strings::to_lower()
+- cudf::strings::capitalize()
+- cudf::strings::title()
+- cudf::strings::swapcase()
+
+Also, using regex patterns that use the shorthand character classes `\d \D \w \W \s \S` will include only appropriate characters with
+code-points between (0-65535).

--- a/cpp/doxygen/unicode.md
+++ b/cpp/doxygen/unicode.md
@@ -1,0 +1,10 @@
+# Unicode Limitations
+
+The strings column currently supports only UTF-8 characters internally.
+For functions that require character testing (e.g. all_characters_of_type()) or
+case conversion (e.g. to_upper(), to_lower(), capitalize(), etc) only the 16-bit [Unicode 13.0](http://www.unicode.org/versions/Unicode13.0.0) character code-points (0-65535) values are supported.
+Case conversion and character testing on characters above code-point 65535 are not supported.
+
+Case conversions that are context-sensitive are not supported. Also, case conversions that result
+in multiple characters are not reversible. That is, adjacent individual characters will not be case converted
+to a single character. For example, converting character ß to upper case will result in the characters "SS". Converting "SS" to lower case will produce "ss".

--- a/cpp/include/cudf/strings/attributes.hpp
+++ b/cpp/include/cudf/strings/attributes.hpp
@@ -19,7 +19,12 @@
 #include <cudf/strings/strings_column_view.hpp>
 
 namespace cudf {
-//! Strings column APIs.
+/**
+ * @brief Strings column APIs.
+ *
+ * @defgroup strings_apis Strings APIs
+ * @{
+ */
 namespace strings {
 /**
  * @brief Returns an integer numeric column containing the length of each string in
@@ -78,4 +83,5 @@ std::unique_ptr<column> code_points(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 }  // namespace strings
+/** @} */  // end of strings_apis group
 }  // namespace cudf

--- a/cpp/include/cudf/strings/capitalize.hpp
+++ b/cpp/include/cudf/strings/capitalize.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_case Case
+ * APIs to convert the upper/lower case of strings characters.
+ * @{
+ */
+
+/**
  * @brief Returns a column of capitalized strings.
  *
  * Any null string entries return corresponding null output column entries.
@@ -64,5 +71,6 @@ std::unique_ptr<column> title(
   strings_column_view const& strings,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/case.hpp
+++ b/cpp/include/cudf/strings/case.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_case Case
+ * APIs to convert the upper/lower case of strings characters.
+ * @{
+ */
+
+/**
  * @brief Converts a column of strings to lower case.
  *
  * Only upper case alphabetical characters are converted. All other characters are copied.
@@ -72,5 +79,6 @@ std::unique_ptr<column> swapcase(
   strings_column_view const& strings,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/char_types/char_types.hpp
+++ b/cpp/include/cudf/strings/char_types/char_types.hpp
@@ -30,16 +30,16 @@ namespace strings {
  * does not match to any explicitly named enumerator.
  */
 enum string_character_types : uint32_t {
-  DECIMAL    = 1 << 0,                             // binary 00000001
-  NUMERIC    = 1 << 1,                             // binary 00000010
-  DIGIT      = 1 << 2,                             // binary 00000100
-  ALPHA      = 1 << 3,                             // binary 00001000
-  SPACE      = 1 << 4,                             // binary 00010000
-  UPPER      = 1 << 5,                             // binary 00100000
-  LOWER      = 1 << 6,                             // binary 01000000
-  ALPHANUM   = DECIMAL | NUMERIC | DIGIT | ALPHA,  // binary 00001111
-  CASE_TYPES = UPPER | LOWER,
-  ALL_TYPES  = ALPHANUM | CASE_TYPES | SPACE
+  DECIMAL    = 1 << 0,                             /// all decimal characters
+  NUMERIC    = 1 << 1,                             /// all numeric characters
+  DIGIT      = 1 << 2,                             /// all digit characters
+  ALPHA      = 1 << 3,                             /// all alphabetic characters
+  SPACE      = 1 << 4,                             /// all space characters
+  UPPER      = 1 << 5,                             /// all upper case characters
+  LOWER      = 1 << 6,                             /// all lower case characters
+  ALPHANUM   = DECIMAL | NUMERIC | DIGIT | ALPHA,  /// all alphanumeric characters
+  CASE_TYPES = UPPER | LOWER,                      /// all case-able characters
+  ALL_TYPES  = ALPHANUM | CASE_TYPES | SPACE       /// all character types
 };
 
 // OR operators for combining types
@@ -67,18 +67,17 @@ string_character_types& operator|=(string_character_types& lhs, string_character
  * characters fit the type then true is set in that output row entry.
  *
  * To ignore all but specific types, set the `verify_types` to those types
- * which should be checked. Otherwise, the default ALL_TYPES will verify all
+ * which should be checked. Otherwise, the default `ALL_TYPES` will verify all
  * characters match `types`.
  *
- * ```
+ * @code{.pseudo}
  * Example:
  * s = ['ab', 'a b', 'a7', 'a B']
  * b1 = s.all_characters_of_type(s,LOWER)
  * b1 is [true, false, false, false]
  * b2 = s.all_characters_of_type(s,LOWER,LOWER|UPPER)
  * b2 is [true, true, true, false]
- *
- * ```
+ * @endcode
  *
  * Any null row results in a null entry for that row in the output column.
  *
@@ -103,13 +102,12 @@ std::unique_ptr<column> all_characters_of_type(
  * The output row entry will be set to `true` if the corresponding string element
  * has at least one character in [-+0-9].
  *
- * ```
+ * @code{.pseudo}
  * Example:
  * s = ['123', '-456', '', 'A', '+7']
  * b = s.is_integer(s)
  * b is [true, true, false, false, true]
- *
- * ```
+ * @endcode
  *
  * Any null row results in a null entry for that row in the output column.
  *
@@ -144,13 +142,12 @@ bool all_integer(strings_column_view const& strings,
  * The output row entry will be set to `true` if the corresponding string element
  * has at least one character in [-+0-9eE.].
  *
- * ```
+ * @code{.pseudo}
  * Example:
  * s = ['123', '-456', '', 'A', '+7', '8.9' '3.7e+5']
  * b = s.is_float(s)
  * b is [true, true, false, false, true, true, true]
- *
- * ```
+ * @endcode
  *
  * Any null row results in a null entry for that row in the output column.
  *

--- a/cpp/include/cudf/strings/combine.hpp
+++ b/cpp/include/cudf/strings/combine.hpp
@@ -42,14 +42,15 @@ namespace strings {
  *
  * The number of strings in the columns provided must be the same.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s1 = ['aa', null, '', 'aa']
  * s2 = ['', 'bb', 'bb', null]
  * r1 = concatenate([s1,s2])
  * r1 is ['aa', null, 'bb', null]
  * r2 = concatenate([s1,s2],':','_')
  * r2 is ['aa:', '_:bb', ':bb', 'aa:_']
- * ```
+ * @endcode
  *
  * @throw cudf::logic_error if input columns are not all strings columns.
  * @throw cudf::logic_error if separator is not valid.
@@ -76,11 +77,12 @@ std::unique_ptr<column> concatenate(
  * This returns a column with one string. Any null entries are ignored unless
  * the narep parameter specifies a replacement string.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ['aa', null, '', 'zz' ]
  * r = join_strings(s,':','_')
  * r is ['aa:_::zz']
- * ```
+ * @endcode
  *
  * @throw cudf::logic_error if separator is not valid.
  *

--- a/cpp/include/cudf/strings/combine.hpp
+++ b/cpp/include/cudf/strings/combine.hpp
@@ -23,6 +23,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_combine Combine
+ * APIs to combine strings row-wise.
+ * @{
+ */
+
+/**
  * @brief Row-wise concatenates the given list of strings columns and
  * returns a single strings column result.
  *
@@ -91,5 +98,6 @@ std::unique_ptr<column> join_strings(
   string_scalar const& narep          = string_scalar("", false),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/contains.hpp
+++ b/cpp/include/cudf/strings/contains.hpp
@@ -34,7 +34,7 @@ namespace strings {
  * @code{.pseudo}
  * Example:
  * s = ["abc","123","def456"]
- * r = contains(s,"\\d+")
+ * r = contains_re(s,"\\d+")
  * r is now [false, true, true]
  * @endcode
  *
@@ -59,7 +59,7 @@ std::unique_ptr<column> contains_re(
  * @code{.pseudo}
  * Example:
  * s = ["abc","123","def456"]
- * r = contains(s,"\\d+")
+ * r = matches_re(s,"\\d+")
  * r is now [false, true, false]
  * @endcode
  *
@@ -84,7 +84,7 @@ std::unique_ptr<column> matches_re(
  * @code{.pseudo}
  * Example:
  * s = ["abc","123","def45"]
- * r = contains(s,"\\d")
+ * r = count_re(s,"\\d")
  * r is now [0, 3, 2]
  * @endcode
  *

--- a/cpp/include/cudf/strings/contains.hpp
+++ b/cpp/include/cudf/strings/contains.hpp
@@ -31,13 +31,16 @@ namespace strings {
  * @brief Returns a boolean column identifying rows which
  * match the given regex pattern.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["abc","123","def456"]
  * r = contains(s,"\\d+")
  * r is now [false, true, true]
- * ```
+ * @endcode
  *
  * Any null string entries return corresponding null output column entries.
+ *
+ * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
  *
  * @param strings Strings instance for this operation.
  * @param pattern Regex pattern to match to each string.
@@ -53,13 +56,16 @@ std::unique_ptr<column> contains_re(
  * @brief Returns a boolean column identifying rows which
  * matching the given regex pattern but only at the beginning the string.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["abc","123","def456"]
  * r = contains(s,"\\d+")
  * r is now [false, true, false]
- * ```
+ * @endcode
  *
  * Any null string entries return corresponding null output column entries.
+ *
+ * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
  *
  * @param strings Strings instance for this operation.
  * @param pattern Regex pattern to match to each string.
@@ -75,13 +81,16 @@ std::unique_ptr<column> matches_re(
  * @brief Returns the number of times the given regex pattern
  * matches in each string.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["abc","123","def45"]
  * r = contains(s,"\\d")
  * r is now [0, 3, 2]
- * ```
+ * @endcode
  *
  * Any null string entries return corresponding null output column entries.
+ *
+ * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
  *
  * @param strings Strings instance for this operation.
  * @param pattern Regex pattern to match within each string.

--- a/cpp/include/cudf/strings/contains.hpp
+++ b/cpp/include/cudf/strings/contains.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_contains Contains
+ * APIs to search for substrings/patterns within strings.
+ * @{
+ */
+
+/**
  * @brief Returns a boolean column identifying rows which
  * match the given regex pattern.
  *
@@ -86,5 +93,6 @@ std::unique_ptr<column> count_re(
   std::string const& pattern,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/convert/convert_booleans.hpp
+++ b/cpp/include/cudf/strings/convert/convert_booleans.hpp
@@ -22,6 +22,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_convert Converters
+ * APIs to convert strings to and from other data-types.
+ * @{
+ */
+
+/**
  * @brief Returns a new BOOL8 column by parsing boolean values from the strings
  * in the provided strings column.
  *
@@ -57,5 +64,6 @@ std::unique_ptr<column> from_booleans(
   string_scalar const& false_string   = string_scalar("false"),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/convert/convert_datetime.hpp
+++ b/cpp/include/cudf/strings/convert/convert_datetime.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_convert Converters
+ * APIs to convert strings to and from other data-types.
+ * @{
+ */
+
+/**
  * @brief Returns a new timestamp column converting a strings column into
  * timestamps using the provided format pattern.
  *
@@ -120,5 +127,6 @@ std::unique_ptr<column> from_timestamps(
   std::string const& format           = "%Y-%m-%dT%H:%M:%SZ",
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/convert/convert_floats.hpp
+++ b/cpp/include/cudf/strings/convert/convert_floats.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_convert Converters
+ * APIs to convert strings to and from other data-types.
+ * @{
+ */
+
+/**
  * @brief Returns a new numeric column by parsing float values from each string
  * in the provided strings column.
  *
@@ -61,5 +68,6 @@ std::unique_ptr<column> to_floats(
 std::unique_ptr<column> from_floats(
   column_view const& floats, rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/convert/convert_integers.hpp
+++ b/cpp/include/cudf/strings/convert/convert_integers.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_convert Converters
+ * APIs to convert strings to and from other data-types.
+ * @{
+ */
+
+/**
  * @brief Returns a new integer numeric column parsing integer values from the
  * provided strings column.
  *
@@ -95,5 +102,6 @@ std::unique_ptr<column> hex_to_integers(
   data_type output_type,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/convert/convert_ipv4.hpp
+++ b/cpp/include/cudf/strings/convert/convert_ipv4.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_convert Converters
+ * APIs to convert strings to and from other data-types.
+ * @{
+ */
+
+/**
  * @brief Converts IPv4 addresses into integers.
  *
  * The IPv4 format is 1-3 character digits [0-9] between 3 dots
@@ -71,5 +78,6 @@ std::unique_ptr<column> integers_to_ipv4(
   column_view const& integers,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/convert/convert_urls.hpp
+++ b/cpp/include/cudf/strings/convert/convert_urls.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_convert Converters
+ * APIs to convert strings to and from other data-types.
+ * @{
+ */
+
+/**
  * @brief Decodes each string using URL encoding.
  *
  * Converts mostly non-ascii characters and control characters into UTF-8 hex code-points
@@ -59,5 +66,6 @@ std::unique_ptr<column> url_decode(
   strings_column_view const& strings,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/convert/convert_urls.hpp
+++ b/cpp/include/cudf/strings/convert/convert_urls.hpp
@@ -53,8 +53,9 @@ std::unique_ptr<column> url_encode(
  * interpreting the 2 following characters as hex values to create the code-point.
  * For example, the sequence '%20' is converted into byte (0x20) which is a single
  * space character. Another example converts '%C3%A9' into 2 sequential bytes
- * (0xc3 and 0xa9 respectively). Overall, 3 characters are converted into one char byte
- * whenever a '%' character is encountered in the string.
+ * (0xc3 and 0xa9 respectively) which is the é character. Overall, 3 characters
+ * are converted into one char byte whenever a '%%' (single percent) character
+ * is encountered in the string.
  *
  * Any null entries will result in corresponding null entries in the output column.
  *

--- a/cpp/include/cudf/strings/copying.hpp
+++ b/cpp/include/cudf/strings/copying.hpp
@@ -26,13 +26,14 @@ namespace detail {
  * of the strings column. The subset of strings selected is between
  * start (inclusive) and end (exclusive) with incrememnts of step.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s1 = ["a", "b", "c", "d", "e", "f"]
  * s2 = slice( s1, 2 )
  * s2 is ["c", "d", "e", "f"]
  * s3 = slice( s1, 1, 2 )
  * s3 is ["b", "d", "f"]
- * ```
+ * @endcode
  *
  * @param strings Strings instance for this operation.
  * @param start Index to first string to select in the column (inclusive).

--- a/cpp/include/cudf/strings/extract.hpp
+++ b/cpp/include/cudf/strings/extract.hpp
@@ -36,12 +36,15 @@ namespace strings {
  *
  * Any null string entries return corresponding null output column entries.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["a1","b2","c3"]
  * r = extract(s,"([ab])(\\d)")
  * r is now [["a","b",null],
  *           ["1","2",null]]
- * ```
+ * @endcode
+ *
+ * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
  *
  * @param strings Strings instance for this operation.
  * @param pattern The regular expression pattern with group indicators.

--- a/cpp/include/cudf/strings/extract.hpp
+++ b/cpp/include/cudf/strings/extract.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_substring Substring
+ * APIs to extract substrings from strings.
+ * @{
+ */
+
+/**
  * @brief Returns a vector of strings columns for each matching group specified in the given regular
  * expression pattern.
  *
@@ -46,5 +53,6 @@ std::unique_ptr<experimental::table> extract(
   std::string const& pattern,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/find.hpp
+++ b/cpp/include/cudf/strings/find.hpp
@@ -22,6 +22,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_find Find
+ * APIs to locate for substrings within strings.
+ * @{
+ */
+
+/**
  * @brief Returns a column of character position values where the target
  * string is first found in each string of the provided column.
  *
@@ -136,5 +143,6 @@ std::unique_ptr<column> ends_with(
   string_scalar const& target,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/find_multiple.hpp
+++ b/cpp/include/cudf/strings/find_multiple.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_find Find
+ * APIs to locate for substrings within strings.
+ * @{
+ */
+
+/**
  * @brief Returns a column with character position values where each
  * of the target strings are found in each string.
  *
@@ -47,5 +54,6 @@ std::unique_ptr<column> find_multiple(
   strings_column_view const& targets,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/find_multiple.hpp
+++ b/cpp/include/cudf/strings/find_multiple.hpp
@@ -34,13 +34,14 @@ namespace strings {
  * The size of the output column is targets.size() * strings.size().
  * output[i] contains the position of target[i % targets.size()] in string[i/targets.size()]
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["abc","def"]
  * t = ["a","c","e"]
  * r = find_multiple(s,t)
  * r is now [ 0, 2,-1,   // for "abc": "a" at pos 0, "c" at pos 2, "e" not found
  *           -1,-1, 1 ]  // for "def": "a" and "b" not found, "e" at  pos 1
- * ```
+ * @endcode
  *
  * @throw cudf::logic_error targets is empty or contains nulls
  *

--- a/cpp/include/cudf/strings/findall.hpp
+++ b/cpp/include/cudf/strings/findall.hpp
@@ -34,6 +34,16 @@ namespace strings {
  * The number of output columns is determined by the string with the most
  * matches.
  *
+ * @code{.pseudo}
+ * Example:
+ * s = ["bunny","rabbit"]
+ * r = findall(s, "[ab]"")
+ * r is now a table of 3 columns:
+ *   ["b","a"]
+ *   [null,"b"]
+ *   [null,"b"]
+ * @endcode
+ *
  * Any null string entries return corresponding null output column entries.
  *
  * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.

--- a/cpp/include/cudf/strings/findall.hpp
+++ b/cpp/include/cudf/strings/findall.hpp
@@ -36,6 +36,8 @@ namespace strings {
  *
  * Any null string entries return corresponding null output column entries.
  *
+ * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
+ *
  * @param strings Strings instance for this operation.
  * @param pattern Regex pattern to match within each string.
  * @param mr Resource for allocating device memory.

--- a/cpp/include/cudf/strings/findall.hpp
+++ b/cpp/include/cudf/strings/findall.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_contains Contains
+ * APIs to search for substrings/patterns within strings.
+ * @{
+ */
+
+/**
  * @brief Returns a table of strings columns for each matching occurrence of the
  * regex pattern within each string.
  *
@@ -39,5 +46,6 @@ std::unique_ptr<experimental::table> findall_re(
   std::string const& pattern,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/padding.hpp
+++ b/cpp/include/cudf/strings/padding.hpp
@@ -46,11 +46,12 @@ enum class pad_side {
  *
  * Null string entries result in null entries in the output column.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ['aa','bbb','cccc','ddddd']
  * r = pad(s,4)
  * r is now ['aa  ','bbb ','cccc','ddddd']
- * ```
+ * @endcode
  *
  * @param strings Strings instance for this operation.
  * @param width The minimum number of characters for each string.
@@ -77,11 +78,12 @@ std::unique_ptr<column> pad(strings_column_view const& strings,
  *
  * Null string entries result in null entries in the output column.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ['1234','-9876','+0.34','-342567']
  * r = zfill(s,6)
  * r is now ['001234','0-9876','0+0.34','-342567']
- * ```
+ * @endcode
  *
  * @param strings Strings instance for this operation.
  * @param width The minimum number of characters for each string.

--- a/cpp/include/cudf/strings/padding.hpp
+++ b/cpp/include/cudf/strings/padding.hpp
@@ -22,6 +22,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_modify Modify
+ * APIs to modify from strings.
+ * @{
+ */
+
+/**
  * @brief Pad types for the pad method specify where the pad
  * character should be placed.
  */
@@ -86,5 +93,6 @@ std::unique_ptr<column> zfill(
   size_type width,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/replace.hpp
+++ b/cpp/include/cudf/strings/replace.hpp
@@ -22,6 +22,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_replace Replace
+ * APIs to replace substrings/patterns within strings.
+ * @{
+ */
+
+/**
  * @brief Replaces target string within each string with the specified
  * replacement string.
  *
@@ -163,5 +170,6 @@ std::unique_ptr<column> replace_nulls(
   string_scalar const& repl           = string_scalar(""),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/replace.hpp
+++ b/cpp/include/cudf/strings/replace.hpp
@@ -42,13 +42,14 @@ namespace strings {
  *
  * Null string entries will return null output string entries.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["hello", "goodbye"]
  * r1 = replace(s,"o","OOO")
  * r1 is now ["hellOOO","gOOOOOOdbye"]
  * r2 = replace(s,"oo","")
  * r2 is now ["hello","gdbye"]
- * ```
+ * @endcode
  *
  * @throw cudf::logic_error if target is an empty string.
  *
@@ -81,11 +82,12 @@ std::unique_ptr<column> replace(
  * string can be appended to each string by specifying -1 for both
  * start and stop.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["abcdefghij","0123456789"]
  * r = s.replace_slice(s,2,5,"z")
  * r is now ["abzfghij", "01z56789"]
- * ```
+ * @endcode
  *
  * @throw cudf::logic_error if start is greater than stop.
  *
@@ -121,7 +123,8 @@ std::unique_ptr<column> replace_slice(
  * The repls argument can optionally contain a single string. In this case, all
  * matching target substrings will be replaced by that single string.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["hello", "goodbye"]
  * tgts = ["e","o"]
  * repls = ["EE","OO"]
@@ -131,7 +134,7 @@ std::unique_ptr<column> replace_slice(
  * repls = ["33",""]
  * r2 = replace(s,tgts,repls)
  * r2 is now ["h33llo", "gdby33"]
- * ```
+ * @endcode
  *
  * @throw cudf::logic_error if targets and repls are different sizes except
  * if repls is a single string.
@@ -154,11 +157,12 @@ std::unique_ptr<column> replace(
  *
  * This returns a strings column with no null entries.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["hello", nullptr, "goodbye"]
  * r = replace_nulls(s,"**")
  * r is now ["hello", "**", "goodbye"]
- * ```
+ * @endcode
  *
  * @param strings Strings column for this operation.
  * @param repl Replacement string for null entries. Default is empty string.

--- a/cpp/include/cudf/strings/replace_re.hpp
+++ b/cpp/include/cudf/strings/replace_re.hpp
@@ -22,10 +22,19 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_replace Replace
+ * APIs to replace substrings/patterns within strings.
+ * @{
+ */
+
+/**
  * @brief For each string, replaces any character sequence matching the given pattern
  * with the provided replacement string.
  *
  * Any null string entries return corresponding null output column entries.
+ *
+ * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
  *
  * @param strings Strings instance for this operation.
  * @param pattern The regular expression pattern to search within each string.
@@ -49,7 +58,7 @@ std::unique_ptr<column> replace_re(
  * Any null string entries return corresponding null output column entries.
  *
  * @param strings Strings instance for this operation.
- * @param pattern The regular expression patterns to search within each string.
+ * @param patterns The regular expression patterns to search within each string.
  * @param repls The strings used for replacement.
  * @param mr Resource for allocating device memory.
  * @return New strings column.

--- a/cpp/include/cudf/strings/replace_re.hpp
+++ b/cpp/include/cudf/strings/replace_re.hpp
@@ -57,6 +57,8 @@ std::unique_ptr<column> replace_re(
  *
  * Any null string entries return corresponding null output column entries.
  *
+ * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
+ *
  * @param strings Strings instance for this operation.
  * @param patterns The regular expression patterns to search within each string.
  * @param repls The strings used for replacement.
@@ -74,6 +76,8 @@ std::unique_ptr<column> replace_re(
  * using the repl template for back-references.
  *
  * Any null string entries return corresponding null output column entries.
+ *
+ * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
  *
  * @param strings Strings instance for this operation.
  * @param pattern The regular expression patterns to search within each string.

--- a/cpp/include/cudf/strings/split/partition.hpp
+++ b/cpp/include/cudf/strings/split/partition.hpp
@@ -22,6 +22,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_split Split
+ * APIs to split strings into multiple columns of strings.
+ * @{
+ */
+
+/**
  * @brief Returns a set of 3 columns by splitting each string using the
  * specified delimiter.
  *
@@ -83,5 +90,6 @@ std::unique_ptr<experimental::table> rpartition(
   string_scalar const& delimiter      = string_scalar(""),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/split/partition.hpp
+++ b/cpp/include/cudf/strings/split/partition.hpp
@@ -40,13 +40,14 @@ namespace strings {
  *
  * Any null string entries return corresponding null output columns.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["ab_cd","def_g_h"]
- * r = rpartition(s,"_")
+ * r = partition(s,"_")
  * r[0] is ["ab","def"]
  * r[1] is ["_","_"]
  * r[2] is ["cd","g_h"]
- * ```
+ * @endcode
  *
  * @param strings Strings instance for this operation.
  * @param delimiter UTF-8 encoded string indentifying where to split each string.
@@ -71,13 +72,14 @@ std::unique_ptr<experimental::table> partition(
  *
  * Any null string entries return corresponding null output columns.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["ab_cd","def_g_h"]
  * r = rpartition(s,"_")
  * r[0] is ["ab","def_g"]
  * r[1] is ["_","_"]
  * r[2] is ["cd","h"]
- * ```
+ * @endcode
  *
  * @param strings Strings instance for this operation.
  * @param delimiter UTF-8 encoded string indentifying where to split each string.

--- a/cpp/include/cudf/strings/split/split.hpp
+++ b/cpp/include/cudf/strings/split/split.hpp
@@ -22,6 +22,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_split Split
+ * APIs to split strings into multiple columns of strings.
+ * @{
+ */
+
+/**
  * @brief Returns a list of columns by splitting each string using the
  * specified delimiter.
  *
@@ -159,5 +166,6 @@ contiguous_split_record_result contiguous_rsplit_record(
   size_type maxsplit                  = -1,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/string_view.cuh
+++ b/cpp/include/cudf/strings/string_view.cuh
@@ -26,8 +26,8 @@
  */
 
 namespace cudf {
-// UTF-8 characters are 1-4 bytes
-using char_utf8 = uint32_t;
+
+using char_utf8 = uint32_t;  //<< UTF-8 characters are 1-4 bytes
 
 /**
  * @brief A non-owning, immutable view of device data that is a variable length
@@ -298,7 +298,8 @@ namespace detail {
 /**
  * @brief Returns the number of bytes in the specified character.
  *
- * @param chr Single character
+ * @param character Single character
+ * @return Number of bytes
  */
 __host__ __device__ size_type bytes_in_char_utf8(char_utf8 character);
 
@@ -306,7 +307,7 @@ __host__ __device__ size_type bytes_in_char_utf8(char_utf8 character);
  * @brief Convert a char array into a char_utf8 value.
  *
  * @param str String containing encoded char bytes.
- * @param[out] chr Single char_utf8 value.
+ * @param[out] character Single char_utf8 value.
  * @return The number of bytes in the character
  */
 __host__ __device__ size_type to_char_utf8(const char* str, char_utf8& character);
@@ -314,7 +315,7 @@ __host__ __device__ size_type to_char_utf8(const char* str, char_utf8& character
 /**
  * @brief Place a char_utf8 value into a char array.
  *
- * @param chr Single character
+ * @param character Single character
  * @param[out] str Allocated char array with enough space to hold the encoded characer.
  * @return The number of bytes in the character
  */

--- a/cpp/include/cudf/strings/strings_column_view.hpp
+++ b/cpp/include/cudf/strings/strings_column_view.hpp
@@ -76,6 +76,7 @@ class strings_column_view : private column_view {
   size_type chars_size() const noexcept;
 };
 
+//! Strings column APIs.
 namespace strings {
 /**
  * @brief Prints the strings to stdout.

--- a/cpp/include/cudf/strings/strip.hpp
+++ b/cpp/include/cudf/strings/strip.hpp
@@ -28,6 +28,9 @@ namespace strings {
  * @{
  */
 
+/**
+ * @brief Direction identifier for strip() function.
+ */
 enum class strip_type {
   LEFT,   //<< strip characters from the beginning of the string
   RIGHT,  //<< strip characters from the end of the string

--- a/cpp/include/cudf/strings/strip.hpp
+++ b/cpp/include/cudf/strings/strip.hpp
@@ -47,11 +47,12 @@ enum class strip_type {
  *
  * Any null string entries return corresponding null output column entries.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = [" aaa ", "_bbbb ", "__cccc  ", "ddd", " ee _ff gg_"]
  * r = strip(s,both," _")
  * r is now ["aaa", "bbbb", "cccc", "ddd", "ee _ff gg"]
- * ```
+ * @endcode
  *
  * @throw cudf::logic_error if `to_strip` is invalid.
  *

--- a/cpp/include/cudf/strings/strip.hpp
+++ b/cpp/include/cudf/strings/strip.hpp
@@ -21,6 +21,13 @@
 
 namespace cudf {
 namespace strings {
+/**
+ * @ingroup strings_apis
+ * @addtogroup strings_modify Modify
+ * APIs to modify from strings.
+ * @{
+ */
+
 enum class strip_type {
   LEFT,   //<< strip characters from the beginning of the string
   RIGHT,  //<< strip characters from the end of the string
@@ -62,5 +69,6 @@ std::unique_ptr<column> strip(
   string_scalar const& to_strip       = string_scalar(""),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/substring.hpp
+++ b/cpp/include/cudf/strings/substring.hpp
@@ -32,7 +32,7 @@ namespace strings {
  * @brief Returns a new strings column that contains substrings of the
  * strings in the provided column.
  *
- * The character positions to retrieve in each string are [start,stop).
+ * The character positions to retrieve in each string are `[start,stop)`.
  * If the start position is outside a string's length, an empty
  * string is returned for that entry. If the stop position is past the
  * end of a string's length, the end of the string is used for
@@ -40,13 +40,14 @@ namespace strings {
  *
  * Null string entries will return null output string entries.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["hello", "goodbye"]
  * r = substring(s,2,6)
  * r is now ["llo","odby"]
  * r2 = substring(s,2,5,2)
  * r2 is now ["lo","ob"]
- * ```
+ * @endcode
  *
  * @param strings Strings column for this operation.
  * @param start First character position to begin the substring.
@@ -66,7 +67,8 @@ std::unique_ptr<column> slice_strings(
  * @brief Returns a new strings column that contains substrings of the
  * strings in the provided column using unique ranges for each string.
  *
- * The character positions to retrieve in each string are [start,stop).
+ * The character positions to retrieve in each string are specified in
+ * the `starts` and `stops` integer columns.
  * If a start position is outside a string's length, an empty
  * string is returned for that entry. If a stop position is past the
  * end of a string's length, the end of the string is used for
@@ -79,13 +81,14 @@ std::unique_ptr<column> slice_strings(
  * The starts and stops column must both be the same integer type and
  * must be the same size as the strings column.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["hello", "goodbye"]
  * starts = [ 1, 2 ]
  * stops = [ 5, 4 ]
  * r = substring_from(s,starts,stops)
  * r is now ["ello","od"]
- * ```
+ * @endcode
  *
  * @throw cudf::logic_error if starts or stops is a different size than the strings column.
  * @throw cudf::logic_error if starts and stops are not same integer type.

--- a/cpp/include/cudf/strings/substring.hpp
+++ b/cpp/include/cudf/strings/substring.hpp
@@ -22,6 +22,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_substring Substring
+ * APIs to extract substrings from strings.
+ * @{
+ */
+
+/**
  * @brief Returns a new strings column that contains substrings of the
  * strings in the provided column.
  *
@@ -96,5 +103,6 @@ std::unique_ptr<column> slice_strings(
   column_view const& stops,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/translate.hpp
+++ b/cpp/include/cudf/strings/translate.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_modify Modify
+ * APIs to modify from strings.
+ * @{
+ */
+
+/**
  * @brief Translates individual characters within each string.
  *
  * This can also be used to remove a character by specifying 0 for the corresponding table entry.
@@ -36,6 +43,7 @@ namespace strings {
  *
  * @param strings Strings instance for this operation.
  * @param chars_table Table of UTF-8 character mappings.
+ * @param mr Resource for allocating device memory.
  * @return New column with padded strings.
  */
 std::unique_ptr<column> translate(
@@ -43,5 +51,6 @@ std::unique_ptr<column> translate(
   std::vector<std::pair<char_utf8, char_utf8>> const& chars_table,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/translate.hpp
+++ b/cpp/include/cudf/strings/translate.hpp
@@ -34,12 +34,13 @@ namespace strings {
  *
  * Null string entries result in null entries in the output column.
  *
- * ```
+ * @code{.pseudo}
+ * Example:
  * s = ["aa","bbb","cccc","abcd"]
  * t = [['a','A'],['b',''],['d':'Q']]
  * r = translate(s,t)
  * r is now ["AA", "", "cccc", "AcQ"]
- * ```
+ * @endcode
  *
  * @param strings Strings instance for this operation.
  * @param chars_table Table of UTF-8 character mappings.

--- a/cpp/include/cudf/strings/wrap.hpp
+++ b/cpp/include/cudf/strings/wrap.hpp
@@ -21,6 +21,13 @@
 namespace cudf {
 namespace strings {
 /**
+ * @ingroup strings_apis
+ * @addtogroup strings_modify Modify
+ * APIs to modify from strings.
+ * @{
+ */
+
+/**
  * @brief Wraps strings onto multiple lines shorter than `width` by replacing appropriate white
  * space with new-line characters (ASCII 0x0A).
  *
@@ -58,5 +65,6 @@ std::unique_ptr<column> wrap(strings_column_view const& strings,
                              size_type width,
                              rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/nvtext/generate_ngrams.hpp
+++ b/cpp/include/nvtext/generate_ngrams.hpp
@@ -21,11 +21,19 @@
 
 namespace nvtext {
 /**
+ * @ingroup nvtext_apis
+ * @addtogroup nvtext_ngrams NGrams
+ * APIs to produce ngrams from strings columns
+ * @{
+ */
+
+/**
  * @brief Returns a single column of strings by generating ngrams from
  * a strings column.
  *
  * An ngram is a grouping of 2 or more strings with a separator. For example,
  * generating bigrams groups all adjacent pairs of strings.
+ *
  * ```
  * ["a", "bb", "ccc"] would generate bigrams as ["a_bb", "bb_ccc"]
  * and trigrams as ["a_bb_ccc"]
@@ -50,4 +58,5 @@ std::unique_ptr<cudf::column> generate_ngrams(
   cudf::string_scalar const& separator = cudf::string_scalar{"_"},
   rmm::mr::device_memory_resource* mr  = rmm::mr::get_default_resource());
 
+/** @} */  // end of group
 }  // namespace nvtext

--- a/cpp/include/nvtext/ngrams_tokenize.hpp
+++ b/cpp/include/nvtext/ngrams_tokenize.hpp
@@ -21,11 +21,19 @@
 
 namespace nvtext {
 /**
+ * @ingroup nvtext_apis
+ * @addtogroup nvtext_ngrams NGrams
+ * APIs to produce ngrams from strings columns
+ * @{
+ */
+
+/**
  * @brief Returns a single column of strings by tokenizing the input strings
  * column and then producing ngrams of each string.
  *
  * An ngram is a grouping of 2 or more tokens with a separator. For example,
  * generating bigrams groups all adjacent pairs of tokens for a string.
+ *
  * ```
  * ["a bb ccc"] can be tokenized to ["a", "bb", "ccc"]
  * bigrams would generate ["a_bb", "bb_ccc"] and trigrams would generate ["a_bb_ccc"]
@@ -50,12 +58,12 @@ namespace nvtext {
  * The size of the output column will be the total number of ngrams generated from
  * the input strings column.
  *
+ * @code{.pseudo}
  * Example:
- * ```
  * s = ["a b c", "d e", "f g h i", "j"]
  * t = ngrams_tokenize(s, 2, " ", "_")
  * t is now ["a_b", "b_c", "d_e", "f_g", "g_h", "h_i"]
- * ```
+ * @endcode
  *
  * All null row entries are ignored and the output contains all valid rows.
  *
@@ -76,4 +84,5 @@ std::unique_ptr<cudf::column> ngrams_tokenize(
   cudf::string_scalar const& separator = cudf::string_scalar{"_"},
   rmm::mr::device_memory_resource* mr  = rmm::mr::get_default_resource());
 
+/** @} */  // end of group
 }  // namespace nvtext

--- a/cpp/include/nvtext/normalize.hpp
+++ b/cpp/include/nvtext/normalize.hpp
@@ -18,7 +18,15 @@
 #include <cudf/column/column.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 
+//! NVText APIs
 namespace nvtext {
+/**
+ * @ingroup nvtext_apis
+ * @addtogroup nvtext_normalize Normalize
+ * APIs to normalize strings column.
+ * @{
+ */
+
 /**
  * @brief Returns a new strings column by normalizing the whitespace in each
  * string in the input column.
@@ -27,12 +35,12 @@ namespace nvtext {
  * (character code-point <= ' ') runs with a single space ' ' and
  * trims whitespace from the beginning and end of the string.
  *
+ * @code{.pseudo}
  * Example:
- * ```
  * s = ["a b", "  c  d\n", "e \t f "]
  * t = normalize_spaces(s)
  * t is now ["a b","c d","e f"]
- * ```
+ * @endcode
  *
  * A null input element at row `i` produces a corresponding null entry
  * for row `i` in the output column.
@@ -45,4 +53,5 @@ std::unique_ptr<cudf::column> normalize_spaces(
   cudf::strings_column_view const& strings,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of group
 }  // namespace nvtext

--- a/cpp/include/nvtext/tokenize.hpp
+++ b/cpp/include/nvtext/tokenize.hpp
@@ -19,7 +19,18 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 
+/**
+ * @brief NVText APIs
+ * @defgroup nvtext_apis NVText APIs
+ */
 namespace nvtext {
+/**
+ * @ingroup nvtext_apis
+ * @addtogroup nvtext_tokenize Tokenize
+ * APIs to tokenize strings column.
+ * @{
+ */
+
 /**
  * @brief Returns a single column of strings by tokenizing the input strings
  * column using the provided characters as delimiters.
@@ -34,12 +45,12 @@ namespace nvtext {
  * to build the output column. That is, tokens found in input row[i] will be placed in
  * the output column directly before tokens found in input row[i+1].
  *
+ * @code{.pseudo}
  * Example:
- * ```
  * s = ["a", "b c", "d  e f "]
  * t = tokenize(s)
  * t is now ["a", "b", "c", "d", "e", "f"]
- * ```
+ * @endcode
  *
  * All null row entries are ignored and the output contains all valid rows.
  *
@@ -66,13 +77,13 @@ std::unique_ptr<cudf::column> tokenize(
  * to build the output column. That is, tokens found in input row[i] will be placed in
  * the output column directly before tokens found in input row[i+1].
  *
+ * @code{.pseudo}
  * Example:
- * ```
  * s = ["a", "b c", "d.e:f;"]
  * d = [".", ":", ";"]
  * t = tokenize(s,d)
  * t is now ["a", "b c", "d", "e", "f"]
- * ```
+ * @endcode
  *
  * All null row entries are ignored and the output contains all valid rows.
  *
@@ -96,12 +107,12 @@ std::unique_ptr<cudf::column> tokenize(
  * Also, any consecutive delimiters found in a string are ignored.
  * This means that only empty strings or null rows will result in a token count of 0.
  *
+ * @code{.pseudo}
  * Example:
- * ```
  * s = ["a", "b c", " ", "d e f"]
  * t = count_tokens(s)
  * t is now [1, 2, 0, 3]
- * ```
+ * @endcode
  *
  * All null row entries are ignored and the output contains all valid rows.
  * The number of tokens for a null element is set to 0 in the output column.
@@ -124,13 +135,13 @@ std::unique_ptr<cudf::column> count_tokens(
  * Also, any consecutive delimiters found in a string are ignored.
  * This means that only empty strings or null rows will result in a token count of 0.
  *
+ * @code{.pseudo}
  * Example:
- * ```
  * s = ["a", "b c", "d.e:f;"]
  * d = [".", ":", ";"]
  * t = count_tokens(s,d)
  * t is now [1, 1, 3]
- * ```
+ * @endcode
  *
  * All null row entries are ignored and the output contains all valid rows.
  * The number of tokens for a null element is set to 0 in the output column.
@@ -147,4 +158,5 @@ std::unique_ptr<cudf::column> count_tokens(
   cudf::strings_column_view const& delimiters,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/** @} */  // end of tokenize group
 }  // namespace nvtext

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -102,7 +102,9 @@ const int32_t* reprog::starts_data() const { return _startinst_ids.data(); }
 
 int32_t reprog::starts_count() const { return static_cast<int>(_startinst_ids.size()); }
 
-// Converts pattern into regex classes
+/**
+ * @brief Converts pattern into regex classes
+ */
 class regex_parser {
   reprog& m_prog;
   const char32_t* pattern;
@@ -458,6 +460,9 @@ class regex_parser {
   }
 
  public:
+  /**
+   * @brief Single parsed pattern element.
+   */
   struct Item {
     int t;
     union {

--- a/cpp/src/text/utilities/tokenize_ops.cuh
+++ b/cpp/src/text/utilities/tokenize_ops.cuh
@@ -36,6 +36,12 @@ using position_pair     = thrust::pair<cudf::size_type, cudf::size_type>;
  * current token's byte offsets within the string.
  */
 struct characters_tokenizer {
+  /**
+   * @brief Constructor for characters_tokenizer.
+   *
+   * @param d_str The string to tokenize.
+   * @param d_delimiter The (optional) delimiter to locate tokens.
+   */
   __device__ characters_tokenizer(cudf::string_view const& d_str,
                                   cudf::string_view const& d_delimiter = cudf::string_view{})
     : d_str{d_str},
@@ -106,6 +112,8 @@ struct characters_tokenizer {
   /**
    * @brief Returns the byte offsets for the current token
    * within this string.
+   *
+   * @return Byte positions of the current token.
    */
   __device__ position_pair token_byte_positions()
   {
@@ -113,12 +121,12 @@ struct characters_tokenizer {
   }
 
  private:
-  cudf::string_view const d_str;          // string to tokenize
-  cudf::string_view const d_delimiter;    // delimiter characters
-  bool spaces;                            // true if current position is delimiter
-  cudf::string_view::const_iterator itr;  // current position in d_str
-  cudf::size_type start_position;         // starting character position of token found
-  cudf::size_type end_position;           // ending character position (excl) of token found
+  cudf::string_view const d_str;          ///< string to tokenize
+  cudf::string_view const d_delimiter;    ///< delimiter characters
+  bool spaces;                            ///< true if current position is delimiter
+  cudf::string_view::const_iterator itr;  ///< current position in d_str
+  cudf::size_type start_position;         ///< starting character position of token found
+  cudf::size_type end_position;           ///< ending character position (excl) of token found
 };
 
 /**
@@ -129,10 +137,10 @@ struct characters_tokenizer {
  * positions into the d_tokens vector.
  */
 struct strings_tokenizer {
-  cudf::column_device_view const d_strings;  // strings to tokenize
-  cudf::string_view const d_delimiter;       // delimiter characters to tokenize around
-  cudf::size_type* d_offsets{};              // offsets into the d_tokens vector for each string
-  string_index_pair* d_tokens{};             // token positions in device memory
+  cudf::column_device_view const d_strings;  ///< strings to tokenize
+  cudf::string_view const d_delimiter;       ///< delimiter characters to tokenize around
+  cudf::size_type* d_offsets{};              ///< offsets into the d_tokens vector for each string
+  string_index_pair* d_tokens{};             ///< token positions in device memory
 
   /**
    * @brief Identifies the token positions within each string.
@@ -173,11 +181,11 @@ using delimiterator = cudf::column_device_view::const_iterator<cudf::string_view
  * each string of a given strings column.
  */
 struct multi_delimiter_strings_tokenizer {
-  cudf::column_device_view const d_strings;  // strings column to tokenize
-  delimiterator delimiters_begin;            // first delimiter
-  delimiterator delimiters_end;              // last delimiter
-  cudf::size_type* d_offsets{};              // offsets into the d_tokens output vector
-  string_index_pair* d_tokens{};             // token positions found for each string
+  cudf::column_device_view const d_strings;  ///< strings column to tokenize
+  delimiterator delimiters_begin;            ///< first delimiter
+  delimiterator delimiters_end;              ///< last delimiter
+  cudf::size_type* d_offsets{};              ///< offsets into the d_tokens output vector
+  string_index_pair* d_tokens{};             ///< token positions found for each string
 
   /**
    * @brief Identifies the token positions within each string.


### PR DESCRIPTION
Closes #4920 
The following pages apply across several strings column APIs and document behavior in nvstrings.
https://docs.rapids.ai/api/nvstrings/stable/regex.html
https://docs.rapids.ai/api/nvstrings/stable/unicode.html
Now that libnvstrings has been ported to libcudf, these documents need to be updated and added to the libcudf documentation.

This PR adds these to the doxygen output as "Related Pages".
Also, appropriate APIs will add links to these pages from their doxygen comments.
Further, the strings-specific APIs will be grouped to make it easier to find them.
