### PR TITLE
[REVIEW] Add cuDF internals documentation (ColumnAccessor) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 - PR #5702 Add inherited methods to python docs and other docs fixes
 - PR #5733 Add support for `size` property in `DataFrame`/ `Series` / `Index`/ `MultiIndex`
 - PR #5743 Reduce number of test cases in concatenate benchmark
+- PR #5752 Add cuDF internals documentation (ColumnAccessor)
 
 ## Bug Fixes
 

--- a/docs/cudf/source/index.rst
+++ b/docs/cudf/source/index.rst
@@ -11,6 +11,7 @@ Welcome to cuDF's documentation!
    dask-xgb-10min.ipynb
    10min-cudf-cupy.ipynb
    guide-to-udfs.ipynb
+   internals.md
 
 Indices and tables
 ==================

--- a/docs/cudf/source/internals.md
+++ b/docs/cudf/source/internals.md
@@ -1,0 +1,95 @@
+cuDF internals
+==============
+
+ColumnAccessor
+--------------
+
+The underlying data structure of cuDF `Series`, `DataFrame` and `Index` objects
+is a `ColumnAccessor`, which can be accessed via their `._data` attribute:
+
+```python
+>>> a = cudf.DataFrame({'x': [1, 2, 3], 'y': ['a', 'b', 'c']})
+>>> a._data
+ColumnAccessor(OrderedColumnDict([('x', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d12e050>), ('y', <cudf.core.column.string.StringColumn object at 0x7f5a7d12e320>)]), multiindex=False, level_names=(None,))
+```
+
+`ColumnAccessor` is a dict-like object that maps column labels to columns.
+In addition, it supports things like selecting multiple columns (both by index and label),
+as well as hierarchical indexing.
+
+```python
+>>> from cudf.core.column_accessor import ColumnAccessor
+```
+
+A ColumnAccessor behaves like an OrderedDict,
+its values are coerced to Columns during construction:
+
+```python
+>>> ca = ColumnAccessor({'x': [1, 2, 3], 'y': ['a', 'b', 'c']})
+>>> ca['x']
+<cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d5789e0>
+>>> ca['y']
+<cudf.core.column.string.StringColumn object at 0x7f5a7d578b90>
+>>> ca.pop('x')
+<cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d5789e0>
+>>> ca
+ColumnAccessor(OrderedColumnDict([('y', <cudf.core.column.string.StringColumn object at 0x7f5a7d578b90>)]), multiindex=False, level_names=(None,))
+```
+
+Columns can be inserted at a specified location:
+
+```python
+>>> ca.insert('z', [3, 4, 5], loc=1)
+>>> ca
+ColumnAccessor(OrderedColumnDict([('x', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d578dd0>), ('z', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d578680>), ('y', <cudf.core.column.string.StringColumn object at 0x7f5a7d12e3b0>)]), multiindex=False, level_names=(None,))
+```
+
+Selecting columns by index:
+
+```python
+>>> ca = ColumnAccessor({'x': [1, 2, 3], 'y': ['a', 'b', 'c'], 'z': [4, 5, 6]})
+>>> ca.select_by_index(1)
+ColumnAccessor(OrderedColumnDict([('y', <cudf.core.column.string.StringColumn object at 0x7f5a7d578830>)]), multiindex=False, level_names=(None,))
+>>> ca.select_by_index([0, 1])
+ColumnAccessor(OrderedColumnDict([('x', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d5789e0>), ('y', <cudf.core.column.string.StringColumn object at 0x7f5a7d578830>)]), multiindex=False, level_names=(None,))    
+>>> ca.select_by_index(slice(1, 3))
+ColumnAccessor(OrderedColumnDict([('y', <cudf.core.column.string.StringColumn object at 0x7f5a7d578830>), ('z', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d5788c0>)]), multiindex=False, level_names=(None,))
+```
+
+Selecting columns by label:
+
+```python
+>>> ca.select_by_label(['y', 'z'])
+ColumnAccessor(OrderedColumnDict([('y', <cudf.core.column.string.StringColumn object at 0x7f5a7d578830>), ('z', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d5788c0>)]), multiindex=False, level_names=(None,))
+>>> ca.select_by_label(slice('x', 'y'))
+ColumnAccessor(OrderedColumnDict([('x', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d5789e0>), ('y', <cudf.core.column.string.StringColumn object at 0x7f5a7d578830>)]), multiindex=False, level_names=(None,))
+```
+
+A ColumnAccessor with tuple keys (and constructed with `multiindex=True`)
+can be hierarchically indexed:
+
+```python
+>>> ca = ColumnAccessor({('a', 'b'): [1, 2, 3], ('a', 'c'): [2, 3, 4], 'b': [4, 5, 6]}, multiindex=True)
+>>> ca.select_by_label('a')
+ColumnAccessor(OrderedColumnDict([('b', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d5789e0>), ('c', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d578dd0>)]), multiindex=False, level_names=(None,))
+>>> ca.select_by_label(('a', 'b'))
+ColumnAccessor(OrderedColumnDict([(('a', 'b'), <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d5789e0>)]), multiindex=False, level_names=(None,))
+```
+
+"Wildcard" indexing is also allowed:
+
+```python
+>>> ca = ColumnAccessor({('a', 'b'): [1, 2, 3], ('a', 'c'): [2, 3, 4], ('d', 'b'): [4, 5, 6]}, multiindex=True)
+>>> ca.select_by_label((slice(None), 'b'))
+ColumnAccessor(OrderedColumnDict([(('a', 'b'), <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d578830>), (('d', 'b'), <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d578680>)]), multiindex=True, level_names=(None, None))
+```
+
+Finally, ColumnAccessors can convert to Pandas `Index` or `MultiIndex` objects:
+
+```python
+>>> ca.to_pandas_index()
+MultiIndex([('a', 'b'),
+            ('a', 'c'),
+            ('d', 'b')],
+           )
+```

