### PR TITLE
[REVIEW] Fix str.translate to convert table characters to UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - PR #5409 Use the correct memory resource when creating empty null masks
 - PR #5399 Fix cpp compiler warnings of unreachable code
 - PR #5446 Fix compile error caused by out-of-date PR merge (4990)
+- PR #5459 Fix str.translate to convert table characters to UTF-8
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/python/cudf/cudf/_lib/strings/translate.pyx
+++ b/python/cudf/cudf/_lib/strings/translate.pyx
@@ -30,10 +30,14 @@ def translate(Column source_strings,
 
     for key in mapping_table:
         value = mapping_table[key]
+        if type(value) is int:
+            value = chr(value)
         if type(value) is str:
-            value = ord(value)
+            value = int.from_bytes(value.encode(), byteorder='big')
+        if type(key) is int:
+            key = chr(key)
         if type(key) is str:
-            key = ord(key)
+            key = int.from_bytes(key.encode(), byteorder='big')
         c_mapping_table.push_back((key, value))
 
     with nogil:

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -1846,6 +1846,10 @@ def test_string_str_translate(data):
             str.maketrans({"+": "-", "-": "$", "?": "!", "B": "."})
         ),
     )
+    assert_eq(
+        ps.str.translate(str.maketrans({"é": "É"})),
+        gs.str.translate(str.maketrans({"é": "É"})),
+    )
 
 
 def test_string_str_code_points():


### PR DESCRIPTION
Fixes #5453 

The `str.maketrans()` function creates character mapping table for the `translate()` API. The values are stored as unicode code-point values (integers). The `cudf::strings::translate()` is expecting UTF-8 encoded characters in its translate table parameter.

For consistency with other strings APIs, the Cython code logic for `translate()` is changed to convert the unicode values to UTF-8 encoded values when creating the mapping table for the call to libcudf.

Also added some multi-byte characters to the pytest function.