### PR TITLE
[REVIEW] Add support to check for "NaT" and "None" strings while typecasting to `datetime64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@
 - PR #5219 Add per context cache for JIT kernels
 - PR #5233 Remove experimental namespace used during libcudf++ refactor
 - PR #5251 Fix more mispellings in cpp comments and strings
+- PR #5270 Add support to check for "NaT" and "None" strings while typecasting to `datetime64`
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -581,3 +581,30 @@ def test_datetime_scalar_timeunit_cast(timeunit):
     pdf["b"] = testscalar
 
     assert_eq(pdf, gdf)
+
+
+def test_str_null_to_datetime():
+    psr = pd.Series(["2001-01-01", "2002-02-02", "2000-01-05", "NaT"])
+    gsr = Series(["2001-01-01", "2002-02-02", "2000-01-05", "NaT"])
+
+    assert_eq(psr.astype("datetime64[s]"), gsr.astype("datetime64[s]"))
+
+    psr = pd.Series(["2001-01-01", "2002-02-02", "2000-01-05", None])
+    gsr = Series(["2001-01-01", "2002-02-02", "2000-01-05", None])
+
+    assert_eq(psr.astype("datetime64[s]"), gsr.astype("datetime64[s]"))
+
+    psr = pd.Series(["2001-01-01", "2002-02-02", "2000-01-05", "None"])
+    gsr = Series(["2001-01-01", "2002-02-02", "2000-01-05", "None"])
+
+    error_type = None
+    try:
+        psr.astype("datetime64[s]")
+    except Exception as e:
+        error_type = type(e)
+
+    if error_type is None:
+        raise Exception("Expected psr.astype('datetime64[s]') to fail")
+
+    with pytest.raises(ValueError):
+        gsr.astype("datetime64[s]")


### PR DESCRIPTION
Fixes: #5117 

1. Checking for `'None'` values and erroring to match pandas behavior.
2. Setting the result values to `null` if we find any `'NaT'` values in the input column.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
