### PR TITLE
Support for JIT compilation of libcudacxx on ppc64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PR #5612 Add `is_hex` strings API
 - PR #5637 Parameterize Null comparator behaviour in Joins
 - PR #5623 Add `is_ipv4` strings API
+- PR #5674 Support JIT backend on PowerPC64
 
 ## Improvements
 

--- a/cpp/src/jit/common_headers.hpp
+++ b/cpp/src/jit/common_headers.hpp
@@ -57,6 +57,11 @@ const std::vector<std::string> compiler_flags{
   "-D_LIBCUDACXX_HAS_NO_CSTDDEF",
   "-D_LIBCUDACXX_HAS_NO_CLIMITS",
   "-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS",
+#if defined(__powerpc64__)
+  "-D__powerpc64__"
+#elif defined(__x86_64__)
+  "-D__x86_64__"
+#endif
 };
 
 const std::unordered_map<std::string, char const*> stringified_headers{

--- a/cpp/src/jit/common_headers.hpp
+++ b/cpp/src/jit/common_headers.hpp
@@ -39,7 +39,8 @@
 namespace cudf {
 namespace jit {
 
-const std::vector<std::string> compiler_flags{
+const std::vector<std::string> compiler_flags
+{
   "-std=c++14",
     // Have jitify prune unused global variables
     "-remove-unused-globals",

--- a/cpp/src/jit/common_headers.hpp
+++ b/cpp/src/jit/common_headers.hpp
@@ -50,12 +50,8 @@ const std::vector<std::string> compiler_flags{
     // __CHAR_BIT__ is from GCC, but libcxx uses it
     "-D__CHAR_BIT__=" + std::to_string(__CHAR_BIT__),
     // enable temporary workarounds to compile libcudacxx with nvrtc
-    "-D_LIBCUDACXX_HAS_NO_CTIME",
-    "-D_LIBCUDACXX_HAS_NO_WCHAR",
-    "-D_LIBCUDACXX_HAS_NO_CFLOAT",
-    "-D_LIBCUDACXX_HAS_NO_STDINT",
-    "-D_LIBCUDACXX_HAS_NO_CSTDDEF",
-    "-D_LIBCUDACXX_HAS_NO_CLIMITS",
+    "-D_LIBCUDACXX_HAS_NO_CTIME", "-D_LIBCUDACXX_HAS_NO_WCHAR", "-D_LIBCUDACXX_HAS_NO_CFLOAT",
+    "-D_LIBCUDACXX_HAS_NO_STDINT", "-D_LIBCUDACXX_HAS_NO_CSTDDEF", "-D_LIBCUDACXX_HAS_NO_CLIMITS",
     "-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS",
 #if defined(__powerpc64__)
     "-D__powerpc64__"

--- a/cpp/src/jit/common_headers.hpp
+++ b/cpp/src/jit/common_headers.hpp
@@ -41,26 +41,26 @@ namespace jit {
 
 const std::vector<std::string> compiler_flags{
   "-std=c++14",
-  // Have jitify prune unused global variables
-  "-remove-unused-globals",
-  // suppress all NVRTC warnings
-  "-w",
-  // force libcudacxx to not include system headers
-  "-D__CUDACC_RTC__",
-  // __CHAR_BIT__ is from GCC, but libcxx uses it
-  "-D__CHAR_BIT__=" + std::to_string(__CHAR_BIT__),
-  // enable temporary workarounds to compile libcudacxx with nvrtc
-  "-D_LIBCUDACXX_HAS_NO_CTIME",
-  "-D_LIBCUDACXX_HAS_NO_WCHAR",
-  "-D_LIBCUDACXX_HAS_NO_CFLOAT",
-  "-D_LIBCUDACXX_HAS_NO_STDINT",
-  "-D_LIBCUDACXX_HAS_NO_CSTDDEF",
-  "-D_LIBCUDACXX_HAS_NO_CLIMITS",
-  "-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS",
+    // Have jitify prune unused global variables
+    "-remove-unused-globals",
+    // suppress all NVRTC warnings
+    "-w",
+    // force libcudacxx to not include system headers
+    "-D__CUDACC_RTC__",
+    // __CHAR_BIT__ is from GCC, but libcxx uses it
+    "-D__CHAR_BIT__=" + std::to_string(__CHAR_BIT__),
+    // enable temporary workarounds to compile libcudacxx with nvrtc
+    "-D_LIBCUDACXX_HAS_NO_CTIME",
+    "-D_LIBCUDACXX_HAS_NO_WCHAR",
+    "-D_LIBCUDACXX_HAS_NO_CFLOAT",
+    "-D_LIBCUDACXX_HAS_NO_STDINT",
+    "-D_LIBCUDACXX_HAS_NO_CSTDDEF",
+    "-D_LIBCUDACXX_HAS_NO_CLIMITS",
+    "-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS",
 #if defined(__powerpc64__)
-  "-D__powerpc64__"
+    "-D__powerpc64__"
 #elif defined(__x86_64__)
-  "-D__x86_64__"
+    "-D__x86_64__"
 #endif
 };
 


### PR DESCRIPTION

This addresses a JIT compile error on Power9. I created a corresponding PR for libcudacxx [here](https://github.com/rapidsai/thirdparty-freestanding/pull/3)

The underlying issue is that the 'hacky' headers in `libcudacxx/include/simt/cfloat` define a too small/large value for `LDBL_MIN` and `LDBL_MAX`, which work for x86_64 but are not portable to ppc. See the link above for the type of JIT error encountered with BlazingSQL queries.

The solution I took was to export another CPU architecture define to NVRTC via jitify, which gets picked up by libcudacxx.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
