### PR TITLE
[REVIEW] Fix fsspec handling of string with "://"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ## Bug Fixes
 
-- PR #XXXX Fix issue where fsspec thinks it has a protocol string
+- PR #6081 Fix issue where fsspec thinks it has a protocol string
 
 
 # cuDF 0.15.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ## Bug Fixes
 
+- PR #XXXX Fix issue where fsspec thinks it has a protocol string
+
 
 # cuDF 0.15.0 (Date TBD)
 

--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -319,6 +319,7 @@ def test_json_null_literal(buffer):
         ],
     )
 
+
 def test_json_bad_protocol_string():
     test_string = '{"field": "s3://path"}'
 
@@ -326,4 +327,3 @@ def test_json_bad_protocol_string():
     got = cudf.read_json(test_string, lines=True)
 
     assert_eq(expect, got)
-

--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -318,3 +318,12 @@ def test_json_null_literal(buffer):
             df["1"]._column.default_na_value(),
         ],
     )
+
+def test_json_bad_protocol_string():
+    test_string = '{"field": "s3://path"}'
+
+    expect = pd.DataFrame([{"field": "s3://path"}])
+    got = cudf.read_json(test_string, lines=True)
+
+    assert_eq(expect, got)
+

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -962,9 +962,16 @@ def get_filepath_or_buffer(
         # fsspec does not expanduser so handle here
         path_or_data = os.path.expanduser(path_or_data)
 
-        fs, _, paths = fsspec.get_fs_token_paths(
-            path_or_data, mode=mode, storage_options=storage_options
-        )
+        try:
+            fs, _, paths = fsspec.get_fs_token_paths(
+                path_or_data, mode=mode, storage_options=storage_options
+            )
+        except ValueError as e:
+            if str(e).startswith("Protocol not known"):
+                return path_or_data, compression
+            else:
+                raise e
+
         if len(paths) == 0:
             raise IOError(f"{path_or_data} could not be resolved to any files")
         elif len(paths) > 1:


### PR DESCRIPTION
If a string passed into a `read_*` call contains `://`, fsspec tries to interpret it as a protocol to read from. We need to catch the error in this situation and continue to pass the string into the actual read call downstream.

Fixes #6046 