### PR TITLE
[REVIEW] Cross join feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - PR #5222 Adding clip feature support to DataFrame and Series
+- PR #5327 Add `cudf::cross_join` feature
 
 ## Improvements
 - PR #5245 Add column reduction benchmark

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -69,6 +69,7 @@ test:
     - test -f $PREFIX/include/cudf/detail/reduction_functions.hpp
     - test -f $PREFIX/include/cudf/detail/repeat.hpp
     - test -f $PREFIX/include/cudf/detail/replace.hpp
+    - test -f $PREFIX/include/cudf/detail/reshape.hpp
     - test -f $PREFIX/include/cudf/detail/scatter.hpp
     - test -f $PREFIX/include/cudf/detail/search.hpp
     - test -f $PREFIX/include/cudf/detail/sequence.hpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -415,6 +415,7 @@ add_library(cudf
             src/merge/merge.cu
             src/partitioning/round_robin.cu
             src/join/join.cu
+            src/join/cross_join.cu
             src/join/semi_join.cu
             src/sort/is_sorted.cu
             src/binaryop/binaryop.cpp

--- a/cpp/include/cudf/detail/reshape.hpp
+++ b/cpp/include/cudf/detail/reshape.hpp
@@ -25,11 +25,11 @@ namespace detail {
 /**
  * @copydoc cudf::tile
  *
- * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param stream CUDA stream used for device memory operations and kernel launches
  */
 std::unique_ptr<table> tile(table_view const& input,
                             size_type count,
-                            rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-                            cudaStream_t stream                 = 0);
+                            cudaStream_t stream                 = 0,
+                            rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/detail/reshape.hpp
+++ b/cpp/include/cudf/detail/reshape.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/types.hpp>
+
+#include <memory>
+
+namespace cudf {
+namespace detail {
+/**
+ * @copydoc cudf::tile
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::unique_ptr<table> tile(table_view const& input,
+                            size_type count,
+                            rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+                            cudaStream_t stream                 = 0);
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -331,8 +331,10 @@ std::unique_ptr<cudf::table> left_anti_join(
  * @brief Performs a cross join on two tables (`left`, `right`)
  *
  * The cross join returns the cartesian product of rows from each table.
- * @note Warning: This function can easily cause out-of-memory errors. The size of the output is equal to 
- *  `left.num_rows() * right.num_rows()`. Use with caution. 
+ *
+ * @note Warning: This function can easily cause out-of-memory errors. The size of the output is
+ * equal to `left.num_rows() * right.num_rows()`. Use with caution.
+ *
  * @code{.pseudo}
  *          Left a: {0, 1, 2}
  *          Right b: {3, 4, 5}

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -328,8 +328,7 @@ std::unique_ptr<cudf::table> left_anti_join(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
- * @brief  Performs a cross join on the specified columns of two
- * tables (left, right)
+ * @brief  Performs a cross join on two tables (left, right)
  *
  * The cross join returns the cartesian product of rows from each table.
  *
@@ -337,25 +336,16 @@ std::unique_ptr<cudf::table> left_anti_join(
  * and tile the right table by the number of rows in the left table.
  *
  * @throws cudf::logic_error if number of columns in either `left` or `right` table is 0
- * @throws cudf::logic_error if number of returned columns is 0
  *
  * @param[in] left                  The left table
  * @param[in] right                 The right table
- * @param[in] return_left_columns   A vector of column indices from `left` to include in the
- *                                  returned table.
- * @param[in] return_right_columns  A vector of column indices from `right` to include in the
- *                                  returned table.
  * @param[in] mr                    Device memory resource to use for device memory allocation
  *
- * @returns                         Result of cross joining `left` and `right` tables, keeping
- *                                  columns specified by `return_left_columns` and
- *                                  `return_right_columns`.
+ * @returns                         Result of cross joining `left` and `right` tables
  */
 std::unique_ptr<cudf::table> cross_join(
   cudf::table_view const& left,
   cudf::table_view const& right,
-  std::vector<cudf::size_type> const& return_left_columns,
-  std::vector<cudf::size_type> const& return_right_columns,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -327,5 +327,36 @@ std::unique_ptr<cudf::table> left_anti_join(
   std::vector<cudf::size_type> const& return_columns,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
+/**
+ * @brief  Performs a cross join on the specified columns of two
+ * tables (left, right)
+ *
+ * The cross join returns the cartesian product of rows from each table.
+ *
+ * The approach is to repeat the left table by the number of rows in the right table
+ * and tile the right table by the number of rows in the left table.
+ *
+ * @throws cudf::logic_error if number of columns in either `left` or `right` table is 0
+ * @throws cudf::logic_error if number of returned columns is 0
+ *
+ * @param[in] left                  The left table
+ * @param[in] right                 The right table
+ * @param[in] return_left_columns   A vector of column indices from `left` to include in the
+ *                                  returned table.
+ * @param[in] return_right_columns  A vector of column indices from `right` to include in the
+ *                                  returned table.
+ * @param[in] mr                    Device memory resource to use for device memory allocation
+ *
+ * @returns                         Result of cross joining `left` and `right` tables, keeping
+ *                                  columns specified by `return_left_columns` and
+ *                                  `return_right_columns`.
+ */
+std::unique_ptr<cudf::table> cross_join(
+  cudf::table_view const& left,
+  cudf::table_view const& right,
+  std::vector<cudf::size_type> const& return_left_columns,
+  std::vector<cudf::size_type> const& return_right_columns,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+
 /** @} */  // end of group
 }  // namespace cudf

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -328,20 +328,23 @@ std::unique_ptr<cudf::table> left_anti_join(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
- * @brief  Performs a cross join on two tables (left, right)
+ * @brief Performs a cross join on two tables (`left`, `right`)
  *
  * The cross join returns the cartesian product of rows from each table.
  *
- * The approach is to repeat the left table by the number of rows in the right table
- * and tile the right table by the number of rows in the left table.
+ * @code{.pseudo}
+ *          Left a: {0, 1, 2}
+ *          Right b: {3, 4, 5}
+ * Result: { a: {0, 0, 0, 1, 1, 1, 2, 2, 2}, b: {3, 4, 5, 3, 4, 5, 3, 4, 5} }
+ * @endcode
+
+ * @throw cudf::logic_error if number of columns in either `left` or `right` table is 0
  *
- * @throws cudf::logic_error if number of columns in either `left` or `right` table is 0
+ * @param left  The left table
+ * @param right The right table
+ * @param mr    Device memory resource used to allocate the returned table's device memory
  *
- * @param[in] left                  The left table
- * @param[in] right                 The right table
- * @param[in] mr                    Device memory resource to use for device memory allocation
- *
- * @returns                         Result of cross joining `left` and `right` tables
+ * @returns     Result of cross joining `left` and `right` tables
  */
 std::unique_ptr<cudf::table> cross_join(
   cudf::table_view const& left,

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -331,7 +331,8 @@ std::unique_ptr<cudf::table> left_anti_join(
  * @brief Performs a cross join on two tables (`left`, `right`)
  *
  * The cross join returns the cartesian product of rows from each table.
- *
+ * @note Warning: This function can easily cause out-of-memory errors. The size of the output is equal to 
+ *  `left.num_rows() * right.num_rows()`. Use with caution. 
  * @code{.pseudo}
  *          Left a: {0, 1, 2}
  *          Right b: {3, 4, 5}

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <cudf/column/column.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -1,0 +1,99 @@
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/gather.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/join.hpp>
+#include <cudf/reshape.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/error.hpp>
+#include <hash/concurrent_unordered_map.cuh>
+
+#include <join/join_common_utils.hpp>
+
+#include <cudf/detail/gather.cuh>
+#include <join/hash_join.cuh>
+#include "cudf/column/column.hpp"
+#include "cudf/filling.hpp"
+#include "cudf/scalar/scalar_factories.hpp"
+#include "cudf/types.hpp"
+#include "cudf/utilities/type_dispatcher.hpp"
+
+namespace cudf {
+namespace detail {
+/**
+ * @brief  Performs a cross join on the specified columns of two
+ * tables (left, right)
+ *
+ * The cross join returns the cartesian product of rows from each table.
+ *
+ * The approach is to repeat the left table by the number of rows in the right table
+ * and tile the right table by the number of rows in the left table.
+ *
+ * @throws cudf::logic_error if number of columns in either `left` or `right` table is 0
+ * @throws cudf::logic_error if number of returned columns is 0
+ *
+ * @param[in] left                  The left table
+ * @param[in] right                 The right table
+ * @param[in] return_left_columns   A vector of column indices from `left` to include in the
+ *                                  returned table.
+ * @param[in] return_right_columns  A vector of column indices from `right` to include in the
+ *                                  returned table.
+ * @param[in] mr                    Device memory resource to use for device memory allocation
+ * @param[in] stream                Cuda stream
+ *
+ * @returns                         Result of cross joining `left` and `right` tables, keeping
+ *                                  columns specified by `return_left_columns` and
+ *                                  `return_right_columns`.
+ */
+std::unique_ptr<cudf::table> cross_join(
+  cudf::table_view const& left,
+  cudf::table_view const& right,
+  std::vector<cudf::size_type> const& return_left_columns,
+  std::vector<cudf::size_type> const& return_right_columns,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+  cudaStream_t stream                 = 0)
+{
+  CUDF_EXPECTS(0 != left.num_columns(), "Left table is empty");
+  CUDF_EXPECTS(0 != right.num_columns(), "Right table is empty");
+
+  // Only repeat/tile the selected columns
+  auto left_selected{left.select(return_left_columns)};
+  auto right_selected{right.select(return_right_columns)};
+
+  // If left or right table has no rows, return an empty table with all selected columns
+  if ((0 == left.num_rows()) || (0 == right.num_rows())) {
+    auto empty_left{empty_like(left_selected)};
+    auto empty_right{empty_like(right_selected)};
+    // TODO: Return empty table with all selected columns
+  }
+
+  // Repeat left table
+  numeric_scalar<size_type> num_repeats{right.num_rows()};
+  auto left_repeated{cudf::repeat(left_selected, num_repeats, mr)};
+
+  // Tile right table
+  auto right_tiled{cudf::tile(right_selected, left.num_rows(), mr)};
+
+  // Concatenate all repeated/tiled columns into one table
+  auto left_repeated_columns{left_repeated->release()};
+  auto right_tiled_columns{right_tiled->release()};
+  std::move(right_tiled_columns.begin(),
+            right_tiled_columns.end(),
+            std::back_inserter(left_repeated_columns));
+
+  return std::make_unique<table>(std::move(left_repeated_columns));
+}
+}  // namespace detail
+
+std::unique_ptr<cudf::table> cross_join(cudf::table_view const& left,
+                                        cudf::table_view const& right,
+                                        std::vector<cudf::size_type> const& return_left_columns,
+                                        std::vector<cudf::size_type> const& return_right_columns,
+                                        rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::cross_join(left, right, return_left_columns, return_right_columns, mr, 0);
+}
+
+}  // namespace cudf

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -1,29 +1,19 @@
-#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/gather.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/repeat.hpp>
+#include <cudf/filling.hpp>
 #include <cudf/join.hpp>
 #include <cudf/reshape.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
-#include <hash/concurrent_unordered_map.cuh>
-
-#include <join/join_common_utils.hpp>
-
-#include <cudf/detail/gather.cuh>
-#include <join/hash_join.cuh>
-#include "cudf/column/column.hpp"
-#include "cudf/filling.hpp"
-#include "cudf/scalar/scalar_factories.hpp"
-#include "cudf/types.hpp"
-#include "cudf/utilities/type_dispatcher.hpp"
 
 namespace cudf {
 namespace detail {
 /**
- * @brief  Performs a cross join on the specified columns of two
- * tables (left, right)
+ * @brief  Performs a cross join on two tables (left, right)
  *
  * The cross join returns the cartesian product of rows from each table.
  *
@@ -31,49 +21,39 @@ namespace detail {
  * and tile the right table by the number of rows in the left table.
  *
  * @throws cudf::logic_error if number of columns in either `left` or `right` table is 0
- * @throws cudf::logic_error if number of returned columns is 0
  *
  * @param[in] left                  The left table
  * @param[in] right                 The right table
- * @param[in] return_left_columns   A vector of column indices from `left` to include in the
- *                                  returned table.
- * @param[in] return_right_columns  A vector of column indices from `right` to include in the
- *                                  returned table.
  * @param[in] mr                    Device memory resource to use for device memory allocation
  * @param[in] stream                Cuda stream
  *
- * @returns                         Result of cross joining `left` and `right` tables, keeping
- *                                  columns specified by `return_left_columns` and
- *                                  `return_right_columns`.
+ * @returns                         Result of cross joining `left` and `right` tables
  */
 std::unique_ptr<cudf::table> cross_join(
   cudf::table_view const& left,
   cudf::table_view const& right,
-  std::vector<cudf::size_type> const& return_left_columns,
-  std::vector<cudf::size_type> const& return_right_columns,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
   cudaStream_t stream                 = 0)
 {
   CUDF_EXPECTS(0 != left.num_columns(), "Left table is empty");
   CUDF_EXPECTS(0 != right.num_columns(), "Right table is empty");
 
-  // Only repeat/tile the selected columns
-  auto left_selected{left.select(return_left_columns)};
-  auto right_selected{right.select(return_right_columns)};
-
-  // If left or right table has no rows, return an empty table with all selected columns
+  // If left or right table has no rows, return an empty table with all columns
   if ((0 == left.num_rows()) || (0 == right.num_rows())) {
-    auto empty_left{empty_like(left_selected)};
-    auto empty_right{empty_like(right_selected)};
-    // TODO: Return empty table with all selected columns
+    auto empty_left_columns{empty_like(left)->release()};
+    auto empty_right_columns{empty_like(right)->release()};
+    std::move(empty_right_columns.begin(),
+              empty_right_columns.end(),
+              std::back_inserter(empty_left_columns));
+    return std::make_unique<table>(std::move(empty_left_columns));
   }
 
   // Repeat left table
   numeric_scalar<size_type> num_repeats{right.num_rows()};
-  auto left_repeated{cudf::repeat(left_selected, num_repeats, mr)};
+  auto left_repeated{detail::repeat(left, num_repeats, mr, stream)};
 
   // Tile right table
-  auto right_tiled{cudf::tile(right_selected, left.num_rows(), mr)};
+  auto right_tiled{cudf::tile(right, left.num_rows(), mr)};
 
   // Concatenate all repeated/tiled columns into one table
   auto left_repeated_columns{left_repeated->release()};
@@ -88,12 +68,10 @@ std::unique_ptr<cudf::table> cross_join(
 
 std::unique_ptr<cudf::table> cross_join(cudf::table_view const& left,
                                         cudf::table_view const& right,
-                                        std::vector<cudf::size_type> const& return_left_columns,
-                                        std::vector<cudf::size_type> const& return_right_columns,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::cross_join(left, right, return_left_columns, return_right_columns, mr, 0);
+  return detail::cross_join(left, right, mr, 0);
 }
 
 }  // namespace cudf

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -57,8 +57,8 @@ std::unique_ptr<cudf::table> cross_join(
 
   // If left or right table has no rows, return an empty table with all columns
   if ((0 == left.num_rows()) || (0 == right.num_rows())) {
-    auto empty_left_columns{empty_like(left)->release()};
-    auto empty_right_columns{empty_like(right)->release()};
+    auto empty_left_columns  = empty_like(left)->release();
+    auto empty_right_columns = empty_like(right)->release();
     std::move(empty_right_columns.begin(),
               empty_right_columns.end(),
               std::back_inserter(empty_left_columns));
@@ -66,15 +66,15 @@ std::unique_ptr<cudf::table> cross_join(
   }
 
   // Repeat left table
-  numeric_scalar<size_type> num_repeats{right.num_rows()};
-  auto left_repeated{detail::repeat(left, num_repeats, mr, stream)};
+  numeric_scalar<size_type> num_repeats = right.num_rows();
+  auto left_repeated                    = detail::repeat(left, num_repeats, mr, stream);
 
   // Tile right table
-  auto right_tiled{detail::tile(right, left.num_rows(), mr, stream)};
+  auto right_tiled = detail::tile(right, left.num_rows(), mr, stream);
 
   // Concatenate all repeated/tiled columns into one table
-  auto left_repeated_columns{left_repeated->release()};
-  auto right_tiled_columns{right_tiled->release()};
+  auto left_repeated_columns = left_repeated->release();
+  auto right_tiled_columns   = right_tiled->release();
   std::move(right_tiled_columns.begin(),
             right_tiled_columns.end(),
             std::back_inserter(left_repeated_columns));

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -18,6 +18,7 @@
 #include <cudf/copying.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/repeat.hpp>
+#include <cudf/detail/reshape.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/join.hpp>
 #include <cudf/reshape.hpp>
@@ -69,7 +70,7 @@ std::unique_ptr<cudf::table> cross_join(
   auto left_repeated{detail::repeat(left, num_repeats, mr, stream)};
 
   // Tile right table
-  auto right_tiled{cudf::tile(right, left.num_rows(), mr)};
+  auto right_tiled{detail::tile(right, left.num_rows(), mr, stream)};
 
   // Concatenate all repeated/tiled columns into one table
   auto left_repeated_columns{left_repeated->release()};

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/detail/gather.hpp>

--- a/cpp/src/reshape/tile.cu
+++ b/cpp/src/reshape/tile.cu
@@ -39,8 +39,8 @@ struct tile_functor {
 namespace detail {
 std::unique_ptr<table> tile(const table_view &in,
                             size_type count,
-                            rmm::mr::device_memory_resource *mr,
-                            cudaStream_t stream)
+                            cudaStream_t stream,
+                            rmm::mr::device_memory_resource *mr)
 {
   CUDF_EXPECTS(count >= 0, "Count cannot be negative");
 
@@ -61,7 +61,7 @@ std::unique_ptr<table> tile(const table_view &in,
                             rmm::mr::device_memory_resource *mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::tile(in, count, mr, 0);
+  return detail::tile(in, count, 0, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/reshape/tile.cu
+++ b/cpp/src/reshape/tile.cu
@@ -16,6 +16,7 @@
 
 #include <cudf/copying.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/reshape.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
@@ -35,11 +36,12 @@ struct tile_functor {
 
 }  // anonymous namespace
 
+namespace detail {
 std::unique_ptr<table> tile(const table_view &in,
                             size_type count,
-                            rmm::mr::device_memory_resource *mr)
+                            rmm::mr::device_memory_resource *mr,
+                            cudaStream_t stream)
 {
-  CUDF_FUNC_RANGE();
   CUDF_EXPECTS(count >= 0, "Count cannot be negative");
 
   auto in_num_rows = in.num_rows();
@@ -50,7 +52,16 @@ std::unique_ptr<table> tile(const table_view &in,
   auto counting_it  = thrust::make_counting_iterator<size_type>(0);
   auto tiled_it     = thrust::make_transform_iterator(counting_it, tile_functor{in_num_rows});
 
-  return detail::gather(in, tiled_it, tiled_it + out_num_rows, false, mr);
+  return detail::gather(in, tiled_it, tiled_it + out_num_rows, false, mr, stream);
+}
+}  // namespace detail
+
+std::unique_ptr<table> tile(const table_view &in,
+                            size_type count,
+                            rmm::mr::device_memory_resource *mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::tile(in, count, mr, 0);
 }
 
 }  // namespace cudf

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -158,6 +158,7 @@ ConfigureTest(GROUPBY_TEST "${GROUPBY_TEST_SRC}")
 
 set(JOIN_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/join/join_tests.cu"
+    "${CMAKE_CURRENT_SOURCE_DIR}/join/cross_join_tests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/join/semi_join_tests.cpp")
 
 ConfigureTest(JOIN_TEST "${JOIN_TEST_SRC}")

--- a/cpp/tests/join/cross_join_tests.cpp
+++ b/cpp/tests/join/cross_join_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/join/cross_join_tests.cpp
+++ b/cpp/tests/join/cross_join_tests.cpp
@@ -33,61 +33,56 @@ struct JoinTest : public cudf::test::BaseFixture {
 
 TEST_F(JoinTest, CrossJoin)
 {
-  std::vector<const char*> a_strings{"quick", "accénted", "turtlé", "composéd"};
-  std::vector<const char*> b_strings{"result", "", "words"};
-  std::vector<const char*> e_strings3{"quick",
-                                      "quick",
-                                      "quick",
-                                      "accénted",
-                                      "accénted",
-                                      "accénted",
-                                      "turtlé",
-                                      "turtlé",
-                                      "turtlé",
-                                      "composéd",
-                                      "composéd",
-                                      "composéd"};
-  std::vector<const char*> e_strings7{
+  auto a_strings  = std::vector<const char*>{"quick", "accénted", "turtlé", "composéd"};
+  auto b_strings  = std::vector<const char*>{"result", "", "words"};
+  auto e_strings3 = std::vector<const char*>{"quick",
+                                             "quick",
+                                             "quick",
+                                             "accénted",
+                                             "accénted",
+                                             "accénted",
+                                             "turtlé",
+                                             "turtlé",
+                                             "turtlé",
+                                             "composéd",
+                                             "composéd",
+                                             "composéd"};
+  auto e_strings7 = std::vector<const char*>{
     "result", "", "words", "result", "", "words", "result", "", "words", "result", "", "words"};
 
-  column_wrapper<int32_t> a_0{10, 20, 20, 50};
-  column_wrapper<float> a_1{5.0, .5, .5, .7};
-  column_wrapper<int8_t> a_2{90, 77, 78, 41};
-
-  cudf::test::strings_column_wrapper a_3(
+  auto a_0 = column_wrapper<int32_t>{10, 20, 20, 50};
+  auto a_1 = column_wrapper<float>{5.0, .5, .5, .7};
+  auto a_2 = column_wrapper<int8_t>{90, 77, 78, 41};
+  auto a_3 = cudf::test::strings_column_wrapper(
     a_strings.begin(),
     a_strings.end(),
     thrust::make_transform_iterator(a_strings.begin(), [](auto str) { return str != nullptr; }));
 
-  column_wrapper<int32_t> b_0{10, 20, 20};
-  column_wrapper<float> b_1{5.0, .7, .7};
-  column_wrapper<int8_t> b_2{90, 75, 62};
-
-  cudf::test::strings_column_wrapper b_3(
+  auto b_0 = column_wrapper<int32_t>{10, 20, 20};
+  auto b_1 = column_wrapper<float>{5.0, .7, .7};
+  auto b_2 = column_wrapper<int8_t>{90, 75, 62};
+  auto b_3 = cudf::test::strings_column_wrapper(
     b_strings.begin(),
     b_strings.end(),
     thrust::make_transform_iterator(b_strings.begin(), [](auto str) { return str != nullptr; }));
 
-  column_wrapper<int32_t> expect_0{10, 10, 10, 20, 20, 20, 20, 20, 20, 50, 50, 50};
-  column_wrapper<float> expect_1{5.0, 5.0, 5.0, .5, .5, .5, .5, .5, .5, .7, .7, .7};
-  column_wrapper<int8_t> expect_2{90, 90, 90, 77, 77, 77, 78, 78, 78, 41, 41, 41};
-
-  cudf::test::strings_column_wrapper expect_3(
+  auto expect_0 = column_wrapper<int32_t>{10, 10, 10, 20, 20, 20, 20, 20, 20, 50, 50, 50};
+  auto expect_1 = column_wrapper<float>{5.0, 5.0, 5.0, .5, .5, .5, .5, .5, .5, .7, .7, .7};
+  auto expect_2 = column_wrapper<int8_t>{90, 90, 90, 77, 77, 77, 78, 78, 78, 41, 41, 41};
+  auto expect_3 = cudf::test::strings_column_wrapper(
     e_strings3.begin(),
     e_strings3.end(),
     thrust::make_transform_iterator(e_strings3.begin(), [](auto str) { return str != nullptr; }));
-
-  column_wrapper<int32_t> expect_4{10, 20, 20, 10, 20, 20, 10, 20, 20, 10, 20, 20};
-  column_wrapper<float> expect_5{5.0, .7, .7, 5.0, .7, .7, 5.0, .7, .7, 5.0, .7, .7};
-  column_wrapper<int8_t> expect_6{90, 75, 62, 90, 75, 62, 90, 75, 62, 90, 75, 62};
-
-  cudf::test::strings_column_wrapper expect_7(
+  auto expect_4 = column_wrapper<int32_t>{10, 20, 20, 10, 20, 20, 10, 20, 20, 10, 20, 20};
+  auto expect_5 = column_wrapper<float>{5.0, .7, .7, 5.0, .7, .7, 5.0, .7, .7, 5.0, .7, .7};
+  auto expect_6 = column_wrapper<int8_t>{90, 75, 62, 90, 75, 62, 90, 75, 62, 90, 75, 62};
+  auto expect_7 = cudf::test::strings_column_wrapper(
     e_strings7.begin(),
     e_strings7.end(),
     thrust::make_transform_iterator(e_strings7.begin(), [](auto str) { return str != nullptr; }));
 
-  cudf::table_view table_a{{a_0, a_1, a_2, a_3}};
-  cudf::table_view table_b{{b_0, b_1, b_2, b_3}};
+  auto table_a = cudf::table_view{{a_0, a_1, a_2, a_3}};
+  auto table_b = cudf::table_view{{b_0, b_1, b_2, b_3}};
 
   auto join_table = cudf::cross_join(table_a, table_b);
 
@@ -105,20 +100,19 @@ TEST_F(JoinTest, CrossJoin)
 
 TEST_F(JoinTest, CrossJoin_exceptions)
 {
-  std::vector<const char*> b_strings{"quick", "words", "result", nullptr};
+  auto b_strings = std::vector<const char*>{"quick", "words", "result", nullptr};
 
-  column_wrapper<int32_t> b_0{10, 20, 20, 50};
-  column_wrapper<float> b_1{5.0, .7, .7, .7};
-  column_wrapper<int8_t> b_2{90, 75, 62, 41};
-
-  cudf::test::strings_column_wrapper b_3(
+  auto b_0 = column_wrapper<int32_t>{10, 20, 20, 50};
+  auto b_1 = column_wrapper<float>{5.0, .7, .7, .7};
+  auto b_2 = column_wrapper<int8_t>{90, 75, 62, 41};
+  auto b_3 = cudf::test::strings_column_wrapper(
     b_strings.begin(),
     b_strings.end(),
     thrust::make_transform_iterator(b_strings.begin(), [](auto str) { return str != nullptr; }));
 
-  std::vector<std::unique_ptr<cudf::column>> column_a;
-  cudf::table table_a(std::move(column_a));
-  cudf::table_view table_b{{b_0, b_1, b_2, b_3}};
+  auto column_a = std::vector<std::unique_ptr<cudf::column>>{};
+  auto table_a  = cudf::table(std::move(column_a));
+  auto table_b  = cudf::table_view{{b_0, b_1, b_2, b_3}};
 
   //
   //  table_a has no columns, table_b has columns
@@ -131,39 +125,36 @@ TEST_F(JoinTest, CrossJoin_exceptions)
 
 TEST_F(JoinTest, CrossJoin_empty_result)
 {
-  std::vector<const char*> a_strings{};
-  std::vector<const char*> b_strings{"quick", "words", "result", nullptr};
-  std::vector<const char*> e_strings{};
+  auto a_strings = std::vector<const char*>{};
+  auto b_strings = std::vector<const char*>{"quick", "words", "result", nullptr};
+  auto e_strings = std::vector<const char*>{};
 
-  column_wrapper<int32_t> a_0{};
-  column_wrapper<float> a_1{};
-  column_wrapper<int8_t> a_2{};
-
-  cudf::test::strings_column_wrapper a_3(
+  auto a_0 = column_wrapper<int32_t>{};
+  auto a_1 = column_wrapper<float>{};
+  auto a_2 = column_wrapper<int8_t>{};
+  auto a_3 = cudf::test::strings_column_wrapper(
     a_strings.begin(),
     a_strings.end(),
     thrust::make_transform_iterator(a_strings.begin(), [](auto str) { return str != nullptr; }));
 
-  column_wrapper<int32_t> b_0{10, 20, 20, 50};
-  column_wrapper<float> b_1{5.0, .7, .7, .7};
-  column_wrapper<int8_t> b_2{90, 75, 62, 41};
-
-  cudf::test::strings_column_wrapper b_3(
+  auto b_0 = column_wrapper<int32_t>{10, 20, 20, 50};
+  auto b_1 = column_wrapper<float>{5.0, .7, .7, .7};
+  auto b_2 = column_wrapper<int8_t>{90, 75, 62, 41};
+  auto b_3 = cudf::test::strings_column_wrapper(
     b_strings.begin(),
     b_strings.end(),
     thrust::make_transform_iterator(b_strings.begin(), [](auto str) { return str != nullptr; }));
 
-  column_wrapper<int32_t> expect_0{};
-  column_wrapper<float> expect_1{};
-  column_wrapper<int8_t> expect_2{};
-
-  cudf::test::strings_column_wrapper expect_3(
+  auto expect_0 = column_wrapper<int32_t>{};
+  auto expect_1 = column_wrapper<float>{};
+  auto expect_2 = column_wrapper<int8_t>{};
+  auto expect_3 = cudf::test::strings_column_wrapper(
     e_strings.begin(),
     e_strings.end(),
     thrust::make_transform_iterator(e_strings.begin(), [](auto str) { return str != nullptr; }));
 
-  cudf::table_view table_a{{a_0, a_1, a_2, a_3}};
-  cudf::table_view table_b{{b_0, b_1, b_2, b_3}};
+  auto table_a = cudf::table_view{{a_0, a_1, a_2, a_3}};
+  auto table_b = cudf::table_view{{b_0, b_1, b_2, b_3}};
 
   auto join_table = cudf::cross_join(table_a, table_b);
 

--- a/cpp/tests/join/cross_join_tests.cpp
+++ b/cpp/tests/join/cross_join_tests.cpp
@@ -86,20 +86,8 @@ TEST_F(JoinTest, CrossJoin)
     e_strings7.end(),
     thrust::make_transform_iterator(e_strings7.begin(), [](auto str) { return str != nullptr; }));
 
-  std::vector<std::unique_ptr<cudf::column>> column_a;
-  column_a.push_back(a_0.release());
-  column_a.push_back(a_1.release());
-  column_a.push_back(a_2.release());
-  column_a.push_back(a_3.release());
-
-  std::vector<std::unique_ptr<cudf::column>> column_b;
-  column_b.push_back(b_0.release());
-  column_b.push_back(b_1.release());
-  column_b.push_back(b_2.release());
-  column_b.push_back(b_3.release());
-
-  cudf::table table_a(std::move(column_a));
-  cudf::table table_b(std::move(column_b));
+  cudf::table_view table_a{{a_0, a_1, a_2, a_3}};
+  cudf::table_view table_b{{b_0, b_1, b_2, b_3}};
 
   auto join_table = cudf::cross_join(table_a, table_b);
 
@@ -129,15 +117,8 @@ TEST_F(JoinTest, CrossJoin_exceptions)
     thrust::make_transform_iterator(b_strings.begin(), [](auto str) { return str != nullptr; }));
 
   std::vector<std::unique_ptr<cudf::column>> column_a;
-
-  std::vector<std::unique_ptr<cudf::column>> column_b;
-  column_b.push_back(b_0.release());
-  column_b.push_back(b_1.release());
-  column_b.push_back(b_2.release());
-  column_b.push_back(b_3.release());
-
   cudf::table table_a(std::move(column_a));
-  cudf::table table_b(std::move(column_b));
+  cudf::table_view table_b{{b_0, b_1, b_2, b_3}};
 
   //
   //  table_a has no columns, table_b has columns
@@ -181,20 +162,8 @@ TEST_F(JoinTest, CrossJoin_empty_result)
     e_strings.end(),
     thrust::make_transform_iterator(e_strings.begin(), [](auto str) { return str != nullptr; }));
 
-  std::vector<std::unique_ptr<cudf::column>> column_a;
-  column_a.push_back(a_0.release());
-  column_a.push_back(a_1.release());
-  column_a.push_back(a_2.release());
-  column_a.push_back(a_3.release());
-
-  std::vector<std::unique_ptr<cudf::column>> column_b;
-  column_b.push_back(b_0.release());
-  column_b.push_back(b_1.release());
-  column_b.push_back(b_2.release());
-  column_b.push_back(b_3.release());
-
-  cudf::table table_a(std::move(column_a));
-  cudf::table table_b(std::move(column_b));
+  cudf::table_view table_a{{a_0, a_1, a_2, a_3}};
+  cudf::table_view table_b{{b_0, b_1, b_2, b_3}};
 
   auto join_table = cudf::cross_join(table_a, table_b);
 

--- a/cpp/tests/join/cross_join_tests.cpp
+++ b/cpp/tests/join/cross_join_tests.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/join.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <tests/utilities/base_fixture.hpp>
+#include <tests/utilities/column_utilities.hpp>
+#include <tests/utilities/column_wrapper.hpp>
+#include <tests/utilities/table_utilities.hpp>
+
+template <typename T>
+using column_wrapper = cudf::test::fixed_width_column_wrapper<T>;
+
+struct JoinTest : public cudf::test::BaseFixture {
+};
+
+TEST_F(JoinTest, CrossJoin)
+{
+  std::vector<const char*> a_strings{"quick", "accénted", "turtlé", "composéd"};
+  std::vector<const char*> b_strings{"result", "", "words"};
+  std::vector<const char*> e_strings3{"quick",
+                                      "quick",
+                                      "quick",
+                                      "accénted",
+                                      "accénted",
+                                      "accénted",
+                                      "turtlé",
+                                      "turtlé",
+                                      "turtlé",
+                                      "composéd",
+                                      "composéd",
+                                      "composéd"};
+  std::vector<const char*> e_strings7{
+    "result", "", "words", "result", "", "words", "result", "", "words", "result", "", "words"};
+
+  column_wrapper<int32_t> a_0{10, 20, 20, 50};
+  column_wrapper<float> a_1{5.0, .5, .5, .7};
+  column_wrapper<int8_t> a_2{90, 77, 78, 41};
+
+  cudf::test::strings_column_wrapper a_3(
+    a_strings.begin(),
+    a_strings.end(),
+    thrust::make_transform_iterator(a_strings.begin(), [](auto str) { return str != nullptr; }));
+
+  column_wrapper<int32_t> b_0{10, 20, 20};
+  column_wrapper<float> b_1{5.0, .7, .7};
+  column_wrapper<int8_t> b_2{90, 75, 62};
+
+  cudf::test::strings_column_wrapper b_3(
+    b_strings.begin(),
+    b_strings.end(),
+    thrust::make_transform_iterator(b_strings.begin(), [](auto str) { return str != nullptr; }));
+
+  column_wrapper<int32_t> expect_0{10, 10, 10, 20, 20, 20, 20, 20, 20, 50, 50, 50};
+  column_wrapper<float> expect_1{5.0, 5.0, 5.0, .5, .5, .5, .5, .5, .5, .7, .7, .7};
+  column_wrapper<int8_t> expect_2{90, 90, 90, 77, 77, 77, 78, 78, 78, 41, 41, 41};
+
+  cudf::test::strings_column_wrapper expect_3(
+    e_strings3.begin(),
+    e_strings3.end(),
+    thrust::make_transform_iterator(e_strings3.begin(), [](auto str) { return str != nullptr; }));
+
+  column_wrapper<int32_t> expect_4{10, 20, 20, 10, 20, 20, 10, 20, 20, 10, 20, 20};
+  column_wrapper<float> expect_5{5.0, .7, .7, 5.0, .7, .7, 5.0, .7, .7, 5.0, .7, .7};
+  column_wrapper<int8_t> expect_6{90, 75, 62, 90, 75, 62, 90, 75, 62, 90, 75, 62};
+
+  cudf::test::strings_column_wrapper expect_7(
+    e_strings7.begin(),
+    e_strings7.end(),
+    thrust::make_transform_iterator(e_strings7.begin(), [](auto str) { return str != nullptr; }));
+
+  std::vector<std::unique_ptr<cudf::column>> column_a;
+  column_a.push_back(a_0.release());
+  column_a.push_back(a_1.release());
+  column_a.push_back(a_2.release());
+  column_a.push_back(a_3.release());
+
+  std::vector<std::unique_ptr<cudf::column>> column_b;
+  column_b.push_back(b_0.release());
+  column_b.push_back(b_1.release());
+  column_b.push_back(b_2.release());
+  column_b.push_back(b_3.release());
+
+  cudf::table table_a(std::move(column_a));
+  cudf::table table_b(std::move(column_b));
+
+  auto join_table = cudf::cross_join(table_a, table_b);
+
+  EXPECT_EQ(join_table->num_columns(), table_a.num_columns() + table_b.num_columns());
+  EXPECT_EQ(join_table->num_rows(), table_a.num_rows() * table_b.num_rows());
+  expect_columns_equal(join_table->get_column(0), expect_0, true);
+  expect_columns_equal(join_table->get_column(1), expect_1, true);
+  expect_columns_equal(join_table->get_column(2), expect_2, true);
+  expect_columns_equal(join_table->get_column(3), expect_3, true);
+  expect_columns_equal(join_table->get_column(4), expect_4, true);
+  expect_columns_equal(join_table->get_column(5), expect_5, true);
+  expect_columns_equal(join_table->get_column(6), expect_6, true);
+  expect_columns_equal(join_table->get_column(7), expect_7, true);
+}
+
+TEST_F(JoinTest, CrossJoin_exceptions)
+{
+  std::vector<const char*> b_strings{"quick", "words", "result", nullptr};
+
+  column_wrapper<int32_t> b_0{10, 20, 20, 50};
+  column_wrapper<float> b_1{5.0, .7, .7, .7};
+  column_wrapper<int8_t> b_2{90, 75, 62, 41};
+
+  cudf::test::strings_column_wrapper b_3(
+    b_strings.begin(),
+    b_strings.end(),
+    thrust::make_transform_iterator(b_strings.begin(), [](auto str) { return str != nullptr; }));
+
+  std::vector<std::unique_ptr<cudf::column>> column_a;
+
+  std::vector<std::unique_ptr<cudf::column>> column_b;
+  column_b.push_back(b_0.release());
+  column_b.push_back(b_1.release());
+  column_b.push_back(b_2.release());
+  column_b.push_back(b_3.release());
+
+  cudf::table table_a(std::move(column_a));
+  cudf::table table_b(std::move(column_b));
+
+  //
+  //  table_a has no columns, table_b has columns
+  //  Let's check different permutations of passing table
+  //  with no columns to verify that exceptions are thrown
+  //
+  EXPECT_THROW(cudf::cross_join(table_a, table_b), cudf::logic_error);
+  EXPECT_THROW(cudf::cross_join(table_b, table_a), cudf::logic_error);
+}
+
+TEST_F(JoinTest, CrossJoin_empty_result)
+{
+  std::vector<const char*> a_strings{};
+  std::vector<const char*> b_strings{"quick", "words", "result", nullptr};
+  std::vector<const char*> e_strings{};
+
+  column_wrapper<int32_t> a_0{};
+  column_wrapper<float> a_1{};
+  column_wrapper<int8_t> a_2{};
+
+  cudf::test::strings_column_wrapper a_3(
+    a_strings.begin(),
+    a_strings.end(),
+    thrust::make_transform_iterator(a_strings.begin(), [](auto str) { return str != nullptr; }));
+
+  column_wrapper<int32_t> b_0{10, 20, 20, 50};
+  column_wrapper<float> b_1{5.0, .7, .7, .7};
+  column_wrapper<int8_t> b_2{90, 75, 62, 41};
+
+  cudf::test::strings_column_wrapper b_3(
+    b_strings.begin(),
+    b_strings.end(),
+    thrust::make_transform_iterator(b_strings.begin(), [](auto str) { return str != nullptr; }));
+
+  column_wrapper<int32_t> expect_0{};
+  column_wrapper<float> expect_1{};
+  column_wrapper<int8_t> expect_2{};
+
+  cudf::test::strings_column_wrapper expect_3(
+    e_strings.begin(),
+    e_strings.end(),
+    thrust::make_transform_iterator(e_strings.begin(), [](auto str) { return str != nullptr; }));
+
+  std::vector<std::unique_ptr<cudf::column>> column_a;
+  column_a.push_back(a_0.release());
+  column_a.push_back(a_1.release());
+  column_a.push_back(a_2.release());
+  column_a.push_back(a_3.release());
+
+  std::vector<std::unique_ptr<cudf::column>> column_b;
+  column_b.push_back(b_0.release());
+  column_b.push_back(b_1.release());
+  column_b.push_back(b_2.release());
+  column_b.push_back(b_3.release());
+
+  cudf::table table_a(std::move(column_a));
+  cudf::table table_b(std::move(column_b));
+
+  auto join_table = cudf::cross_join(table_a, table_b);
+
+  EXPECT_EQ(join_table->num_columns(), table_a.num_columns() + table_b.num_columns());
+  EXPECT_EQ(join_table->num_rows(), 0);
+}


### PR DESCRIPTION
Closes #3194.

This PR adds a feature for [cross join](https://www.w3resource.com/sql/joins/cross-join.php), which accepts two input tables and produces an output table with the cartesian product of their rows.