### PR TITLE
[REVIEW] Remove unused `is_simple` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - PR #5420 Aligning signature of `Series.value_counts` to Pandas
 - PR #5427 Add Java bindings for unsigned data types
 - PR #5429 Improve text wrapping in libcudf documentation
+- PR #5443 Remove unused `is_simple` trait
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/utilities/traits.hpp
+++ b/cpp/include/cudf/utilities/traits.hpp
@@ -385,42 +385,6 @@ constexpr inline bool is_compound(data_type type)
 }
 
 /**
- * @brief Indicates whether the type `T` is a simple type.
- *
- * "Simple" element types are implemented with only a single column, i.e.,
- * `num_children() == 0` for columns of "simple" elements
- *
- * @tparam T The type to verify
- * @return true `T` corresponds to a simple type
- * @return false `T` corresponds to a compound type
- **/
-template <typename T>
-constexpr inline bool is_simple()
-{
-  return not is_compound<T>();
-}
-
-struct is_simple_impl {
-  template <typename T>
-  bool operator()()
-  {
-    return is_simple<T>();
-  }
-};
-
-/**
- * @brief Indicates whether elements of `type` are simple.
- *
- * "Simple" element types are implemented with only a single column, i.e.,
- * `num_children() == 0` for columns of "simple" elements
- *
- * @param type The `data_type` to verify
- * @return true `type` is a simple type
- * @return false `type` is a compound type
- **/
-constexpr inline bool is_simple(data_type type) { return not is_compound(type); }
-
-/**
  * @brief Indicates whether `T` is a nested type.
  *
  * "Nested" types are distinct from compound types in that they

--- a/cpp/tests/types/traits_test.cpp
+++ b/cpp/tests/types/traits_test.cpp
@@ -146,6 +146,6 @@ TYPED_TEST(TypedTraitsTest, NotEqualityComparableWithList)
   EXPECT_FALSE(comparable);
 }
 
-// TODO: Tests for is_compound/is_simple, is_fixed_width
+// TODO: Tests for is_compound, is_fixed_width
 
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
This trait is unused. On top of that, I don't think it is necessary to name the `not` (aka complement) of `is_compound` when we already have `is_fixed_width`. 