### PR TITLE
[REVIEW] fix JNI build dependency on Spdlog [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@
 
 ## Bug Fixes
 
+- PR #5230 fix JNI build dependency on Spdlog
 - PR #5181 Allocate null count using the default resource in `copy_if`
 - PR #5141 Use user-provided resource correctly in `unary_operation()` and `shift()`
 - PR #5064 Fix `hash()` and `construct_join_output_df()` to use user-provided memory resource correctly

--- a/conda/environments/cudf_dev_cuda10.0.yml
+++ b/conda/environments/cudf_dev_cuda10.0.yml
@@ -10,7 +10,7 @@ dependencies:
   - clang-tools=8.0.1
   - cupy>=6.6.0,<8.0.0a0,!=7.1.0
   - rmm=0.14.*
-  - cmake>=3.12
+  - cmake>=3.14
   - cmake_setuptools>=0.1.3
   - python>=3.6,<3.8
   - numba>=0.49.0

--- a/conda/environments/cudf_dev_cuda10.1.yml
+++ b/conda/environments/cudf_dev_cuda10.1.yml
@@ -10,7 +10,7 @@ dependencies:
   - clang-tools=8.0.1
   - cupy>=6.6.0,<8.0.0a0,!=7.1.0
   - rmm=0.14.*
-  - cmake>=3.12
+  - cmake>=3.14
   - cmake_setuptools>=0.1.3
   - python>=3.6,<3.8
   - numba>=0.49.0

--- a/conda/environments/cudf_dev_cuda10.2.yml
+++ b/conda/environments/cudf_dev_cuda10.2.yml
@@ -10,7 +10,7 @@ dependencies:
   - clang-tools=8.0.1
   - cupy>=6.6.0,<8.0.0a0,!=7.1.0
   - rmm=0.14.*
-  - cmake>=3.12
+  - cmake>=3.14
   - cmake_setuptools>=0.1.3
   - python>=3.6,<3.8
   - numba>=0.49.0

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -103,11 +103,10 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODUL
 include(FeatureSummary)
 include(CheckIncludeFiles)
 include(CheckLibraryExists)
+include(FetchContent)
 
 ###################################################################################################
 # - SPDLOG ----------------------------------------------------------------------------------------
-
-include(FetchContent)
 
 FetchContent_Declare(
     spdlog
@@ -115,8 +114,11 @@ FetchContent_Declare(
     GIT_TAG        v1.6.0
     GIT_SHALLOW    true
 )
-
-FetchContent_MakeAvailable(spdlog)
+if(NOT spdlog_POPULATED)
+    FetchContent_Populate(spdlog)
+    # We are not using the spdlog CMake targets, so no need to call `add_subdirectory()`.
+endif()
+set(SPDLOG_INCLUDE "${spdlog_SOURCE_DIR}/include")
 
 ###################################################################################################
 # - CUDF ------------------------------------------------------------------------------------------
@@ -208,6 +210,7 @@ include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                     "${CMAKE_SOURCE_DIR}/src"
                     "${JNI_INCLUDE_DIRS}"
                     "${CUDF_INCLUDE}"
+                    "${SPDLOG_INCLUDE}"
                     "${RMM_INCLUDE}")
 
 ###################################################################################################
@@ -257,6 +260,6 @@ endif(PER_THREAD_DEFAULT_STREAM)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(cudfjni spdlog_header_only cudf rmm ${CUDART_LIBRARY} cuda nvrtc)
+target_link_libraries(cudfjni cudf rmm ${CUDART_LIBRARY} cuda nvrtc)
 
 

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 project(CUDF_JNI VERSION 0.7.0 LANGUAGES C CXX CUDA)
 
@@ -103,6 +103,20 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODUL
 include(FeatureSummary)
 include(CheckIncludeFiles)
 include(CheckLibraryExists)
+
+###################################################################################################
+# - SPDLOG ----------------------------------------------------------------------------------------
+
+include(FetchContent)
+
+FetchContent_Declare(
+    spdlog
+    GIT_REPOSITORY https://github.com/gabime/spdlog.git
+    GIT_TAG        v1.6.0
+    GIT_SHALLOW    true
+)
+
+FetchContent_MakeAvailable(spdlog)
 
 ###################################################################################################
 # - CUDF ------------------------------------------------------------------------------------------
@@ -243,6 +257,6 @@ endif(PER_THREAD_DEFAULT_STREAM)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(cudfjni cudf rmm ${CUDART_LIBRARY} cuda nvrtc)
+target_link_libraries(cudfjni spdlog_header_only cudf rmm ${CUDART_LIBRARY} cuda nvrtc)
 
 


### PR DESCRIPTION
For the Spark CI we can't rely on conda to pull in spdlog, so doing it directly in cmake instead.

@revans2 @jlowe 