### PR TITLE
[REVIEW] Remove dependency on `rmm._DevicePointer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - PR #5309 Handle host frames in serialization
 - PR #5312 Test serializing `Series` after `slice`
 - PR #5248 Support interleave_columns for string types
-- PR #5362 Remove dependency on `rmm._DevicePointer
+- PR #5362 Remove dependency on `rmm._DevicePointer`
 - PR #5302 Add missing comparison operators to `fixed_point` type
 - PR #5354 Split Dask deserialization methods by dask/cuda
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #5309 Handle host frames in serialization
 - PR #5312 Test serializing `Series` after `slice`
 - PR #5248 Support interleave_columns for string types
+- PR #5362 Remove dependency on `rmm._DevicePointer
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -5,7 +5,7 @@ import pickle
 import numpy as np
 
 import rmm
-from rmm import DeviceBuffer, _DevicePointer
+from rmm import DeviceBuffer
 
 from cudf.core.abc import Serializable
 
@@ -31,10 +31,6 @@ class Buffer(Serializable):
         if isinstance(data, Buffer):
             self.ptr = data.ptr
             self.size = data.size
-            self._owner = owner or data
-        elif isinstance(data, _DevicePointer):
-            self.ptr = data.ptr
-            self.size = size
             self._owner = owner or data
         elif hasattr(data, "__array_interface__") or hasattr(
             data, "__cuda_array_interface__"

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -17,7 +17,7 @@ class Buffer(Serializable):
 
         Parameters
         ----------
-        data : Buffer, rmm._DevicePointer, array_like, int
+        data : Buffer, array_like, int
             An array-like object or integer representing a
             device or host pointer to pre-allocated memory.
         size : int, optional


### PR DESCRIPTION
Removes the dependency on the (unused) `rmm._DevicePointer`.