### PR TITLE
[WIP] Fix for reading columns out-of-order they appear in parquet files.

### DIFF
--- a/cpp/src/io/parquet/parquet_gpu.h
+++ b/cpp/src/io/parquet/parquet_gpu.h
@@ -133,7 +133,8 @@ struct ColumnChunkDesc {
                                      int8_t converted_type_,
                                      int8_t decimal_scale_,
                                      int32_t ts_clock_rate_,
-                                     int32_t col_index_)
+                                     int32_t col_index_,
+                                     int32_t src_col_index_)
     : compressed_data(compressed_data_),
       compressed_size(compressed_size_),
       num_values(num_values_),
@@ -153,7 +154,8 @@ struct ColumnChunkDesc {
       converted_type(converted_type_),
       decimal_scale(decimal_scale_),
       ts_clock_rate(ts_clock_rate_),
-      col_index(col_index_)
+      col_index(col_index_),
+      src_col_index(src_col_index_)
   {
   }
 
@@ -180,7 +182,8 @@ struct ColumnChunkDesc {
   int8_t decimal_scale;                       // decimal scale pow(10, -decimal_scale)
   int32_t ts_clock_rate;  // output timestamp clock frequency (0=default, 1000=ms, 1000000000=ns)
 
-  int32_t col_index;  // my output column index
+  int32_t col_index;      // my output column index
+  int32_t src_col_index;  // my src (order in the file) input index
 };
 
 /**

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -745,9 +745,9 @@ void reader::impl::allocate_nesting_info(
   // buffer to keep it to a single gpu allocation
   size_t const total_page_nesting_infos = std::accumulate(
     chunks.host_ptr(), chunks.host_ptr() + chunks.size(), 0, [&](int total, auto &chunk) {
-      auto const col_index = chunk.col_index;
+      auto const src_col_index = chunk.src_col_index;
       // the leaf schema represents the bottom of the nested hierarchy
-      auto const &leaf_schema               = _metadata->get_column_leaf_schema(col_index);
+      auto const &leaf_schema               = _metadata->get_column_leaf_schema(src_col_index);
       auto const per_page_nesting_info_size = leaf_schema.max_definition_level + 1;
       return total + (per_page_nesting_info_size * chunk.num_data_pages);
     });
@@ -761,8 +761,8 @@ void reader::impl::allocate_nesting_info(
   int target_page_index = 0;
   int src_info_index    = 0;
   for (size_t idx = 0; idx < chunks.size(); idx++) {
-    int col_index                  = chunks[idx].col_index;
-    auto &leaf_schema              = _metadata->get_column_leaf_schema(col_index);
+    int src_col_index              = chunks[idx].src_col_index;
+    auto &leaf_schema              = _metadata->get_column_leaf_schema(src_col_index);
     int per_page_nesting_info_size = leaf_schema.max_definition_level + 1;
 
     // skip my dict pages
@@ -782,12 +782,13 @@ void reader::impl::allocate_nesting_info(
   // fill in
   int nesting_info_index = 0;
   for (size_t idx = 0; idx < chunks.size(); idx++) {
-    int col_index = chunks[idx].col_index;
+    int col_index     = chunks[idx].col_index;
+    int src_col_index = chunks[idx].src_col_index;
 
     // the leaf schema represents the bottom of the nested hierarchy
-    auto &leaf_schema = _metadata->get_column_leaf_schema(col_index);
+    auto &leaf_schema = _metadata->get_column_leaf_schema(src_col_index);
     // real depth of the output cudf column hiearchy (1 == no nesting, 2 == 1 level, etc)
-    int max_depth = _metadata->get_nesting_depth(col_index);
+    int max_depth = _metadata->get_nesting_depth(src_col_index);
 
     // # of nesting infos stored per page for this column
     size_t per_page_nesting_info_size = leaf_schema.max_definition_level + 1;
@@ -795,7 +796,7 @@ void reader::impl::allocate_nesting_info(
     col_nesting_info[col_index].resize(max_depth);
 
     // fill in host-side nesting info
-    int schema_idx     = _metadata->get_column_leaf_schema_index(col_index);
+    int schema_idx     = _metadata->get_column_leaf_schema_index(src_col_index);
     auto cur_schema    = _metadata->get_schema(schema_idx);
     int output_col_idx = max_depth - 1;
     while (schema_idx > 0) {
@@ -1107,7 +1108,8 @@ table_with_metadata reader::impl::read(size_type skip_rows,
                                            converted_type,
                                            leaf_schema.decimal_scale,
                                            clock_rate,
-                                           i));
+                                           i,
+                                           col.first));
 
         // Map each column chunk to its column index and its source index
         chunk_source_map[chunks.size() - 1] = row_group_source;


### PR DESCRIPTION

Fixes: https://github.com/rapidsai/cudf/issues/6048
Potentially also fixes: https://github.com/rapidsai/tpcx-bb/issues/93

Posting this as WIP so further tests can be run.  I also need to add proper unit tests as well.

