### PR TITLE
[REVIEW] Replace use of assert_frame_equal in tests with assert_eq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
 - PR #5708 Add support for `dummy_na` in `get_dummies`
 - PR #5709 Update java build to help cu-spacial with java bindings
 - PR #5713 Remove old NVTX utilities
+- PR #5726 Replace use of `assert_frame_equal` in tests with `assert_eq`
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/tests/test_array_function.py
+++ b/python/cudf/cudf/tests/test_array_function.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import cudf
+from cudf.tests.utils import assert_eq
 from cudf.utils.utils import IS_NEP18_ACTIVE
 
 missing_arrfunc_cond = not IS_NEP18_ACTIVE
@@ -29,10 +30,7 @@ def test_array_func_cudf_series(np_ar, func):
     expect = func(np_ar)
     got = func(cudf_ser)
 
-    if np.isscalar(expect):
-        np.testing.assert_approx_equal(expect, got)
-    else:
-        np.testing.assert_array_equal(expect, got.to_pandas().values)
+    assert_eq(expect, got)
 
 
 # TODO: Make it future proof
@@ -60,8 +58,7 @@ def test_array_func_cudf_dataframe(pd_df, func):
     cudf_df = cudf.from_pandas(pd_df)
     expect = func(pd_df)
     got = func(cudf_df)
-
-    pd.testing.assert_series_equal(expect, got.to_pandas())
+    assert_eq(expect, got)
 
 
 @pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
@@ -91,11 +88,7 @@ def test_array_func_cudf_index(np_ar, func):
     cudf_index = cudf.core.index.as_index(cudf.Series(np_ar))
     expect = func(np_ar)
     got = func(cudf_index)
-
-    if np.isscalar(expect):
-        np.testing.assert_approx_equal(expect, got)
-    else:
-        np.testing.assert_array_equal(expect, got.to_pandas().values)
+    assert_eq(expect, got)
 
 
 @pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)

--- a/python/cudf/cudf/tests/test_array_function.py
+++ b/python/cudf/cudf/tests/test_array_function.py
@@ -30,7 +30,10 @@ def test_array_func_cudf_series(np_ar, func):
     expect = func(np_ar)
     got = func(cudf_ser)
 
-    assert_eq(expect, got)
+    if np.isscalar(expect):
+        assert_eq(expect, got)
+    else:
+        assert_eq(expect, got.to_array())
 
 
 # TODO: Make it future proof

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -68,16 +68,12 @@ def test_concat_dataframe(index, nulls, axis):
     for c in [i for i in ("x", "y", "z") if i != index]:
         res = gd.concat([gdf[c], gdf2[c], gdf[c]], axis=axis).to_pandas()
         sol = pd.concat([df[c], df2[c], df[c]], axis=axis)
-        pd.util.testing.assert_series_equal(
-            res, sol, check_names=False, check_categorical=False
-        )
+        assert_eq(res, sol, check_names=False, check_categorical=False)
 
     # Index
     res = gd.concat([gdf.index, gdf2.index], axis=axis).to_pandas()
     sol = df.index.append(df2.index)
-    pd.util.testing.assert_index_equal(
-        res, sol, check_names=False, check_categorical=False
-    )
+    assert_eq(res, sol, check_names=False, check_categorical=False)
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -61,9 +61,7 @@ def test_concat_dataframe(index, nulls, axis):
     # DataFrame
     res = gd.concat([gdf, gdf2, gdf, gdf_empty1], axis=axis).to_pandas()
     sol = pd.concat([df, df2, df, df_empty1], axis=axis)
-    pd.util.testing.assert_frame_equal(
-        res, sol, check_names=False, check_categorical=False
-    )
+    assert_eq(res, sol, check_names=False, check_categorical=False)
 
     # Series
     for c in [i for i in ("x", "y", "z") if i != index]:
@@ -161,9 +159,7 @@ def test_concat_misordered_columns():
     res = gd.concat([gdf, gdf2]).to_pandas()
     sol = pd.concat([df, df2], sort=False)
 
