### PR TITLE
[REVIEW] Fix issue related to `string` to `datetime64` column typecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,7 @@
 - PR #5914 Link CUDA against libcudf_kafka
 - PR #5895 Do not break kafka client consumption loop on local client timeout
 - PR #5915 Fix reference count on Java DeviceMemoryBuffer after contiguousSplit
+- PR #5941 Fix issue related to `string` to `datetime64` column typecast
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -4519,8 +4519,15 @@ class StringColumn(column.ColumnBase):
             if "format" not in kwargs:
                 if len(self) > 0:
                     # infer on host from the first not na element
-                    fmt = datetime.infer_format(self[self.notna()][0])
-                    kwargs.update(format=fmt)
+                    # or return all null column if all values
+                    # are null in current column
+                    if self.null_count == len(self):
+                        return column.column_empty(
+                            len(self), dtype=out_dtype, masked=True
+                        )
+                    else:
+                        fmt = datetime.infer_format(self[self.notna()][0])
+                        kwargs.update(format=fmt)
 
             # Check for None strings
             if len(self) > 0 and self.binary_operator("eq", "None").any():

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -11,7 +11,7 @@ import pytest
 import cudf
 from cudf.core import DataFrame, Series
 from cudf.core.index import DatetimeIndex
-from cudf.tests.utils import NUMERIC_TYPES, assert_eq
+from cudf.tests.utils import DATETIME_TYPES, NUMERIC_TYPES, assert_eq
 
 
 def data1():
@@ -788,17 +788,23 @@ def test_datetime_scalar_timeunit_cast(timeunit):
     assert_eq(pdf, gdf)
 
 
-def test_str_null_to_datetime():
-    psr = pd.Series(["2001-01-01", "2002-02-02", "2000-01-05", "NaT"])
-    gsr = Series(["2001-01-01", "2002-02-02", "2000-01-05", "NaT"])
+@pytest.mark.parametrize(
+    "data",
+    [
+        ["2001-01-01", "2002-02-02", "2000-01-05", "NaT"],
+        ["2001-01-01", "2002-02-02", "2000-01-05", None],
+        [None, None, None, None, None],
+    ],
+)
+@pytest.mark.parametrize("dtype", DATETIME_TYPES)
+def test_str_null_to_datetime(data, dtype):
+    psr = pd.Series(data)
+    gsr = Series(data)
 
-    assert_eq(psr.astype("datetime64[s]"), gsr.astype("datetime64[s]"))
+    assert_eq(psr.astype(dtype), gsr.astype(dtype))
 
-    psr = pd.Series(["2001-01-01", "2002-02-02", "2000-01-05", None])
-    gsr = Series(["2001-01-01", "2002-02-02", "2000-01-05", None])
 
-    assert_eq(psr.astype("datetime64[s]"), gsr.astype("datetime64[s]"))
-
+def test_str_to_datetime_error():
     psr = pd.Series(["2001-01-01", "2002-02-02", "2000-01-05", "None"])
     gsr = Series(["2001-01-01", "2002-02-02", "2000-01-05", "None"])
 


### PR DESCRIPTION
Fixes: #5939 

This PR fixes issue related to `string` to `datetime64` when all values of the column are null. In this scenario `self[self.notna()]` will always result in empty column, and `self[self.notna()][0]` will lead to index error, hence guarding this code-flow with an all null check.


<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
