### PR TITLE
Mark host frames as not needing to be writeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - PR #5373 Remove legacy nvstrings/nvcategory/nvtext
 - PR #5362 Remove dependency on `rmm._DevicePointer`
 - PR #5302 Add missing comparison operators to `fixed_point` type
+- PR #5824 Mark host frames as not needing to be writeable
 - PR #5354 Split Dask deserialization methods by dask/cuda
 - PR #5363 Handle `0-dim` inputs while broadcasting to a column
 - PR #5396 Remove legacy tests env variable from build.sh

--- a/python/cudf/cudf/core/abc.py
+++ b/python/cudf/cudf/core/abc.py
@@ -95,6 +95,7 @@ class Serializable(abc.ABC):
         :meta private:
         """
         header, frames = self.device_serialize()
+        header["writeable"] = len(frames) * (None,)
         frames = [
             f.to_host_array().data if c else memoryview(f)
             for c, f in zip(header["is-cuda"], frames)


### PR DESCRIPTION
Leverages a feature in Dask to bypass copying of frames on host. ( https://github.com/dask/distributed/pull/4004 ) This can offer a notable speed up when working with `"dask"` serialization.

cc @quasiben