### PR TITLE
Avoid chaining `Buffer`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PR #5302 Add missing comparison operators to `fixed_point` type
 - PR #5354 Split Dask deserialization methods by dask/cuda
 - PR #5363 Handle `0-dim` inputs while broadcasting to a column
+- PR #5379 Avoid chaining `Buffer`s
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -31,7 +31,7 @@ class Buffer(Serializable):
         if isinstance(data, Buffer):
             self.ptr = data.ptr
             self.size = data.size
-            self._owner = owner or data
+            self._owner = owner or data._owner
         elif hasattr(data, "__array_interface__") or hasattr(
             data, "__cuda_array_interface__"
         ):


### PR DESCRIPTION
Previously if we constructed a `Buffer` from a `Buffer`, the new `Buffer` would reference the old `Buffer` used to create that. However this can result in `Buffer`s that have chained references, which is inefficient and unneeded. Also it makes it difficult to determine what object actually owns the data. Instead just shortcut around the provided `Buffer` and reference the object owning the data. This will avoid chained `Buffer`s and ensure the underlying data remains valid even if the old `Buffer` scopes out. Plus makes it easier to inspect the `Buffer`.

cc @quasiben @pentschev