### PR TITLE
[REVIEW] allow linking arrow libraries statically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ## Improvements
 
+- PR #5479 Link Arrow libraries statically
 - PR #5414 Use new release of Thrust/CUB in the JNI build
 - PR #5403 Update required CMake version to 3.14 in contribution guide
 - PR #5245 Add column reduction benchmark

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -185,14 +185,44 @@ endif("$ENV{CONDA_BUILD}" STREQUAL "1")
 ###################################################################################################
 # - find arrow ------------------------------------------------------------------------------------
 
-message(STATUS "BUILDING ARROW")
-include(ConfigureArrow)
+option(ARROW_STATIC_LIB "Build and statically link with Arrow libraries" OFF)
 
-if(ARROW_FOUND)
+if(ARROW_STATIC_LIB)
+  message(STATUS "BUILDING ARROW")
+  include(ConfigureArrow)
+
+  if(ARROW_FOUND)
     message(STATUS "Apache Arrow found in ${ARROW_INCLUDE_DIR}")
-else()
+  else()
     message(FATAL_ERROR "Apache Arrow not found, please check your settings.")
-endif(ARROW_FOUND)
+  endif(ARROW_FOUND)
+
+  add_library(arrow STATIC IMPORTED ${ARROW_LIB})
+  add_library(arrow_cuda STATIC IMPORTED ${ARROW_CUDA_LIB})
+else()
+  find_path(ARROW_INCLUDE_DIR "arrow"
+      HINTS "$ENV{ARROW_ROOT}/include")
+
+  find_library(ARROW_LIB "arrow"
+      NAMES libarrow
+      HINTS "$ENV{ARROW_ROOT}/lib" "$ENV{ARROW_ROOT}/build")
+
+  find_library(ARROW_CUDA_LIB "arrow_cuda"
+      NAMES libarrow_cuda
+      HINTS "$ENV{ARROW_ROOT}/lib" "$ENV{ARROW_ROOT}/build")
+
+  message(STATUS "ARROW: ARROW_INCLUDE_DIR set to ${ARROW_INCLUDE_DIR}")
+  message(STATUS "ARROW: ARROW_LIB set to ${ARROW_LIB}")
+  message(STATUS "ARROW: ARROW_CUDA_LIB set to ${ARROW_CUDA_LIB}")
+
+  add_library(arrow SHARED IMPORTED ${ARROW_LIB})
+  add_library(arrow_cuda SHARED IMPORTED ${ARROW_CUDA_LIB})
+endif(ARROW_STATIC_LIB)
+
+if(ARROW_INCLUDE_DIR AND ARROW_LIB AND ARROW_CUDA_LIB)
+  set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${ARROW_LIB})
+  set_target_properties(arrow_cuda PROPERTIES IMPORTED_LOCATION ${ARROW_CUDA_LIB})
+endif(ARROW_INCLUDE_DIR AND ARROW_LIB AND ARROW_CUDA_LIB)
 
 ###################################################################################################
 # - copy libcu++ ------------------------------------------------------------------------------------
@@ -693,7 +723,7 @@ endif(HT_DEFAULT_ALLOCATOR)
 # - link libraries --------------------------------------------------------------------------------
 
 # link targets for cuDF
