### PR TITLE
Drop `auto_pickle` decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #5288 Drop `auto_pickle` decorator #5288
+
 ## Bug Fixes
 
 # cuDF 0.14.0 (Date TBD)

--- a/python/cudf/cudf/_lib/column.pyx
+++ b/python/cudf/cudf/_lib/column.pyx
@@ -2,7 +2,6 @@
 
 import numpy as np
 import pandas as pd
-import cython
 import rmm
 
 import cudf
@@ -28,7 +27,6 @@ from cudf._lib.cpp.column.column_view cimport column_view
 cimport cudf._lib.cpp.types as libcudf_types
 
 
-@cython.auto_pickle(True)
 cdef class Column:
     """
     A Column stores columnar data in device memory.


### PR DESCRIPTION
Since Cython 0.26+, `auto_pickle` is already added to any `cdef class`. So this shouldn't be needed. Besides pickling is largely handled through `serialize` and `deserialize` methods of `Serializable` subclasses.