### PR TITLE
[REVIEW] Explicit dictionary constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,7 @@
 - PR #5795 Clarify documentation on Boost dependency
 - PR #5803 Add in Java support for the repeat command
 - PR #5825 Enable ORC statistics generation by default
-- PR #5xxx Make dictionary_wrapper constructor from a value explicit
+- PR #5832 Make dictionary_wrapper constructor from a value explicit
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@
 - PR #5795 Clarify documentation on Boost dependency
 - PR #5803 Add in Java support for the repeat command
 - PR #5825 Enable ORC statistics generation by default
+- PR #5xxx Make dictionary_wrapper constructor from a value explicit
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -263,7 +263,7 @@ struct scalar_pair_accessor : public scalar_value_accessor<Element> {
   const value_type operator()(size_type) const
   {
 #if defined(__CUDA_ARCH__)
-    return {super_t::dscalar.value(), super_t::dscalar.is_valid()};
+    return {Element(super_t::dscalar.value()), super_t::dscalar.is_valid()};
 #else
     CUDF_FAIL("unsupported device scalar iterator operation");
 #endif

--- a/cpp/include/cudf/wrappers/dictionary.hpp
+++ b/cpp/include/cudf/wrappers/dictionary.hpp
@@ -53,7 +53,7 @@ struct dictionary_wrapper {
   dictionary_wrapper& operator=(const dictionary_wrapper&) = default;
 
   // construct object from type
-  CUDA_HOST_DEVICE_CALLABLE constexpr dictionary_wrapper(value_type v) : _value{v} {}
+  CUDA_HOST_DEVICE_CALLABLE constexpr explicit dictionary_wrapper(value_type v) : _value{v} {}
 
   // conversion operator
   CUDA_HOST_DEVICE_CALLABLE explicit operator value_type() const { return _value; }


### PR DESCRIPTION
This PR makes the `dictionary32` constructor from an `int32` explicit. An implicit constructor here defeats the purpose of being a strongly typed wrapper.

This is a dependency of #5494.

The underlying issue this solves is similar to [a change made](https://github.com/rapidsai/cudf/pull/5735/files#diff-777506cef1eaa73782fd6985a6b0f430L50) in #5735, where timestamps could be constructed from a duration type's representation. Quoting from discussion with @jrhemstad:

> The exact mechanism that caused this `operator*` problem is this:
> Boiling away the cruft, the `operator*` definition looks like this:
> ```
> template <class T, class Period, class Rep>
> enable_if_t
> <
>     is_convertible<T, common_type_t<T, Rep>::type>::value,
>     duration<common_type_t<T, Rep>::type, Period>
> >
> operator*(const T& s, const duration<Rep, Period>& d);
> ```
> So this allows multiplication between a `duration` type and any type `T` so long as `T` is convertible to the common type between `T` and the duration's representation `Rep`.  "common_type" is defined as "For a list of types, what type are they all implicitly convertible to?" e.g., `common_type_t<int, short, char> == int`
> So for example, `std::chrono::days::Rep == int32_t`.
>  If `T == timestamp_D`, then it first checks "What is the common type between `timestamp_D` and `int32_t`?". Well, because `int32_t` is implicitly convertible to `timestamp_D` (thanks to that constructor) then `common_type_t<timestamp_D, int32_t> == timestamp_D`. So then we end up with `is_convertible<timestamp_D, timestamp_D>`, and that is true because a type is always convertible to itself.
> Therefore, the type substitution for `operator*` passes, even though the actual instantiation of `operator*(timestamp_D, duration<...>)` is ill-formed.

In this case, the implicit constructor of a `dictionary32` from an `int32` meant that it met the criteria for the overload of `operator*` with a duration, which isn't desired.

Aside from the change to the constructor, this only affected one place that relied on the implicit constructor.