### PR TITLE
[REVIEW] Fix to_timestamp to initialize default year to 1970

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #6073 Fix issue related to `.loc` incase of `DatetimeIndex`
 - PR #6081 Fix issue where fsspec thinks it has a protocol string
 - PR #6100 Fix issue in `Series.factorize` to correctly pick `na_sentinel` value
+- PR #6113 Fix to_timestamp to initialize default year to 1970
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -199,7 +199,7 @@ struct parse_datetime {
     auto length = d_string.size_bytes();
     for (size_t idx = 0; idx < items_count; ++idx) {
       auto item = d_format_items[idx];
-      if (length < item.length) return 1;
+      if (length < item.length) item.length = length;
       if (item.item_type == format_char_type::literal) {  // static character we'll just skip;
         // consume item.length bytes from string
         ptr += item.length;
@@ -305,7 +305,7 @@ struct parse_datetime {
     string_view d_str = d_strings.element<string_view>(idx);
     if (d_str.empty()) return epoch_time;
     //
-    int32_t timeparts[TP_ARRAYSIZE] = {0, 1, 1};                // month and day are 1-based
+    int32_t timeparts[TP_ARRAYSIZE] = {1970, 1, 1};             // month and day are 1-based
     if (parse_into_parts(d_str, timeparts)) return epoch_time;  // unexpected parse case
     //
     return T{T::duration(timestamp_from_parts(timeparts, units))};

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -198,9 +198,10 @@ struct parse_datetime {
     auto ptr    = d_string.data();
     auto length = d_string.size_bytes();
     for (size_t idx = 0; idx < items_count; ++idx) {
-      auto item = d_format_items[idx];
-      if (length < item.length) item.length = length;
-      if (item.item_type == format_char_type::literal) {  // static character we'll just skip;
+      auto item   = d_format_items[idx];
+      item.length = std::min(item.length, length);
+      if (item.item_type == format_char_type::literal) {
+        // static character we'll just skip;
         // consume item.length bytes from string
         ptr += item.length;
         length -= item.length;

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -199,7 +199,7 @@ struct parse_datetime {
     auto length = d_string.size_bytes();
     for (size_t idx = 0; idx < items_count; ++idx) {
       auto item   = d_format_items[idx];
-      item.length = std::min(item.length, length);
+      item.length = static_cast<int8_t>(std::min(static_cast<size_type>(item.length), length));
       if (item.item_type == format_char_type::literal) {
         // static character we'll just skip;
         // consume item.length bytes from string

--- a/cpp/tests/strings/datetime_tests.cpp
+++ b/cpp/tests/strings/datetime_tests.cpp
@@ -303,3 +303,22 @@ TEST_F(StringsDatetimeTest, Errors)
     1530705600};
   EXPECT_THROW(cudf::strings::from_timestamps(timestamps, ""), cudf::logic_error);
 }
+
+//#include <cudf/unary.hpp>
+
+TEST_F(StringsDatetimeTest, ToTimestampSingleSpecifier)
+{
+  cudf::test::strings_column_wrapper strings{"12", "10", "09", "05"};
+  auto strings_view = cudf::strings_column_view(strings);
+  auto results      = cudf::strings::to_timestamps(
+    strings_view, cudf::data_type{cudf::type_id::TIMESTAMP_DAYS}, "%d");
+  cudf::test::fixed_width_column_wrapper<cudf::timestamp_D, cudf::timestamp_D::rep> expected_days{
+    11, 9, 8, 4};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_days);
+
+  results = cudf::strings::to_timestamps(
+    strings_view, cudf::data_type{cudf::type_id::TIMESTAMP_DAYS}, "%m");
+  cudf::test::fixed_width_column_wrapper<cudf::timestamp_D, cudf::timestamp_D::rep> expected_months{
+    334, 273, 243, 120};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_months);
+}

--- a/cpp/tests/strings/datetime_tests.cpp
+++ b/cpp/tests/strings/datetime_tests.cpp
@@ -304,8 +304,6 @@ TEST_F(StringsDatetimeTest, Errors)
   EXPECT_THROW(cudf::strings::from_timestamps(timestamps, ""), cudf::logic_error);
 }
 
-//#include <cudf/unary.hpp>
-
 TEST_F(StringsDatetimeTest, ToTimestampSingleSpecifier)
 {
   cudf::test::strings_column_wrapper strings{"12", "10", "09", "05"};


### PR DESCRIPTION
Closes #6109 
The `cudf::strings::to_timestamp()` conversion logic was not initializing to year 1970 so if the year is not included in the string/format specifiers the incorrect year was being used.

Also added gtest per examples in #6109 