### PR TITLE
[REVIEW] Add explicit conversion for fixed_point to bool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - PR #5817 Enable more `fixed_point` unit tests by introducing "scale-less" constructor
 - PR #5822 Add `cudf_kafka` to `custreamz` run time conda dependency and fix bash syntax issue
 - PR #5851 Add support for `Index.sort_values`
+- PR #5859 Add conversion form `fixed_point` to `bool`
 
 ## Improvements
 

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -343,9 +343,9 @@ class fixed_point {
   }
 
   /**
-   * @brief Explicit conversion operator to bool
+   * @brief Explicit conversion operator to `bool`
    *
-   * @return The `fixed_point` value as a boolean (zero is false, nonzero is true)
+   * @return The `fixed_point` value as a boolean (zero is `false`, nonzero is `true`)
    */
   CUDA_HOST_DEVICE_CALLABLE explicit constexpr operator bool() const
   {

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -343,6 +343,16 @@ class fixed_point {
   }
 
   /**
+   * @brief Explicit conversion operator to bool
+   *
+   * @return The `fixed_point` value as a boolean (zero is false, nonzero is true)
+   */
+  CUDA_HOST_DEVICE_CALLABLE explicit constexpr operator bool() const
+  {
+    return static_cast<bool>(_value);
+  }
+
+  /**
    * @brief operator +=
    *
    * @tparam Rep1 Representation type of number being added to `this`

--- a/cpp/tests/fixed_point/fixed_point_tests.cu
+++ b/cpp/tests/fixed_point/fixed_point_tests.cu
@@ -335,6 +335,26 @@ TYPED_TEST(FixedPointTestBothReps, DecimalXXThrust)
   EXPECT_EQ(vec2, vec3);
 }
 
+TYPED_TEST(FixedPointTestBothReps, BoolConversion)
+{
+  using decimalXX = fixed_point<TypeParam, Radix::BASE_10>;
+
+  decimalXX truthy_value{1.234567, scale_type{0}};
+  decimalXX falsy_value{0, scale_type{0}};
+
+  // Test explicit conversions
+  EXPECT_EQ(bool(truthy_value), true);
+  EXPECT_EQ(bool(falsy_value), false);
+
+  // These operators also *explicitly* convert to bool
+  EXPECT_EQ(truthy_value && true, true);
+  EXPECT_EQ(true && truthy_value, true);
+  EXPECT_EQ(falsy_value || false, false);
+  EXPECT_EQ(false || falsy_value, false);
+  EXPECT_EQ(!truthy_value, false);
+  EXPECT_EQ(!falsy_value, true);
+}
+
 TEST_F(FixedPointTest, OverflowDecimal32)
 {
   // This flag is needed to avoid warnings with ASSERT_DEATH

--- a/cpp/tests/fixed_point/fixed_point_tests.cu
+++ b/cpp/tests/fixed_point/fixed_point_tests.cu
@@ -343,8 +343,8 @@ TYPED_TEST(FixedPointTestBothReps, BoolConversion)
   decimalXX falsy_value{0, scale_type{0}};
 
   // Test explicit conversions
-  EXPECT_EQ(bool(truthy_value), true);
-  EXPECT_EQ(bool(falsy_value), false);
+  EXPECT_EQ(static_cast<bool>(truthy_value), true);
+  EXPECT_EQ(static_cast<bool>(falsy_value), false);
 
   // These operators also *explicitly* convert to bool
   EXPECT_EQ(truthy_value && true, true);


### PR DESCRIPTION
This PR adds an explicit conversion template specialization from `fixed_point` values to `bool`. Below, I explain the problem this is solving in case it's helpful for someone in the future.

While developing the AST interpreter (#5494), I implemented a logical "and" operator. I noticed that the expression `fixed_point_value && true` tries to convert fixed_point to a bool with [this cast operator](https://github.com/rapidsai/cudf/blob/120c871176a47eb27d76cf56a698ae881f493f56/cpp/include/cudf/fixed_point/fixed_point.hpp#L332-L343) but fails to compile (`bool` passes the `is_integral` trait, and is thus an allowed cast by [the `is_supported_construction_value` trait](https://github.com/rapidsai/cudf/blob/120c871176a47eb27d76cf56a698ae881f493f56/cpp/include/cudf/fixed_point/fixed_point.hpp#L66-L70)).

The compilation failure is in `left_shift` (it can't compile [this line](https://github.com/rapidsai/cudf/blob/120c871176a47eb27d76cf56a698ae881f493f56/cpp/include/cudf/fixed_point/fixed_point.hpp#L169), which tries to multiply the cast-to type `bool` by the scale factor. You might wonder why this is happening -- the conversion is marked explicit. The cause is that logical operators perform **explicit conversions** <sup>[1, 2]</sup>. References for this behavior are below.

<sup>[1]</sup> https://en.cppreference.com/w/cpp/language/operator_logical (bold added)

> If the operand is not bool, it is converted to bool using **contextual conversion to bool**: it is only well-formed if the declaration bool t(arg) is well-formed, for some invented temporary t.

<sup>[2]</sup>  https://en.cppreference.com/w/cpp/language/implicit_conversion (under "Contextual conversions", bold added)

> In the following contexts, the type bool is expected and the implicit conversion is performed if the declaration bool t(e); is well-formed (that is, an explicit conversion function such as explicit T::operator bool() const; is considered). Such expression e is said to be contextually converted to bool.
> - the controlling expression of if, while, for;
> - **the operands of the built-in logical operators !, && and ||;**
> - the first operand of the conditional operator ?:;
> - the predicate in a static_assert declaration;
> - the expression in a noexcept specifier;