### PR TITLE
[WIP] Enable ORC statistics generation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@
 - PR #5800 Expose arrow datasource instead of directly taking a RandomAccessFile
 - PR #5795 Clarify documentation on Boost dependency
 - PR #5803 Add in Java support for the repeat command
+- PR #5825 Enable ORC statistics generation by default
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/_lib/orc.pyx
+++ b/python/cudf/cudf/_lib/orc.pyx
@@ -76,7 +76,7 @@ cpdef read_orc(filepath_or_buffer, columns=None,
 cpdef write_orc(Table table,
                 path_or_buf,
                 compression=None,
-                enable_statistics=False):
+                enable_statistics=True):
     """
     Cython function to call into libcudf API, see `write_orc`.
 

--- a/python/cudf/cudf/io/orc.py
+++ b/python/cudf/cudf/io/orc.py
@@ -78,7 +78,7 @@ def read_orc(
 
 
 @ioutils.doc_to_orc()
-def to_orc(df, fname, compression=None, enable_statistics=False, **kwargs):
+def to_orc(df, fname, compression=None, enable_statistics=True, **kwargs):
     """{docstring}"""
 
     path_or_buf = ioutils.get_writer_filepath_or_buffer(

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -293,6 +293,8 @@ fname : str
     File path or object where the ORC dataset will be stored.
 compression : {{ 'snappy', None }}, default None
     Name of the compression to use. Use None for no compression.
+enable_statistics: boolean, default True
+    Enable writing column statistics.
 
 See Also
 --------


### PR DESCRIPTION
Fixes #5707
Hive assumes that the metadata is included in ORC files.

In the C++ API, `enable_statistics`'s default is already `true`, so this PR also establishes consistency between the Python and C++ APIs.

No measurable overhead was observed in the benchmark due to enabled statistics.