### PR TITLE
[REVIEW] Fix compile warning by disallowing bool column type for slice_strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #5382 Fix CategoricalDtype equality comparisons
 - PR #5385 Fix index issues in `DataFrame.from_gpu_matrix`
 - PR #5390 Fix Java data type IDs and string interleave test
+- PR #5410 Fix compile warning by disallowing bool column type for slice_strings
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/cpp/include/cudf/strings/substring.hpp
+++ b/cpp/include/cudf/strings/substring.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/strings/substring.cu
+++ b/cpp/src/strings/substring.cu
@@ -256,7 +256,8 @@ struct compute_substrings_from_fn {
 // type dispatcher.
 struct compute_substrings {
   template <typename PositionType,
-            std::enable_if_t<std::is_integral<PositionType>::value>* = nullptr>
+            std::enable_if_t<std::is_integral<PositionType>::value and
+                             not std::is_same<PositionType, bool>::value>* = nullptr>
   std::unique_ptr<column> operator()(column_device_view const& d_column,
                                      size_type null_count,
                                      column_view const& starts_column,
@@ -273,13 +274,10 @@ struct compute_substrings {
   }
 
   template <typename PositionType,
-            std::enable_if_t<not std::is_integral<PositionType>::value>* = nullptr>
-  std::unique_ptr<column> operator()(column_device_view const& d_column,
-                                     size_type null_count,
-                                     column_view const& starts_column,
-                                     column_view const& stops_column,
-                                     rmm::mr::device_memory_resource* mr,
-                                     cudaStream_t stream) const
+            typename... Args,
+            std::enable_if_t<not std::is_integral<PositionType>::value or
+                             std::is_same<PositionType, bool>::value>* = nullptr>
+  std::unique_ptr<column> operator()(Args&&... args) const
   {
     CUDF_FAIL("Positions values must be an integral type.");
   }


### PR DESCRIPTION
Current build includes a compile warning for `cudf::strings::slice_strings` function in `src/cpp/strings/substring.cu` 

```
Building CUDA object CMakeFiles/cudf.dir/src/strings/substring.cu.o
_deps/thrust-src/thrust/iterator/iterator_adaptor.h(210): warning: incrementing a bool value is deprecated
          detected during:
            instantiation of "void thrust::iterator_adaptor<Derived, Base, Value, System, Traversal, Reference, Difference>::increment() [with Derived=thrust::counting_iterator<__nv_bool, thrust::use_default, thrust::use_default, thrust::use_default>, Base=__nv_bool, Value=__nv_bool, System=thrust::any_system_tag, Traversal=thrust::random_access_traversal_tag, Reference=__nv_bool, Difference=signed int]" 
....
```

The warning occurs because the dispatcher functor `compute_substrings` includes integral types but should not include `bool` type. The values are expected to be integer position values for each string and `bool` is an inappropriate and unexpected type.

This PR fixes the SFINAE declarations to relegate `bool` column types to the `operator()` which throws an exception for unexpected types.