-    pd.util.testing.assert_frame_equal(
-        res, sol, check_names=False, check_categorical=False
-    )
+    assert_eq(res, sol, check_names=False, check_categorical=False)
 
 
 @pytest.mark.parametrize("axis", [1, "columns"])

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -168,7 +168,7 @@ def test_csv_reader_numeric_data(dtype, nelem, tmpdir):
     out = read_csv(str(fname), names=list(df.columns.values), dtype=dtypes)
 
     assert len(out.columns) == len(df.columns)
-    pd.util.testing.assert_frame_equal(df, out.to_pandas())
+    assert_eq(df, out)
 
 
 @pytest.mark.parametrize("parse_dates", [["date2"], [0], ["date1", 1, "bad"]])
@@ -303,7 +303,7 @@ def test_csv_reader_skiprows_skipfooter(tmpdir):
 
     assert len(out.columns) == len(df_out.columns)
     assert len(out) == len(df_out)
-    pd.util.testing.assert_frame_equal(df_out, out.to_pandas())
+    assert_eq(df_out, out)
 
 
 def test_csv_reader_negative_vals(tmpdir):
@@ -402,9 +402,7 @@ def test_csv_reader_usecols_int_char(tmpdir):
 
     assert len(out.columns) == len(df_out.columns)
     assert len(out) == len(df_out)
-    pd.util.testing.assert_frame_equal(
-        df_out, out.to_pandas(), check_names=False
-    )
+    assert_eq(df_out, out, check_names=False)
 
 
 def test_csv_reader_mangle_dupe_cols(tmpdir):
@@ -413,7 +411,7 @@ def test_csv_reader_mangle_dupe_cols(tmpdir):
     # Default: mangle_dupe_cols=True
     pd_df = pd.read_csv(StringIO(buffer))
     cu_df = read_csv(StringIO(buffer))
-    pd.util.testing.assert_frame_equal(cu_df.to_pandas(), pd_df)
+    assert_eq(cu_df, pd_df)
 
     # Pandas does not support mangle_dupe_cols=False
     cu_df = read_csv(StringIO(buffer), mangle_dupe_cols=False)
@@ -657,7 +655,7 @@ def test_csv_reader_bools(tmpdir, names, dtypes, data, trues, falses):
         false_values=falses,
     )
 
-    pd.util.testing.assert_frame_equal(df_out, out.to_pandas())
+    assert_eq(df_out, out)
 
 
 def test_csv_quotednumbers(tmpdir):
@@ -1056,7 +1054,7 @@ def test_csv_reader_delim_whitespace():
     # with header row
     cu_df = read_csv(StringIO(buffer), delim_whitespace=True)
     pd_df = pd.read_csv(StringIO(buffer), delim_whitespace=True)
-    pd.util.testing.assert_frame_equal(pd_df, cu_df.to_pandas())
+    assert_eq(pd_df, cu_df)
 
     # without header row
     cu_df = read_csv(StringIO(buffer), delim_whitespace=True, header=None)
@@ -1087,7 +1085,7 @@ def test_csv_reader_header_quotation():
     cu_df = read_csv(StringIO(buffer))
     pd_df = pd.read_csv(StringIO(buffer))
     assert cu_df.shape == (1, 3)
-    pd.util.testing.assert_frame_equal(pd_df, cu_df.to_pandas())
+    assert_eq(pd_df, cu_df)
 
     # test cases that fail with pandas
     buffer_pd_fail = '"1,one," , ",2,two" ,3\n4,5,6'
@@ -1112,7 +1110,7 @@ def test_csv_reader_index_col():
     # using a column name
     cu_df = read_csv(StringIO(buffer), names=names, index_col="int1")
     pd_df = pd.read_csv(StringIO(buffer), names=names, index_col="int1")
-    pd.util.testing.assert_frame_equal(pd_df, cu_df.to_pandas())
+    assert_eq(pd_df, cu_df)
 
     # using a column index
     cu_df = read_csv(StringIO(buffer), header=None, index_col=0)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -746,7 +746,7 @@ def test_dataframe_append_empty():
 
     assert len(gdf["newcol"]) == len(pdf)
     assert len(pdf["newcol"]) == len(pdf)
-    pd.testing.assert_frame_equal(gdf.to_pandas(), pdf)
+    assert_eq(gdf, pdf)
 
 
 def test_dataframe_setitem_from_masked_object():
