### PR TITLE
Fix reference count on Java DeviceMemoryBuffer after contiguousSplit [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@
 - PR #5872 libcudf_kafka r_path is causing docker build failures on centos7
 - PR #5869 Fix bug in parquet writer in writing string column with offset
 - PR #5895 Do not break kafka client consumption loop on local client timeout
+- PR #5915 Fix reference count on Java DeviceMemoryBuffer after contiguousSplit
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -3079,6 +3079,8 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
       toClose.add(data);
       toClose.add(valid);
       toClose.add(offsets);
+      contiguousBuffer.incRefCount();
+      toClose.add(contiguousBuffer);
     }
 
     public long getViewHandle() {

--- a/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
@@ -136,8 +136,7 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
   @Override
   public synchronized final DeviceMemoryBuffer slice(long offset, long len) {
     addressOutOfBoundsCheck(address + offset, len, "slice");
-    refCount++;
-    cleaner.addRef();
+    incRefCount();
     return new DeviceMemoryBuffer(getAddress() + offset, len, this);
   }
 
@@ -151,8 +150,7 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
       return null;
     }
     addressOutOfBoundsCheck(view.address, view.length, "sliceFrom");
-    refCount++;
-    cleaner.addRef();
+    incRefCount();
     return new DeviceMemoryBuffer(view.address, view.length, this);
   }
 }

--- a/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
@@ -95,8 +95,7 @@ abstract public class MemoryBuffer implements AutoCloseable {
     this.cleaner = cleaner;
     if (cleaner != null) {
       this.id = cleaner.id;
-      refCount++;
-      cleaner.addRef();
+      incRefCount();
       MemoryCleaner.register(this, cleaner);
     } else {
       this.id = -1;
@@ -189,5 +188,19 @@ abstract public class MemoryBuffer implements AutoCloseable {
         "address=0x" + Long.toHexString(address) +
         ", length=" + length +
         ", id=" + id + "}";
+  }
+
+  /**
+   * Increment the reference count for this column.  You need to call close on this
+   * to decrement the reference count again.
+   */
+  public synchronized void incRefCount() {
+    refCount++;
+    cleaner.addRef();
+  }
+
+  // visible for testing
+  synchronized int getRefCount() {
+    return refCount;
   }
 }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -2829,4 +2829,13 @@ public class ColumnVectorTest extends CudfTestBase {
       assertColumnsAreEqual(expected, v);
     }
   }
+
+  @Test
+  void testContiguousSplitConstructor() {
+    try (Table tmp = new Table.TestBuilder().column(1, 2).column(3, 4).build();
+         ContiguousTable ct = tmp.contiguousSplit()[0]) {
+      // one reference for the device buffer itself, two more for the column using it
+      assertEquals(3, ct.getBuffer().getRefCount());
+    }
+  }
 }


### PR DESCRIPTION
After #5815 columns created from a contiguous table are not incrementing the refcount of the underlying device memory buffer.  That means columns are no longer being "sliced" from the buffer such that they are able to hold the buffer open after the buffer closes.  The RAPIDS Accelerator for Apache Spark relies upon this behavior.

This updates the `ColumnVector` constructor for a column built from a contiguous table to increment the reference count of the underlying buffer and add it to the list of items to close when the column is finally closed.  To avoid having to explicitly slice the underlying buffer and create unnecessary object overhead, I exposed the reference counting as a method as has been done in other cudf Java classes.

