### PR TITLE
[REVIEW] Fix compilation issue with gcc 7.4.0 and CUDA 10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,7 +176,6 @@
 - PR #5671 Fix chunksize issue with `DataFrame.to_csv`
 - PR #5672 Fix crash in parquet writer while writing large string data
 - PR #5692 Fix compilation issue with gcc 7.4.0 and CUDA 10.1
-
 - PR #5693 Add fix missing from PR 5656 to update local docker image to py3.7
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@
 - PR #5656 Fix issue with incorrect docker image being used in local build script
 - PR #5671 Fix chunksize issue with `DataFrame.to_csv`
 - PR #5672 Fix crash in parquet writer while writing large string data
+- PR #5692 Fix compilation issue with gcc 7.4.0 and CUDA 10.1
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/cpp/src/hash/concurrent_unordered_map.cuh
+++ b/cpp/src/hash/concurrent_unordered_map.cuh
@@ -164,7 +164,7 @@ class concurrent_unordered_map {
     CUDF_FUNC_RANGE();
     using Self = concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>;
 
-    auto deleter = [stream](Self* p) { p->destroy(stream); };
+    auto deleter = [stream](Self* p) { (*p).destroy(stream); };
 
     return std::unique_ptr<Self, std::function<void(Self*)>>{
       new Self(capacity, unused_element, unused_key, hash_function, equal, allocator, stream),

--- a/cpp/src/hash/concurrent_unordered_map.cuh
+++ b/cpp/src/hash/concurrent_unordered_map.cuh
@@ -164,6 +164,8 @@ class concurrent_unordered_map {
     CUDF_FUNC_RANGE();
     using Self = concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>;
 
+    // Note: need `(*p).destroy` instead of `p->destroy` here
+    // due to compiler bug: https://github.com/rapidsai/cudf/pull/5692
     auto deleter = [stream](Self* p) { (*p).destroy(stream); };
 
     return std::unique_ptr<Self, std::function<void(Self*)>>{

--- a/cpp/src/hash/concurrent_unordered_multimap.cuh
+++ b/cpp/src/hash/concurrent_unordered_multimap.cuh
@@ -117,7 +117,7 @@ class concurrent_unordered_multimap {
                                                Allocator,
                                                count_collisions>;
 
-    auto deleter = [stream](Self* p) { p->destroy(stream); };
+    auto deleter = [stream](Self* p) { (*p).destroy(stream); };
 
     return std::unique_ptr<Self, std::function<void(Self*)>>{
       new Self(capacity, init, hash_function, equal, allocator, stream), deleter};

--- a/cpp/src/hash/concurrent_unordered_multimap.cuh
+++ b/cpp/src/hash/concurrent_unordered_multimap.cuh
@@ -117,6 +117,8 @@ class concurrent_unordered_multimap {
                                                Allocator,
                                                count_collisions>;
 
+    // Note: need `(*p).destroy` instead of `p->destroy` here
+    // due to compiler bug: https://github.com/rapidsai/cudf/pull/5692
     auto deleter = [stream](Self* p) { (*p).destroy(stream); };
 
     return std::unique_ptr<Self, std::function<void(Self*)>>{


### PR DESCRIPTION
This is a workaround for an unknown bug that gives the following error on gcc 7.4.0 and CUDA 10.1:

```bash
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_multimap.cuh: In instantiation of ‘concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::create(size_type, bool, const Hasher&, const Equality&, const allocator_type&, cudaStream_t)::<lambda(Self*)> [with Key = unsigned int; Element = int; size_type = long unsigned int; Key unused_key = 4294967295; Element unused_element = 2147483647; Hasher = MurmurHash3_32<unsigned int>; Equality = equal_to<unsigned int>; Allocator = default_allocator<thrust::pair<unsigned int, int> >; bool count_collisions = false; Self = concurrent_unordered_multimap<unsigned int, int, long unsigned int, 4294967295, 2147483647, MurmurHash3_32<unsigned int>, equal_to<unsigned int>, default_allocator<thrust::pair<unsigned int, int> > >]’:
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_multimap.cuh:120:17:   required from ‘struct concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::create(size_type, bool, const Hasher&, const Equality&, const allocator_type&, cudaStream_t) [with Key = unsigned int; Element = int; size_type = long unsigned int; Key unused_key = 4294967295; Element unused_element = 2147483647; Hasher = MurmurHash3_32<unsigned int>; Equality = equal_to<unsigned int>; Allocator = default_allocator<thrust::pair<unsigned int, int> >; bool count_collisions = false; concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::allocator_type = default_allocator<thrust::pair<unsigned int, int> >; cudaStream_t = CUstream_st*]::<lambda(using Self = class concurrent_unordered_multimap<unsigned int, int, long unsigned int, 4294967295, 2147483647, MurmurHash3_32<unsigned int>, equal_to<unsigned int>, default_allocator<thrust::pair<unsigned int, int> > >*)>’
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_multimap.cuh:120:6:   required from ‘static auto concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::create(size_type, bool, const Hasher&, const Equality&, const allocator_type&, cudaStream_t) [with Key = unsigned int; Element = int; size_type = long unsigned int; Key unused_key = 4294967295; Element unused_element = 2147483647; Hasher = MurmurHash3_32<unsigned int>; Equality = equal_to<unsigned int>; Allocator = default_allocator<thrust::pair<unsigned int, int> >; bool count_collisions = false; concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::allocator_type = default_allocator<thrust::pair<unsigned int, int> >; cudaStream_t = CUstream_st*]’
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/join/hash_join.cuh:226:40:   required from ‘std::enable_if_t<((JoinKind == INNER_JOIN) || (JoinKind == LEFT_JOIN)), std::pair<thrust::device_vector<int, rmm::mr::thrust_allocator<int> >, thrust::device_vector<int, rmm::mr::thrust_allocator<int> > > > cudf::detail::get_base_hash_join_indices(const cudf::table_view&, const cudf::table_view&, bool, cudf::null_equality, cudaStream_t) [with cudf::detail::join_kind JoinKind = (cudf::detail::join_kind)0; std::enable_if_t<((JoinKind == INNER_JOIN) || (JoinKind == LEFT_JOIN)), std::pair<thrust::device_vector<int, rmm::mr::thrust_allocator<int> >, thrust::device_vector<int, rmm::mr::thrust_allocator<int> > > > = std::pair<thrust::device_vector<int, rmm::mr::thrust_allocator<int> >, thrust::device_vector<int, rmm::mr::thrust_allocator<int> > >; cudaStream_t = CUstream_st*]’
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/join/join.cu:215:50:   required from ‘std::pair<thrust::device_vector<int, rmm::mr::thrust_allocator<int> >, thrust::device_vector<int, rmm::mr::thrust_allocator<int> > > cudf::detail::get_base_join_indices(const cudf::table_view&, const cudf::table_view&, cudf::null_equality, cudaStream_t) [with cudf::detail::join_kind JoinKind = (cudf::detail::join_kind)0; cudaStream_t = CUstream_st*]’
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/join/join.cu:434:56:   required from ‘std::unique_ptr<cudf::table> cudf::detail::join_call_compute_df(const cudf::table_view&, const cudf::table_view&, const std::vector<int>&, const std::vector<int>&, const std::vector<std::pair<int, int> >&, cudf::null_equality, rmm::mr::device_memory_resource*, cudaStream_t) [with cudf::detail::join_kind JoinKind = (cudf::detail::join_kind)0; cudaStream_t = CUstream_st*]’
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/join/join.cu:453:138:   required from here
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_multimap.cuh:120:43: error: ‘this’ was not captured for this lambda function
     auto deleter = [stream](Self* p) { p->destroy(stream); };
                                    ~~~~~~~^~~~~~~~
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_multimap.cuh:120:43: error: cannot call member function ‘void concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::destroy(cudaStream_t) [with Key = unsigned int; Element = int; size_type = long unsigned int; Key unused_key = 4294967295; Element unused_element = 2147483647; Hasher = MurmurHash3_32<unsigned int>; Equality = equal_to<unsigned int>; Allocator = default_allocator<thrust::pair<unsigned int, int> >; bool count_collisions = false; cudaStream_t = CUstream_st*]’ without object
[  4%] Building CUDA object CMakeFiles/cudf.dir/src/search/search.cu.o
/home/ashwint/local/include/c++/7.4.0/bits/std_function.h:686:1: error: ‘std::function<_Res(_ArgTypes ...)>::function(_Functor) [with _Functor = concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::create(size_type, bool, const Hasher&, const Equality&, const allocator_type&, cudaStream_t) [with Key = unsigned int; Element = int; size_type = long unsigned int; Key unused_key = 4294967295; Element unused_element = 2147483647; Hasher = MurmurHash3_32<unsigned int>; Equality = equal_to<unsigned int>; Allocator = default_allocator<thrust::pair<unsigned int, int> >; bool count_collisions = false; concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::allocator_type = default_allocator<thrust::pair<unsigned int, int> >; cudaStream_t = CUstream_st*]::<lambda(Self*)>; <template-parameter-2-2> = void; <template-parameter-2-3> = void; _Res = void; _ArgTypes = {concurrent_unordered_multimap<unsigned int, int, long unsigned int, 4294967295, 2147483647, MurmurHash3_32<unsigned int>, equal_to<unsigned int>, default_allocator<thrust::pair<unsigned int, int> >, false>*}]’, declared using local type ‘concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::create(size_type, bool, const Hasher&, const Equality&, const allocator_type&, cudaStream_t) [with Key = unsigned int; Element = int; size_type = long unsigned int; Key unused_key = 4294967295; Element unused_element = 2147483647; Hasher = MurmurHash3_32<unsigned int>; Equality = equal_to<unsigned int>; Allocator = default_allocator<thrust::pair<unsigned int, int> >; bool count_collisions = false; concurrent_unordered_multimap<Key, Element, size_type, unused_key, unused_element, Hasher, Equality, Allocator, count_collisions>::allocator_type = default_allocator<thrust::pair<unsigned int, int> >; cudaStream_t = CUstream_st*]::<lambda(Self*)>’, is used but never defined [-fpermissive]
       function(_Functor __f)

home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_map.cuh: In instantiation of ‘concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::create(concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::size_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::mapped_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::key_type, const Hasher&, const Equality&, const allocator_type&, cudaStream_t)::<lambda(Self*)> [with Key = int; Element = bool; Hasher = cudf::row_hasher<MurmurHash3_32>; Equality = cudf::row_equality_comparator<true>; Allocator = default_allocator<thrust::pair<int, bool> >; Self = concurrent_unordered_map<int, bool, cudf::row_hasher<MurmurHash3_32>, cudf::row_equality_comparator<true> >]’:
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_map.cuh:167:17:   required from ‘struct concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::create(concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::size_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::mapped_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::key_type, const Hasher&, const Equality&, const allocator_type&, cudaStream_t) [with Key = int; Element = bool; Hasher = cudf::row_hasher<MurmurHash3_32>; Equality = cudf::row_equality_comparator<true>; Allocator = default_allocator<thrust::pair<int, bool> >; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::size_type = long unsigned int; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::mapped_type = bool; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::key_type = int; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::allocator_type = default_allocator<thrust::pair<int, bool> >; cudaStream_t = CUstream_st*]::<lambda(using Self = class concurrent_unordered_map<int, bool, cudf::row_hasher<MurmurHash3_32>, cudf::row_equality_comparator<true> >*)>’
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_map.cuh:167:6:   required from ‘static auto concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::create(concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::size_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::mapped_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::key_type, const Hasher&, const Equality&, const allocator_type&, cudaStream_t) [with Key = int; Element = bool; Hasher = cudf::row_hasher<MurmurHash3_32>; Equality = cudf::row_equality_comparator<true>; Allocator = default_allocator<thrust::pair<int, bool> >; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::size_type = long unsigned int; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::mapped_type = bool; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::key_type = int; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::allocator_type = default_allocator<thrust::pair<int, bool> >; cudaStream_t = CUstream_st*]’
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/join/semi_join.cu:113:46:   required from ‘std::unique_ptr<cudf::table> cudf::detail::left_semi_anti_join(const cudf::table_view&, const cudf::table_view&, const std::vector<int>&, const std::vector<int>&, const std::vector<int>&, cudf::null_equality, rmm::mr::device_memory_resource*, cudaStream_t) [with cudf::detail::join_kind JoinKind = (cudf::detail::join_kind)3; cudaStream_t = CUstream_st*]’
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/join/semi_join.cu:162:141:   required from here
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_map.cuh:167:43: error: ‘this’ was not captured for this lambda function
     auto deleter = [stream](Self* p) { p->destroy(stream); };
                                    ~~~~~~~^~~~~~~~
/home/ashwint/workspace/github/rapidsai/cudf/cpp/src/hash/concurrent_unordered_map.cuh:167:43: error: cannot call member function ‘void concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::destroy(cudaStream_t) [with Key = int; Element = bool; Hasher = cudf::row_hasher<MurmurHash3_32>; Equality = cudf::row_equality_comparator<true>; Allocator = default_allocator<thrust::pair<int, bool> >; cudaStream_t = CUstream_st*]’ without object
/home/ashwint/local/include/c++/7.4.0/bits/std_function.h:686:1: error: ‘std::function<_Res(_ArgTypes ...)>::function(_Functor) [with _Functor = concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::create(concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::size_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::mapped_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::key_type, const Hasher&, const Equality&, const allocator_type&, cudaStream_t) [with Key = int; Element = bool; Hasher = cudf::row_hasher<MurmurHash3_32>; Equality = cudf::row_equality_comparator<true>; Allocator = default_allocator<thrust::pair<int, bool> >; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::size_type = long unsigned int; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::mapped_type = bool; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::key_type = int; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::allocator_type = default_allocator<thrust::pair<int, bool> >; cudaStream_t = CUstream_st*]::<lambda(Self*)>; <template-parameter-2-2> = void; <template-parameter-2-3> = void; _Res = void; _ArgTypes = {concurrent_unordered_map<int, bool, cudf::row_hasher<MurmurHash3_32, true>, cudf::row_equality_comparator<true>, default_allocator<thrust::pair<int, bool> > >*}]’, declared using local type ‘concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::create(concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::size_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::mapped_type, concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::key_type, const Hasher&, const Equality&, const allocator_type&, cudaStream_t) [with Key = int; Element = bool; Hasher = cudf::row_hasher<MurmurHash3_32>; Equality = cudf::row_equality_comparator<true>; Allocator = default_allocator<thrust::pair<int, bool> >; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::size_type = long unsigned int; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::mapped_type = bool; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::key_type = int; concurrent_unordered_map<Key, Element, Hasher, Equality, Allocator>::allocator_type = default_allocator<thrust::pair<int, bool> >; cudaStream_t = CUstream_st*]::<lambda(Self*)>’, is used but never defined [-fpermissive]
       function(_Functor __f)
 ^     ~~~~~~~~~~~~~~~~~~~~~~
```

