### PR TITLE
[REVIEW] FIX Remove unnecessary mkdir command [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,7 +283,7 @@
 - PR #5915 Fix reference count on Java DeviceMemoryBuffer after contiguousSplit
 - PR #5929 Revised assertEquals for List Columns in java tests
 - PR #5947 Fix null count for child device column vector
-
+- PR #5951 Fix mkdir error in benchmark build
 
 # cuDF 0.14.0 (03 Jun 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,7 @@
 - PR #5947 Fix null count for child device column vector
 - PR #5951 Fix mkdir error in benchmark build
 
+
 # cuDF 0.14.0 (03 Jun 2020)
 
 ## New Features

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -31,9 +31,6 @@ export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 # Set Benchmark Vars
 export GBENCH_BENCHMARKS_DIR=${WORKSPACE}/cpp/build/gbenchmarks/
 
-# Ensure ASV results directory exists
-mkdir -p ${ASVRESULTS_DIR}
-
 # Set `LIBCUDF_KERNEL_CACHE_PATH` environment variable to $HOME/.jitify-cache because
 # it's local to the container's virtual file system, and not shared with other CI jobs
 # like `/tmp` is.


### PR DESCRIPTION
Fixes the following error in libcudf nightly benchmark builds:

```
mkdir: missing operand
```

Forgot to remove this line when updating for S3 functionality.