### PR TITLE
[REVIEW] libcudf_kafka r_path is causing docker build failures on centos7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,7 +261,7 @@
 - PR #5844 Fix `.str.cat` when objects with different index are passed
 - PR #5849 Modify custreamz api to integrate seamlessly with python streamz
 - PR #5866 cudf_kafka python version inconsistencies in Anaconda packages
-
+- PR #5872 libcudf_kafka r_path is causing docker build failures on centos7
 
 # cuDF 0.14.0 (03 Jun 2020)
 

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -2,6 +2,7 @@
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
+{% set py_version=environ.get('CONDA_PY', 36) %}
 
 package:
   name: cudf_kafka
@@ -12,7 +13,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: {{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CC
     - CXX
@@ -22,6 +23,7 @@ build:
 
 requirements:
   build:
+    - python
     - cmake >=3.14.0
   host:
     - cython >=0.29,<0.30

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -23,9 +23,9 @@ build:
 
 requirements:
   build:
-    - python
     - cmake >=3.14.0
   host:
+    - python
     - cython >=0.29,<0.30
     - setuptools
     - cudf {{ version }}

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   host:
     - python
     - python-confluent-kafka
+    - cudf_kafka {{ version }}
   run:
     - python
     - streamz 

--- a/cpp/libcudf_kafka/CMakeLists.txt
+++ b/cpp/libcudf_kafka/CMakeLists.txt
@@ -133,6 +133,8 @@ add_library(cudf_kafka SHARED
     src/kafka_consumer.cpp
 )
 
+set_target_properties(cudf_kafka PROPERTIES BUILD_RPATH "\$ORIGIN")
+
 # Include paths
 include_directories("${CMAKE_SOURCE_DIR}/include"
                     "${CMAKE_CURRENT_SOURCE_DIR}/include/cudf")


### PR DESCRIPTION
libcudf_kafka is not passing its transitive dependencies to custreamz which is causing for docker container image builds to fail for centos7 across all python and cuda versions.

This closes: #5871 