### PR TITLE
[REVIEW] Use sorted lists instead of sets for pytest parameterization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - PR #5458 Install meta packages for dependencies
 - PR #5467 Move doc customization scripts to Jenkins
 - PR #5477 Add `is_index_type` trait 
+- PR #5487 Use sorted lists instead of sets for pytest parameterization
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -215,7 +215,7 @@ def test_string_series_compare(obj, cmpop, cmp_obj):
 @pytest.mark.parametrize("obj_class", ["Series", "Index"])
 @pytest.mark.parametrize("nelem", [1, 2, 100])
 @pytest.mark.parametrize("cmpop", _cmpops)
-@pytest.mark.parametrize("dtype", utils.NUMERIC_TYPES | {"datetime64[ms]"})
+@pytest.mark.parametrize("dtype", utils.NUMERIC_TYPES + ["datetime64[ms]"])
 def test_series_compare_scalar(nelem, cmpop, obj_class, dtype):
     arr1 = np.random.randint(0, 100, 100).astype(dtype)
     sr1 = Series(arr1)

--- a/python/cudf/cudf/tests/test_column.py
+++ b/python/cudf/cudf/tests/test_column.py
@@ -7,10 +7,16 @@ import pyarrow as pa
 import pytest
 
 import cudf
+import cudf.utils.dtypes as dtypeutils
 from cudf.core.column.column import as_column
-from cudf.tests.utils import ALL_TYPES, assert_eq
+from cudf.tests.utils import assert_eq
 
-dtypes = ALL_TYPES - {"datetime64[s]", "datetime64[ms]", "datetime64[us]"}
+dtypes = sorted(
+    list(
+        dtypeutils.ALL_TYPES
+        - {"datetime64[s]", "datetime64[ms]", "datetime64[us]"}
+    )
+)
 
 
 @pytest.fixture(params=dtypes, ids=dtypes)

--- a/python/cudf/cudf/tests/test_copying.py
+++ b/python/cudf/cudf/tests/test_copying.py
@@ -9,7 +9,7 @@ from cudf.core import Series
 from cudf.tests.utils import NUMERIC_TYPES, OTHER_TYPES, assert_eq
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | OTHER_TYPES)
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + OTHER_TYPES)
 def test_repeat(dtype):
     arr = np.random.rand(10) * 10
     repeats = np.random.randint(10, size=10)

--- a/python/cudf/cudf/tests/test_cuda_array_interface.py
+++ b/python/cudf/cudf/tests/test_cuda_array_interface.py
@@ -13,7 +13,7 @@ import cudf
 from cudf.tests.utils import DATETIME_TYPES, NUMERIC_TYPES, assert_eq
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | DATETIME_TYPES)
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES)
 @pytest.mark.parametrize("module", ["cupy", "numba"])
 def test_cuda_array_interface_interop_in(dtype, module):
     np_data = np.arange(10).astype(dtype)
@@ -41,7 +41,7 @@ def test_cuda_array_interface_interop_in(dtype, module):
         assert_eq(pd_data, gdf["test"])
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | DATETIME_TYPES | {"str"})
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES + ["str"])
 @pytest.mark.parametrize("module", ["cupy", "numba"])
 def test_cuda_array_interface_interop_out(dtype, module):
     expectation = does_not_raise()
@@ -72,7 +72,7 @@ def test_cuda_array_interface_interop_out(dtype, module):
         assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | DATETIME_TYPES)
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES)
 @pytest.mark.parametrize("module", ["cupy", "numba"])
 def test_cuda_array_interface_interop_out_masked(dtype, module):
     expectation = does_not_raise()
@@ -103,7 +103,7 @@ def test_cuda_array_interface_interop_out_masked(dtype, module):
         module_data = module_constructor(cudf_data)  # noqa: F841
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | DATETIME_TYPES)
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES)
 @pytest.mark.parametrize("nulls", ["all", "some", "bools", "none"])
 @pytest.mark.parametrize("mask_type", ["bits", "bools"])
 def test_cuda_array_interface_as_column(dtype, nulls, mask_type):

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2356,7 +2356,7 @@ def test_dataframe_empty_sort_index():
     assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("dtype", dtypes | {"category"})
+@pytest.mark.parametrize("dtype", dtypes + ["category"])
 def test_dataframe_0_row_dtype(dtype):
     if dtype == "category":
         data = pd.Series(["a", "b", "c", "d", "e"], dtype="category")

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1193,7 +1193,7 @@ def test_index_in_dataframe_constructor():
     assert pd.testing.assert_frame_equal(a.loc[4:], b.loc[4:].to_pandas())
 
 
