### PR TITLE
[REVIEW] Expose the HOST_BUFFER parquet sink to python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@
 - PR #5045 Remove call to `unique()` in concat when `axis=1`
 - PR #5085 Print more precise numerical strings in unit tests
 - PR #5028 Add Docker 19 support to local gpuci build
+- PR #5094 Expose the HOST_BUFFER parquet sink to python
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/io/__init__.py
+++ b/python/cudf/cudf/io/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
+import cudf._lib.io.utils
 from cudf.io.avro import read_avro
 from cudf.io.csv import read_csv, to_csv
 from cudf.io.dlpack import from_dlpack
@@ -13,7 +14,5 @@ from cudf.io.parquet import (
     read_parquet_metadata,
     write_to_dataset,
 )
-import cudf._lib.io.utils
-
 
 HostBuffer = cudf._lib.io.utils.HostBuffer

--- a/python/cudf/cudf/io/__init__.py
+++ b/python/cudf/cudf/io/__init__.py
@@ -13,3 +13,7 @@ from cudf.io.parquet import (
     read_parquet_metadata,
     write_to_dataset,
 )
+import cudf._lib.io.utils
+
+
+HostBuffer = cudf._lib.io.utils.HostBuffer

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -609,6 +609,18 @@ def test_parquet_writer_bytes_io(simple_gdf):
     assert_eq(cudf.read_parquet(output), cudf.concat([simple_gdf, simple_gdf]))
 
 
+def test_parquet_writer_host_buffer(tmpdir, simple_gdf):
+    buffer = cudf.io.HostBuffer()
+    simple_gdf.to_parquet(buffer)
+
+    assert_eq(cudf.read_parquet(buffer), simple_gdf)
+
+    gdf_fname = tmpdir.join("gdf.parquet")
+    with open(gdf_fname, "wb") as o:
+        o.write(buffer.read())
+    assert_eq(cudf.read_parquet(gdf_fname), simple_gdf)
+
+
 @pytest.mark.parametrize("cols", [["b"], ["c", "b"]])
 def test_parquet_write_partitioned(tmpdir_factory, cols):
     # Checks that write_to_dataset is wrapping to_parquet


### PR DESCRIPTION
Expose the HOST_BUFFER sink type to python for parquet files.
(As discussed here: https://github.com/rapidsai/cudf/pull/5061#issuecomment-622477757 )


