### PR TITLE
[REVIEW] Parameterize Null comparator behaviour in Joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #5536 Parquet reader - add support for multiple sources
 - PR #5607 Add Java bindings for duration types
 - PR #5612 Add `is_hex` strings API
+- PR #5637 Parameterize Null comparator behaviour in Joins
 
 ## Improvements
 

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -90,7 +90,7 @@ std::unique_ptr<cudf::table> inner_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<std::pair<cudf::size_type, cudf::size_type>> const& columns_in_common,
-  null_equality compare_nulls = null_equality::EQUAL,
+  null_equality compare_nulls         = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
@@ -158,7 +158,7 @@ std::unique_ptr<cudf::table> left_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<std::pair<cudf::size_type, cudf::size_type>> const& columns_in_common,
-  null_equality compare_nulls = null_equality::EQUAL,
+  null_equality compare_nulls         = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
@@ -226,7 +226,7 @@ std::unique_ptr<cudf::table> full_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<std::pair<cudf::size_type, cudf::size_type>> const& columns_in_common,
-  null_equality compare_nulls = null_equality::EQUAL,
+  null_equality compare_nulls         = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 /**
  * @brief Performs a left semi join on the specified columns of two
@@ -281,7 +281,7 @@ std::unique_ptr<cudf::table> left_semi_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<cudf::size_type> const& return_columns,
-  null_equality compare_nulls = null_equality::EQUAL,
+  null_equality compare_nulls         = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
@@ -337,7 +337,7 @@ std::unique_ptr<cudf::table> left_anti_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<cudf::size_type> const& return_columns,
-  null_equality compare_nulls = null_equality::EQUAL,
+  null_equality compare_nulls         = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -76,6 +76,8 @@ namespace cudf {
  * from `left_on` columns. Else, for every column in `left_on` and `right_on`,
  * an output column will be produced.  For each of these pairs (L, R), L
  * should exist in `left_on` and R should exist in `right_on`.
+ * @param[in] compare_nulls_equal is a bool that controls whether null join-key values
+ * should match (as per Pandas semantics), or not (as per SQL semantics)
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return Result of joining `left` and `right` tables on the columns
@@ -88,6 +90,7 @@ std::unique_ptr<cudf::table> inner_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<std::pair<cudf::size_type, cudf::size_type>> const& columns_in_common,
+  bool compare_nulls_equal = true,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
@@ -141,6 +144,8 @@ std::unique_ptr<cudf::table> inner_join(
  * from `left_on` columns. Else, for every column in `left_on` and `right_on`,
  * an output column will be produced.  For each of these pairs (L, R), L
  * should exist in `left_on` and R should exist in `right_on`.
+ * @param[in] compare_nulls_equal is a bool that controls whether null join-key values
+ * should match (as per Pandas semantics), or not (as per SQL semantics)
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return Result of joining `left` and `right` tables on the columns
@@ -153,6 +158,7 @@ std::unique_ptr<cudf::table> left_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<std::pair<cudf::size_type, cudf::size_type>> const& columns_in_common,
+  bool compare_nulls_equal = true,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
@@ -206,6 +212,8 @@ std::unique_ptr<cudf::table> left_join(
  * from `left_on` columns. Else, for every column in `left_on` and `right_on`,
  * an output column will be produced.  For each of these pairs (L, R), L
  * should exist in `left_on` and R should exist in `right_on`.
+ * @param[in] compare_nulls_equal is a bool that controls whether null join-key values
+ * should match (as per Pandas semantics), or not (as per SQL semantics)
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return Result of joining `left` and `right` tables on the columns
@@ -218,6 +226,7 @@ std::unique_ptr<cudf::table> full_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<std::pair<cudf::size_type, cudf::size_type>> const& columns_in_common,
+  bool compare_nulls_equal = true,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 /**
  * @brief Performs a left semi join on the specified columns of two
@@ -246,20 +255,23 @@ std::unique_ptr<cudf::table> full_join(
  * @throw cudf::logic_error if the number of returned columns is 0
  * @throw cudf::logic_error if the number of elements in `left_on` and `right_on` are not equal
  *
- * @param[in] left             The left table
- * @param[in] right            The right table
- * @param[in] left_on          The column indices from `left` to join on.
- *                             The column from `left` indicated by `left_on[i]`
- *                             will be compared against the column from `right`
- *                             indicated by `right_on[i]`.
- * @param[in] right_on         The column indices from `right` to join on.
- *                             The column from `right` indicated by `right_on[i]`
- *                             will be compared against the column from `left`
- *                             indicated by `left_on[i]`.
- * @param[in] return_columns   A vector of column indices from `left` to
- *                             include in the returned table.
- * @param[in] mr               Device memory resource used to allocate the returned table's device
- *                             memory
+ * @param[in] left                The left table
+ * @param[in] right               The right table
+ * @param[in] left_on             The column indices from `left` to join on.
+ *                                The column from `left` indicated by `left_on[i]`
+ *                                will be compared against the column from `right`
+ *                                indicated by `right_on[i]`.
+ * @param[in] right_on            The column indices from `right` to join on.
+ *                                The column from `right` indicated by `right_on[i]`
+ *                                will be compared against the column from `left`
+ *                                indicated by `left_on[i]`.
+ * @param[in] return_columns      A vector of column indices from `left` to
+ *                                include in the returned table.
+ * @param[in] compare_nulls_equal A bool that controls whether null join-key values
+ *                                should match (as per Pandas semantics),
+ *                                or not (as per SQL semantics)
+ * @param[in] mr                  Device memory resource used to allocate the returned table's
+ *                                device memory
  *
  * @return                     Result of joining `left` and `right` tables on the columns
  *                             specified by `left_on` and `right_on`. The resulting table
@@ -271,6 +283,7 @@ std::unique_ptr<cudf::table> left_semi_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<cudf::size_type> const& return_columns,
+  bool compare_nulls_equal = true,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
@@ -300,24 +313,27 @@ std::unique_ptr<cudf::table> left_semi_join(
  * @throw cudf::logic_error if the number of returned columns is 0
  * @throw cudf::logic_error if the number of elements in `left_on` and `right_on` are not equal
  *
- * @param[in] left             The left table
- * @param[in] right            The right table
- * @param[in] left_on          The column indices from `left` to join on.
- *                             The column from `left` indicated by `left_on[i]`
- *                             will be compared against the column from `right`
- *                             indicated by `right_on[i]`.
- * @param[in] right_on         The column indices from `right` to join on.
- *                             The column from `right` indicated by `right_on[i]`
- *                             will be compared against the column from `left`
- *                             indicated by `left_on[i]`.
- * @param[in] return_columns   A vector of column indices from `left` to
- *                             include in the returned table.
- * @param[in] mr               Device memory resource used to allocate the returned table's device
- *                             memory
+ * @param[in] left                The left table
+ * @param[in] right               The right table
+ * @param[in] left_on             The column indices from `left` to join on.
+ *                                The column from `left` indicated by `left_on[i]`
+ *                                will be compared against the column from `right`
+ *                                indicated by `right_on[i]`.
+ * @param[in] right_on            The column indices from `right` to join on.
+ *                                The column from `right` indicated by `right_on[i]`
+ *                                will be compared against the column from `left`
+ *                                indicated by `left_on[i]`.
+ * @param[in] return_columns      A vector of column indices from `left` to
+ *                                include in the returned table.
+ * @param[in] compare_nulls_equal A bool that controls whether null join-key values
+ *                                should match (as per Pandas semantics),
+ *                                or not (as per SQL semantics)
+ * @param[in] mr                  Device memory resource used to allocate the returned table's
+ *                                device memory
  *
- * @return                     Result of joining `left` and `right` tables on the columns
- *                             specified by `left_on` and `right_on`. The resulting table
- *                             will contain `return_columns` from `left` that match in right.
+ * @return                        Result of joining `left` and `right` tables on the columns
+ *                                specified by `left_on` and `right_on`. The resulting table
+ *                                will contain `return_columns` from `left` that match in right.
  */
 std::unique_ptr<cudf::table> left_anti_join(
   cudf::table_view const& left,
@@ -325,6 +341,7 @@ std::unique_ptr<cudf::table> left_anti_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<cudf::size_type> const& return_columns,
+  bool compare_nulls_equal = true,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -76,8 +76,8 @@ namespace cudf {
  * from `left_on` columns. Else, for every column in `left_on` and `right_on`,
  * an output column will be produced.  For each of these pairs (L, R), L
  * should exist in `left_on` and R should exist in `right_on`.
- * @param[in] compare_nulls_equal is a bool that controls whether null join-key values
- * should match (as per Pandas semantics), or not (as per SQL semantics)
+ * @param[in] compare_nulls controls whether null join-key values
+ * should match or not.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return Result of joining `left` and `right` tables on the columns
@@ -90,7 +90,7 @@ std::unique_ptr<cudf::table> inner_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<std::pair<cudf::size_type, cudf::size_type>> const& columns_in_common,
-  bool compare_nulls_equal = true,
+  null_equality compare_nulls = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
@@ -144,8 +144,8 @@ std::unique_ptr<cudf::table> inner_join(
  * from `left_on` columns. Else, for every column in `left_on` and `right_on`,
  * an output column will be produced.  For each of these pairs (L, R), L
  * should exist in `left_on` and R should exist in `right_on`.
- * @param[in] compare_nulls_equal is a bool that controls whether null join-key values
- * should match (as per Pandas semantics), or not (as per SQL semantics)
+ * @param[in] compare_nulls controls whether null join-key values
+ * should match or not.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return Result of joining `left` and `right` tables on the columns
@@ -158,7 +158,7 @@ std::unique_ptr<cudf::table> left_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<std::pair<cudf::size_type, cudf::size_type>> const& columns_in_common,
-  bool compare_nulls_equal = true,
+  null_equality compare_nulls = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
@@ -212,8 +212,8 @@ std::unique_ptr<cudf::table> left_join(
  * from `left_on` columns. Else, for every column in `left_on` and `right_on`,
  * an output column will be produced.  For each of these pairs (L, R), L
  * should exist in `left_on` and R should exist in `right_on`.
- * @param[in] compare_nulls_equal is a bool that controls whether null join-key values
- * should match (as per Pandas semantics), or not (as per SQL semantics)
+ * @param[in] compare_nulls controls whether null join-key values
+ * should match or not.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return Result of joining `left` and `right` tables on the columns
@@ -226,7 +226,7 @@ std::unique_ptr<cudf::table> full_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<std::pair<cudf::size_type, cudf::size_type>> const& columns_in_common,
-  bool compare_nulls_equal = true,
+  null_equality compare_nulls = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 /**
  * @brief Performs a left semi join on the specified columns of two
@@ -255,23 +255,21 @@ std::unique_ptr<cudf::table> full_join(
  * @throw cudf::logic_error if the number of returned columns is 0
  * @throw cudf::logic_error if the number of elements in `left_on` and `right_on` are not equal
  *
- * @param[in] left                The left table
- * @param[in] right               The right table
- * @param[in] left_on             The column indices from `left` to join on.
- *                                The column from `left` indicated by `left_on[i]`
- *                                will be compared against the column from `right`
- *                                indicated by `right_on[i]`.
- * @param[in] right_on            The column indices from `right` to join on.
- *                                The column from `right` indicated by `right_on[i]`
- *                                will be compared against the column from `left`
- *                                indicated by `left_on[i]`.
- * @param[in] return_columns      A vector of column indices from `left` to
- *                                include in the returned table.
- * @param[in] compare_nulls_equal A bool that controls whether null join-key values
- *                                should match (as per Pandas semantics),
- *                                or not (as per SQL semantics)
- * @param[in] mr                  Device memory resource used to allocate the returned table's
- *                                device memory
+ * @param[in] left             The left table
+ * @param[in] right            The right table
+ * @param[in] left_on          The column indices from `left` to join on.
+ *                             The column from `left` indicated by `left_on[i]`
+ *                             will be compared against the column from `right`
+ *                             indicated by `right_on[i]`.
+ * @param[in] right_on         The column indices from `right` to join on.
+ *                             The column from `right` indicated by `right_on[i]`
+ *                             will be compared against the column from `left`
+ *                             indicated by `left_on[i]`.
+ * @param[in] return_columns   A vector of column indices from `left` to
+ *                             include in the returned table.
+ * @param[in] compare_nulls    Controls whether null join-key values should match or not.
+ * @param[in] mr               Device memory resource used to allocate the returned table's
+ *                             device memory
  *
  * @return                     Result of joining `left` and `right` tables on the columns
  *                             specified by `left_on` and `right_on`. The resulting table
@@ -283,7 +281,7 @@ std::unique_ptr<cudf::table> left_semi_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<cudf::size_type> const& return_columns,
-  bool compare_nulls_equal = true,
+  null_equality compare_nulls = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**
@@ -313,27 +311,25 @@ std::unique_ptr<cudf::table> left_semi_join(
  * @throw cudf::logic_error if the number of returned columns is 0
  * @throw cudf::logic_error if the number of elements in `left_on` and `right_on` are not equal
  *
- * @param[in] left                The left table
- * @param[in] right               The right table
- * @param[in] left_on             The column indices from `left` to join on.
- *                                The column from `left` indicated by `left_on[i]`
- *                                will be compared against the column from `right`
- *                                indicated by `right_on[i]`.
- * @param[in] right_on            The column indices from `right` to join on.
- *                                The column from `right` indicated by `right_on[i]`
- *                                will be compared against the column from `left`
- *                                indicated by `left_on[i]`.
- * @param[in] return_columns      A vector of column indices from `left` to
- *                                include in the returned table.
- * @param[in] compare_nulls_equal A bool that controls whether null join-key values
- *                                should match (as per Pandas semantics),
- *                                or not (as per SQL semantics)
- * @param[in] mr                  Device memory resource used to allocate the returned table's
- *                                device memory
+ * @param[in] left             The left table
+ * @param[in] right            The right table
+ * @param[in] left_on          The column indices from `left` to join on.
+ *                             The column from `left` indicated by `left_on[i]`
+ *                             will be compared against the column from `right`
+ *                             indicated by `right_on[i]`.
+ * @param[in] right_on         The column indices from `right` to join on.
+ *                             The column from `right` indicated by `right_on[i]`
+ *                             will be compared against the column from `left`
+ *                             indicated by `left_on[i]`.
+ * @param[in] return_columns   A vector of column indices from `left` to
+ *                             include in the returned table.
+ * @param[in] compare_nulls    Controls whether null join-key values should match or not.
+ * @param[in] mr               Device memory resource used to allocate the returned table's
+ *                             device memory
  *
- * @return                        Result of joining `left` and `right` tables on the columns
- *                                specified by `left_on` and `right_on`. The resulting table
- *                                will contain `return_columns` from `left` that match in right.
+ * @return                     Result of joining `left` and `right` tables on the columns
+ *                             specified by `left_on` and `right_on`. The resulting table
+ *                             will contain `return_columns` from `left` that match in right.
  */
 std::unique_ptr<cudf::table> left_anti_join(
   cudf::table_view const& left,
@@ -341,7 +337,7 @@ std::unique_ptr<cudf::table> left_anti_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<cudf::size_type> const& return_columns,
-  bool compare_nulls_equal = true,
+  null_equality compare_nulls = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 /**

--- a/cpp/src/join/hash_join.cuh
+++ b/cpp/src/join/hash_join.cuh
@@ -45,6 +45,8 @@ namespace detail {
  * @param probe_table The left hand table
  * @param hash_table A hash table built on the build table that maps the index
  * of every row to the hash value of that row.
+ * @param compare_nulls_equal is a bool that controls whether null join-key values
+ * should match (as per Pandas semantics), or not (as per SQL semantics)
  * @param stream CUDA stream used for device memory operations and kernel launches
  *
  * @return An estimate of the size of the output of the join operation
@@ -53,6 +55,7 @@ template <join_kind JoinKind, typename multimap_type>
 size_type estimate_join_output_size(table_device_view build_table,
                                     table_device_view probe_table,
                                     multimap_type const& hash_table,
+                                    bool compare_nulls_equal,
                                     cudaStream_t stream)
 {
   const size_type build_table_num_rows{build_table.num_rows()};
@@ -111,7 +114,7 @@ size_type estimate_join_output_size(table_device_view build_table,
     size_estimate.set_value(0);
 
     row_hash hash_probe{probe_table};
-    row_equality equality{probe_table, build_table};
+    row_equality equality{probe_table, build_table, compare_nulls_equal};
     // Probe the hash table without actually building the output to simply
     // find what the size of the output will be.
     compute_join_output_size<JoinKind, multimap_type, block_size>
@@ -198,12 +201,13 @@ std::enable_if_t<(JoinKind == join_kind::INNER_JOIN || JoinKind == join_kind::LE
 get_base_hash_join_indices(table_view const& left,
                            table_view const& right,
                            bool flip_join_indices,
+                           bool compare_nulls_equal,
                            cudaStream_t stream)
 {
   // The `right` table is always used for building the hash map. We want to build the hash map
   // on the smaller table. Thus, if `left` is smaller than `right`, swap `left/right`.
   if ((JoinKind == join_kind::INNER_JOIN) && (right.num_rows() > left.num_rows())) {
-    return get_base_hash_join_indices<JoinKind>(right, left, true, stream);
+    return get_base_hash_join_indices<JoinKind>(right, left, true, compare_nulls_equal, stream);
   }
   // Trivial left join case - exit early
   if ((JoinKind == join_kind::LEFT_JOIN) && (right.num_rows() == 0)) {
@@ -238,7 +242,7 @@ get_base_hash_join_indices(table_view const& left,
   }
 
   size_type estimated_size = estimate_join_output_size<JoinKind, multimap_type>(
-    *build_table, *probe_table, *hash_table, stream);
+    *build_table, *probe_table, *hash_table, compare_nulls_equal, stream);
 
   // If the estimated output size is zero, return immediately
   if (estimated_size == 0) {
@@ -264,7 +268,7 @@ get_base_hash_join_indices(table_view const& left,
     write_index.set_value(0);
 
     row_hash hash_probe{*probe_table};
-    row_equality equality{*probe_table, *build_table};
+    row_equality equality{*probe_table, *build_table, compare_nulls_equal};
     const auto& join_output_l =
       flip_join_indices ? right_indices.data().get() : left_indices.data().get();
     const auto& join_output_r =

--- a/cpp/src/join/hash_join.cuh
+++ b/cpp/src/join/hash_join.cuh
@@ -22,6 +22,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 
+#include "cudf/types.hpp"
 #include "join_common_utils.hpp"
 #include "join_kernels.cuh"
 
@@ -45,8 +46,7 @@ namespace detail {
  * @param probe_table The left hand table
  * @param hash_table A hash table built on the build table that maps the index
  * of every row to the hash value of that row.
- * @param compare_nulls_equal is a bool that controls whether null join-key values
- * should match (as per Pandas semantics), or not (as per SQL semantics)
+ * @param compare_nulls Controls whether null join-key values should match or not.
  * @param stream CUDA stream used for device memory operations and kernel launches
  *
  * @return An estimate of the size of the output of the join operation
@@ -55,7 +55,7 @@ template <join_kind JoinKind, typename multimap_type>
 size_type estimate_join_output_size(table_device_view build_table,
                                     table_device_view probe_table,
                                     multimap_type const& hash_table,
-                                    bool compare_nulls_equal,
+                                    null_equality compare_nulls,
                                     cudaStream_t stream)
 {
   const size_type build_table_num_rows{build_table.num_rows()};
@@ -114,7 +114,7 @@ size_type estimate_join_output_size(table_device_view build_table,
     size_estimate.set_value(0);
 
     row_hash hash_probe{probe_table};
-    row_equality equality{probe_table, build_table, compare_nulls_equal};
+    row_equality equality{probe_table, build_table, compare_nulls == null_equality::EQUAL};
     // Probe the hash table without actually building the output to simply
     // find what the size of the output will be.
     compute_join_output_size<JoinKind, multimap_type, block_size>
@@ -191,6 +191,7 @@ get_trivial_left_join_indices(table_view const& left, cudaStream_t stream)
  * @param right Table of right columns to join
  * @param flip_join_indices Flag that indicates whether the left and right
  * tables have been flipped, meaning the output indices should also be flipped
+ * @param compare_nulls Controls whether null join-key values should match or not.
  * @param stream CUDA stream used for device memory operations and kernel launches
  *
  * @return Join output indices vector pair
@@ -201,13 +202,13 @@ std::enable_if_t<(JoinKind == join_kind::INNER_JOIN || JoinKind == join_kind::LE
 get_base_hash_join_indices(table_view const& left,
                            table_view const& right,
                            bool flip_join_indices,
-                           bool compare_nulls_equal,
+                           null_equality compare_nulls,
                            cudaStream_t stream)
 {
   // The `right` table is always used for building the hash map. We want to build the hash map
   // on the smaller table. Thus, if `left` is smaller than `right`, swap `left/right`.
   if ((JoinKind == join_kind::INNER_JOIN) && (right.num_rows() > left.num_rows())) {
-    return get_base_hash_join_indices<JoinKind>(right, left, true, compare_nulls_equal, stream);
+    return get_base_hash_join_indices<JoinKind>(right, left, true, compare_nulls, stream);
   }
   // Trivial left join case - exit early
   if ((JoinKind == join_kind::LEFT_JOIN) && (right.num_rows() == 0)) {
@@ -242,7 +243,7 @@ get_base_hash_join_indices(table_view const& left,
   }
 
   size_type estimated_size = estimate_join_output_size<JoinKind, multimap_type>(
-    *build_table, *probe_table, *hash_table, compare_nulls_equal, stream);
+    *build_table, *probe_table, *hash_table, compare_nulls, stream);
 
   // If the estimated output size is zero, return immediately
   if (estimated_size == 0) {
@@ -268,7 +269,7 @@ get_base_hash_join_indices(table_view const& left,
     write_index.set_value(0);
 
     row_hash hash_probe{*probe_table};
-    row_equality equality{*probe_table, *build_table, compare_nulls_equal};
+    row_equality equality{*probe_table, *build_table, compare_nulls == null_equality::EQUAL};
     const auto& join_output_l =
       flip_join_indices ? right_indices.data().get() : left_indices.data().get();
     const auto& join_output_r =

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -431,8 +431,8 @@ std::unique_ptr<table> join_call_compute_df(
     return get_empty_joined_table(left, right, columns_in_common);
   }
 
-  auto joined_indices =
-    get_base_join_indices<JoinKind>(left.select(left_on), right.select(right_on), compare_nulls, stream);
+  auto joined_indices = get_base_join_indices<JoinKind>(
+    left.select(left_on), right.select(right_on), compare_nulls, stream);
 
   return construct_join_output_df<JoinKind>(
     left, right, joined_indices, columns_in_common, mr, stream);

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -190,13 +190,15 @@ get_left_join_indices_complement(rmm::device_vector<size_type>& right_indices,
  *
  * @param left  Table of left columns to join
  * @param right Table of right  columns to join
+ * @param compare_nulls_equal is a bool that controls whether null join-key values
+ * should match (as per Pandas semantics), or not (as per SQL semantics)
  * @param stream CUDA stream used for device memory operations and kernel launches.
  *
  * @return Join output indices vector pair
  */
 template <join_kind JoinKind>
 std::pair<rmm::device_vector<size_type>, rmm::device_vector<size_type>> get_base_join_indices(
-  table_view const& left, table_view const& right, cudaStream_t stream)
+  table_view const& left, table_view const& right, bool compare_nulls_equal, cudaStream_t stream)
 {
   CUDF_EXPECTS(0 != left.num_columns(), "Selected left dataset is empty");
   CUDF_EXPECTS(0 != right.num_columns(), "Selected right dataset is empty");
@@ -209,7 +211,7 @@ std::pair<rmm::device_vector<size_type>, rmm::device_vector<size_type>> get_base
 
   constexpr join_kind BaseJoinKind =
     (JoinKind == join_kind::FULL_JOIN) ? join_kind::LEFT_JOIN : JoinKind;
-  return get_base_hash_join_indices<BaseJoinKind>(left, right, false, stream);
+  return get_base_hash_join_indices<BaseJoinKind>(left, right, false, compare_nulls_equal, stream);
 }
 
 /**
@@ -386,6 +388,8 @@ std::unique_ptr<table> construct_join_output_df(
  * `right_on` if it is inner join or gathered from both `left_on` and
  * `right_on` if it is full join. Else, for every column in `left_on` and
  * `right_on`, an output column will be produced.
+ * @param compare_nulls_equal is a bool that controls whether null join-key values
+ * should match (as per Pandas semantics), or not (as per SQL semantics)
  * @param mr Device memory resource used to allocate the returned table's device memory
  * @param stream CUDA stream used for device memory operations and kernel launches.
  *
@@ -400,6 +404,7 @@ std::unique_ptr<table> join_call_compute_df(
   std::vector<size_type> const& left_on,
   std::vector<size_type> const& right_on,
   std::vector<std::pair<size_type, size_type>> const& columns_in_common,
+  bool compare_nulls_equal,
   rmm::mr::device_memory_resource* mr,
   cudaStream_t stream = 0)
 {
@@ -427,7 +432,7 @@ std::unique_ptr<table> join_call_compute_df(
   }
 
   auto joined_indices =
-    get_base_join_indices<JoinKind>(left.select(left_on), right.select(right_on), stream);
+    get_base_join_indices<JoinKind>(left.select(left_on), right.select(right_on), compare_nulls_equal, stream);
 
   return construct_join_output_df<JoinKind>(
     left, right, joined_indices, columns_in_common, mr, stream);
@@ -441,11 +446,12 @@ std::unique_ptr<table> inner_join(
   std::vector<size_type> const& left_on,
   std::vector<size_type> const& right_on,
   std::vector<std::pair<size_type, size_type>> const& columns_in_common,
+  bool compare_nulls_equal,
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::join_call_compute_df<::cudf::detail::join_kind::INNER_JOIN>(
-    left, right, left_on, right_on, columns_in_common, mr);
+    left, right, left_on, right_on, columns_in_common, compare_nulls_equal, mr);
 }
 
 std::unique_ptr<table> left_join(
@@ -454,11 +460,12 @@ std::unique_ptr<table> left_join(
   std::vector<size_type> const& left_on,
   std::vector<size_type> const& right_on,
   std::vector<std::pair<size_type, size_type>> const& columns_in_common,
+  bool compare_nulls_equal,
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::join_call_compute_df<::cudf::detail::join_kind::LEFT_JOIN>(
-    left, right, left_on, right_on, columns_in_common, mr);
+    left, right, left_on, right_on, columns_in_common, compare_nulls_equal, mr);
 }
 
 std::unique_ptr<table> full_join(
@@ -467,11 +474,12 @@ std::unique_ptr<table> full_join(
   std::vector<size_type> const& left_on,
   std::vector<size_type> const& right_on,
   std::vector<std::pair<size_type, size_type>> const& columns_in_common,
+  bool compare_nulls_equal,
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::join_call_compute_df<::cudf::detail::join_kind::FULL_JOIN>(
-    left, right, left_on, right_on, columns_in_common, mr);
+    left, right, left_on, right_on, columns_in_common, compare_nulls_equal, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -23,6 +23,8 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/error.hpp>
 
+#include "cudf/detail/utilities/cuda.cuh"
+#include "cudf/types.hpp"
 #include "hash_join.cuh"
 #include "join_common_utils.hpp"
 #include "nested_loop_join.cuh"
@@ -190,15 +192,14 @@ get_left_join_indices_complement(rmm::device_vector<size_type>& right_indices,
  *
  * @param left  Table of left columns to join
  * @param right Table of right  columns to join
- * @param compare_nulls_equal is a bool that controls whether null join-key values
- * should match (as per Pandas semantics), or not (as per SQL semantics)
+ * @param compare_nulls Controls whether null join-key values should match or not.
  * @param stream CUDA stream used for device memory operations and kernel launches.
  *
  * @return Join output indices vector pair
  */
 template <join_kind JoinKind>
 std::pair<rmm::device_vector<size_type>, rmm::device_vector<size_type>> get_base_join_indices(
-  table_view const& left, table_view const& right, bool compare_nulls_equal, cudaStream_t stream)
+  table_view const& left, table_view const& right, null_equality compare_nulls, cudaStream_t stream)
 {
   CUDF_EXPECTS(0 != left.num_columns(), "Selected left dataset is empty");
   CUDF_EXPECTS(0 != right.num_columns(), "Selected right dataset is empty");
@@ -211,7 +212,7 @@ std::pair<rmm::device_vector<size_type>, rmm::device_vector<size_type>> get_base
 
   constexpr join_kind BaseJoinKind =
     (JoinKind == join_kind::FULL_JOIN) ? join_kind::LEFT_JOIN : JoinKind;
-  return get_base_hash_join_indices<BaseJoinKind>(left, right, false, compare_nulls_equal, stream);
+  return get_base_hash_join_indices<BaseJoinKind>(left, right, false, compare_nulls, stream);
 }
 
 /**
@@ -388,8 +389,7 @@ std::unique_ptr<table> construct_join_output_df(
  * `right_on` if it is inner join or gathered from both `left_on` and
  * `right_on` if it is full join. Else, for every column in `left_on` and
  * `right_on`, an output column will be produced.
- * @param compare_nulls_equal is a bool that controls whether null join-key values
- * should match (as per Pandas semantics), or not (as per SQL semantics)
+ * @param compare_nulls Controls whether null join-key values should match or not.
  * @param mr Device memory resource used to allocate the returned table's device memory
  * @param stream CUDA stream used for device memory operations and kernel launches.
  *
@@ -404,7 +404,7 @@ std::unique_ptr<table> join_call_compute_df(
   std::vector<size_type> const& left_on,
   std::vector<size_type> const& right_on,
   std::vector<std::pair<size_type, size_type>> const& columns_in_common,
-  bool compare_nulls_equal,
+  null_equality compare_nulls,
   rmm::mr::device_memory_resource* mr,
   cudaStream_t stream = 0)
 {
@@ -432,7 +432,7 @@ std::unique_ptr<table> join_call_compute_df(
   }
 
   auto joined_indices =
-    get_base_join_indices<JoinKind>(left.select(left_on), right.select(right_on), compare_nulls_equal, stream);
+    get_base_join_indices<JoinKind>(left.select(left_on), right.select(right_on), compare_nulls, stream);
 
   return construct_join_output_df<JoinKind>(
     left, right, joined_indices, columns_in_common, mr, stream);
@@ -446,12 +446,12 @@ std::unique_ptr<table> inner_join(
   std::vector<size_type> const& left_on,
   std::vector<size_type> const& right_on,
   std::vector<std::pair<size_type, size_type>> const& columns_in_common,
-  bool compare_nulls_equal,
+  null_equality compare_nulls,
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::join_call_compute_df<::cudf::detail::join_kind::INNER_JOIN>(
-    left, right, left_on, right_on, columns_in_common, compare_nulls_equal, mr);
+    left, right, left_on, right_on, columns_in_common, compare_nulls, mr);
 }
 
 std::unique_ptr<table> left_join(
@@ -460,12 +460,12 @@ std::unique_ptr<table> left_join(
   std::vector<size_type> const& left_on,
   std::vector<size_type> const& right_on,
   std::vector<std::pair<size_type, size_type>> const& columns_in_common,
-  bool compare_nulls_equal,
+  null_equality compare_nulls,
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::join_call_compute_df<::cudf::detail::join_kind::LEFT_JOIN>(
-    left, right, left_on, right_on, columns_in_common, compare_nulls_equal, mr);
+    left, right, left_on, right_on, columns_in_common, compare_nulls, mr);
 }
 
 std::unique_ptr<table> full_join(
@@ -474,12 +474,12 @@ std::unique_ptr<table> full_join(
   std::vector<size_type> const& left_on,
   std::vector<size_type> const& right_on,
   std::vector<std::pair<size_type, size_type>> const& columns_in_common,
-  bool compare_nulls_equal,
+  null_equality compare_nulls,
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::join_call_compute_df<::cudf::detail::join_kind::FULL_JOIN>(
-    left, right, left_on, right_on, columns_in_common, compare_nulls_equal, mr);
+    left, right, left_on, right_on, columns_in_common, compare_nulls, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/join/nested_loop_join.cuh
+++ b/cpp/src/join/nested_loop_join.cuh
@@ -135,8 +135,8 @@ get_base_nested_loop_join_indices(table_view const& left,
   auto left_table  = table_device_view::create(left, stream);
   auto right_table = table_device_view::create(right, stream);
 
-  size_type estimated_size =
-    estimate_nested_loop_join_output_size(*left_table, *right_table, JoinKind, compare_nulls, stream);
+  size_type estimated_size = estimate_nested_loop_join_output_size(
+    *left_table, *right_table, JoinKind, compare_nulls, stream);
 
   // If the estimated output size is zero, return immediately
   if (estimated_size == 0) {

--- a/cpp/src/join/nested_loop_join.cuh
+++ b/cpp/src/join/nested_loop_join.cuh
@@ -38,6 +38,8 @@ namespace detail {
  * @param left The left hand table
  * @param right The right hand table
  * @param JoinKind The type of join to be performed
+ * @param compare_nulls_equal is a bool that controls whether null join-key values
+ * should match (as per Pandas semantics), or not (as per SQL semantics)
  * @param stream CUDA stream used for device memory operations and kernel launches
  *
  * @return An estimate of the size of the output of the join operation
@@ -45,6 +47,7 @@ namespace detail {
 size_type estimate_nested_loop_join_output_size(table_device_view left,
                                                 table_device_view right,
                                                 join_kind JoinKind,
+                                                bool compare_nulls_equal,
                                                 cudaStream_t stream)
 {
   const size_type left_num_rows{left.num_rows()};
@@ -85,7 +88,7 @@ size_type estimate_nested_loop_join_output_size(table_device_view left,
 
   size_estimate.set_value(0);
 
-  row_equality equality{left, right};
+  row_equality equality{left, right, compare_nulls_equal};
   // Determine number of output rows without actually building the output to simply
   // find what the size of the output will be.
   compute_nested_loop_join_output_size<block_size><<<numBlocks * num_sms, block_size, 0, stream>>>(
@@ -106,6 +109,8 @@ size_type estimate_nested_loop_join_output_size(table_device_view left,
  * @param flip_join_indices Flag that indicates whether the left and right
  * tables have been flipped, meaning the output indices should also be flipped
  * @param JoinKind The type of join to be performed
+ * @param compare_nulls_equal is a bool that controls whether null join-key values
+ * should match (as per Pandas semantics), or not (as per SQL semantics)
  * @param stream CUDA stream used for device memory operations and kernel launches
  *
  * @return Join output indices vector pair
@@ -115,12 +120,13 @@ get_base_nested_loop_join_indices(table_view const& left,
                                   table_view const& right,
                                   bool flip_join_indices,
                                   join_kind JoinKind,
+                                  bool compare_nulls_equal,
                                   cudaStream_t stream)
 {
   // The `right` table is always used for the inner loop. We want to use the smaller table
   // for the inner loop. Thus, if `left` is smaller than `right`, swap `left/right`.
   if ((JoinKind == join_kind::INNER_JOIN) && (right.num_rows() > left.num_rows())) {
-    return get_base_nested_loop_join_indices(right, left, true, JoinKind, stream);
+    return get_base_nested_loop_join_indices(right, left, true, JoinKind, compare_nulls_equal, stream);
   }
   // Trivial left join case - exit early
   if ((JoinKind == join_kind::LEFT_JOIN) && (right.num_rows() == 0)) {
@@ -131,7 +137,7 @@ get_base_nested_loop_join_indices(table_view const& left,
   auto right_table = table_device_view::create(right, stream);
 
   size_type estimated_size =
-    estimate_nested_loop_join_output_size(*left_table, *right_table, JoinKind, stream);
+    estimate_nested_loop_join_output_size(*left_table, *right_table, JoinKind, compare_nulls_equal, stream);
 
   // If the estimated output size is zero, return immediately
   if (estimated_size == 0) {
@@ -156,7 +162,7 @@ get_base_nested_loop_join_indices(table_view const& left,
     detail::grid_1d config(left_table->num_rows(), block_size);
     write_index.set_value(0);
 
-    row_equality equality{*left_table, *right_table};
+    row_equality equality{*left_table, *right_table, compare_nulls_equal};
     const auto& join_output_l =
       flip_join_indices ? right_indices.data().get() : left_indices.data().get();
     const auto& join_output_r =

--- a/cpp/src/join/nested_loop_join.cuh
+++ b/cpp/src/join/nested_loop_join.cuh
@@ -23,6 +23,7 @@
 #include <cudf/table/table_view.hpp>
 #include <iostream>
 
+#include "cudf/types.hpp"
 #include "hash_join.cuh"
 #include "join_common_utils.hpp"
 #include "join_kernels.cuh"
@@ -38,8 +39,7 @@ namespace detail {
  * @param left The left hand table
  * @param right The right hand table
  * @param JoinKind The type of join to be performed
- * @param compare_nulls_equal is a bool that controls whether null join-key values
- * should match (as per Pandas semantics), or not (as per SQL semantics)
+ * @param compare_nulls Controls whether null join-key values should match or not.
  * @param stream CUDA stream used for device memory operations and kernel launches
  *
  * @return An estimate of the size of the output of the join operation
@@ -47,7 +47,7 @@ namespace detail {
 size_type estimate_nested_loop_join_output_size(table_device_view left,
                                                 table_device_view right,
                                                 join_kind JoinKind,
-                                                bool compare_nulls_equal,
+                                                null_equality compare_nulls,
                                                 cudaStream_t stream)
 {
   const size_type left_num_rows{left.num_rows()};
@@ -88,7 +88,7 @@ size_type estimate_nested_loop_join_output_size(table_device_view left,
 
   size_estimate.set_value(0);
 
-  row_equality equality{left, right, compare_nulls_equal};
+  row_equality equality{left, right, compare_nulls == null_equality::EQUAL};
   // Determine number of output rows without actually building the output to simply
   // find what the size of the output will be.
   compute_nested_loop_join_output_size<block_size><<<numBlocks * num_sms, block_size, 0, stream>>>(
@@ -109,8 +109,7 @@ size_type estimate_nested_loop_join_output_size(table_device_view left,
  * @param flip_join_indices Flag that indicates whether the left and right
  * tables have been flipped, meaning the output indices should also be flipped
  * @param JoinKind The type of join to be performed
- * @param compare_nulls_equal is a bool that controls whether null join-key values
- * should match (as per Pandas semantics), or not (as per SQL semantics)
+ * @param compare_nulls Controls whether null join-key values should match or not.
  * @param stream CUDA stream used for device memory operations and kernel launches
  *
  * @return Join output indices vector pair
@@ -120,13 +119,13 @@ get_base_nested_loop_join_indices(table_view const& left,
                                   table_view const& right,
                                   bool flip_join_indices,
                                   join_kind JoinKind,
-                                  bool compare_nulls_equal,
+                                  null_equality compare_nulls,
                                   cudaStream_t stream)
 {
   // The `right` table is always used for the inner loop. We want to use the smaller table
   // for the inner loop. Thus, if `left` is smaller than `right`, swap `left/right`.
   if ((JoinKind == join_kind::INNER_JOIN) && (right.num_rows() > left.num_rows())) {
-    return get_base_nested_loop_join_indices(right, left, true, JoinKind, compare_nulls_equal, stream);
+    return get_base_nested_loop_join_indices(right, left, true, JoinKind, compare_nulls, stream);
   }
   // Trivial left join case - exit early
   if ((JoinKind == join_kind::LEFT_JOIN) && (right.num_rows() == 0)) {
@@ -137,7 +136,7 @@ get_base_nested_loop_join_indices(table_view const& left,
   auto right_table = table_device_view::create(right, stream);
 
   size_type estimated_size =
-    estimate_nested_loop_join_output_size(*left_table, *right_table, JoinKind, compare_nulls_equal, stream);
+    estimate_nested_loop_join_output_size(*left_table, *right_table, JoinKind, compare_nulls, stream);
 
   // If the estimated output size is zero, return immediately
   if (estimated_size == 0) {
@@ -162,7 +161,7 @@ get_base_nested_loop_join_indices(table_view const& left,
     detail::grid_1d config(left_table->num_rows(), block_size);
     write_index.set_value(0);
 
-    row_equality equality{*left_table, *right_table, compare_nulls_equal};
+    row_equality equality{*left_table, *right_table, compare_nulls == null_equality::EQUAL};
     const auto& join_output_l =
       flip_join_indices ? right_indices.data().get() : left_indices.data().get();
     const auto& join_output_r =

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -28,6 +28,7 @@
 
 #include <cudf/detail/gather.cuh>
 #include <join/hash_join.cuh>
+#include "cudf/types.hpp"
 
 namespace cudf {
 namespace detail {
@@ -47,29 +48,27 @@ namespace detail {
  * @throws cudf::logic_error if number of returned columns is 0
  * @throws cudf::logic_error if number of elements in `right_on` and `left_on` are not equal
  *
- * @param[in] left                The left table
- * @param[in] right               The right table
- * @param[in] left_on             The column indices from `left` to join on.
- *                                The column from `left` indicated by `left_on[i]`
- *                                will be compared against the column from `right`
- *                                indicated by `right_on[i]`.
- * @param[in] right_on            The column indices from `right` to join on.
- *                                The column from `right` indicated by `right_on[i]`
- *                                will be compared against the column from `left`
- *                                indicated by `left_on[i]`.
- * @param[in] return_columns      A vector of column indices from `left` to
- *                                include in the returned table.
- * @param[in] compare_nulls_equal A bool that controls whether null join-key values
- *                                should match (as per Pandas semantics),
- *                                or not (as per SQL semantics)
- * @param[in] mr                  Device memory resource to used to allocate the returned table's
- *                                device memory
- * @param[in] stream              CUDA stream used for device memory operations and kernel launches.
- * @tparam    join_kind           Indicates whether to do LEFT_SEMI_JOIN or LEFT_ANTI_JOIN
+ * @param[in] left             The left table
+ * @param[in] right            The right table
+ * @param[in] left_on          The column indices from `left` to join on.
+ *                             The column from `left` indicated by `left_on[i]`
+ *                             will be compared against the column from `right`
+ *                             indicated by `right_on[i]`.
+ * @param[in] right_on         The column indices from `right` to join on.
+ *                             The column from `right` indicated by `right_on[i]`
+ *                             will be compared against the column from `left`
+ *                             indicated by `left_on[i]`.
+ * @param[in] return_columns   A vector of column indices from `left` to
+ *                             include in the returned table.
+ * @param[in] compare_nulls    Controls whether null join-key values should match or not.
+ * @param[in] mr               Device memory resource to used to allocate the returned table's
+ *                             device memory
+ * @param[in] stream           CUDA stream used for device memory operations and kernel launches.
+ * @tparam    join_kind        Indicates whether to do LEFT_SEMI_JOIN or LEFT_ANTI_JOIN
  *
- * @returns                       Result of joining `left` and `right` tables on the columns
- *                                specified by `left_on` and `right_on`. The resulting table
- *                                will contain `return_columns` from `left` that match in right.
+ * @returns                    Result of joining `left` and `right` tables on the columns
+ *                             specified by `left_on` and `right_on`. The resulting table
+ *                             will contain `return_columns` from `left` that match in right.
  */
 template <join_kind JoinKind>
 std::unique_ptr<cudf::table> left_semi_anti_join(
@@ -78,7 +77,7 @@ std::unique_ptr<cudf::table> left_semi_anti_join(
   std::vector<cudf::size_type> const& left_on,
   std::vector<cudf::size_type> const& right_on,
   std::vector<cudf::size_type> const& return_columns,
-  bool compare_nulls_equal,
+  null_equality compare_nulls,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
   cudaStream_t stream                 = 0)
 {
@@ -104,12 +103,12 @@ std::unique_ptr<cudf::table> left_semi_anti_join(
   auto right_rows_d            = table_device_view::create(right.select(right_on), stream);
   size_t const hash_table_size = compute_hash_table_size(right.num_rows());
   row_hash hash_build{*right_rows_d};
-  row_equality equality_build{*right_rows_d, *right_rows_d, compare_nulls_equal};
+  row_equality equality_build{*right_rows_d, *right_rows_d, compare_nulls == null_equality::EQUAL};
 
   // Going to join it with left table
   auto left_rows_d = table_device_view::create(left.select(left_on), stream);
   row_hash hash_probe{*left_rows_d};
-  row_equality equality_probe{*left_rows_d, *right_rows_d, compare_nulls_equal};
+  row_equality equality_probe{*left_rows_d, *right_rows_d, compare_nulls == null_equality::EQUAL};
 
   auto hash_table_ptr = hash_table_type::create(hash_table_size,
                                                 std::numeric_limits<bool>::max(),
@@ -156,12 +155,12 @@ std::unique_ptr<cudf::table> left_semi_join(cudf::table_view const& left,
                                             std::vector<cudf::size_type> const& left_on,
                                             std::vector<cudf::size_type> const& right_on,
                                             std::vector<cudf::size_type> const& return_columns,
-                                            bool compare_nulls_equal,
+                                            null_equality compare_nulls,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::left_semi_anti_join<detail::join_kind::LEFT_SEMI_JOIN>(
-    left, right, left_on, right_on, return_columns, compare_nulls_equal, mr, 0);
+    left, right, left_on, right_on, return_columns, compare_nulls, mr, 0);
 }
 
 std::unique_ptr<cudf::table> left_anti_join(cudf::table_view const& left,
@@ -169,12 +168,12 @@ std::unique_ptr<cudf::table> left_anti_join(cudf::table_view const& left,
                                             std::vector<cudf::size_type> const& left_on,
                                             std::vector<cudf::size_type> const& right_on,
                                             std::vector<cudf::size_type> const& return_columns,
-                                            bool compare_nulls_equal,
+                                            null_equality compare_nulls,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::left_semi_anti_join<detail::join_kind::LEFT_ANTI_JOIN>(
-    left, right, left_on, right_on, return_columns, compare_nulls_equal, mr, 0);
+    left, right, left_on, right_on, return_columns, compare_nulls, mr, 0);
 }
 
 }  // namespace cudf

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -27,6 +27,7 @@
 #include <tests/utilities/column_wrapper.hpp>
 #include <tests/utilities/table_utilities.hpp>
 #include <tests/utilities/type_lists.hpp>
+#include "cudf/types.hpp"
 
 template <typename T>
 using column_wrapper = cudf::test::fixed_width_column_wrapper<T>;
@@ -278,7 +279,7 @@ TEST_F(JoinTest, FullJoinOnNulls)
   // Repeat test with compare_nulls_equal=false,
   // as per SQL standard.
 
-  result            = cudf::full_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, false);
+  result            = cudf::full_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
   result_sort_order = cudf::sorted_order(result->view());
   sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
@@ -452,7 +453,7 @@ TEST_F(JoinTest, LeftJoinOnNulls)
   // Repeat test with compare_nulls_equal=false,
   // as per SQL standard.
 
-  result            = cudf::left_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, false);
+  result            = cudf::left_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
   result_sort_order = cudf::sorted_order(result->view());
   sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
@@ -607,7 +608,7 @@ TEST_F(JoinTest, InnerJoinOnNulls)
   // Repeat test with compare_nulls_equal=false,
   // as per SQL standard.
 
-  result            = cudf::inner_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, false);
+  result            = cudf::inner_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
   result_sort_order = cudf::sorted_order(result->view());
   sorted_result     = cudf::gather(result->view(), *result_sort_order);
 

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -215,13 +215,16 @@ TEST_F(JoinTest, FullJoinWithNulls)
 
 TEST_F(JoinTest, FullJoinOnNulls)
 {
-  column_wrapper<int32_t> col0_0{{3, 1}, {1, 0}};
-  strcol_wrapper col0_1({"s0", "s1"});
-  column_wrapper<int32_t> col0_2{{0, 1}};
+  // clang-format off
+  column_wrapper<int32_t> col0_0{{  3,    1 },
+                                 {  1,    0  }};
+  strcol_wrapper          col0_1({"s0", "s1" });
+  column_wrapper<int32_t> col0_2{{  0,    1 }};
 
-  column_wrapper<int32_t> col1_0{{2, 5, 3, 7}, {1, 1, 1, 0}};
-  strcol_wrapper col1_1({"s1", "s0", "s0", "s1"});
-  column_wrapper<int32_t> col1_2{{1, 4, 2, 8}};
+  column_wrapper<int32_t> col1_0{{  2,    5,    3,    7 },
+                                 {  1,    1,    1,    0 }};
+  strcol_wrapper          col1_1({"s1", "s0", "s0", "s1" });
+  column_wrapper<int32_t> col1_2{{  1,    4,    2,    8 }};
 
   CVector cols0, cols1;
   cols0.push_back(col0_0.release());
@@ -245,11 +248,14 @@ TEST_F(JoinTest, FullJoinOnNulls)
   cudf::test::print(sorted_result->get_column(2).view(), std::cout, ",\t\t");
   cudf::test::print(sorted_result->get_column(3).view(), std::cout, ",\t\t");
 #endif
-
-  column_wrapper<int32_t> col_gold_0{{2, 5, 3, -1}, {1, 1, 1, 0}};
-  strcol_wrapper col_gold_1({"s1", "s0", "s0", "s1"});
-  column_wrapper<int32_t> col_gold_2{{-1, -1, 0, 1}, {0, 0, 1, 1}};
-  column_wrapper<int32_t> col_gold_3{{1, 4, 2, 8}, {1, 1, 1, 1}};
+ 
+  column_wrapper<int32_t> col_gold_0{{   2,    5,    3,    -1},
+                                     {   1,    1,    1,     0}};
+  strcol_wrapper          col_gold_1({ "s1", "s0", "s0",  "s1"});
+  column_wrapper<int32_t> col_gold_2{{  -1,   -1,    0,     1}, 
+                                     {   0,    0,    1,     1}};
+  column_wrapper<int32_t> col_gold_3{{   1,    4,    2,     8}, 
+                                     {   1,    1,    1,     1}};
 
   CVector cols_gold;
   cols_gold.push_back(col_gold_0.release());
@@ -274,14 +280,19 @@ TEST_F(JoinTest, FullJoinOnNulls)
   // Repeat test with compare_nulls_equal=false,
   // as per SQL standard.
 
-  result = cudf::full_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
+  result            = cudf::full_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
   result_sort_order = cudf::sorted_order(result->view());
   sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
-  col_gold_0 = {{2, 5, 3, -1, -1}, {1, 1, 1, 0, 0}};
-  col_gold_1 = strcol_wrapper({"s1", "s0", "s0", "s1", "s1"});
-  col_gold_2 = {{-1, -1, 0, -1, 1}, {0, 0, 1, 0, 2}};
-  col_gold_3 = {{1, 4, 2, 8, -1}, {1, 1, 1, 1, 0}};
+  col_gold_0 =               {{   2,    5,    3,    -1,   -1},
+                              {   1,    1,    1,     0,    0}};
+  col_gold_1 = strcol_wrapper({ "s1", "s0", "s0",  "s1", "s1"});
+  col_gold_2 =               {{  -1,   -1,    0,    -1,    1}, 
+                              {   0,    0,    1,     0,    2}};
+  col_gold_3 =               {{   1,    4,    2,     8,   -1}, 
+                              {   1,    1,    1,     1,    0}};
+
+  // clang-format on
 
   CVector cols_gold_nulls_unequal;
   cols_gold_nulls_unequal.push_back(col_gold_0.release());
@@ -380,13 +391,16 @@ TEST_F(JoinTest, LeftJoinWithNulls)
 
 TEST_F(JoinTest, LeftJoinOnNulls)
 {
-  column_wrapper<int32_t> col0_0{{3, 1, 2}, {1, 0, 1}};
-  strcol_wrapper col0_1({"s0", "s1", "s2"});
-  column_wrapper<int32_t> col0_2{{0, 1, 2}};
+  // clang-format off
+  column_wrapper<int32_t> col0_0{{  3,    1,    2},
+                                 {  1,    0,    1}};
+  strcol_wrapper          col0_1({"s0", "s1", "s2" });
+  column_wrapper<int32_t> col0_2{{  0,    1,    2 }};
 
-  column_wrapper<int32_t> col1_0{{2, 5, 3, 7}, {1, 1, 1, 0}};
-  strcol_wrapper col1_1({"s1", "s0", "s0", "s1"});
-  column_wrapper<int32_t> col1_2{{1, 4, 2, 8}};
+  column_wrapper<int32_t> col1_0{{  2,    5,    3,    7 },
+                                 {  1,    1,    1,    0 }};
+  strcol_wrapper          col1_1({"s1", "s0", "s0", "s1" });
+  column_wrapper<int32_t> col1_2{{  1,    4,    2,    8 }};
 
   CVector cols0, cols1;
   cols0.push_back(col0_0.release());
@@ -410,11 +424,15 @@ TEST_F(JoinTest, LeftJoinOnNulls)
   cudf::test::print(sorted_result->get_column(2).view(), std::cout, ",\t\t");
   cudf::test::print(sorted_result->get_column(3).view(), std::cout, ",\t\t");
 #endif
-
-  column_wrapper<int32_t> col_gold_0{{3, -1, 2}, {1, 0, 1}};
-  strcol_wrapper col_gold_1({"s0", "s1", "s2"}, {1, 1, 1});
-  column_wrapper<int32_t> col_gold_2{{0, 1, 2}, {1, 1, 1}};
-  column_wrapper<int32_t> col_gold_3{{2, 8, -1}, {1, 1, 0}};
+ 
+  column_wrapper<int32_t> col_gold_0{{   3,    -1,    2},
+                                     {   1,     0,    1}};
+  strcol_wrapper          col_gold_1({ "s0",  "s1", "s2"},
+                                     {   1,     1,    1});
+  column_wrapper<int32_t> col_gold_2{{   0,     1,    2}, 
+                                     {   1,     1,    1}};
+  column_wrapper<int32_t> col_gold_3{{   2,     8,   -1}, 
+                                     {   1,     1,    0}};
 
   CVector cols_gold;
   cols_gold.push_back(col_gold_0.release());
@@ -439,15 +457,20 @@ TEST_F(JoinTest, LeftJoinOnNulls)
   // Repeat test with compare_nulls_equal=false,
   // as per SQL standard.
 
-  result = cudf::left_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
+  result            = cudf::left_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
   result_sort_order = cudf::sorted_order(result->view());
   sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
-  col_gold_0 = {{3, -1, 2}, {1, 0, 1}};
-  col_gold_1 = strcol_wrapper({"s0", "s1", "s2"}, {1, 1, 1});
-  col_gold_2 = {{0, 1, 2}, {1, 1, 1}};
-  col_gold_3 = {{2, -1, -1}, {1, 0, 0}};
+  col_gold_0 =               {{   3,    -1,    2},
+                              {   1,     0,    1}};
+  col_gold_1 = strcol_wrapper({ "s0",  "s1", "s2"},
+                              {   1,     1,    1});
+  col_gold_2 =               {{   0,     1,    2}, 
+                              {   1,     1,    1}};
+  col_gold_3 =               {{   2,    -1,   -1}, 
+                              {   1,     0,    0}};
 
+  // clang-format on
   CVector cols_gold_nulls_unequal;
   cols_gold_nulls_unequal.push_back(col_gold_0.release());
   cols_gold_nulls_unequal.push_back(col_gold_1.release());
@@ -546,13 +569,16 @@ TEST_F(JoinTest, InnerJoinWithNulls)
 // Test to check join behaviour when join keys are null.
 TEST_F(JoinTest, InnerJoinOnNulls)
 {
-  column_wrapper<int32_t> col0_0{{3, 1, 2, 0, 2}};
-  strcol_wrapper col0_1({"s1", "s1", "s8", "s4", "s0"}, {1, 1, 0, 1, 1});
-  column_wrapper<int32_t> col0_2{{0, 1, 2, 4, 1}};
+  // clang-format off
+  column_wrapper<int32_t> col0_0{{  3,    1,    2,    0,    2}};
+  strcol_wrapper          col0_1({"s1", "s1", "s8", "s4", "s0"}, 
+                                 {  1,    1,    0,    1,    1});
+  column_wrapper<int32_t> col0_2{{  0,    1,    2,    4,    1}};
 
-  column_wrapper<int32_t> col1_0{{2, 2, 0, 4, 3}};
-  strcol_wrapper col1_1({"s1", "s0", "s1", "s2", "s1"}, {1, 0, 1, 1, 1});
-  column_wrapper<int32_t> col1_2{{1, 0, 1, 2, 1}};
+  column_wrapper<int32_t> col1_0{{  2,    2,    0,    4,    3}};
+  strcol_wrapper          col1_1({"s1", "s0", "s1", "s2", "s1"}, 
+                                 {  1,    0,    1,    1,    1});
+  column_wrapper<int32_t> col1_2{{  1,    0,    1,    2,    1}};
 
   CVector cols0, cols1;
   cols0.push_back(col0_0.release());
@@ -569,10 +595,11 @@ TEST_F(JoinTest, InnerJoinOnNulls)
   auto result_sort_order = cudf::sorted_order(result->view());
   auto sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
-  column_wrapper<int32_t> col_gold_0{{3, 2}};
-  strcol_wrapper col_gold_1({"s1", "s0"}, {1, 0});
-  column_wrapper<int32_t> col_gold_2{{0, 2}};
-  column_wrapper<int32_t> col_gold_3{{1, 0}};
+  column_wrapper<int32_t> col_gold_0 {{  3,    2}};
+  strcol_wrapper          col_gold_1 ({"s1", "s0"}, 
+                                      {  1,    0});
+  column_wrapper<int32_t> col_gold_2{{   0,    2}};
+  column_wrapper<int32_t> col_gold_3{{   1,    0}};
   CVector cols_gold;
   cols_gold.push_back(col_gold_0.release());
   cols_gold.push_back(col_gold_1.release());
@@ -583,18 +610,21 @@ TEST_F(JoinTest, InnerJoinOnNulls)
   auto gold_sort_order = cudf::sorted_order(gold.view());
   auto sorted_gold     = cudf::gather(gold.view(), *gold_sort_order);
   cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
-
+  
   // Repeat test with compare_nulls_equal=false,
   // as per SQL standard.
 
-  result = cudf::inner_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
+  result            = cudf::inner_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
   result_sort_order = cudf::sorted_order(result->view());
   sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
-  col_gold_0 = {{3}};
-  col_gold_1 = strcol_wrapper({"s1"}, {1});
-  col_gold_2 = {{0}};
-  col_gold_3 = {{1}};
+  col_gold_0 =               {{  3}};
+  col_gold_1 = strcol_wrapper({"s1"}, 
+                              {  1});
+  col_gold_2 =               {{  0}};
+  col_gold_3 =               {{  1}};
+
+  // clang-format on
 
   CVector cols_gold_sql;
   cols_gold_sql.push_back(col_gold_0.release());

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -212,6 +212,97 @@ TEST_F(JoinTest, FullJoinWithNulls)
   cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
 }
 
+TEST_F(JoinTest, FullJoinOnNulls)
+{
+  column_wrapper<int32_t> col0_0{{  3,    1 },
+                                 {  1,    0  }};
+  strcol_wrapper          col0_1({"s0", "s1" });
+  column_wrapper<int32_t> col0_2{{  0,    1 }};
+
+  column_wrapper<int32_t> col1_0{{  2,    5,    3,    7 },
+                                 {  1,    1,    1,    0 }};
+  strcol_wrapper          col1_1({"s1", "s0", "s0", "s1" });
+  column_wrapper<int32_t> col1_2{{  1,    4,    2,    8 }};
+
+  CVector cols0, cols1;
+  cols0.push_back(col0_0.release());
+  cols0.push_back(col0_1.release());
+  cols0.push_back(col0_2.release());
+  cols1.push_back(col1_0.release());
+  cols1.push_back(col1_1.release());
+  cols1.push_back(col1_2.release());
+
+  Table t0(std::move(cols0));
+  Table t1(std::move(cols1));
+
+  auto result            = cudf::full_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}});
+  auto result_sort_order = cudf::sorted_order(result->view());
+  auto sorted_result     = cudf::gather(result->view(), *result_sort_order);
+
+#if 0
+  std::cout << "Actual Results:\n";
+  cudf::test::print(sorted_result->get_column(0).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_result->get_column(1).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_result->get_column(2).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_result->get_column(3).view(), std::cout, ",\t\t");
+#endif
+ 
+  column_wrapper<int32_t> col_gold_0{{   2,    5,    3,    -1},
+                                     {   1,    1,    1,     0}};
+  strcol_wrapper          col_gold_1({ "s1", "s0", "s0",  "s1"});
+  column_wrapper<int32_t> col_gold_2{{  -1,   -1,    0,     1}, 
+                                     {   0,    0,    1,     1}};
+  column_wrapper<int32_t> col_gold_3{{   1,    4,    2,     8}, 
+                                     {   1,    1,    1,     1}};
+
+  CVector cols_gold;
+  cols_gold.push_back(col_gold_0.release());
+  cols_gold.push_back(col_gold_1.release());
+  cols_gold.push_back(col_gold_2.release());
+  cols_gold.push_back(col_gold_3.release());
+  Table gold(std::move(cols_gold));
+
+  auto gold_sort_order = cudf::sorted_order(gold.view());
+  auto sorted_gold     = cudf::gather(gold.view(), *gold_sort_order);
+
+#if 0
+  std::cout << "Expected Results:\n";
+  cudf::test::print(sorted_gold->get_column(0).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_gold->get_column(1).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_gold->get_column(2).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_gold->get_column(3).view(), std::cout, ",\t\t");
+#endif
+
+  cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
+
+  // Repeat test with compare_nulls_equal=false,
+  // as per SQL standard.
+
+  result            = cudf::full_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, false);
+  result_sort_order = cudf::sorted_order(result->view());
+  sorted_result     = cudf::gather(result->view(), *result_sort_order);
+
+  col_gold_0 =               {{   2,    5,    3,    -1,   -1},
+                              {   1,    1,    1,     0,    0}};
+  col_gold_1 = strcol_wrapper({ "s1", "s0", "s0",  "s1", "s1"});
+  col_gold_2 =               {{  -1,   -1,    0,    -1,    1}, 
+                              {   0,    0,    1,     0,    2}};
+  col_gold_3 =               {{   1,    4,    2,     8,   -1}, 
+                              {   1,    1,    1,     1,    0}};
+  
+  CVector cols_gold_nulls_unequal;
+  cols_gold_nulls_unequal.push_back(col_gold_0.release());
+  cols_gold_nulls_unequal.push_back(col_gold_1.release());
+  cols_gold_nulls_unequal.push_back(col_gold_2.release());
+  cols_gold_nulls_unequal.push_back(col_gold_3.release());
+  Table gold_nulls_unequal{std::move(cols_gold_nulls_unequal)};
+
+  gold_sort_order = cudf::sorted_order(gold_nulls_unequal.view());
+  sorted_gold     = cudf::gather(gold_nulls_unequal.view(), *gold_sort_order);
+
+  cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
+}
+
 TEST_F(JoinTest, LeftJoinNoNulls)
 {
   column_wrapper<int32_t> col0_0{{3, 1, 2, 0, 3}};
@@ -294,6 +385,99 @@ TEST_F(JoinTest, LeftJoinWithNulls)
   cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
 }
 
