### PR TITLE
[REVIEW] Update cache.h docstring

### DIFF
--- a/cpp/src/jit/cache.h
+++ b/cpp/src/jit/cache.h
@@ -40,7 +40,9 @@ using named_prog = std::pair<std::string, std::shared_ptr<Tv>>;
  * This function returns a path to the cache directory, creating it if it
  * doesn't exist.
  *
- * The default cache directory `$TEMPDIR/cudf_$CUDF_VERSION`.
+ * The default cache directory is `$HOME/.cudf/$CUDF_VERSION`. If no overrides
+ * are used and if $HOME is not defined, returns an empty path and file
+ * caching is not used.
  **/
 boost::filesystem::path getCacheDir();
 


### PR DESCRIPTION
This small PR fixes a docstring in `src/jit/cache.h` to match the implemented behavior (which is consistent with the docstring in `src/jit/cache.cpp`).