### PR TITLE
[REVIEW] Small refactor of `print_differences`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #6002 Add Java bindings for md5
 - PR #6067 Added compute codes for aarch64 devices
 - PR #6083 Small cleanup
+- PR #6103 Small refactor of `print_differences`
 
 ## Bug Fixes
 

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -180,9 +180,6 @@ std::string differences_message(thrust::device_vector<int> const& differences,
     auto diff_lhs = cudf::detail::slice(lhs, index, index + 1);
     auto diff_rhs = cudf::detail::slice(rhs, index, index + 1);
 
-    std::vector<std::string> h_left_strings  = to_strings(diff_lhs);
-    std::vector<std::string> h_right_strings = to_strings(diff_rhs);
-
     return depth_str + "first difference: " + "lhs[" + std::to_string(index) +
            "] = " + to_string(diff_lhs, "") + ", rhs[" + std::to_string(index) +
            "] = " + to_string(diff_rhs, "");

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -212,7 +212,7 @@ struct column_comparator_impl {
 
     if (not differences.empty()) {
       auto const msg = differences_message(differences, lhs, rhs, print_all_differences, depth);
-      EXPECT_EQ(differences.size(), size_t{0}) << msg;
+      GTEST_FAIL() << msg;
     }
   }
 };
@@ -305,7 +305,7 @@ struct column_comparator_impl<list_view, check_exact_equality> {
 
     if (not differences.empty()) {
       auto const msg = differences_message(differences, lhs, rhs, print_all_differences, depth);
-      EXPECT_EQ(differences.size(), size_t{0}) << msg;
+      GTEST_FAIL() << msg;
     }
 
     // recurse

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -210,10 +210,8 @@ struct column_comparator_impl {
 
     differences.resize(thrust::distance(differences.begin(), diff_iter));  // shrink back down
 
-    if (not differences.empty()) {
-      auto const msg = differences_message(differences, lhs, rhs, print_all_differences, depth);
-      GTEST_FAIL() << msg;
-    }
+    if (not differences.empty())
+      GTEST_FAIL() << differences_message(differences, lhs, rhs, print_all_differences, depth);
   }
 };
 
@@ -303,10 +301,8 @@ struct column_comparator_impl<list_view, check_exact_equality> {
 
     differences.resize(thrust::distance(differences.begin(), diff_iter));  // shrink back down
 
-    if (not differences.empty()) {
-      auto const msg = differences_message(differences, lhs, rhs, print_all_differences, depth);
-      GTEST_FAIL() << msg;
-    }
+    if (not differences.empty())
+      GTEST_FAIL() << differences_message(differences, lhs, rhs, print_all_differences, depth);
 
     // recurse
     auto lhs_child = lhs_l.get_sliced_child(0);


### PR DESCRIPTION
While "debugging" and trying to understand the `CUDF_TEST_EXPECT_COLUMNS_EQUAL` code I got down the "call stack" to find a function `print_differences` that is responsible for 2 things:

1. Printing the differences
2. Performing the `EXPECT_EQ` on the difference `thrust::device_vector`

For a function called `print_differences` I was very surprised to find the final `EXPECT_EQ` inside - especially when you combine that with the fact that the first line of the function is:
```cpp
if (differences.size() <= 0) { return; }
```
The options are to remain the function to something like `check_if_any_differences_and_print` but whenever you have to put `AND` or `OR` into a function name - that is a sign you should refactor.

This small clean up job pulls out the `EXPECT_EQ` and renames `print_differences` accordingly. This makes the code much more clear.