### PR TITLE
[WIP] Remove usages of default device_buffer constructor

### DIFF
--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -94,7 +94,7 @@ class column {
   column(data_type dtype,
          size_type size,
          B1&& data,
-         B2&& null_mask                                  = {},
+         B2&& null_mask                                  = rmm::device_buffer{0},
          size_type null_count                            = UNKNOWN_NULL_COUNT,
          std::vector<std::unique_ptr<column>>&& children = {})
     : _type{dtype},
@@ -305,12 +305,12 @@ class column {
   operator mutable_column_view() { return this->mutable_view(); };
 
  private:
-  data_type _type{EMPTY};           ///< Logical type of elements in the column
-  cudf::size_type _size{};          ///< The number of elements in the column
-  rmm::device_buffer _data{};       ///< Dense, contiguous, type erased device memory
-                                    ///< buffer containing the column elements
-  rmm::device_buffer _null_mask{};  ///< Bitmask used to represent null values.
-                                    ///< May be empty if `null_count() == 0`
+  data_type _type{EMPTY};            ///< Logical type of elements in the column
+  cudf::size_type _size{};           ///< The number of elements in the column
+  rmm::device_buffer _data{0};       ///< Dense, contiguous, type erased device memory
+                                     ///< buffer containing the column elements
+  rmm::device_buffer _null_mask{0};  ///< Bitmask used to represent null values.
+                                     ///< May be empty if `null_count() == 0`
   mutable size_type _null_count{UNKNOWN_NULL_COUNT};  ///< The number of null elements
   std::vector<std::unique_ptr<column>> _children{};   ///< Depending on element type, child
                                                       ///< columns may contain additional data

--- a/cpp/include/cudf/detail/reduction.cuh
+++ b/cpp/include/cudf/detail/reduction.cuh
@@ -57,17 +57,10 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
   rmm::device_scalar<OutputType> dev_result{identity, stream, mr};
 
   // Allocate temporary storage
-  rmm::device_buffer d_temp_storage;
   size_t temp_storage_bytes = 0;
-  cub::DeviceReduce::Reduce(d_temp_storage.data(),
-                            temp_storage_bytes,
-                            d_in,
-                            dev_result.data(),
-                            num_items,
-                            binary_op,
-                            identity,
-                            stream);
-  d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+  cub::DeviceReduce::Reduce(
+    nullptr, temp_storage_bytes, d_in, dev_result.data(), num_items, binary_op, identity, stream);
+  rmm::device_buffer d_temp_storage{temp_storage_bytes, stream};
 
   // Run reduction
   cub::DeviceReduce::Reduce(d_temp_storage.data(),
@@ -101,17 +94,10 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
   rmm::device_scalar<OutputType> dev_result{identity, stream};
 
   // Allocate temporary storage
-  rmm::device_buffer d_temp_storage;
   size_t temp_storage_bytes = 0;
-  cub::DeviceReduce::Reduce(d_temp_storage.data(),
-                            temp_storage_bytes,
-                            d_in,
-                            dev_result.data(),
-                            num_items,
-                            binary_op,
-                            identity,
-                            stream);
-  d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+  cub::DeviceReduce::Reduce(
+    nullptr, temp_storage_bytes, d_in, dev_result.data(), num_items, binary_op, identity, stream);
+  rmm::device_buffer d_temp_storage{temp_storage_bytes, stream};
 
   // Run reduction
   cub::DeviceReduce::Reduce(d_temp_storage.data(),
@@ -178,9 +164,8 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
   rmm::device_scalar<IntermediateType> intermediate_result{identity, stream};
 
   // Allocate temporary storage
-  rmm::device_buffer d_temp_storage;
   size_t temp_storage_bytes = 0;
-  cub::DeviceReduce::Reduce(d_temp_storage.data(),
+  cub::DeviceReduce::Reduce(nullptr,
                             temp_storage_bytes,
                             d_in,
                             intermediate_result.data(),
@@ -188,7 +173,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                             binary_op,
                             identity,
                             stream);
-  d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+  rmm::device_buffer d_temp_storage{temp_storage_bytes, stream};
 
   // Run reduction
   cub::DeviceReduce::Reduce(d_temp_storage.data(),

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -254,7 +254,7 @@ class string_scalar : public scalar {
  public:
   using value_type = cudf::string_view;
 
-  string_scalar() : scalar(data_type(STRING)) {}
+  string_scalar()                           = default;
   ~string_scalar()                          = default;
   string_scalar(string_scalar&& other)      = default;
   string_scalar(string_scalar const& other) = default;
@@ -341,7 +341,7 @@ class string_scalar : public scalar {
   const char* data() const { return static_cast<const char*>(_data.data()); }
 
  protected:
-  rmm::device_buffer _data{};  ///< device memory containing the string
+  rmm::device_buffer _data{0};  ///< device memory containing the string
 };
 
 /**

--- a/cpp/src/column/column_factories.cpp
+++ b/cpp/src/column/column_factories.cpp
@@ -49,9 +49,12 @@ std::size_t size_of(data_type element_type)
 }
 
 // Empty column of specified type
-std::unique_ptr<column> make_empty_column(data_type type)
+std::unique_ptr<column> make_empty_column(
+  data_type type,
+  cudaStream_t stream                 = 0,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
 {
-  return std::make_unique<column>(type, 0, rmm::device_buffer{});
+  return std::make_unique<column>(type, 0, rmm::device_buffer{0, stream, mr});
 }
 
 // Allocate storage for a specified number of numeric elements
@@ -195,7 +198,7 @@ std::unique_ptr<column> make_column_from_scalar(scalar const& s,
                                                 rmm::mr::device_memory_resource* mr,
                                                 cudaStream_t stream)
 {
-  if (size == 0) return make_empty_column(s.type());
+  if (size == 0) return make_empty_column(s.type(), stream, mr);
   return type_dispatcher(s.type(), column_from_scalar_dispatch{}, s, size, mr, stream);
 }
 

--- a/cpp/src/dictionary/dictionary_factories.cu
+++ b/cpp/src/dictionary/dictionary_factories.cu
@@ -66,7 +66,7 @@ std::unique_ptr<column> make_dictionary_column(std::unique_ptr<column> keys_colu
   children.emplace_back(std::move(keys_column));
   return std::make_unique<column>(data_type{DICTIONARY32},
                                   count,
-                                  rmm::device_buffer{},
+                                  rmm::device_buffer{0},
                                   std::move(null_mask),
                                   null_count,
                                   std::move(children));

--- a/cpp/src/dlpack/dlpack.cpp
+++ b/cpp/src/dlpack/dlpack.cpp
@@ -96,7 +96,7 @@ DLDataType data_type_to_DLDataType(data_type type)
 struct dltensor_context {
   int64_t shape[2];
   int64_t strides[2];
-  rmm::device_buffer buffer;
+  rmm::device_buffer buffer{0};
 
   static void deleter(DLManagedTensor* arg)
   {

--- a/cpp/src/groupby/sort/group_nth_element.cu
+++ b/cpp/src/groupby/sort/group_nth_element.cu
@@ -105,7 +105,9 @@ std::unique_ptr<column> group_nth_element(column_view const &values,
   }
   auto output_table = cudf::detail::gather(
     table_view{{values}}, nth_index.begin(), nth_index.end(), true, mr, stream);
-  if (!output_table->get_column(0).has_nulls()) output_table->get_column(0).set_null_mask({}, 0);
+  if (!output_table->get_column(0).has_nulls()) {
+    output_table->get_column(0).set_null_mask(rmm::device_buffer{0, stream, mr}, 0);
+  }
   return std::make_unique<column>(std::move(output_table->get_column(0)));
 }
 }  // namespace detail

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -486,7 +486,7 @@ reader::impl::impl(std::unique_ptr<datasource> source,
                    std::string filepath,
                    reader_options const &options,
                    rmm::mr::device_memory_resource *mr)
-  : source_(std::move(source)), filepath_(filepath), args_(options), mr_(mr)
+  : args_(options), mr_(mr), source_(std::move(source)), filepath_(filepath), data_(0)
 {
   CUDF_EXPECTS(args_.lines, "Only JSON Lines format is currently supported.\n");
 

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -151,7 +151,8 @@ class orc_column_view {
       _data(col.head<uint8_t>() + col.offset() * _type_width),
       _nulls(col.nullable() ? col.null_mask() : nullptr),
       _clockscale(to_clockscale<uint8_t>(col.type().id())),
-      _type_kind(to_orc_type(col.type().id()))
+      _type_kind(to_orc_type(col.type().id())),
+      _indexes(0, stream)
   {
     if (_string_type && _data_count > 0) {
       strings_column_view view{col};

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -113,7 +113,8 @@ class parquet_column_view {
       _data_count(col.size()),
       _null_count(col.null_count()),
       _data(col.head<uint8_t>() + col.offset() * _type_width),
-      _nulls(col.nullable() ? col.null_mask() : nullptr)
+      _nulls(col.nullable() ? col.null_mask() : nullptr),
+      _indexes(0, stream)
   {
     switch (col.type().id()) {
       case cudf::type_id::INT8:

--- a/cpp/src/io/utilities/column_buffer.hpp
+++ b/cpp/src/io/utilities/column_buffer.hpp
@@ -69,6 +69,7 @@ struct column_buffer {
                 bool is_nullable                    = true,
                 cudaStream_t stream                 = 0,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
+    : _data{0, stream}, _null_mask{0, stream}
   {
     if (type.id() == type_id::STRING) {
       _strings.resize(size);
@@ -92,8 +93,8 @@ struct column_buffer {
   auto& null_count() { return _null_count; }
 
   rmm::device_vector<str_pair> _strings;
-  rmm::device_buffer _data{};
-  rmm::device_buffer _null_mask{};
+  rmm::device_buffer _data;
+  rmm::device_buffer _null_mask;
   size_type _null_count{0};
 };
 

--- a/cpp/src/io/utilities/hostdevice_vector.hpp
+++ b/cpp/src/io/utilities/hostdevice_vector.hpp
@@ -40,12 +40,9 @@ class hostdevice_vector {
   }
 
   explicit hostdevice_vector(size_t initial_size, size_t max_size, cudaStream_t stream = 0)
-    : num_elements(initial_size), max_elements(max_size)
+    : num_elements(initial_size), max_elements(max_size), d_data(sizeof(T) * max_elements, stream)
   {
-    if (max_elements != 0) {
-      CUDA_TRY(cudaMallocHost(&h_data, sizeof(T) * max_elements));
-      d_data.resize(sizeof(T) * max_elements, stream);
-    }
+    if (max_elements != 0) { CUDA_TRY(cudaMallocHost(&h_data, sizeof(T) * max_elements)); }
   }
 
   ~hostdevice_vector()

--- a/cpp/src/quantiles/quantile.cu
+++ b/cpp/src/quantiles/quantile.cu
@@ -81,10 +81,7 @@ struct quantile_functor {
         ordered_indices,
         [input = *d_input] __device__(size_type idx) { return input.is_valid_nocheck(idx); });
 
-      rmm::device_buffer mask;
-      size_type null_count;
-
-      std::tie(mask, null_count) = valid_if(
+      auto mask_and_count = valid_if(
         q_device.begin(),
         q_device.end(),
         [sorted_validity, interp = interp, size = size] __device__(double q) {
@@ -93,7 +90,7 @@ struct quantile_functor {
         stream,
         mr);
 
-      output->set_null_mask(std::move(mask), null_count);
+      output->set_null_mask(std::move(mask_and_count.first), mask_and_count.second);
     }
 
     return output;

--- a/cpp/src/strings/combine.cu
+++ b/cpp/src/strings/combine.cu
@@ -430,13 +430,14 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
                        }
                      });
 
-  return make_strings_column(strings_count,
-                             std::move(offsets_column),
-                             std::move(chars_column),
-                             null_count,
-                             (null_count) ? std::move(valid_mask.first) : rmm::device_buffer{},
-                             stream,
-                             mr);
+  return make_strings_column(
+    strings_count,
+    std::move(offsets_column),
+    std::move(chars_column),
+    null_count,
+    (null_count) ? std::move(valid_mask.first) : rmm::device_buffer{0, stream, mr},
+    stream,
+    mr);
 }
 
 }  // namespace detail

--- a/cpp/src/text/tokenize.cu
+++ b/cpp/src/text/tokenize.cu
@@ -206,7 +206,7 @@ std::unique_ptr<cudf::column> character_tokenize(cudf::strings_column_view const
                                    std::move(offsets_column),
                                    std::move(chars_column),
                                    0,
-                                   rmm::device_buffer{},
+                                   rmm::device_buffer{0, stream, mr},
                                    stream,
                                    mr);
 }

--- a/cpp/src/transform/bools_to_mask.cu
+++ b/cpp/src/transform/bools_to_mask.cu
@@ -32,7 +32,9 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
 {
   CUDF_EXPECTS(input.type().id() == BOOL8, "Input is not of type bool");
 
-  if (input.size() == 0) { return std::make_pair(std::make_unique<rmm::device_buffer>(), 0); }
+  if (input.size() == 0) {
+    return std::make_pair(std::make_unique<rmm::device_buffer>(0, stream, mr), 0);
+  }
 
   auto input_device_view_ptr = column_device_view::create(input, stream);
   auto input_device_view     = *input_device_view_ptr;

--- a/cpp/src/transform/nans_to_nulls.cu
+++ b/cpp/src/transform/nans_to_nulls.cu
@@ -77,7 +77,9 @@ struct dispatch_nan_to_null {
 std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> nans_to_nulls(
   column_view const& input, rmm::mr::device_memory_resource* mr, cudaStream_t stream)
 {
-  if (input.size() == 0) { return std::make_pair(std::make_unique<rmm::device_buffer>(), 0); }
+  if (input.size() == 0) {
+    return std::make_pair(std::make_unique<rmm::device_buffer>(0, stream, mr), 0);
+  }
 
   return cudf::type_dispatcher(input.type(), dispatch_nan_to_null{}, input, mr, stream);
 }


### PR DESCRIPTION
In anticipation of https://github.com/rapidsai/rmm/pull/424, removes all uses of the `device_buffer` default constructor. 

This turned out to be more tedious and require more code changes than I was hoping.

I was hoping to also tackle part of https://github.com/rapidsai/rmm/issues/418, but that's going to require even more work. This is because there are lots of cases where a `device_buffer` is being constructed, but there isn't any stream argument available to pass in. 