### PR TITLE
[REVIEW] Fix APPLY_BOOLEAN_MASK_BENCH segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - PR #5300 Add support to ignore `None` in `cudf.concat` input
 - PR #5334 Fix pickling sizeof test
 - PR #5337 Fix broken alias from DataFrame.{at,iat} to {loc, iloc}
-- PR #5347 Fix APPLY_BOOLEAN_MASK_BENCHMARK segfault 
+- PR #5347 Fix APPLY_BOOLEAN_MASK_BENCH segfault 
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #5300 Add support to ignore `None` in `cudf.concat` input
 - PR #5334 Fix pickling sizeof test
 - PR #5337 Fix broken alias from DataFrame.{at,iat} to {loc, iloc}
+- PR #5347 Fix APPLY_BOOLEAN_MASK_BENCHMARK segfault 
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/cpp/benchmarks/stream_compaction/apply_boolean_mask_benchmark.cpp
+++ b/cpp/benchmarks/stream_compaction/apply_boolean_mask_benchmark.cpp
@@ -103,7 +103,7 @@ void BM_apply_boolean_mask(benchmark::State& state, cudf::size_type num_columns)
     columns.emplace_back(data.cbegin(), data.cend(), validity.cbegin());
   }
 
-  std::vector<bool> mask_data(num_columns);
+  std::vector<bool> mask_data(column_size);
   std::generate_n(
     mask_data.begin(), column_size, [&]() { return random_int(0, 100) < percent_true; });
   mask_wrapper mask(mask_data.begin(), mask_data.end());


### PR DESCRIPTION
Trivial fix of num_columns to column_size in a benchmark that caused a segfault.