-dtypes = NUMERIC_TYPES | DATETIME_TYPES | {"bool"}
+dtypes = NUMERIC_TYPES + DATETIME_TYPES + ["bool"]
 
 
 @pytest.mark.parametrize("nelem", [0, 2, 3, 100, 1000])
@@ -1728,7 +1728,7 @@ def test_series_hash_encode(nrows):
     assert enc_with_name_arr[0] != enc_arr[0]
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | {"bool"})
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + ["bool"])
 def test_cuda_array_interface(dtype):
 
     np_data = np.arange(10).astype(dtype)
@@ -1901,7 +1901,7 @@ def test_arrow_handle_no_index_name(pdf, gdf):
 @pytest.mark.parametrize("num_rows", [1, 3, 10, 100])
 @pytest.mark.parametrize("num_bins", [1, 2, 4, 20])
 @pytest.mark.parametrize("right", [True, False])
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | {"bool"})
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + ["bool"])
 def test_series_digitize(num_rows, num_bins, right, dtype):
     data = np.random.randint(0, 100, num_rows).astype(dtype)
     bins = np.unique(np.sort(np.random.randint(2, 95, num_bins).astype(dtype)))

--- a/python/cudf/cudf/tests/test_feather.py
+++ b/python/cudf/cudf/tests/test_feather.py
@@ -24,7 +24,7 @@ if LooseVersion(pd.__version__) < LooseVersion("0.24"):
 
 @pytest.fixture(params=[0, 1, 10, 100])
 def pdf(request):
-    types = NUMERIC_TYPES | {"bool"}
+    types = NUMERIC_TYPES + ["bool"]
     renamer = {
         "C_l0_g" + str(idx): "col_" + val for (idx, val) in enumerate(types)
     }

--- a/python/cudf/cudf/tests/test_hdf.py
+++ b/python/cudf/cudf/tests/test_hdf.py
@@ -21,7 +21,7 @@ except ImportError:
 
 @pytest.fixture(params=[0, 1, 10, 100])
 def pdf(request):
-    types = NUMERIC_TYPES | DATETIME_TYPES | {"bool"}
+    types = NUMERIC_TYPES + DATETIME_TYPES + ["bool"]
     renamer = {
         "C_l0_g" + str(idx): "col_" + val for (idx, val) in enumerate(types)
     }

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -497,7 +497,7 @@ def test_index_where(data, condition, other, error):
             gs.where(gs_condition, other=gs_other)
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | OTHER_TYPES)
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + OTHER_TYPES)
 @pytest.mark.parametrize("copy", [True, False])
 def test_index_astype(dtype, copy):
     pdi = pd.Index([1, 2, 3])

--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -23,7 +23,7 @@ def make_numeric_dataframe(nrows, dtype):
 
 @pytest.fixture(params=[0, 1, 10, 100])
 def pdf(request):
-    types = NUMERIC_TYPES | DATETIME_TYPES | {"bool"}
+    types = NUMERIC_TYPES + DATETIME_TYPES + ["bool"]
     renamer = {
         "C_l0_g" + str(idx): "col_" + val for (idx, val) in enumerate(types)
     }

--- a/python/cudf/cudf/tests/test_repr.py
+++ b/python/cudf/cudf/tests/test_repr.py
@@ -9,7 +9,7 @@ from hypothesis import given, settings
 import cudf
 from cudf.tests import utils
 
-repr_categories = utils.NUMERIC_TYPES | {"str", "category", "datetime64[ns]"}
+repr_categories = utils.NUMERIC_TYPES + ["str", "category", "datetime64[ns]"]
 
 
 @pytest.mark.parametrize("dtype", repr_categories)

--- a/python/cudf/cudf/tests/test_reshape.py
+++ b/python/cudf/cudf/tests/test_reshape.py
@@ -16,7 +16,7 @@ from cudf.tests.utils import (
 @pytest.mark.parametrize("num_id_vars", [0, 1, 2, 10])
 @pytest.mark.parametrize("num_value_vars", [0, 1, 2, 10])
 @pytest.mark.parametrize("num_rows", [1, 2, 1000])
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | DATETIME_TYPES)
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES)
 @pytest.mark.parametrize("nulls", ["none", "some", "all"])
 def test_melt(nulls, num_id_vars, num_value_vars, num_rows, dtype):
     if dtype not in ["float32", "float64"] and nulls in ["some", "all"]:
@@ -70,7 +70,7 @@ def test_melt(nulls, num_id_vars, num_value_vars, num_rows, dtype):
 @pytest.mark.parametrize("num_rows", [1, 2, 1000])
 @pytest.mark.parametrize(
     "dtype",
-    list(NUMERIC_TYPES | DATETIME_TYPES)
+    list(NUMERIC_TYPES + DATETIME_TYPES)
     + [pytest.param("str", marks=pytest.mark.xfail())],
 )
 @pytest.mark.parametrize("nulls", ["none", "some"])
