### PR TITLE
Revert fallback for `tolist` being absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@
 - PR #5750 Add RMM_ROOT/include to the spdlog search path in JNI build
 - PR #5763 Update Java slf4j version to match Spark 3.0
 - PR #5766 Fix issue related to `iloc` and slicing a `DataFrame`
+- PR #5827 Revert fallback for `tolist` being absent
 - PR #5774 Add fallback for when `tolist` is absent
 - PR #5319 Disallow SUM and specialize MEAN of timestamp types
 - PR #5797 Fix a missing data issue in some Parquet files

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -21,13 +21,13 @@ requirements:
   host:
     - python
     - cudf {{ version }}
-    - dask >=2.15.0
-    - distributed >=2.15.0
+    - dask >=2.22.0
+    - distributed >=2.22.0
   run:
     - python
     - cudf {{ version }}
-    - dask >=2.15.0
-    - distributed >=2.15.0
+    - dask >=2.22.0
+    - distributed >=2.22.0
 
 
 about:

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -491,9 +491,12 @@ class Index(Frame, Serializable):
         return self._values.to_arrow()
 
     def tolist(self):
-        # TODO: This needs to raise an error instead.
-        # xref: https://github.com/rapidsai/cudf/issues/5689
-        return self.to_arrow().to_pylist()
+
+        raise TypeError(
+            "cuDF does not support conversion to host memory "
+            "via `tolist()` method. Consider using "
+            "`.to_arrow().to_pylist()` to construct a Python list."
+        )
 
     to_list = tolist
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -850,9 +850,12 @@ class Series(Frame, Serializable):
         return out
 
     def tolist(self):
-        # TODO: This needs to raise an error instead.
-        # xref: https://github.com/rapidsai/cudf/issues/5689
-        return self.to_arrow().to_pylist()
+
+        raise TypeError(
+            "cuDF does not support conversion to host memory "
+            "via `tolist()` method. Consider using "
+            "`.to_arrow().to_pylist()` to construct a Python list."
+        )
 
     to_list = tolist
 

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -1310,10 +1310,16 @@ def test_index_drop_duplicates(data, dtype):
 )
 def test_index_tolist(data, dtype):
     gdi = cudf.Index(data, dtype=dtype)
-    pdi = pd.Index(data, dtype=dtype)
-    # TODO: This needs to check for a raised error instead.
-    # xref: https://github.com/rapidsai/cudf/issues/5689
-    assert_eq(gdi.tolist(), pdi.tolist())
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            r"cuDF does not support conversion to host memory "
+            r"via `tolist()` method. Consider using "
+            r"`.to_arrow().to_pylist()` to construct a Python list."
+        ),
+    ):
+        gdi.tolist()
 
 
 @pytest.mark.parametrize("data", [[], [1], [1, 2, 3]])

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -337,12 +337,16 @@ def test_series_column_iter_error():
 def test_series_tolist(data):
     psr = pd.Series(data)
     gsr = cudf.from_pandas(psr)
-    # TODO: This needs to check for a raised error instead.
-    # xref: https://github.com/rapidsai/cudf/issues/5689
-    got = gsr.tolist()
-    expected = [x if not pd.isnull(x) else None for x in psr.tolist()]
 
-    np.testing.assert_array_equal(got, expected)
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            r"cuDF does not support conversion to host memory "
+            r"via `tolist()` method. Consider using "
+            r"`.to_arrow().to_pylist()` to construct a Python list."
+        ),
+    ):
+        gsr.tolist()
 
 
 @pytest.mark.parametrize(

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -6,7 +6,7 @@ import pyarrow as pa
 
 from dask.dataframe.categorical import categorical_dtype_dispatch
 from dask.dataframe.core import get_parallel_type, make_meta, meta_nonempty
-from dask.dataframe.methods import concat_dispatch
+from dask.dataframe.methods import concat_dispatch, tolist_dispatch
 from dask.dataframe.utils import (
     UNKNOWN_CATEGORIES,
     _nonempty_scalar,
@@ -14,13 +14,6 @@ from dask.dataframe.utils import (
     is_arraylike,
     is_scalar,
 )
-
-try:
-    from dask.dataframe.methods import tolist_dispatch
-except ImportError:  # Fallback for Dask without `tolist` dispatch
-    from dask.utils import Dispatch
-
-    tolist_dispatch = Dispatch("tolist")
 
 import cudf
 from cudf.utils.dtypes import is_string_dtype


### PR DESCRIPTION
Reverts PR ( https://github.com/rapidsai/cudf/pull/5774 )
Requires PR ( https://github.com/rapidsai/integration/pull/89 )

Reverts back to @galipremsagar original `tolist`. Also bumps the Dask + Distributed version requirements to 2.22.0+ to include PR ( https://github.com/dask/dask/pull/6444 ).

cc @kkraus14