### PR TITLE
[REVIEW] Add detail headers for strings converter functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@
 - PR #5156 Raise error when applying boolean mask containing null values.
 - PR #5137 Add java bindings for getSizeInBytes in DType
 - PR #5159 Add `make_meta_object` in `dask_cudf` backend and add `str.split` test
+- PR #5198 Add detail headers for strings converter functions
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/strings/detail/combine.hpp
+++ b/cpp/include/cudf/strings/detail/combine.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/strings/detail/combine.hpp
+++ b/cpp/include/cudf/strings/detail/combine.hpp
@@ -30,12 +30,11 @@ namespace detail {
  *
  * @param stream Stream on which to run kernels
  */
-std::unique_ptr<column> concatenate(
-  table_view const& strings_columns,
-  string_scalar const& separator      = string_scalar(""),
-  string_scalar const& narep          = string_scalar("", false),
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<column> concatenate(table_view const& strings_columns,
+                                    string_scalar const& separator,
+                                    string_scalar const& narep,
+                                    cudaStream_t stream,
+                                    rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc join_strings(table_view const&,string_scalar const&,string_scalar
@@ -43,12 +42,11 @@ std::unique_ptr<column> concatenate(
  *
  * @param stream Stream on which to run kernels
  */
-std::unique_ptr<column> join_strings(
-  strings_column_view const& strings,
-  string_scalar const& separator      = string_scalar(""),
-  string_scalar const& narep          = string_scalar("", false),
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<column> join_strings(strings_column_view const& strings,
+                                     string_scalar const& separator,
+                                     string_scalar const& narep,
+                                     cudaStream_t stream,
+                                     rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace strings

--- a/cpp/include/cudf/strings/detail/combine.hpp
+++ b/cpp/include/cudf/strings/detail/combine.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/table/table_view.hpp>
+
+namespace cudf {
+namespace strings {
+namespace detail {
+
+/**
+ * @copydoc concatenate(table_view const&,string_scalar const&,string_scalar
+ * const&,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to run kernels
+ */
+std::unique_ptr<column> concatenate(
+  table_view const& strings_columns,
+  string_scalar const& separator      = string_scalar(""),
+  string_scalar const& narep          = string_scalar("", false),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+/**
+ * @copydoc join_strings(table_view const&,string_scalar const&,string_scalar
+ * const&,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to run kernels
+ */
+std::unique_ptr<column> join_strings(
+  strings_column_view const& strings,
+  string_scalar const& separator      = string_scalar(""),
+  string_scalar const& narep          = string_scalar("", false),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+}  // namespace detail
+}  // namespace strings
+}  // namespace cudf

--- a/cpp/include/cudf/strings/detail/combine.hpp
+++ b/cpp/include/cudf/strings/detail/combine.hpp
@@ -34,8 +34,8 @@ std::unique_ptr<column> concatenate(
   table_view const& strings_columns,
   string_scalar const& separator      = string_scalar(""),
   string_scalar const& narep          = string_scalar("", false),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
  * @copydoc join_strings(table_view const&,string_scalar const&,string_scalar
@@ -47,8 +47,8 @@ std::unique_ptr<column> join_strings(
   strings_column_view const& strings,
   string_scalar const& separator      = string_scalar(""),
   string_scalar const& narep          = string_scalar("", false),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 }  // namespace detail
 }  // namespace strings

--- a/cpp/include/cudf/strings/detail/converters.hpp
+++ b/cpp/include/cudf/strings/detail/converters.hpp
@@ -31,8 +31,8 @@ namespace detail {
 std::unique_ptr<column> to_integers(
   strings_column_view const& strings,
   data_type output_type,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
  * @copydoc from_integers(strings_column_view const&,rmm::mr::device_memory_resource*)
@@ -41,8 +41,8 @@ std::unique_ptr<column> to_integers(
  */
 std::unique_ptr<column> from_integers(
   column_view const& integers,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
  * @copydoc to_floats(strings_column_view const&,data_type,rmm::mr::device_memory_resource*)
@@ -52,8 +52,8 @@ std::unique_ptr<column> from_integers(
 std::unique_ptr<column> to_floats(
   strings_column_view const& strings,
   data_type output_type,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
  * @copydoc from_floats(strings_column_view const&,rmm::mr::device_memory_resource*)
@@ -62,8 +62,8 @@ std::unique_ptr<column> to_floats(
  */
 std::unique_ptr<column> from_floats(
   column_view const& floats,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
  * @copydoc to_booleans(strings_column_view const&,string_scalar
@@ -74,8 +74,8 @@ std::unique_ptr<column> from_floats(
 std::unique_ptr<column> to_booleans(
   strings_column_view const& strings,
   string_scalar const& true_string    = string_scalar("true"),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
  * @copydoc from_booleans(strings_column_view const&,string_scalar const&,string_scalar
@@ -87,8 +87,8 @@ std::unique_ptr<column> from_booleans(
   column_view const& booleans,
   string_scalar const& true_string    = string_scalar("true"),
   string_scalar const& false_string   = string_scalar("false"),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
  * @copydoc to_timestamps(strings_column_view const&,data_type,std::string
@@ -100,8 +100,8 @@ std::unique_ptr<cudf::column> to_timestamps(
   strings_column_view const& strings,
   data_type timestamp_type,
   std::string const& format,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
  * @copydoc from_timestamps(strings_column_view const&,std::string
@@ -112,8 +112,8 @@ std::unique_ptr<cudf::column> to_timestamps(
 std::unique_ptr<column> from_timestamps(
   column_view const& timestamps,
   std::string const& format           = "%Y-%m-%dT%H:%M:%SZ",
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0);
+  cudaStream_t stream                 = cudaStream_t{},
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 }  // namespace detail
 }  // namespace strings

--- a/cpp/include/cudf/strings/detail/converters.hpp
+++ b/cpp/include/cudf/strings/detail/converters.hpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+
+namespace cudf {
+namespace strings {
+namespace detail {
+
+/**
+ * @copydoc to_integers(strings_column_view const&,data_type,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to execute kernels.
+ */
+std::unique_ptr<column> to_integers(
+  strings_column_view const& strings,
+  data_type output_type,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+/**
+ * @copydoc from_integers(strings_column_view const&,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to execute kernels.
+ */
+std::unique_ptr<column> from_integers(
+  column_view const& integers,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+/**
+ * @copydoc to_floats(strings_column_view const&,data_type,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to execute kernels.
+ */
+std::unique_ptr<column> to_floats(
+  strings_column_view const& strings,
+  data_type output_type,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+/**
+ * @copydoc from_floats(strings_column_view const&,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to execute kernels.
+ */
+std::unique_ptr<column> from_floats(
+  column_view const& floats,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+/**
+ * @copydoc to_booleans(strings_column_view const&,string_scalar
+ * const&,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to execute kernels.
+ */
+std::unique_ptr<column> to_booleans(
+  strings_column_view const& strings,
+  string_scalar const& true_string    = string_scalar("true"),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+/**
+ * @copydoc from_booleans(strings_column_view const&,string_scalar const&,string_scalar
+ * const&,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to execute kernels.
+ */
+std::unique_ptr<column> from_booleans(
+  column_view const& booleans,
+  string_scalar const& true_string    = string_scalar("true"),
+  string_scalar const& false_string   = string_scalar("false"),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+/**
+ * @copydoc to_timestamps(strings_column_view const&,data_type,std::string
+ * const&,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to execute kernels.
+ */
+std::unique_ptr<cudf::column> to_timestamps(
+  strings_column_view const& strings,
+  data_type timestamp_type,
+  std::string const& format,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+/**
+ * @copydoc from_timestamps(strings_column_view const&,std::string
+ * const&,rmm::mr::device_memory_resource*)
+ *
+ * @param stream Stream on which to execute kernels.
+ */
+std::unique_ptr<column> from_timestamps(
+  column_view const& timestamps,
+  std::string const& format           = "%Y-%m-%dT%H:%M:%SZ",
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0);
+
+}  // namespace detail
+}  // namespace strings
+}  // namespace cudf

--- a/cpp/include/cudf/strings/detail/converters.hpp
+++ b/cpp/include/cudf/strings/detail/converters.hpp
@@ -28,42 +28,38 @@ namespace detail {
  *
  * @param stream Stream on which to execute kernels.
  */
-std::unique_ptr<column> to_integers(
-  strings_column_view const& strings,
-  data_type output_type,
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<column> to_integers(strings_column_view const& strings,
+                                    data_type output_type,
+                                    cudaStream_t stream,
+                                    rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc from_integers(strings_column_view const&,rmm::mr::device_memory_resource*)
  *
  * @param stream Stream on which to execute kernels.
  */
-std::unique_ptr<column> from_integers(
-  column_view const& integers,
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<column> from_integers(column_view const& integers,
+                                      cudaStream_t stream,
+                                      rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc to_floats(strings_column_view const&,data_type,rmm::mr::device_memory_resource*)
  *
  * @param stream Stream on which to execute kernels.
  */
-std::unique_ptr<column> to_floats(
-  strings_column_view const& strings,
-  data_type output_type,
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<column> to_floats(strings_column_view const& strings,
+                                  data_type output_type,
+                                  cudaStream_t stream,
+                                  rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc from_floats(strings_column_view const&,rmm::mr::device_memory_resource*)
  *
  * @param stream Stream on which to execute kernels.
  */
-std::unique_ptr<column> from_floats(
-  column_view const& floats,
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<column> from_floats(column_view const& floats,
+                                    cudaStream_t stream,
+                                    rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc to_booleans(strings_column_view const&,string_scalar
@@ -71,11 +67,10 @@ std::unique_ptr<column> from_floats(
  *
  * @param stream Stream on which to execute kernels.
  */
-std::unique_ptr<column> to_booleans(
-  strings_column_view const& strings,
-  string_scalar const& true_string    = string_scalar("true"),
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<column> to_booleans(strings_column_view const& strings,
+                                    string_scalar const& true_string,
+                                    cudaStream_t stream,
+                                    rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc from_booleans(strings_column_view const&,string_scalar const&,string_scalar
@@ -83,12 +78,11 @@ std::unique_ptr<column> to_booleans(
  *
  * @param stream Stream on which to execute kernels.
  */
-std::unique_ptr<column> from_booleans(
-  column_view const& booleans,
-  string_scalar const& true_string    = string_scalar("true"),
-  string_scalar const& false_string   = string_scalar("false"),
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<column> from_booleans(column_view const& booleans,
+                                      string_scalar const& true_string,
+                                      string_scalar const& false_string,
+                                      cudaStream_t stream,
+                                      rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc to_timestamps(strings_column_view const&,data_type,std::string
@@ -96,12 +90,11 @@ std::unique_ptr<column> from_booleans(
  *
  * @param stream Stream on which to execute kernels.
  */
-std::unique_ptr<cudf::column> to_timestamps(
-  strings_column_view const& strings,
-  data_type timestamp_type,
-  std::string const& format,
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& strings,
+                                            data_type timestamp_type,
+                                            std::string const& format,
+                                            cudaStream_t stream,
+                                            rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc from_timestamps(strings_column_view const&,std::string
@@ -109,11 +102,10 @@ std::unique_ptr<cudf::column> to_timestamps(
  *
  * @param stream Stream on which to execute kernels.
  */
-std::unique_ptr<column> from_timestamps(
-  column_view const& timestamps,
-  std::string const& format           = "%Y-%m-%dT%H:%M:%SZ",
-  cudaStream_t stream                 = cudaStream_t{},
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+std::unique_ptr<column> from_timestamps(column_view const& timestamps,
+                                        std::string const& format,
+                                        cudaStream_t stream,
+                                        rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace strings

--- a/cpp/src/strings/combine.cu
+++ b/cpp/src/strings/combine.cu
@@ -41,8 +41,8 @@ namespace detail {
 std::unique_ptr<column> concatenate(table_view const& strings_columns,
                                     string_scalar const& separator,
                                     string_scalar const& narep,
-                                    rmm::mr::device_memory_resource* mr,
-                                    cudaStream_t stream)
+                                    cudaStream_t stream,
+                                    rmm::mr::device_memory_resource* mr)
 {
   auto num_columns = strings_columns.num_columns();
   CUDF_EXPECTS(num_columns > 0, "At least one column must be specified");
@@ -154,8 +154,8 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
 std::unique_ptr<column> join_strings(strings_column_view const& strings,
                                      string_scalar const& separator,
                                      string_scalar const& narep,
-                                     rmm::mr::device_memory_resource* mr,
-                                     cudaStream_t stream)
+                                     cudaStream_t stream,
+                                     rmm::mr::device_memory_resource* mr)
 {
   auto strings_count = strings.size();
   if (strings_count == 0) return detail::make_empty_strings_column(mr, stream);
@@ -254,7 +254,7 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::concatenate(strings_columns, separator, narep, mr);
+  return detail::concatenate(strings_columns, separator, narep, cudaStream_t{}, mr);
 }
 
 std::unique_ptr<column> join_strings(strings_column_view const& strings,
@@ -263,7 +263,7 @@ std::unique_ptr<column> join_strings(strings_column_view const& strings,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::join_strings(strings, separator, narep, mr);
+  return detail::join_strings(strings, separator, narep, cudaStream_t{}, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/combine.cu
+++ b/cpp/src/strings/combine.cu
@@ -20,6 +20,7 @@
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/strings/combine.hpp>
+#include <cudf/strings/detail/combine.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
@@ -37,12 +38,11 @@ namespace cudf {
 namespace strings {
 namespace detail {
 //
-std::unique_ptr<column> concatenate(
-  table_view const& strings_columns,
-  string_scalar const& separator      = string_scalar(""),
-  string_scalar const& narep          = string_scalar("", false),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<column> concatenate(table_view const& strings_columns,
+                                    string_scalar const& separator,
+                                    string_scalar const& narep,
+                                    rmm::mr::device_memory_resource* mr,
+                                    cudaStream_t stream)
 {
   auto num_columns = strings_columns.num_columns();
   CUDF_EXPECTS(num_columns > 0, "At least one column must be specified");
@@ -151,12 +151,11 @@ std::unique_ptr<column> concatenate(
 }
 
 //
-std::unique_ptr<column> join_strings(
-  strings_column_view const& strings,
-  string_scalar const& separator      = string_scalar(""),
-  string_scalar const& narep          = string_scalar("", false),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<column> join_strings(strings_column_view const& strings,
+                                     string_scalar const& separator,
+                                     string_scalar const& narep,
+                                     rmm::mr::device_memory_resource* mr,
+                                     cudaStream_t stream)
 {
   auto strings_count = strings.size();
   if (strings_count == 0) return detail::make_empty_strings_column(mr, stream);

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -36,8 +36,8 @@ namespace detail {
 // Convert strings column to boolean column
 std::unique_ptr<column> to_booleans(strings_column_view const& strings,
                                     string_scalar const& true_string,
-                                    rmm::mr::device_memory_resource* mr,
-                                    cudaStream_t stream)
+                                    cudaStream_t stream,
+                                    rmm::mr::device_memory_resource* mr)
 {
   size_type strings_count = strings.size();
   if (strings_count == 0) return make_numeric_column(data_type{BOOL8}, 0);
@@ -80,7 +80,7 @@ std::unique_ptr<column> to_booleans(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_booleans(strings, true_string, mr);
+  return detail::to_booleans(strings, true_string, cudaStream_t{}, mr);
 }
 
 namespace detail {
@@ -88,8 +88,8 @@ namespace detail {
 std::unique_ptr<column> from_booleans(column_view const& booleans,
                                       string_scalar const& true_string,
                                       string_scalar const& false_string,
-                                      rmm::mr::device_memory_resource* mr,
-                                      cudaStream_t stream)
+                                      cudaStream_t stream,
+                                      rmm::mr::device_memory_resource* mr)
 {
   size_type strings_count = booleans.size();
   if (strings_count == 0) return make_empty_strings_column(mr, stream);
@@ -158,7 +158,7 @@ std::unique_ptr<column> from_booleans(column_view const& booleans,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_booleans(booleans, true_string, false_string, mr);
+  return detail::from_booleans(booleans, true_string, false_string, cudaStream_t{}, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -18,6 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/convert/convert_booleans.hpp>
+#include <cudf/strings/detail/converters.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
@@ -33,11 +34,10 @@ namespace cudf {
 namespace strings {
 namespace detail {
 // Convert strings column to boolean column
-std::unique_ptr<column> to_booleans(
-  strings_column_view const& strings,
-  string_scalar const& true_string    = string_scalar("true"),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<column> to_booleans(strings_column_view const& strings,
+                                    string_scalar const& true_string,
+                                    rmm::mr::device_memory_resource* mr,
+                                    cudaStream_t stream)
 {
   size_type strings_count = strings.size();
   if (strings_count == 0) return make_numeric_column(data_type{BOOL8}, 0);
@@ -85,12 +85,11 @@ std::unique_ptr<column> to_booleans(strings_column_view const& strings,
 
 namespace detail {
 // Convert boolean column to strings column
-std::unique_ptr<column> from_booleans(
-  column_view const& booleans,
-  string_scalar const& true_string    = string_scalar("true"),
-  string_scalar const& false_string   = string_scalar("false"),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<column> from_booleans(column_view const& booleans,
+                                      string_scalar const& true_string,
+                                      string_scalar const& false_string,
+                                      rmm::mr::device_memory_resource* mr,
+                                      cudaStream_t stream)
 {
   size_type strings_count = booleans.size();
   if (strings_count == 0) return make_empty_strings_column(mr, stream);

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -383,8 +383,8 @@ struct dispatch_to_timestamps_fn {
 std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& strings,
                                             data_type timestamp_type,
                                             std::string const& format,
-                                            rmm::mr::device_memory_resource* mr,
-                                            cudaStream_t stream)
+                                            cudaStream_t stream,
+                                            rmm::mr::device_memory_resource* mr)
 {
   size_type strings_count = strings.size();
   if (strings_count == 0) return make_timestamp_column(timestamp_type, 0);
@@ -419,7 +419,7 @@ std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& strings,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_timestamps(strings, timestamp_type, format, mr);
+  return detail::to_timestamps(strings, timestamp_type, format, cudaStream_t{}, mr);
 }
 
 namespace detail {
@@ -714,8 +714,8 @@ struct dispatch_from_timestamps_fn {
 //
 std::unique_ptr<column> from_timestamps(column_view const& timestamps,
                                         std::string const& format,
-                                        rmm::mr::device_memory_resource* mr,
-                                        cudaStream_t stream)
+                                        cudaStream_t stream,
+                                        rmm::mr::device_memory_resource* mr)
 {
   size_type strings_count = timestamps.size();
   if (strings_count == 0) return make_empty_strings_column(mr, stream);
@@ -782,7 +782,7 @@ std::unique_ptr<column> from_timestamps(column_view const& timestamps,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_timestamps(timestamps, format, mr);
+  return detail::from_timestamps(timestamps, format, cudaStream_t{}, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -18,6 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/convert/convert_datetime.hpp>
+#include <cudf/strings/detail/converters.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
@@ -379,12 +380,11 @@ struct dispatch_to_timestamps_fn {
 }  // namespace
 
 //
-std::unique_ptr<cudf::column> to_timestamps(
-  strings_column_view const& strings,
-  data_type timestamp_type,
-  std::string const& format,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& strings,
+                                            data_type timestamp_type,
+                                            std::string const& format,
+                                            rmm::mr::device_memory_resource* mr,
+                                            cudaStream_t stream)
 {
   size_type strings_count = strings.size();
   if (strings_count == 0) return make_timestamp_column(timestamp_type, 0);
@@ -712,11 +712,10 @@ struct dispatch_from_timestamps_fn {
 }  // namespace
 
 //
-std::unique_ptr<column> from_timestamps(
-  column_view const& timestamps,
-  std::string const& format           = "%Y-%m-%dT%H:%M:%SZ",
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<column> from_timestamps(column_view const& timestamps,
+                                        std::string const& format,
+                                        rmm::mr::device_memory_resource* mr,
+                                        cudaStream_t stream)
 {
   size_type strings_count = timestamps.size();
   if (strings_count == 0) return make_empty_strings_column(mr, stream);

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -18,6 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/convert/convert_floats.hpp>
+#include <cudf/strings/detail/converters.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
@@ -164,11 +165,10 @@ struct dispatch_to_floats_fn {
 }  // namespace
 
 // This will convert a strings column into any float column type.
-std::unique_ptr<column> to_floats(
-  strings_column_view const& strings,
-  data_type output_type,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<column> to_floats(strings_column_view const& strings,
+                                  data_type output_type,
+                                  rmm::mr::device_memory_resource* mr,
+                                  cudaStream_t stream)
 {
   size_type strings_count = strings.size();
   if (strings_count == 0) return make_numeric_column(output_type, 0);
@@ -510,10 +510,9 @@ struct dispatch_from_floats_fn {
 }  // namespace
 
 // This will convert all float column types into a strings column.
-std::unique_ptr<column> from_floats(
-  column_view const& floats,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<column> from_floats(column_view const& floats,
+                                    rmm::mr::device_memory_resource* mr,
+                                    cudaStream_t stream)
 {
   size_type strings_count = floats.size();
   if (strings_count == 0) return detail::make_empty_strings_column(mr, stream);

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -167,8 +167,8 @@ struct dispatch_to_floats_fn {
 // This will convert a strings column into any float column type.
 std::unique_ptr<column> to_floats(strings_column_view const& strings,
                                   data_type output_type,
-                                  rmm::mr::device_memory_resource* mr,
-                                  cudaStream_t stream)
+                                  cudaStream_t stream,
+                                  rmm::mr::device_memory_resource* mr)
 {
   size_type strings_count = strings.size();
   if (strings_count == 0) return make_numeric_column(output_type, 0);
@@ -198,7 +198,7 @@ std::unique_ptr<column> to_floats(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_floats(strings, output_type, mr);
+  return detail::to_floats(strings, output_type, cudaStream_t{}, mr);
 }
 
 namespace detail {
@@ -511,8 +511,8 @@ struct dispatch_from_floats_fn {
 
 // This will convert all float column types into a strings column.
 std::unique_ptr<column> from_floats(column_view const& floats,
-                                    rmm::mr::device_memory_resource* mr,
-                                    cudaStream_t stream)
+                                    cudaStream_t stream,
+                                    rmm::mr::device_memory_resource* mr)
 {
   size_type strings_count = floats.size();
   if (strings_count == 0) return detail::make_empty_strings_column(mr, stream);
@@ -528,7 +528,7 @@ std::unique_ptr<column> from_floats(column_view const& floats,
 std::unique_ptr<column> from_floats(column_view const& floats, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_floats(floats, mr);
+  return detail::from_floats(floats, cudaStream_t{}, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -119,8 +119,8 @@ void dispatch_to_integers_fn::operator()<bool>(column_device_view const&,
 // This will convert a strings column into any integer column type.
 std::unique_ptr<column> to_integers(strings_column_view const& strings,
                                     data_type output_type,
-                                    rmm::mr::device_memory_resource* mr,
-                                    cudaStream_t stream)
+                                    cudaStream_t stream,
+                                    rmm::mr::device_memory_resource* mr)
 {
   size_type strings_count = strings.size();
   if (strings_count == 0) return make_numeric_column(output_type, 0);
@@ -149,7 +149,7 @@ std::unique_ptr<column> to_integers(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_integers(strings, output_type, mr);
+  return detail::to_integers(strings, output_type, cudaStream_t{}, mr);
 }
 
 namespace detail {
@@ -327,8 +327,8 @@ std::unique_ptr<column> dispatch_from_integers_fn::operator()<bool>(
 
 // This will convert all integer column types into a strings column.
 std::unique_ptr<column> from_integers(column_view const& integers,
-                                      rmm::mr::device_memory_resource* mr,
-                                      cudaStream_t stream)
+                                      cudaStream_t stream,
+                                      rmm::mr::device_memory_resource* mr)
 {
   size_type strings_count = integers.size();
   if (strings_count == 0) return detail::make_empty_strings_column(mr, stream);
@@ -345,7 +345,7 @@ std::unique_ptr<column> from_integers(column_view const& integers,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_integers(integers, mr);
+  return detail::from_integers(integers, cudaStream_t{}, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -18,6 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/convert/convert_integers.hpp>
+#include <cudf/strings/detail/converters.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
@@ -116,11 +117,10 @@ void dispatch_to_integers_fn::operator()<bool>(column_device_view const&,
 }  // namespace
 
 // This will convert a strings column into any integer column type.
-std::unique_ptr<column> to_integers(
-  strings_column_view const& strings,
-  data_type output_type,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<column> to_integers(strings_column_view const& strings,
+                                    data_type output_type,
+                                    rmm::mr::device_memory_resource* mr,
+                                    cudaStream_t stream)
 {
   size_type strings_count = strings.size();
   if (strings_count == 0) return make_numeric_column(output_type, 0);
@@ -326,10 +326,9 @@ std::unique_ptr<column> dispatch_from_integers_fn::operator()<bool>(
 }  // namespace
 
 // This will convert all integer column types into a strings column.
-std::unique_ptr<column> from_integers(
-  column_view const& integers,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-  cudaStream_t stream                 = 0)
+std::unique_ptr<column> from_integers(column_view const& integers,
+                                      rmm::mr::device_memory_resource* mr,
+                                      cudaStream_t stream)
 {
   size_type strings_count = integers.size();
   if (strings_count == 0) return detail::make_empty_strings_column(mr, stream);


### PR DESCRIPTION
This PR is simply adding detail headers for declaring the following strings API functions:
- `to_integers/from_integers`
- `to_floats/from_floats`
- `to_booleans/from_booleans`
- `to_timestamps/from_timestamps`

Also adding detail header for `concatenate` and `join_strings`

These functions are used in the CSV writer (in #4484) but it calls the external API instead of the detail API since these headers did not exist.
https://github.com/rapidsai/cudf/blob/80d562d2636780e11ea0cdb68ac2412ac3073619/cpp/src/io/csv/writer_impl.cu#L297
https://github.com/rapidsai/cudf/blob/80d562d2636780e11ea0cdb68ac2412ac3073619/cpp/src/io/csv/writer_impl.cu#L286
https://github.com/rapidsai/cudf/blob/80d562d2636780e11ea0cdb68ac2412ac3073619/cpp/src/io/csv/writer_impl.cu#L245
https://github.com/rapidsai/cudf/blob/80d562d2636780e11ea0cdb68ac2412ac3073619/cpp/src/io/csv/writer_impl.cu#L326
https://github.com/rapidsai/cudf/blob/80d562d2636780e11ea0cdb68ac2412ac3073619/cpp/src/io/csv/writer_impl.cu#L525
https://github.com/rapidsai/cudf/blob/80d562d2636780e11ea0cdb68ac2412ac3073619/cpp/src/io/csv/writer_impl.cu#L407

There is no code logic change. The detail APIs are declared in headers that can be included by other libcudf functions like the CSV writer.