### PR TITLE
Fix Java build for ORC read args change and update package version [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #6081 Fix issue where fsspec thinks it has a protocol string
 - PR #6100 Fix issue in `Series.factorize` to correctly pick `na_sentinel` value
 - PR #6110 Handle `format` for other input types in `to_datetime`
+- PR #6118 Fix Java build for ORC read args change and update package version
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ai.rapids</groupId>
     <artifactId>cudf</artifactId>
-    <version>0.15-SNAPSHOT</version>
+    <version>0.16-SNAPSHOT</version>
 
     <name>cudfjni</name>
     <description>

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1059,7 +1059,6 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readORC(
 
     cudf::io::read_orc_args read_arg{*source};
     read_arg.columns = n_filter_col_names.as_cpp_vector();
-    read_arg.stripe = -1;
     read_arg.skip_rows = -1;
     read_arg.num_rows = -1;
     read_arg.use_index = false;


### PR DESCRIPTION
This fixes the Java bindings build after #6024 updated the ORC read args structure and removed a field being written by the JNI code.  This also updates the package version from 0.15-SNAPSHOT to 0.16-SNAPSHOT.