### PR TITLE
Handle array of cupy scalars in to_column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #5337 Fix broken alias from DataFrame.{at,iat} to {loc, iloc}
 - PR #5347 Fix APPLY_BOOLEAN_MASK_BENCH segfault 
 - PR #5367 Fix API for `cudf::repeat` in `cudf::cross_join`
+- PR #5377 Handle array of cupy scalars in to_column
 
 # cuDF 0.14.0 (Date TBD)
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1419,7 +1419,7 @@ def as_column(arbitrary, nan_as_null=None, dtype=None, length=None):
         if is_categorical_dtype(arbitrary):
             data = as_column(pa.array(arbitrary, from_pandas=True))
         elif arbitrary.dtype == np.bool:
-            data = as_column(cupy.asarray(arbitrary), dtype=arbitrary.dtype,)
+            data = as_column(cupy.asarray(arbitrary), dtype=arbitrary.dtype)
         elif arbitrary.dtype.kind in ("f"):
             arb_dtype = check_cast_unsupported_dtype(arbitrary.dtype)
             data = as_column(
@@ -1481,7 +1481,11 @@ def as_column(arbitrary, nan_as_null=None, dtype=None, length=None):
 
         if dtype is not None:
             arbitrary = arbitrary.astype(dtype)
-        elif shape and shape[0] and hasattr(arbitrary[0], "__cuda_array_interface__"):
+        elif (
+            shape
+            and shape[0]
+            and hasattr(arbitrary[0], "__cuda_array_interface__")
+        ):
             arbitrary = arbitrary.astype(arbitrary[0].dtype)
 
         if arb_dtype.kind == "M":
@@ -1522,7 +1526,7 @@ def as_column(arbitrary, nan_as_null=None, dtype=None, length=None):
                 nan_as_null=nan_as_null,
             )
         else:
-            data = as_column(cupy.asarray(arbitrary), nan_as_null=nan_as_null,)
+            data = as_column(cupy.asarray(arbitrary), nan_as_null=nan_as_null)
 
     elif isinstance(arbitrary, pd.core.arrays.numpy_.PandasArray):
         if is_categorical_dtype(arbitrary.dtype):

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1481,7 +1481,7 @@ def as_column(arbitrary, nan_as_null=None, dtype=None, length=None):
 
         if dtype is not None:
             arbitrary = arbitrary.astype(dtype)
-        elif shape and shape[0] and isinstance(arbitrary[0], cupy.ndarray):
+        elif shape and shape[0] and hasattr(arbitrary[0], "__cuda_array_interface__"):
             arbitrary = arbitrary.astype(arbitrary[0].dtype)
 
         if arb_dtype.kind == "M":

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1481,6 +1481,8 @@ def as_column(arbitrary, nan_as_null=None, dtype=None, length=None):
 
         if dtype is not None:
             arbitrary = arbitrary.astype(dtype)
+        elif shape and shape[0] and isinstance(arbitrary[0], cupy.ndarray):
+            arbitrary = arbitrary.astype(arbitrary[0].dtype)
 
         if arb_dtype.kind == "M":
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1481,12 +1481,17 @@ def as_column(arbitrary, nan_as_null=None, dtype=None, length=None):
 
         if dtype is not None:
             arbitrary = arbitrary.astype(dtype)
-        elif (
+        if (
             shape
             and shape[0]
             and hasattr(arbitrary[0], "__cuda_array_interface__")
         ):
-            arbitrary = arbitrary.astype(arbitrary[0].dtype)
+            return as_column(
+                cupy.asarray(arbitrary, dtype=arbitrary[0].dtype),
+                nan_as_null=nan_as_null,
+                dtype=dtype,
+                length=length,
+            )
 
         if arb_dtype.kind == "M":
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1476,11 +1476,8 @@ def as_column(arbitrary, nan_as_null=None, dtype=None, length=None):
             raise ValueError("Data must be 1-dimensional")
 
         arbitrary = np.asarray(arbitrary)
-        if not arbitrary.flags["C_CONTIGUOUS"]:
-            arbitrary = np.ascontiguousarray(arbitrary)
 
-        if dtype is not None:
-            arbitrary = arbitrary.astype(dtype)
+        # Handle case that `arbitary` elements are cupy arrays
         if (
             shape
             and shape[0]
@@ -1492,6 +1489,12 @@ def as_column(arbitrary, nan_as_null=None, dtype=None, length=None):
                 dtype=dtype,
                 length=length,
             )
+
+        if not arbitrary.flags["C_CONTIGUOUS"]:
+            arbitrary = np.ascontiguousarray(arbitrary)
+
+        if dtype is not None:
+            arbitrary = arbitrary.astype(dtype)
 
         if arb_dtype.kind == "M":
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -139,6 +139,15 @@ def test_series_basic():
     np.testing.assert_equal(series.to_array(), np.hstack([a1]))
 
 
+def test_series_from_cupy_scalars():
+    data = [0.1, 0.2, 0.3]
+    data_np = np.array(data)
+    data_cp = cupy.array(data)
+    s_np = Series([data_np[0], data_np[2]])
+    s_cp = Series([data_cp[0], data_cp[2]])
+    assert_eq(s_np, s_cp)
+
+
 @pytest.mark.parametrize("a", [[1, 2, 3], [1, 10, 30]])
 @pytest.mark.parametrize("b", [[4, 5, 6], [-11, -100, 30]])
 def test_append_index(a, b):


### PR DESCRIPTION
I noticed that using `quantile` in dask_cudf was causing a pyarrow error in `to_column`.  It seems that the following behavior was not supported:

```python
import cudf, cupy
data = cupy.array([0.1, 0.2, 0.3])
cudf.Series([data[0], data[2]])
``` 
**Error**:
```
E   pyarrow.lib.ArrowInvalid: Could not convert 0.1 with type cupy.core.core.ndarray: did not recognize Python value type when inferring an Arrow data type
```

This PR introduces a simple fix (handles the case that the elements of `arbitrary` are of type `cupy.ndarray`).  I'll be happy to raise a separate issue if others feel a more robust solution is needed here.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
