### PR TITLE
[REVIEW] column_utilities: print more precise numerical strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@
 - PR #5034 Use loc to apply boolmask to frame efficiently when constructing query result
 - PR #5039 Make `annotate` picklable
 - PR #5045 Remove call to `unique()` in concat when `axis=1`
+- PR #5085 Print more precise numerical strings in unit tests
 
 ## Bug Fixes
 

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -290,6 +290,17 @@ std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c)
   }
 }
 
+template< typename T >
+static auto numeric_to_string_precise(T value)
+{
+  std::ostringstream o;
+
+  o << std::setprecision(std::numeric_limits<T>::max_digits10)
+    << value;
+
+  return o.str();
+}
+
 struct column_view_printer {
   template <typename Element, typename std::enable_if_t<is_numeric<Element>()>* = nullptr>
   void operator()(cudf::column_view const& col, std::vector<std::string>& out)
@@ -304,13 +315,13 @@ struct column_view_printer {
                      out.begin(),
                      [&h_data](auto idx) {
                        return bit_is_set(h_data.second.data(), idx)
-                                ? std::to_string(h_data.first[idx])
+                                ? numeric_to_string_precise(h_data.first[idx])
                                 : std::string("NULL");
                      });
 
     } else {
       std::transform(h_data.first.begin(), h_data.first.end(), out.begin(), [](Element el) {
-        return std::to_string(el);
+        return numeric_to_string_precise(el);
       });
     }
   }

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -290,13 +290,17 @@ std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c)
   }
 }
 
-template <typename T>
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value>* = nullptr>
+static auto numeric_to_string_precise(T value)
+{
+  return std::to_string(value);
+}
+
+template <typename T, typename std::enable_if_t<std::is_floating_point<T>::value>* = nullptr>
 static auto numeric_to_string_precise(T value)
 {
   std::ostringstream o;
-
   o << std::setprecision(std::numeric_limits<T>::max_digits10) << value;
-
   return o.str();
 }
 

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -290,13 +290,12 @@ std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c)
   }
 }
 
-template< typename T >
+template <typename T>
 static auto numeric_to_string_precise(T value)
 {
   std::ostringstream o;
 
-  o << std::setprecision(std::numeric_limits<T>::max_digits10)
-    << value;
+  o << std::setprecision(std::numeric_limits<T>::max_digits10) << value;
 
   return o.str();
 }

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -16,9 +16,6 @@
 
 #include <cudf/copying.hpp>
 #include <cudf/strings/strings_column_view.hpp>
