### PR TITLE
Install `contextvars` backport on Python 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,7 @@
 - PR #5118 Fix naming for java string length operators
 - PR #5129 Fix missed reference in tests from 5118
 - PR #5122 Fix `clang-format` `custrings` bug
+- PR #5122 Install `contextvars` backport on Python 3.6
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,7 +261,7 @@
 - PR #5118 Fix naming for java string length operators
 - PR #5129 Fix missed reference in tests from 5118
 - PR #5122 Fix `clang-format` `custrings` bug
-- PR #5122 Install `contextvars` backport on Python 3.6
+- PR #5138 Install `contextvars` backport on Python 3.6
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -119,7 +119,7 @@ else
     fi
 
     # Install contextvars on Python 3.6
-    py_ver=$(python -c "import sys; print('.'.join(sys.version_info[:2]))")
+    py_ver=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
     if [ "$py_ver" == "3.6" ];then
         conda install contextvars
     fi

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -118,6 +118,13 @@ else
         export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
     fi
 
+    # Install contextvars on Python 3.6
+    py_ver=$(python -c "import sys; print('.'.join(sys.version_info[:2]))")
+    if [ "$py_ver" == "3.6" ];then
+        export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
+	conda install contextvars
+    fi
+
     cd $WORKSPACE/python/nvstrings
     logger "Python py.test for nvstrings..."
     py.test --cache-clear --junitxml=${WORKSPACE}/junit-nvstrings.xml -v --cov-config=.coveragerc --cov=nvstrings --cov-report=xml:${WORKSPACE}/python/nvstrings/nvstrings-coverage.xml --cov-report term

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -57,6 +57,13 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
+
+# Install contextvars on Python 3.6
+py_ver=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
+if [ "$py_ver" == "3.6" ];then
+    conda install contextvars
+fi
+
 conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
               "dask>=2.15.0" "distributed>=2.15.0" "numpy>=1.16" "double-conversion" \
               "rapidjson" "flatbuffers" "boost-cpp" "fsspec>=0.6.0" "dlpack" \
@@ -116,12 +123,6 @@ else
     if [ "$np_ver" == "1.16" ];then
         logger "export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1"
         export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
-    fi
-
-    # Install contextvars on Python 3.6
-    py_ver=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
-    if [ "$py_ver" == "3.6" ];then
-        conda install contextvars
     fi
 
     cd $WORKSPACE/python/nvstrings

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -121,8 +121,7 @@ else
     # Install contextvars on Python 3.6
     py_ver=$(python -c "import sys; print('.'.join(sys.version_info[:2]))")
     if [ "$py_ver" == "3.6" ];then
-        export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
-	conda install contextvars
+        conda install contextvars
     fi
 
     cd $WORKSPACE/python/nvstrings


### PR DESCRIPTION
Installs `contextvars` on Python 3.6, which is [now needed by Distributed]( https://github.com/dask/distributed/blob/77f6c55f2482544871cf38b3730fb6f902bf2682/requirements.txt#L3 ). Can be dropped after there is a Distributed release with that requirement listed.

cc @kkraus14 @cjnolet