--- a/docs/cudf/source/internals.md
+++ b/docs/cudf/source/internals.md
@@ -4,8 +4,9 @@ cuDF internals
 ColumnAccessor
 --------------
 
-The underlying data structure of cuDF `Series`, `DataFrame` and `Index` objects
-is a `ColumnAccessor`, which can be accessed via their `._data` attribute:
+cuDF  `Series`, `DataFrame` and `Index` are all subclasses of an internal `Frame` class.
+The underlying data structure of `Frame` is a `ColumnAccessor`,
+which can be accessed via the `._data` attribute:
 
 ```python
 >>> a = cudf.DataFrame({'x': [1, 2, 3], 'y': ['a', 'b', 'c']})
@@ -13,7 +14,7 @@ is a `ColumnAccessor`, which can be accessed via their `._data` attribute:
 ColumnAccessor(OrderedColumnDict([('x', <cudf.core.column.numerical.NumericalColumn object at 0x7f5a7d12e050>), ('y', <cudf.core.column.string.StringColumn object at 0x7f5a7d12e320>)]), multiindex=False, level_names=(None,))
 ```
 
-`ColumnAccessor` is a dict-like object that maps column labels to columns.
+`ColumnAccessor` is an ordered, dict-like object that maps column labels to columns.
 In addition, it supports things like selecting multiple columns (both by index and label),
 as well as hierarchical indexing.
 

--- a/python/cudf/cudf/_lib/csv.pyx
+++ b/python/cudf/cudf/_lib/csv.pyx
@@ -364,7 +364,7 @@ def read_csv(
     # Set index if the index_col parameter is passed
     if index_col is not None and index_col is not False:
         if isinstance(index_col, int):
-            df = df.set_index(df._data.get_by_index(index_col).names[0])
+            df = df.set_index(df._data.select_by_index(index_col).names[0])
             if names is None:
                 df._index.name = index_col
         else:

--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -193,7 +193,7 @@ class ColumnAccessor(MutableMapping):
             level_names=self.level_names,
         )
 
-    def get_by_label(self, key):
+    def select_by_label(self, key):
         """
         Return a subset of this column accessor,
         composed of the keys specified by `key`.
@@ -207,71 +207,16 @@ class ColumnAccessor(MutableMapping):
         ColumnAccessor
         """
         if isinstance(key, slice):
-            return self.get_by_label_slice(key)
+            return self._select_by_label_slice(key)
         elif pd.api.types.is_list_like(key) and not isinstance(key, tuple):
