### PR TITLE
[OPS] TST Run unit tests with numba 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,7 @@
 - PR #5951 Fix mkdir error in benchmark build
 - PR #5949 Find Arrow include directory for JNI builds
 - PR #5964 Fix API doc page title tag
+- PR #5979 Test numba 0.51.0
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -72,7 +72,7 @@ conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
 
 # https://docs.rapids.ai/maintainers/depmgmt/
 conda remove --force rapids-build-env
-conda install -y -c numba/label/dev "numba=0.51.0"
+conda install -y -c numba/label/dev "numba==0.51.0"
 
 # Install the master version of dask, distributed, and streamz
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -72,7 +72,7 @@ conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
 
 # https://docs.rapids.ai/maintainers/depmgmt/
 conda remove --force rapids-build-env
-conda install -y -c numba "numba=0.51.0"
+conda install -y -c numba/label/dev "numba=0.51.0"
 
 # Install the master version of dask, distributed, and streamz
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -71,7 +71,7 @@ conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
               "ucx-py=${MINOR_VERSION}" \
 
 # https://docs.rapids.ai/maintainers/depmgmt/
-conda remove -f rapids-build-env
+conda remove --force rapids-build-env
 conda install -y -c numba "numba=0.51.0"
 
 # Install the master version of dask, distributed, and streamz

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -72,7 +72,7 @@ conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
 
 # https://docs.rapids.ai/maintainers/depmgmt/
 conda remove --force rapids-build-env
-conda install -y -c numba/label/dev "numba==0.51.0"
+conda install -y -c numba/label/dev -c conda-forge "numba==0.51.0"
 
 # Install the master version of dask, distributed, and streamz
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -71,8 +71,8 @@ conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
               "ucx-py=${MINOR_VERSION}" \
 
 # https://docs.rapids.ai/maintainers/depmgmt/
-# conda remove -f rapids-build-env rapids-notebook-env
-# conda install "your-pkg=1.0.0"
+conda remove -f rapids-build-env
+conda install -y -c numba "numba=0.51.0"
 
 # Install the master version of dask, distributed, and streamz
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"


### PR DESCRIPTION
Do a GPU test run to see if the timeout issues seen in a pre-release version of numba 0.51 is still present in the recently released 0.51.0 packages

cc @jakirkham @kkraus14 