### PR TITLE
[REVIEW] Remove table concatenate from experimental namespace and add detail API with stream parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 - PR #5085 Print more precise numerical strings in unit tests
 - PR #5028 Add Docker 19 support to local gpuci build
 - PR #5093 Add `.cat.as_known` related test in `dask_cudf`
+- PR #5106 Add detail API for `cudf::concatenate` with tables
 
 ## Bug Fixes
 

--- a/cpp/benchmarks/column/concatenate_benchmark.cpp
+++ b/cpp/benchmarks/column/concatenate_benchmark.cpp
@@ -125,7 +125,7 @@ static void BM_concatenate_tables(benchmark::State& state)
 
   for (auto _ : state) {
     cuda_event_timer raii(state, true, 0);
-    auto result = cudf::experimental::concatenate(table_views);
+    auto result = cudf::concatenate(table_views);
   }
 
   state.SetBytesProcessed(state.iterations() * num_cols * num_rows * num_tables * sizeof(T));

--- a/cpp/include/cudf/concatenate.hpp
+++ b/cpp/include/cudf/concatenate.hpp
@@ -56,8 +56,6 @@ std::unique_ptr<column> concatenate(
   std::vector<column_view> const& columns_to_concat,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
-namespace experimental {
-
 /**
  * @brief Columns of `tables_to_concat` are concatenated vertically to return a
  * single table_view
@@ -83,10 +81,8 @@ namespace experimental {
  * @return Unique pointer to a single table having all the rows from the
  * elements of `tables_to_concat` respectively in the same order.
  **/
-std::unique_ptr<table> concatenate(
+std::unique_ptr<experimental::table> concatenate(
   std::vector<table_view> const& tables_to_concat,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
-
-}  // namespace experimental
 
 }  // namespace cudf

--- a/cpp/include/cudf/detail/concatenate.cuh
+++ b/cpp/include/cudf/detail/concatenate.cuh
@@ -25,16 +25,9 @@
 namespace cudf {
 namespace detail {
 /**
- * @brief Concatenates the null mask bits of all the column device views in the
- * `views` array to the destination bitmask.
- *
- * @param d_views Vector of column device views whose bitmasks need to be concatenated
- * @param d_offsets Prefix sum of sizes of elements of `d_views`
- * @param dest_mask Pointer to array that contains the combined bitmask
- * of the column views
- * @param output_size The total number of null masks bits that are being concatenated
- * @param stream stream on which all memory allocations and copies
- * will be performed
+ * @copydoc cudf::concatenate_masks(std::vector<column_view> const&,rmm::mr::device_memory_resource*)
+ * 
+ * @param stream stream on which all memory allocations and copies will be performed
  */
 void concatenate_masks(rmm::device_vector<column_device_view> const& d_views,
                        rmm::device_vector<size_t> const& d_offsets,
@@ -43,35 +36,31 @@ void concatenate_masks(rmm::device_vector<column_device_view> const& d_views,
                        cudaStream_t stream);
 
 /**
- * @brief Concatenates `views[i]`'s bitmask from the bits
- * `[views[i].offset(), views[i].offset() + views[i].size())` for all elements
- * views[i] in views into an array
- *
- * @param views Vector of column views whose bitmasks need to be concatenated
- * @param dest_mask Pointer to array that contains the combined bitmask
- * of the column views
- * @param stream stream on which all memory allocations and copies
- * will be performed
+ * @copydoc cudf::concatenate_masks(std::vector<column_view> const&,bitmask_type*)
+ * 
+ * @param stream stream on which all memory allocations and copies will be performed
  */
 void concatenate_masks(std::vector<column_view> const& views,
                        bitmask_type* dest_mask,
                        cudaStream_t stream);
 
 /**
- * @brief Concatenates multiple columns into a single column.
+ * @copydoc cudf::concatenate(std::vector<column_view> const&,rmm::mr::device_memory_resource*)
  *
- * @throws cudf::logic_error
- * If types of the input columns mismatch
- *
- * @param columns_to_concat The column views to be concatenated into a single
- * column
- * @param mr Optional The resource to use for all allocations
  * @param stream Optional The stream on which to execute all allocations and copies
- * @return Unique pointer to a single table having all the rows from the
- * elements of `columns_to_concat` respectively in the same order.
  */
 std::unique_ptr<column> concatenate(
   std::vector<column_view> const& columns_to_concat,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+/**
+ * @copydoc cudf::concatenate(std::vector<table_view> const&,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Optional The stream on which to execute all allocations and copies
+ */
+std::unique_ptr<experimental::table> concatenate(
+  std::vector<table_view> const& tables_to_concat,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
   cudaStream_t stream                 = 0);
 

--- a/cpp/include/cudf/detail/concatenate.cuh
+++ b/cpp/include/cudf/detail/concatenate.cuh
@@ -25,8 +25,9 @@
 namespace cudf {
 namespace detail {
 /**
- * @copydoc cudf::concatenate_masks(std::vector<column_view> const&,rmm::mr::device_memory_resource*)
- * 
+ * @copydoc cudf::concatenate_masks(std::vector<column_view>
+ * const&,rmm::mr::device_memory_resource*)
+ *
  * @param stream stream on which all memory allocations and copies will be performed
  */
 void concatenate_masks(rmm::device_vector<column_device_view> const& d_views,
@@ -37,7 +38,7 @@ void concatenate_masks(rmm::device_vector<column_device_view> const& d_views,
 
 /**
  * @copydoc cudf::concatenate_masks(std::vector<column_view> const&,bitmask_type*)
- * 
+ *
  * @param stream stream on which all memory allocations and copies will be performed
  */
 void concatenate_masks(std::vector<column_view> const& views,

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -337,6 +337,30 @@ std::unique_ptr<column> concatenate(std::vector<column_view> const& columns_to_c
   return experimental::type_dispatcher(type, concatenate_dispatch{columns_to_concat, mr, stream});
 }
 
+std::unique_ptr<experimental::table> concatenate(std::vector<table_view> const& tables_to_concat,
+                                   rmm::mr::device_memory_resource* mr,
+                                   cudaStream_t stream)
+{
+  if (tables_to_concat.size() == 0) { return std::make_unique<experimental::table>(); }
+
+  table_view const first_table = tables_to_concat.front();
+  CUDF_EXPECTS(std::all_of(tables_to_concat.begin(),
+                           tables_to_concat.end(),
+                           [&first_table](auto const& t) {
+                             return t.num_columns() == first_table.num_columns() &&
+                                    have_same_types(first_table, t);
+                           }),
+               "Mismatch in table columns to concatenate.");
+
+  std::vector<std::unique_ptr<column>> concat_columns;
+  for (size_type i = 0; i < first_table.num_columns(); ++i) {
+    std::vector<column_view> cols;
+    for (auto& t : tables_to_concat) { cols.emplace_back(t.column(i)); }
+    concat_columns.emplace_back(detail::concatenate(cols, mr, stream));
+  }
+  return std::make_unique<experimental::table>(std::move(concat_columns));
+}
+
 }  // namespace detail
 
 rmm::device_buffer concatenate_masks(std::vector<column_view> const& views,
@@ -369,30 +393,11 @@ std::unique_ptr<column> concatenate(std::vector<column_view> const& columns_to_c
   return detail::concatenate(columns_to_concat, mr, 0);
 }
 
-namespace experimental {
-std::unique_ptr<table> concatenate(std::vector<table_view> const& tables_to_concat,
+std::unique_ptr<experimental::table> concatenate(std::vector<table_view> const& tables_to_concat,
                                    rmm::mr::device_memory_resource* mr)
 {
-  if (tables_to_concat.size() == 0) { return std::make_unique<table>(); }
-
-  table_view const first_table = tables_to_concat.front();
-  CUDF_EXPECTS(std::all_of(tables_to_concat.begin(),
-                           tables_to_concat.end(),
-                           [&first_table](auto const& t) {
-                             return t.num_columns() == first_table.num_columns() &&
-                                    have_same_types(first_table, t);
-                           }),
-               "Mismatch in table columns to concatenate.");
-
-  std::vector<std::unique_ptr<column>> concat_columns;
-  for (size_type i = 0; i < first_table.num_columns(); ++i) {
-    std::vector<column_view> cols;
-    for (auto& t : tables_to_concat) { cols.emplace_back(t.column(i)); }
-    concat_columns.emplace_back(cudf::concatenate(cols, mr));
-  }
-  return std::make_unique<table>(std::move(concat_columns));
+  CUDF_FUNC_RANGE();
+  return detail::concatenate(tables_to_concat, mr, 0);
 }
-
-}  // namespace experimental
 
 }  // namespace cudf

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -338,8 +338,8 @@ std::unique_ptr<column> concatenate(std::vector<column_view> const& columns_to_c
 }
 
 std::unique_ptr<experimental::table> concatenate(std::vector<table_view> const& tables_to_concat,
-                                   rmm::mr::device_memory_resource* mr,
-                                   cudaStream_t stream)
+                                                 rmm::mr::device_memory_resource* mr,
+                                                 cudaStream_t stream)
 {
   if (tables_to_concat.size() == 0) { return std::make_unique<experimental::table>(); }
 
@@ -394,7 +394,7 @@ std::unique_ptr<column> concatenate(std::vector<column_view> const& columns_to_c
 }
 
 std::unique_ptr<experimental::table> concatenate(std::vector<table_view> const& tables_to_concat,
-                                   rmm::mr::device_memory_resource* mr)
+                                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::concatenate(tables_to_concat, mr, 0);

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/detail/concatenate.cuh>
 #include <cudf/detail/gather.cuh>
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
@@ -324,7 +324,7 @@ std::unique_ptr<experimental::table> construct_join_output_df(
                                                            rmm::mr::get_default_resource(),
                                                            stream);
       common_table =
-        concatenate({common_from_right->view(), common_from_left->view()}, mr);
+        cudf::detail::concatenate({common_from_right->view(), common_from_left->view()}, mr, stream);
     }
     joined_indices = concatenate_vector_pairs(complement_indices, joined_indices);
   } else {

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -323,8 +323,8 @@ std::unique_ptr<experimental::table> construct_join_output_df(
                                                            nullify_out_of_bounds,
                                                            rmm::mr::get_default_resource(),
                                                            stream);
-      common_table =
-        cudf::detail::concatenate({common_from_right->view(), common_from_left->view()}, mr, stream);
+      common_table           = cudf::detail::concatenate(
+        {common_from_right->view(), common_from_left->view()}, mr, stream);
     }
     joined_indices = concatenate_vector_pairs(complement_indices, joined_indices);
   } else {

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -320,7 +320,7 @@ std::unique_ptr<experimental::table> construct_join_output_df(
                                                            joined_indices.first.end(),
                                                            nullify_out_of_bounds);
       common_table =
-        experimental::concatenate({common_from_right->view(), common_from_left->view()});
+        concatenate({common_from_right->view(), common_from_left->view()});
     }
     joined_indices = concatenate_vector_pairs(complement_indices, joined_indices);
   } else {

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -179,7 +179,7 @@ TEST_F(TableTest, ConcatenateTables)
   cols_table2.push_back(col3_table2.release());
   Table t2(std::move(cols_table2));
 
-  auto concat_table = cudf::experimental::concatenate({t1.view(), t2.view()});
+  auto concat_table = cudf::concatenate({t1.view(), t2.view()});
 
   cudf::test::expect_tables_equal(*concat_table, gold_table);
 }
@@ -209,7 +209,7 @@ TEST_F(TableTest, ConcatenateTablesWithOffsets)
     table_views_to_concat.push_back(partitioned1[1]);
     table_views_to_concat.push_back(partitioned2[1]);
     std::unique_ptr<cudf::experimental::table> concatenated_tables =
-      cudf::experimental::concatenate(table_views_to_concat);
+      cudf::concatenate(table_views_to_concat);
 
     column_wrapper<int32_t> exp1_1{{5, 8, 5, 6, 6, 15, 14, 13}};
     cudf::test::strings_column_wrapper exp2_1(
@@ -222,7 +222,7 @@ TEST_F(TableTest, ConcatenateTablesWithOffsets)
     table_views_to_concat.push_back(partitioned1[0]);
     table_views_to_concat.push_back(partitioned2[1]);
     std::unique_ptr<cudf::experimental::table> concatenated_tables =
-      cudf::experimental::concatenate(table_views_to_concat);
+      cudf::concatenate(table_views_to_concat);
 
     column_wrapper<int32_t> exp1_1{{5, 4, 3, 6, 15, 14, 13}};
     cudf::test::strings_column_wrapper exp2_1(
@@ -235,7 +235,7 @@ TEST_F(TableTest, ConcatenateTablesWithOffsets)
     table_views_to_concat.push_back(partitioned1[1]);
     table_views_to_concat.push_back(partitioned2[0]);
     std::unique_ptr<cudf::experimental::table> concatenated_tables =
-      cudf::experimental::concatenate(table_views_to_concat);
+      cudf::concatenate(table_views_to_concat);
 
     column_wrapper<int32_t> exp1_1{{5, 8, 5, 6, 5, 8, 5}};
     cudf::test::strings_column_wrapper exp2_1({"dada", "kite", "dog", "ln", "dada", "kite", "dog"});
@@ -271,7 +271,7 @@ TEST_F(TableTest, ConcatenateTablesWithOffsetsAndNulls)
     table_views_to_concat.push_back(partitioned1[1]);
     table_views_to_concat.push_back(partitioned2[1]);
     std::unique_ptr<cudf::experimental::table> concatenated_tables =
-      cudf::experimental::concatenate(table_views_to_concat);
+      cudf::concatenate(table_views_to_concat);
 
     cudf::test::fixed_width_column_wrapper<int32_t> exp1_1{{5, 8, 5, 6, 6, 15, 14, 13},
                                                            {1, 1, 1, 1, 1, 1, 1, 0}};
@@ -285,7 +285,7 @@ TEST_F(TableTest, ConcatenateTablesWithOffsetsAndNulls)
     table_views_to_concat.push_back(partitioned1[1]);
     table_views_to_concat.push_back(partitioned2[0]);
     std::unique_ptr<cudf::experimental::table> concatenated_tables =
-      cudf::experimental::concatenate(table_views_to_concat);
+      cudf::concatenate(table_views_to_concat);
 
     cudf::test::fixed_width_column_wrapper<int32_t> exp1_1{5, 8, 5, 6, 5, 8, 5};
     cudf::test::strings_column_wrapper exp2_1({"dada", "kite", "dog", "ln", "dada", "kite", "dog"},

--- a/cpp/tests/io/orc_test.cu
+++ b/cpp/tests/io/orc_test.cu
@@ -448,7 +448,7 @@ TEST_F(OrcChunkedWriterTest, SimpleTable)
   auto table1 = create_random_fixed_table<int>(5, 5, true);
   auto table2 = create_random_fixed_table<int>(5, 5, true);
 
-  auto full_table = cudf::experimental::concatenate({*table1, *table2});
+  auto full_table = cudf::concatenate({*table1, *table2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedSimple.orc");
   cudf_io::write_orc_chunked_args args{cudf_io::sink_info{filepath}};
@@ -469,7 +469,7 @@ TEST_F(OrcChunkedWriterTest, LargeTables)
   auto table1 = create_random_fixed_table<int>(512, 4096, true);
   auto table2 = create_random_fixed_table<int>(512, 8192, true);
 
-  auto full_table = cudf::experimental::concatenate({*table1, *table2});
+  auto full_table = cudf::concatenate({*table1, *table2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedLarge.orc");
   cudf_io::write_orc_chunked_args args{cudf_io::sink_info{filepath}};
@@ -496,7 +496,7 @@ TEST_F(OrcChunkedWriterTest, ManyTables)
     tables.push_back(std::move(tbl));
   }
 
-  auto expected = cudf::experimental::concatenate(table_views);
+  auto expected = cudf::concatenate(table_views);
 
   auto filepath = temp_env->get_temp_filepath("ChunkedManyTables.orc");
   cudf_io::write_orc_chunked_args args{cudf_io::sink_info{filepath}};
@@ -528,7 +528,7 @@ TEST_F(OrcChunkedWriterTest, Strings)
   cols.push_back(strings2.release());
   cudf::experimental::table tbl2(std::move(cols));
 
-  auto expected = cudf::experimental::concatenate({tbl1, tbl2});
+  auto expected = cudf::concatenate({tbl1, tbl2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedStrings.orc");
   cudf_io::write_orc_chunked_args args{cudf_io::sink_info{filepath}};
@@ -577,7 +577,7 @@ TEST_F(OrcChunkedWriterTest, ReadStripes)
   auto table1 = create_random_fixed_table<int>(5, 5, true);
   auto table2 = create_random_fixed_table<int>(5, 5, true);
 
-  auto full_table = cudf::experimental::concatenate({*table2, *table1, *table2});
+  auto full_table = cudf::concatenate({*table2, *table1, *table2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedStripes.orc");
   cudf_io::write_orc_chunked_args args{cudf_io::sink_info{filepath}};
@@ -644,7 +644,7 @@ TYPED_TEST(OrcChunkedWriterNumericTypeTest, UnalignedSize)
   cols.push_back(c2b_w.release());
   cudf::experimental::table tbl2(std::move(cols));
 
-  auto expected = cudf::experimental::concatenate({tbl1, tbl2});
+  auto expected = cudf::concatenate({tbl1, tbl2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedUnalignedSize.orc");
   cudf_io::write_orc_chunked_args args{cudf_io::sink_info{filepath}};
@@ -692,7 +692,7 @@ TYPED_TEST(OrcChunkedWriterNumericTypeTest, UnalignedSize2)
   cols.push_back(c2b_w.release());
   cudf::experimental::table tbl2(std::move(cols));
 
-  auto expected = cudf::experimental::concatenate({tbl1, tbl2});
+  auto expected = cudf::concatenate({tbl1, tbl2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedUnalignedSize2.orc");
   cudf_io::write_orc_chunked_args args{cudf_io::sink_info{filepath}};

--- a/cpp/tests/io/parquet_test.cu
+++ b/cpp/tests/io/parquet_test.cu
@@ -616,7 +616,7 @@ TEST_F(ParquetChunkedWriterTest, SimpleTable)
   auto table1 = create_random_fixed_table<int>(5, 5, true);
   auto table2 = create_random_fixed_table<int>(5, 5, true);
 
-  auto full_table = cudf::experimental::concatenate({*table1, *table2});
+  auto full_table = cudf::concatenate({*table1, *table2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedSimple.parquet");
   cudf_io::write_parquet_chunked_args args{cudf_io::sink_info{filepath}};
@@ -637,7 +637,7 @@ TEST_F(ParquetChunkedWriterTest, LargeTables)
   auto table1 = create_random_fixed_table<int>(512, 4096, true);
   auto table2 = create_random_fixed_table<int>(512, 8192, true);
 
-  auto full_table = cudf::experimental::concatenate({*table1, *table2});
+  auto full_table = cudf::concatenate({*table1, *table2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedLarge.parquet");
   cudf_io::write_parquet_chunked_args args{cudf_io::sink_info{filepath}};
@@ -664,7 +664,7 @@ TEST_F(ParquetChunkedWriterTest, ManyTables)
     tables.push_back(std::move(tbl));
   }
 
-  auto expected = cudf::experimental::concatenate(table_views);
+  auto expected = cudf::concatenate(table_views);
 
   auto filepath = temp_env->get_temp_filepath("ChunkedManyTables.parquet");
   cudf_io::write_parquet_chunked_args args{cudf_io::sink_info{filepath}};
@@ -696,7 +696,7 @@ TEST_F(ParquetChunkedWriterTest, Strings)
   cols.push_back(strings2.release());
   cudf::experimental::table tbl2(std::move(cols));
 
-  auto expected = cudf::experimental::concatenate({tbl1, tbl2});
+  auto expected = cudf::concatenate({tbl1, tbl2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedStrings.parquet");
   cudf_io::write_parquet_chunked_args args{cudf_io::sink_info{filepath}};
@@ -745,7 +745,7 @@ TEST_F(ParquetChunkedWriterTest, ReadRowGroups)
   auto table1 = create_random_fixed_table<int>(5, 5, true);
   auto table2 = create_random_fixed_table<int>(5, 5, true);
 
-  auto full_table = cudf::experimental::concatenate({*table2, *table1, *table2});
+  auto full_table = cudf::concatenate({*table2, *table1, *table2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedRowGroups.parquet");
   cudf_io::write_parquet_chunked_args args{cudf_io::sink_info{filepath}};
@@ -812,7 +812,7 @@ TYPED_TEST(ParquetChunkedWriterNumericTypeTest, UnalignedSize)
   cols.push_back(c2b_w.release());
   cudf::experimental::table tbl2(std::move(cols));
 
-  auto expected = cudf::experimental::concatenate({tbl1, tbl2});
+  auto expected = cudf::concatenate({tbl1, tbl2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedUnalignedSize.parquet");
   cudf_io::write_parquet_chunked_args args{cudf_io::sink_info{filepath}};
@@ -860,7 +860,7 @@ TYPED_TEST(ParquetChunkedWriterNumericTypeTest, UnalignedSize2)
   cols.push_back(c2b_w.release());
   cudf::experimental::table tbl2(std::move(cols));
 
-  auto expected = cudf::experimental::concatenate({tbl1, tbl2});
+  auto expected = cudf::concatenate({tbl1, tbl2});
 
   auto filepath = temp_env->get_temp_filepath("ChunkedUnalignedSize2.parquet");
   cudf_io::write_parquet_chunked_args args{cudf_io::sink_info{filepath}};

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -951,7 +951,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_concatenate(JNIEnv *env, 
       JNI_NULL_CHECK(env, tables[i], "input table included a null", NULL);
       to_concat.push_back(*tables[i]);
     }
-    std::unique_ptr<cudf::experimental::table> table_result = cudf::experimental::concatenate(to_concat);
+    std::unique_ptr<cudf::experimental::table> table_result = cudf::concatenate(to_concat);
     return cudf::jni::convert_table_for_return(env, table_result);
   }
   CATCH_STD(env, NULL);

--- a/python/cudf/cudf/_lib/cpp/concatenate.pxd
+++ b/python/cudf/cudf/_lib/cpp/concatenate.pxd
@@ -15,7 +15,6 @@ cdef extern from "cudf/concatenate.hpp" namespace "cudf" nogil:
     cdef unique_ptr[column] concatenate_columns "cudf::concatenate"(
         const vector[column_view] columns
     ) except +
-    cdef unique_ptr[table] concatenate_tables \
-        "cudf::experimental::concatenate"(
+    cdef unique_ptr[table] concatenate_tables "cudf::concatenate"(
         const vector[table_view] tables
     ) except +


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/5081

Also removes unnecessary `experimental` namespace from `concatenate`; the legacy version of this API was named `cudf::concat`, so there isn't a name conflict.