### PR TITLE
Fix pickling sizeof test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #5271 Fix issue when different dtype values are passed to `.cat.add_categories`
 - PR #5299 Update package version for Java bindings
 - PR #5300 Add support to ignore `None` in `cudf.concat` input
+- PR #5334 Fix pickling sizeof test
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/python/cudf/cudf/tests/test_pickling.py
+++ b/python/cudf/cudf/tests/test_pickling.py
@@ -73,8 +73,9 @@ def test_sizeof_dataframe():
     assert sizeof >= nbytes
 
     serialized_nbytes = len(pickle.dumps(df, protocol=pickle.HIGHEST_PROTOCOL))
-    # Serialized size should be close to what __sizeof__ is giving
-    np.testing.assert_approx_equal(sizeof, serialized_nbytes, significant=2)
+
+    # assert at least sizeof bytes were serialized
+    assert serialized_nbytes >= sizeof
 
 
 def test_pickle_index():


### PR DESCRIPTION
This test assumes that pickling the data will yield something of the same size. While that seems reasonable, it's not quite right as a bunch of information about how to extract the pickled data and rebuild Python objects will be included. So instead merely check that the pickled data is at least the size of the object. IOW no data was lost by pickling. However don't tightly enforce equality.