### PR TITLE
[REVIEW] Fix column create from dictionary column view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,7 @@
 - PR #5763 Update Java slf4j version to match Spark 3.0
 - PR #5766 Fix issue related to `iloc` and slicing a `DataFrame`
 - PR #5319 Disallow SUM and specialize MEAN of timestamp types
+- PR #5787 Fix column create from dictionary column view
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -573,6 +573,7 @@ set(DICTIONARY_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/dictionary/set_keys_test.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/dictionary/slice_test.cpp")
 
+ConfigureTest(DICTIONARY_TEST "${DICTIONARY_TEST_SRC}")
 
 ###################################################################################################
 # - encode tests -----------------------------------------------------------------------------------

--- a/cpp/tests/dictionary/slice_test.cpp
+++ b/cpp/tests/dictionary/slice_test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cudf/copying.hpp>
+#include <cudf/detail/copy.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/dictionary/update_keys.hpp>
@@ -57,6 +58,11 @@ TEST_F(DictionarySliceTest, SliceColumn)
     auto added = cudf::dictionary::set_keys(cudf::dictionary_column_view(result.front()), new_keys);
     output     = cudf::dictionary::decode(cudf::dictionary_column_view(*added));
     cudf::test::expect_columns_equal(expected, *output);
+  }
+  {
+    // check new column is created correctly from sliced view (issue 5768)
+    cudf::column new_col(result.front());
+    cudf::test::expect_columns_equal(result.front(), new_col.view());
   }
 }
 


### PR DESCRIPTION
Closes #5768 

When creating a new `cudf::column` from a `cudf::column_view` of a dictionary type that was created by slicing a dictionary column, the new column logic was not accounting for the offset in that sliced view.

This PR corrects the `create_column_from_view` logic (already specialized for dictionary type) which copies the `keys` and `indices` child columns.

Also, the `gtests/DICTIONARY_TEST` was accidentally removed in this change:
https://github.com/rapidsai/cudf/pull/5572/files#diff-7f4ca86c1e86c9dd7460309b8d4da71b
This PR reinstates the gtest and adds a new test case for creating a column from a view.
