### PR TITLE
[REVIEW] Fix chunksize issue with `DataFrame.to_csv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@
 - PR #5644 Fix issue related to Dataframe init when passing in `columns`
 - PR #5664 Update conda upload versions for new supported CUDA/Python
 - PR #5656 Fix issue with incorrect docker image being used in local build script
+- PR #5671 Fix chunksize issue with `DataFrame.to_csv`
 
 # cuDF 0.14.0 (Date TBD)
 

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -515,7 +515,7 @@ void writer::impl::write(table_view const& table,
       // create string table view from str_column_vec:
       //
       auto str_table_ptr = std::make_unique<cudf::table>(std::move(str_column_vec));
-      table_view str_table_view{std::move(*str_table_ptr)};
+      auto str_table_view = str_table_ptr->view();
 
       // concatenate columns in each row into one big string column
       //(using null representation and delimiter):
@@ -524,9 +524,7 @@ void writer::impl::write(table_view const& table,
       auto str_concat_col =
         cudf::strings::concatenate(str_table_view, delimiter_str, options_.na_rep(), mr_);
 
-      strings_column_view strings_converted{std::move(*str_concat_col)};
-
-      write_chunked(strings_converted, metadata, stream);
+      write_chunked(str_concat_col->view(), metadata, stream);
     }
   }
 

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -514,7 +514,7 @@ void writer::impl::write(table_view const& table,
 
       // create string table view from str_column_vec:
       //
-      auto str_table_ptr = std::make_unique<cudf::table>(std::move(str_column_vec));
+      auto str_table_ptr  = std::make_unique<cudf::table>(std::move(str_column_vec));
       auto str_table_view = str_table_ptr->view();
 
       // concatenate columns in each row into one big string column

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -499,6 +499,8 @@ void writer::impl::write(table_view const& table,
     //
     column_to_strings_fn converter{options_, mr_};
     for (auto&& sub_view : vector_views) {
+      // Skip if the table has no rows
+      if (sub_view.num_rows() == 0) continue;
       std::vector<std::unique_ptr<column>> str_column_vec;
 
       // populate vector of string-converted columns:

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -1548,7 +1548,7 @@ def test_csv_write_chunksize_corner_case(tmpdir):
     # With this num of rows and chunksize
     # libcudf splits table such a way that it
     # will end up creating an empty table slice
-    # which caused the issue.
+    # which caused the issue 5588.
     df_fname = tmpdir.join("gdf_df_17.csv")
     df = cudf.DataFrame({"a": np.arange(10_000)})
     df.to_csv(df_fname, chunksize=1000, index=False)

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -1547,7 +1547,7 @@ def test_csv_writer_empty_dataframe(tmpdir):
 def test_csv_write_chunksize_corner_case(tmpdir):
     # With this num of rows and chunksize
     # libcudf splits table such a way that it
-    # will end up creating a empty table slice
+    # will end up creating an empty table slice
     # which caused the issue.
     df_fname = tmpdir.join("gdf_df_17.csv")
     df = cudf.DataFrame({"a": np.arange(10_000)})

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -1542,3 +1542,16 @@ def test_csv_writer_empty_dataframe(tmpdir):
 
     assert df.shape == (0, 2)
     assert all(df.dtypes == ["object", "object"])
+
+
+def test_csv_write_chunksize_corner_case(tmpdir):
+    # With this num of rows and chunksize
+    # libcudf splits table such a way that it
+    # will end up creating a empty table slice
+    # which caused the issue.
+    df_fname = tmpdir.join("gdf_df_17.csv")
+    df = cudf.DataFrame({"a": np.arange(10_000)})
+    df.to_csv(df_fname, chunksize=1000, index=False)
+    got = cudf.read_csv(df_fname)
+
+    assert_eq(df, got)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
Due to split, it introduced an empty table with `0` rows which caused this issue. 

closes #5588 