### PR TITLE
[REVIEW] Fix null count for child device column vector [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,7 @@
 - PR #5895 Do not break kafka client consumption loop on local client timeout
 - PR #5915 Fix reference count on Java DeviceMemoryBuffer after contiguousSplit
 - PR #5929 Revised assertEquals for List Columns in java tests
+- PR #5947 Fix null count for child device column vector
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -92,7 +92,7 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
 
     @Override
     public long getNullCount() {
-      return  offHeap.getNativeNullCount();
+      return  offHeap.getNativeNullCount(viewHandle);
     }
 
     @Override
@@ -3103,6 +3103,10 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
         return ColumnVector.getNativeNullCount(getViewHandle());
       }
       return getNativeNullCountColumn(columnHandle);
+    }
+
+    public long getNativeNullCount(long someViewHandle) {
+      return ColumnVector.getNativeNullCount(someViewHandle);
     }
 
     private void setNativeNullCount(int nullCount) throws CudfException {

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -2746,6 +2746,10 @@ public class ColumnVectorTest extends CudfTestBase {
          ColumnVector v = ColumnVector.concatenate(res1, res2);
          ColumnVector expected = ColumnVector.fromLists(new HostColumnVector.ColumnBuilder.ListType(true, 3,
              new HostColumnVector.ColumnBuilder.BasicType(true, 8, DType.STRING)) , list, list3, list2)) {
+      assert res1.getNullCount() == 1: "Null count is incorrect on input column";
+      assert res1.getChildColumnViewAccess(0).getNullCount() == 0 : "Null count is incorrect on input column";
+      assert res2.getNullCount() == 0 : "Null count is incorrect on input column";
+      assert res2.getChildColumnViewAccess(0).getNullCount() == 2 : "Null count is incorrect on input column";
       assertColumnsAreEqual(expected, v);
     }
   }


### PR DESCRIPTION
This fixes an oversight bug with nullcount on child columns for list. I have modified a test as well to show the issue as other tests were not catching this. 