-            return self.get_by_label_list_like(key)
+            return self._select_by_label_list_like(key)
         else:
             if isinstance(key, tuple):
                 if any(isinstance(k, slice) for k in key):
-                    return self.get_by_label_with_wildcard(key)
-            return self.get_by_label_grouped(key)
+                    return self._select_by_label_with_wildcard(key)
+            return self._select_by_label_grouped(key)
 
-    def get_by_label_list_like(self, key):
-        return self.__class__(
-            to_flat_dict({k: self._grouped_data[k] for k in key}),
-            multiindex=self.multiindex,
-            level_names=self.level_names,
-        )
-
-    def get_by_label_grouped(self, key):
-        result = self._grouped_data[key]
-        if isinstance(result, cudf.core.column.ColumnBase):
-            return self.__class__({key: result})
-        else:
-            result = to_flat_dict(result)
-            if not isinstance(key, tuple):
-                key = (key,)
-            return self.__class__(
-                result,
-                multiindex=self.nlevels - len(key) > 1,
-                level_names=self.level_names[len(key) :],
-            )
-
-    def get_by_label_slice(self, key):
-        start, stop = key.start, key.stop
-        if key.step is not None:
-            raise TypeError("Label slicing with step is not supported")
-
-        if start is None:
-            start = self.names[0]
-        if stop is None:
-            stop = self.names[-1]
-        start = self._pad_key(start, slice(None))
-        stop = self._pad_key(stop, slice(None))
-        for idx, name in enumerate(self.names):
-            if _compare_keys(name, start):
-                start_idx = idx
-                break
-        for idx, name in enumerate(reversed(self.names)):
-            if _compare_keys(name, stop):
-                stop_idx = len(self.names) - idx
-                break
-        keys = self.names[start_idx:stop_idx]
-        return self.__class__(
-            {k: self._data[k] for k in keys},
-            multiindex=self.multiindex,
-            level_names=self.level_names,
-        )
-
-    def get_by_label_with_wildcard(self, key):
-        key = self._pad_key(key, slice(None))
-        return self.__class__(
-            {k: self._data[k] for k in self._data if _compare_keys(k, key)},
-            multiindex=self.multiindex,
-            level_names=self.level_names,
-        )
-
-    def get_by_index(self, index):
+    def select_by_index(self, index):
         """
         Return a ColumnAccessor composed of the columns
         specified by index.
@@ -308,6 +253,61 @@ class ColumnAccessor(MutableMapping):
         key = self._pad_key(key)
         self._data[key] = value
         self._clear_cache()
+
+    def _select_by_label_list_like(self, key):
+        return self.__class__(
+            to_flat_dict({k: self._grouped_data[k] for k in key}),
+            multiindex=self.multiindex,
+            level_names=self.level_names,
+        )
+
+    def _select_by_label_grouped(self, key):
+        result = self._grouped_data[key]
+        if isinstance(result, cudf.core.column.ColumnBase):
+            return self.__class__({key: result})
+        else:
+            result = to_flat_dict(result)
+            if not isinstance(key, tuple):
+                key = (key,)
+            return self.__class__(
+                result,
+                multiindex=self.nlevels - len(key) > 1,
+                level_names=self.level_names[len(key) :],
+            )
+
+    def _select_by_label_slice(self, key):
+        start, stop = key.start, key.stop
+        if key.step is not None:
+            raise TypeError("Label slicing with step is not supported")
+
+        if start is None:
+            start = self.names[0]
+        if stop is None:
+            stop = self.names[-1]
+        start = self._pad_key(start, slice(None))
+        stop = self._pad_key(stop, slice(None))
+        for idx, name in enumerate(self.names):
+            if _compare_keys(name, start):
+                start_idx = idx
+                break
+        for idx, name in enumerate(reversed(self.names)):
+            if _compare_keys(name, stop):
+                stop_idx = len(self.names) - idx
+                break
+        keys = self.names[start_idx:stop_idx]
+        return self.__class__(
+            {k: self._data[k] for k in keys},
+            multiindex=self.multiindex,
+            level_names=self.level_names,
+        )
+
+    def _select_by_label_with_wildcard(self, key):
+        key = self._pad_key(key, slice(None))
+        return self.__class__(
+            {k: self._data[k] for k in self._data if _compare_keys(k, key)},
+            multiindex=self.multiindex,
+            level_names=self.level_names,
+        )
 
     def _pad_key(self, key, pad_value=""):
         """

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -374,7 +374,7 @@ class DataFrame(Frame, Serializable):
                     self._data[col_name] = column.column_empty(
                         row_count=len(self), dtype=None, masked=True
                     )
