### PR TITLE
[REVIEW] Small fix for dataframe constructor with cuda array interface objects that don't have `descr` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - PR #5364 Validate array interface during buffer construction
 - PR #5418 Add support for `DataFrame.info`
 - PR #5425 Add Python `Groupby.rolling()`
-- PR #5359 Add duration types 
+- PR #5359 Add duration types
 - PR #5434 Add nvtext function generate_character_grams
 - PR #5442 Add support for `cudf.isclose`
 - PR #5444 Remove usage of deprecated RMM APIs and headers.
@@ -29,7 +29,7 @@
 - PR #5488 Add plumbings for `.str.replace_tokens`
 - PR #5502 Add Unsigned int types support in dlpack
 - PR #5497 Add `.str.isinteger` & `.str.isfloat`
-- PR #5511 Port of clx subword tokenizer to cudf 
+- PR #5511 Port of clx subword tokenizer to cudf
 - PR #5528 Add unsigned int reading and writing support to parquet
 - PR #5510 Add support for `cudf.Index` to create Indexes
 - PR #5460 Add support to write to remote filesystems
@@ -96,7 +96,7 @@
 - PR #5468 Add cudf::unique_count(table_view)
 - PR #5482 Use rmm::device_uvector in place of rmm::device_vector in copy_if
 - PR #5483 Add NVTX range calls to dictionary APIs
-- PR #5477 Add `is_index_type` trait 
+- PR #5477 Add `is_index_type` trait
 - PR #5487 Use sorted lists instead of sets for pytest parameterization
 - PR #5491 allow build libcudf in custom dir
 - PR #5501 Adding only unsigned types support for categorical column codes
@@ -133,7 +133,7 @@
 - PR #5334 Fix pickling sizeof test
 - PR #5337 Fix broken alias from DataFrame.{at,iat} to {loc, iloc}
 - PR #5347 Fix APPLY_BOOLEAN_MASK_BENCH segfault
-- PR #5368 Fix loc indexing issue with `datetime` type index 
+- PR #5368 Fix loc indexing issue with `datetime` type index
 - PR #5367 Fix API for `cudf::repeat` in `cudf::cross_join`
 - PR #5377 Handle array of cupy scalars in to_column
 - PR #5326 Fix `DataFrame.__init__` for list of scalar inputs and related dask issue
@@ -148,7 +148,7 @@
 - PR #5399 Fix cpp compiler warnings of unreachable code
 - PR #5439 Fix nvtext ngrams_tokenize performance for multi-byte UTF8
 - PR #5446 Fix compile error caused by out-of-date PR merge (4990)
-- PR #5423 Fix any() reduction ignore nulls 
+- PR #5423 Fix any() reduction ignore nulls
 - PR #5459 Fix str.translate to convert table characters to UTF-8
 - PR #5480 Fix merge sort docs
 - PR #5465 Fix benchmark out of memory errors due to multiple initialization
@@ -179,6 +179,7 @@
 - PR #5672 Fix crash in parquet writer while writing large string data
 - PR #5692 Fix compilation issue with gcc 7.4.0 and CUDA 10.1
 - PR #5693 Add fix missing from PR 5656 to update local docker image to py3.7
+- PR #5703 Small fix for dataframe constructor with cuda array interface objects that don't have `descr` field
 
 # cuDF 0.14.0 (03 Jun 2020)
 
@@ -288,7 +289,7 @@
 - PR #4841 Remove unused `single_lane_block_popc_reduce` function
 - PR #4842 Added Java bindings for titlizing a String column
 - PR #4847 Replace legacy NVTX calls with "standalone" NVTX bindings calls
-- PR #4851 Performance improvements relating to `concat` 
+- PR #4851 Performance improvements relating to `concat`
 - PR #4852 Add NVTX range calls to strings and nvtext APIs
 - PR #4849 Update Java bindings to use new NVTX API
 - PR #4845 Add CUDF_FUNC_RANGE to top-level cuIO function APIs
@@ -316,7 +317,7 @@
 - PR #4912 Drop old `valid` check in `element_indexing`
 - PR #4924 Properly handle npartition argument in rearrange_by_hash
 - PR #4918 Adding support for `cupy.ndarray` in `series.loc`
-- PR #4909 Added ability to transform a column using cuda method in Java bindings 
+- PR #4909 Added ability to transform a column using cuda method in Java bindings
 - PR #3259 Add .clang-format file & format all files
 - PR #4943 Fix-up error handling in GPU detection
 - PR #4917 Add support for casting unsupported `dtypes` of same kind
@@ -430,7 +431,7 @@
 - PR #4749 Setting `nan_as_null=True` while creating a column in DataFrame creation
 - PR #4761 Fix issues with `nan_as_null` in certain case
 - PR #4650 Fix type mismatch & result format issue in `searchsorted`
-- PR #4755 Fix Java build to deal with new quantiles API 
+- PR #4755 Fix Java build to deal with new quantiles API
 - PR #4720 Fix issue related to `dtype` param not being adhered incase of cuda arrays
 - PR #4756 Fix regex error checking for valid quantifier condition
 - PR #4777 Fix data pointer for column slices of zero length
@@ -454,7 +455,7 @@
 - PR #4883 Fix series get/set to match pandas
 - PR #4861 Fix to_integers illegal-memory-access with all-empty strings column
 - PR #4860 Fix issues in HostMemoryBufferTest, and testNormalizeNANsAndZeros
