### PR TITLE
[REVIEW] Fix issue with column creation when chunked arrays are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #5382 Fix CategoricalDtype equality comparisons
 - PR #5385 Fix index issues in `DataFrame.from_gpu_matrix`
 - PR #5390 Fix Java data type IDs and string interleave test
+- PR #5404 Fix issue with column creation when chunked arrays are passed
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1373,7 +1373,7 @@ def as_column(arbitrary, nan_as_null=None, dtype=None, length=None):
             as_column(chunk, dtype=dtype) for chunk in arbitrary.chunks
         ]
 
-        if dtype and dtype != "empty":
+        if dtype:
             new_dtype = dtype
         else:
             pa_type = arbitrary.type

--- a/python/cudf/cudf/tests/test_column.py
+++ b/python/cudf/cudf/tests/test_column.py
@@ -3,10 +3,10 @@
 import cupy as cp
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 import cudf
-import pyarrow as pa
 from cudf.core.column.column import as_column
 from cudf.tests.utils import assert_eq
 
@@ -48,7 +48,7 @@ def test_column_offset_and_size(pandas_input, offset, size):
     elif pd.api.types.is_string_dtype(col.dtype):
         assert col.size == (col.children[0].size - 1)
         assert col.size == (
-                (col.children[0].data.size / col.children[0].dtype.itemsize) - 1
+            (col.children[0].data.size / col.children[0].dtype.itemsize) - 1
         )
     else:
         assert col.size == (col.data.size / col.dtype.itemsize)
@@ -137,8 +137,8 @@ def test_column_chunked_array_creation():
     pyarrow_array = pa.array([1, 2, 3] * 1000)
     chunked_array = pa.chunked_array(pyarrow_array)
 
-    actual_column = cudf.core.column.as_column(chunked_array, dtype='float')
-    expected_column = cudf.core.column.as_column(pyarrow_array, dtype='float')
+    actual_column = cudf.core.column.as_column(chunked_array, dtype="float")
+    expected_column = cudf.core.column.as_column(pyarrow_array, dtype="float")
 
     assert_eq(cudf.Series(actual_column), cudf.Series(expected_column))
 


### PR DESCRIPTION
Fixes: #5395 

This PR fixes an issue in column creation when there is a `pyarrow.ChunkedArray` passed and we have a `dtype` value as non-None, we were doing an equality check against an not know dtype to numpy which is "empty". 

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
