### PR TITLE
Fix Java memory resource handler to rethrow original exception object [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,7 @@
 - PR #6016 Fix benchmark fixture segfault
 - PR #6003 Fix concurrent JSON reads crash
 - PR #6032 Change black version to 19.10b0 in .pre-commit-config.yaml
+- PR #6041 Fix Java memory resource handler to rethrow original exception object
 
 
 # cuDF 0.14.0 (03 Jun 2020)

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -276,7 +276,7 @@ private:
         break;
       } catch (std::bad_alloc const &e) {
         if (!on_alloc_fail(num_bytes)) {
-          throw e;
+          throw;
         }
       }
     }
@@ -285,10 +285,10 @@ private:
     try {
       check_for_threshold_callback(total_before, total_after, alloc_thresholds,
                                    on_alloc_threshold_method, "onAllocThreshold", total_after);
-    } catch (std::exception e) {
+    } catch (std::exception const &e) {
       // Free the allocation as app will think the exception means the memory was not allocated.
       resource->deallocate(result, num_bytes, stream);
-      throw e;
+      throw;
     }
 
     return result;


### PR DESCRIPTION
The JNI can install an RMM memory resource that calls back into Java to handle allocation failures.  If the callback fails to address the issue then it rethrows the C++ exception, but instead of throwing the original exception object it makes a copy of the object at the `std::bad_alloc` level, losing the `what()` details of the specific exception.   This fixes the JNI memory handler to throw the original C++ exception object.