### PR TITLE
[REVIEW] Return false for sign-only string in libcudf is_float and is_integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,7 @@
 - PR #5070 Fix libcudf++ csv reader support for hex dtypes, doublequotes and empty columns
 - PR #5057 Fix metadata_out parameter not reaching parquet `write_all`
 - PR #5076 Fix JNI code for null_policy enum change
+- PR #5089 Return false for sign-only string in libcudf is_float and is_integer
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/cpp/include/cudf/strings/string.cuh
+++ b/cpp/include/cudf/strings/string.cuh
@@ -38,9 +38,11 @@ __device__ bool is_integer(string_view const& d_str)
 {
   if (d_str.empty()) return false;
   auto begin = d_str.begin();
+  auto end   = d_str.end();
   if (*begin == '+' || *begin == '-') ++begin;
-  return thrust::all_of(
-    thrust::seq, begin, d_str.end(), [] __device__(auto chr) { return chr >= '0' && chr <= '9'; });
+  return (thrust::distance(begin, end) > 0) &&
+         thrust::all_of(
+           thrust::seq, begin, end, [] __device__(auto chr) { return chr >= '0' && chr <= '9'; });
 }
 
 /**
@@ -75,6 +77,7 @@ __device__ bool is_float(string_view const& d_str)
   const char* data    = d_str.data();
   // sign character allowed at the beginning of the string
   size_type chidx = (*data == '-' || *data == '+') ? 1 : 0;
+  bool result     = chidx < bytes;
   // check for float chars [0-9] and a single decimal '.'
   // and scientific notation [eE][+-][0-9]
   for (; chidx < bytes; ++chidx) {
@@ -93,7 +96,7 @@ __device__ bool is_float(string_view const& d_str)
     }
     return false;
   }
-  return true;
+  return result;
 }
 
 }  // namespace string

--- a/cpp/tests/strings/chars_types_tests.cpp
+++ b/cpp/tests/strings/chars_types_tests.cpp
@@ -242,9 +242,9 @@ TEST_F(StringsCharsTest, EmptyStringsColumn)
 TEST_F(StringsCharsTest, Integers)
 {
   cudf::test::strings_column_wrapper strings1(
-    {"+175", "-34", "9.8", "17+2", "+-14", "1234567890", "67de", "", "1e10"});
+    {"+175", "-34", "9.8", "17+2", "+-14", "1234567890", "67de", "", "1e10", "-", "++", ""});
   auto results = cudf::strings::is_integer(cudf::strings_column_view(strings1));
-  cudf::test::fixed_width_column_wrapper<bool> expected1({1, 1, 0, 0, 0, 1, 0, 0, 0});
+  cudf::test::fixed_width_column_wrapper<bool> expected1({1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0});
   cudf::test::expect_columns_equal(*results, expected1);
   EXPECT_FALSE(cudf::strings::all_integer(cudf::strings_column_view(strings1)));
 
@@ -259,22 +259,23 @@ TEST_F(StringsCharsTest, Integers)
 TEST_F(StringsCharsTest, Floats)
 {
   cudf::test::strings_column_wrapper strings1({"+175",
-                                               "-34",
-                                               "9.8",
-                                               "17+2",
-                                               "+-14",
-                                               "1234567890",
+                                               "-9.8",
+                                               "7+2",
+                                               "+-4",
                                                "6.7e17",
                                                "-1.2e-5",
                                                "e",
                                                ".e",
                                                "1.e+-2",
-                                               "000.000",
+                                               "00.00",
                                                "1.0e+1.0",
-                                               "1.2.3"});
+                                               "1.2.3",
+                                               "+",
+                                               "--",
+                                               ""});
   auto results = cudf::strings::is_float(cudf::strings_column_view(strings1));
   cudf::test::fixed_width_column_wrapper<bool> expected1(
-    {1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0});
+    {1, 1, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0});
   cudf::test::expect_columns_equal(*results, expected1);
   EXPECT_FALSE(cudf::strings::all_float(cudf::strings_column_view(strings1)));
 


### PR DESCRIPTION
Closes #5083 

Converting a single-character string with only the sign '+' or '-' to integer or float will throw an exception in Pandas. This PR fixes the functions `is_integer/all_integer` and `is_float/all_float` functions used by cudf to return false if only the sign character is present.

Also, adds gtests for sign-only strings.