### PR TITLE
[REVIEW] Do not break consumption loop on local client timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,7 @@
 - PR #5866 cudf_kafka python version inconsistencies in Anaconda packages
 - PR #5872 libcudf_kafka r_path is causing docker build failures on centos7
 - PR #5869 Fix bug in parquet writer in writing string column with offset
+- PR #5895 Do not break kafka client consumption loop on local client timeout
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/cpp/libcudf_kafka/src/kafka_consumer.cpp
+++ b/cpp/libcudf_kafka/src/kafka_consumer.cpp
@@ -125,7 +125,7 @@ void kafka_consumer::consume_to_buffer()
       buffer.append(delimiter);
       messages_read++;
     } else if (msg->err() == RdKafka::ErrorCode::ERR__PARTITION_EOF) {
-      // If there are no more messages or a timeout reading a message occurs then return
+      // If there are no more messages return
       break;
     }
   }

--- a/cpp/libcudf_kafka/src/kafka_consumer.cpp
+++ b/cpp/libcudf_kafka/src/kafka_consumer.cpp
@@ -124,8 +124,7 @@ void kafka_consumer::consume_to_buffer()
       buffer.append(static_cast<char *>(msg->payload()));
       buffer.append(delimiter);
       messages_read++;
-    } else if (msg->err() == RdKafka::ErrorCode::ERR__TIMED_OUT ||
-               msg->err() == RdKafka::ErrorCode::ERR__PARTITION_EOF) {
+    } else if (msg->err() == RdKafka::ErrorCode::ERR__PARTITION_EOF) {
       // If there are no more messages or a timeout reading a message occurs then return
       break;
     }


### PR DESCRIPTION
Clients who choose to use a single KafkaConsumer object may experience local client socket timeouts which given the previous implementation would break the consumption loop. This changes so that the consumption loop is not broken on that event.

This closes #5886 