### PR TITLE
[REVIEW] Automatically typecast unsupported datetime scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,7 @@
 - PR #5191 Fix the use of the device memory resource
 - PR #5212 Fix memory leak in `dlpack.pyx:from_dlpack()`
 - PR #5224 Add new headers from 5198 to libcudf/meta.yaml
+- PR #5228 Fix datetime64 scalar dtype handling for unsupported time units
 
 
 # cuDF 0.13.0 (31 Mar 2020)

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -531,6 +531,7 @@ def test_datetime_dataframe():
 
     assert_eq(ps.isnull(), gs.isnull())
 
+
 # Cudf autocasts unsupported time_units
 @pytest.mark.parametrize(
     "dtype",
@@ -544,7 +545,8 @@ def test_datetime_array_timeunit_cast(dtype):
             np.datetime64("2019-11-20"),
             np.datetime64("1918-11-20"),
             np.datetime64("2118-11-20"),
-        ], dtype=dtype
+        ],
+        dtype=dtype,
     )
 
     gs = Series(testdata)
@@ -553,19 +555,16 @@ def test_datetime_array_timeunit_cast(dtype):
     assert_eq(ps, gs)
 
     gdf = DataFrame()
-    gdf['a'] = np.arange(5)
-    gdf['b'] = testdata
+    gdf["a"] = np.arange(5)
+    gdf["b"] = testdata
 
     pdf = pd.DataFrame()
-    pdf['a'] = np.arange(5)
-    pdf['b'] = testdata
+    pdf["a"] = np.arange(5)
+    pdf["b"] = testdata
     assert_eq(pdf, gdf)
 
 
-@pytest.mark.parametrize(
-    "timeunit",
-    ["D", "W", "M", "Y"],
-)
+@pytest.mark.parametrize("timeunit", ["D", "W", "M", "Y"])
 def test_datetime_scalar_timeunit_cast(timeunit):
     testscalar = np.datetime64("2016-11-20", timeunit)
 
@@ -574,11 +573,11 @@ def test_datetime_scalar_timeunit_cast(timeunit):
     assert_eq(ps, gs)
 
     gdf = DataFrame()
-    gdf['a'] = np.arange(5)
-    gdf['b'] = testscalar
+    gdf["a"] = np.arange(5)
+    gdf["b"] = testscalar
 
     pdf = pd.DataFrame()
-    pdf['a'] = np.arange(5)
-    pdf['b'] = testscalar
+    pdf["a"] = np.arange(5)
+    pdf["b"] = testscalar
 
     assert_eq(pdf, gdf)

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -530,3 +530,55 @@ def test_datetime_dataframe():
     assert_eq(ps.dropna(), gs.dropna())
 
     assert_eq(ps.isnull(), gs.isnull())
+
+# Cudf autocasts unsupported time_units
+@pytest.mark.parametrize(
+    "dtype",
+    ["datetime64[D]", "datetime64[W]", "datetime64[M]", "datetime64[Y]"],
+)
+def test_datetime_array_timeunit_cast(dtype):
+    testdata = np.array(
+        [
+            np.datetime64("2016-11-20"),
+            np.datetime64("2020-11-20"),
+            np.datetime64("2019-11-20"),
+            np.datetime64("1918-11-20"),
+            np.datetime64("2118-11-20"),
+        ], dtype=dtype
+    )
+
+    gs = Series(testdata)
+    ps = pd.Series(testdata)
+
+    assert_eq(ps, gs)
+
+    gdf = DataFrame()
+    gdf['a'] = np.arange(5)
+    gdf['b'] = testdata
+
+    pdf = pd.DataFrame()
+    pdf['a'] = np.arange(5)
+    pdf['b'] = testdata
+    assert_eq(pdf, gdf)
+
+
+@pytest.mark.parametrize(
+    "timeunit",
+    ["D", "W", "M", "Y"],
+)
+def test_datetime_scalar_timeunit_cast(timeunit):
+    testscalar = np.datetime64("2016-11-20", timeunit)
+
+    gs = Series(testscalar)
+    ps = pd.Series(testscalar)
+    assert_eq(ps, gs)
+
+    gdf = DataFrame()
+    gdf['a'] = np.arange(5)
+    gdf['b'] = testscalar
+
+    pdf = pd.DataFrame()
+    pdf['a'] = np.arange(5)
+    pdf['b'] = testscalar
+
+    assert_eq(pdf, gdf)

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -174,6 +174,11 @@ def to_cudf_compatible_scalar(val, dtype=None):
     if dtype is not None:
         val = val.astype(dtype)
 
+    if val.dtype.type is np.datetime64:
+        time_unit, _ = np.datetime_data(val.dtype)
+        if time_unit in ("D", "W", "M", "Y"):
+            val = val.astype("datetime64[s]")
+
     return val
 
 


### PR DESCRIPTION
Fixes #5120 

Assigning cudf series/dataframes with datetime scalars of time_unit `'D', 'W', 'M', 'Y'` creates a series with the corresponding dtype `datetime64[D]` etc. but fails downstream since these time units are not supported. This PR does the following:

- [X] Autocast datetime64 scalars to a supported time_unit similar to the logic employed for [datetime arrays](https://github.com/rapidsai/cudf/blob/f1488b3f8a120af21c2c63abc34fe753bdd7645d/python/cudf/cudf/core/column/column.py#L1469-L1473)

- [X] Add tests for the auto casting behavior for both datetime arrays and scalars.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