@@ -795,7 +795,7 @@ def test_dataframe_append_to_empty():
     gdf["a"] = []
     gdf["b"] = [1, 2, 3]
 
-    pd.testing.assert_frame_equal(gdf.to_pandas(), pdf)
+    assert_eq(gdf, pdf)
 
 
 def test_dataframe_setitem_index_len1():
@@ -975,7 +975,7 @@ def test_concat_empty_dataframe(df_1, df_2):
     # ignoring dtypes as pandas upcasts int to float
     # on concatenation with empty dataframes
 
-    pd.testing.assert_frame_equal(got.to_pandas(), expect, check_dtype=False)
+    assert_eq(got, expect, check_dtype=False)
 
 
 @pytest.mark.parametrize(
@@ -1012,7 +1012,7 @@ def test_concat_different_column_dataframe(df1_d, df2_d):
     for col in numeric_cols:
         got[col] = got[col].astype(np.float64).fillna(np.nan)
 
-    pd.testing.assert_frame_equal(got.to_pandas(), expect, check_dtype=False)
+    assert_eq(got, expect, check_dtype=False)
 
 
 @pytest.mark.parametrize("ser_1", [pd.Series([1, 2, 3]), pd.Series([])])
@@ -1021,7 +1021,7 @@ def test_concat_empty_series(ser_1, ser_2):
     got = gd.concat([Series(ser_1), Series(ser_2)])
     expect = pd.concat([ser_1, ser_2])
 
-    pd.testing.assert_series_equal(got.to_pandas(), expect)
+    assert_eq(got, expect)
 
 
 def test_concat_with_axis():
@@ -1122,13 +1122,13 @@ def test_from_pandas():
     gdf = gd.DataFrame.from_pandas(df)
     assert isinstance(gdf, gd.DataFrame)
 
-    pd.testing.assert_frame_equal(df, gdf.to_pandas())
+    assert_eq(df, gdf)
 
     s = df.x
     gs = gd.Series.from_pandas(s)
     assert isinstance(gs, gd.Series)
 
-    pd.testing.assert_series_equal(s, gs.to_pandas())
+    assert_eq(s, gs)
 
 
 @pytest.mark.parametrize("dtypes", [int, float])
@@ -1179,33 +1179,33 @@ def test_from_gpu_matrix():
     df = pd.DataFrame(h_ary, columns=["a", "b", "c"])
     assert isinstance(gdf, gd.DataFrame)
 
-    pd.testing.assert_frame_equal(df, gdf.to_pandas())
+    assert_eq(df, gdf)
 
     gdf = gd.DataFrame.from_gpu_matrix(d_ary)
     df = pd.DataFrame(h_ary)
     assert isinstance(gdf, gd.DataFrame)
 
-    pd.testing.assert_frame_equal(df, gdf.to_pandas())
+    assert_eq(df, gdf)
 
     gdf = gd.DataFrame.from_gpu_matrix(d_ary, index=["a", "b"])
     df = pd.DataFrame(h_ary, index=["a", "b"])
     assert isinstance(gdf, gd.DataFrame)
 
-    pd.testing.assert_frame_equal(df, gdf.to_pandas())
+    assert_eq(df, gdf)
 
     gdf = gd.DataFrame.from_gpu_matrix(d_ary, index=0)
     df = pd.DataFrame(h_ary)
     df = df.set_index(keys=0, drop=False)
     assert isinstance(gdf, gd.DataFrame)
 
-    pd.testing.assert_frame_equal(df, gdf.to_pandas())
+    assert_eq(df, gdf)
 
     gdf = gd.DataFrame.from_gpu_matrix(d_ary, index=1)
     df = pd.DataFrame(h_ary)
     df = df.set_index(keys=1, drop=False)
     assert isinstance(gdf, gd.DataFrame)
 
-    pd.testing.assert_frame_equal(df, gdf.to_pandas())
+    assert_eq(df, gdf)
 
 
 def test_from_gpu_matrix_wrong_dimensions():
@@ -1233,8 +1233,8 @@ def test_index_in_dataframe_constructor():
     a = pd.DataFrame({"x": [1, 2, 3]}, index=[4.0, 5.0, 6.0])
     b = gd.DataFrame({"x": [1, 2, 3]}, index=[4.0, 5.0, 6.0])
 
-    pd.testing.assert_frame_equal(a, b.to_pandas())
-    assert pd.testing.assert_frame_equal(a.loc[4:], b.loc[4:].to_pandas())
+    assert_eq(a, b)
+    assert_eq(a.loc[4:], b.loc[4:])
 
 
 dtypes = NUMERIC_TYPES + DATETIME_TYPES + ["bool"]
@@ -1255,7 +1255,7 @@ def test_from_arrow(nelem, data_type):
     gdf = gd.DataFrame.from_arrow(padf)
     assert isinstance(gdf, gd.DataFrame)
 
-    pd.testing.assert_frame_equal(df, gdf.to_pandas())
+    assert_eq(df, gdf)
 
     s = pa.Array.from_pandas(df.a)
     gs = gd.Series.from_arrow(s)
@@ -1359,7 +1359,7 @@ def test_from_arrow_missing_categorical():
     gd_cat = gd.Series(pa_cat)
 
     assert isinstance(gd_cat, gd.Series)
-    pd.testing.assert_series_equal(
+    assert_eq(
         pd.Series(pa_cat.to_pandas()),  # PyArrow returns a pd.Categorical
         gd_cat.to_pandas(),
     )

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -7,11 +7,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from pandas.util.testing import (
-    assert_frame_equal,
-    assert_index_equal,
-    assert_series_equal,
-)
 
 import cudf
 from cudf.core import DataFrame, Series
@@ -164,7 +159,7 @@ def test_dt_series(data, field):
     gdf_data = Series(pd_data)
     base = getattr(pd_data.dt, field)
     test = getattr(gdf_data.dt, field).to_pandas().astype("int64")
-    assert_series_equal(base, test)
+    assert_eq(base, test)
 
 
 @pytest.mark.parametrize("data", [data1()])
@@ -172,9 +167,7 @@ def test_dt_series(data, field):
 def test_dt_index(data, field):
     pd_data = data.copy()
     gdf_data = DatetimeIndex(pd_data)
-    assert_index_equal(
-        getattr(gdf_data, field).to_pandas(), getattr(pd_data, field)
-    )
+    assert_eq(getattr(gdf_data, field), getattr(pd_data, field))
 
 
 def test_setitem_datetime():
@@ -214,34 +207,34 @@ def test_issue_165():
 
     base = df_pandas.query("dates==@start_date")
     test = df_cudf.query("dates==@start_date")
-    assert_frame_equal(base, test.to_pandas())
+    assert_eq(base, test)
     assert len(test) > 0
 
     mask = df_cudf.dates == start_date
     base_mask = df_pandas.dates == start_date
-    assert_series_equal(mask.to_pandas(), base_mask, check_names=False)
+    assert_eq(mask, base_mask, check_names=False)
     assert mask.to_pandas().sum() > 0
 
     start_date_ts = pd.Timestamp(start_date)
     test = df_cudf.query("dates==@start_date_ts")
     base = df_pandas.query("dates==@start_date_ts")
-    assert_frame_equal(base, test.to_pandas())
+    assert_eq(base, test)
     assert len(test) > 0
 
     mask = df_cudf.dates == start_date_ts
     base_mask = df_pandas.dates == start_date_ts
-    assert_series_equal(mask.to_pandas(), base_mask, check_names=False)
+    assert_eq(mask, base_mask, check_names=False)
     assert mask.to_pandas().sum() > 0
 
     start_date_np = np.datetime64(start_date_ts, "ns")
     test = df_cudf.query("dates==@start_date_np")
     base = df_pandas.query("dates==@start_date_np")
-    assert_frame_equal(base, test.to_pandas())
+    assert_eq(base, test)
     assert len(test) > 0
 
     mask = df_cudf.dates == start_date_np
     base_mask = df_pandas.dates == start_date_np
-    assert_series_equal(mask.to_pandas(), base_mask, check_names=False)
+    assert_eq(mask, base_mask, check_names=False)
     assert mask.to_pandas().sum() > 0
 
 

--- a/python/cudf/cudf/tests/test_fill.py
+++ b/python/cudf/cudf/tests/test_fill.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import pytest
-from pandas.util.testing import assert_series_equal
 
 import cudf
+from cudf.tests.utils import assert_eq
 
 
 @pytest.mark.parametrize(
@@ -55,7 +55,7 @@ def test_fill(data, fill_value, begin, end, inplace):
 
     ps[begin:end] = fill_value
 
-    assert_series_equal(ps, actual.to_pandas())
+    assert_eq(ps, actual)
 
 
 @pytest.mark.xfail(raises=ValueError)

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -288,7 +288,7 @@ def test_groupby_apply_grouped():
     expect = expect_grpby.apply(emulate)
     expect = expect.sort_values(["key1", "key2"])
 
-    pd.util.testing.assert_frame_equal(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize("nelem", [100, 500])

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -698,7 +698,7 @@ def test_dataframe_masked_slicing(nelem, slice_start, slice_end):
     expect = do_slice(gdf.to_pandas())
     got = do_slice(gdf).to_pandas()
 
-    pd.testing.assert_frame_equal(expect, got)
+    assert_eq(expect, got)
 
 
 def test_dataframe_boolean_mask_with_None():

--- a/python/cudf/cudf/tests/test_joining.py
+++ b/python/cudf/cudf/tests/test_joining.py
@@ -106,10 +106,8 @@ def test_dataframe_join_how(aa, bb, how, method):
             # TODO: What is the less hacky way?
             expect.index.name = "bob"
             got.index.name = "mary"
-            pd.util.testing.assert_frame_equal(
-                got.to_pandas()
-                .sort_values(got.columns.to_list())
-                .reset_index(drop=True),
+            assert_eq(
+                got.sort_values(got.columns.to_list()).reset_index(drop=True),
                 expect.sort_values(expect.columns.to_list()).reset_index(
                     drop=True
                 ),
@@ -183,11 +181,8 @@ def test_dataframe_join_cats():
     expect = lhs.to_pandas().join(rhs.to_pandas())
 
     # Note: pandas make an object Index after joining
-    pd.util.testing.assert_frame_equal(
-        got.sort_values(by="b")
-        .to_pandas()
-        .sort_index()
-        .reset_index(drop=True),
+    assert_eq(
+        got.sort_values(by="b").sort_index().reset_index(drop=True),
         expect.reset_index(drop=True),
     )
 
@@ -322,7 +317,7 @@ def test_dataframe_merge_on(on):
         list(pddf_joined.columns)
     ).reset_index(drop=True)
 
-    pd.util.testing.assert_frame_equal(cdf_result, pdf_result, check_like=True)
+    assert_eq(cdf_result, pdf_result, check_like=True)
 
     merge_func_result_cdf = (
         join_result_cudf.to_pandas()
@@ -330,9 +325,7 @@ def test_dataframe_merge_on(on):
         .reset_index(drop=True)
     )
 
-    pd.util.testing.assert_frame_equal(
-        merge_func_result_cdf, cdf_result, check_like=True
-    )
+    assert_eq(merge_func_result_cdf, cdf_result, check_like=True)
 
 
 def test_dataframe_merge_on_unknown_column():

--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -248,8 +248,7 @@ def test_json_lines_compression(tmpdir, ext, out_comp, in_comp):
     cu_df = cudf.read_json(
         str(fname), compression=in_comp, lines=True, dtype=["int", "int"]
     )
-
-    pd.util.testing.assert_frame_equal(pd_df, cu_df.to_pandas())
+    assert_eq(pd_df, cu_df)
 
 
 @pytest.mark.filterwarnings("ignore:Using CPU")

--- a/python/cudf/cudf/tests/test_pickling.py
+++ b/python/cudf/cudf/tests/test_pickling.py
@@ -39,13 +39,13 @@ def check_serialization(df):
         for b in buffers:
             assert isinstance(b, pickle.PickleBuffer)
         loaded = pickle.loads(serialbytes, buffers=buffers)
-        pd.util.testing.assert_frame_equal(loaded.to_pandas(), df.to_pandas())
+        assert_eq(loaded, df)
 
 
 def assert_frame_picklable(df):
     serialbytes = pickle.dumps(df)
     loaded = pickle.loads(serialbytes)
-    pd.util.testing.assert_frame_equal(loaded.to_pandas(), df.to_pandas())
+    assert_eq(loaded, df)
 
 
 def test_pickle_dataframe_numeric():

--- a/python/cudf/cudf/tests/test_query.py
+++ b/python/cudf/cudf/tests/test_query.py
@@ -9,7 +9,6 @@ from itertools import product
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.util.testing import assert_frame_equal
 
 import cudf
 from cudf.core import DataFrame
@@ -142,7 +141,7 @@ def test_query_splitted_combine():
 
     # Should equal to just querying the original GDF
     expect = gdf.query(expr).to_pandas()
-    assert_frame_equal(got, expect)
+    assert_eq(got, expect)
 
 
 def test_query_empty_frames():
@@ -154,7 +153,7 @@ def test_query_empty_frames():
     expect = empty_pdf.query(expr)
 
     # assert equal results
-    assert_frame_equal(got, expect)
+    assert_eq(got, expect)
 
 
 @pytest.mark.parametrize(("a_val", "b_val", "c_val"), [(4, 3, 15)])

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -95,7 +95,7 @@ def test_dataframe_replace():
     gdf1 = DataFrame.from_pandas(pdf1)
     pdf2 = pdf1.replace(0, 4)
     gdf2 = gdf1.replace(0, 4)
-    pd.testing.assert_frame_equal(gdf2.to_pandas(), pdf2)
+    assert_eq(gdf2, pdf2)
 
     # categorical
     pdf4 = pd.DataFrame(
@@ -105,25 +105,25 @@ def test_dataframe_replace():
     gdf4 = DataFrame.from_pandas(pdf4)
     pdf5 = pdf4.replace("two", "three")
     gdf5 = gdf4.replace("two", "three")
-    pd.testing.assert_frame_equal(gdf5.to_pandas(), pdf5)
+    assert_eq(gdf5, pdf5)
 
     # list input
     pdf6 = pdf1.replace([0, 1], [4, 5])
     gdf6 = gdf1.replace([0, 1], [4, 5])
-    pd.testing.assert_frame_equal(gdf6.to_pandas(), pdf6)
+    assert_eq(gdf6, pdf6)
 
     pdf7 = pdf1.replace([0, 1], 4)
     gdf7 = gdf1.replace([0, 1], 4)
-    pd.testing.assert_frame_equal(gdf7.to_pandas(), pdf7)
+    assert_eq(gdf7, pdf7)
 
     # dict input:
     pdf8 = pdf1.replace({"a": 0, "b": 0}, {"a": 4, "b": 5})
     gdf8 = gdf1.replace({"a": 0, "b": 0}, {"a": 4, "b": 5})
-    pd.testing.assert_frame_equal(gdf8.to_pandas(), pdf8)
+    assert_eq(gdf8, pdf8)
 
     pdf9 = pdf1.replace({"a": 0}, {"a": 4})
     gdf9 = gdf1.replace({"a": 0}, {"a": 4})
-    pd.testing.assert_frame_equal(gdf9.to_pandas(), pdf9)
+    assert_eq(gdf9, pdf9)
 
 
 def test_dataframe_replace_with_nulls():
@@ -132,25 +132,25 @@ def test_dataframe_replace_with_nulls():
     gdf1 = DataFrame.from_pandas(pdf1)
     pdf2 = pdf1.replace(0, 4)
     gdf2 = gdf1.replace(0, None).fillna(4)
-    pd.testing.assert_frame_equal(gdf2.to_pandas(), pdf2)
+    assert_eq(gdf2, pdf2)
 
     # list input
     pdf6 = pdf1.replace([0, 1], [4, 5])
     gdf6 = gdf1.replace([0, 1], [4, None]).fillna(5)
-    pd.testing.assert_frame_equal(gdf6.to_pandas(), pdf6)
+    assert_eq(gdf6, pdf6)
 
     pdf7 = pdf1.replace([0, 1], 4)
     gdf7 = gdf1.replace([0, 1], None).fillna(4)
-    pd.testing.assert_frame_equal(gdf7.to_pandas(), pdf7)
+    assert_eq(gdf7, pdf7)
 
     # dict input:
     pdf8 = pdf1.replace({"a": 0, "b": 0}, {"a": 4, "b": 5})
     gdf8 = gdf1.replace({"a": 0, "b": 0}, {"a": None, "b": 5}).fillna(4)
-    pd.testing.assert_frame_equal(gdf8.to_pandas(), pdf8)
+    assert_eq(gdf8, pdf8)
 
     gdf1 = DataFrame({"a": [0, 1, 2, 3], "b": [0, 1, 2, None]})
     gdf9 = gdf1.replace([0, 1], [4, 5]).fillna(3)
-    pd.testing.assert_frame_equal(gdf9.to_pandas(), pdf6)
+    assert_eq(gdf9, pdf6)
 
 
 def test_replace_strings():

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -13,24 +13,24 @@ def test_series_replace():
     a2 = np.array([5, 1, 2, 3, 4])
     sr1 = Series(a1)
     sr2 = sr1.replace(0, 5)
-    np.testing.assert_equal(sr2.to_array(), a2)
+    assert_eq(a2, sr2.to_array())
 
     # Categorical
     psr3 = pd.Series(["one", "two", "three"], dtype="category")
     psr4 = psr3.replace("one", "two")
     sr3 = Series.from_pandas(psr3)
     sr4 = sr3.replace("one", "two")
-    pd.testing.assert_series_equal(sr4.to_pandas(), psr4)
+    assert_eq(psr4, sr4)
 
     psr5 = psr3.replace("one", "five")
     sr5 = sr3.replace("one", "five")
 
-    pd.testing.assert_series_equal(sr5.to_pandas(), psr5)
+    assert_eq(psr5, sr5)
 
     # List input
     a6 = np.array([5, 6, 2, 3, 4])
     sr6 = sr1.replace([0, 1], [5, 6])
-    np.testing.assert_equal(sr6.to_array(), a6)
+    assert_eq(a6, sr6.to_array())
 
     with pytest.raises(TypeError):
         sr1.replace([0, 1], [5.5, 6.5])
@@ -38,7 +38,7 @@ def test_series_replace():
     # Series input
     a8 = np.array([5, 5, 5, 3, 4])
     sr8 = sr1.replace(sr1[:3], 5)
-    np.testing.assert_equal(sr8.to_array(), a8)
+    assert_eq(a8, sr8.to_array())
 
     # large input containing null
     sr9 = Series(list(range(400)) + [None])
@@ -68,12 +68,12 @@ def test_series_replace_with_nulls():
     a2 = np.array([-10, 1, 2, 3, 4])
     sr1 = Series(a1)
     sr2 = sr1.replace(0, None).fillna(-10)
-    np.testing.assert_equal(sr2.to_array(), a2)
+    assert_eq(a2, sr2.to_array())
 
     # List input
     a6 = np.array([-10, 6, 2, 3, 4])
     sr6 = sr1.replace([0, 1], [None, 6]).fillna(-10)
-    np.testing.assert_equal(sr6.to_array(), a6)
+    assert_eq(a6, sr6.to_array())
 
     sr1 = Series([0, 1, 2, 3, 4, None])
     with pytest.raises(TypeError):
@@ -82,11 +82,11 @@ def test_series_replace_with_nulls():
     # Series input
     a8 = np.array([-10, -10, -10, 3, 4, -10])
     sr8 = sr1.replace(sr1[:3], None).fillna(-10)
-    np.testing.assert_equal(sr8.to_array(), a8)
+    assert_eq(a8, sr8.to_array())
 
     a9 = np.array([-10, 6, 2, 3, 4, -10])
     sr9 = sr1.replace([0, 1], [None, 6]).fillna(-10)
-    np.testing.assert_equal(sr9.to_array(), a9)
+    assert_eq(a9, sr9.to_array())
 
 
 def test_dataframe_replace():

--- a/python/cudf/cudf/tests/test_reshape.py
+++ b/python/cudf/cudf/tests/test_reshape.py
@@ -61,9 +61,9 @@ def test_melt(nulls, num_id_vars, num_value_vars, num_rows, dtype):
     # cuDF's melt makes it Categorical because it doesn't support strings
     expect["variable"] = expect["variable"].astype("category")
 
-    pd.testing.assert_frame_equal(expect, got.to_pandas())
+    assert_eq(expect, got)
 
-    pd.testing.assert_frame_equal(expect, got_from_melt_method.to_pandas())
+    assert_eq(expect, got_from_melt_method)
 
 
 @pytest.mark.parametrize("num_cols", [1, 2, 10])

--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -131,7 +131,7 @@ def test_series_scale():
     scaled = (arr - vmin) / (vmax - vmin)
     assert scaled.min() == 0
     assert scaled.max() == 1
-    pd.testing.assert_series_equal(sr.scale().to_pandas(), scaled)
+    assert_eq(sr.scale(), scaled)
 
 
 @pytest.mark.parametrize("int_method", interpolation_methods)

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -1258,9 +1258,9 @@ def test_strings_rsplit(data, n, expand):
     gs = Series(data)
     ps = pd.Series(data)
 
-    pd.testing.assert_frame_equal(
+    assert_eq(
         ps.str.rsplit(n=n, expand=expand).reset_index(),
-        gs.str.rsplit(n=n, expand=expand).to_pandas().reset_index(),
+        gs.str.rsplit(n=n, expand=expand).reset_index(),
         check_index_type=False,
     )
     assert_eq(
@@ -1294,9 +1294,9 @@ def test_strings_split(data, n, expand):
     gs = Series(data)
     ps = pd.Series(data)
 
-    pd.testing.assert_frame_equal(
+    assert_eq(
         ps.str.split(n=n, expand=expand).reset_index(),
-        gs.str.split(n=n, expand=expand).to_pandas().reset_index(),
+        gs.str.split(n=n, expand=expand).reset_index(),
         check_index_type=False,
     )
 

--- a/python/cudf/cudf/tests/test_text.py
+++ b/python/cudf/cudf/tests/test_text.py
@@ -3,7 +3,6 @@
 import cupy
 import numpy as np
 import pytest
-from pandas.util.testing import assert_series_equal
 
 import cudf
 from cudf.tests.utils import assert_eq
@@ -42,7 +41,7 @@ def test_tokenize():
     actual = strings.str.tokenize()
 
     assert type(expected) == type(actual)
-    assert_series_equal(expected.to_pandas(), actual.to_pandas())
+    assert_eq(expected, actual)
 
 
 @pytest.mark.parametrize(
@@ -70,9 +69,7 @@ def test_token_count(delimiter, expected_token_counts):
     actual = strings.str.token_count(delimiter)
 
     assert type(expected) == type(actual)
-    assert_series_equal(
-        expected.to_pandas(), actual.to_pandas(), check_dtype=False
-    )
+    assert_eq(expected, actual, check_dtype=False)
 
 
 def test_normalize_spaces():
@@ -96,7 +93,7 @@ def test_normalize_spaces():
     actual = strings.str.normalize_spaces()
 
     assert type(expected) == type(actual)
-    assert_series_equal(expected.to_pandas(), actual.to_pandas())
+    assert_eq(expected, actual)
 
 
 @pytest.mark.parametrize(
@@ -139,7 +136,7 @@ def test_ngrams(n, separator, expected_values):
     actual = strings.str.ngrams(n=n, separator=separator)
 
     assert type(expected) == type(actual)
-    assert_series_equal(expected.to_pandas(), actual.to_pandas())
+    assert_eq(expected, actual)
 
 
 @pytest.mark.parametrize(
@@ -172,7 +169,7 @@ def test_character_ngrams(n, expected_values):
     actual = strings.str.character_ngrams(n=n)
 
     assert type(expected) == type(actual)
-    assert_series_equal(expected.to_pandas(), actual.to_pandas())
+    assert_eq(expected, actual)
 
 
 @pytest.mark.parametrize(
@@ -205,7 +202,7 @@ def test_ngrams_tokenize(n, separator, expected_values):
     actual = strings.str.ngrams_tokenize(n=n, separator=separator)
 
     assert type(expected) == type(actual)
-    assert_series_equal(expected.to_pandas(), actual.to_pandas())
+    assert_eq(expected, actual)
 
 
 def test_character_tokenize_series():


### PR DESCRIPTION
Since the logic for comparing cudf/Pandas objects is in the `assert_eq` utility function, we should aim to use that wherever possible.

cc: @brandon-b-miller 