### PR TITLE
[REVIEW] Java APIs for missing date/time operators [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - PR #5514 `convert_datetime.cu` Small Cleanup
 - PR #5496 Rename .cu tests (zero cuda kernels) to .cpp files
 - PR #5526 Change `type_id` to enum class
+- PR #5559 Java APIs for missing date/time operators
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -809,11 +809,47 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * <p>
    * Postconditions - A new vector is allocated with the result. The caller owns the vector and
    * is responsible for its lifecycle.
-   * @return - A new INT16 vector allocated on the GPU.
+   * @return A new INT16 vector allocated on the GPU.
    */
   public ColumnVector second() {
     assert type.hasTimeResolution();
     return new ColumnVector(second(getNativeView()));
+  }
+
+  /**
+   * Get the day of the week from a timestamp.
+   * <p>
+   * Postconditions - A new vector is allocated with the result. The caller owns the vector and
+   * is responsible for its lifecycle.
+   * @return A new INT16 vector allocated on the GPU. Monday=1, ..., Sunday=7
+   */
+  public ColumnVector weekDay() {
+    assert type.isTimestamp();
+    return new ColumnVector(weekDay(getNativeView()));
+  }
+
+  /**
+   * Get the date that is the last day of the month for this timestamp.
+   * <p>
+   * Postconditions - A new vector is allocated with the result. The caller owns the vector and
+   * is responsible for its lifecycle.
+   * @return A new TIMESTAMP_DAYS vector allocated on the GPU.
+   */
+  public ColumnVector lastDayOfMonth() {
+    assert type.isTimestamp();
+    return new ColumnVector(lastDayOfMonth(getNativeView()));
+  }
+
+  /**
+   * Get the day of the year from a timestamp.
+   * <p>
+   * Postconditions - A new vector is allocated with the result. The caller owns the vector and
+   * is responsible for its lifecycle.
+   * @return A new INT16 vector allocated on the GPU. The value is between [1, {365-366}]
+   */
+  public ColumnVector dayOfYear() {
+    assert type.isTimestamp();
+    return new ColumnVector(dayOfYear(getNativeView()));
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -2344,7 +2380,7 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
    * using the replace template for back-references.
    * @param columnView native handle of the cudf::column_view being operated on.
    * @param pattern The regular expression patterns to search within each string.
-   * @param repl The replacement template for creating the output string.
+   * @param replace The replacement template for creating the output string.
    * @return native handle of the resulting cudf column containing the string results.
    */
   private static native long stringReplaceWithBackrefs(long columnView, String pattern,
@@ -2506,6 +2542,12 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
   private static native long minute(long viewHandle) throws CudfException;
 
   private static native long second(long viewHandle) throws CudfException;
+
+  private static native long weekDay(long viewHandle) throws CudfException;
+
+  private static native long lastDayOfMonth(long viewHandle) throws CudfException;
+
+  private static native long dayOfYear(long viewHandle) throws CudfException;
 
   private static native boolean containsScalar(long columnViewHaystack, long scalarHandle) throws CudfException;
 

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -563,6 +563,44 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_second(JNIEnv *env, jcl
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_weekDay(JNIEnv *env, jclass,
+                                                                jlong input_ptr) {
+  JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
+    std::unique_ptr<cudf::column> output = cudf::datetime::extract_weekday(*input);
+    return reinterpret_cast<jlong>(output.release());
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_lastDayOfMonth(JNIEnv *env, jclass,
+                                                                jlong input_ptr) {
+  JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
+    std::unique_ptr<cudf::column> output = cudf::datetime::last_day_of_month(*input);
+    return reinterpret_cast<jlong>(output.release());
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_dayOfYear(JNIEnv *env, jclass,
+                                                                jlong input_ptr) {
+  JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    const cudf::column_view *input = reinterpret_cast<cudf::column_view *>(input_ptr);
+    std::unique_ptr<cudf::column> output = cudf::datetime::day_of_year(*input);
+    return reinterpret_cast<jlong>(output.release());
+  }
+  CATCH_STD(env, 0);
+}
+
+
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_castTo(JNIEnv *env, jobject j_object,
                                                                 jlong handle, jint type) {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -564,7 +564,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_second(JNIEnv *env, jcl
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_weekDay(JNIEnv *env, jclass,
-                                                                jlong input_ptr) {
+                                                                 jlong input_ptr) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
     cudf::jni::auto_set_device(env);
@@ -576,7 +576,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_weekDay(JNIEnv *env, jc
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_lastDayOfMonth(JNIEnv *env, jclass,
-                                                                jlong input_ptr) {
+                                                                        jlong input_ptr) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
     cudf::jni::auto_set_device(env);
@@ -588,7 +588,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_lastDayOfMonth(JNIEnv *
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_dayOfYear(JNIEnv *env, jclass,
-                                                                jlong input_ptr) {
+                                                                   jlong input_ptr) {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
     cudf::jni::auto_set_device(env);
@@ -598,8 +598,6 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_dayOfYear(JNIEnv *env, 
   }
   CATCH_STD(env, 0);
 }
-
-
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_castTo(JNIEnv *env, jobject j_object,
                                                                 jlong handle, jint type) {

--- a/java/src/test/java/ai/rapids/cudf/TimestampColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TimestampColumnVectorTest.java
@@ -32,17 +32,17 @@ public class TimestampColumnVectorTest extends CudfTestBase {
                                   -1528,    //1965-10-26
                                   17716};   //2018-07-04 
 
-  static final long[] TIMES_S = {-131968728L,   //'1965-10-26 14:01:12'
-                                 1530705600L,   //'2018-07-04 12:00:00'
-                                 1674631932L,   //'2023-01-25 07:32:12'
-                                 -131968728L,   //'1965-10-26 14:01:12'
-                                 1530705600L};  //'2018-07-04 12:00:00'
+  static final long[] TIMES_S = {-131968728L,   //'1965-10-26 14:01:12' Tuesday
+                                 1530705600L,   //'2018-07-04 12:00:00' Wednesday
+                                 1674631932L,   //'2023-01-25 07:32:12' Wednesday
+                                 -131968728L,   //'1965-10-26 14:01:12' Tuesday
+                                 1530705600L};  //'2018-07-04 12:00:00' Wednesday
 
-  static final long[] TIMES_MS = {-131968727762L,   //'1965-10-26 14:01:12.238'
-                                  1530705600115L,   //'2018-07-04 12:00:00.115'
-                                  1674631932929L,   //'2023-01-25 07:32:12.929'
-                                  -131968727762L,   //'1965-10-26 14:01:12.238'
-                                  1530705600115L};  //'2018-07-04 12:00:00.115'
+  static final long[] TIMES_MS = {-131968727762L,   //'1965-10-26 14:01:12.238' Tuesday
+                                  1530705600115L,   //'2018-07-04 12:00:00.115' Wednesday
+                                  1674631932929L,   //'2023-01-25 07:32:12.929' Wednesday
+                                  -131968727762L,   //'1965-10-26 14:01:12.238' Tuesday
+                                  1530705600115L};  //'2018-07-04 12:00:00.115' Wednesday
 
   static final long[] TIMES_US = {-131968727761703L,   //'1965-10-26 14:01:12.238297'
                                   1530705600115254L,   //'2018-07-04 12:00:00.115254'
@@ -234,6 +234,80 @@ public class TimestampColumnVectorTest extends CudfTestBase {
       assertEquals(12, result.getShort(0));
       assertEquals(0, result.getShort(1));
       assertEquals(12, result.getShort(2));
+    }
+  }
+
+  @Test
+  public void testWeekDay() {
+    try (ColumnVector timestampColumnVector = ColumnVector.timestampMilliSecondsFromLongs(TIMES_MS);
+         ColumnVector result = timestampColumnVector.weekDay();
+         ColumnVector expected = ColumnVector.fromBoxedShorts(
+                 (short)2, (short)3, (short)3, (short)2, (short)3)) {
+      assertColumnsAreEqual(expected, result);
+    }
+
+    try (ColumnVector timestampColumnVector = ColumnVector.timestampSecondsFromLongs(TIMES_S);
+         ColumnVector result = timestampColumnVector.weekDay();
+         ColumnVector expected = ColumnVector.fromBoxedShorts(
+                 (short)2, (short)3, (short)3, (short)2, (short)3)) {
+      assertColumnsAreEqual(expected, result);
+    }
+
+    try (ColumnVector timestampColumnVector = ColumnVector.timestampDaysFromBoxedInts(
+            17713, 17714, 17715, 17716, 17717, 17718, 17719, 17720);
+         ColumnVector result = timestampColumnVector.weekDay();
+         ColumnVector expected = ColumnVector.fromBoxedShorts(
+                 (short)7, (short)1, (short)2, (short)3, (short)4, (short)5, (short)6, (short)7)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  public void testLastDayOfMonth() {
+    int[] EXPECTED = new int[]{
+            -1523,    //1965-10-31
+            17743,    //2018-07-31
+            19388,    //2023-01-31
+            -1523,    //1965-10-31
+            17743};   //2018-07-31
+    try (ColumnVector timestampColumnVector = ColumnVector.timestampMilliSecondsFromLongs(TIMES_MS);
+         ColumnVector result = timestampColumnVector.lastDayOfMonth();
+         ColumnVector expected = ColumnVector.daysFromInts(EXPECTED)) {
+      assertColumnsAreEqual(expected, result);
+    }
+
+    try (ColumnVector timestampColumnVector = ColumnVector.timestampSecondsFromLongs(TIMES_S);
+         ColumnVector result = timestampColumnVector.lastDayOfMonth();
+         ColumnVector expected = ColumnVector.daysFromInts(EXPECTED)) {
+      assertColumnsAreEqual(expected, result);
+    }
+
+    try (ColumnVector timestampColumnVector = ColumnVector.daysFromInts(TIMES_DAY);
+         ColumnVector result = timestampColumnVector.lastDayOfMonth();
+         ColumnVector expected = ColumnVector.daysFromInts(EXPECTED)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  public void testDayOfYear() {
+    short[] EXPECTED = new short[]{299, 185, 25, 299, 185};
+    try (ColumnVector timestampColumnVector = ColumnVector.timestampMilliSecondsFromLongs(TIMES_MS);
+         ColumnVector result = timestampColumnVector.dayOfYear();
+         ColumnVector expected = ColumnVector.fromShorts(EXPECTED)) {
+      assertColumnsAreEqual(expected, result);
+    }
+
+    try (ColumnVector timestampColumnVector = ColumnVector.timestampSecondsFromLongs(TIMES_S);
+         ColumnVector result = timestampColumnVector.dayOfYear();
+         ColumnVector expected = ColumnVector.fromShorts(EXPECTED)) {
+      assertColumnsAreEqual(expected, result);
+    }
+
+    try (ColumnVector timestampColumnVector = ColumnVector.daysFromInts(TIMES_DAY);
+         ColumnVector result = timestampColumnVector.dayOfYear();
+         ColumnVector expected = ColumnVector.fromShorts(EXPECTED)) {
+      assertColumnsAreEqual(expected, result);
     }
   }
 


### PR DESCRIPTION
This adds week day, last day of month, and day of year to the java APIs.  This should make the java API in sync with cudf on date time operations.