### PR TITLE
[WIP] Use pool_memory_resource in gtest and benchmark fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
 - PR #5662 Make Java ColumnVector(long nativePointer) constructor public
 - PR #5679 Use `pickle5` to test older Python versions
 - PR #5684 Use `pickle5` in `Serializable` (when available)
+- PR #5705 Use pool_memory_resource in fixtures in place of cnmem_memory_resource
 
 ## Bug Fixes
 

--- a/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -66,8 +66,9 @@ class benchmark : public ::benchmark::Fixture {
 
   virtual void TearDown(const ::benchmark::State& state)
   {
-    delete mr->get_upstream();
+    auto upstream = mr->get_upstream();
     delete mr;
+    delete upstream;
 
     rmm::mr::set_default_resource(nullptr);  // reset default resource to the initial resource
   }

--- a/cpp/tests/jit/jit-cache-multiprocess-test.cpp
+++ b/cpp/tests/jit/jit-cache-multiprocess-test.cpp
@@ -117,6 +117,6 @@ int main(int argc, char **argv)
   // the fork. So we hardcode the rmm_mode to "cuda"
   auto const rmm_mode = "cuda";
   auto resource       = cudf::test::create_memory_resource(rmm_mode);
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_default_resource(resource);
   return RUN_ALL_TESTS();
 }

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -299,5 +299,6 @@ inline auto parse_cudf_test_opts(int argc, char **argv)
     } else {                                                            \
       delete resource;                                                  \
     }                                                                   \
+    rmm::mr::set_default_resource(nullptr);                             \
     return ret;                                                         \
   }


### PR DESCRIPTION
This PR replaces the cnmem_memory_resource used in libcudf gtests and gbenchmarks with pool_memory_resource.

This is a step toward removing cnmem from RMM.

Note, some of the resource lifetime management could be improved. Since @jrhemstad said he is looking into owning wrappers that would help with this, I decided to take a simple approach in this PR since the set of MR types used is small.

Update: waiting on #rapidsai/rmm#444 to resolve the above cleanly.
