### PR TITLE
Coerce frames to `Buffer`s in deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PR #5268 Rely on NumPy arrays for out-of-band pickling
 - PR #5288 Drop `auto_pickle` decorator #5288
 - PR #5231 Type `Buffer` as `uint8`
+- PR #5308 Coerce frames to `Buffer`s in deserialization
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/abc.py
+++ b/python/cudf/cudf/core/abc.py
@@ -28,12 +28,8 @@ class Serializable(abc.ABC):
 
     @classmethod
     def device_deserialize(cls, header, frames):
-        for f in frames:
-            # some frames are empty -- meta/empty partitions/etc
-            if len(f) > 0:
-                assert hasattr(f, "__cuda_array_interface__")
-
         typ = pickle.loads(header["type-serialized"])
+        frames = [cudf.core.buffer.Buffer(f) for f in frames]
         obj = typ.deserialize(header, frames)
 
         return obj


### PR DESCRIPTION
To ensure that the result after deserialization looks like that before serialization, make sure to coerce frames in device deserialization to `Buffer` objects. As a result, when subclasses get frames in `deserialize` they can rely on them being `Buffer`s.