### PR TITLE
[REVIEW] Added custreamz functions that were missing in interface layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,7 @@
 - PR #5813 Fix normalizer exception with all-null strings column
 - PR #5820 Fix ListColumn.to_arrow for all null case
 - PR #5837 Bash syntax error in prebuild.sh preventing `cudf_kafka` and `libcudf_kafka` from being uploaded to Anaconda
+- PR #5841 Added custreamz functions that were missing in interface layer
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/python/cudf_kafka/cudf_kafka/_lib/kafka.pxd
+++ b/python/cudf_kafka/cudf_kafka/_lib/kafka.pxd
@@ -63,11 +63,11 @@ cdef class KafkaDatasource(Datasource):
 
     cpdef int64_t get_committed_offset(self, string topic, int32_t partition)
 
-    cpdef map[string, int64_t] get_watermark_offset(string, topic,
+    cpdef map[string, int64_t] get_watermark_offset(self, string topic,
                                                     int32_t partition,
                                                     int32_t timeout,
-                                                    bool cached) except +
+                                                    bool cached)
 
-    cpdef void unsubscribe() except +
+    cpdef void unsubscribe(self)
 
-    cpdef void close(int timeout) except +
+    cpdef void close(self, int timeout)

--- a/python/cudf_kafka/cudf_kafka/_lib/kafka.pxd
+++ b/python/cudf_kafka/cudf_kafka/_lib/kafka.pxd
@@ -62,3 +62,12 @@ cdef class KafkaDatasource(Datasource):
                              int64_t offset)
 
     cpdef int64_t get_committed_offset(self, string topic, int32_t partition)
+
+    cpdef map[string, int64_t] get_watermark_offset(string, topic,
+                                                    int32_t partition,
+                                                    int32_t timeout,
+                                                    bool cached) except +
+
+    cpdef void unsubscribe() except +
+
+    cpdef void close(int timeout) except +

--- a/python/cudf_kafka/cudf_kafka/_lib/kafka.pyx
+++ b/python/cudf_kafka/cudf_kafka/_lib/kafka.pyx
@@ -58,4 +58,4 @@ cdef class KafkaDatasource(Datasource):
         (<kafka_consumer *> self.c_datasource.get()).unsubscribe()
 
     cpdef void close(int timeout):
-        (<kafka_consumer *> self.c_datasource.get()).close()
+        (<kafka_consumer *> self.c_datasource.get()).close(timeout)

--- a/python/cudf_kafka/cudf_kafka/_lib/kafka.pyx
+++ b/python/cudf_kafka/cudf_kafka/_lib/kafka.pyx
@@ -46,3 +46,16 @@ cdef class KafkaDatasource(Datasource):
                                        int32_t partition):
         return (<kafka_consumer *> self.c_datasource.get()). \
             get_committed_offset(topic, partition)
+
+    cpdef map[string, int64_t] get_watermark_offset(string topic,
+                                                    int32_t partition,
+                                                    int32_t timeout,
+                                                    bool cached):
+        return (<kafka_consumer *> self.c_datasource.get()). \
+            get_watermark_offset(topic, partition, timeout, cached)
+
+    cpdef void unsubscribe():
+        (<kafka_consumer *> self.c_datasource.get()).unsubscribe()
+
+    cpdef void close(int timeout):
+        (<kafka_consumer *> self.c_datasource.get()).close()

--- a/python/cudf_kafka/cudf_kafka/_lib/kafka.pyx
+++ b/python/cudf_kafka/cudf_kafka/_lib/kafka.pyx
@@ -47,15 +47,15 @@ cdef class KafkaDatasource(Datasource):
         return (<kafka_consumer *> self.c_datasource.get()). \
             get_committed_offset(topic, partition)
 
-    cpdef map[string, int64_t] get_watermark_offset(string topic,
+    cpdef map[string, int64_t] get_watermark_offset(self, string topic,
                                                     int32_t partition,
                                                     int32_t timeout,
                                                     bool cached):
         return (<kafka_consumer *> self.c_datasource.get()). \
             get_watermark_offset(topic, partition, timeout, cached)
 
-    cpdef void unsubscribe():
+    cpdef void unsubscribe(self):
         (<kafka_consumer *> self.c_datasource.get()).unsubscribe()
 
-    cpdef void close(int timeout):
+    cpdef void close(self, int timeout):
         (<kafka_consumer *> self.c_datasource.get()).close(timeout)

--- a/python/custreamz/custreamz/kafka.py
+++ b/python/custreamz/custreamz/kafka.py
@@ -219,7 +219,7 @@ class Consumer(CudfKafkaClient):
         offsets = ()
 
         try:
-            offsets = self.kafka_meta_client.get_watermark_offsets(
+            offsets = self.kafka_meta_client.get_watermark_offset(
                 topic=partition.topic,
                 partition=partition.partition,
                 timeout=timeout,


### PR DESCRIPTION
get_watermark_offset, unsubscribe, and close are missing from custreamz cython interface. They should be added to kafka.pyx and kafka.pxd

This closes: #5840 