### PR TITLE
[REVIEW] fix gcc-9 compile errors under CUDA 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,7 @@
 - PR #5377 Handle array of cupy scalars in to_column
 - PR #5326 Fix `DataFrame.__init__` for list of scalar inputs and related dask issue
 - PR #5383 Fix cython `type_id` enum mismatch
+- PR #5982 Fix gcc-9 compile errors under CUDA 11
 - PR #5382 Fix CategoricalDtype equality comparisons
 - PR #5385 Fix index issues in `DataFrame.from_gpu_matrix`
 - PR #5390 Fix Java data type IDs and string interleave test

--- a/cpp/src/interop/from_arrow.cu
+++ b/cpp/src/interop/from_arrow.cu
@@ -138,7 +138,7 @@ struct dispatch_to_cudf_column {
       col->set_null_mask(std::move(out_mask));
     }
 
-    return std::move(col);
+    return col;
   }
 };
 

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -116,7 +116,7 @@ col_map_ptr_type create_col_names_hash_map(column_view column_name_hashes, cudaS
                      [map = *key_col_map, column_data] __device__(size_type idx) mutable {
                        map.insert(thrust::make_pair(column_data[idx], idx));
                      });
-  return std::move(key_col_map);
+  return key_col_map;
 }
 
 /**
@@ -171,7 +171,7 @@ std::unique_ptr<table> create_json_keys_info_table(
                                          key_counter.data(),
                                          info_table_mdv.data(),
                                          stream);
-  return std::move(info_table);
+  return info_table;
 }
 
 /**

--- a/cpp/src/lists/copying/gather.cu
+++ b/cpp/src/lists/copying/gather.cu
@@ -126,7 +126,7 @@ std::unique_ptr<column> gather_list_leaf(column_view const& column,
     leaf_column->set_null_mask(std::move(validity.first), validity.second);
   }
 
-  return std::move(leaf_column);
+  return leaf_column;
 }
 
 /**


### PR DESCRIPTION
When compiling libcudf with gcc-9 under CUDA 11, getting these type of errors:
```bash
error: moving a local object in a return statement prevents copy elision
```
Compiler suggests removing the `std::move()` call.

@jrhemstad @kkraus14 