### PR TITLE
[REVIEW] Reduce number of concatenate benchmark test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
 - PR #5720 Replace owning raw pointers with std::unique_ptr
 - PR #5702 Add inherited methods to python docs and other docs fixes
 - PR #5733 Add support for `size` property in `DataFrame`/ `Series` / `Index`/ `MultiIndex`
+- PR #5743 Reduce number of test cases in concatenate benchmark
 
 ## Bug Fixes
 

--- a/cpp/benchmarks/column/concatenate_benchmark.cpp
+++ b/cpp/benchmarks/column/concatenate_benchmark.cpp
@@ -73,7 +73,7 @@ static void BM_concatenate(benchmark::State& state)
   BENCHMARK_TEMPLATE_DEFINE_F(Concatenate, name, type, nullable)          \
   (::benchmark::State & state) { BM_concatenate<type, nullable>(state); } \
   BENCHMARK_REGISTER_F(Concatenate, name)                                 \
-    ->RangeMultiplier(4)                                                  \
+    ->RangeMultiplier(8)                                                  \
     ->Ranges({{1 << 6, 1 << 18}, {2, 1024}})                              \
     ->Unit(benchmark::kMillisecond)                                       \
     ->UseManualTime();
@@ -135,7 +135,7 @@ static void BM_concatenate_tables(benchmark::State& state)
   BENCHMARK_TEMPLATE_DEFINE_F(Concatenate, name, type, nullable)                 \
   (::benchmark::State & state) { BM_concatenate_tables<type, nullable>(state); } \
   BENCHMARK_REGISTER_F(Concatenate, name)                                        \
-    ->RangeMultiplier(4)                                                         \
+    ->RangeMultiplier(8)                                                         \
     ->Ranges({{1 << 8, 1 << 12}, {2, 32}, {2, 128}})                             \
     ->Unit(benchmark::kMillisecond)                                              \
     ->UseManualTime();
@@ -196,7 +196,7 @@ static void BM_concatenate_strings(benchmark::State& state)
   BENCHMARK_TEMPLATE_DEFINE_F(ConcatenateStrings, name, nullable)           \
   (::benchmark::State & state) { BM_concatenate_strings<nullable>(state); } \
   BENCHMARK_REGISTER_F(ConcatenateStrings, name)                            \
-    ->RangeMultiplier(4)                                                    \
+    ->RangeMultiplier(8)                                                    \
     ->Ranges({{1 << 8, 1 << 14}, {8, 128}, {2, 256}})                       \
     ->Unit(benchmark::kMillisecond)                                         \
     ->UseManualTime();


### PR DESCRIPTION
The concatenate benchmark is taking an excessive amount of CI time because it sweeps a large range of parameters. Increasing the range multiplier from 4 to 8 will greatly reduce the number of test cases, which should alleviate the issue.