### PR TITLE
[REVIEW] Add cudf_kafka to the list of custreamz run dependencies in the conda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - PR #5782 Add Kafka support to custreamz
 - PR #5642 Add `GroupBy.groups()`
 - PR #5810 Make Cython subdirs packages and simplify package_data
+- PR #5822 Add `cudf_kafka` to `custreamz` run time conda dependency and fix bash syntax issue
 
 ## Improvements
 

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -60,11 +60,11 @@ source ci/cpu/cudf/build_cudf.sh
 logger "Build conda pkg for dask-cudf..."
 source ci/cpu/dask-cudf/build_dask_cudf.sh
 
-logger "Build conda pkg for custreamz..."
-source ci/cpu/custreamz/build_custreamz.sh
-
 logger "Build conda pkg for cudf_kafka..."
 source ci/cpu/cudf_kafka/build_cudf_kafka.sh
+
+logger "Build conda pkg for custreamz..."
+source ci/cpu/custreamz/build_custreamz.sh
 ################################################################################
 # UPLOAD - Conda packages
 ################################################################################

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -22,7 +22,7 @@ else
 fi
 
 #We only want to upload libcudf_kafka once per python/CUDA combo
-if [ "$PYTHON" == "3.7" && "$CUDA" == "10.1" ]; then
+if [[ "$PYTHON" == "3.7" && "$CUDA" == "10.1" ]]; then
     export UPLOAD_LIBCUDF_KAFKA=1
 else
     export UPLOAD_LIBCUDF_KAFKA=0

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - dask >=2.15.0
     - distributed >=2.15.0
     - python-confluent-kafka
+    - cudf_kafka {{ version }}
 
 test:
   imports:


### PR DESCRIPTION
Added `cudf_kafka` to list of run dependencies for custreamz in conda recipe

This closes #5821 