### PR TITLE
[REVIEW] fix gcc-9 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,7 @@
 - PR #5383 Fix cython `type_id` enum mismatch
 - PR #5982 Fix gcc-9 compile errors under CUDA 11
 - PR #5382 Fix CategoricalDtype equality comparisons
+- PR #5989 Fix gcc-9 warnings on narrowing conversion
 - PR #5385 Fix index issues in `DataFrame.from_gpu_matrix`
 - PR #5390 Fix Java data type IDs and string interleave test
 - PR #5392 Fix documentation links

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -209,7 +209,8 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
   cudf::size_type strings_count = strings.size();
   if (strings_count == 0) return cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32});
   CUDF_EXPECTS(strings_count > 1, "the input strings must include at least 2 strings");
-  CUDF_EXPECTS(size_t{strings_count} * size_t{strings_count} < std::numeric_limits<int32_t>().max(),
+  CUDF_EXPECTS(static_cast<size_t>(strings_count) * static_cast<size_t>(strings_count) <
+                 std::numeric_limits<int32_t>().max(),
                "too many strings to create the output column");
 
   // create device column of the input strings column


### PR DESCRIPTION
When compiling with gcc-9 under CUDA 11, it produces these warnings:
```bash
warning: invalid narrowing conversion from "signed int" to "unsigned long"
```
I think gcc-9 is more strict about type conversions when using the curly brace initialization.

@davidwendt 