### PR TITLE
[REVIEW] Use user-provided resource correctly in `unary_operation()` and `shift()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@
 
 ## Bug Fixes
 
+- PR #5141 Use user-provided resource correctly in `unary_operation()` and `shift()`
 - PR #5064 Fix `hash()` and `construct_join_output_df()` to use user-provided memory resource correctly
 - PR #4386 Update Java package to 0.14
 - PR #4466 Fix merge key column sorting

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -60,7 +60,7 @@ struct shift_functor {
     using ScalarType = cudf::experimental::scalar_type_t<T>;
     auto& scalar     = static_cast<ScalarType const&>(fill_value);
 
-    auto device_input  = column_device_view::create(input);
+    auto device_input = column_device_view::create(input);
     auto output =
       detail::allocate_like(input, input.size(), mask_allocation_policy::NEVER, mr, stream);
     auto device_output = mutable_column_device_view::create(*output);

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -60,7 +60,7 @@ struct shift_functor {
     auto& scalar     = static_cast<ScalarType const&>(fill_value);
 
     auto device_input  = column_device_view::create(input);
-    auto output        = allocate_like(input, mask_allocation_policy::NEVER);
+    auto output        = allocate_like(input, mask_allocation_policy::NEVER, mr);
     auto device_output = mutable_column_device_view::create(*output);
 
     auto size        = input.size();

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -16,6 +16,7 @@
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/copying.hpp>
+#include <cudf/detail/copy.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/scalar/scalar.hpp>
@@ -60,7 +61,7 @@ struct shift_functor {
     auto& scalar     = static_cast<ScalarType const&>(fill_value);
 
     auto device_input  = column_device_view::create(input);
-    auto output        = allocate_like(input, mask_allocation_policy::NEVER, mr);
+    auto output        = detail::allocate_like(input, input.size(), mask_allocation_policy::NEVER, mr, stream);
     auto device_output = mutable_column_device_view::create(*output);
 
     auto size        = input.size();

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -61,7 +61,8 @@ struct shift_functor {
     auto& scalar     = static_cast<ScalarType const&>(fill_value);
 
     auto device_input  = column_device_view::create(input);
-    auto output        = detail::allocate_like(input, input.size(), mask_allocation_policy::NEVER, mr, stream);
+    auto output =
+      detail::allocate_like(input, input.size(), mask_allocation_policy::NEVER, mr, stream);
     auto device_output = mutable_column_device_view::create(*output);
 
     auto size        = input.size();

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -44,7 +44,9 @@ struct launcher {
                                         input.null_count());
 
       } else {
-        return cudf::experimental::allocate_like(input);
+        return cudf::experimental::allocate_like(input,
+                                                 mask_allocation_policy::RETAIN,
+                                                 mr);
       }
     }();
 

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -44,9 +44,7 @@ struct launcher {
                                         input.null_count());
 
       } else {
-        return cudf::experimental::allocate_like(input,
-                                                 mask_allocation_policy::NEVER,
-                                                 mr);
+        return cudf::experimental::allocate_like(input, mask_allocation_policy::NEVER, mr);
       }
     }();
 

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -45,11 +45,8 @@ struct launcher {
                                         input.null_count());
 
       } else {
-        return cudf::experimental::detail::allocate_like(input,
-                                                         input.size(),
-                                                         mask_allocation_policy::NEVER,
-                                                         mr,
-                                                         stream);
+        return cudf::experimental::detail::allocate_like(
+            input, input.size(), mask_allocation_policy::NEVER, mr, stream);
       }
     }();
 

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -19,6 +19,7 @@
 
 #include <rmm/thrust_rmm_allocator.h>
 #include <cudf/copying.hpp>
+#include <cudf/detail/copy.hpp>
 #include <cudf/unary.hpp>
 #include <cudf/utilities/error.hpp>
 
@@ -44,7 +45,11 @@ struct launcher {
                                         input.null_count());
 
       } else {
-        return cudf::experimental::allocate_like(input, mask_allocation_policy::NEVER, mr);
+        return cudf::experimental::detail::allocate_like(input,
+                                                         input.size(),
+                                                         mask_allocation_policy::NEVER,
+                                                         mr,
+                                                         stream);
       }
     }();
 

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -46,7 +46,7 @@ struct launcher {
 
       } else {
         return cudf::experimental::detail::allocate_like(
-            input, input.size(), mask_allocation_policy::NEVER, mr, stream);
+          input, input.size(), mask_allocation_policy::NEVER, mr, stream);
       }
     }();
 

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -45,7 +45,7 @@ struct launcher {
 
       } else {
         return cudf::experimental::allocate_like(input,
-                                                 mask_allocation_policy::RETAIN,
+                                                 mask_allocation_policy::NEVER,
                                                  mr);
       }
     }();


### PR DESCRIPTION
This is a fix for #5140. Note that this change still ignores the stream argument because [`allocate_like`](https://github.com/rapidsai/cudf/blob/branch-0.14/cpp/include/cudf/copying.hpp#L168-L171) currently does not take it. This should be fixed once the `allocate_like` is modified to take a stream argument.