### PR TITLE
syntax fix for bash anaconda upload script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@
 - PR #5797 Fix a missing data issue in some Parquet files
 - PR #5787 Fix column create from dictionary column view
 - PR #5820 Fix ListColumn.to_arrow for all null case
+- PR #5837 Bash syntax error in prebuild.sh preventing `cudf_kafka` and `libcudf_kafka` from being uploaded to Anaconda
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -22,7 +22,7 @@ else
 fi
 
 #We only want to upload libcudf_kafka once per python/CUDA combo
-if [[ "$PYTHON" == "3.7" && "$CUDA" == "10.1" ]]; then
+if [[ "$PYTHON" == "3.7" ]] && [[ "$CUDA" == "10.1" ]]; then
     export UPLOAD_LIBCUDF_KAFKA=1
 else
     export UPLOAD_LIBCUDF_KAFKA=0

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2020, NVIDIA CORPORATION.
+set -e
+
 #Upload cudf once per PYTHON
 if [[ "$CUDA" == "10.1" ]]; then
     export UPLOAD_CUDF=1


### PR DESCRIPTION
There is an error in the prebuild.sh bash script preventing cudf_kafka and libcudf_kafka packages from being uploaded to anaconda.

this closes #5836 