### PR TITLE
WIP: Implement `Serializable` for Dask-cuDF objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - PR #5288 Drop `auto_pickle` decorator #5288
 - PR #5231 Type `Buffer` as `uint8`
+- PR #5294 Implement `Serializable` for Dask-cuDF objects
 
 ## Bug Fixes
 


### PR DESCRIPTION
Subclasses `Serializable` for Dask-cuDF objects and implements `serialize` and `deserialize` methods (replacing `__getstate__` and `__setstate__`). Should allow more efficient serialization when possible. Otherwise it can still fallback to pickle.

**Note:** Adding PR ( https://github.com/dask/distributed/pull/3832 ) upstream to make sure Dask registers Dask-cuDF object serialization methods.

cc @rjzamora