### PR TITLE
[REVIEW] Add missing join types to java [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - PR #5496 Rename .cu tests (zero cuda kernels) to .cpp files
 - PR #5526 Change `type_id` to enum class
 - PR #5559 Java APIs for missing date/time operators
+- PR #5562 Add missing joing type for java
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 - PR #5496 Rename .cu tests (zero cuda kernels) to .cpp files
 - PR #5526 Change `type_id` to enum class
 - PR #5559 Java APIs for missing date/time operators
-- PR #5562 Add missing joing type for java
+- PR #5562 Add missing join type for java
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -354,11 +354,16 @@ public final class Table implements AutoCloseable {
   private static native long[] innerJoin(long leftTable, int[] leftJoinCols, long rightTable,
                                          int[] rightJoinCols) throws CudfException;
 
+  private static native long[] fullJoin(long leftTable, int[] leftJoinCols, long rightTable,
+                                         int[] rightJoinCols) throws CudfException;
+
   private static native long[] leftSemiJoin(long leftTable, int[] leftJoinCols, long rightTable,
       int[] rightJoinCols) throws CudfException;
 
   private static native long[] leftAntiJoin(long leftTable, int[] leftJoinCols, long rightTable,
       int[] rightJoinCols) throws CudfException;
+
+  private static native long[] crossJoin(long leftTable, long rightTable) throws CudfException;
 
   private static native long[] concatenate(long[] cudfTablePointers) throws CudfException;
 
@@ -933,6 +938,17 @@ public final class Table implements AutoCloseable {
       assert valueTable.columns[i].getType() == this.getColumn(i).getType() :
           "Input and values tables' data types do not match";
     }
+  }
+
+  /**
+   * Joins two tables all of the left against all of the right. Be careful as this
+   * gets very big and you can easily use up all of the GPUs memory.
+   * @param right teh right table
+   * @return the joined table.  The order of the columns returned will be left columns,
+   * right columns.
+   */
+  public Table crossJoin(Table right) {
+    return new Table(Table.crossJoin(this.nativeHandle, right.nativeHandle));
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -1631,6 +1647,21 @@ public final class Table implements AutoCloseable {
     public Table innerJoin(TableOperation rightJoinIndices) {
       return new Table(Table.innerJoin(operation.table.nativeHandle, operation.indices,
           rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices));
+    }
+
+    /**
+     * Joins two tables on the join columns that are passed in.
+     * Usage:
+     * Table t1 ...
+     * Table t2 ...
+     * Table result = t1.onColumns(0,1).fullJoin(t2.onColumns(2,3));
+     * @param rightJoinIndices - Indices of the right table to join on
+     * @return the joined table.  The order of the columns returned will be join columns,
+     * left non-join columns, right non-join columns.
+     */
+    public Table fullJoin(TableOperation rightJoinIndices) {
+      return new Table(Table.fullJoin(operation.table.nativeHandle, operation.indices,
+              rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices));
     }
 
     /**

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -943,7 +943,7 @@ public final class Table implements AutoCloseable {
   /**
    * Joins two tables all of the left against all of the right. Be careful as this
    * gets very big and you can easily use up all of the GPUs memory.
-   * @param right teh right table
+   * @param right the right table
    * @return the joined table.  The order of the columns returned will be left columns,
    * right columns.
    */

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -848,6 +848,42 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerJoin(JNIEnv *env, jc
   CATCH_STD(env, NULL);
 }
 
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_fullJoin(JNIEnv *env, jclass clazz,
+                                                                jlong left_table,
+                                                                jintArray left_col_join_indices,
+                                                                jlong right_table,
+                                                                jintArray right_col_join_indices) {
+  JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
+  JNI_NULL_CHECK(env, left_col_join_indices, "left_col_join_indices is null", NULL);
+  JNI_NULL_CHECK(env, right_table, "right_table is null", NULL);
+  JNI_NULL_CHECK(env, right_col_join_indices, "right_col_join_indices is null", NULL);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::table_view *n_left_table = reinterpret_cast<cudf::table_view *>(left_table);
+    cudf::table_view *n_right_table = reinterpret_cast<cudf::table_view *>(right_table);
+    cudf::jni::native_jintArray left_join_cols_arr(env, left_col_join_indices);
+    std::vector<cudf::size_type> left_join_cols(
+        left_join_cols_arr.data(), left_join_cols_arr.data() + left_join_cols_arr.size());
+    cudf::jni::native_jintArray right_join_cols_arr(env, right_col_join_indices);
+    std::vector<cudf::size_type> right_join_cols(
+        right_join_cols_arr.data(), right_join_cols_arr.data() + right_join_cols_arr.size());
+
+    int dedupe_size = left_join_cols.size();
+    std::vector<std::pair<cudf::size_type, cudf::size_type>> dedupe(dedupe_size);
+    for (int i = 0; i < dedupe_size; i++) {
+      dedupe[i].first = left_join_cols[i];
+      dedupe[i].second = right_join_cols[i];
+    }
+
+    std::unique_ptr<cudf::table> result =
+        cudf::full_join(*n_left_table, *n_right_table, left_join_cols, right_join_cols, dedupe);
+
+    return cudf::jni::convert_table_for_return(env, result);
+  }
+  CATCH_STD(env, NULL);
+}
+
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftSemiJoin(
     JNIEnv *env, jclass, jlong left_table, jintArray left_col_join_indices, jlong right_table,
     jintArray right_col_join_indices) {
@@ -904,6 +940,25 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftAntiJoin(
 
     std::unique_ptr<cudf::table> result = cudf::left_anti_join(
         *n_left_table, *n_right_table, left_join_cols, right_join_cols, return_cols);
+
+    return cudf::jni::convert_table_for_return(env, result);
+  }
+  CATCH_STD(env, NULL);
+}
+
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_crossJoin(JNIEnv *env, jclass clazz,
+                                                                 jlong left_table,
+                                                                 jlong right_table) {
+  JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
+  JNI_NULL_CHECK(env, right_table, "right_table is null", NULL);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::table_view *n_left_table = reinterpret_cast<cudf::table_view *>(left_table);
+    cudf::table_view *n_right_table = reinterpret_cast<cudf::table_view *>(right_table);
+
+    std::unique_ptr<cudf::table> result =
+        cudf::cross_join(*n_left_table, *n_right_table);
 
     return cudf::jni::convert_table_for_return(env, result);
   }


### PR DESCRIPTION
This adds in join APIs for `fullJoin` and `crossJoin`, which were missing from java.