### PR TITLE
[REVIEW] Fix jitcache-multiprocess test failure, fix CUDA 11 related CI issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,7 @@
 - PR #5915 Fix reference count on Java DeviceMemoryBuffer after contiguousSplit
 - PR #5942 Fix JIT cache multiprocess test failure
 
+
 # cuDF 0.14.0 (03 Jun 2020)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,7 +281,7 @@
 - PR #5914 Link CUDA against libcudf_kafka
 - PR #5895 Do not break kafka client consumption loop on local client timeout
 - PR #5915 Fix reference count on Java DeviceMemoryBuffer after contiguousSplit
-
+- PR #5942 Fix JIT cache multiprocess test failure
 
 # cuDF 0.14.0 (03 Jun 2020)
 

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -3,7 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
-{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.2').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.1').split('.')[:2]) %}
 
 package:
   name: cudf
@@ -31,7 +31,7 @@ requirements:
   run:
     - python
     - pandas >=1.0,<1.1.0dev0
-    - cupy >=6.6.0,<8.0.0dev0,!=7.1.0
+    - cupy >=6.6.0,<8.0.0a0,!=7.1.0
     - numba >=0.49.0
     - numpy
     - pyarrow 0.17.1.*

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -3,6 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.2').split('.')[:2]) %}
 
 package:
   name: cudf
@@ -29,8 +30,8 @@ requirements:
     - rmm {{ minor_version }}.*
   run:
     - python
-    - pandas >=1.0,<1.1.0a0
-    - cupy >=6.6.0,<8.0.0a0,!=7.1.0
+    - pandas >=1.0,<1.1.0dev0
+    - cupy >=6.6.0,<8.0.0dev0,!=7.1.0
     - numba >=0.49.0
     - numpy
     - pyarrow 0.17.1.*
@@ -40,6 +41,8 @@ requirements:
     - fsspec>=0.6.0
 
 test:
+  requires:
+    - cudatoolkit {{ cuda_version }}.*
   commands:
     - python -c "import cudf"
 

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -3,6 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.1').split('.')[:2]) %}
 
 package:
   name: cudf_kafka
@@ -36,6 +37,8 @@ requirements:
     - cudf {{ version }}
 
 test:
+  requires:
+    - cudatoolkit {{ cuda_version }}.*
   commands:
     - python -c "import cudf_kafka"
 

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -3,7 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
-{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.2').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.1').split('.')[:2]) %}
 
 package:
   name: custreamz
@@ -35,9 +35,8 @@ requirements:
 test:
   requires:
     - cudatoolkit {{ cuda_version }}.*
-  imports:
-    - cudf
-    - streamz
+  commands:
+    - python -c "import custreamz"
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -3,6 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.2').split('.')[:2]) %}
 
 package:
   name: custreamz
@@ -32,6 +33,8 @@ requirements:
     - cudf_kafka {{ version }}
 
 test:
+  requires:
+    - cudatoolkit {{ cuda_version }}.*
   imports:
     - cudf
     - streamz

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -3,6 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.1').split('.')[:2]) %}
 
 package:
   name: dask-cudf
@@ -28,6 +29,10 @@ requirements:
     - cudf {{ version }}
     - dask >=2.22.0
     - distributed >=2.22.0
+  
+test:
+  requires:
+    - cudatoolkit {{ cuda_version }}.*
 
 
 about:

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -2,7 +2,7 @@
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
-{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.0').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.1').split('.')[:2]) %}
 
 package:
   name: libcudf

--- a/cpp/tests/jit/jit-cache-test.hpp
+++ b/cpp/tests/jit/jit-cache-test.hpp
@@ -24,7 +24,12 @@
 
 #include <jit/cache.h>
 
-struct JitCacheTest : public cudf::test::BaseFixture, public cudf::jit::cudfJitCache {
+// Note that this test does not inherit from cudf::test::BaseFixture because
+// doing so would cause the CUDA context to be created before the fork in
+// the JitCacheMultiProcessTest, where we need it to be created after the fork
+// to ensure the forked child has a context. These tests do not need the
+// memory_resource member of BaseFixture.
+struct JitCacheTest : public ::testing::Test, public cudf::jit::cudfJitCache {
   JitCacheTest() : grid(1), block(1) {}
 
   virtual ~JitCacheTest() {}

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5420,7 +5420,6 @@ class DataFrame(Frame, Serializable):
         self,
         axis=None,
         skipna=None,
-        dtype=None,
         level=None,
         numeric_only=None,
         **kwargs,
@@ -5430,12 +5429,16 @@ class DataFrame(Frame, Serializable):
 
         Parameters
         ----------
-
+        axis: {index (0), columns(1)}
+            Axis for the function to be applied on.
         skipna: bool, default True
             Exclude NA/null values when computing the result.
-
-        dtype: data type
-            Data type to cast the result to.
+        level: int or level name, default None
+            If the axis is a MultiIndex (hierarchical), count along a
+            particular level, collapsing into a Series.
+        numeric_only: bool, default None
+            Include only float, int, boolean columns. If None, will attempt to
+            use everything, then use only numeric data.
 
         Returns
         -------
@@ -5458,7 +5461,6 @@ class DataFrame(Frame, Serializable):
             "min",
             axis=axis,
             skipna=skipna,
-            dtype=dtype,
             level=level,
             numeric_only=numeric_only,
             **kwargs,
@@ -5468,7 +5470,6 @@ class DataFrame(Frame, Serializable):
         self,
         axis=None,
         skipna=None,
-        dtype=None,
         level=None,
         numeric_only=None,
         **kwargs,
@@ -5478,12 +5479,16 @@ class DataFrame(Frame, Serializable):
 
         Parameters
         ----------
-
+        axis: {index (0), columns(1)}
+            Axis for the function to be applied on.
         skipna: bool, default True
             Exclude NA/null values when computing the result.
-
-        dtype: data type
-            Data type to cast the result to.
+        level: int or level name, default None
+            If the axis is a MultiIndex (hierarchical), count along a
+            particular level, collapsing into a Series.
+        numeric_only: bool, default None
+            Include only float, int, boolean columns. If None, will attempt to
+            use everything, then use only numeric data.
 
         Returns
         -------
@@ -5506,7 +5511,6 @@ class DataFrame(Frame, Serializable):
             "max",
             axis=axis,
             skipna=skipna,
-            dtype=dtype,
             level=level,
             numeric_only=numeric_only,
             **kwargs,

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5417,12 +5417,7 @@ class DataFrame(Frame, Serializable):
         )
 
     def min(
-        self,
-        axis=None,
-        skipna=None,
-        level=None,
-        numeric_only=None,
-        **kwargs,
+        self, axis=None, skipna=None, level=None, numeric_only=None, **kwargs,
     ):
         """
         Return the minimum of the values in the DataFrame.
@@ -5467,12 +5462,7 @@ class DataFrame(Frame, Serializable):
         )
 
     def max(
-        self,
-        axis=None,
-        skipna=None,
-        level=None,
-        numeric_only=None,
-        **kwargs,
+        self, axis=None, skipna=None, level=None, numeric_only=None, **kwargs,
     ):
         """
         Return the maximum of the values in the DataFrame.


### PR DESCRIPTION
Recent changes to `rmm::mr::get_default_resource()` caused the CUDA context
to be created in the JITCACHE_MULTIPROCESS_TEST before the child process is
forked, which caused the child to not get a context.  This PR fixes the failure.

