### PR TITLE
Explicitly require NumPy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Bug Fixes
 
+- PR #5269 Explicitly require NumPy
+
 # cuDF 0.14.0 (Date TBD)
 
 ## New Features

--- a/conda/environments/cudf_dev_cuda10.0.yml
+++ b/conda/environments/cudf_dev_cuda10.0.yml
@@ -14,6 +14,7 @@ dependencies:
   - cmake_setuptools>=0.1.3
   - python>=3.6,<3.8
   - numba>=0.49.0
+  - numpy
   - pandas>=0.25,<0.26
   - pyarrow=0.15.0
   - fastavro>=0.22.9

--- a/conda/environments/cudf_dev_cuda10.1.yml
+++ b/conda/environments/cudf_dev_cuda10.1.yml
@@ -14,6 +14,7 @@ dependencies:
   - cmake_setuptools>=0.1.3
   - python>=3.6,<3.8
   - numba>=0.49.0
+  - numpy
   - pandas>=0.25,<0.26
   - pyarrow=0.15.0
   - fastavro>=0.22.9

--- a/conda/environments/cudf_dev_cuda10.2.yml
+++ b/conda/environments/cudf_dev_cuda10.2.yml
@@ -14,6 +14,7 @@ dependencies:
   - cmake_setuptools>=0.1.3
   - python>=3.6,<3.8
   - numba>=0.49.0
+  - numpy
   - pandas>=0.25,<0.26
   - pyarrow=0.15.0
   - fastavro>=0.22.9

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - pandas >=0.25,<0.26
     - cupy >=6.6.0,<8.0.0a0,!=7.1.0
     - numba >=0.49.0
+    - numpy
     - pyarrow 0.15.0.*
     - fastavro >=0.22.0
     - rmm {{ minor_version }}.*


### PR DESCRIPTION
Already we are using NumPy in the code. Thus far this has worked because Numba requires NumPy. So we have depended on NumPy implicitly. This makes the NumPy requirement explicit.