### PR TITLE
[REVIEW] Apply API change from cudf::repeat in cudf::cross_join.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #5334 Fix pickling sizeof test
 - PR #5337 Fix broken alias from DataFrame.{at,iat} to {loc, iloc}
 - PR #5347 Fix APPLY_BOOLEAN_MASK_BENCH segfault 
+- PR #5367 Fix API for `cudf::repeat` in `cudf::cross_join`
 
 # cuDF 0.14.0 (Date TBD)
 

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -54,8 +54,7 @@ std::unique_ptr<cudf::table> cross_join(
   }
 
   // Repeat left table
-  numeric_scalar<size_type> num_repeats = right.num_rows();
-  auto left_repeated                    = detail::repeat(left, num_repeats, mr, stream);
+  auto left_repeated = detail::repeat(left, right.num_rows(), mr, stream);
 
   // Tile right table
   auto right_tiled = detail::tile(right, left.num_rows(), stream, mr);


### PR DESCRIPTION
Applies the API change to `cudf::repeat` from #5355 to the `cudf::cross_join` feature introduced in #5327. (I should have merged `branch-0.15` into one of those PRs before the other PR was merged.)