### PR TITLE
Rely on NumPy arrays for out-of-band pickling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #5268 Rely on NumPy arrays for out-of-band pickling
+
 ## Bug Fixes
 
 # cuDF 0.14.0 (Date TBD)

--- a/python/cudf/cudf/core/abc.py
+++ b/python/cudf/cudf/core/abc.py
@@ -55,8 +55,5 @@ class Serializable(abc.ABC):
 
     def __reduce_ex__(self, protocol):
         header, frames = self.host_serialize()
-        if protocol >= 5:
-            frames = [pickle.PickleBuffer(f) for f in frames]
-        else:
-            frames = [numpy.asarray(f) for f in frames]
+        frames = [numpy.asarray(f) for f in frames]
         return self.host_deserialize, (header, frames)

--- a/python/cudf/cudf/core/abc.py
+++ b/python/cudf/cudf/core/abc.py
@@ -4,8 +4,6 @@ import abc
 import pickle
 from abc import abstractmethod
 
-import numpy
-
 import rmm
 
 import cudf
@@ -53,5 +51,5 @@ class Serializable(abc.ABC):
 
     def __reduce_ex__(self, protocol):
         header, frames = self.host_serialize()
-        frames = [numpy.asarray(f) for f in frames]
+        frames = [f.obj for f in frames]
         return self.host_deserialize, (header, frames)


### PR DESCRIPTION
As NumPy arrays are always pickleable and they support pickle protocol version 5 (out-of-band pickling) on their own, just use NumPy arrays when pickling `Serializable` objects.