### PR TITLE
[REVIEW] update docker image to py3.7 [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,7 @@
 - PR #5656 Fix issue with incorrect docker image being used in local build script
 - PR #5671 Fix chunksize issue with `DataFrame.to_csv`
 - PR #5672 Fix crash in parquet writer while writing large string data
-
+- PR #5693 Add fix missing from PR 5656 to update local docker image to py3.7
 
 # cuDF 0.14.0 (03 Jun 2020)
 

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -3,7 +3,7 @@
 GIT_DESCRIBE_TAG=`git describe --tags`
 MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
-DOCKER_IMAGE="gpuci/rapidsai:${MINOR_VERSION}-cuda10.1-devel-ubuntu16.04-py3.6"
+DOCKER_IMAGE="gpuci/rapidsai:${MINOR_VERSION}-cuda10.1-devel-ubuntu16.04-py3.7"
 REPO_PATH=${PWD}
 RAPIDS_DIR_IN_CONTAINER="/rapids"
 CPP_BUILD_DIR="cpp/build"


### PR DESCRIPTION
PR fixes local docker image ('DOCKER_IMAGE' string) used by build script:
- Replaces py3.6 with py3.7 (in line with dropping Python 3.6 support for v0.15 -> https://github.com/rapidsai/ops/issues/1017)

This fix was missing from https://github.com/rapidsai/cudf/pull/5656