### PR TITLE
[WIP] File datasource without mmap + multithreaded Parquet reads

### DIFF
--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -262,7 +262,7 @@ std::unique_ptr<datasource> datasource::create(const std::string &filepath,
                                                size_t size)
 {
   // Use our own memory mapping implementation for direct file reads
-  return std::make_unique<memory_mapped_source>(filepath.c_str(), offset, size);
+  return std::make_unique<file_source>(filepath.c_str());
 }
 
 std::unique_ptr<datasource> datasource::create(const char *data, size_t size)


### PR DESCRIPTION
Parquet reader uses 4 threads to read the input data.
The datasource does not use mmap, uses pread instead.