### PR TITLE
[REVIEW] Disable numeric::fixed_point for use in cudf::copy_if

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,7 @@
 - PR #5825 Enable ORC statistics generation by default
 - PR #5832 Make dictionary_wrapper constructor from a value explicit
 - PR #5833 Pin `dask` and `distributed` version to `2.22.0`
-- PR #5853 Change default ctor declaration for `fixed_point` to use `=default`
+- PR #5853 Disable `fixed_point` for use in `copy_if`
 - PR #5854 Raise informative error in `DataFrame.iterrows` and `DataFrame.itertuples`
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@
 - PR #5825 Enable ORC statistics generation by default
 - PR #5832 Make dictionary_wrapper constructor from a value explicit
 - PR #5833 Pin `dask` and `distributed` version to `2.22.0`
+- PR #5853 Change default ctor declararation for fixed-point to use `=default`
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,7 @@
 - PR #5825 Enable ORC statistics generation by default
 - PR #5832 Make dictionary_wrapper constructor from a value explicit
 - PR #5833 Pin `dask` and `distributed` version to `2.22.0`
-- PR #5853 Change default ctor declararation for fixed-point to use `=default`
+- PR #5853 Change default ctor declaration for fixed-point to use `=default`
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@
 - PR #5825 Enable ORC statistics generation by default
 - PR #5832 Make dictionary_wrapper constructor from a value explicit
 - PR #5833 Pin `dask` and `distributed` version to `2.22.0`
-- PR #5853 Change default ctor declaration for fixed-point to use `=default`
+- PR #5853 Change default ctor declaration for `fixed_point` to use `=default`
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/detail/copy_if.cuh
+++ b/cpp/include/cudf/detail/copy_if.cuh
@@ -24,6 +24,7 @@
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/device_atomics.cuh>
 #include <cudf/null_mask.hpp>
+#include <cudf/strings/string_view.cuh>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
@@ -197,41 +198,8 @@ __launch_bounds__(block_size) __global__
   }
 }
 
