### PR TITLE
Update package version for Java bindings [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ## Bug Fixes
 
 - PR #5269 Explicitly require NumPy
+- PR #5299 Update package version for Java bindings
+
 
 # cuDF 0.14.0 (Date TBD)
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ai.rapids</groupId>
     <artifactId>cudf</artifactId>
-    <version>0.14-SNAPSHOT</version>
+    <version>0.15-SNAPSHOT</version>
 
     <name>cudfjni</name>
     <description>


### PR DESCRIPTION
Updating the Java version to match the libcudf version.