-- PR #4879 Fix output for `cudf.concat` with `axis=1` for pandas parity 
+- PR #4879 Fix output for `cudf.concat` with `axis=1` for pandas parity
 - PR #4838 Fix to support empty inputs to `replace` method
 - PR #4859 JSON reader: fix data type inference for string columns
 - PR #4868 Temporary fix to skip validation on Dask related runs
@@ -492,7 +493,7 @@
 - PR #5070 Fix libcudf++ csv reader support for hex dtypes, doublequotes and empty columns
 - PR #5057 Fix metadata_out parameter not reaching parquet `write_all`
 - PR #5076 Fix JNI code for null_policy enum change
-- PR #5031 grouped_time_range_rolling_window assumes ASC sort order 
+- PR #5031 grouped_time_range_rolling_window assumes ASC sort order
 - PR #5032 grouped_time_range_rolling_window should permit invocation without specifying grouping_keys
 - PR #5103 Fix `read_csv` issue with names and header
 - PR #5090 Fix losing nulls while creating DataFrame from dictionary
@@ -605,7 +606,7 @@
 - PR #4028 Port json.pyx to use new libcudf APIs
 - PR #4014 ORC/Parquet: add count parameter to stripe/rowgroup-based reader API
 - PR #3880 Add aggregation infrastructure support for cudf::reduce
-- PR #4059 Add aggregation infrastructure support for cudf::scan 
+- PR #4059 Add aggregation infrastructure support for cudf::scan
 - PR #4021 Change quantiles signature for clarity.
 - PR #4057 Handle offsets in cython Column class
 - PR #4045 Reorganize `libxx` directory
@@ -2047,7 +2048,7 @@
 
 - PR #821 Fix flake8 issues revealed by flake8 update
 - PR #808 Resolved renamed `d_columns_valids` variable name
-- PR #820 CSV Reader: fix the issue where reader adds additional rows when file uses 
+- PR #820 CSV Reader: fix the issue where reader adds additional rows when file uses
  as a line terminator
 - PR #780 CSV Reader: Fix scientific notation parsing and null values for empty quotes
 - PR #815 CSV Reader: Fix data parsing when tabs are present in the input CSV file

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -224,14 +224,15 @@ class DataFrame(Frame, Serializable):
             # descr is an optional field of the _cuda_ary_iface_
             if "descr" in arr_interface:
                 if len(arr_interface["descr"]) == 1:
-                    new_df = self._from_arrays(data, index=index,
-                                               columns=columns)
+                    new_df = self._from_arrays(
+                        data, index=index, columns=columns
+                    )
                 else:
-                    new_df = self.from_records(data, index=index,
-                                               columns=columns)
+                    new_df = self.from_records(
+                        data, index=index, columns=columns
+                    )
             else:
-                new_df = self._from_arrays(data, index=index,
-                                           columns=columns)
+                new_df = self._from_arrays(data, index=index, columns=columns)
 
             self._data = new_df._data
             self._index = new_df._index

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -220,10 +220,19 @@ class DataFrame(Frame, Serializable):
                 )
         elif hasattr(data, "__cuda_array_interface__"):
             arr_interface = data.__cuda_array_interface__
-            if len(arr_interface["descr"]) == 1:
-                new_df = self._from_arrays(data, index=index, columns=columns)
+
+            # descr is an optional field of the _cuda_ary_iface_
+            if "descr" in arr_interface:
+                if len(arr_interface["descr"]) == 1:
+                    new_df = self._from_arrays(data, index=index,
+                                               columns=columns)
+                else:
+                    new_df = self.from_records(data, index=index,
+                                               columns=columns)
             else:
-                new_df = self.from_records(data, index=index, columns=columns)
+                new_df = self._from_arrays(data, index=index,
+                                           columns=columns)
+
             self._data = new_df._data
             self._index = new_df._index
             self.columns = new_df.columns

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -5538,8 +5538,13 @@ def test_dataframe_init_from_arrays_cols(data, cols, index):
     if isinstance(data, cupy.core.ndarray):
         # pandas can't handle cupy arrays in general
         pd_data = data.get()
+
+        # additional test for building DataFrame with gpu array whose
+        # cuda array interface has no `descr` attribute
+        numba_data = cuda.as_cuda_array(data)
     else:
         pd_data = data
+        numba_data = None
 
     # verify with columns & index
     pdf = pd.DataFrame(pd_data, columns=cols, index=index)
@@ -5557,6 +5562,10 @@ def test_dataframe_init_from_arrays_cols(data, cols, index):
     gdf = DataFrame(gd_data)
 
     assert_eq(pdf, gdf, check_dtype=False)
+
+    if numba_data is not None:
+        gdf = DataFrame(numba_data)
+        assert_eq(pdf, gdf, check_dtype=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As of right now in branch-0.15, cuDF DataFrames cannot be constructed from numba arrays: 

```python
>>> import cudf
>>> from numba import cuda
>>> import numpy as np
>>> a = cuda.to_device(np.arange(10))
>>> b = cudf.DataFrame(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/galahad/miniconda3/envs/ns0715-38/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/home/galahad/miniconda3/envs/ns0715-38/lib/python3.8/site-packages/cudf/core/dataframe.py", line 223, in __init__
    if len(arr_interface["descr"]) == 1:
KeyError: 'descr'
```
That is because the `descr` attribute of the `__cuda_array_intereface__` is optional, and Numba device arrays in particular don't have it. This PR applies a small fix to check for the existence of the attribute before checking its length. 

I wasn't sure if we wanted explicit pytests with Numba device arrays, but I would be glad to add them if we do. 