### PR TITLE
[REVIEW] Remove invalid examples page from libcudf doxygen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,7 @@
 - PR #5020 Fix `conda install pre_commit` not found when setting up dev environment
 - PR #5030 Fix Groupby sort=True
 - PR #5041 Fix invalid java test for shift right unsigned
+- PR #5043 Remove invalid examples page libcudf doxygen
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/cpp/include/cudf/copying.hpp
+++ b/cpp/include/cudf/copying.hpp
@@ -91,7 +91,7 @@ std::unique_ptr<table> gather(
  * `scatter_map` and throw an error if any of its values are out of bounds.
  * @param mr The resource to use for all allocations
  * @return Result of scattering values from source to target
- *---------------------------------------------------------------------------**/
+ */
 std::unique_ptr<table> scatter(
   table_view const& source,
   column_view const& scatter_map,
@@ -129,7 +129,7 @@ std::unique_ptr<table> scatter(
  * `scatter_map` and throw an error if any of its values are out of bounds.
  * @param mr The resource to use for all allocations
  * @return Result of scattering values from source to target
- *---------------------------------------------------------------------------**/
+ */
 std::unique_ptr<table> scatter(
   std::vector<std::unique_ptr<scalar>> const& source,
   column_view const& indices,
@@ -137,17 +137,17 @@ std::unique_ptr<table> scatter(
   bool check_bounds                   = false,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
-/** ---------------------------------------------------------------------------*
+/**
  * @brief Indicates when to allocate a mask, based on an existing mask.
- * ---------------------------------------------------------------------------**/
+ */
 enum class mask_allocation_policy {
   NEVER,   ///< Do not allocate a null mask, regardless of input
   RETAIN,  ///< Allocate a null mask if the input contains one
   ALWAYS   ///< Allocate a null mask, regardless of input
 };
 
-/*
- * Initializes and returns an empty column of the same type as the `input`.
+/**
+ * @brief Initializes and returns an empty column of the same type as the `input`.
  *
  * @param[in] input Immutable view of input column to emulate
  * @return std::unique_ptr<column> An empty column of same type as `input`
@@ -283,10 +283,11 @@ std::unique_ptr<column> copy_range(
  * @note It is the caller's responsibility to ensure that the returned views
  * do not outlive the viewed device memory.
  *
- * @example:
+ * @code{.pseudo}
  * input:   {10, 12, 14, 16, 18, 20, 22, 24, 26, 28}
  * indices: {1, 3, 5, 9, 2, 4, 8, 8}
  * output:  {{12, 14}, {20, 22, 24, 26}, {14, 16}, {}}
+ * @endcode
  *
  * @throws `cudf::logic_error` if `indices` size is not even.
  * @throws `cudf::logic_error` When the values in the pair are strictly decreasing.
@@ -312,12 +313,13 @@ std::vector<column_view> slice(column_view const& input, std::vector<size_type> 
  * @note It is the caller's responsibility to ensure that the returned views
  * do not outlive the viewed device memory.
  *
- * @example:
+ * @code{.pseudo}
  * input:   [{10, 12, 14, 16, 18, 20, 22, 24, 26, 28},
  *           {50, 52, 54, 56, 58, 60, 62, 64, 66, 68}]
  * indices: {1, 3, 5, 9, 2, 4, 8, 8}
  * output:  [{{12, 14}, {20, 22, 24, 26}, {14, 16}, {}},
  *           {{52, 54}, {60, 22, 24, 26}, {14, 16}, {}}]
+ * @endcode
  *
  * @throws `cudf::logic_error` if `indices` size is not even.
  * @throws `cudf::logic_error` When the values in the pair are strictly decreasing.
@@ -345,10 +347,12 @@ std::vector<table_view> slice(table_view const& input, std::vector<size_type> co
  * @note It is the caller's responsibility to ensure that the returned views
  * do not outlive the viewed device memory.
  *
+ * @code{.pseudo}
  * Example:
  * input:   {10, 12, 14, 16, 18, 20, 22, 24, 26, 28}
  * splits:  {2, 5, 9}
  * output:  {{10, 12}, {14, 16, 18}, {20, 22, 24, 26}, {28}}
+ * @endcode
  *
  * @throws `cudf::logic_error` if `splits` has end index > size of `input`.
  * @throws `cudf::logic_error` When the value in `splits` is not in the range [0, input.size()).
@@ -375,13 +379,14 @@ std::vector<column_view> split(column_view const& input, std::vector<size_type> 
  * @note It is the caller's responsibility to ensure that the returned views
  * do not outlive the viewed device memory.
  *
+ * @code{.pseudo}
  * Example:
  * input:   [{10, 12, 14, 16, 18, 20, 22, 24, 26, 28},
  *           {50, 52, 54, 56, 58, 60, 62, 64, 66, 68}]
  * splits:  {2, 5, 9}
  * output:  [{{10, 12}, {14, 16, 18}, {20, 22, 24, 26}, {28}},
  *           {{50, 52}, {54, 56, 58}, {60, 62, 64, 66}, {68}}]
- *
+ * @endcode
  *
  * @throws `cudf::logic_error` if `splits` has end index > size of `input`.
  * @throws `cudf::logic_error` When the value in `splits` is not in the range [0, input.size()).
@@ -429,12 +434,14 @@ struct contiguous_split_result {
  * do not outlive the viewed device memory contained in the `all_data` field of the
  * returned contiguous_split_result.
  *
+ * @code{.pseudo}
  * Example:
  * input:   [{10, 12, 14, 16, 18, 20, 22, 24, 26, 28},
  *           {50, 52, 54, 56, 58, 60, 62, 64, 66, 68}]
  * splits:  {2, 5, 9}
  * output:  [{{10, 12}, {14, 16, 18}, {20, 22, 24, 26}, {28}},
  *           {{50, 52}, {54, 56, 58}, {60, 62, 64, 66}, {68}}]
+ * @endcode
  *
  *
  * @throws `cudf::logic_error` if `splits` has end index > size of `input`.
@@ -458,7 +465,7 @@ std::vector<contiguous_split_result> contiguous_split(
  *          @p rhs based on the value of the corresponding element in @p boolean_mask
  *
  * Selects each element i in the output column from either @p rhs or @p lhs using the following
- * rule: output[i] = (boolean_mask.valid(i) and boolean_mask[i]) ? lhs[i] : rhs[i]
+ * rule: `output[i] = (boolean_mask.valid(i) and boolean_mask[i]) ? lhs[i] : rhs[i]`
  *
  * @throws cudf::logic_error if lhs and rhs are not of the same type
  * @throws cudf::logic_error if lhs and rhs are not of the same length
@@ -485,6 +492,7 @@ std::unique_ptr<column> copy_if_else(
  * Some elements in the output may be indeterminable from the input. For those
  * elements, the value will be determined by `fill_values`.
  *
+ * @code{.pseudo}
  * Examples
  * -------------------------------------------------
  * input       = [0, 1, 2, 3, 4]
@@ -496,6 +504,7 @@ std::unique_ptr<column> copy_if_else(
  * offset      = -2
  * fill_values = 7
  * return      = [3, 2, 1, 7, 7]
+ * @endcode
  *
  * @note if the input is nullable, the output will be nullable.
  * @note if the fill value is null, the output will be nullable.
@@ -513,12 +522,12 @@ std::unique_ptr<column> shift(column_view const& input,
                               rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
                               cudaStream_t stream                 = 0);
 
-/*
+/**
  * @brief   Returns a new column, where each element is selected from either @p lhs or
  *          @p rhs based on the value of the corresponding element in @p boolean_mask
  *
  * Selects each element i in the output column from either @p rhs or @p lhs using the following
- * rule: output[i] = (boolean_mask.valid(i) and boolean_mask[i]) ? lhs : rhs[i]
+ * rule: `output[i] = (boolean_mask.valid(i) and boolean_mask[i]) ? lhs : rhs[i]`
  *
  * @throws cudf::logic_error if lhs and rhs are not of the same type
  * @throws cudf::logic_error if boolean mask is not of type bool
@@ -542,7 +551,7 @@ std::unique_ptr<column> copy_if_else(
  *          @p rhs based on the value of the corresponding element in @p boolean_mask
  *
  * Selects each element i in the output column from either @p rhs or @p lhs using the following
- * rule: output[i] = (boolean_mask.valid(i) and boolean_mask[i]) ? lhs[i] : rhs
+ * rule: `output[i] = (boolean_mask.valid(i) and boolean_mask[i]) ? lhs[i] : rhs`
  *
  * @throws cudf::logic_error if lhs and rhs are not of the same type
  * @throws cudf::logic_error if boolean mask is not of type bool
@@ -566,7 +575,7 @@ std::unique_ptr<column> copy_if_else(
  *          @p rhs based on the value of the corresponding element in @p boolean_mask
  *
  * Selects each element i in the output column from either @p rhs or @p lhs using the following
- * rule: output[i] = (boolean_mask.valid(i) and boolean_mask[i]) ? lhs : rhs
+ * rule: `output[i] = (boolean_mask.valid(i) and boolean_mask[i]) ? lhs : rhs`
  *
  * @throws cudf::logic_error if boolean mask is not of type bool
  * @param[in] left-hand scalar
@@ -595,12 +604,14 @@ std::unique_ptr<column> copy_if_else(
  * If boolean mask is `true`, corresponding value in target is updated with
  * value from corresponding `input` column, else it is left untouched.
  *
+ * @code{.pseudo}
  * Example:
  * input: {{1, 5, 6, 8, 9}}
  * boolean_mask: {true, false, false, false, true, true, false, true, true, false}
  * target:       {{   2,     2,     3,     4,    4,     7,    7,    7,    8,    10}}
  *
  * output:       {{   1,     2,     3,     4,    5,     6,    7,    8,    9,    10}}
+ * @endcode
  *
  * @throw  cudf::logic_error if input.num_columns() != target.num_columns()
  * @throws cudf::logic_error if any `i`th input_column type != `i`th target_column type
@@ -629,12 +640,14 @@ std::unique_ptr<table> boolean_mask_scatter(
  * table at the location of the `i`th true value in `boolean_mask`.
  * All other rows in the output will equal the same row in `target`.
  *
+ * @code{.pseudo}
  * Example:
  * input: {11}
  * boolean_mask: {true, false, false, false, true, true, false, true, true, false}
  * target:       {{   2,     2,     3,     4,    4,     7,    7,    7,    8,    10}}
  *
  * output:       {{   11,    2,     3,     4,   11,    11,    7,   11,   11,    10}}
+ * @endcode
  *
  * @throw  cudf::logic_error if input.size() != target.num_columns()
  * @throws cudf::logic_error if any `i`th input_scalar type != `i`th target_column type

--- a/cpp/include/cudf/detail/search.hpp
+++ b/cpp/include/cudf/detail/search.hpp
@@ -75,6 +75,7 @@ std::unique_ptr<column> lower_bound(
  * For each row v in @p values, find the last index in @p t where
  *  inserting the row will maintain the sort order of @p t
  *
+ * @code{.pseudo}
  * Example:
  *
  *  Single Column:
@@ -84,14 +85,16 @@ std::unique_ptr<column> lower_bound(
  *   result = {  3 }
  *
  *  Multi Column:
- *    idx        0    1    2    3    4
+ *      idx        0    1    2    3    4
  *   t      = {{  10,  20,  20,  20,  20 },
  *             { 5.0,  .5,  .5,  .7,  .7 },
  *             {  90,  77,  78,  61,  61 }}
  *   values = {{ 20 },
  *             { .7 },
  *             { 61 }}
- *   result =  {  5  *   *
+ *   result =  {  5  }
+ * @endcode
+ *
  * @param column          Table to search
  * @param values          Find insert locations for these values
  * @param column_order    Vector of column sort order
@@ -115,14 +118,14 @@ std::unique_ptr<column> upper_bound(
  * @throws cudf::logic_error
  * If `col.type() != values.type()`
  *
- * @example:
- *
+ * @code{.pseudo}
  *  Single Column:
  *      idx      0   1   2   3   4
  *      col = { 10, 20, 20, 30, 50 }
  *  Scalar:
  *   value = { 20 }
  *   result = true
+ * @endcode
  *
  * @param col      A column object
  * @param value    A scalar value to search for in `col`
@@ -145,12 +148,12 @@ bool contains(column_view const& col,
  * @throws cudf::logic_error
  * If `haystack.type() != needles.type()`
  *
- * @example:
- *
+ * @code{.pseudo}
  *   haystack = { 10, 20, 30, 40, 50 }
  *   needles  = { 20, 40, 60, 80 }
  *
  *   result = { false, true, false, true, false }
+ * @endcode
  *
  * @param haystack  A column object
  * @param needles   A column of values to search for in `col`

--- a/cpp/include/cudf/detail/stream_compaction.hpp
+++ b/cpp/include/cudf/detail/stream_compaction.hpp
@@ -38,7 +38,8 @@ namespace detail {
  *
  * Any non-nullable column in the input is treated as all non-null.
  *
- * @example input   {col1: {1, 2,    3,    null},
+ * @code{.pseudo}
+ *          input   {col1: {1, 2,    3,    null},
  *                   col2: {4, 5,    null, null},
  *                   col3: {7, null, null, null}}
  *          keys = {0, 1, 2} // All columns
@@ -47,6 +48,7 @@ namespace detail {
  *          output {col1: {1, 2}
  *                  col2: {4, 5}
  *                  col3: {7, null}}
+ * @endcode
  *
  * @note if @p input.num_rows() is zero, or @p keys is empty or has no nulls,
  * there is no error, and an empty `table` is returned

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -27,24 +27,26 @@ namespace experimental {
 
 /**
  * @brief  Performs an inner join on the specified columns of two
- * tables (left, right)
+ * tables (`left`, `right`)
  *
  * Inner Join returns rows from both tables as long as the values
  * in the columns being joined on match.
  *
- * @example Left a: {0, 1, 2}
+ * @code{.pseudo}
+ *          Left a: {0, 1, 2}
  *          Right b: {1, 2, 3}, a: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {1}
  *          columns_in_common: { {0, 1} }
  * Result: { a: {1, 2}, b: {1, 2} }
  *
- * @example Left a: {0, 1, 2}
+ *          Left a: {0, 1, 2}
  *          Right b: {1, 2, 3}, c: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {0}
  *          columns_in_common: { }
  * Result: { a: {1, 2}, b: {1, 2}, c: {1, 2} }
+ * @endcode
  *
  * @throws cudf::logic_error if `columns_in_common` contains a pair of indices
  * (L, R) if L does not exist in `left_on` or R does not exist in `right_on`.
@@ -88,26 +90,28 @@ std::unique_ptr<cudf::experimental::table> inner_join(
 
 /**
  * @brief  Performs a left join (also known as left outer join) on the
- * specified columns of two tables (left, right)
+ * specified columns of two tables (`left`, `right`)
  *
  * Left Join returns all the rows from the left table and those rows from the
  * right table that match on the joined columns.
  * For rows from the right table that do not have a match, the corresponding
  * values in the left columns will be null.
  *
- * @example Left a: {0, 1, 2}
+ * @code{.pseudo}
+ *          Left a: {0, 1, 2}
  *          Right b: {1, 2, 3}, a: {1 ,2 ,5}
  *          left_on: {0}
  *          right_on: {1}
  *          columns_in_common: { {0, 1} }
  * Result: { a: {0, 1, 2}, b: {NULL, 1, 2} }
  *
- * @example Left a: {0, 1, 2}
+ *          Left a: {0, 1, 2}
  *          Right b: {1, 2, 3}, c: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {0}
  *          columns_in_common: { }
  * Result: { a: {0, 1, 2}, b: {NULL, 1, 2}, c: {NULL, 1, 2} }
+ * @endcode
  *
  * @throws cudf::logic_error if `columns_in_common` contains a pair of indices
  * (L, R) if L does not exist in `left_on` or R does not exist in `right_on`.
@@ -151,26 +155,28 @@ std::unique_ptr<cudf::experimental::table> left_join(
 
 /**
  * @brief  Performs a full join (also known as full outer join) on the
- * specified columns of two tables (left, right)
+ * specified columns of two tables (`left`, `right`)
  *
  * Full Join returns the rows that would be returned by a left join and those
  * rows from the right table that do not have a match.
  * For rows from the right table that do not have a match, the corresponding
  * values in the left columns will be null.
  *
- * @example Left a: {0, 1, 2}
+ * @code{.pseudo}
+ *          Left a: {0, 1, 2}
  *          Right b: {1, 2, 3}, c: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {1}
  *          columns_in_common: { {0, 1} }
  * Result: { a: {0, 1, 2, NULL}, b: {NULL, 1, 2, 3}, c: {NULL, 1, 2, 5} }
  *
- * @example Left a: {0, 1, 2}
+ *          Left a: {0, 1, 2}
  *          Right b: {1, 2, 3}, c: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {0}
  *          columns_in_common: { }
  * Result: { a: {0, 1, 2, NULL}, b: {NULL, 1, 2, 3}, c: {NULL, 1, 2, 5} }
+ * @endcode
  *
  * @throws cudf::logic_error if `columns_in_common` contains a pair of indices
  * (L, R) if L does not exist in `left_on` or R does not exist in `right_on`.
@@ -213,24 +219,26 @@ std::unique_ptr<cudf::experimental::table> full_join(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 /**
  * @brief  Performs a left semi join on the specified columns of two
- * tables (left, right)
+ * tables (`left`, `right`)
  *
  * A left semi join only returns data from the left table, and only
  * returns rows that exist in the right table.
  *
- * @example TableA a: {0, 1, 2}
+ * @code{.pseudo}
+ *          TableA a: {0, 1, 2}
  *          TableB b: {1, 2, 3}, a: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {1}
  *          return_columns: { 0 }
  * Result: { a: {1, 2} }
  *
- * @example TableA a: {0, 1, 2}, c: {1, 2, 5}
+ *          TableA a: {0, 1, 2}, c: {1, 2, 5}
  *          TableB b: {1, 2, 3}
  *          left_on: {0}
  *          right_on: {0}
  *          return_columns: { 1 }
  * Result: { c: {1, 2} }
+ * @endcode
  *
  * @throws cudf::logic_error if number of columns in either `left` or `right` table is 0
  * @throws cudf::logic_error if number of returned columns is 0
@@ -264,24 +272,26 @@ std::unique_ptr<cudf::experimental::table> left_semi_join(
 
 /**
  * @brief  Performs a left anti join on the specified columns of two
- * tables (left, right)
+ * tables (`left`, `right`)
  *
  * A left anti join only returns data from the left table, and only
  * returns rows that do not exist in the right table.
  *
- * @example TableA a: {0, 1, 2}
+ * @code{.pseudo}
+ *          TableA a: {0, 1, 2}
  *          TableB b: {1, 2, 3}, a: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {1}
  *          return_columns: { 0 }
  * Result: { a: {0} }
  *
- * @example TableA a: {0, 1, 2}, c: {1, 2, 5}
+ *          TableA a: {0, 1, 2}, c: {1, 2, 5}
  *          TableB b: {1, 2, 3}
  *          left_on: {0}
  *          right_on: {0}
  *          return_columns: { 1 }
  * Result: { c: {1} }
+ * @endcode
  *
  * @throws cudf::logic_error if number of columns in either `left` or `right` table is 0
  * @throws cudf::logic_error if number of returned columns is 0

--- a/cpp/include/cudf/legacy/join.hpp
+++ b/cpp/include/cudf/legacy/join.hpp
@@ -23,14 +23,14 @@ namespace cudf {
  * @brief  Performs an inner join on the specified columns of two
  * tables (left, right)
  *
- * @example TableA a: {0, 1, 2}
+ * Example TableA a: {0, 1, 2}
  *          TableB b: {1, 2, 3}, a: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {1}
  *          columns_in_common: { {0, 1} }
  * Result: { a: {1, 2}, b: {1, 2} }
  *
- * @example TableA a: {0, 1, 2}
+ * Example TableA a: {0, 1, 2}
  *          TableB b: {1, 2, 3}, c: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {0}
@@ -76,14 +76,14 @@ cudf::table inner_join(
  * @brief  Performs a left join (also known as left outer join) on the
  * specified columns of two tables (left, right)
  *
- * @example TableA a: {0, 1, 2}
+ * Example TableA a: {0, 1, 2}
  *          TableB b: {1, 2, 3}, a: {1 ,2 ,5}
  *          left_on: {0}
  *          right_on: {1}
  *          columns_in_common: { {0, 1} }
  * Result: { a: {0, 1, 2}, b: {NULL, 1, 2} }
  *
- * @example TableA a: {0, 1, 2}
+ * Example TableA a: {0, 1, 2}
  *          TableB b: {1, 2, 3}, c: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {0}
@@ -131,14 +131,14 @@ cudf::table left_join(
  * @brief  Performs a full join (also known as full outer join) on the
  * specified columns of two tables (left, right)
  *
- * @example TableA a: {0, 1, 2}
+ * Example TableA a: {0, 1, 2}
  *          TableB b: {1, 2, 3}, c: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {1}
  *          columns_in_common: { {0, 1} }
  * Result: { a: {0, 1, 2, NULL}, b: {NULL, 1, 2, 3}, c: {NULL, 1, 2, 5} }
  *
- * @example TableA a: {0, 1, 2}
+ * Example TableA a: {0, 1, 2}
  *          TableB b: {1, 2, 3}, c: {1, 2, 5}
  *          left_on: {0}
  *          right_on: {0}

--- a/cpp/include/cudf/legacy/search.hpp
+++ b/cpp/include/cudf/legacy/search.hpp
@@ -107,7 +107,7 @@ gdf_column upper_bound(table const& t,
  * @throws cudf::logic_error
  * If dtype of `column` and `value` doesn't match
  *
- * @example:
+ * Example:
  *
  *  Single Column:
  *      idx      0   1   2   3   4

--- a/cpp/include/cudf/search.hpp
+++ b/cpp/include/cudf/search.hpp
@@ -32,6 +32,7 @@ namespace experimental {
  * For each row v in @p values, find the first index in @p t where
  *  inserting the row will maintain the sort order of @p t
  *
+ * @code{.pseudo}
  * Example:
  *
  *  Single column:
@@ -49,6 +50,7 @@ namespace experimental {
  *             { .7 },
  *             { 61 }}
  *   result =  {  3 }
+ * @endcode
  *
  * @param t               Table to search
  * @param values          Find insert locations for these values
@@ -73,6 +75,7 @@ std::unique_ptr<column> lower_bound(
  * For each row v in @p values, find the last index in @p t where
  *  inserting the row will maintain the sort order of @p t
  *
+ * @code{.pseudo}
  * Example:
  *
  *  Single Column:
@@ -82,14 +85,16 @@ std::unique_ptr<column> lower_bound(
  *   result = {  3 }
  *
  *  Multi Column:
- *    idx        0    1    2    3    4
+ *      idx        0    1    2    3    4
  *   t      = {{  10,  20,  20,  20,  20 },
  *             { 5.0,  .5,  .5,  .7,  .7 },
  *             {  90,  77,  78,  61,  61 }}
  *   values = {{ 20 },
  *             { .7 },
  *             { 61 }}
- *   result =  {  5  *   *
+ *   result =  {  5 }
+ * @endcode
+ *
  * @param column          Table to search
  * @param values          Find insert locations for these values
  * @param column_order    Vector of column sort order
@@ -112,14 +117,14 @@ std::unique_ptr<column> upper_bound(
  * @throws cudf::logic_error
  * If `col.type() != values.type()`
  *
- * @example:
- *
+ * @code{.pseudo}
  *  Single Column:
  *      idx      0   1   2   3   4
  *      col = { 10, 20, 20, 30, 50 }
  *  Scalar:
  *   value = { 20 }
  *   result = true
+ * @endcode
  *
  * @param col      A column object
  * @param value    A scalar value to search for in `col`
@@ -141,12 +146,12 @@ bool contains(column_view const& col,
  * @throws cudf::logic_error
  * If `haystack.type() != needles.type()`
  *
- * @example:
- *
+ * @code{.pseudo}
  *   haystack = { 10, 20, 30, 40, 50 }
  *   needles  = { 20, 40, 60, 80 }
  *
  *   result = { false, true, false, true, false }
+ * @endcode
  *
  * @param haystack  A column object
  * @param needles   A column of values to search for in `col`

--- a/cpp/include/cudf/sorting.hpp
+++ b/cpp/include/cudf/sorting.hpp
@@ -135,18 +135,20 @@ std::unique_ptr<table> sort_by_key(
   std::vector<null_order> const& null_precedence = {},
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_default_resource());
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Computes the ranks of input column in sorted order.
  * Rank indicate the position of each element in the sorted column and rank
  * value starts from 1.
  *
- * @example input = { 3, 4, 5, 4, 1, 2}
+ * @code{.pseudo}
+ * input = { 3, 4, 5, 4, 1, 2}
  * Result for different rank_method are
  * FIRST    = {3, 4, 6, 5, 1, 2}
  * AVERAGE  = {3, 4.5, 6, 4.5, 1, 2}
  * MIN      = {3, 4, 6, 4, 1, 2}
  * MAX      = {3, 5, 6, 5, 1, 2}
  * DENSE    = {3, 4, 5, 4, 1, 2}
+ * @endcode
  *
  * @param input The column to rank
  * @param method The ranking method used for tie breaking (same values).
@@ -161,7 +163,7 @@ std::unique_ptr<table> sort_by_key(
  * element of the column of `input`. The output column type will be `size_type`
  * column by default or else `double` when `method=rank_method::AVERAGE` or
  *`percentage=True`
- *---------------------------------------------------------------------------**/
+ */
 std::unique_ptr<column> rank(column_view const& input,
                              rank_method method,
                              order column_order,

--- a/cpp/include/cudf/stream_compaction.hpp
+++ b/cpp/include/cudf/stream_compaction.hpp
@@ -34,7 +34,8 @@ namespace experimental {
  *
  * Any non-nullable column in the input is treated as all non-null.
  *
- * @example input   {col1: {1, 2,    3,    null},
+ * @code{.pseudo}
+ *          input   {col1: {1, 2,    3,    null},
  *                   col2: {4, 5,    null, null},
  *                   col3: {7, null, null, null}}
  *          keys = {0, 1, 2} // All columns
@@ -43,6 +44,7 @@ namespace experimental {
  *          output {col1: {1, 2}
  *                  col2: {4, 5}
  *                  col3: {7, null}}
+ * @endcode
  *
  * @note if @p input.num_rows() is zero, or @p keys is empty or has no nulls,
  * there is no error, and an empty `table` is returned
@@ -64,7 +66,8 @@ std::unique_ptr<experimental::table> drop_nulls(
 /**
  * @brief Filters a table to remove null elements.
  *
- * @example input   {col1: {1, 2,    3,    null},
+ * @code{.pseudo}
+ *          input   {col1: {1, 2,    3,    null},
  *                   col2: {4, 5,    null, null},
  *                   col3: {7, null, null, null}}
  *          keys = {0, 1, 2} //All columns
@@ -72,6 +75,7 @@ std::unique_ptr<experimental::table> drop_nulls(
  *          output {col1: {1}
  *                  col2: {4}
  *                  col3: {7}}
+ * @endcode
  *
  * @overload drop_nulls
  *


### PR DESCRIPTION
This is essentially removing the `@example` specifier or replacing it with a `@code` block.
The invalid examples page can be seen here:
https://docs.rapids.ai/api/libcudf/nightly/examples.html
https://docs.rapids.ai/api/libcudf/stable/examples.html

This is doxygen struggling to work with an invalid `@example` usage in various source files.
This PR simply removes them or replaces them as appropriate. The page/tab will disappear.

There are no code changes in the PR. This is only fixing comments.