### PR TITLE
[WIP] File datasource without mmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - PR #5477 Add `is_index_type` trait 
 - PR #5487 Use sorted lists instead of sets for pytest parameterization
 - PR #5491 allow build libcudf in custom dir
+- PR #5509 Add a file datasource that avoid the use of mmap
 
 ## Bug Fixes
 

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -262,7 +262,7 @@ std::unique_ptr<datasource> datasource::create(const std::string &filepath,
                                                size_t size)
 {
   // Use our own memory mapping implementation for direct file reads
-  return std::make_unique<memory_mapped_source>(filepath.c_str(), offset, size);
+  return std::make_unique<file_source>(filepath.c_str());
 }
 
 std::unique_ptr<datasource> datasource::create(const char *data, size_t size)


### PR DESCRIPTION
Experimental change - adds a datasource type that reads directly from opened file, instead of memory mapping it.