@@ -106,7 +106,7 @@ def test_df_stack(nulls, num_cols, num_rows, dtype):
 @pytest.mark.parametrize("num_rows", [1, 2, 10, 1000])
 @pytest.mark.parametrize("num_cols", [1, 2, 10])
 @pytest.mark.parametrize(
-    "dtype", NUMERIC_TYPES | DATETIME_TYPES | {"category"}
+    "dtype", NUMERIC_TYPES + DATETIME_TYPES + ["category"]
 )
 @pytest.mark.parametrize("nulls", ["none", "some"])
 def test_interleave_columns(nulls, num_cols, num_rows, dtype):

--- a/python/cudf/cudf/tests/test_scalar.py
+++ b/python/cudf/cudf/tests/test_scalar.py
@@ -88,7 +88,7 @@ def test_round_trip_scalar(value):
     np.testing.assert_equal(s.value, value)
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | DATETIME_TYPES | {"object"})
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES + ["object"])
 def test_null_scalar(dtype):
     s = Scalar(None, dtype=dtype)
     assert s.value is None

--- a/python/cudf/cudf/tests/test_sorting.py
+++ b/python/cudf/cudf/tests/test_sorting.py
@@ -176,7 +176,7 @@ def test_dataframe_nsmallest_sliced(counts, sliceobj):
 
 @pytest.mark.parametrize("num_cols", [1, 2, 3, 5])
 @pytest.mark.parametrize("num_rows", [0, 1, 2, 1000])
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | DATETIME_TYPES)
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES)
 @pytest.mark.parametrize("ascending", [True, False])
 @pytest.mark.parametrize("na_position", ["first", "last"])
 def test_dataframe_multi_column(

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
+import cudf.utils.dtypes as dtypeutils
 from cudf import concat
 from cudf.core import DataFrame, Series
 from cudf.core.column.string import StringColumn
@@ -2040,7 +2041,9 @@ def test_string_int_to_ipv4():
     assert_eq(expected, got)
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES - {"int64", "uint64"})
+@pytest.mark.parametrize(
+    "dtype", sorted(list(dtypeutils.NUMERIC_TYPES - {"int64", "uint64"}))
+)
 def test_string_int_to_ipv4_dtype_fail(dtype):
     gsr = Series([1, 2, 3, 4, 5]).astype(dtype)
     with pytest.raises(TypeError):

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -160,7 +160,7 @@ def test_string_repr(ps_gs, item):
 
 
 @pytest.mark.parametrize(
-    "dtype", NUMERIC_TYPES | DATETIME_TYPES | {"bool", "object", "str"}
+    "dtype", NUMERIC_TYPES + DATETIME_TYPES + ["bool", "object", "str"]
 )
 def test_string_astype(dtype):
     if (
@@ -197,7 +197,7 @@ def test_string_astype(dtype):
 
 
 @pytest.mark.parametrize(
-    "dtype", NUMERIC_TYPES | DATETIME_TYPES | {"bool", "object", "str"}
+    "dtype", NUMERIC_TYPES + DATETIME_TYPES + ["bool", "object", "str"]
 )
 def test_string_empty_astype(dtype):
     data = []
@@ -210,7 +210,7 @@ def test_string_empty_astype(dtype):
     assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | DATETIME_TYPES | {"bool"})
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES + ["bool"])
 def test_string_numeric_astype(dtype):
     if dtype.startswith("bool"):
         data = [1, 0, 1, 0, 1]
@@ -243,7 +243,7 @@ def test_string_numeric_astype(dtype):
     assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES | DATETIME_TYPES | {"bool"})
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES + ["bool"])
 def test_string_empty_numeric_astype(dtype):
     data = []
 

--- a/python/cudf/cudf/tests/test_udf_binops.py
+++ b/python/cudf/cudf/tests/test_udf_binops.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 
 import cudf._lib as libcudf
+import cudf.utils.dtypes as dtypeutils
 from cudf.core import Series
-from cudf.tests.utils import NUMERIC_TYPES
 
 try:
     # Numba >= 0.49
@@ -18,7 +18,9 @@ except ImportError:
     from numba import numpy_support
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES - {"int8"})
+@pytest.mark.parametrize(
+    "dtype", sorted(list(dtypeutils.NUMERIC_TYPES - {"int8"}))
+)
 def test_generic_ptx(dtype):
 
     size = 500

