### PR TITLE
[REVIEW] shutdown RMM in JNI to avoid truncating logs [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 
 ## Bug Fixes
 
+- PR #5594 Shutdown RMM in JNI to avoid truncating logs
 - PR #5525 Make sure to allocate bitmasks of string columns only once
 - PR #5336 Initialize conversion tables on a per-context basis
 - PR #5283 Fix strings::ipv4_to_integers overflow to negative

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -182,6 +182,8 @@ public class Rmm {
     }
     Cuda.setDevice(gpuId);
     initialize(allocationMode, logConf, poolSize);
+    // Destroy the `Logging_memory_resource` so RMM logs get flushed.
+    Runtime.getRuntime().addShutdownHook(new Thread(Rmm::shutdown));
   }
 
   /**


### PR DESCRIPTION
@jlowe @revans2 