+TEST_F(JoinTest, LeftJoinOnNulls)
+{
+  column_wrapper<int32_t> col0_0{{  3,    1,    2},
+                                 {  1,    0,    1}};
+  strcol_wrapper          col0_1({"s0", "s1", "s2" });
+  column_wrapper<int32_t> col0_2{{  0,    1,    2 }};
+
+  column_wrapper<int32_t> col1_0{{  2,    5,    3,    7 },
+                                 {  1,    1,    1,    0 }};
+  strcol_wrapper          col1_1({"s1", "s0", "s0", "s1" });
+  column_wrapper<int32_t> col1_2{{  1,    4,    2,    8 }};
+
+  CVector cols0, cols1;
+  cols0.push_back(col0_0.release());
+  cols0.push_back(col0_1.release());
+  cols0.push_back(col0_2.release());
+  cols1.push_back(col1_0.release());
+  cols1.push_back(col1_1.release());
+  cols1.push_back(col1_2.release());
+
+  Table t0(std::move(cols0));
+  Table t1(std::move(cols1));
+
+  auto result            = cudf::left_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}});
+  auto result_sort_order = cudf::sorted_order(result->view());
+  auto sorted_result     = cudf::gather(result->view(), *result_sort_order);
+
+#if 0
+  std::cout << "Actual Results:\n";
+  cudf::test::print(sorted_result->get_column(0).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_result->get_column(1).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_result->get_column(2).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_result->get_column(3).view(), std::cout, ",\t\t");
+#endif
+ 
+  column_wrapper<int32_t> col_gold_0{{   3,    -1,    2},
+                                     {   1,     0,    1}};
+  strcol_wrapper          col_gold_1({ "s0",  "s1", "s2"},
+                                     {   1,     1,    1});
+  column_wrapper<int32_t> col_gold_2{{   0,     1,    2}, 
+                                     {   1,     1,    1}};
+  column_wrapper<int32_t> col_gold_3{{   2,     8,   -1}, 
+                                     {   1,     1,    0}};
+
+  CVector cols_gold;
+  cols_gold.push_back(col_gold_0.release());
+  cols_gold.push_back(col_gold_1.release());
+  cols_gold.push_back(col_gold_2.release());
+  cols_gold.push_back(col_gold_3.release());
+  Table gold(std::move(cols_gold));
+
+  auto gold_sort_order = cudf::sorted_order(gold.view());
+  auto sorted_gold     = cudf::gather(gold.view(), *gold_sort_order);
+
+#if 0
+  std::cout << "Expected Results:\n";
+  cudf::test::print(sorted_gold->get_column(0).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_gold->get_column(1).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_gold->get_column(2).view(), std::cout, ",\t\t");
+  cudf::test::print(sorted_gold->get_column(3).view(), std::cout, ",\t\t");
+#endif
+
+  cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
+
+  // Repeat test with compare_nulls_equal=false,
+  // as per SQL standard.
+
+  result            = cudf::left_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, false);
+  result_sort_order = cudf::sorted_order(result->view());
+  sorted_result     = cudf::gather(result->view(), *result_sort_order);
+
+  col_gold_0 =               {{   3,    -1,    2},
+                              {   1,     0,    1}};
+  col_gold_1 = strcol_wrapper({ "s0",  "s1", "s2"},
+                              {   1,     1,    1});
+  col_gold_2 =               {{   0,     1,    2}, 
+                              {   1,     1,    1}};
+  col_gold_3 =               {{   2,    -1,   -1}, 
+                              {   1,     0,    0}};
+
+  CVector cols_gold_nulls_unequal;
+  cols_gold_nulls_unequal.push_back(col_gold_0.release());
+  cols_gold_nulls_unequal.push_back(col_gold_1.release());
+  cols_gold_nulls_unequal.push_back(col_gold_2.release());
+  cols_gold_nulls_unequal.push_back(col_gold_3.release());
+  Table gold_nulls_unequal{std::move(cols_gold_nulls_unequal)};
+
+  gold_sort_order = cudf::sorted_order(gold_nulls_unequal.view());
+  sorted_gold     = cudf::gather(gold_nulls_unequal.view(), *gold_sort_order);
+
+  cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
+}
+
 TEST_F(JoinTest, InnerJoinNoNulls)
 {
   column_wrapper<int32_t> col0_0{{3, 1, 2, 0, 2}};
@@ -373,6 +557,75 @@ TEST_F(JoinTest, InnerJoinWithNulls)
 
   auto gold_sort_order = cudf::sorted_order(gold.view());
   auto sorted_gold     = cudf::gather(gold.view(), *gold_sort_order);
+  cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
+}
+
+// Test to check join behaviour when join keys are null.
+TEST_F(JoinTest, InnerJoinOnNulls)
+{
+  column_wrapper<int32_t> col0_0{{  3,    1,    2,    0,    2}};
+  strcol_wrapper          col0_1({"s1", "s1", "s8", "s4", "s0"}, 
+                                 {  1,    1,    0,    1,    1});
+  column_wrapper<int32_t> col0_2{{  0,    1,    2,    4,    1}};
+
+  column_wrapper<int32_t> col1_0{{  2,    2,    0,    4,    3}};
+  strcol_wrapper          col1_1({"s1", "s0", "s1", "s2", "s1"}, 
+                                 {  1,    0,    1,    1,    1});
+  column_wrapper<int32_t> col1_2{{  1,    0,    1,    2,    1}};
+
+  CVector cols0, cols1;
+  cols0.push_back(col0_0.release());
+  cols0.push_back(col0_1.release());
+  cols0.push_back(col0_2.release());
+  cols1.push_back(col1_0.release());
+  cols1.push_back(col1_1.release());
+  cols1.push_back(col1_2.release());
+
+  Table t0(std::move(cols0));
+  Table t1(std::move(cols1));
+
+  auto result            = cudf::inner_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}});
+  auto result_sort_order = cudf::sorted_order(result->view());
+  auto sorted_result     = cudf::gather(result->view(), *result_sort_order);
+
+  column_wrapper<int32_t> col_gold_0 {{  3,    2}};
+  strcol_wrapper          col_gold_1 ({"s1", "s0"}, 
+                                      {  1,    0});
+  column_wrapper<int32_t> col_gold_2{{   0,    2}};
+  column_wrapper<int32_t> col_gold_3{{   1,    0}};
+  CVector cols_gold;
+  cols_gold.push_back(col_gold_0.release());
+  cols_gold.push_back(col_gold_1.release());
+  cols_gold.push_back(col_gold_2.release());
+  cols_gold.push_back(col_gold_3.release());
+  Table gold(std::move(cols_gold));
+
+  auto gold_sort_order = cudf::sorted_order(gold.view());
+  auto sorted_gold     = cudf::gather(gold.view(), *gold_sort_order);
+  cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
+  
+  // Repeat test with compare_nulls_equal=false,
+  // as per SQL standard.
+
+  result            = cudf::inner_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, false);
+  result_sort_order = cudf::sorted_order(result->view());
+  sorted_result     = cudf::gather(result->view(), *result_sort_order);
+
+  col_gold_0 =               {{  3}};
+  col_gold_1 = strcol_wrapper({"s1"}, 
+                              {  1});
+  col_gold_2 =               {{  0}};
+  col_gold_3 =               {{  1}};
+
+  CVector cols_gold_sql;
+  cols_gold_sql.push_back(col_gold_0.release());
+  cols_gold_sql.push_back(col_gold_1.release());
+  cols_gold_sql.push_back(col_gold_2.release());
+  cols_gold_sql.push_back(col_gold_3.release());
+  Table gold_sql(std::move(cols_gold_sql));
+
+  gold_sort_order = cudf::sorted_order(gold_sql.view());
+  sorted_gold     = cudf::gather(gold_sql.view(), *gold_sort_order);
   cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
 }
 

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -288,7 +288,7 @@ TEST_F(JoinTest, FullJoinOnNulls)
                               {   1,    1,    1,     0,    0}};
   col_gold_1 = strcol_wrapper({ "s1", "s0", "s0",  "s1", "s1"});
   col_gold_2 =               {{  -1,   -1,    0,    -1,    1}, 
-                              {   0,    0,    1,     0,    2}};
+                              {   0,    0,    1,     0,    1}};
   col_gold_3 =               {{   1,    4,    2,     8,   -1}, 
                               {   1,    1,    1,     1,    0}};
 

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -215,15 +215,13 @@ TEST_F(JoinTest, FullJoinWithNulls)
 
 TEST_F(JoinTest, FullJoinOnNulls)
 {
-  column_wrapper<int32_t> col0_0{{  3,    1 },
-                                 {  1,    0  }};
-  strcol_wrapper          col0_1({"s0", "s1" });
-  column_wrapper<int32_t> col0_2{{  0,    1 }};
+  column_wrapper<int32_t> col0_0{{3, 1}, {1, 0}};
+  strcol_wrapper col0_1({"s0", "s1"});
+  column_wrapper<int32_t> col0_2{{0, 1}};
 
-  column_wrapper<int32_t> col1_0{{  2,    5,    3,    7 },
-                                 {  1,    1,    1,    0 }};
-  strcol_wrapper          col1_1({"s1", "s0", "s0", "s1" });
-  column_wrapper<int32_t> col1_2{{  1,    4,    2,    8 }};
+  column_wrapper<int32_t> col1_0{{2, 5, 3, 7}, {1, 1, 1, 0}};
+  strcol_wrapper col1_1({"s1", "s0", "s0", "s1"});
+  column_wrapper<int32_t> col1_2{{1, 4, 2, 8}};
 
   CVector cols0, cols1;
   cols0.push_back(col0_0.release());
@@ -247,14 +245,11 @@ TEST_F(JoinTest, FullJoinOnNulls)
   cudf::test::print(sorted_result->get_column(2).view(), std::cout, ",\t\t");
   cudf::test::print(sorted_result->get_column(3).view(), std::cout, ",\t\t");
 #endif
- 
-  column_wrapper<int32_t> col_gold_0{{   2,    5,    3,    -1},
-                                     {   1,    1,    1,     0}};
-  strcol_wrapper          col_gold_1({ "s1", "s0", "s0",  "s1"});
-  column_wrapper<int32_t> col_gold_2{{  -1,   -1,    0,     1}, 
-                                     {   0,    0,    1,     1}};
-  column_wrapper<int32_t> col_gold_3{{   1,    4,    2,     8}, 
-                                     {   1,    1,    1,     1}};
+
+  column_wrapper<int32_t> col_gold_0{{2, 5, 3, -1}, {1, 1, 1, 0}};
+  strcol_wrapper col_gold_1({"s1", "s0", "s0", "s1"});
+  column_wrapper<int32_t> col_gold_2{{-1, -1, 0, 1}, {0, 0, 1, 1}};
+  column_wrapper<int32_t> col_gold_3{{1, 4, 2, 8}, {1, 1, 1, 1}};
 
   CVector cols_gold;
   cols_gold.push_back(col_gold_0.release());
@@ -279,18 +274,15 @@ TEST_F(JoinTest, FullJoinOnNulls)
   // Repeat test with compare_nulls_equal=false,
   // as per SQL standard.
 
-  result            = cudf::full_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
+  result = cudf::full_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
   result_sort_order = cudf::sorted_order(result->view());
   sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
-  col_gold_0 =               {{   2,    5,    3,    -1,   -1},
-                              {   1,    1,    1,     0,    0}};
-  col_gold_1 = strcol_wrapper({ "s1", "s0", "s0",  "s1", "s1"});
-  col_gold_2 =               {{  -1,   -1,    0,    -1,    1}, 
-                              {   0,    0,    1,     0,    2}};
-  col_gold_3 =               {{   1,    4,    2,     8,   -1}, 
-                              {   1,    1,    1,     1,    0}};
-  
+  col_gold_0 = {{2, 5, 3, -1, -1}, {1, 1, 1, 0, 0}};
+  col_gold_1 = strcol_wrapper({"s1", "s0", "s0", "s1", "s1"});
+  col_gold_2 = {{-1, -1, 0, -1, 1}, {0, 0, 1, 0, 2}};
+  col_gold_3 = {{1, 4, 2, 8, -1}, {1, 1, 1, 1, 0}};
+
   CVector cols_gold_nulls_unequal;
   cols_gold_nulls_unequal.push_back(col_gold_0.release());
   cols_gold_nulls_unequal.push_back(col_gold_1.release());
@@ -388,15 +380,13 @@ TEST_F(JoinTest, LeftJoinWithNulls)
 
 TEST_F(JoinTest, LeftJoinOnNulls)
 {
-  column_wrapper<int32_t> col0_0{{  3,    1,    2},
-                                 {  1,    0,    1}};
-  strcol_wrapper          col0_1({"s0", "s1", "s2" });
-  column_wrapper<int32_t> col0_2{{  0,    1,    2 }};
+  column_wrapper<int32_t> col0_0{{3, 1, 2}, {1, 0, 1}};
+  strcol_wrapper col0_1({"s0", "s1", "s2"});
+  column_wrapper<int32_t> col0_2{{0, 1, 2}};
 
-  column_wrapper<int32_t> col1_0{{  2,    5,    3,    7 },
-                                 {  1,    1,    1,    0 }};
-  strcol_wrapper          col1_1({"s1", "s0", "s0", "s1" });
-  column_wrapper<int32_t> col1_2{{  1,    4,    2,    8 }};
+  column_wrapper<int32_t> col1_0{{2, 5, 3, 7}, {1, 1, 1, 0}};
+  strcol_wrapper col1_1({"s1", "s0", "s0", "s1"});
+  column_wrapper<int32_t> col1_2{{1, 4, 2, 8}};
 
   CVector cols0, cols1;
   cols0.push_back(col0_0.release());
@@ -420,15 +410,11 @@ TEST_F(JoinTest, LeftJoinOnNulls)
   cudf::test::print(sorted_result->get_column(2).view(), std::cout, ",\t\t");
   cudf::test::print(sorted_result->get_column(3).view(), std::cout, ",\t\t");
 #endif
- 
-  column_wrapper<int32_t> col_gold_0{{   3,    -1,    2},
-                                     {   1,     0,    1}};
-  strcol_wrapper          col_gold_1({ "s0",  "s1", "s2"},
-                                     {   1,     1,    1});
-  column_wrapper<int32_t> col_gold_2{{   0,     1,    2}, 
-                                     {   1,     1,    1}};
-  column_wrapper<int32_t> col_gold_3{{   2,     8,   -1}, 
-                                     {   1,     1,    0}};
+
+  column_wrapper<int32_t> col_gold_0{{3, -1, 2}, {1, 0, 1}};
+  strcol_wrapper col_gold_1({"s0", "s1", "s2"}, {1, 1, 1});
+  column_wrapper<int32_t> col_gold_2{{0, 1, 2}, {1, 1, 1}};
+  column_wrapper<int32_t> col_gold_3{{2, 8, -1}, {1, 1, 0}};
 
   CVector cols_gold;
   cols_gold.push_back(col_gold_0.release());
@@ -453,18 +439,14 @@ TEST_F(JoinTest, LeftJoinOnNulls)
   // Repeat test with compare_nulls_equal=false,
   // as per SQL standard.
 
-  result            = cudf::left_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
+  result = cudf::left_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
   result_sort_order = cudf::sorted_order(result->view());
   sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
-  col_gold_0 =               {{   3,    -1,    2},
-                              {   1,     0,    1}};
-  col_gold_1 = strcol_wrapper({ "s0",  "s1", "s2"},
-                              {   1,     1,    1});
-  col_gold_2 =               {{   0,     1,    2}, 
-                              {   1,     1,    1}};
-  col_gold_3 =               {{   2,    -1,   -1}, 
-                              {   1,     0,    0}};
+  col_gold_0 = {{3, -1, 2}, {1, 0, 1}};
+  col_gold_1 = strcol_wrapper({"s0", "s1", "s2"}, {1, 1, 1});
+  col_gold_2 = {{0, 1, 2}, {1, 1, 1}};
+  col_gold_3 = {{2, -1, -1}, {1, 0, 0}};
 
   CVector cols_gold_nulls_unequal;
   cols_gold_nulls_unequal.push_back(col_gold_0.release());
@@ -564,15 +546,13 @@ TEST_F(JoinTest, InnerJoinWithNulls)
 // Test to check join behaviour when join keys are null.
 TEST_F(JoinTest, InnerJoinOnNulls)
 {
-  column_wrapper<int32_t> col0_0{{  3,    1,    2,    0,    2}};
-  strcol_wrapper          col0_1({"s1", "s1", "s8", "s4", "s0"}, 
-                                 {  1,    1,    0,    1,    1});
-  column_wrapper<int32_t> col0_2{{  0,    1,    2,    4,    1}};
+  column_wrapper<int32_t> col0_0{{3, 1, 2, 0, 2}};
+  strcol_wrapper col0_1({"s1", "s1", "s8", "s4", "s0"}, {1, 1, 0, 1, 1});
+  column_wrapper<int32_t> col0_2{{0, 1, 2, 4, 1}};
 
-  column_wrapper<int32_t> col1_0{{  2,    2,    0,    4,    3}};
-  strcol_wrapper          col1_1({"s1", "s0", "s1", "s2", "s1"}, 
-                                 {  1,    0,    1,    1,    1});
-  column_wrapper<int32_t> col1_2{{  1,    0,    1,    2,    1}};
+  column_wrapper<int32_t> col1_0{{2, 2, 0, 4, 3}};
+  strcol_wrapper col1_1({"s1", "s0", "s1", "s2", "s1"}, {1, 0, 1, 1, 1});
+  column_wrapper<int32_t> col1_2{{1, 0, 1, 2, 1}};
 
   CVector cols0, cols1;
   cols0.push_back(col0_0.release());
@@ -589,11 +569,10 @@ TEST_F(JoinTest, InnerJoinOnNulls)
   auto result_sort_order = cudf::sorted_order(result->view());
   auto sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
-  column_wrapper<int32_t> col_gold_0 {{  3,    2}};
-  strcol_wrapper          col_gold_1 ({"s1", "s0"}, 
-                                      {  1,    0});
-  column_wrapper<int32_t> col_gold_2{{   0,    2}};
-  column_wrapper<int32_t> col_gold_3{{   1,    0}};
+  column_wrapper<int32_t> col_gold_0{{3, 2}};
+  strcol_wrapper col_gold_1({"s1", "s0"}, {1, 0});
+  column_wrapper<int32_t> col_gold_2{{0, 2}};
+  column_wrapper<int32_t> col_gold_3{{1, 0}};
   CVector cols_gold;
   cols_gold.push_back(col_gold_0.release());
   cols_gold.push_back(col_gold_1.release());
@@ -604,19 +583,18 @@ TEST_F(JoinTest, InnerJoinOnNulls)
   auto gold_sort_order = cudf::sorted_order(gold.view());
   auto sorted_gold     = cudf::gather(gold.view(), *gold_sort_order);
   cudf::test::expect_tables_equal(*sorted_gold, *sorted_result);
-  
+
   // Repeat test with compare_nulls_equal=false,
   // as per SQL standard.
 
-  result            = cudf::inner_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
+  result = cudf::inner_join(t0, t1, {0, 1}, {0, 1}, {{0, 0}, {1, 1}}, cudf::null_equality::UNEQUAL);
   result_sort_order = cudf::sorted_order(result->view());
   sorted_result     = cudf::gather(result->view(), *result_sort_order);
 
-  col_gold_0 =               {{  3}};
-  col_gold_1 = strcol_wrapper({"s1"}, 
-                              {  1});
-  col_gold_2 =               {{  0}};
-  col_gold_3 =               {{  1}};
+  col_gold_0 = {{3}};
+  col_gold_1 = strcol_wrapper({"s1"}, {1});
+  col_gold_2 = {{0}};
+  col_gold_3 = {{1}};
 
   CVector cols_gold_sql;
   cols_gold_sql.push_back(col_gold_0.release());

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -349,19 +349,19 @@ public final class Table implements AutoCloseable {
                                        boolean[] areNullsSmallest) throws CudfException;
 
   private static native long[] leftJoin(long leftTable, int[] leftJoinCols, long rightTable,
-                                        int[] rightJoinCols) throws CudfException;
+                                        int[] rightJoinCols, boolean compareNullsEqual) throws CudfException;
 
   private static native long[] innerJoin(long leftTable, int[] leftJoinCols, long rightTable,
-                                         int[] rightJoinCols) throws CudfException;
+                                         int[] rightJoinCols, boolean compareNullsEqual) throws CudfException;
 
   private static native long[] fullJoin(long leftTable, int[] leftJoinCols, long rightTable,
-                                         int[] rightJoinCols) throws CudfException;
+                                         int[] rightJoinCols, boolean compareNullsEqual) throws CudfException;
 
   private static native long[] leftSemiJoin(long leftTable, int[] leftJoinCols, long rightTable,
-      int[] rightJoinCols) throws CudfException;
+      int[] rightJoinCols, boolean compareNullsEqual) throws CudfException;
 
   private static native long[] leftAntiJoin(long leftTable, int[] leftJoinCols, long rightTable,
-      int[] rightJoinCols) throws CudfException;
+      int[] rightJoinCols, boolean compareNullsEqual) throws CudfException;
 
   private static native long[] crossJoin(long leftTable, long rightTable) throws CudfException;
 
