### PR TITLE
Use lot less memory in `label_encoding()`

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -846,6 +846,17 @@ class ColumnBase(Column):
             ordered = False
 
         sr = cudf.Series(self)
+
+        # Re-label self w.r.t. the provided categories
+        if is_categorical_dtype(dtype) and hasattr(dtype, "categories"):
+            labels = sr.label_encoding(cats=dtype.categories)
+            return build_categorical_column(
+                categories=dtype.categories,
+                codes=labels._column,
+                mask=self.mask,
+                ordered=ordered,
+            ).astype(dtype)
+
         labels, cats = sr.factorize()
 
         # columns include null index in factorization; remove:

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -848,7 +848,7 @@ class ColumnBase(Column):
         sr = cudf.Series(self)
 
         # Re-label self w.r.t. the provided categories
-        if is_categorical_dtype(dtype) and hasattr(dtype, "categories"):
+        if isinstance(dtype, (cudf.CategoricalDtype, pd.CategoricalDtype)):
             labels = sr.label_encoding(cats=dtype.categories)
             return build_categorical_column(
                 categories=dtype.categories,

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1639,7 +1639,7 @@ class Series(Frame):
         values : sequence of input values
         dtype: numpy.dtype; optional
                Specifies the output dtype.  If `None` is given, the
-               smallest possible integer dtype (starting with np.int32)
+               smallest possible integer dtype (starting with np.int8)
                is used.
         na_sentinel : number
             Value to indicate missing category.
@@ -1650,7 +1650,7 @@ class Series(Frame):
         from cudf import DataFrame
 
         if dtype is None:
-            dtype = min_scalar_type(len(cats), 32)
+            dtype = min_scalar_type(len(cats), 8)
 
         cats = Series(cats).astype(self.dtype)
         order = Series(cupy.arange(len(self)))

--- a/python/cudf/cudf/tests/test_label_encode.py
+++ b/python/cudf/cudf/tests/test_label_encode.py
@@ -118,7 +118,8 @@ def test_label_encode_float_output():
 )
 def test_label_encode_dtype(ncats, cat_dtype):
     s = Series([str(i % ncats) for i in range(ncats + 1)])
-    encoded_col = s.label_encoding(cats=s.unique().astype(np.int64))
+    cats = s.unique().astype(s.dtype)
+    encoded_col = s.label_encoding(cats=cats)
     np.testing.assert_equal(encoded_col.dtype, cat_dtype)
 
 

--- a/python/cudf/cudf/tests/test_label_encode.py
+++ b/python/cudf/cudf/tests/test_label_encode.py
@@ -6,7 +6,7 @@ from itertools import product
 import numpy as np
 import pytest
 
-from cudf.core import DataFrame
+from cudf.core import DataFrame, Series
 
 
 def _random_float(nelem, dtype):
@@ -117,7 +117,7 @@ def test_label_encode_float_output():
     "ncats,cat_dtype", [(10, np.int8), (127, np.int8), (128, np.int16)]
 )
 def test_label_encode_dtype(ncats, cat_dtype):
-    s = cudf.Series([ str(i%ncats) for i in range(ncats + 1)])
+    s = Series([ str(i%ncats) for i in range(ncats + 1)])
     encoded_col = s.label_encoding(cats=s.unique().astype(np.int64))
     np.testing.assert_equal(encoded_col.dtype, cat_dtype)
 

--- a/python/cudf/cudf/tests/test_label_encode.py
+++ b/python/cudf/cudf/tests/test_label_encode.py
@@ -113,11 +113,11 @@ def test_label_encode_float_output():
     np.testing.assert_equal(got, handcoded)
 
 
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "ncats,cat_dtype", [(10, np.int8), (127, np.int8), (128, np.int16)]
 )
 def test_label_encode_dtype(ncats, cat_dtype):
-    s = Series([ str(i%ncats) for i in range(ncats + 1)])
+    s = Series([str(i % ncats) for i in range(ncats + 1)])
     encoded_col = s.label_encoding(cats=s.unique().astype(np.int64))
     np.testing.assert_equal(encoded_col.dtype, cat_dtype)
 

--- a/python/cudf/cudf/tests/test_label_encode.py
+++ b/python/cudf/cudf/tests/test_label_encode.py
@@ -113,6 +113,15 @@ def test_label_encode_float_output():
     np.testing.assert_equal(got, handcoded)
 
 
+@pytest.mark.parameterize(
+    "ncats,cat_dtype", [(10, np.int8), (127, np.int8), (128, np.int16)]
+)
+def test_label_encode_dtype(ncats, cat_dtype):
+    s = cudf.Series([ str(i%ncats) for i in range(ncats + 1)])
+    encoded_col = s.label_encoding(cats=s.unique().astype(np.int64))
+    np.testing.assert_equal(encoded_col.dtype, cat_dtype)
+
+
 if __name__ == "__main__":
     test_label_encode()
     test_label_encode_drop_one()


### PR DESCRIPTION

When using `cudf` to load up dataset with many categorifiable columns, I noticed much bigger memory footprint compared to `pandas`, after `astype('category')` on many columns.

It points to `core/series.py: label_encoding()`, where `np.int32` is used as the starting point of searching for a minimum type size.  In many workloads the number of categories for a series is under a couple of hundreds, and fits well within `np.int8` or `np.int16`.  Doing so will save a lot of memory foot print for larger tabular datasets, with many categorifiable columns.

`np.uint8` would be even better, but that'd be a more involved change, punting for now.

Simple test showing the memory usage of the resulting labels:

```
sz = 100000

for n_cats in [65535, 255, 127, 10]: 
    s = cudf.Series([ str(i%n_cats) for i in range(sz) ])
    lab, cat = s.factorize()
    print(f"{int(lab.memory_usage()/sz)} bytes per cat, {len(cat)} categories x {sz} items, total {lab.memory_usage()} bytes.")

```
before the fix, it'd take up 400,000 bytes regardless there are 10 or 65K categories:
```
4 bytes per cat, 65535 categories x 100000 items, total 400000 bytes.
4 bytes per cat, 255 categories x 100000 items, total 400000 bytes.
4 bytes per cat, 127 categories x 100000 items, total 400000 bytes.
4 bytes per cat, 10 categories x 100000 items, total 400000 bytes.
```

The output with the fix:
```
4 bytes per cat, 65535 categories x 100000 items, total 400000 bytes.
2 bytes per cat, 255 categories x 100000 items, total 200000 bytes.
1 bytes per cat, 127 categories x 100000 items, total 100000 bytes.
1 bytes per cat, 10 categories x 100000 items, total 100000 bytes.
```

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
