### PR TITLE
[REVIEW] cudf_kafka python version inconsistencies in Anaconda packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,7 @@
 - PR #5837 Bash syntax error in prebuild.sh preventing `cudf_kafka` and `libcudf_kafka` from being uploaded to Anaconda
 - PR #5841 Added custreamz functions that were missing in interface layer
 - PR #5849 Modify custreamz api to integrate seamlessly with python streamz
+- PR #5866 cudf_kafka python version inconsistencies in Anaconda packages
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/ci/cpu/cudf_kafka/build_cudf_kafka.sh
+++ b/ci/cpu/cudf_kafka/build_cudf_kafka.sh
@@ -1,6 +1,10 @@
+#!/usr/bin/env bash
 set -e
 
-echo "Building cudf_kafka"
-CUDA_REL=${CUDA_VERSION%.*}
+# Logger function for build status output
+function logger() {
+  echo -e "\n>>>> $@\n"
+}
 
-conda build conda/recipes/cudf_kafka
+logger "Building cudf_kafka"
+conda build conda/recipes/cudf_kafka --python=$PYTHON


### PR DESCRIPTION
The cudf_kafka Anaconda package is inconsistent in the version of Python it uses. Some builds result in Python 3.7 while others result in Python 3.8. It seems to be a matter of which build finishes first in CI as to the final version in the package.

Also the custreamz Anaconda package requires that cudf_kafka be manually installed first. It should be the case that installing custreamz from conda should automatically install cudf_kafka.

This closes #5865 