### PR TITLE
[REVIEW] Use the correct memory resource when creating empty null masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #5382 Fix CategoricalDtype equality comparisons
 - PR #5385 Fix index issues in `DataFrame.from_gpu_matrix`
 - PR #5390 Fix Java data type IDs and string interleave test
+- PR #5409 Use the correct memory resource when creating empty null masks
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/cpp/include/cudf/strings/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/strings/detail/copy_if_else.cuh
@@ -71,7 +71,7 @@ std::unique_ptr<cudf::column> copy_if_else(
     stream,
     mr);
   size_type null_count = valid_mask.second;
-  rmm::device_buffer null_mask;
+  rmm::device_buffer null_mask{0, stream, mr};
   if (null_count) null_mask = valid_mask.first;
 
   // build offsets column

--- a/cpp/include/cudf/strings/detail/copy_range.cuh
+++ b/cpp/include/cudf/strings/detail/copy_range.cuh
@@ -141,7 +141,7 @@ std::unique_ptr<column> copy_range(
     }
 
     auto null_count = valid_mask.second;
-    rmm::device_buffer null_mask{};
+    rmm::device_buffer null_mask{0, stream, mr};
     if (target.parent().nullable() || null_count > 0) { null_mask = std::move(valid_mask.first); }
 
     // build offsets column

--- a/cpp/include/cudf/strings/detail/merge.cuh
+++ b/cpp/include/cudf/strings/detail/merge.cuh
@@ -59,7 +59,7 @@ std::unique_ptr<column> merge(strings_column_view const& lhs,
   auto d_rhs      = *rhs_column;
 
   // caller will set the null mask
-  rmm::device_buffer null_mask;
+  rmm::device_buffer null_mask{0, stream, mr};
   size_type null_count = lhs.null_count() + rhs.null_count();
   if (null_count > 0)
     null_mask = create_null_mask(strings_count, mask_state::ALL_VALID, stream, mr);

--- a/cpp/include/cudf/strings/detail/scatter.cuh
+++ b/cpp/include/cudf/strings/detail/scatter.cuh
@@ -61,7 +61,7 @@ std::unique_ptr<column> scatter(
   if (strings_count == 0) return make_empty_strings_column(mr, stream);
 
   // create null mask -- caller must update this
-  rmm::device_buffer null_mask;
+  rmm::device_buffer null_mask{0, stream, mr};
   if (target.has_nulls()) null_mask = copy_bitmask(target.parent(), stream, mr);
 
   // create string vectors

--- a/cpp/include/cudf/strings/detail/strings_column_factories.cuh
+++ b/cpp/include/cudf/strings/detail/strings_column_factories.cuh
@@ -73,7 +73,7 @@ std::unique_ptr<column> make_strings_column(
     stream,
     mr);
   auto null_count = new_nulls.second;
-  rmm::device_buffer null_mask;
+  rmm::device_buffer null_mask{0, stream, mr};
   if (null_count > 0) null_mask = std::move(new_nulls.first);
 
   // build chars column

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -637,7 +637,7 @@ rmm::device_buffer copy_bitmask(column_view const &view,
                                 cudaStream_t stream,
                                 rmm::mr::device_memory_resource *mr)
 {
-  rmm::device_buffer null_mask{};
+  rmm::device_buffer null_mask{0, stream, mr};
   if (view.nullable()) {
     null_mask =
       copy_bitmask(view.null_mask(), view.offset(), view.offset() + view.size(), stream, mr);
@@ -651,7 +651,7 @@ rmm::device_buffer bitmask_and(table_view const &view,
                                cudaStream_t stream)
 {
   CUDF_FUNC_RANGE();
-  rmm::device_buffer null_mask{};
+  rmm::device_buffer null_mask{0, stream, mr};
   if (view.num_rows() == 0 or view.num_columns() == 0) { return null_mask; }
 
   std::vector<bitmask_type const *> masks;

--- a/cpp/src/dictionary/dictionary_factories.cu
+++ b/cpp/src/dictionary/dictionary_factories.cu
@@ -36,7 +36,7 @@ std::unique_ptr<column> make_dictionary_column(column_view const& keys_column,
                            0,
                            indices_column.offset()};
   auto indices_copy = std::make_unique<column>(indices_view, stream, mr);
-  rmm::device_buffer null_mask;
+  rmm::device_buffer null_mask{0, stream, mr};
   auto null_count = indices_column.null_count();
   if (null_count) null_mask = copy_bitmask(indices_column, stream, mr);
 

--- a/cpp/src/strings/combine.cu
+++ b/cpp/src/strings/combine.cu
@@ -208,7 +208,7 @@ std::unique_ptr<column> join_strings(strings_column_view const& strings,
   // build null mask
   // only one entry so it is either all valid or all null
   size_type null_count = 0;
-  rmm::device_buffer null_mask;  // init to null null-mask
+  rmm::device_buffer null_mask{0, stream, mr};  // init to null null-mask
   if (strings.null_count() == strings_count && !narep.is_valid()) {
     null_mask  = create_null_mask(1, cudf::mask_state::ALL_NULL, stream, mr);
     null_count = 1;

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -246,7 +246,7 @@ std::unique_ptr<column> concatenate(std::vector<column_view> const& columns,
   auto d_new_offsets = offsets_column->mutable_view().data<int32_t>();
   offsets_column->set_null_count(0);
 
-  rmm::device_buffer null_mask;
+  rmm::device_buffer null_mask{0, stream, mr};
   size_type null_count{};
   if (has_nulls) {
     null_mask = create_null_mask(strings_count, mask_state::UNINITIALIZED, stream, mr);

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -75,7 +75,7 @@ std::unique_ptr<column> make_strings_column(
     stream,
     mr);
   auto null_count = new_nulls.second;
-  rmm::device_buffer null_mask;
+  rmm::device_buffer null_mask{0, stream, mr};
   if (null_count > 0) null_mask = std::move(new_nulls.first);
 
   // build chars column

--- a/cpp/src/strings/substring.cu
+++ b/cpp/src/strings/substring.cu
@@ -215,7 +215,7 @@ struct compute_substrings_from_fn {
     auto strings_count = d_column.size();
 
     // Copy the null mask
-    rmm::device_buffer null_mask;
+    rmm::device_buffer null_mask{0, stream, mr};
     if (d_column.nullable())
       null_mask = rmm::device_buffer(
         d_column.null_mask(), cudf::bitmask_allocation_size_bytes(strings_count), stream, mr);


### PR DESCRIPTION
Issue #5067

Fix a missed case where empty null masks are initialized with the default memory recourse and returned to the caller if the input is not nullable.
Since `device_buffer` holds on to the memory resource, it should be initialized with the correct resource even if no allocation is happening at the time.