### PR TITLE
Add RMM_ROOT/include to the spdlog search path in JNI build [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@
 - PR #5719 Fix Frame._concat() with categorical columns
 - PR #5736 Disable unsigned type in ORC writer benchmarks
 - PR #5745 Update JNI cast for inability to cast timestamp and integer types
+- PR #5750 Add RMM_ROOT/include to the spdlog search path in JNI build
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -123,6 +123,7 @@ find_path(LIBCUDACXX_INCLUDE "simt"
 
 find_path(SPDLOG_INCLUDE "spdlog"
     HINTS "$ENV{RMM_ROOT}/_deps/spdlog-src/include"
+          "$ENV{RMM_ROOT}/include"
           "$ENV{CONDA_PREFIX}/include")
 
 ###################################################################################################


### PR DESCRIPTION
#5659 added `SPDLOG_INCLUDE` to the JNI cmake, but it only looks under RMM_ROOT/_deps and CONDA_PREFIX/include.  In a non-conda environment CONDA_PREFIX is not going to be set, and RMM_ROOT may be set to where RMM is installed rather than the RMM build directory.  Therefore cmake needs to search for the spdlog includes under RMM_ROOT/include as well.