-target_link_libraries(cudf rmm ${ARROW_CUDA_LIB} ${ARROW_LIB} nvrtc ${CUDART_LIBRARY} cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(cudf rmm arrow arrow_cuda nvrtc ${CUDART_LIBRARY} cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -692,9 +692,6 @@ endif(HT_DEFAULT_ALLOCATOR)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-# Get all the symbols from the Arrow CUDA Library for Cython
-set(ARROW_CUDA_LIB_LINK -Wl,--whole-archive ${ARROW_CUDA_LIB} -Wl,--no-whole-archive)
-
 # link targets for cuDF
 target_link_libraries(cudf rmm ${ARROW_CUDA_LIB_LINK} ${ARROW_LIB} nvrtc ${CUDART_LIBRARY} cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -693,7 +693,7 @@ endif(HT_DEFAULT_ALLOCATOR)
 # - link libraries --------------------------------------------------------------------------------
 
 # link targets for cuDF
-target_link_libraries(cudf rmm ${ARROW_CUDA_LIB_LINK} ${ARROW_LIB} nvrtc ${CUDART_LIBRARY} cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(cudf rmm ${ARROW_CUDA_LIB} ${ARROW_LIB} nvrtc ${CUDART_LIBRARY} cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -185,28 +185,14 @@ endif("$ENV{CONDA_BUILD}" STREQUAL "1")
 ###################################################################################################
 # - find arrow ------------------------------------------------------------------------------------
 
-find_path(ARROW_INCLUDE "arrow"
-          HINTS "$ENV{ARROW_ROOT}/include")
+message(STATUS "BUILDING ARROW")
+include(ConfigureArrow)
 
-find_library(ARROW_LIBRARY "arrow"
-             NAMES libarrow
-             HINTS "$ENV{ARROW_ROOT}/lib" "$ENV{ARROW_ROOT}/build")
-
-find_library(ARROW_CUDA_LIBRARY "arrow_cuda"
-             NAMES libarrow_cuda
-             HINTS "$ENV{ARROW_ROOT}/lib" "$ENV{ARROW_ROOT}/build")
-
-message(STATUS "ARROW: ARROW_INCLUDE set to ${ARROW_INCLUDE}")
-message(STATUS "ARROW: ARROW_LIBRARY set to ${ARROW_LIBRARY}")
-message(STATUS "ARROW: ARROW_CUDA_LIBRARY set to ${ARROW_CUDA_LIBRARY}")
-
-add_library(arrow SHARED IMPORTED ${ARROW_LIBRARY})
-add_library(arrow_cuda SHARED IMPORTED ${ARROW_CUDA_LIBRARY})
-
-if(ARROW_INCLUDE AND ARROW_LIBRARY AND ARROW_CUDA_LIBRARY)
-    set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${ARROW_LIBRARY})
-    set_target_properties(arrow_cuda PROPERTIES IMPORTED_LOCATION ${ARROW_CUDA_LIBRARY})
-endif(ARROW_INCLUDE AND ARROW_LIBRARY AND ARROW_CUDA_LIBRARY)
+if(ARROW_FOUND)
+    message(STATUS "Apache Arrow found in ${ARROW_INCLUDE_DIR}")
+else()
+    message(FATAL_ERROR "Apache Arrow not found, please check your settings.")
+endif(ARROW_FOUND)
 
 ###################################################################################################
 # - copy libcu++ ------------------------------------------------------------------------------------
@@ -353,7 +339,7 @@ include_directories("${CMAKE_BINARY_DIR}/include"
                     "${CMAKE_BINARY_DIR}/include/jit"
                     "${CMAKE_SOURCE_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/src"
-                    "${ARROW_INCLUDE}"
+                    "${ARROW_INCLUDE_DIR}"
                     "${ZLIB_INCLUDE_DIRS}"
                     "${Boost_INCLUDE_DIRS}"
                     "${RMM_INCLUDE}"
@@ -706,8 +692,11 @@ endif(HT_DEFAULT_ALLOCATOR)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
+# Get all the symbols from the Arrow CUDA Library for Cython
+set(ARROW_CUDA_LIB_LINK -Wl,--whole-archive ${ARROW_CUDA_LIB} -Wl,--no-whole-archive)
+
 # link targets for cuDF
-target_link_libraries(cudf rmm arrow arrow_cuda nvrtc ${CUDART_LIBRARY} cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(cudf rmm ${ARROW_CUDA_LIB_LINK} ${ARROW_LIB} nvrtc ${CUDART_LIBRARY} cuda ${ZLIB_LIBRARIES} ${Boost_LIBRARIES})
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories("${CMAKE_BINARY_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/thirdparty/dlpack/include"
                     "${GTEST_INCLUDE_DIR}"
                     "${GBENCH_INCLUDE_DIR}"
-                    "${ARROW_INCLUDE}"
+                    "${ARROW_INCLUDE_DIR}"
                     "${RMM_INCLUDE}"
                     "${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/cpp/cmake/Modules/ConfigureArrow.cmake
+++ b/cpp/cmake/Modules/ConfigureArrow.cmake
@@ -97,10 +97,4 @@ message(STATUS "FlatBuffers installed here: " ${FLATBUFFERS_ROOT})
 set(FLATBUFFERS_INCLUDE_DIR "${FLATBUFFERS_ROOT}/include")
 set(FLATBUFFERS_LIBRARY_DIR "${FLATBUFFERS_ROOT}/lib")
 
-file(INSTALL ${ARROW_INCLUDE_DIR}/arrow/gpu DESTINATION include/arrow)
-
-install(DIRECTORY ${ARROW_INCLUDE_DIR}/arrow/gpu
-    DESTINATION include/arrow
-    COMPONENT cudf)
-
 add_definitions(-DARROW_METADATA_V4)

--- a/cpp/cmake/Modules/ConfigureArrow.cmake
+++ b/cpp/cmake/Modules/ConfigureArrow.cmake
@@ -1,0 +1,106 @@
+set(ARROW_ROOT ${CMAKE_BINARY_DIR}/arrow)
+
+set(ARROW_CMAKE_ARGS " -DARROW_WITH_LZ4=OFF"
+    " -DARROW_WITH_ZSTD=OFF"
+    " -DARROW_WITH_BROTLI=OFF"
+    " -DARROW_WITH_SNAPPY=OFF"
+    " -DARROW_WITH_ZLIB=OFF"
+    " -DARROW_BUILD_STATIC=ON"
+    " -DARROW_BUILD_SHARED=OFF"
+    " -DARROW_BOOST_USE_SHARED=OFF"
+    " -DARROW_BUILD_TESTS=OFF"
+    " -DARROW_TEST_LINKAGE=OFF"
+    " -DARROW_TEST_MEMCHECK=OFF"
+    " -DARROW_BUILD_BENCHMARKS=OFF"
+    " -DARROW_IPC=ON"
+    " -DARROW_FLIGHT=OFF"
+    " -DARROW_COMPUTE=OFF"
+    " -DARROW_CUDA=ON"
+    " -DARROW_JEMALLOC=OFF"
+    " -DARROW_BOOST_VENDORED=OFF"
+    " -DARROW_PYTHON=OFF"
+    " -DARROW_USE_GLOG=OFF"
+    " -DARROW_DATASET=ON"
+    " -DARROW_BUILD_UTILITIES=OFF"
+    " -DARROW_HDFS=OFF"
+    " -DCMAKE_VERBOSE_MAKEFILE=ON")
+
+if(NOT CMAKE_CXX11_ABI)
+  message(STATUS "ARROW: Disabling the GLIBCXX11 ABI")
+  list(APPEND ARROW_CMAKE_ARGS " -DARROW_TENSORFLOW=ON")
+elseif(CMAKE_CXX11_ABI)
+  message(STATUS "ARROW: Enabling the GLIBCXX11 ABI")
+  list(APPEND ARROW_CMAKE_ARGS " -DARROW_TENSORFLOW=OFF")
+endif(NOT CMAKE_CXX11_ABI)
+
+configure_file("${CMAKE_SOURCE_DIR}/cmake/Templates/Arrow.CMakeLists.txt.cmake"
+    "${ARROW_ROOT}/CMakeLists.txt")
+
+file(MAKE_DIRECTORY "${ARROW_ROOT}/build")
+file(MAKE_DIRECTORY "${ARROW_ROOT}/install")
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE ARROW_CONFIG
+    WORKING_DIRECTORY ${ARROW_ROOT})
+
+if(ARROW_CONFIG)
+  message(FATAL_ERROR "Configuring Arrow failed: " ${ARROW_CONFIG})
+endif(ARROW_CONFIG)
+
+set(PARALLEL_BUILD -j)
+if($ENV{PARALLEL_LEVEL})
+  set(NUM_JOBS $ENV{PARALLEL_LEVEL})
+  set(PARALLEL_BUILD "${PARALLEL_BUILD}${NUM_JOBS}")
+endif($ENV{PARALLEL_LEVEL})
+
+if(${NUM_JOBS})
+  if(${NUM_JOBS} EQUAL 1)
+    message(STATUS "ARROW BUILD: Enabling Sequential CMake build")
+  elseif(${NUM_JOBS} GREATER 1)
+    message(STATUS "ARROW BUILD: Enabling Parallel CMake build with ${NUM_JOBS} jobs")
+  endif(${NUM_JOBS} EQUAL 1)
+else()
+  message(STATUS "ARROW BUILD: Enabling Parallel CMake build with all threads")
+endif(${NUM_JOBS})
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND} --build .. -- ${PARALLEL_BUILD}
+    RESULT_VARIABLE ARROW_BUILD
+    WORKING_DIRECTORY ${ARROW_ROOT}/build)
+
+if(ARROW_BUILD)
+  message(FATAL_ERROR "Building Arrow failed: " ${ARROW_BUILD})
+endif(ARROW_BUILD)
+
+message(STATUS "Arrow installed here: " ${ARROW_ROOT}/install)
+set(ARROW_LIBRARY_DIR "${ARROW_ROOT}/install/lib")
+set(ARROW_INCLUDE_DIR "${ARROW_ROOT}/install/include")
+
+find_library(ARROW_LIB arrow
+    NO_DEFAULT_PATH
+    HINTS "${ARROW_LIBRARY_DIR}")
+
+find_library(ARROW_CUDA_LIB arrow_cuda
+    NO_DEFAULT_PATH
+    HINTS "${ARROW_LIBRARY_DIR}")
+
+if(ARROW_LIB AND ARROW_CUDA_LIB)
+  message(STATUS "Arrow library: " ${ARROW_LIB})
+  message(STATUS "Arrow CUDA library: " ${ARROW_CUDA_LIB})
+  set(ARROW_FOUND TRUE)
+endif(ARROW_LIB AND ARROW_CUDA_LIB)
+
+set(FLATBUFFERS_ROOT "${ARROW_ROOT}/build/flatbuffers_ep-prefix/src/flatbuffers_ep-install")
+
+message(STATUS "FlatBuffers installed here: " ${FLATBUFFERS_ROOT})
+set(FLATBUFFERS_INCLUDE_DIR "${FLATBUFFERS_ROOT}/include")
+set(FLATBUFFERS_LIBRARY_DIR "${FLATBUFFERS_ROOT}/lib")
+
+file(INSTALL ${ARROW_INCLUDE_DIR}/arrow/gpu DESTINATION include/arrow)
+
+install(DIRECTORY ${ARROW_INCLUDE_DIR}/arrow/gpu
+    DESTINATION include/arrow
+    COMPONENT cudf)
+
+add_definitions(-DARROW_METADATA_V4)

--- a/cpp/cmake/Templates/Arrow.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/Arrow.CMakeLists.txt.cmake
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.14)
+
+include(ExternalProject)
+
+ExternalProject_Add(Arrow
+    GIT_REPOSITORY    https://github.com/apache/arrow.git
+    GIT_TAG           apache-arrow-0.17.1
+    SOURCE_DIR        "${ARROW_ROOT}/arrow"
+    SOURCE_SUBDIR     "cpp"
+    BINARY_DIR        "${ARROW_ROOT}/build"
+    INSTALL_DIR       "${ARROW_ROOT}/install"
+    CMAKE_ARGS        ${ARROW_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${ARROW_ROOT}/install)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -73,7 +73,7 @@ include_directories("${CMAKE_BINARY_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/src"
                     "${CMAKE_SOURCE_DIR}/thirdparty/dlpack/include"
                     "${GTEST_INCLUDE_DIR}"
-                    "${ARROW_INCLUDE}"
+                    "${ARROW_INCLUDE_DIR}"
                     "${ZLIB_INCLUDE_DIRS}"
                     "${Boost_INCLUDE_DIRS}"
                     "${RMM_INCLUDE}")


### PR DESCRIPTION
Link Arrow libraries statically per java requirements.

This partially rolls back #5408.

Fixes #5457 

@kkraus14 @jlowe 