### PR TITLE
[REVIEW] Update java build to help cu-spacial with java bindings [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 - PR #5662 Make Java ColumnVector(long nativePointer) constructor public
 - PR #5679 Use `pickle5` to test older Python versions
 - PR #5684 Use `pickle5` in `Serializable` (when available)
+- PR #5709 Update java build to help cu-spacial with java bindings
 
 ## Bug Fixes
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -185,6 +185,12 @@
                                     <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
+                            <execution>
+                                <id>test-jars</id>
+                                <goals>
+                                    <goal>test-jar</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
                     <plugin>
@@ -421,6 +427,16 @@
                     <!--Set by groovy script-->
                     <classifier>${cuda.classifier}</classifier>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>tests</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -47,7 +47,8 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable {
   private int refCount;
 
   /**
-   * Wrap an existing on device cudf::column with the corresponding ColumnVector.
+   * Wrap an existing on device cudf::column with the corresponding ColumnVector. The new
+   * ColumnVector takes ownership of the pointer and will free it when the ref count reaches zero.
    * @param nativePointer host address of the cudf::column object which will be
    *                      owned by this instance.
    */

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -38,18 +38,64 @@ public class NativeDepsLoader {
   private static ClassLoader loader = NativeDepsLoader.class.getClassLoader();
   private static boolean loaded = false;
 
-  static synchronized void loadNativeDeps() {
+  /**
+   * Load the native libraries needed for libcudf, if not loaded already.
+   */
+  public static synchronized void loadNativeDeps() {
     if (!loaded) {
-      String os = System.getProperty("os.name");
-      String arch = System.getProperty("os.arch");
       try {
-        for (String toLoad : loadOrder) {
-          loadDep(os, arch, toLoad);
-        }
+        loadNativeDeps(loadOrder);
         loaded = true;
       } catch (Throwable t) {
         log.error("Could not load cudf jni library...", t);
       }
+    }
+  }
+
+  /**
+   * Allows other libraries to reuse the same native deps loading logic. Libraries will be searched
+   * for under ${os.arch}/${os.name}/ in the class path using the class loader for this class. It
+   * will also look for the libraries under ./target/native-deps/${os.arch}/${os.name} to help
+   * facilitate testing while building.
+   * <br/>
+   * Because this just loads the libraries and loading the libraries themselves needs to be a
+   * singleton operation it is recommended that any library using this provide their own wrapper
+   * function similar to
+   * <pre>
+   *     private static boolean loaded = false;
+   *     static synchronized void loadNativeDeps() {
+   *         if (!loaded) {
+   *             try {
+   *                 // If you also depend on the cudf liobrary being loaded, be sure it is loaded
+   *                 // first
+   *                 ai.rapids.cudf.NativeDepsLoader.loadNativeDeps();
+   *                 ai.rapids.cudf.NativeDepsLoader.loadNativeDeps(new String[]{...});
+   *                 loaded = true;
+   *             } catch (Throwable t) {
+   *                 log.error("Could not load ...", t);
+   *             }
+   *         }
+   *     }
+   * </pre>
+   * This function should be called from the static initialization block of any class that uses
+   * JNI. For example
+   * <pre>
+   *     public class UsesJNI {
+   *         static {
+   *             MyNativeDepsLoader.loadNativeDeps();
+   *         }
+   *     }
+   * </pre>
+   * @param loadOrder the base name of the libraries. for example libfoo.so would be passed in as
+   *                  "foo".  The libraries are loaded in the order provided.
+   * @throws IOException on any error trying to load the libraries.
+   */
+  public static void loadNativeDeps(String[] loadOrder) throws IOException {
+    String os = System.getProperty("os.name");
+    String arch = System.getProperty("os.arch");
+
+    for (String toLoad : loadOrder) {
+      loadDep(os, arch, toLoad);
     }
   }
 

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -86,7 +86,7 @@ public class NativeDepsLoader {
    *         }
    *     }
    * </pre>
-   * @param loadOrder the base name of the libraries. for example libfoo.so would be passed in as
+   * @param loadOrder the base name of the libraries. For example libfoo.so would be passed in as
    *                  "foo".  The libraries are loaded in the order provided.
    * @throws IOException on any error trying to load the libraries.
    */

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -70,11 +70,12 @@ public final class Table implements AutoCloseable {
   }
 
   /**
-   * Table class makes a copy of the array of cudfColumns passed to it. The class will decrease the
-   * refcount on itself and all its contents when closed and free resources if refcount is zero
+   * Create a Table from an array of existing on device cudf::column pointers. Ownership of the
+   * columns is transferred to the ColumnVectors held by the new Table. In the case of an exception
+   * the columns will be deleted.
    * @param cudfColumns - Array of nativeHandles
    */
-  Table(long[] cudfColumns) {
+  public Table(long[] cudfColumns) {
     assert cudfColumns != null && cudfColumns.length > 0 : "CudfColumns can't be null or empty";
     this.columns = new ColumnVector[cudfColumns.length];
     try {

--- a/java/src/test/java/ai/rapids/cudf/CudfTestBase.java
+++ b/java/src/test/java/ai/rapids/cudf/CudfTestBase.java
@@ -24,17 +24,17 @@ import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-class CudfTestBase {
+public class CudfTestBase {
   static final long RMM_POOL_SIZE_DEFAULT = 512 * 1024 * 1024;
 
   final int rmmAllocationMode;
   final long rmmPoolSize;
 
-  CudfTestBase() {
+  public CudfTestBase() {
     this(RmmAllocationMode.POOL, RMM_POOL_SIZE_DEFAULT);
   }
 
-  CudfTestBase(int allocationMode, long poolSize) {
+  public CudfTestBase(int allocationMode, long poolSize) {
     this.rmmAllocationMode = allocationMode;
     this.rmmPoolSize = poolSize;
   }


### PR DESCRIPTION
This fixes  #5685
This fixes  #5686
This fixes #5706

This fixes a number of things that the cu-spacial team has requested to help them build java bindings for their project.  These include providing a common way to load native dependencies; better access to testing classes that we have written; and opening up the Table constructor so other libraries can return a Table from code in a JNI function.