### PR TITLE
Fix broken alias from DataFrame.{at,iat} to {loc,iloc}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #5271 Fix issue when different dtype values are passed to `.cat.add_categories`
 - PR #5299 Update package version for Java bindings
 - PR #5300 Add support to ignore `None` in `cudf.concat` input
+- PR #5329 Fix broken alias from DataFrame.{at,iat} to {loc, iloc}
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - PR #5299 Update package version for Java bindings
 - PR #5300 Add support to ignore `None` in `cudf.concat` input
 - PR #5334 Fix pickling sizeof test
-- PR #5329 Fix broken alias from DataFrame.{at,iat} to {loc, iloc}
+- PR #5337 Fix broken alias from DataFrame.{at,iat} to {loc, iloc}
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -2157,12 +2157,14 @@ class DataFrame(Frame, Serializable):
         """
         return _DataFrameIlocIndexer(self)
 
+    @property
     def iat(self):
         """
         Alias for ``DataFrame.iloc``; provided for compatibility with Pandas.
         """
         return self.iloc
 
+    @property
     def at(self):
         """
         Alias for ``DataFrame.loc``; provided for compatibility with Pandas.

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -248,6 +248,12 @@ def test_dataframe_loc(scalar, step):
     # Full slice
     assert_eq(df.loc[:, "c"], pdf.loc[:, "c"])
 
+    # Repeat with at[]
+    assert_eq(df.loc[:, ["a"]], df.at[:, ["a"]])
+    assert_eq(df.loc[:, "d"], df.at[:, "d"])
+    assert_eq(df.loc[scalar], df.at[scalar])
+    assert_eq(df.loc[:, "c"], df.at[:, "c"])
+
     begin = 110
     end = 122
 
@@ -271,6 +277,16 @@ def test_dataframe_loc(scalar, step):
         df.loc[begin, "a":"a"], pdf.loc[begin, "a":"a"], check_dtype=False
     )
 
+    # Repeat with at[]
+    assert_eq(
+        df.loc[begin:end:step, ["c", "d", "a"]],
+        df.at[begin:end:step, ["c", "d", "a"]],
+    )
+    assert_eq(df.loc[begin:end, ["c", "d"]], df.at[begin:end, ["c", "d"]])
+    assert_eq(df.loc[begin:end:step, "a":"c"], df.at[begin:end:step, "a":"c"])
+    assert_eq(df.loc[begin:begin, "a"], df.at[begin:begin, "a"])
+    assert_eq(df.loc[begin, "a":"a"], df.at[begin, "a":"a"], check_dtype=False)
+
     # Make int64 index
     offset = 50
     df2 = df[offset:]
@@ -280,6 +296,12 @@ def test_dataframe_loc(scalar, step):
     assert_eq(
         df2.loc[begin:end, ["c", "d", "a"]],
         pdf2.loc[begin:end, ["c", "d", "a"]],
+    )
+
+    # Repeat with at[]
+    assert_eq(
+        df2.loc[begin:end, ["c", "d", "a"]],
+        df2.at[begin:end, ["c", "d", "a"]],
     )
 
 
@@ -537,6 +559,22 @@ def test_dataframe_iloc(nelem):
     assert_eq(gdf.iloc[0], pdf.iloc[0])
     assert_eq(gdf.iloc[1], pdf.iloc[1])
     assert_eq(gdf.iloc[nelem - 1], pdf.iloc[nelem - 1])
+
+    # Repeat the above with iat[]
+    assert_eq(gdf.iloc[-1:1], gdf.iat[-1:1])
+    assert_eq(gdf.iloc[nelem - 1 : -1], gdf.iat[nelem - 1 : -1])
+    assert_eq(gdf.iloc[0 : nelem - 1], gdf.iat[0 : nelem - 1])
+    assert_eq(gdf.iloc[0:nelem], gdf.iat[0:nelem])
+    assert_eq(gdf.iloc[1:1], gdf.iat[1:1])
+    assert_eq(gdf.iloc[1:2], gdf.iat[1:2])
+    assert_eq(gdf.iloc[nelem - 1 : nelem + 1], gdf.iat[nelem - 1 : nelem + 1])
+    assert_eq(gdf.iloc[nelem : nelem * 2], gdf.iat[nelem : nelem * 2])
+
+    assert_eq(gdf.iloc[-1 * nelem], gdf.iat[-1 * nelem])
+    assert_eq(gdf.iloc[-1], gdf.iat[-1])
+    assert_eq(gdf.iloc[0], gdf.iat[0])
+    assert_eq(gdf.iloc[1], gdf.iat[1])
+    assert_eq(gdf.iloc[nelem - 1], gdf.iat[nelem - 1])
 
 
 @pytest.mark.xfail(raises=AssertionError, reason="Series.index are different")


### PR DESCRIPTION
Fixes issue #5329.  Use `@property` because `loc` and `iloc` are.