### PR TITLE
Make Java ColumnVector(long nativePointer) constructor public [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 - PR #5602 Add support for concatenation of `Series` & `DataFrame` in `cudf.concat` when `axis=0`
 - PR #5603 Refactor JIT `parser.cpp`
 - PR #5643 Update `isort` to 5.0.4
+- PR #5662 Make Java ColumnVector(long nativePointer) constructor public
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -48,8 +48,10 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
 
   /**
    * Wrap an existing on device cudf::column with the corresponding ColumnVector.
+   * @param nativePointer host address of the cudf::column object which will be
+   *                      owned by this instance.
    */
-  ColumnVector(long nativePointer) {
+  public ColumnVector(long nativePointer) {
     assert nativePointer != 0;
     offHeap = new OffHeapState(nativePointer);
     MemoryCleaner.register(this, offHeap);


### PR DESCRIPTION
Fixes #5661

This exposes the `ColumnVector(long nativePointer)` constructor in the Java bindings to allow other Java packages to construct a `ColumnVector` instance from an existing `cudf::column` instance.