@@ -1626,12 +1626,14 @@ public final class Table implements AutoCloseable {
      * Table t2 ...
      * Table result = t1.onColumns(0,1).leftJoin(t2.onColumns(2,3));
      * @param rightJoinIndices - Indices of the right table to join on
+     * @param compareNullsEqual - Whether null join-key values should match or not.
      * @return the joined table.  The order of the columns returned will be join columns,
      * left non-join columns, right non-join columns.
      */
-    public Table leftJoin(TableOperation rightJoinIndices) {
+    public Table leftJoin(TableOperation rightJoinIndices, boolean compareNullsEqual) {
       return new Table(Table.leftJoin(operation.table.nativeHandle, operation.indices,
-          rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices));
+          rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices,
+          compareNullsEqual));
     }
 
     /**
@@ -1641,12 +1643,14 @@ public final class Table implements AutoCloseable {
      * Table t2 ...
      * Table result = t1.onColumns(0,1).innerJoin(t2.onColumns(2,3));
      * @param rightJoinIndices - Indices of the right table to join on
+     * @param compareNullsEqual - Whether null join-key values should match or not.
      * @return the joined table.  The order of the columns returned will be join columns,
      * left non-join columns, right non-join columns.
      */
-    public Table innerJoin(TableOperation rightJoinIndices) {
+    public Table innerJoin(TableOperation rightJoinIndices, boolean compareNullsEqual) {
       return new Table(Table.innerJoin(operation.table.nativeHandle, operation.indices,
-          rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices));
+          rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices,
+          compareNullsEqual));
     }
 
     /**
@@ -1656,12 +1660,14 @@ public final class Table implements AutoCloseable {
      * Table t2 ...
      * Table result = t1.onColumns(0,1).fullJoin(t2.onColumns(2,3));
      * @param rightJoinIndices - Indices of the right table to join on
+     * @param compareNullsEqual - Whether null join-key values should match or not.
      * @return the joined table.  The order of the columns returned will be join columns,
      * left non-join columns, right non-join columns.
      */
