### PR TITLE
Fix JNI build on GCC 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,7 @@
 - PR #5122 Fix `clang-format` `custrings` bug
 - PR #5138 Install `contextvars` backport on Python 3.6
 - PR #5145 Fix an issue with calling an aggregation operation on `SeriesGroupBy`
+- PR #5148 Fix JNI build for GCC 8
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -143,6 +143,7 @@
         <native.build.path>${basedir}/target/cmake-build</native.build.path>
         <skipNativeCopy>false</skipNativeCopy>
         <cxx11.abi.value>ON</cxx11.abi.value>
+        <cxx.flags/>
         <CUDA_STATIC_RUNTIME>OFF</CUDA_STATIC_RUNTIME>
         <PER_THREAD_DEFAULT_STREAM>OFF</PER_THREAD_DEFAULT_STREAM>
     </properties>
@@ -152,6 +153,12 @@
             <id>abiOff</id>
             <properties>
                 <cxx11.abi.value>OFF</cxx11.abi.value>
+            </properties>
+        </profile>
+        <profile>
+            <id>no-cxx-deprecation-warnings</id>
+            <properties>
+                <cxx.flags>-Wno-deprecated-declarations</cxx.flags>
             </properties>
         </profile>
         <profile>
@@ -336,6 +343,7 @@
                                     <arg value="-DCUDA_STATIC_RUNTIME=${CUDA_STATIC_RUNTIME}" />
                                     <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}" />
                                     <arg value="-DCMAKE_CXX11_ABI=${cxx11.abi.value}"/>
+                                    <arg value="-DCMAKE_CXX_FLAGS=${cxx.flags}"/>
                                 </exec>
                                 <exec dir="${native.build.path}"
                                       failonerror="true"

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -435,6 +435,7 @@ public:
     this->cstr = other.cstr;
     this->cstr_length = other.cstr_length;
     other.cstr = NULL;
+    return *this;
   }
 
   bool is_null() const noexcept { return orig == NULL; }

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -242,6 +242,7 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Cuda_eventQuery(JNIEnv* env, jcla
     JNI_CUDA_TRY(env, false, result);
   }
   CATCH_STD(env, false);
+  return false;
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_eventRecord(JNIEnv* env, jclass,


### PR DESCRIPTION
This fixes a couple of issues when building CUDF/Java with GCC-8:

1. `native_jstring::operator =()` and `Java_ai_rapids_cudf_Cuda_eventQuery()` neglect to return values. This has been remedied.
1. `rmm.hpp` generates a number of deprecation errors, simply from inclusion:
```
     [exec] In file included from /home/mithunr/workspace/dev/rapids/cudf/java/src/main/native/src/TableJni.cpp:31:
     [exec] /home/mithunr/workspace/dev/rapids/cudf/java/src/main/native/include/jni_utils.hpp: In member function 'cudf::jni::native_jstring& cudf::jni::native_jstring::operator=(const cudf::jni::native_jstring&&)':
     [exec] /home/mithunr/workspace/dev/rapids/cudf/java/src/main/native/include/jni_utils.hpp:438:3: error: no return statement in function returning non-void [-Werror=return-type]
```
This obfuscates actual build error messages. Added an option to suppress these warnings, for the Java build.
