### PR TITLE
[REVIEW] Reduce number of cases of reduction benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
 - PR #5720 Replace owning raw pointers with std::unique_ptr
 - PR #5702 Add inherited methods to python docs and other docs fixes
 - PR #5733 Add support for `size` property in `DataFrame`/ `Series` / `Index`/ `MultiIndex`
+- PR #5744 Reduce number of test cases in reduction benchmark
 
 ## Bug Fixes
 

--- a/cpp/benchmarks/reduction/reduce_benchmark.cpp
+++ b/cpp/benchmarks/reduction/reduce_benchmark.cpp
@@ -64,12 +64,11 @@ void BM_reduction(benchmark::State& state, std::unique_ptr<cudf::aggregation> co
   }                                                               \
   BENCHMARK_REGISTER_F(Reduction, name)                           \
     ->UseManualTime()                                             \
-    ->Arg(10000)     /* 10k */                                    \
-    ->Arg(100000)    /* 100k */                                   \
-    ->Arg(1000000)   /* 1M */                                     \
-    ->Arg(10000000)  /* 10M */                                    \
-    ->Arg(100000000) /* 100M */                                   \
-    ->Iterations(1000);
+    ->Arg(10000)      /* 10k */                                   \
+    ->Arg(100000)     /* 100k */                                  \
+    ->Arg(1000000)    /* 1M */                                    \
+    ->Arg(10000000)   /* 10M */                                   \
+    ->Arg(100000000); /* 100M */
 
 #define REDUCE_BENCHMARK_DEFINE(type, aggregation) \
   RBM_BENCHMARK_DEFINE(concat(type, _, aggregation), type, aggregation)

--- a/cpp/benchmarks/reduction/reduce_benchmark.cpp
+++ b/cpp/benchmarks/reduction/reduce_benchmark.cpp
@@ -64,11 +64,12 @@ void BM_reduction(benchmark::State& state, std::unique_ptr<cudf::aggregation> co
   }                                                               \
   BENCHMARK_REGISTER_F(Reduction, name)                           \
     ->UseManualTime()                                             \
-    ->Arg(10000)      /* 10k */                                   \
-    ->Arg(100000)     /* 100k */                                  \
-    ->Arg(1000000)    /* 1M */                                    \
-    ->Arg(10000000)   /* 10M */                                   \
-    ->Arg(100000000); /* 100M */
+    ->Arg(10000)     /* 10k */                                    \
+    ->Arg(100000)    /* 100k */                                   \
+    ->Arg(1000000)   /* 1M */                                     \
+    ->Arg(10000000)  /* 10M */                                    \
+    ->Arg(100000000) /* 100M */                                   \
+    ->Iterations(1000);
 
 #define REDUCE_BENCHMARK_DEFINE(type, aggregation) \
   RBM_BENCHMARK_DEFINE(concat(type, _, aggregation), type, aggregation)
@@ -82,10 +83,15 @@ void BM_reduction(benchmark::State& state, std::unique_ptr<cudf::aggregation> co
   REDUCE_BENCHMARK_DEFINE(double, aggregation);
 
 REDUCE_BENCHMARK_NUMERIC(sum);
-REDUCE_BENCHMARK_NUMERIC(product);
-REDUCE_BENCHMARK_NUMERIC(min);
+REDUCE_BENCHMARK_DEFINE(int32_t, product);
+REDUCE_BENCHMARK_DEFINE(float, product);
+REDUCE_BENCHMARK_DEFINE(int64_t, min);
+REDUCE_BENCHMARK_DEFINE(double, min);
 using cudf::timestamp_ms;
 REDUCE_BENCHMARK_DEFINE(timestamp_ms, min);
-REDUCE_BENCHMARK_NUMERIC(mean);
-REDUCE_BENCHMARK_NUMERIC(variance);
-REDUCE_BENCHMARK_NUMERIC(std);
+REDUCE_BENCHMARK_DEFINE(int8_t, mean);
+REDUCE_BENCHMARK_DEFINE(float, mean);
+REDUCE_BENCHMARK_DEFINE(int32_t, variance);
+REDUCE_BENCHMARK_DEFINE(double, variance);
+REDUCE_BENCHMARK_DEFINE(int64_t, std);
+REDUCE_BENCHMARK_DEFINE(float, std);


### PR DESCRIPTION
Runtime 00:22:46 REDUCTION_BENCH

~- [x] fix number of iterations (1000)~
- [x] reduce number of cases (reduced no. of types)
- column sizes are 10k,100k,1M,10M,100M.

This change reduces to ~6.5 minute.