-#include <iomanip>
-#include <limits>
-#include <sstream>
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/column_utilities.hpp>
 #include <tests/utilities/column_wrapper.hpp>

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -232,8 +232,8 @@ TYPED_TEST(ColumnUtilitiesTestFloatingPoint, PrintColumnWithInvalids)
 {
   const char* delimiter = ",";
 
-  cudf::test::fixed_width_column_wrapper<TypeParam> cudf_col({10001523.25, 2.0, 3.75, 0.000000034, 5.3},
-                                                             {1, 0, 1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<TypeParam> cudf_col(
+    {10001523.25, 2.0, 3.75, 0.000000034, 5.3}, {1, 0, 1, 0, 1});
 
   auto expected = std::is_same<TypeParam, double>::value
                     ? "10001523.25,NULL,3.75,NULL,5.2999999999999998"

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -16,11 +16,15 @@
 
 #include <cudf/copying.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <iomanip>
+#include <limits>
+#include <sstream>
 #include <tests/utilities/base_fixture.hpp>
 #include <tests/utilities/column_utilities.hpp>
 #include <tests/utilities/column_wrapper.hpp>
 #include <tests/utilities/cudf_gtest.hpp>
 #include <tests/utilities/type_lists.hpp>
+#include <type_traits>
 
 #include <thrust/iterator/constant_iterator.h>
 
@@ -36,11 +40,16 @@ struct ColumnUtilitiesTest : public cudf::test::BaseFixture {
 };
 
 template <typename T>
-struct ColumnUtilitiesTestNumeric : public cudf::test::BaseFixture {
+struct ColumnUtilitiesTestIntegral : public cudf::test::BaseFixture {
+};
+
+template <typename T>
+struct ColumnUtilitiesTestFloatingPoint : public cudf::test::BaseFixture {
 };
 
 TYPED_TEST_CASE(ColumnUtilitiesTest, cudf::test::FixedWidthTypes);
-TYPED_TEST_CASE(ColumnUtilitiesTestNumeric, cudf::test::NumericTypes);
+TYPED_TEST_CASE(ColumnUtilitiesTestIntegral, cudf::test::IntegralTypes);
+TYPED_TEST_CASE(ColumnUtilitiesTestFloatingPoint, cudf::test::FloatingPointTypes);
 
 TYPED_TEST(ColumnUtilitiesTest, NonNullableToHost)
 {
@@ -173,7 +182,7 @@ TEST_F(ColumnUtilitiesStringsTest, StringsToHostAllNulls)
   EXPECT_TRUE(std::all_of(results.begin(), results.end(), [](auto s) { return s.empty(); }));
 }
 
-TYPED_TEST(ColumnUtilitiesTestNumeric, PrintColumnNumeric)
+TYPED_TEST(ColumnUtilitiesTestIntegral, PrintColumnNumeric)
 {
   const char* delimiter = ",";
 
@@ -193,7 +202,7 @@ TYPED_TEST(ColumnUtilitiesTestNumeric, PrintColumnNumeric)
   EXPECT_EQ(cudf::test::to_string(cudf_col, delimiter), tmp.str());
 }
 
-TYPED_TEST(ColumnUtilitiesTestNumeric, PrintColumnWithInvalids)
+TYPED_TEST(ColumnUtilitiesTestIntegral, PrintColumnWithInvalids)
 {
   const char* delimiter = ",";
 
@@ -206,6 +215,34 @@ TYPED_TEST(ColumnUtilitiesTestNumeric, PrintColumnWithInvalids)
       << std::to_string(std_col[4]);
 
   EXPECT_EQ(cudf::test::to_string(cudf_col, delimiter), tmp.str());
+}
+
+TYPED_TEST(ColumnUtilitiesTestFloatingPoint, PrintColumnNumeric)
+{
+  const char* delimiter = ",";
+
+  cudf::test::fixed_width_column_wrapper<TypeParam> cudf_col(
+    {10001523.25, 2.0, 3.75, 0.000000034, 5.3});
+
+  auto expected = std::is_same<TypeParam, double>::value
+                    ? "10001523.25,2,3.75,3.4e-08,5.2999999999999998"
+                    : "10001523,2,3.75,3.39999993e-08,5.30000019";
+
+  EXPECT_EQ(cudf::test::to_string(cudf_col, delimiter), expected);
+}
+
+TYPED_TEST(ColumnUtilitiesTestFloatingPoint, PrintColumnWithInvalids)
+{
+  const char* delimiter = ",";
+
+  cudf::test::fixed_width_column_wrapper<TypeParam> cudf_col({10001523.25, 2.0, 3.75, 0.000000034, 5.3},
+                                                             {1, 0, 1, 0, 1});
+
+  auto expected = std::is_same<TypeParam, double>::value
+                    ? "10001523.25,NULL,3.75,NULL,5.2999999999999998"
+                    : "10001523,NULL,3.75,NULL,5.30000019";
+
+  EXPECT_EQ(cudf::test::to_string(cudf_col, delimiter), expected);
 }
 
 TEST_F(ColumnUtilitiesStringsTest, StringsToString)


### PR DESCRIPTION
These changes enable higher precision printing of floating-point values such as doubles and floats when comparing columns (`expect_column_equals`).

Previously:
```
../../../../tests/utilities/column_utilities.cu:220: Failure
      Expected: differences.size()
      Which is: 1
To be equal to: size_t{0}
      Which is: 0
differences:
lhs[0] = 0, rhs[0] = 0

```
With these changes:
```
differences:
lhs[0] = 0, rhs[0] = 1.5604449514735574e-12
```

This empowers developers to write unit tests with specific expected values. For instance, higher precision may be required when writing functions which utilize trigonometric operations.

_Note:_ I intentionally avoid using `std::fixed`, as that will unnecessarily lengthen the string.