--- a/python/cudf/cudf/tests/test_unaops.py
+++ b/python/cudf/cudf/tests/test_unaops.py
@@ -25,7 +25,7 @@ def test_series_invert(dtype):
     np.testing.assert_equal((~sr).to_array(), ~arr)
 
 
-@pytest.mark.parametrize("dtype", utils.INTEGER_TYPES | {"bool"})
+@pytest.mark.parametrize("dtype", utils.INTEGER_TYPES + ["bool"])
 def test_series_not(dtype):
     import pandas as pd
 

--- a/python/cudf/cudf/tests/utils.py
+++ b/python/cudf/cudf/tests/utils.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 from cudf import Series
+import cudf.utils.dtypes as dtypeutils
 from cudf._lib.null_mask import bitmask_allocation_size_bytes
 
 supported_numpy_dtypes = [
@@ -20,20 +21,15 @@ supported_numpy_dtypes = [
     "datetime64[us]",
 ]
 
-SIGNED_INTEGER_TYPES = {"int8", "int16", "int32", "int64"}
-UNSIGNED_TYPES = {"uint8", "uint16", "uint32", "uint64"}
-INTEGER_TYPES = SIGNED_INTEGER_TYPES | UNSIGNED_TYPES
-FLOAT_TYPES = {"float32", "float64"}
-SIGNED_TYPES = SIGNED_INTEGER_TYPES | FLOAT_TYPES
-NUMERIC_TYPES = SIGNED_TYPES | UNSIGNED_TYPES
-DATETIME_TYPES = {
-    "datetime64[s]",
-    "datetime64[ms]",
-    "datetime64[us]",
-    "datetime64[ns]",
-}
-OTHER_TYPES = {"bool", "category", "str"}
-ALL_TYPES = NUMERIC_TYPES | DATETIME_TYPES | OTHER_TYPES
+SIGNED_INTEGER_TYPES = sorted(list(dtypeutils.SIGNED_INTEGER_TYPES))
+UNSIGNED_TYPES = sorted(list(dtypeutils.UNSIGNED_TYPES))
+INTEGER_TYPES = sorted(list(dtypeutils.INTEGER_TYPES))
+FLOAT_TYPES = sorted(list(dtypeutils.FLOAT_TYPES))
+SIGNED_TYPES = sorted(list(dtypeutils.SIGNED_TYPES))
+NUMERIC_TYPES = sorted(list(dtypeutils.NUMERIC_TYPES))
+DATETIME_TYPES = sorted(list(dtypeutils.DATETIME_TYPES))
+OTHER_TYPES = sorted(list(dtypeutils.OTHER_TYPES))
+ALL_TYPES = sorted(list(dtypeutils.ALL_TYPES))
 
 
 def random_bitmask(size):

--- a/python/cudf/cudf/tests/utils.py
+++ b/python/cudf/cudf/tests/utils.py
@@ -5,8 +5,8 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 
-from cudf import Series
 import cudf.utils.dtypes as dtypeutils
+from cudf import Series
 from cudf._lib.null_mask import bitmask_allocation_size_bytes
 
 supported_numpy_dtypes = [

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -44,6 +44,7 @@ DATETIME_TYPES = {
 OTHER_TYPES = {"bool", "category", "str"}
 ALL_TYPES = NUMERIC_TYPES | DATETIME_TYPES | OTHER_TYPES
 
+
 def np_to_pa_dtype(dtype):
     """Util to convert numpy dtype to PyArrow dtype.
     """

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -29,6 +29,20 @@ _np_pa_dtypes = {
     np.str_: pa.string(),
 }
 
+SIGNED_INTEGER_TYPES = {"int8", "int16", "int32", "int64"}
+UNSIGNED_TYPES = {"uint8", "uint16", "uint32", "uint64"}
+INTEGER_TYPES = SIGNED_INTEGER_TYPES | UNSIGNED_TYPES
+FLOAT_TYPES = {"float32", "float64"}
+SIGNED_TYPES = SIGNED_INTEGER_TYPES | FLOAT_TYPES
+NUMERIC_TYPES = SIGNED_TYPES | UNSIGNED_TYPES
+DATETIME_TYPES = {
+    "datetime64[s]",
+    "datetime64[ms]",
+    "datetime64[us]",
+    "datetime64[ns]",
+}
+OTHER_TYPES = {"bool", "category", "str"}
+ALL_TYPES = NUMERIC_TYPES | DATETIME_TYPES | OTHER_TYPES
 
 def np_to_pa_dtype(dtype):
     """Util to convert numpy dtype to PyArrow dtype.


### PR DESCRIPTION
Use sorted lists so pytests are collected deterministically. This fixes running pytests in parallel with `pytest-xdist`.