### PR TITLE
Use `pickle5` in `Serializable` (when available)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - PR #5643 Update `isort` to 5.0.4
 - PR #5662 Make Java ColumnVector(long nativePointer) constructor public
 - PR #5679 Use `pickle5` to test older Python versions
+- PR #5684 Use `pickle5` in `Serializable` (when available)
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/abc.py
+++ b/python/cudf/cudf/core/abc.py
@@ -1,12 +1,20 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
 import abc
-import pickle
+import sys
 from abc import abstractmethod
 
 import rmm
 
 import cudf
+
+if sys.version_info < (3, 8):
+    try:
+        import pickle5 as pickle
+    except ImportError:
+        import pickle
+else:
+    import pickle
 
 
 class Serializable(abc.ABC):


### PR DESCRIPTION
When using an older Python version that lacks pickle protocol 5, make sure to use `pickle5` with `Serializable` (when available). This is [what Dask does]( https://github.com/dask/distributed/blob/d9da4d79cafa1e5f46058b45f2e8209c99590506/distributed/protocol/serialize.py#L43 ) as well. So this should make sure we are compatible.