### PR TITLE
[REVIEW] Add new headers from 5198 to conda/recipes/libcudf/meta.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,7 @@
 - PR #5193 Fix OOB read in csv reader
 - PR #5191 Fix the use of the device memory resource
 - PR #5212 Fix memory leak in `dlpack.pyx:from_dlpack()`
+- PR #5224 Add new headers from 5198 to libcudf/meta.yaml
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -157,7 +157,9 @@ test:
     - test -f $PREFIX/include/cudf/strings/convert/convert_ipv4.hpp
     - test -f $PREFIX/include/cudf/strings/convert/convert_urls.hpp
     - test -f $PREFIX/include/cudf/strings/copying.hpp
+    - test -f $PREFIX/include/cudf/strings/detail/combine.hpp
     - test -f $PREFIX/include/cudf/strings/detail/concatenate.hpp
+    - test -f $PREFIX/include/cudf/strings/detail/converters.hpp
     - test -f $PREFIX/include/cudf/strings/detail/fill.hpp
     - test -f $PREFIX/include/cudf/strings/detail/utilities.hpp
     - test -f $PREFIX/include/cudf/strings/extract.hpp


### PR DESCRIPTION
This fixes build/CI issue that is failing style checks.
It appears that new header files have to be added manually to the `conda/recipes/libcudf/meta.yaml` file in order to pass copyright style check.