### PR TITLE
[REVIEW] Enable wrapping long class names in libcudf Doxygen tables [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PR #5405 Add Error message to `StringColumn.unary_operator`
 - PR #5424 Add python plumbing for `.str.character_tokenize`
 - PR #5420 Aligning signature of `Series.value_counts` to Pandas
+- PR #5429 Improve text wrapping in libcudf documentation
 
 ## Bug Fixes
 

--- a/cpp/doxygen/rapids.css
+++ b/cpp/doxygen/rapids.css
@@ -93,3 +93,27 @@
 .navpath li.navelem {
   background-color: #FAF6FF;   /* A nearly white RAPIDS purple background */
 }
+
+/* Add some CSS to make class / function lists nicer in the presence of long templated names */
+
+.directory td.entry {
+  white-space: normal;                /* Allow text wrapping for long class names */
+  min-width:   512px;                 /* But don't wrap them too much. */
+
+  /* This indent and padding causes any long class names that are wrapped to be indented on 
+     wrapped lines */
+  text-indent: -65px;
+  padding-left: 55px;
+}
+
+/* Prevent arrows from being negatively indented */
+.arrow {
+  text-indent: 0px;
+  padding-left: 10px;
+}
+
+/* Prevent icons from being negatively indented */
+.icona {
+  text-indent: 0px;
+  padding-left: 0px;
+}


### PR DESCRIPTION
This PR adds some CSS for libcudf Doxygen to allow long class names in lists to wrap, improving readability of documentation, especially in "narrow" browser windows (previously they were only readable on my screen when the window was maximized!)

Before:

![image](https://user-images.githubusercontent.com/783069/84111041-64580700-aa69-11ea-956f-3ec0ab059e6a.png)

After:

![image](https://user-images.githubusercontent.com/783069/84110944-3246a500-aa69-11ea-8eeb-3b1be18d55de.png)