-// Dispatch functor which performs the scatter for fixed column types and gather for other
-template <typename Filter, int block_size>
-struct scatter_gather_functor {
-  // There are two operator functions, one for fixed-width column types and another for columns that
-  // can have children such as string_view. fixed-width column gatherer is simpler and the kernel is
-  // specifically designed for better performance compared to the generic gather used for strings.
-
-  // operator for non-fixed-width types.
-  template <typename T, std::enable_if_t<not cudf::is_fixed_width<T>()>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(
-    cudf::column_view const& input,
-    cudf::size_type const& output_size,
-    cudf::size_type const* block_offsets,
-    Filter filter,
-    cudf::size_type per_thread,
-    rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
-    cudaStream_t stream                 = 0)
-  {
-    rmm::device_uvector<cudf::size_type> indices(output_size, stream);
-
-    thrust::copy_if(rmm::exec_policy(stream)->on(stream),
-                    thrust::counting_iterator<cudf::size_type>(0),
-                    thrust::counting_iterator<cudf::size_type>(input.size()),
-                    indices.begin(),
-                    filter);
-
-    auto output_table = cudf::detail::gather(
-      cudf::table_view{{input}}, indices.begin(), indices.end(), false, mr, stream);
-
-    // There will be only one column
-    return std::make_unique<cudf::column>(std::move(output_table->get_column(0)));
-  }
-
-  // operator template for fixed-width types
-  template <typename T, std::enable_if_t<cudf::is_fixed_width<T>()>* = nullptr>
+template <typename T, typename Filter, int block_size>
+struct scatter_gather_functor_impl {
   std::unique_ptr<cudf::column> operator()(
     cudf::column_view const& input,
     cudf::size_type const& output_size,
@@ -276,6 +244,82 @@ struct scatter_gather_functor {
     return output_column;
   }
 };
+
+template <typename Filter, int block_size>
+struct scatter_gather_functor_impl<cudf::string_view, Filter, block_size> {
+  std::unique_ptr<cudf::column> operator()(
+    cudf::column_view const& input,
+    cudf::size_type const& output_size,
+    cudf::size_type const* block_offsets,
+    Filter filter,
+    cudf::size_type per_thread,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+    cudaStream_t stream                 = 0)
+  {
+    rmm::device_uvector<cudf::size_type> indices(output_size, stream);
+
+    thrust::copy_if(rmm::exec_policy(stream)->on(stream),
+                    thrust::counting_iterator<cudf::size_type>(0),
+                    thrust::counting_iterator<cudf::size_type>(input.size()),
+                    indices.begin(),
+                    filter);
+
+    auto output_table = cudf::detail::gather(
+      cudf::table_view{{input}}, indices.begin(), indices.end(), false, mr, stream);
+
+    // There will be only one column
+    return std::make_unique<cudf::column>(std::move(output_table->get_column(0)));
+  }
+};
+
+template <typename Filter, int block_size>
+struct scatter_gather_functor_impl<numeric::decimal32, Filter, block_size> {
+  std::unique_ptr<cudf::column> operator()(
+    cudf::column_view const& input,
+    cudf::size_type const& output_size,
+    cudf::size_type const* block_offsets,
+    Filter filter,
+    cudf::size_type per_thread,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+    cudaStream_t stream                 = 0)
+  {
+    CUDF_FAIL("fixed_point type not supported for this operation yet");
+  }
+};
+
+template <typename Filter, int block_size>
+struct scatter_gather_functor_impl<numeric::decimal64, Filter, block_size> {
+  std::unique_ptr<cudf::column> operator()(
+    cudf::column_view const& input,
+    cudf::size_type const& output_size,
+    cudf::size_type const* block_offsets,
+    Filter filter,
+    cudf::size_type per_thread,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+    cudaStream_t stream                 = 0)
+  {
+    CUDF_FAIL("fixed_point type not supported for this operation yet");
+  }
+};
+
+// Dispatch functor which performs the scatter for fixed column types and gather for other
+template <typename Filter, int block_size>
+struct scatter_gather_functor {
+  template <typename Element>
+  std::unique_ptr<cudf::column> operator()(
+    cudf::column_view const& input,
+    cudf::size_type const& output_size,
+    cudf::size_type const* block_offsets,
+    Filter filter,
+    cudf::size_type per_thread,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource(),
+    cudaStream_t stream                 = 0)
+  {
+    scatter_gather_functor_impl<Element, Filter, block_size> copier{};
+    return copier(input, output_size, block_offsets, filter, per_thread, mr, stream);
+  }
+};
+
 }  // namespace
 
 namespace cudf {

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -283,8 +283,8 @@ struct scaled_integer {
  */
 template <typename Rep, Radix Rad>
 class fixed_point {
-  Rep _value;
-  scale_type _scale;
+  Rep _value{};
+  scale_type _scale{0};
 
  public:
   /**
@@ -315,8 +315,7 @@ class fixed_point {
    * @brief Default constructor that constructs `fixed_point` number with a
    * value and scale of zero
    */
-  CUDA_HOST_DEVICE_CALLABLE
-  fixed_point() : _value{0}, _scale{scale_type{0}} {}
+  fixed_point() = default;
 
   /**
    * @brief Explicit conversion operator

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -283,8 +283,8 @@ struct scaled_integer {
  */
 template <typename Rep, Radix Rad>
 class fixed_point {
-  Rep _value{};
-  scale_type _scale{0};
+  Rep _value;
+  scale_type _scale;
 
  public:
   /**
@@ -326,7 +326,8 @@ class fixed_point {
    * @brief Default constructor that constructs `fixed_point` number with a
    * value and scale of zero
    */
-  fixed_point() = default;
+  CUDA_HOST_DEVICE_CALLABLE
+  fixed_point() : _value{0}, _scale{scale_type{0}} {}
 
   /**
    * @brief Explicit conversion operator


### PR DESCRIPTION
PR #5704 added the `fixed_point` type as an official libcudf type through the `type-dispatcher`.
This caused a series of compile warnings like the following:
```
/opt/conda/envs/rapids/conda-bld/libcudf_1596199878217/work/cpp/include/cudf/detail/copy_if.cuh(107): warning: dynamic initialization is not supported for a function-scope static __shared__ variable within a __device__/__global__ function
09:01:26           detected during:
09:01:26             instantiation of "void <unnamed>::scatter_kernel<T,Filter,block_size,has_validity>(cudf::mutable_column_device_view, cudf::size_type *, cudf::column_device_view, const cudf::size_type *, cudf::size_type, cudf::size_type, Filter) [with T=numeric::decimal32, Filter=<unnamed>::boolean_mask_filter<true>, block_size=256, has_validity=true]" 
```
Although the warnings did not appear to fail any builds, there are many of them making it difficult to assess any new warnings.
Here is an example of a successful build which include the warnings:
https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/prb/job/cudf-gpu-build/30235/consoleFull
Search for `copy_if` to locate the first one (there are about 60 though maybe more).

The warning complains about this line:
https://github.com/rapidsai/cudf/blob/b7245b10a8d7f8cb711f4394eabf4178d10fc772/cpp/include/cudf/detail/copy_if.cuh#L107
but only for fixed-point types `decimal32` and `decimal64`, none of the other types.
This line looks correct since `block_size` is known at compile time.

The warning appears on Linux 16.04 (gcc 5.4.0) / Linux (gcc 7.5.0) with either CUDA 10.1 or CUDA 10.2.
It seems the compiler is confused on the size of `T` when `T=numeric::decimal32` or `T=numeric::decimal32`

Simply changing the default constructor from
```
CUDA_HOST_DEVICE_CALLABLE fixed_point() : _value{0}, _scale{scale_type{0}} {}
```
to 
```
fixed_point() = default;
```
makes the compile warning disappear. 
I also tried adding `constexpr` to the original declaration without success.

I've attempted to create a smaller testcase for submitting as an `nvcc` bug with minor success.
If an nvbug is created, I will add a link to this PR.

Since the described change is supposed to fail as well as referenced http://nvbugs/3085337
This PR changes the code to disable `fixed_point` for use in `cudf::copy_if` instead.