### PR TITLE
[REVIEW] Fix benchmark_fixture cnmem errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - PR #5439 Fix nvtext ngrams_tokenize performance for multi-byte UTF8
 - PR #5446 Fix compile error caused by out-of-date PR merge (4990)
 - PR #5459 Fix str.translate to convert table characters to UTF-8
+- PR #5465 Fix benchmark out of memory errors due to multiple initialization
 
 
 # cuDF 0.14.0 (Date TBD)


### PR DESCRIPTION
Fixes errors caused by multiple initialization of cnmem in google benchmarks.