-    public Table fullJoin(TableOperation rightJoinIndices) {
+    public Table fullJoin(TableOperation rightJoinIndices, boolean compareNullsEqual) {
       return new Table(Table.fullJoin(operation.table.nativeHandle, operation.indices,
-              rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices));
+              rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices,
+              compareNullsEqual));
     }
 
     /**
@@ -1672,11 +1678,13 @@ public final class Table implements AutoCloseable {
      * Table t2 ...
      * Table result = t1.onColumns(0,1).leftSemiJoin(t2.onColumns(2,3));
      * @param rightJoinIndices - Indices of the right table to join on
+     * @param compareNullsEqual - Whether null join-key values should match or not.
      * @return the left semi-joined table.
      */
-    public Table leftSemiJoin(TableOperation rightJoinIndices) {
+    public Table leftSemiJoin(TableOperation rightJoinIndices, boolean compareNullsEqual) {
       return new Table(Table.leftSemiJoin(operation.table.nativeHandle, operation.indices,
-          rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices));
+          rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices,
+          compareNullsEqual));
     }
 
     /**
@@ -1687,11 +1695,13 @@ public final class Table implements AutoCloseable {
      * Table t2 ...
      * Table result = t1.onColumns(0,1).leftAntiJoin(t2.onColumns(2,3));
      * @param rightJoinIndices - Indices of the right table to join on
+     * @param compareNullsEqual - Whether null join-key values should match or not.
      * @return the left anti-joined table.
      */