-            self._data = self._data.get_by_label(columns)
+            self._data = self._data.select_by_label(columns)
 
     def _init_from_list_like(self, data, index=None, columns=None):
         if index is None:

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -450,7 +450,7 @@ class Frame(libcudf.table.Table):
 
         If downcast is True, try and downcast from a DataFrame to a Series
         """
-        new_data = self._data.get_by_label(labels)
+        new_data = self._data.select_by_label(labels)
         if downcast:
             if is_scalar(labels):
                 nlevels = 1
@@ -469,7 +469,7 @@ class Frame(libcudf.table.Table):
         Returns columns of the Frame specified by `labels`
 
         """
-        data = self._data.get_by_index(indices)
+        data = self._data.select_by_index(indices)
         return self._constructor(
             data, columns=data.to_pandas_index(), index=self.index
         )

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -856,7 +856,7 @@ class Index(Frame, Serializable):
         # in case of MultiIndex
         if isinstance(lhs, cudf.MultiIndex):
             if level is not None and isinstance(level, int):
-                on = lhs._data.get_by_index(level).names[0]
+                on = lhs._data.select_by_index(level).names[0]
             right_names = (on,) or right_names
             on = right_names[0]
             if how == "outer":

--- a/python/cudf/cudf/tests/test_column_accessor.py
+++ b/python/cudf/cudf/tests/test_column_accessor.py
@@ -100,16 +100,16 @@ def test_column_size_mismatch():
         _ = ColumnAccessor({"a": [1], "b": [1, 2]})
 
 
-def test_get_by_label_simple():
+def test_select_by_label_simple():
     """
     Test getting a column by label
     """
     ca = ColumnAccessor({"a": [1, 2, 3], "b": [2, 3, 4]})
-    check_ca_equal(ca.get_by_label("a"), ColumnAccessor({"a": [1, 2, 3]}))
-    check_ca_equal(ca.get_by_label("b"), ColumnAccessor({"b": [2, 3, 4]}))
+    check_ca_equal(ca.select_by_label("a"), ColumnAccessor({"a": [1, 2, 3]}))
+    check_ca_equal(ca.select_by_label("b"), ColumnAccessor({"b": [2, 3, 4]}))
 
 
-def test_get_by_label_multiindex():
+def test_select_by_label_multiindex():
     """
     Test getting column(s) by label with MultiIndex
     """
@@ -127,33 +127,33 @@ def test_get_by_label_multiindex():
         {("b", "c"): [1, 2, 3], ("b", "e"): [2, 3, 4], ("d", "e"): [3, 4, 5]},
         multiindex=True,
     )
-    got = ca.get_by_label("a")
+    got = ca.select_by_label("a")
     check_ca_equal(expect, got)
 
     expect = ColumnAccessor({"c": [1, 2, 3], "e": [2, 3, 4]}, multiindex=False)
-    got = ca.get_by_label(("a", "b"))
+    got = ca.select_by_label(("a", "b"))
     check_ca_equal(expect, got)
 
     expect = ColumnAccessor(
         {("b", "c"): [1, 2, 3], ("b", "e"): [2, 3, 4], ("d", "e"): [3, 4, 5]},
         multiindex=True,
     )
-    got = ca.get_by_label("a")
+    got = ca.select_by_label("a")
     check_ca_equal(expect, got)
 
     expect = ColumnAccessor({"c": [1, 2, 3], "e": [2, 3, 4]}, multiindex=False)
-    got = ca.get_by_label(("a", "b"))
+    got = ca.select_by_label(("a", "b"))
     check_ca_equal(expect, got)
 
 
