### PR TITLE
[REVIEW] Just use `None` for `strides` in `Buffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #5917 Just use `None` for `strides` in `Buffer`
+
 ## Bug Fixes
 
 # cuDF 0.15.0 (Date TBD)

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -68,7 +68,7 @@ class Buffer(Serializable):
         intf = {
             "data": (self.ptr, False),
             "shape": (self.size,),
-            "strides": (1,),
+            "strides": None,
             "typestr": "|u1",
             "version": 0,
         }

--- a/python/cudf/cudf/core/buffer.py
+++ b/python/cudf/cudf/core/buffer.py
@@ -106,6 +106,7 @@ class Buffer(Serializable):
         header["type-serialized"] = pickle.dumps(type(self))
         header["constructor-kwargs"] = {}
         header["desc"] = self.__cuda_array_interface__.copy()
+        header["desc"]["strides"] = (1,)
         frames = [self]
         return header, frames
 


### PR DESCRIPTION
Originally there were some issues in CuPy and Numba with how they implemented `__cuda_array_interface__` and handled other objects that supported it where they couldn't handle `strides` of `None` cleanly. So we added `strides` here with what it should be. However both libraries have since cleaned this up ( CuPy 6.6.0+, https://github.com/cupy/cupy/pull/2669 and Numba 0.46.0+, https://github.com/numba/numba/pull/4609 ) and we require newer versions of both. As some code contains fast paths when `strides` is `None`, switch to using `None` here as we ensure contiguous data in `Buffer`s. This should allow us to take advantage of those fast paths where possible.
