### PR TITLE
Explicitly require `dask-cuda` and `ucx-py` on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@
 - PR #5833 Pin `dask` and `distributed` version to `2.22.0`
 - PR #5853 Disable `fixed_point` for use in `copy_if`
 - PR #5854 Raise informative error in `DataFrame.iterrows` and `DataFrame.itertuples`
+- PR #5863 Explicitly require `ucx-py` on CI
 
 ## Bug Fixes
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -67,6 +67,7 @@ fi
 conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
               "rapids-build-env=$MINOR_VERSION.*" \
               "rapids-notebook-env=$MINOR_VERSION.*" \
+              "dask-cuda=${MINOR_VERSION}" \
               "ucx-py=${MINOR_VERSION}" \
 
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -66,7 +66,8 @@ fi
 
 conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
               "rapids-build-env=$MINOR_VERSION.*" \
-              "rapids-notebook-env=$MINOR_VERSION.*"
+              "rapids-notebook-env=$MINOR_VERSION.*" \
+              "ucx-py=${MINOR_VERSION}" \
 
 # https://docs.rapids.ai/maintainers/depmgmt/
 # conda remove -f rapids-build-env rapids-notebook-env

--- a/python/dask_cudf/dask_cudf/tests/test_distributed.py
+++ b/python/dask_cudf/dask_cudf/tests/test_distributed.py
@@ -9,6 +9,7 @@ from distributed.utils_test import loop  # noqa: F401
 import dask_cudf
 
 import cudf
+from cudf.tests.utils import assert_eq
 
 dask_cuda = pytest.importorskip("dask_cuda")
 
@@ -26,7 +27,7 @@ def test_basic(loop, delayed):  # noqa: F811
             gdf = pdf.map_partitions(cudf.DataFrame.from_pandas)
             if delayed:
                 gdf = dd.from_delayed(gdf.to_delayed())
-            dd.assert_eq(pdf.head(), gdf.head())
+            assert_eq(pdf.head(), gdf.head())
 
 
 def test_merge():


### PR DESCRIPTION
As we are proposing dropping `ucx-py` from `rapids-build-env` in PR ( https://github.com/rapidsai/integration/pull/94 ), this explicitly adds `ucx-py` to cuDF's CI, which is needed by [this test]( https://github.com/rapidsai/cudf/blob/0b7ad98c7c2d23e989d57ac47481f5ca9873b58c/python/dask_cudf/dask_cudf/tests/test_distributed.py#L57 ). Also adds `dask-cuda`, which is needed by [these tests]( https://github.com/rapidsai/cudf/blob/0b7ad98c7c2d23e989d57ac47481f5ca9873b58c/python/dask_cudf/dask_cudf/tests/test_distributed.py#L13 ).