### PR TITLE
Fix Numba deprecation warnings with Numba 0.49+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ## Improvements
 
+- PR #5033 Fix Numba deprecations warnings with Numba 0.49+
 - PR #4950 Fix import errors with Numba 0.49+
 - PR #4825 Update the iloc exp in dataframe.py
 - PR #4450 Parquet writer: add parameter to retrieve the raw file metadata

--- a/python/cudf/cudf/_lib/aggregation.pyx
+++ b/python/cudf/cudf/_lib/aggregation.pyx
@@ -18,6 +18,13 @@ from cudf._lib.types cimport (
 )
 from cudf._lib.types import Interpolation
 
+try:
+    # Numba >= 0.49
+    from numba.np import numpy_support
+except ImportError:
+    # Numba <= 0.49
+    from numba import numpy_support
+
 cimport cudf._lib.cpp.types as libcudf_types
 cimport cudf._lib.cpp.aggregation as libcudf_aggregation
 
@@ -216,7 +223,7 @@ cdef class _AggregationFactory:
         cdef string cpp_str
 
         # Handling UDF type
-        nb_type = numba.numpy_support.from_dtype(kwargs['dtype'])
+        nb_type = numpy_support.from_dtype(kwargs['dtype'])
         type_signature = (nb_type[:],)
         compiled_op = cudautils.compile_udf(op, type_signature)
         output_np_dtype = np.dtype(compiled_op[1])

--- a/python/cudf/cudf/_lib/transform.pyx
+++ b/python/cudf/cudf/_lib/transform.pyx
@@ -1,7 +1,6 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
 import numpy as np
-import numba.numpy_support
 from cudf.utils import cudautils
 
 from libcpp.string cimport string
@@ -22,6 +21,14 @@ from cudf._lib.cpp.types cimport (
 )
 from cudf._lib.types import np_to_cudf_types
 from cudf._lib.cpp.column.column_view cimport column_view
+
+try:
+    # Numba >= 0.49
+    from numba.np import numpy_support
+except ImportError:
+    # Numba <= 0.49
+    from numba import numpy_support
+
 cimport cudf._lib.cpp.transform as libcudf_transform
 
 
@@ -67,7 +74,7 @@ def transform(Column input, op):
     cdef type_id c_tid
     cdef data_type c_dtype
 
-    nb_type = numba.numpy_support.from_dtype(input.dtype)
+    nb_type = numpy_support.from_dtype(input.dtype)
     nb_signature = (nb_type,)
     compiled_op = cudautils.compile_udf(op, nb_signature)
     c_str = compiled_op[0].encode('UTF-8')

--- a/python/cudf/cudf/utils/applyutils.py
+++ b/python/cudf/cudf/utils/applyutils.py
@@ -5,6 +5,12 @@ import functools
 import cupy
 from numba import cuda
 
+import cudf._lib as libcudf
+from cudf.core.column import column
+from cudf.core.series import Series
+from cudf.utils import utils
+from cudf.utils.docutils import docfmt_partial
+
 try:
     # Numba >= 0.49
     from numba.core.utils import pysignature
@@ -12,11 +18,6 @@ except ImportError:
     # Numba <= 0.49
     from numba.utils import pysignature
 
-import cudf._lib as libcudf
-from cudf.core.column import column
-from cudf.core.series import Series
-from cudf.utils import utils
-from cudf.utils.docutils import docfmt_partial
 
 _doc_applyparams = """
 df : DataFrame

--- a/python/cudf/cudf/utils/applyutils.py
+++ b/python/cudf/cudf/utils/applyutils.py
@@ -4,7 +4,13 @@ import functools
 
 import cupy
 from numba import cuda
-from numba.utils import pysignature
+
+try:
+    # Numba >= 0.49
+    from numba.core.utils import pysignature
+except ImportError:
+    # Numba <= 0.49
+    from numba.utils import pysignature
 
 import cudf._lib as libcudf
 from cudf.core.column import column

--- a/python/cudf/cudf/utils/cudautils.py
+++ b/python/cudf/cudf/utils/cudautils.py
@@ -6,13 +6,6 @@ import cupy
 import numpy as np
 from numba import cuda
 
-try:
-    # Numba >= 0.49
-    from numba.np import numpy_support
-except ImportError:
-    # Numba <= 0.49
-    from numba import numpy_support
-
 import rmm
 
 from cudf.utils.utils import (
@@ -22,6 +15,15 @@ from cudf.utils.utils import (
     mask_get,
     rint,
 )
+
+try:
+    # Numba >= 0.49
+    from numba.np import numpy_support
+except ImportError:
+    # Numba <= 0.49
+    from numba import numpy_support
+
+
 
 # GPU array type casting
 

--- a/python/cudf/cudf/utils/cudautils.py
+++ b/python/cudf/cudf/utils/cudautils.py
@@ -24,7 +24,6 @@ except ImportError:
     from numba import numpy_support
 
 
-
 # GPU array type casting
 
 

--- a/python/cudf/cudf/utils/cudautils.py
+++ b/python/cudf/cudf/utils/cudautils.py
@@ -4,7 +4,14 @@ from functools import lru_cache
 
 import cupy
 import numpy as np
-from numba import cuda, numpy_support
+from numba import cuda
+
+try:
+    # Numba >= 0.49
+    from numba.np import numpy_support
+except ImportError:
+    # Numba <= 0.49
+    from numba import numpy_support
 
 import rmm
 


### PR DESCRIPTION
Many "internal" parts of Numba were moved with the release of 0.49. The old module locations can still be imported with a shim for the 0.49 release, but its use results in the emission of NumbaDeprecationWarning messages. The shims will be removed in Numba 0.50.

This PR avoids the deprecation warnings and enables import from the new module paths where available, so that cuDF can be used with Numba 0.48, 0.49, or (a future release of) 0.50.

Once Numba 0.49 or above is a cuDF requirement, the `try .. except ImportError` blocks can be replaced with imports exclusively from the new locations.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
