### PR TITLE
[REVIEW] Use rmm::device_uvector in place of rmm::device_vector for `cudf::detail::copy_if`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - PR #5437 Improve libcudf join documentation
 - PR #5458 Install meta packages for dependencies
 - PR #5467 Move doc customization scripts to Jenkins
+- PR #5482 Use rmm::device_uvector in place of rmm::device_vector in copy_if
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/detail/copy_if.cuh
+++ b/cpp/include/cudf/detail/copy_if.cuh
@@ -33,6 +33,7 @@
 
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <algorithm>
 #include <cub/cub.cuh>
@@ -213,8 +214,7 @@ struct scatter_gather_functor {
     rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
     cudaStream_t stream                 = 0)
   {
-    // Actually we gather here
-    rmm::device_vector<cudf::size_type> indices(output_size, 0);
+    rmm::device_uvector<cudf::size_type> indices(output_size, stream);
 
     thrust::copy_if(rmm::exec_policy(stream)->on(stream),
                     thrust::counting_iterator<cudf::size_type>(0),
@@ -272,7 +272,7 @@ struct scatter_gather_functor {
                                                         per_thread,
                                                         filter);
 
-    if (has_valid) { output_column->set_null_count(null_count.value()); }
+    if (has_valid) { output_column->set_null_count(null_count.value(stream)); }
     return output_column;
   }
 };
@@ -309,45 +309,50 @@ std::unique_ptr<table> copy_if(
     elements_per_thread(compute_block_counts<Filter, block_size>, input.num_rows(), block_size);
   cudf::detail::grid_1d grid{input.num_rows(), block_size, per_thread};
 
-  // allocate temp storage for block counts and offsets
-  // TODO: use an uninitialized vector to avoid the initialization kernel
-  rmm::device_vector<cudf::size_type> block_counts(2 * grid.num_blocks + 1, 0);
-  auto block_offsets = &block_counts[grid.num_blocks];
+  // temp storage for block counts and offsets
+  rmm::device_uvector<cudf::size_type> block_counts(grid.num_blocks, stream);
+  rmm::device_uvector<cudf::size_type> block_offsets(grid.num_blocks + 1, stream);
 
   // 1. Find the count of elements in each block that "pass" the mask
   compute_block_counts<Filter, block_size><<<grid.num_blocks, block_size, 0, stream>>>(
-    thrust::raw_pointer_cast(block_counts.data()), input.num_rows(), per_thread, filter);
+    block_counts.begin(), input.num_rows(), per_thread, filter);
 
-  CHECK_CUDA(stream);
-
-  cudf::size_type output_size = 0;
+  // initialize just the first element of block_offsets to 0 since the InclusiveSum below
+  // starts at the second element.
+  CUDA_TRY(cudaMemsetAsync(block_offsets.begin(), 0, sizeof(cudf::size_type), stream));
 
   // 2. Find the offset for each block's output using a scan of block counts
   if (grid.num_blocks > 1) {
     // Determine and allocate temporary device storage
     size_t temp_storage_bytes = 0;
-    cub::DeviceScan::InclusiveSum(
-      nullptr, temp_storage_bytes, &block_counts[0], &block_offsets[1], grid.num_blocks, stream);
+    cub::DeviceScan::InclusiveSum(nullptr,
+                                  temp_storage_bytes,
+                                  block_counts.begin(),
+                                  block_offsets.begin() + 1,
+                                  grid.num_blocks,
+                                  stream);
     rmm::device_buffer d_temp_storage(temp_storage_bytes, stream);
 
     // Run exclusive prefix sum
     cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
                                   temp_storage_bytes,
-                                  &block_counts[0],
-                                  &block_offsets[1],
+                                  block_counts.begin(),
+                                  block_offsets.begin() + 1,
                                   grid.num_blocks,
                                   stream);
-
-    CUDA_TRY(cudaStreamSynchronize(stream));
-    // As it is InclusiveSum, last value in block_offsets will be output_size
-    output_size = block_counts.back();
-  } else {
-    // With num_blocks <= 1, block_offsets will always be `0`
-    CUDA_TRY(cudaStreamSynchronize(stream));
-    output_size = block_counts[grid.num_blocks - 1];
   }
 
-  CHECK_CUDA(stream);
+  // As it is InclusiveSum, last value in block_offsets will be output_size
+  // unless num_blocks == 1, in which case output_size is just block_counts[0]
+  cudf::size_type output_size{0};
+  CUDA_TRY(cudaMemcpyAsync(
+    &output_size,
+    grid.num_blocks > 1 ? block_offsets.begin() + grid.num_blocks : block_counts.begin(),
+    sizeof(cudf::size_type),
+    cudaMemcpyDefault,
+    stream));
+
+  CUDA_TRY(cudaStreamSynchronize(stream));
 
   if (output_size == input.num_rows()) {
     return std::make_unique<table>(input, stream, mr);
@@ -358,7 +363,7 @@ std::unique_ptr<table> copy_if(
                                    scatter_gather_functor<Filter, block_size>{},
                                    col_view,
                                    output_size,
-                                   thrust::raw_pointer_cast(block_offsets),
+                                   block_offsets.begin(),
                                    filter,
                                    mr,
                                    stream);


### PR DESCRIPTION
This PR uses rmm::device_uvector in place of rmm::device_vector for `cudf::detail::copy_if`. This can serve as an example of how to make this change in libcudf algorithms, which we need to do throughout the library in order to resolve #2631 and #5380

First and foremost, this makes the code safe to use on non-default streams (see #2631). In the new code, notice that every line of code in copy.if.cuh that allocates, reads, or writes device memory takes a stream parameter now, whereas before a lot of the simple operations on `device_vector` (including the constructor) did not. From now on we should be looking for this pattern in libcudf in reviews.

You can see in these screenshots from NSight systems the impact of this change. This is using device_vector (before this PR). You can see at the start of copy_if there is a kernel (_kernel_agent) followed by cudaDeviceSynchronize. The kernel here is the initialization kernel ("uninitialized_fill") in Thrust. Also, Thrust then synchronizes the entire device after initializing.   Note that this includes an optimization to pack two vectors into a single vector to avoid two kernel invocations and two device synchronizes! This makes the code more complex due to the extra offsetting required.

<img width="979" alt="image" src="https://user-images.githubusercontent.com/783069/84734431-28cab900-afe4-11ea-9c70-9f2bce50e16a.png">

In the second screenshot, we use uvector. Now you don't see any kernels or synchronization (or any CUDA calls whatsoever) before the `compute_block_counts` kernel. Here we even use two separate uvectors since there is no initialization overhead (and allocation overhead is negligible with the RMM pool).

<img width="969" alt="image" src="https://user-images.githubusercontent.com/783069/84734596-a989b500-afe4-11ea-9516-31e389b1486f.png">

Note that for very large columns (100M+ rows), this change has negligible benefit. But for small columns it is significant. For 10K floats, (single column) I saw a 30% performance improvement (12% for two float columns of that size). For 1M floats (single column) the improvement was still about 12%. Even at 10M rows (single column), there is a single-digit percentage improvement. 