-    public Table leftAntiJoin(TableOperation rightJoinIndices) {
+    public Table leftAntiJoin(TableOperation rightJoinIndices, boolean compareNullsEqual) {
       return new Table(Table.leftAntiJoin(operation.table.nativeHandle, operation.indices,
-          rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices));
+          rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices,
+          compareNullsEqual));
     }
 
     /**

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -1641,6 +1641,20 @@ public final class Table implements AutoCloseable {
      * Usage:
      * Table t1 ...
      * Table t2 ...
+     * Table result = t1.onColumns(0,1).leftJoin(t2.onColumns(2,3));
+     * @param rightJoinIndices - Indices of the right table to join on
+     * @return the joined table.  The order of the columns returned will be join columns,
+     * left non-join columns, right non-join columns.
+     */
+    public Table leftJoin(TableOperation rightJoinIndices) {
+        return leftJoin(rightJoinIndices, true);
+    }
+
+    /**
+     * Joins two tables on the join columns that are passed in.
+     * Usage:
+     * Table t1 ...
+     * Table t2 ...
      * Table result = t1.onColumns(0,1).innerJoin(t2.onColumns(2,3));
      * @param rightJoinIndices - Indices of the right table to join on
      * @param compareNullsEqual - Whether null join-key values should match or not.
@@ -1651,6 +1665,20 @@ public final class Table implements AutoCloseable {
       return new Table(Table.innerJoin(operation.table.nativeHandle, operation.indices,
           rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices,
           compareNullsEqual));
+    }
+
+    /**
+     * Joins two tables on the join columns that are passed in.
+     * Usage:
+     * Table t1 ...
+     * Table t2 ...
+     * Table result = t1.onColumns(0,1).innerJoin(t2.onColumns(2,3));
+     * @param rightJoinIndices - Indices of the right table to join on
+     * @return the joined table.  The order of the columns returned will be join columns,
+     * left non-join columns, right non-join columns.
+     */
+    public Table innerJoin(TableOperation rightJoinIndices) {
+      return innerJoin(rightJoinIndices, true);
     }
 
     /**
@@ -1671,6 +1699,20 @@ public final class Table implements AutoCloseable {
     }
 
     /**
+     * Joins two tables on the join columns that are passed in.
+     * Usage:
+     * Table t1 ...
+     * Table t2 ...
+     * Table result = t1.onColumns(0,1).fullJoin(t2.onColumns(2,3));
+     * @param rightJoinIndices - Indices of the right table to join on
+     * @return the joined table.  The order of the columns returned will be join columns,
+     * left non-join columns, right non-join columns.
+     */
+    public Table fullJoin(TableOperation rightJoinIndices) {
+      return fullJoin(rightJoinIndices, true);
+    }
+
+    /**
      * Performs a semi-join between a left table and a right table, returning only the rows from
      * the left table that match rows in the right table on the join keys.
      * Usage:
@@ -1688,6 +1730,20 @@ public final class Table implements AutoCloseable {
     }
 
     /**
+     * Performs a semi-join between a left table and a right table, returning only the rows from
+     * the left table that match rows in the right table on the join keys.
+     * Usage:
+     * Table t1 ...
+     * Table t2 ...
+     * Table result = t1.onColumns(0,1).leftSemiJoin(t2.onColumns(2,3));
+     * @param rightJoinIndices - Indices of the right table to join on
+     * @return the left semi-joined table.
+     */
+    public Table leftSemiJoin(TableOperation rightJoinIndices) {
+      return leftSemiJoin(rightJoinIndices, true);
+    }
+
+    /**
      * Performs an anti-join between a left table and a right table, returning only the rows from
      * the left table that do not match rows in the right table on the join keys.
      * Usage:
@@ -1702,6 +1758,20 @@ public final class Table implements AutoCloseable {
       return new Table(Table.leftAntiJoin(operation.table.nativeHandle, operation.indices,
           rightJoinIndices.operation.table.nativeHandle, rightJoinIndices.operation.indices,
           compareNullsEqual));
+    }
+
+    /**
+     * Performs an anti-join between a left table and a right table, returning only the rows from
+     * the left table that do not match rows in the right table on the join keys.
+     * Usage:
+     * Table t1 ...
+     * Table t2 ...
+     * Table result = t1.onColumns(0,1).leftAntiJoin(t2.onColumns(2,3));
+     * @param rightJoinIndices - Indices of the right table to join on
+     * @return the left anti-joined table.
+     */
+    public Table leftAntiJoin(TableOperation rightJoinIndices) {
+      return leftAntiJoin(rightJoinIndices, true);
     }
 
     /**

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -779,7 +779,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftJoin(JNIEnv *env, jcl
                                                                 jlong left_table,
                                                                 jintArray left_col_join_indices,
                                                                 jlong right_table,
-                                                                jintArray right_col_join_indices) {
+                                                                jintArray right_col_join_indices,
+                                                                jboolean compare_nulls_equal) {
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
   JNI_NULL_CHECK(env, left_col_join_indices, "left_col_join_indices is null", NULL);
   JNI_NULL_CHECK(env, right_table, "right_table is null", NULL);
@@ -804,7 +805,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftJoin(JNIEnv *env, jcl
     }
 
     std::unique_ptr<cudf::table> result =
-        cudf::left_join(*n_left_table, *n_right_table, left_join_cols, right_join_cols, dedupe);
+        cudf::left_join(*n_left_table, *n_right_table, left_join_cols, right_join_cols, dedupe,
+            static_cast<bool>(compare_nulls_equal)? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL);
 
     return cudf::jni::convert_table_for_return(env, result);
   }
@@ -815,7 +817,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerJoin(JNIEnv *env, jc
                                                                  jlong left_table,
                                                                  jintArray left_col_join_indices,
                                                                  jlong right_table,
-                                                                 jintArray right_col_join_indices) {
+                                                                 jintArray right_col_join_indices,
+                                                                 jboolean compare_nulls_equal) {
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
   JNI_NULL_CHECK(env, left_col_join_indices, "left_col_join_indices is null", NULL);
   JNI_NULL_CHECK(env, right_table, "right_table is null", NULL);
@@ -840,7 +843,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerJoin(JNIEnv *env, jc
     }
 
     std::unique_ptr<cudf::table> result =
-        cudf::inner_join(*n_left_table, *n_right_table, left_join_cols, right_join_cols, dedupe);
+        cudf::inner_join(*n_left_table, *n_right_table, left_join_cols, right_join_cols, dedupe,
+            static_cast<bool>(compare_nulls_equal)? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL);
 
     return cudf::jni::convert_table_for_return(env, result);
   }
@@ -851,7 +855,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_fullJoin(JNIEnv *env, jcl
                                                                 jlong left_table,
                                                                 jintArray left_col_join_indices,
                                                                 jlong right_table,
-                                                                jintArray right_col_join_indices) {
+                                                                jintArray right_col_join_indices,
+                                                                jboolean compare_nulls_equal) {
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
   JNI_NULL_CHECK(env, left_col_join_indices, "left_col_join_indices is null", NULL);
   JNI_NULL_CHECK(env, right_table, "right_table is null", NULL);
@@ -876,7 +881,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_fullJoin(JNIEnv *env, jcl
     }
 
     std::unique_ptr<cudf::table> result =
-        cudf::full_join(*n_left_table, *n_right_table, left_join_cols, right_join_cols, dedupe);
+        cudf::full_join(*n_left_table, *n_right_table, left_join_cols, right_join_cols, dedupe,
+            static_cast<bool>(compare_nulls_equal)? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL);
 
     return cudf::jni::convert_table_for_return(env, result);
   }
@@ -885,7 +891,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_fullJoin(JNIEnv *env, jcl
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftSemiJoin(
     JNIEnv *env, jclass, jlong left_table, jintArray left_col_join_indices, jlong right_table,
-    jintArray right_col_join_indices) {
+    jintArray right_col_join_indices, jboolean compare_nulls_equal) {
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
   JNI_NULL_CHECK(env, left_col_join_indices, "left_col_join_indices is null", NULL);
   JNI_NULL_CHECK(env, right_table, "right_table is null", NULL);
@@ -907,7 +913,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftSemiJoin(
     }
 
     std::unique_ptr<cudf::table> result = cudf::left_semi_join(
-        *n_left_table, *n_right_table, left_join_cols, right_join_cols, return_cols);
+        *n_left_table, *n_right_table, left_join_cols, right_join_cols, return_cols,
+          static_cast<bool>(compare_nulls_equal)? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL);
 
     return cudf::jni::convert_table_for_return(env, result);
   }
@@ -916,7 +923,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftSemiJoin(
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftAntiJoin(
     JNIEnv *env, jclass, jlong left_table, jintArray left_col_join_indices, jlong right_table,
-    jintArray right_col_join_indices) {
+    jintArray right_col_join_indices, jboolean compare_nulls_equal) {
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
   JNI_NULL_CHECK(env, left_col_join_indices, "left_col_join_indices is null", NULL);
   JNI_NULL_CHECK(env, right_table, "right_table is null", NULL);
@@ -938,7 +945,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftAntiJoin(
     }
 
     std::unique_ptr<cudf::table> result = cudf::left_anti_join(
-        *n_left_table, *n_right_table, left_join_cols, right_join_cols, return_cols);
+        *n_left_table, *n_right_table, left_join_cols, right_join_cols, return_cols,
+            static_cast<bool>(compare_nulls_equal)? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL);
 
     return cudf::jni::convert_table_for_return(env, result);
   }

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -695,7 +695,7 @@ public class TableTest extends CudfTestBase {
 
            Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0));
            Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
-           assertTablesAreEqual(expectedResults, orderedJoinedTable);
+         assertTablesAreEqual(expectedResults, orderedJoinedTable);
        }
 
        try (Table expectedResults = new Table.TestBuilder()

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -669,7 +669,7 @@ public class TableTest extends CudfTestBase {
              .column( 100,  101, 102,  103,  104,  105,  106, 107, 108, 109) // left
              .column(null, null, 203, null, null, null, null, 201, 202, 204) // right
              .build();
-         Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0));
+         Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
@@ -685,7 +685,7 @@ public class TableTest extends CudfTestBase {
              .column(306, 301, 360, 109, 335, 254, 317, 361, 251, 326)
              .column( 20,  21,  22,  23,  24,  25,  26,  27,  28,  29)
              .build();
-         Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(new int[]{0}));
+         Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(new int[]{0}), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true));
          Table expected = new Table.TestBuilder()
              .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317) // common
@@ -711,7 +711,7 @@ public class TableTest extends CudfTestBase {
                  .column( 103,  104,  100,  101,  106, 108, 107,  105, 109, 102, null, null) // left
                  .column(null, null, null, null, null, 201, 200, null, 203, 202,  204,  205) // right
                  .build();
-         Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0));
+         Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(0, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
@@ -727,7 +727,7 @@ public class TableTest extends CudfTestBase {
                  .column(306, 301, 360, 109, 335, 254, 317, 361, 251, 326)
                  .column(200, 201, 202, 203, 204, 205, 206, 207, 208, 209)
                  .build();
-         Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(new int[]{0}));
+         Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(new int[]{0}), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true));
          Table expected = new Table.TestBuilder()
                  .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317) // common
@@ -753,7 +753,7 @@ public class TableTest extends CudfTestBase {
              .column(102, 107, 108, 109) // left
              .column(202, 200, 201, 203) // right
              .build();
-         Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0));
+         Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
@@ -769,7 +769,7 @@ public class TableTest extends CudfTestBase {
              .column(306, 301, 360, 109, 335, 254, 317, 361, 251, 326)
              .column(200, 201, 202, 203, 204, 205, 206, 207, 208, 209)
              .build();
-         Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(new int[]{0}));
+         Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(new int[]{0}), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true));
          Table expected = new Table.TestBuilder()
              .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317) // common
@@ -794,7 +794,7 @@ public class TableTest extends CudfTestBase {
              .column(  9,   6,   5,   8)
              .column(102, 107, 108, 109)
              .build();
-         Table joinedTable = leftTable.onColumns(0).leftSemiJoin(rightTable.onColumns(0));
+         Table joinedTable = leftTable.onColumns(0).leftSemiJoin(rightTable.onColumns(0), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
@@ -811,7 +811,7 @@ public class TableTest extends CudfTestBase {
              .column( 306,  301,  360,  109,  335,  254,  317,  361,  251,  326)
              .column("20", "21", "22", "23", "24", "25", "26", "27", "28", "29")
              .build();
-         Table joinedTable = leftTable.onColumns(0, 2).leftSemiJoin(rightTable.onColumns(0, 1));
+         Table joinedTable = leftTable.onColumns(0, 2).leftSemiJoin(rightTable.onColumns(0, 1), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(0, true));
          Table expected = new Table.TestBuilder()
              .column(254,   326,   361)
@@ -836,7 +836,7 @@ public class TableTest extends CudfTestBase {
              .column(  2,   3,   0,   1,   7,   4)
              .column(100, 101, 103, 104, 105, 106)
              .build();
-         Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0));
+         Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
@@ -853,7 +853,7 @@ public class TableTest extends CudfTestBase {
              .column( 306,  301,  360,  109,  335,  254,  317,  361,  251,  326)
              .column("20", "21", "22", "23", "24", "25", "26", "27", "28", "29")
              .build();
-         Table joinedTable = leftTable.onColumns(0, 2).leftAntiJoin(rightTable.onColumns(0, 1));
+         Table joinedTable = leftTable.onColumns(0, 2).leftAntiJoin(rightTable.onColumns(0, 1), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(2, true));
          Table expected = new Table.TestBuilder()
              .column( 360,  326, null,  306, null,  251,  301,  317)

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -675,6 +675,41 @@ public class TableTest extends CudfTestBase {
     }
   }
 
+ @Test
+  void testLeftJoinOnNullKeys() {
+    try (Table leftTable = new Table.TestBuilder()
+        .column(  2,   3,   9,   0,   1,   7,   4, null, null,   8)
+        .column(100, 101, 102, 103, 104, 105, 106,  107,  108, 109)
+        .build();
+         
+         Table rightTable = new Table.TestBuilder()
+             .column(null, null,   9,   8,  10,  32)
+             .column( 201,  202, 203, 204, 205, 206)
+             .build();
+
+         Table expectedResultsWithNullsEqual = new Table.TestBuilder()
+             .column(   2,    3,   9,    0,    1,    7,    4, null, null, null, null,   8) // common
+             .column( 100,  101, 102,  103,  104,  105,  106,  107,  107,  108,  108, 109) // left
+             .column(null, null, 203, null, null, null, null,  201,  202,  201,  202, 204) // right
+             .build();
+
+         Table joinedTableWithNullsEqual = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), true);
+         Table orderedJoinedTableWithNullsEqual = joinedTableWithNullsEqual.orderBy(Table.asc(1, true));
+
+         Table expectedResultsWithNullsUnequal = new Table.TestBuilder()
+             .column(   2,    3,   9,    0,    1,    7,    4, null, null,    8) // common
+             .column( 100,  101, 102,  103,  104,  105,  106,  107,  108,  109) // left
+             .column(null, null, 203, null, null, null, null, null, null,  204) // right
+             .build();
+
+         Table joinedTableWithNullsUnequal = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), false);
+         Table orderedJoinedTableWithNullsUnequal = joinedTableWithNullsUnequal.orderBy(Table.asc(1, true))) {
+
+      assertTablesAreEqual(expectedResultsWithNullsEqual, orderedJoinedTableWithNullsEqual);
+      assertTablesAreEqual(expectedResultsWithNullsUnequal, orderedJoinedTableWithNullsUnequal);
+    }
+  }
+
   @Test
   void testLeftJoin() {
     try (Table leftTable = new Table.TestBuilder()
@@ -685,7 +720,7 @@ public class TableTest extends CudfTestBase {
              .column(306, 301, 360, 109, 335, 254, 317, 361, 251, 326)
              .column( 20,  21,  22,  23,  24,  25,  26,  27,  28,  29)
              .build();
-         Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(new int[]{0}), true);
+         Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true));
          Table expected = new Table.TestBuilder()
              .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317) // common
@@ -714,6 +749,42 @@ public class TableTest extends CudfTestBase {
          Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(0, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
+    }
+  }
+
+  @Test
+  void testFullJoinOnNullKeys() {
+    try (Table leftTable = new Table.TestBuilder()
+            .column(  2,   3, null,   0,   1,   7,   4, null,   5,   8)
+            .column(100, 101,  102, 103, 104, 105, 106,  107, 108, 109)
+            .build();
+         Table rightTable = new Table.TestBuilder()
+                 .column(null,   5, null,   8,  10,  32)
+                 .column( 200, 201,  202, 203, 204, 205)
+                 .build()) {
+
+      // First, test that null-key rows match, with compareNullsEqual=true.
+      try (Table expectedResults = new Table.TestBuilder()
+              .column(null, null, null, null,    0,    1,    2,    3,    4,   5,    7,   8,   10,   32) // common
+              .column( 102,  102,  107,  107,  103,  104,  100,  101,  106, 108,  105, 109, null, null) // left
+              .column( 200,  202,  200,  202, null, null, null, null, null, 201, null, 203,  204,  205) // right
+              .build();
+           Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0), true);
+           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(0, true), Table.asc(1, true))) {
+        assertTablesAreEqual(expectedResults, orderedJoinedTable);
+      }
+
+      // Next, test that null-key rows do not match, with compareNullsEqual=false.
+      try (Table expectedResults = new Table.TestBuilder()
+              .column(null, null, null, null,    0,    1,    2,    3,    4,   5,    7,   8,   10,   32) // common
+              .column(null, null,  102,  107,  103,  104,  100,  101,  106, 108,  105, 109, null, null) // left
+              .column( 200,  202, null, null, null, null, null, null, null, 201, null, 203,  204,  205) // right
+              .build();
+           Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0), false);
+           Table orderedJoinedTable = joinedTable.orderBy(
+                   Table.asc(0, true), Table.asc(1, true), Table.asc(2, true))) {
+        assertTablesAreEqual(expectedResults, orderedJoinedTable);
+      }
     }
   }
 
@@ -756,6 +827,41 @@ public class TableTest extends CudfTestBase {
          Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
+    }
+  }
+
+  @Test
+  void testInnerJoinOnNullKeys() {
+    try (Table leftTable = new Table.TestBuilder()
+             .column(  2,   3,   9,   0,   1,   7,   4,   6, null,   8)
+             .column(100, 101, 102, 103, 104, 105, 106, 107,  108, 109)
+             .build();
+         Table rightTable = new Table.TestBuilder()
+             .column(  6, null,   9,   8,  10,  32)
+             .column(200,  201, 202, 203, 204, 205)
+             .build()) {
+
+      // First, test that null-key rows match, with compareNullsEqual=true.
+      try (Table expected = new Table.TestBuilder()
+             .column(  9,   6, null,   8) // common
+             .column(102, 107,  108, 109) // left
+             .column(202, 200,  201, 203) // right
+             .build();
+         Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0), true);
+         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+        assertTablesAreEqual(expected, orderedJoinedTable);
+      }
+
+      // Next, test that null-key rows do not match, with compareNullsEqual=false.
+      try (Table expected = new Table.TestBuilder()
+              .column(  9,   6,    8) // common
+              .column(102, 107,  109) // left
+              .column(202, 200,  203) // right
+              .build();
+           Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0), false);
+           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))){
+        assertTablesAreEqual(expected, orderedJoinedTable);
+      }
     }
   }
 
@@ -823,6 +929,39 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
+  void testLeftSemiJoinOnNullKeys() {
+    try (Table leftTable = new Table.TestBuilder()
+            .column(  2,   3,   9,   0,   1,   7,   4,   6, null,   8)
+            .column(100, 101, 102, 103, 104, 105, 106, 107,  108, 109)
+            .build();
+         Table rightTable = new Table.TestBuilder()
+                 .column(  6, null,   9,   8,  10,  32)
+                 .column(201,  202, 203, 204, 205, 206)
+                 .build()) {
+
+       // First, test that null-key rows match, with compareNullsEqual=true.
+       try (Table expected = new Table.TestBuilder()
+               .column(  9,   6, null,   8)
+               .column(102, 107,  108, 109)
+               .build();
+            Table joinedTable = leftTable.onColumns(0).leftSemiJoin(rightTable.onColumns(0), true);
+            Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+          assertTablesAreEqual(expected, orderedJoinedTable);
+       }
+
+      // Next, test that null-key rows do not match, with compareNullsEqual=false.
+      try (Table expected = new Table.TestBuilder()
+              .column(  9,   6,   8)
+              .column(102, 107, 109)
+              .build();
+           Table joinedTable = leftTable.onColumns(0).leftSemiJoin(rightTable.onColumns(0), false);
+           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+        assertTablesAreEqual(expected, orderedJoinedTable);
+      }
+    }
+  }
+
+  @Test
   void testLeftAntiJoin() {
     try (Table leftTable = new Table.TestBuilder()
         .column(  2,   3,   9,   0,   1,   7,   4,   6,   5,   8)
@@ -839,6 +978,39 @@ public class TableTest extends CudfTestBase {
          Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0), true);
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
+    }
+  }
+
+  @Test
+  void testLeftAntiJoinOnNullKeys() {
+    try (Table leftTable = new Table.TestBuilder()
+            .column(  2,   3,   9,   0,   1,   7,   4,   6, null,   8)
+            .column(100, 101, 102, 103, 104, 105, 106, 107,  108, 109)
+            .build();
+         Table rightTable = new Table.TestBuilder()
+                 .column(  6, null,   9,   8,  10,  32)
+                 .column(201,  202, 203, 204, 205, 206)
+                 .build()) {
+
+      // First, test that null-key rows match, with compareNullsEqual=true.
+      try (Table expected = new Table.TestBuilder()
+              .column(  2,   3,   0,   1,   7,   4)
+              .column(100, 101, 103, 104, 105, 106)
+              .build();
+           Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0), true);
+           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+        assertTablesAreEqual(expected, orderedJoinedTable);
+      }
+
+      // Next, test that null-key rows do not match, with compareNullsEqual=false.
+      try (Table expected = new Table.TestBuilder()
+              .column(  2,   3,   0,   1,   7,   4, null)
+              .column(100, 101, 103, 104, 105, 106,  108)
+              .build();
+           Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0), false);
+           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+        assertTablesAreEqual(expected, orderedJoinedTable);
+      }
     }
   }
 

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -685,28 +685,29 @@ public class TableTest extends CudfTestBase {
          Table rightTable = new Table.TestBuilder()
              .column(null, null,   9,   8,  10,  32)
              .column( 201,  202, 203, 204, 205, 206)
-             .build();
+             .build()) {
 
-         Table expectedResultsWithNullsEqual = new Table.TestBuilder()
-             .column(   2,    3,   9,    0,    1,    7,    4, null, null, null, null,   8) // common
-             .column( 100,  101, 102,  103,  104,  105,  106,  107,  107,  108,  108, 109) // left
-             .column(null, null, 203, null, null, null, null,  201,  202,  201,  202, 204) // right
-             .build();
+       try (Table expectedResults = new Table.TestBuilder()
+           .column(   2,    3,   9,    0,    1,    7,    4, null, null, null, null,   8) // common
+           .column( 100,  101, 102,  103,  104,  105,  106,  107,  107,  108,  108, 109) // left
+           .column(null, null, 203, null, null, null, null,  201,  202,  201,  202, 204) // right
+           .build();
 
-         Table joinedTableWithNullsEqual = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), true);
-         Table orderedJoinedTableWithNullsEqual = joinedTableWithNullsEqual.orderBy(Table.asc(1, true));
+           Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0));
+           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+           assertTablesAreEqual(expectedResults, orderedJoinedTable);
+       }
 
-         Table expectedResultsWithNullsUnequal = new Table.TestBuilder()
-             .column(   2,    3,   9,    0,    1,    7,    4, null, null,    8) // common
-             .column( 100,  101, 102,  103,  104,  105,  106,  107,  108,  109) // left
-             .column(null, null, 203, null, null, null, null, null, null,  204) // right
-             .build();
+       try (Table expectedResults = new Table.TestBuilder()
+           .column(   2,    3,   9,    0,    1,    7,    4, null, null,    8) // common
+           .column( 100,  101, 102,  103,  104,  105,  106,  107,  108,  109) // left
+           .column(null, null, 203, null, null, null, null, null, null,  204) // right
+           .build();
 
-         Table joinedTableWithNullsUnequal = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), false);
-         Table orderedJoinedTableWithNullsUnequal = joinedTableWithNullsUnequal.orderBy(Table.asc(1, true))) {
-
-      assertTablesAreEqual(expectedResultsWithNullsEqual, orderedJoinedTableWithNullsEqual);
-      assertTablesAreEqual(expectedResultsWithNullsUnequal, orderedJoinedTableWithNullsUnequal);
+           Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), false);
+           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+         assertTablesAreEqual(expectedResults, orderedJoinedTable);
+       }
     }
   }
 
@@ -769,7 +770,7 @@ public class TableTest extends CudfTestBase {
               .column( 102,  102,  107,  107,  103,  104,  100,  101,  106, 108,  105, 109, null, null) // left
               .column( 200,  202,  200,  202, null, null, null, null, null, 201, null, 203,  204,  205) // right
               .build();
-           Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0), true);
+           Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0));
            Table orderedJoinedTable = joinedTable.orderBy(Table.asc(0, true), Table.asc(1, true))) {
         assertTablesAreEqual(expectedResults, orderedJoinedTable);
       }
@@ -847,7 +848,7 @@ public class TableTest extends CudfTestBase {
              .column(102, 107,  108, 109) // left
              .column(202, 200,  201, 203) // right
              .build();
-         Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0), true);
+         Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0));
          Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
         assertTablesAreEqual(expected, orderedJoinedTable);
       }
@@ -944,7 +945,7 @@ public class TableTest extends CudfTestBase {
                .column(  9,   6, null,   8)
                .column(102, 107,  108, 109)
                .build();
-            Table joinedTable = leftTable.onColumns(0).leftSemiJoin(rightTable.onColumns(0), true);
+            Table joinedTable = leftTable.onColumns(0).leftSemiJoin(rightTable.onColumns(0));
             Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
           assertTablesAreEqual(expected, orderedJoinedTable);
        }
@@ -997,7 +998,7 @@ public class TableTest extends CudfTestBase {
               .column(  2,   3,   0,   1,   7,   4)
               .column(100, 101, 103, 104, 105, 106)
               .build();
-           Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0), true);
+           Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0));
            Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
         assertTablesAreEqual(expected, orderedJoinedTable);
       }


### PR DESCRIPTION
By default, `NULL` join keys compare as equal, in CUDF. This is consistent
with the semantics in Pandas.
However, this behaviour cannot be parameterized to follow SQL semantics
(which dictates that `NULL <> NULL`).

This commit allows the caller of `cudf::*join()` to choose between SQL
and Pandas semantics, while keeping the default behaviour intact.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
