### PR TITLE
[REVIEW] Instantiate Table instances in Frame._concat to avoid DF.insert() overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - PR #5562 Add missing join type for java
 - PR #5584 Refactor `CompactProtocolReader::InitSchema`
 - PR #5591 Add `__arrow_array__` protocol and raise a descriptive error message
+- PR #5601 Instantiate Table instances in `Frame._concat` to avoid `DF.insert()` overhead
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -186,17 +186,25 @@ class Frame(libcudf.table.Table):
             if 1 == first_data_column_position:
                 table_index = as_index(cols[0])
             elif first_data_column_position > 1:
-                table_index = libcudf.table.Table(data=dict(zip(
-                    indices[:first_data_column_position],
-                    cols[:first_data_column_position]
-                )))
-            tables.append(libcudf.table.Table(
-                data=dict(zip(
-                    indices[first_data_column_position:],
-                    cols[first_data_column_position:]
-                )),
-                index=table_index
-            ))
+                table_index = libcudf.table.Table(
+                    data=dict(
+                        zip(
+                            indices[:first_data_column_position],
+                            cols[:first_data_column_position],
+                        )
+                    )
+                )
+            tables.append(
+                libcudf.table.Table(
+                    data=dict(
+                        zip(
+                            indices[first_data_column_position:],
+                            cols[first_data_column_position:],
+                        )
+                    ),
+                    index=table_index,
+                )
+            )
 
         # Concatenate the Tables
         out = cls._from_table(

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -182,16 +182,21 @@ class Frame(libcudf.table.Table):
         # names with their integer positions in the `cols` list
         tables = []
         for cols in columns:
-            table_cols = cols[first_data_column_position:]
-            table_names = indices[first_data_column_position:]
-            table = cls(data=dict(zip(table_names, table_cols)))
+            table_index = None
             if 1 == first_data_column_position:
-                table._index = as_index(cols[0])
+                table_index = as_index(cols[0])
             elif first_data_column_position > 1:
-                index_cols = cols[:first_data_column_position]
-                index_names = indices[:first_data_column_position]
-                table._index = cls(data=dict(zip(index_names, index_cols)))
-            tables.append(table)
+                table_index = libcudf.table.Table(data=dict(zip(
+                    indices[:first_data_column_position],
+                    cols[:first_data_column_position]
+                )))
+            tables.append(libcudf.table.Table(
+                data=dict(zip(
+                    indices[first_data_column_position:],
+                    cols[first_data_column_position:]
+                )),
+                index=table_index
+            ))
 
         # Concatenate the Tables
         out = cls._from_table(


### PR DESCRIPTION
Instantiate Table instances in `Frame._concat()` to avoid overhead from all the small `DF.insert()` calls in the DF constructor.

This is a small perf boost individually that can add up when doing many `concat` operations.