### PR TITLE
[REVIEW] Update CONTRIBUTING.md for `clang-format` pre-commit hook [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@
 - PR #5093 Add `.cat.as_known` related test in `dask_cudf`
 - PR #5104 Add missing `.inl` files to clang-format and git commit hook
 - PR #5101 Add POSITION_INDEPENDENT_CODE flag to static cudftestutil library
+- PR #5109 Update CONTRIBUTING.md for `clang-format` pre-commit hook
 
 ## Bug Fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,21 @@ flake8 --config=python/cudf/.flake8.cython
 Additionally, many editors have plugins that will apply `isort` and `Black` as
 you edit files, as well as use `flake8` to report any style / syntax issues.
 
+#### C++/CUDA
+
+cuDF uses [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html)
+
+In order to format the C++/CUDA files, navigate to the root (`cudf`) directory and run:
+```
+python3 ./cpp/scripts/run-clang-format.py -inplace
+```
+
+Additionally, many editors have plugins or extensions that you can set up to automatically run `clang-format` either manually or on file save.
+
+#### Pre-commit hooks
+
 Optionally, you may wish to setup [pre-commit hooks](https://pre-commit.com/)
-to automatically run `isort`, `Black`, and `flake8` when you make a git commit.
+to automatically run `isort`, `Black`, `flake8` and `clang-format` when you make a git commit.
 This can be done by installing `pre-commit` via `conda` or `pip`:
 
 ```bash
@@ -107,17 +120,8 @@ and then running:
 pre-commit install
 ```
 
-from the root of the cuDF repository. Now `isort`, `Black`, and `flake8` will be
+from the root of the cuDF repository. Now `isort`, `Black`, `flake8` and `clang-format` will be
 run each time you commit changes.
-
-#### C++/CUDA
-
-cuDF uses [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html)
-
-In order to format the C++/CUDA files, navigate to the root (`cudf`) directory and run:
-```
-python3 ./cpp/scripts/run-clang-format.py -inplace
-```
 
 ### Get libcudf Dependencies
 


### PR DESCRIPTION
Updating the documentation to reflect that pre-commit hooks will now run `clang-format` for C++/CUDA as well as the existing hooks for Python.