### PR TITLE
Split Dask deserialization methods by dask/cuda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #5309 Handle host frames in serialization
 - PR #5312 Test serializing `Series` after `slice`
 - PR #5248 Support interleave_columns for string types
+- PR #5354 Split Dask deserialization methods by dask/cuda
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -11,8 +11,6 @@ try:
         with log_errors():
             return x.device_serialize()
 
-    # all (de-)serializations are attached to cudf Objects:
-    # Series/DataFrame/Index/Column/Buffer/etc
     @dask_serialize.register(Serializable)
     def dask_serialize_cudf_object(x):
         with log_errors():

--- a/python/cudf/cudf/comm/serialize.py
+++ b/python/cudf/cudf/comm/serialize.py
@@ -17,13 +17,14 @@ try:
             return x.host_serialize()
 
     @cuda_deserialize.register(Serializable)
-    @dask_deserialize.register(Serializable)
-    def deserialize_cudf_object(header, frames):
+    def cuda_deserialize_cudf_object(header, frames):
         with log_errors():
-            if header["serializer"] == "cuda":
-                return Serializable.device_deserialize(header, frames)
-            elif header["serializer"] == "dask":
-                return Serializable.host_deserialize(header, frames)
+            return Serializable.device_deserialize(header, frames)
+
+    @dask_deserialize.register(Serializable)
+    def dask_deserialize_cudf_object(header, frames):
+        with log_errors():
+            return Serializable.host_deserialize(header, frames)
 
 
 except ImportError:


### PR DESCRIPTION
As Dask already routes to the right deserialization function based on whether `"dask"` or `"cuda"` deserialization was used, split the deserialization function into 2 deserialization functions for these 2 cases. This should avoid us needing to check which deserialization to perform. Also this is very lightweight to implement thanks to the fact that this logic is already captured in methods of `Serializable`.