### PR TITLE
[REVIEW] Remove unused native deps from java library [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@
 - PR #5213 Documentation enhancements to `cudf` python APIs
 - PR #5251 Fix more mispellings in cpp comments and strings
 - PR #5270 Add support to check for "NaT" and "None" strings while typecasting to `datetime64`
+- PR #5298 Remove unused native deps from java library
 
 ## Bug Fixes
 

--- a/java/README.md
+++ b/java/README.md
@@ -53,13 +53,15 @@ CUDA 10.0:
 Build the native code first, and make sure the a JDK is installed and available. 
 If you use the default cmake options libcudart will be dynamically linked to libcudf and librmm
 which are included.  If you do this the resulting jar will have a classifier associated with it
-because that jar can only be used with a single version of the CUDA runtime.  If you want
-to remove that requirement you can build RMM and cuDF with `-DCUDA_STATIC_RUNTIME=ON` when
-running cmake, and similarly -DCUDA_STATIC_RUNTIME=ON when running maven.  This will statically 
-link in the CUDA runtime and result in a jar with no
-classifier that should run on any host that has a version of the driver new enough to support
-the runtime that this was built with.  Official releases will indicate in the release notes
-the minimum driver version required.
+because that jar can only be used with a single version of the CUDA runtime.  
+
+
+There is experimental work to try and remove that requirement but it is not fully functionaly
+you can build RMM and cuDF with `-DCUDA_STATIC_RUNTIME=ON` when running cmake, and similarly 
+-DCUDA_STATIC_RUNTIME=ON when running maven.  This will statically  link in the CUDA runtime
+and result in a jar with no classifier that should run on any host that has a version of the
+driver new enough to support the runtime that this was built with. Unfortunely libnvrtc is still
+required for runtime code generation which also is tied to a specific version of cuda.
 
 To build with maven for dynamic linking you would run.
 

--- a/java/README.md
+++ b/java/README.md
@@ -56,11 +56,11 @@ which are included.  If you do this the resulting jar will have a classifier ass
 because that jar can only be used with a single version of the CUDA runtime.  
 
 
-There is experimental work to try and remove that requirement but it is not fully functionaly
+There is experimental work to try and remove that requirement but it is not fully functional
 you can build RMM and cuDF with `-DCUDA_STATIC_RUNTIME=ON` when running cmake, and similarly 
--DCUDA_STATIC_RUNTIME=ON when running maven.  This will statically  link in the CUDA runtime
+`-DCUDA_STATIC_RUNTIME=ON` when running maven.  This will statically link in the CUDA runtime
 and result in a jar with no classifier that should run on any host that has a version of the
-driver new enough to support the runtime that this was built with. Unfortunely libnvrtc is still
+driver new enough to support the runtime that this was built with. Unfortunately `libnvrtc` is still
 required for runtime code generation which also is tied to a specific version of cuda.
 
 To build with maven for dynamic linking you would run.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -231,45 +231,6 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>COPY_NVRTC</id>
-            <activation>
-                <property>
-                    <name>CUDA_STATIC_RUNTIME</name>
-                    <value>ON</value>
-                </property>
-            </activation>
-            <build>
-            <plugins>
-              <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-nvrtc</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <overwrite>true</overwrite>
-                            <skip>${skipNativeCopy}</skip>
-                            <outputDirectory>${basedir}/target/native-deps/${os.arch}/${os.name}</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <!--Set by groovy script-->
-                                    <directory>${cuda.path}</directory>
-                                    <includes>
-                                        <include>libnvrtc.so</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-              </plugin>
-          </plugins>
-      </build>
-        </profile>
     </profiles>
 
     <build>
@@ -454,14 +415,7 @@
                             }
 
                             if (pom.properties['CUDA_STATIC_RUNTIME'] == 'ON') {
-                                // We want to pull in nvrtc in this case
-                                def libnvrtc =  ~/libnvrtc\\.so.*\\s+=>\\s+(.*)libnvrtc.*\\.so.*\\s+.*/
-                                def rtcm = libnvrtc.matcher(sout)
-                                if (rtcm.find()) {
-                                  pom.properties['cuda.path'] = rtcm.group(1)
-                                } else {
-                                  fail('could not find libnvrtc which we need to package when statically linking')
-                                }
+                                println 'WARNING RUNNING WITH STATIC LINKING DOES NOT FULLY WORK. USE WITH CAUTION.'
                             }
                             </source>
                         </configuration>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -479,8 +479,6 @@
                                     <directory>${native.cudf.path}</directory>
                                     <includes>
                                         <include>libcudf.so</include>
-                                        <include>libNVCategory.so</include>
-                                        <include>libNVStrings.so</include>
                                     </includes>
                                 </resource>
                                 <resource>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -231,6 +231,45 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>COPY_NVRTC</id>
+            <activation>
+                <property>
+                    <name>CUDA_STATIC_RUNTIME</name>
+                    <value>ON</value>
+                </property>
+            </activation>
+            <build>
+            <plugins>
+              <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-nvrtc</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <skip>${skipNativeCopy}</skip>
+                            <outputDirectory>${basedir}/target/native-deps/${os.arch}/${os.name}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <!--Set by groovy script-->
+                                    <directory>${cuda.path}</directory>
+                                    <includes>
+                                        <include>libnvrtc.so</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+              </plugin>
+          </plugins>
+      </build>
+        </profile>
     </profiles>
 
     <build>
