### PR TITLE
[REVIEW] Fix nvtext ngrams_tokenize performance for multi-byte UTF8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - PR #5404 Fix issue with column creation when chunked arrays are passed
 - PR #5409 Use the correct memory resource when creating empty null masks
 - PR #5399 Fix cpp compiler warnings of unreachable code
+- PR #5439 Fix nvtext ngrams_tokenize performance for multi-byte UTF8
 
 
 # cuDF 0.14.0 (Date TBD)


### PR DESCRIPTION
Closes #5412 
This PR improves the speed of tokenization in the `nvtext::ngrams_tokenizer` as well as other nvtext tokenize APIs.

The internal nvtext tokenizing function currently uses a `cudf::string_view::const_iterator` to navigate and locate token delimiters. Once located, the byte-offsets need to be retrieved to build the output. The internal `characters_tokenizer` functor was using character positions to keep track of found tokens. This means converting these positions to byte-offsets for each token can be costly for long strings containing multi-byte UTF-8 characters as described in the issue.

This PR modifies the functor to store byte-offsets internally instead of character positions so the conversion is not required. The iterator maintains both character and byte position so the byte-offset should never need to be recomputed.

Testing with the data and logic provided in issue #5412 the `ngrams_tokenize` speed improved from about 4.805 seconds to 0.158 seconds (on my GV100)  -- 10x faster even than the original nvstrings/nvtext implementation.