### PR TITLE
[REVIEW] Fix issue related to typecasting when using a `CategoricalDtype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@
 - PR #5578 Fix getattr logic in GroupBy
 - PR #5490 Fix python column view
 - PR #5608 Fix issue related to string types being represented as binary types
+- PR #5619 Fix issue related to typecasting when using a `CategoricalDtype`
 
 
 # cuDF 0.14.0 (Date TBD)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -884,8 +884,8 @@ class ColumnBase(Column, Serializable):
                 categories=dtype.categories,
                 codes=labels._column,
                 mask=self.mask,
-                ordered=ordered,
-            ).astype(dtype)
+                ordered=dtype.ordered,
+            )
 
         cats = sr.unique().astype(sr.dtype)
         label_dtype = min_unsigned_type(len(cats))

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -904,7 +904,7 @@ class ColumnBase(Column, Serializable):
             codes=labels._column,
             mask=self.mask,
             ordered=ordered,
-        ).astype(dtype)
+        )
 
     def as_numerical_column(self, dtype, **kwargs):
         raise NotImplementedError

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -880,6 +880,12 @@ class ColumnBase(Column, Serializable):
         # Re-label self w.r.t. the provided categories
         if isinstance(dtype, (cudf.CategoricalDtype, pd.CategoricalDtype)):
             labels = sr.label_encoding(cats=dtype.categories)
+            if "ordered" in kwargs:
+                warnings.warn(
+                    "Ignoring the `ordered` parameters passed in `**kwargs`, "
+                    "will be using ordered parameter of CategoricalDtype"
+                )
+
             return build_categorical_column(
                 categories=dtype.categories,
                 codes=labels._column,

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -882,8 +882,8 @@ class ColumnBase(Column, Serializable):
             labels = sr.label_encoding(cats=dtype.categories)
             if "ordered" in kwargs:
                 warnings.warn(
-                    "Ignoring the `ordered` parameters passed in `**kwargs`, "
-                    "will be using ordered parameter of CategoricalDtype"
+                    "Ignoring the `ordered` parameter passed in `**kwargs`, "
+                    "will be using `ordered` parameter of CategoricalDtype"
                 )
 
             return build_categorical_column(

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2245,7 +2245,7 @@ class Series(Frame, Serializable):
         cats = self.unique().astype(self.dtype)
 
         name = self.name  # label_encoding mutates self.name
-        labels = self.label_encoding(cats=cats)
+        labels = self.label_encoding(cats=cats, na_sentinel=na_sentinel)
         self.name = name
 
         return labels, cats

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2140,16 +2140,50 @@ class Series(Frame, Serializable):
         Parameters
         ----------
         values : sequence of input values
-        dtype: numpy.dtype; optional
-               Specifies the output dtype.  If `None` is given, the
-               smallest possible integer dtype (starting with np.int8)
-               is used.
-        na_sentinel : number
+        dtype : numpy.dtype; optional
+            Specifies the output dtype.  If `None` is given, the
+            smallest possible integer dtype (starting with np.int8)
+            is used.
+        na_sentinel : number, default -1
             Value to indicate missing category.
 
         Returns
         -------
         A sequence of encoded labels with value between 0 and n-1 classes(cats)
+
+        Examples
+        --------
+        >>> import cudf
+        >>> s = cudf.Series([1, 2, 3, 4, 10])
+        >>> s.label_encoding([2, 3])
+        0   -1
+        1    0
+        2    1
+        3   -1
+        4   -1
+        dtype: int8
+
+        `na_sentinel` parameter can be used to
+        control the value when there is no encoding.
+
+        >>> s.label_encoding([2, 3], na_sentinel=10)
+        0    10
+        1     0
+        2     1
+        3    10
+        4    10
+        dtype: int8
+
+        When none of `cats` values exist in s, entire
+        Series will be `na_sentinel`.
+
+        >>> s.label_encoding(['a', 'b', 'c'])
+        0   -1
+        1   -1
+        2   -1
+        3   -1
+        4   -1
+        dtype: int8
         """
         from cudf import DataFrame
 
@@ -2172,9 +2206,7 @@ class Series(Frame, Serializable):
             return _return_sentinel_series()
 
         try:
-            # Where there is a type-cast from string to numeric types,
-            # there is a possibility for ValueError when strings
-            # are having non-numeric values, in such cases we have
+            # Where there is a type-cast failure, we have
             # to catch the exception and return encoded labels
             # with na_sentinel values as there would be no corresponding
             # encoded values of cats in self.

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -471,6 +471,10 @@ def test_categorical_dataframe_slice_copy():
     [
         pd.Series([1, 2, 3, 89]),
         pd.Series([1, 2, 3, 89, 3, 1, 89], dtype="category"),
+        pd.Series(["1", "2", "3", "4", "5"], dtype="category"),
+        pd.Series(["1.0", "2.5", "3.001", "9"], dtype="category"),
+        pd.Series(["1", "2", "3", None, "4", "5"], dtype="category"),
+        pd.Series(["1.0", "2.5", "3.001", None, "9"], dtype="category"),
         pd.Series(["a", "b", "c", "c", "b", "a", "b", "b"]),
         pd.Series(["aa", "b", "c", "c", "bb", "bb", "a", "b", "b"]),
         pd.Series([1, 2, 3, 89, None, np.nan, np.NaN], dtype="float64"),
@@ -488,6 +492,8 @@ def test_categorical_dataframe_slice_copy():
         pd.CategoricalDtype(categories=["aa", "bb", "c"]),
         pd.CategoricalDtype(categories=["a", "bb", "c"]),
         pd.CategoricalDtype(categories=["a", "b", "c"]),
+        pd.CategoricalDtype(categories=["1", "2", "3", "4"]),
+        pd.CategoricalDtype(categories=["1.0", "2.5", "3.001", "9"]),
         pd.CategoricalDtype(categories=[]),
     ],
 )


### PR DESCRIPTION
Fixes: #5617 

This PR fixes issue where we were trying to cast `cats` with `self` dtype irrespective of a check if only one of them is an `object` dtype. In which case we should be returning `na_sentinel`.

With this change we actually don't have to re-typecast the categorical column being constructed in `as_categorical_column`, thus avoiding double type-casting.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
