### PR TITLE
[REVIEW] Revised assertEquals for List Columns in java tests [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,7 @@
 - PR #5915 Fix reference count on Java DeviceMemoryBuffer after contiguousSplit
 - PR #5929 Revised assertEquals for List Columns in java tests
 
+
 # cuDF 0.14.0 (03 Jun 2020)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,7 +278,7 @@
 - PR #5914 Link CUDA against libcudf_kafka
 - PR #5895 Do not break kafka client consumption loop on local client timeout
 - PR #5915 Fix reference count on Java DeviceMemoryBuffer after contiguousSplit
-
+- PR #5929 Revised assertEquals for List Columns in java tests
 
 # cuDF 0.14.0 (03 Jun 2020)
 

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -113,7 +113,7 @@ public final class HostColumnVector implements AutoCloseable {
     }
 
 
-    private Object getElement(int rowIndex) {
+    Object getElement(int rowIndex) {
       if (type == DType.LIST) {
         List retList = new ArrayList();
         int start = offsets.getInt(rowIndex * DType.INT32.getSizeInBytes());
@@ -155,11 +155,25 @@ public final class HostColumnVector implements AutoCloseable {
     private Object readValue(int index){
       assert index < rows * type.getSizeInBytes();
       switch (type) {
-        case INT32: return data.getInt(index);
-        case INT64: return data.getLong(index);
+        case INT32: // fall through
+        case UINT32: // fall through
+        case TIMESTAMP_DAYS:
+        case DURATION_DAYS: return data.getInt(index);
+        case INT64: // fall through
+        case UINT64: // fall through
+        case DURATION_MICROSECONDS: // fall through
+        case DURATION_MILLISECONDS: // fall through
+        case DURATION_NANOSECONDS: // fall through
+        case DURATION_SECONDS: // fall through
+        case TIMESTAMP_MICROSECONDS: // fall through
+        case TIMESTAMP_MILLISECONDS: // fall through
+        case TIMESTAMP_NANOSECONDS: // fall through
+        case TIMESTAMP_SECONDS: return data.getLong(index);
         case FLOAT32: return data.getFloat(index);
         case FLOAT64: return data.getDouble(index);
+        case UINT8: // fall through
         case INT8: return data.getByte(index);
+        case UINT16: // fall through
         case INT16: return data.getShort(index);
         case BOOL8: return data.getBoolean(index);
         default: throw new UnsupportedOperationException("Do not support " + type);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -2119,11 +2119,11 @@ public class ColumnVectorTest extends CudfTestBase {
       try (ColumnVector v = ColumnVector.fromStrings("Héllo there", "thésé", "null", "", "ARé some", "test strings");
            ColumnVector expected = ColumnVector.fromLists(
                    new HostColumnVector.ColumnBuilder.ListType(true, 6,
-                           new HostColumnVector.ColumnBuilder.BasicType(true, 8, DType.STRING)),
+                           new HostColumnVector.ColumnBuilder.BasicType(true, 9, DType.STRING)),
                    Arrays.asList("Héllo", "there"),
                    Arrays.asList("thésé"),
                    Arrays.asList("null"),
-                   Arrays.asList(),
+                   Arrays.asList(""),
                    Arrays.asList("ARé", "some"),
                    Arrays.asList("test", "strings"));
            Scalar pattern = Scalar.fromString(" ");

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -84,23 +84,23 @@ public class TableTest extends CudfTestBase {
   }
 
   public static void assertColumnsAreEqual(ColumnVector expected, ColumnVector cv, String colName) {
-    assertPartialNestedColumnsAreEqual(expected, 0, expected.getRowCount(), cv, colName, true);
+    assertPartialColumnsAreEqual(expected, 0, expected.getRowCount(), cv, colName, true);
   }
 
   public static void assertColumnsAreEqual(HostColumnVector expected, HostColumnVector cv, String colName) {
-    assertPartialNestedColumnsAreEqual(expected, 0, expected.getRowCount(), cv, colName, true);
+    assertPartialColumnsAreEqual(expected, 0, expected.getRowCount(), cv, colName, true);
   }
 
-  public static void assertPartialNestedColumnsAreEqual(ColumnVector expected, long rowOffset, long length,
-                                                        ColumnVector cv, String colName, boolean enableNullCheck) {
+  public static void assertPartialColumnsAreEqual(ColumnVector expected, long rowOffset, long length,
+                                                  ColumnVector cv, String colName, boolean enableNullCheck) {
     try (HostColumnVector hostExpected = expected.copyToHost();
          HostColumnVector hostcv = cv.copyToHost()) {
-      assertPartialNestedColumnsAreEqual(hostExpected, rowOffset, length, hostcv, colName, enableNullCheck);
+      assertPartialColumnsAreEqual(hostExpected, rowOffset, length, hostcv, colName, enableNullCheck);
     }
   }
 
-  public static void assertPartialNestedColumnsAreEqual(HostColumnVector expected, long rowOffset, long length,
-                                                        HostColumnVector cv, String colName, boolean enableNullCheck) {
+  public static void assertPartialColumnsAreEqual(HostColumnVector expected, long rowOffset, long length,
+                                                  HostColumnVector cv, String colName, boolean enableNullCheck) {
     assertEquals(expected.getType(), cv.getType(), "Type For Column " + colName);
     assertEquals(length, cv.getRowCount(), "Row Count For Column " + colName);
     if (enableNullCheck) {
@@ -168,9 +168,9 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-  public static void assertPartialNestedColumnsAreEqual(HostColumnVector.NestedHostColumnVector expected,
-                                                        HostColumnVector.NestedHostColumnVector cv,
-                                                        String colName, boolean enableNullCheck) {
+  public static void assertPartialColumnsAreEqual(HostColumnVector.NestedHostColumnVector expected,
+                                                  HostColumnVector.NestedHostColumnVector cv,
+                                                  String colName, boolean enableNullCheck) {
     assertEquals(expected.getType(), cv.getType(), "Type For Column " + colName);
     assertEquals(expected.getRows(), cv.getRows(), "Row Count For Column " + colName);
     if (enableNullCheck) {
@@ -222,7 +222,7 @@ public class TableTest extends CudfTestBase {
             assertEquals(expected.getNestedChildren().size(),
                 cv.getNestedChildren().size(), " num children don't match");
             for (int k = 0; k < expected.getNestedChildren().size(); k++)
-            assertPartialNestedColumnsAreEqual(expected.getNestedChildren().get(k),
+            assertPartialColumnsAreEqual(expected.getNestedChildren().get(k),
                 cv.getNestedChildren().get(k), colName, enableNullCheck);
             break;
           default:
@@ -242,7 +242,7 @@ public class TableTest extends CudfTestBase {
       }
     }
     for (int j = 0; j < expected.children.size(); j++) {
-      assertPartialNestedColumnsAreEqual(expected.children.get(j), input.children.get(j), colName, enableNullCheck);
+      assertPartialColumnsAreEqual(expected.children.get(j), input.children.get(j), colName, enableNullCheck);
     }
   }
 
@@ -256,7 +256,7 @@ public class TableTest extends CudfTestBase {
       if (rowOffset != 0 || length != expected.getRowCount()) {
         name = name + " PART " + rowOffset + "-" + (rowOffset + length - 1);
       }
-      assertPartialNestedColumnsAreEqual(expect, rowOffset, length, cv, name, enableNullCheck);
+      assertPartialColumnsAreEqual(expect, rowOffset, length, cv, name, enableNullCheck);
     }
   }
 


### PR DESCRIPTION
1. Please write a description in this text box of the changes that are being
   made.

Added a more thorough check in `assertColumn`s in` TableTest `and fixed one test that was caught by this change

2. Please ensure that you have written units tests for the changes made/features
   added.
Tests with list columns are affected and they now take the new path when `assertColumnsAreEqual` is called.

Fixes https://github.com/rapidsai/cudf/issues/5888