### PR TITLE
[REVIEW] Build compile error fix in column_utilities.cu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - PR #5399 Fix cpp compiler warnings of unreachable code
 - PR #5446 Fix compile error caused by out-of-date PR merge (4990)
 
+
 # cuDF 0.14.0 (Date TBD)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@
 - PR #5404 Fix issue with column creation when chunked arrays are passed
 - PR #5409 Use the correct memory resource when creating empty null masks
 - PR #5399 Fix cpp compiler warnings of unreachable code
-
+- PR #5446 Fix compile error caused by out-of-date PR merge (4990)
 
 # cuDF 0.14.0 (Date TBD)
 

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -473,7 +473,9 @@ struct column_view_printer {
   }
 
   template <typename Element, typename std::enable_if_t<is_duration<Element>()>* = nullptr>
-  void operator()(cudf::column_view const& col, std::vector<std::string>& out)
+  void operator()(cudf::column_view const& col,
+                  std::vector<std::string>& out,
+                  std::string const& indent)
   {
     CUDF_FAIL("duration printing not supported yet");
   }


### PR DESCRIPTION

This PR https://github.com/rapidsai/cudf/pull/4990 got merged and was a little bit behind.  An overload for duration types hadn't had it's param list updated.   One line fix here.

