### PR TITLE
Update JNI cast for inability to cast timestamp and integer types [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,8 @@
 - PR #5703 Small fix for dataframe constructor with cuda array interface objects that don't have `descr` field
 - PR #5719 Fix Frame._concat() with categorical columns
 - PR #5736 Disable unsigned type in ORC writer benchmarks
+- PR #5745 Update JNI cast for inability to cast timestamp and integer types
+
 
 # cuDF 0.14.0 (03 Jun 2020)
 

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -50,6 +50,35 @@
 
 #include "jni_utils.hpp"
 
+namespace {
+
+// convert a timestamp type to the corresponding duration type
+cudf::data_type timestamp_to_duration(cudf::data_type dt) {
+  cudf::type_id duration_type_id;
+  switch (dt.id()) {
+    case cudf::type_id::TIMESTAMP_DAYS:
+      duration_type_id = cudf::type_id::DURATION_DAYS;
+      break;
+    case cudf::type_id::TIMESTAMP_SECONDS:
+      duration_type_id = cudf::type_id::DURATION_SECONDS;
+      break;
+    case cudf::type_id::TIMESTAMP_MILLISECONDS:
+      duration_type_id = cudf::type_id::DURATION_MILLISECONDS;
+      break;
+    case cudf::type_id::TIMESTAMP_MICROSECONDS:
+      duration_type_id = cudf::type_id::DURATION_MICROSECONDS;
+      break;
+    case cudf::type_id::TIMESTAMP_NANOSECONDS:
+      duration_type_id = cudf::type_id::DURATION_NANOSECONDS;
+      break;
+    default:
+      throw std::logic_error("Unexpected type in timestamp_to_duration");
+  }
+  return cudf::data_type(duration_type_id);
+}
+
+} // anonymous namespace
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_upperStrings(JNIEnv *env, jobject j_object,
@@ -649,6 +678,37 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_castTo(JNIEnv *env, job
           break;
         default: JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Invalid data type", 0);
       }
+    } else if (cudf::is_timestamp(n_data_type) && cudf::is_numeric(column->type())) {
+      // This is a temporary workaround to allow Java to cast from integral types into a timestamp
+      // without forcing an intermediate duration column to be manifested.  Ultimately this style of
+      // "reinterpret" casting will be supported via https://github.com/rapidsai/cudf/pull/5358
+      if (n_data_type.id() == cudf::type_id::TIMESTAMP_DAYS) {
+        if (column->type().id() != cudf::type_id::INT32) {
+          JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Numeric cast to TIMESTAMP_DAYS requires INT32", 0);
+        }
+      } else {
+        if (column->type().id() != cudf::type_id::INT64) {
+          JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Numeric cast to non-day timestamp requires INT64", 0);
+        }
+      }
+      cudf::data_type duration_type = timestamp_to_duration(n_data_type);
+      cudf::column_view duration_view = cudf::column_view(duration_type,
+                                                          column->size(),
+                                                          column->head(),
+                                                          column->null_mask(),
+                                                          column->null_count());
+      result = cudf::cast(duration_view, n_data_type);
+    } else if (cudf::is_timestamp(column->type()) && cudf::is_numeric(n_data_type)) {
+      // This is a temporary workaround to allow Java to cast from timestamp types to integral types
+      // without forcing an intermediate duration column to be manifested.  Ultimately this style of
+      // "reinterpret" casting will be supported via https://github.com/rapidsai/cudf/pull/5358
+      cudf::data_type duration_type = timestamp_to_duration(column->type());
+      cudf::column_view duration_view = cudf::column_view(duration_type,
+                                                          column->size(),
+                                                          column->head(),
+                                                          column->null_mask(),
+                                                          column->null_count());
+      result = cudf::cast(duration_view, n_data_type);
     } else {
       result = cudf::cast(*column, n_data_type);
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -1605,13 +1605,13 @@ public class ColumnVectorTest extends CudfTestBase {
          ColumnVector expectedDays = ColumnVector.daysFromInts(values);
          ColumnVector days = cv.asTimestampDays();
          ColumnVector expectedUs = ColumnVector.timestampMicroSecondsFromLongs(longValues);
-         ColumnVector us = cv.asTimestampMicroseconds();
+         ColumnVector us = longs.asTimestampMicroseconds();
          ColumnVector expectedNs = ColumnVector.timestampNanoSecondsFromLongs(longValues);
-         ColumnVector ns = cv.asTimestampNanoseconds();
+         ColumnVector ns = longs.asTimestampNanoseconds();
          ColumnVector expectedMs = ColumnVector.timestampMilliSecondsFromLongs(longValues);
-         ColumnVector ms = cv.asTimestampMilliseconds();
+         ColumnVector ms = longs.asTimestampMilliseconds();
          ColumnVector expectedS = ColumnVector.timestampSecondsFromLongs(longValues);
-         ColumnVector s = cv.asTimestampSeconds();) {
+         ColumnVector s = longs.asTimestampSeconds();) {
       assertColumnsAreEqual(expectedUnsignedInts, unsignedInts);
       assertColumnsAreEqual(expectedBytes, bytes);
       assertColumnsAreEqual(expectedUnsignedBytes, unsignedBytes);


### PR DESCRIPTION
Recently libcudf stopped supporting casting between timestamp and integral columns which broke the Java bindings.  Without a cast that reinterprets the bits, like the `logical_cast` being added in #5358, Java would need to manifest a duration column first.

This updates the Java bindings for cast to preserve the old behavior of casting between timestamps and integers.  When `logical_cast` is added, support for casting between timestamps and integral types with the old cast method will be removed and instead applications must either use the new cast method in those cases or explicitly cast to a duration first.