### PR TITLE
Fix memory leak in dlpack.pyx:from_dlpack()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,7 @@
 - PR #5185 Fix flake8 configuration and issues from new flake8 version
 - PR #5193 Fix OOB read in csv reader
 - PR #5191 Fix the use of the device memory resource
+- PR #5212 Fix memory leak in `dlpack.pyx:from_dlpack()`
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/python/cudf/cudf/_lib/dlpack.pyx
+++ b/python/cudf/cudf/_lib/dlpack.pyx
@@ -40,10 +40,12 @@ def from_dlpack(dlpack_capsule):
             cpp_from_dlpack(dlpack_tensor)
         )
 
-    return Table.from_unique_ptr(
+    res = Table.from_unique_ptr(
         move(c_result),
         column_names=range(0, c_result.get()[0].num_columns())
     )
+    dlpack_tensor.deleter(dlpack_tensor)
+    return res
 
 
 def to_dlpack(Table source_table):


### PR DESCRIPTION
A`dlpack` can only be used once.  Functions that set its name to `"used_dltensor"` should also invoke its `deleter()` as well.

`cupy.fromDlpack()` went through [the same problem in July 2018](https://github.com/cupy/cupy/pull/1445), fixed by [adding a `deleter()` call](https://github.com/cupy/cupy/blob/e6474838a922b7869fb56380c8b9421702da1b26/cupy/core/dlpack.pyx#L148-L152) in the finalizer `__dealloc__()` of the memory mgr, who set the tensor name to `"used_dltensor"`.

Fixes #4277 