### PR TITLE
[REVIEW] Remove deprecated RMM APIs and headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #5418 Add support for `DataFrame.info`
 - PR #5425 Add Python `Groupby.rolling()`
 - PR #5359 Add duration types 
+- PR #5444 Remove usage of deprecated RMM APIs and headers.
 
 ## Improvements
 

--- a/cpp/benchmarks/join/generate_input_tables.cuh
+++ b/cpp/benchmarks/join/generate_input_tables.cuh
@@ -24,7 +24,6 @@
 #include <thrust/sequence.h>
 #include <cassert>
 
-#include <rmm/rmm.h>
 #include <cudf/detail/utilities/device_atomics.cuh>
 #include <cudf/utilities/error.hpp>
 

--- a/cpp/src/column/column_device_view.cu
+++ b/cpp/src/column/column_device_view.cu
@@ -19,7 +19,6 @@
 #include <cudf/utilities/error.hpp>
 #include <numeric>
 
-#include <rmm/rmm_api.h>
 #include <rmm/thrust_rmm_allocator.h>
 
 namespace cudf {

--- a/cpp/src/hash/hash_allocator.cuh
+++ b/cpp/src/hash/hash_allocator.cuh
@@ -19,7 +19,6 @@
 
 #include <new>
 
-#include <rmm/rmm.h>
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>

--- a/cpp/src/io/comp/uncomp.cpp
+++ b/cpp/src/io/comp/uncomp.cpp
@@ -15,7 +15,6 @@
  */
 
 #include <cuda_runtime.h>
-#include <rmm/rmm.h>
 #include <string.h>  // memset
 #include <zlib.h>    // uncompress
 #include "io_uncomp.h"

--- a/cpp/src/reductions/scan.cu
+++ b/cpp/src/reductions/scan.cu
@@ -4,7 +4,6 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 
-#include <rmm/rmm.h>
 #include <cudf/null_mask.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>

--- a/cpp/src/strings/regex/regexec.cu
+++ b/cpp/src/strings/regex/regexec.cu
@@ -19,9 +19,6 @@
 #include <rmm/device_buffer.hpp>
 #include <strings/regex/regex.cuh>
 
-#include <rmm/rmm_api.h>
-#include <rmm/rmm.hpp>
-
 namespace cudf {
 namespace strings {
 namespace detail {
@@ -99,18 +96,6 @@ std::unique_ptr<reprog_device, std::function<void(reprog_device*)>> reprog_devic
   if (insts_count > MAX_STACK_INSTS) {
     auto relist_alloc_size = relist::alloc_size(insts_count);
     rlm_size               = relist_alloc_size * 2L * strings_count;  // reljunk has 2 relist ptrs
-    size_t freeSize        = 0;
-    size_t totalSize       = 0;
-    rmmGetInfo(&freeSize, &totalSize, stream);
-    if (rlm_size + memsize > freeSize)  // do not allocate more than we have
-    {                                   // otherwise, this is unrecoverable
-      std::ostringstream message;
-      message << "cuDF failure at: " __FILE__ ":" << __LINE__ << ": ";
-      message << "number of instructions (" << insts_count << ") ";
-      message << "and number of strings (" << strings_count << ") ";
-      message << "exceeds available memory";
-      throw cudf::logic_error(message.str());
-    }
   }
 
   // allocate memory to store prog data

--- a/cpp/src/strings/utilities.cu
+++ b/cpp/src/strings/utilities.cu
@@ -24,8 +24,6 @@
 #include "char_types/char_cases.h"
 #include "char_types/char_flags.h"
 
-#include <rmm/rmm.h>
-#include <rmm/rmm_api.h>
 #include <rmm/thrust_rmm_allocator.h>
 #include <thrust/transform_reduce.h>
 #include <thrust/transform_scan.h>

--- a/cpp/src/table/table_device_view.cu
+++ b/cpp/src/table/table_device_view.cu
@@ -19,7 +19,6 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/error.hpp>
 
-
 #include <algorithm>
 #include <numeric>
 #include <vector>

--- a/cpp/src/table/table_device_view.cu
+++ b/cpp/src/table/table_device_view.cu
@@ -19,7 +19,6 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/rmm.h>
 
 #include <algorithm>
 #include <numeric>

--- a/cpp/tests/error/error_handling_test.cu
+++ b/cpp/tests/error/error_handling_test.cu
@@ -15,7 +15,6 @@
  */
 #include <cudf/utilities/error.hpp>
 
-
 #include <tests/utilities/base_fixture.hpp>
 
 #include <cstring>

--- a/cpp/tests/error/error_handling_test.cu
+++ b/cpp/tests/error/error_handling_test.cu
@@ -15,7 +15,6 @@
  */
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/rmm.h>
 
 #include <tests/utilities/base_fixture.hpp>
 


### PR DESCRIPTION
Closes #5444

In anticipation of https://github.com/rapidsai/rmm/pull/396, removes all references to deprecated RMM headers and APIs. 