-def test_get_by_label_simple_slice():
+def test_select_by_label_simple_slice():
     ca = ColumnAccessor({"a": [1, 2, 3], "b": [2, 3, 4], "c": [3, 4, 5]})
     expect = ColumnAccessor({"b": [2, 3, 4], "c": [3, 4, 5]})
-    got = ca.get_by_label(slice("b", "c"))
+    got = ca.select_by_label(slice("b", "c"))
     check_ca_equal(expect, got)
 
 
-def test_get_by_label_multiindex_slice():
+def test_select_by_label_multiindex_slice():
     ca = ColumnAccessor(
         {
             ("a", "b", "c"): [1, 2, 3],
@@ -164,7 +164,7 @@ def test_get_by_label_multiindex_slice():
         multiindex=True,
     )  # pandas needs columns to be sorted to do slicing with multiindex
     expect = ca
-    got = ca.get_by_label(slice(None, None))
+    got = ca.select_by_label(slice(None, None))
     check_ca_equal(expect, got)
 
     expect = ColumnAccessor(
@@ -175,29 +175,29 @@ def test_get_by_label_multiindex_slice():
         },
         multiindex=True,
     )
-    got = ca.get_by_label(slice(("a", "b", "e"), ("b", "x", "")))
+    got = ca.select_by_label(slice(("a", "b", "e"), ("b", "x", "")))
     check_ca_equal(expect, got)
 
 
 def test_by_label_list():
     ca = ColumnAccessor({"a": [1, 2, 3], "b": [2, 3, 4], "c": [3, 4, 5]})
     expect = ColumnAccessor({"b": [2, 3, 4], "c": [3, 4, 5]})
-    got = ca.get_by_label(["b", "c"])
+    got = ca.select_by_label(["b", "c"])
     check_ca_equal(expect, got)
 
 
-def test_get_by_index_simple():
+def test_select_by_index_simple():
     """
     Test getting a column by label
     """
     ca = ColumnAccessor({"a": [1, 2, 3], "b": [2, 3, 4]})
-    check_ca_equal(ca.get_by_index(0), ColumnAccessor({"a": [1, 2, 3]}))
-    check_ca_equal(ca.get_by_index(1), ColumnAccessor({"b": [2, 3, 4]}))
-    check_ca_equal(ca.get_by_index([0, 1]), ca)
-    check_ca_equal(ca.get_by_index(slice(0, None)), ca)
+    check_ca_equal(ca.select_by_index(0), ColumnAccessor({"a": [1, 2, 3]}))
+    check_ca_equal(ca.select_by_index(1), ColumnAccessor({"b": [2, 3, 4]}))
+    check_ca_equal(ca.select_by_index([0, 1]), ca)
+    check_ca_equal(ca.select_by_index(slice(0, None)), ca)
 
 
-def test_get_by_index_multiindex():
+def test_select_by_index_multiindex():
     """
     Test getting column(s) by label with MultiIndex
     """
@@ -219,7 +219,7 @@ def test_get_by_index_multiindex():
         },
         multiindex=True,
     )
-    got = ca.get_by_index(slice(0, 3))
+    got = ca.select_by_index(slice(0, 3))
     check_ca_equal(expect, got)
 
     expect = ColumnAccessor(
@@ -230,11 +230,11 @@ def test_get_by_index_multiindex():
         },
         multiindex=True,
     )
-    got = ca.get_by_index([0, 1, 3])
+    got = ca.select_by_index([0, 1, 3])
     check_ca_equal(expect, got)
 
 
-def test_get_by_index_empty():
+def test_select_by_index_empty():
     ca = ColumnAccessor(
         {
             ("a", "b", "c"): [1, 2, 3],
@@ -247,8 +247,8 @@ def test_get_by_index_empty():
     expect = ColumnAccessor(
         {}, multiindex=True, level_names=((None, None, None))
     )
-    got = ca.get_by_index(slice(None, 0))
+    got = ca.select_by_index(slice(None, 0))
     check_ca_equal(expect, got)
 
-    got = ca.get_by_index([])
+    got = ca.select_by_index([])
     check_ca_equal(expect, got)


### PR DESCRIPTION
Begin documenting the internals of cuDF with `ColumnAccessor`. Also renames the `get_by*` methods of `ColumnAccessor` to `select_by*`.