### PR TITLE
Initialize Driver API before calling it in Cython

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 - PR #5085 Print more precise numerical strings in unit tests
 - PR #5028 Add Docker 19 support to local gpuci build
 - PR #5093 Add `.cat.as_known` related test in `dask_cudf`
+- PR #5107 Initialize Driver API before calling it in Cython
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/_cuda/gpu.pxd
+++ b/python/cudf/cudf/_cuda/gpu.pxd
@@ -378,6 +378,7 @@ cdef extern from "cuda.h" nogil:
         cudaUUID_t  uuid
         int  warpSize
 
+    CUresult cuInit(unsigned int Flags)
     CUresult cuDeviceGetName(char* name, int length, int device)
 
     CUresult cuGetErrorName(CUresult error, const char** pStr)

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -23,11 +23,12 @@ from cudf._cuda.gpu cimport underlying_type_attribute as c_attr
 class CUDARuntimeError(RuntimeError):
 
     def __init__(self, cudaError_t status):
-        self.status = status
         cdef str name = cudaGetErrorName(status).decode()
         cdef str msg = cudaGetErrorString(status).decode()
         super(CUDARuntimeError, self).__init__(
             '%s: %s' % (name, msg))
+
+        self.status = status
 
     def __reduce__(self):
         return (type(self), (self.status,))
@@ -36,8 +37,6 @@ class CUDARuntimeError(RuntimeError):
 class CUDADriverError(RuntimeError):
 
     def __init__(self, CUresult status):
-        self.status = status
-
         cdef const char* name_cstr
         cdef CUresult name_status = cuGetErrorName(status, &name_cstr)
         if name_status != 0:
@@ -53,6 +52,8 @@ class CUDADriverError(RuntimeError):
 
         super(CUDADriverError, self).__init__(
             '%s: %s' % (name, msg))
+
+        self.status = status
 
     def __reduce__(self):
         return (type(self), (self.status,))

--- a/python/cudf/cudf/_cuda/gpu.pyx
+++ b/python/cudf/cudf/_cuda/gpu.pyx
@@ -37,6 +37,10 @@ class CUDARuntimeError(RuntimeError):
 class CUDADriverError(RuntimeError):
 
     def __init__(self, CUresult status):
+        cdef CUresult init_status = cuInit(0)
+        if init_status != 0:
+            raise CUDADriverError(init_status)
+
         cdef const char* name_cstr
         cdef CUresult name_status = cuGetErrorName(status, &name_cstr)
         if name_status != 0:
@@ -368,12 +372,17 @@ def deviceGetName(int device):
     and status code.
     """
 
+    cdef CUresult init_status = cuInit(0)
+    if init_status != 0:
+        raise CUDADriverError(init_status)
+
     cdef char[256] device_name
-    cdef CUresult status = cuDeviceGetName(
+    cdef CUresult device_name_status = cuDeviceGetName(
         device_name,
         sizeof(device_name),
         device
     )
-    if status != 0:
-        raise CUDADriverError(status)
+    if device_name_status != 0:
+        raise CUDADriverError(device_name_status)
+
     return device_name.decode()


### PR DESCRIPTION
Make sure that we have called `cuInit` to initialize the CUDA Driver API before making any other Driver API calls.