### PR TITLE
Support out-of-band buffers in Python pickling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #5072 Adding cython binding to `get_element`
 - PR #4881 Support row_number in rolling_window
 - PR #5068 Add Java bindings for arctan2
+- PR #5132 Support out-of-band buffers in Python pickling
 
 ## Improvements
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -58,7 +58,7 @@ class Buffer:
                 raise TypeError("data must be Buffer, array-like or integer")
             self._init_from_array_like(np.asarray(data), owner)
 
-    def __reduce__(self):
+    def __reduce_ex__(self, protocol):
         data = self.to_host_array()
         return self.__class__, (data,)
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -59,7 +59,8 @@ class Buffer:
             self._init_from_array_like(np.asarray(data), owner)
 
     def __reduce__(self):
-        return self.__class__, (self.to_host_array(),)
+        data = self.to_host_array()
+        return self.__class__, (data,)
 
     def __len__(self):
         return self.size

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -60,6 +60,8 @@ class Buffer:
 
     def __reduce_ex__(self, protocol):
         data = self.to_host_array()
+        if protocol >= 5:
+            data = pickle.PickleBuffer(data)
         return self.__class__, (data,)
 
     def __len__(self):


### PR DESCRIPTION
When Python pickle's protocol 5 or greater is used, this change will support more efficient serialization of out-of-band buffers. This is analogous to Dask's custom serialization except for pickling. As such this is helpful in *any* Python serialization case where pickling is used. If an older pickling protocol is used, we simply proceed as before.