### PR TITLE
[REVIEW] add shared documentation for doxygen param (mr, stream)

### DIFF
--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -2128,7 +2128,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = _DOXYGEN_
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/cpp/include/cudf/copying.hpp
+++ b/cpp/include/cudf/copying.hpp
@@ -188,7 +188,7 @@ std::unique_ptr<column> allocate_like(
  * @param[in] input Immutable view of input column to emulate
  * @param[in] size The desired number of elements that the new column should have capacity for
  * @param[in] mask_alloc Optional, Policy for allocating null mask. Defaults to RETAIN.
- * @param[in] mr Device memory resource used to allocate the returned column's device memory
+ * @copydetails param_mr_doc1
  * @return A column with sufficient uninitialized capacity to hold the specified number of elements
  * as `input` of the same type as `input.type()`
  */
@@ -273,7 +273,7 @@ void copy_range_in_place(column_view const& source,
  * @param source_end The index of the last element in the source range
  * (exclusive)
  * @param target_begin The starting index of the target range (inclusive)
- * @param mr Device memory resource used to allocate the returned column's device memory.
+ * @param mr @copydetails param_mr_doc2
  * @return std::unique_ptr<column> The result target column
  */
 std::unique_ptr<column> copy_range(

--- a/cpp/include/doxygen_groups.h
+++ b/cpp/include/doxygen_groups.h
@@ -132,3 +132,26 @@
  *   @defgroup utility_error Exception
  * @}
  */
+
+#ifdef _DOXYGEN_
+namespace cudf {
+/**
+ * @brief placeholder for device memory resource documentation
+ *
+ * @param[in] mr Device memory resource used to allocate the returned object's device memory.
+ */
+void param_mr_doc1();
+/**
+ * @brief placeholder for device memory resource documentation
+ *
+ * Device memory resource used to allocate the returned object's device memory.
+ */
+void param_mr_doc2();
+/**
+ * @brief placeholder for CUDA stream documentation
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+void param_stream_doc();
+}  // namespace cudf
+#endif  // _DOXYGEN_


### PR DESCRIPTION
share documentation for doxygen 
`@param mr`
`@param stream`

**Usage:**
 `@copydetails param_mr_doc1` 
OR
 `@param mr @copydetails param_mr_doc2`

