### PR TITLE
[REVIEW] Fix invalid java test [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@
 - PR #5021 Fix bug with unsigned right shift and scalar lhs
 - PR #5020 Fix `conda install pre_commit` not found when setting up dev environment
 - PR #5030 Fix Groupby sort=True
+- PR #5041 Fix invalid java test for shift right unsigned
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/java/src/test/java/ai/rapids/cudf/BinaryOpTest.java
+++ b/java/src/test/java/ai/rapids/cudf/BinaryOpTest.java
@@ -1072,16 +1072,6 @@ public class BinaryOpTest extends CudfTestBase {
                (b, l, r, i) -> b.append(((long)(l.getInt(i) >>> r))))) {
         assertColumnsAreEqual(expected, answer, "int32 >>> scalar = int64");
       }
-
-      try (Scalar s = Scalar.fromShort((short) 0x0000FFFF);
-           ColumnVector answer = s.shiftRightUnsigned(shiftBy, DType.INT16);
-           ColumnVector expected = forEachS(DType.INT16, (short) 0x0000FFFF,  shiftBy,
-               (b, l, r, i) -> {
-                 int shifted = l >>> r.getInt(i);
-                 b.append((short) shifted);
-               })) {
-        assertColumnsAreEqual(expected, answer, "scalar short >>> int32 = int16");
-      }
     }
   }
 


### PR DESCRIPTION
A recent change fixed some bugs in shift right unsigned. The java test covering that operator was faulty because it relied on java itself to produce the result for a short, which java does not support an unsigned right shift on a short.  It casts it to an int before doing the cast.  Because of that the test itself was invalid and was inadvertently relying on the broken behavior to work.

So I just removed that part of the test