@@ -413,6 +452,17 @@
                             } else {
                                 pom.properties['cuda.classifier'] = ''
                             }
+
+                            if (pom.properties['CUDA_STATIC_RUNTIME'] == 'ON') {
+                                // We want to pull in nvrtc in this case
+                                def libnvrtc =  ~/libnvrtc\\.so.*\\s+=>\\s+(.*)libnvrtc.*\\.so.*\\s+.*/
+                                def rtcm = libnvrtc.matcher(sout)
+                                if (rtcm.find()) {
+                                  pom.properties['cuda.path'] = rtcm.group(1)
+                                } else {
+                                  fail('could not find libnvrtc which we need to package when statically linking')
+                                }
+                            }
                             </source>
                         </configuration>
                     </execution>
@@ -424,22 +474,6 @@
                 <configuration>
                     <!--Set by groovy script-->
                     <classifier>${cuda.classifier}</classifier>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>native-maven-plugin</artifactId>
-                <version>1.0-alpha-8</version>
-                <extensions>true</extensions>
-
-                <configuration>
-                    <javahClassNames>
-                        <javahClassName>ai.rapids.cudf.Cuda</javahClassName>
-                        <javahClassName>ai.rapids.cudf.ColumnVector</javahClassName>
-                        <javahClassName>ai.rapids.cudf.Table</javahClassName>
-                        <javahClassName>ai.rapids.cudf.Rmm</javahClassName>
-                    </javahClassNames>
-                    <javahOutputDirectory>${basedir}/src/main/native/include/</javahOutputDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -34,8 +34,6 @@ public class NativeDepsLoader {
   private static final String[] loadOrder = new String[] {
       "boost_filesystem",
       "rmm",
-      "NVStrings",
-      "NVCategory",
       "cudf",
       "cudfjni"
   };

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -31,22 +31,54 @@ import java.net.URL;
  */
 public class NativeDepsLoader {
   private static final Logger log = LoggerFactory.getLogger(NativeDepsLoader.class);
-  private static final String[] loadOrder = new String[] {
-      "boost_filesystem",
-      "rmm",
-      "cudf",
-      "cudfjni"
+  private static final Loader[] loadOrder = new Loader[] {
+      new Optional("nvrtc"),
+      new Required("boost_filesystem"),
+      new Required("rmm"),
+      new Required("cudf"),
+      new Required("cudfjni")
   };
   private static ClassLoader loader = NativeDepsLoader.class.getClassLoader();
   private static boolean loaded = false;
+
+  private static abstract class Loader {
+    protected final String baseName;
+    public Loader(String baseName) {
+      this.baseName = baseName;
+    }
+
+    public abstract void load(String os, String arch) throws IOException;
+  }
+
+  private static class Required extends Loader {
+    public Required(String baseName) {
+      super(baseName);
+    }
+
+    @Override
+    public void load(String os, String arch) throws IOException {
+      loadDep(os, arch, this.baseName, true);
+    }
+  }
+
+  private static class Optional extends Loader {
+    public Optional(String baseName) {
+      super(baseName);
+    }
+
+    @Override
+    public void load(String os, String arch) throws IOException {
+      loadDep(os, arch, this.baseName, false);
+    }
+  }
 
   static synchronized void loadNativeDeps() {
     if (!loaded) {
       String os = System.getProperty("os.name");
       String arch = System.getProperty("os.arch");
       try {
-        for (String toLoad : loadOrder) {
-          loadDep(os, arch, toLoad);
+        for (Loader toLoad : loadOrder) {
+          toLoad.load(os, arch);
         }
         loaded = true;
       } catch (Throwable t) {
@@ -55,7 +87,8 @@ public class NativeDepsLoader {
     }
   }
 
-  private static void loadDep(String os, String arch, String baseName) throws IOException {
+  private static void loadDep(String os, String arch, String baseName, boolean required)
+          throws IOException {
     String path = arch + "/" + os + "/" + System.mapLibraryName(baseName);
     File loc;
     URL resource = loader.getResource(path);
@@ -63,7 +96,11 @@ public class NativeDepsLoader {
       // It looks like we are not running from the jar, or there are issues with the jar
       File f = new File("./target/native-deps/" + path);
       if (!f.exists()) {
-        throw new FileNotFoundException("Could not locate native dependency " + path);
+        if (required) {
+          throw new FileNotFoundException("Could not locate native dependency " + path);
+        }
+        // Not required so we will skip it
+        return;
       }
       resource = f.toURL();
     }


### PR DESCRIPTION
This removes nvstrings and nvcategory from what is packaged in the java jar.  They are no longer used so we can remove them.

This also adds in packaging of libnvrtc if static linking is enabled.  This is not 100% perfect as libnvrtc will do a dlopen on libnvrtc-builtins.so  But it is a step in the right direction.