### PR TITLE
[REVIEW] Install meta packages for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - PR #5443 Remove unused `is_simple` trait
 - PR #5441 Update Java HostMemoryBuffer to only load native libs when necessary
 - PR #5437 Improve libcudf join documentation
+- PR #5458 Install meta packages for dependencies
 
 ## Bug Fixes
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -68,6 +68,10 @@ conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
               "rapids-build-env=$MINOR_VERSION.*" \
               "rapids-notebook-env=$MINOR_VERSION.*"
 
+# https://docs.rapids.ai/maintainers/depmgmt/ 
+# conda remove -f rapids-build-env rapids-notebook-env
+# conda install "your-pkg=1.0.0"
+
 # Install the master version of dask, distributed, and streamz
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -65,11 +65,8 @@ if [ "$py_ver" == "3.6" ];then
 fi
 
 conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
-              "dask>=2.15.0" "distributed>=2.15.0" "numpy>=1.16" "double-conversion" \
-              "rapidjson" "flatbuffers" "boost-cpp=1.72.0" "fsspec>=0.6.0" "dlpack" \
-              "feather-format" "cupy>=6.6.0,<8.0.0a0,!=7.1.0" "arrow-cpp=0.17.1" "arrow-cpp-proc=*=cuda" "pyarrow=0.17.1" \
-              "fastavro>=0.22.0" "pandas>=0.25,<0.26" "hypothesis" "s3fs" "gcsfs" \
-              "boto3" "moto" "httpretty" "streamz" "ipython=7.3*" "jupyterlab" "librdkafka>=1.3"
+              "rapids-build-env=$MINOR_VERSION.*" \
+              "rapids-notebook-env=$MINOR_VERSION.*"
 
 # Install the master version of dask, distributed, and streamz
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"


### PR DESCRIPTION
Install dependencies via `rapids-build-env` and `rapids-notebook-env` (which are pre-installed in the containers).

This brings the repo in line with https://docs.rapids.ai/maintainers/depmgmt/