### PR TITLE
[REVIEW] Fix issue where `np.nan` is being return instead of `NAT` for datetime/duration types

### DIFF
--- a/python/cudf/cudf/_lib/reduce.pyx
+++ b/python/cudf/cudf/_lib/reduce.pyx
@@ -1,6 +1,6 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
-import pandas as pd
+import cudf
 from cudf._lib.cpp.reduce cimport cpp_reduce, cpp_scan, scan_type
 from cudf._lib.cpp.scalar.scalar cimport scalar
 from cudf._lib.cpp.types cimport data_type, type_id
@@ -58,11 +58,7 @@ def reduce(reduction_op, Column incol, dtype=None, **kwargs):
         if reduction_op == 'product':
             return incol.dtype.type(1)
 
-        if pd.api.types.is_datetime64_dtype(col_dtype) \
-                or pd.api.types.is_timedelta64_dtype(col_dtype):
-            return col_dtype.type("nat")
-        else:
-            return np.nan
+        return cudf.utils.dtypes._get_nan_for_dtype(col_dtype)
 
     with nogil:
         c_result = move(cpp_reduce(

--- a/python/cudf/cudf/_lib/reduce.pyx
+++ b/python/cudf/cudf/_lib/reduce.pyx
@@ -1,5 +1,6 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
+import pandas as pd
 from cudf._lib.cpp.reduce cimport cpp_reduce, cpp_scan, scan_type
 from cudf._lib.cpp.scalar.scalar cimport scalar
 from cudf._lib.cpp.types cimport data_type, type_id
@@ -56,7 +57,12 @@ def reduce(reduction_op, Column incol, dtype=None, **kwargs):
             return incol.dtype.type(0)
         if reduction_op == 'product':
             return incol.dtype.type(1)
-        return np.nan
+
+        if pd.api.types.is_datetime64_dtype(col_dtype) \
+                or pd.api.types.is_timedelta64_dtype(col_dtype):
+            return col_dtype.type("nat")
+        else:
+            return np.nan
 
     with nogil:
         c_result = move(cpp_reduce(

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -1214,6 +1214,18 @@ class CategoricalColumn(column.ColumnBase):
             "Categorical column views are not currently supported"
         )
 
+    def sum(self, dtype=None):
+        raise TypeError("Categorical cannot perform the operation sum")
+
+    def product(self, dtype=None):
+        raise TypeError("Categorical cannot perform the operation prod")
+
+    def std(self, ddof=1, dtype=np.float64):
+        raise TypeError("Categorical cannot perform the operation std")
+
+    def var(self, ddof=1, dtype=np.float64):
+        raise TypeError("Categorical cannot perform the operation var")
+
 
 def _create_empty_categorical_column(categorical_column, dtype):
 

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -290,6 +290,18 @@ class DatetimeColumn(column.ColumnBase):
         else:
             return False
 
+    def sum(self, dtype=None):
+        raise TypeError(f"cannot perform sum with type {self.dtype}")
+
+    def product(self, dtype=None):
+        raise TypeError(f"cannot perform prod with type {self.dtype}")
+
+    def std(self, ddof=1, dtype=np.float64):
+        raise TypeError(f"cannot perform std with type {self.dtype}")
+
+    def var(self, ddof=1, dtype=np.float64):
+        raise TypeError(f"cannot perform var with type {self.dtype}")
+
 
 @annotate("BINARY_OP", color="orange", domain="cudf_python")
 def binop(lhs, rhs, op, out_dtype):

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -340,6 +340,12 @@ class TimeDeltaColumn(column.ColumnBase):
                 self.as_numerical.sum(dtype=dtype), unit=self.time_unit
             )
 
+    def product(self, dtype=None):
+        raise TypeError(f"cannot perform prod with type {self.dtype}")
+
+    def var(self, ddof=1, dtype=np.float64):
+        raise TypeError(f"cannot perform var with type {self.dtype}")
+
     def components(self, index=None):
         """
         Return a Dataframe of the components of the Timedeltas.

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2689,7 +2689,7 @@ class Series(Frame, Serializable):
                 result_series = result_series.dropna()
         else:
             if self.has_nulls:
-                return np.nan
+                return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
             result_series = self
 
@@ -2751,7 +2751,7 @@ class Series(Frame, Serializable):
                 result_series = result_series.dropna()
         else:
             if self.has_nulls:
-                return np.nan
+                return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
             result_series = self
 
@@ -2814,6 +2814,9 @@ class Series(Frame, Serializable):
                 "numeric_only parameter is not implemented yet"
             )
 
+        if isinstance(self._column, DatetimeColumn):
+            raise TypeError(f"cannot perform sum with type {self.dtype}")
+
         skipna = True if skipna is None else skipna
 
         if skipna:
@@ -2822,14 +2825,14 @@ class Series(Frame, Serializable):
                 result_series = result_series.dropna()
         else:
             if self.has_nulls:
-                return np.nan
+                return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
             result_series = self
 
         if min_count > 0:
             valid_count = len(result_series) - result_series.null_count
             if valid_count < min_count:
-                return np.nan
+                return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
         elif min_count < 0:
             msg = "min_count value cannot be negative({0}), will default to 0."
             warnings.warn(msg.format(min_count))
@@ -2893,6 +2896,9 @@ class Series(Frame, Serializable):
                 "numeric_only parameter is not implemented yet"
             )
 
+        if isinstance(self._column, (DatetimeColumn, TimeDeltaColumn)):
+            raise TypeError(f"cannot perform prod with type {self.dtype}")
+
         skipna = True if skipna is None else skipna
 
         if skipna:
@@ -2901,14 +2907,14 @@ class Series(Frame, Serializable):
                 result_series = result_series.dropna()
         else:
             if self.has_nulls:
-                return np.nan
+                return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
             result_series = self
 
         if min_count > 0:
             valid_count = len(result_series) - result_series.null_count
             if valid_count < min_count:
-                return np.nan
+                return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
         elif min_count < 0:
             msg = "min_count value cannot be negative({0}), will default to 0."
             warnings.warn(msg.format(min_count))
@@ -3246,7 +3252,7 @@ class Series(Frame, Serializable):
                 result_series = result_series.dropna()
         else:
             if self.has_nulls:
-                return np.nan
+                return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
             result_series = self
 
@@ -3299,6 +3305,9 @@ class Series(Frame, Serializable):
                 "numeric_only parameter is not implemented yet"
             )
 
+        if isinstance(self._column, DatetimeColumn):
+            raise TypeError(f"cannot perform std with type {self.dtype}")
+
         skipna = True if skipna is None else skipna
 
         if skipna:
@@ -3307,7 +3316,7 @@ class Series(Frame, Serializable):
                 result_series = result_series.dropna()
         else:
             if self.has_nulls:
-                return np.nan
+                return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
             result_series = self
 
@@ -3360,6 +3369,9 @@ class Series(Frame, Serializable):
                 "numeric_only parameter is not implemented yet"
             )
 
+        if isinstance(self._column, (DatetimeColumn, TimeDeltaColumn)):
+            raise TypeError(f"cannot perform var with type {self.dtype}")
+
         skipna = True if skipna is None else skipna
 
         if skipna:
@@ -3368,7 +3380,7 @@ class Series(Frame, Serializable):
                 result_series = result_series.dropna()
         else:
             if self.has_nulls:
-                return np.nan
+                return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
             result_series = self
 
@@ -3380,8 +3392,13 @@ class Series(Frame, Serializable):
     def median(self, skipna=True):
         """Compute the median of the series
         """
+
+        if isinstance(self._column, DatetimeColumn):
+            raise TypeError(f"cannot perform median with type {self.dtype}")
+
         if not skipna and self.has_nulls:
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
+
         # enforce linear in case the default ever changes
         return self.quantile(0.5, interpolation="linear", exact=True)
 
@@ -3430,15 +3447,18 @@ class Series(Frame, Serializable):
                 "numeric_only parameter is not implemented yet"
             )
 
+        if isinstance(self._column, (DatetimeColumn, TimeDeltaColumn)):
+            raise TypeError(f"cannot perform kurt with type {self.dtype}")
+
         skipna = True if skipna is None else skipna
 
         if self.empty or (not skipna and self.has_nulls):
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
         self = self.nans_to_nulls().dropna()
 
         if len(self) < 4:
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
         n = len(self)
         miu = self.mean()
@@ -3489,15 +3509,18 @@ class Series(Frame, Serializable):
                 "numeric_only parameter is not implemented yet"
             )
 
+        if isinstance(self._column, (DatetimeColumn, TimeDeltaColumn)):
+            raise TypeError(f"cannot perform skew with type {self.dtype}")
+
         skipna = True if skipna is None else skipna
 
         if self.empty or (not skipna and self.has_nulls):
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
         self = self.nans_to_nulls().dropna()
 
         if len(self) < 3:
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
         n = len(self)
         miu = self.mean()
@@ -3544,8 +3567,16 @@ class Series(Frame, Serializable):
                 "min_periods parameter is not implemented yet"
             )
 
+        if isinstance(
+            self._column, (DatetimeColumn, TimeDeltaColumn)
+        ) or isinstance(other._column, (DatetimeColumn, TimeDeltaColumn)):
+            raise TypeError(
+                f"cannot perform covarience with types {self.dtype}, "
+                f"{other.dtype}"
+            )
+
         if self.empty or other.empty:
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
         lhs = self.nans_to_nulls().dropna()
         rhs = other.nans_to_nulls().dropna()
@@ -3553,7 +3584,7 @@ class Series(Frame, Serializable):
         lhs, rhs = _align_indices([lhs, rhs], how="inner")
 
         if lhs.empty or rhs.empty or (len(lhs) == 1 and len(rhs) == 1):
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
         result = (lhs - lhs.mean()) * (rhs - rhs.mean())
         cov_sample = result.sum() / (len(lhs) - 1)
@@ -3573,22 +3604,28 @@ class Series(Frame, Serializable):
         """
 
         assert method in ("pearson",) and min_periods in (None,)
+        if isinstance(
+            self._column, (DatetimeColumn, TimeDeltaColumn)
+        ) or isinstance(other._column, (DatetimeColumn, TimeDeltaColumn)):
+            raise TypeError(
+                f"cannot perform corr with types {self.dtype}, {other.dtype}"
+            )
 
         if self.empty or other.empty:
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
         lhs = self.nans_to_nulls().dropna()
         rhs = other.nans_to_nulls().dropna()
         lhs, rhs = _align_indices([lhs, rhs], how="inner")
 
         if lhs.empty or rhs.empty:
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
 
         cov = lhs.cov(rhs)
         lhs_std, rhs_std = lhs.std(), rhs.std()
 
         if not cov or lhs_std == 0 or rhs_std == 0:
-            return np.nan
+            return cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
         return cov / lhs_std / rhs_std
 
     def isin(self, values):
@@ -3821,7 +3858,11 @@ class Series(Frame, Serializable):
         if isinstance(q, Number):
             res = self._column.quantile(q, interpolation, exact)
             res = res[0]
-            return np.nan if res is None else res
+            return (
+                cudf.utils.dtypes._get_nan_for_dtype(self.dtype)
+                if res is None
+                else res
+            )
 
         if not quant_index:
             return Series(

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -1111,3 +1111,28 @@ def test_datetime_strftime_not_implemented_formats(date_format):
 
     with pytest.raises(NotImplementedError):
         gsr.dt.strftime(date_format=date_format)
+
+
+@pytest.mark.parametrize("op", ["max", "min"])
+@pytest.mark.parametrize(
+    "data",
+    [
+        [],
+        [1, 2, 3, 100],
+        [10, None, 100, None, None],
+        [None, None, None],
+        [1231],
+    ],
+)
+@pytest.mark.parametrize("dtype", DATETIME_TYPES)
+def test_datetime_reductions(data, op, dtype):
+    sr = cudf.Series(data, dtype=dtype)
+    psr = sr.to_pandas()
+
+    actual = getattr(sr, op)()
+    expected = getattr(psr, op)()
+
+    if np.isnat(expected.to_numpy()) and np.isnat(actual):
+        assert True
+    else:
+        assert_eq(expected.to_numpy(), actual)

--- a/python/cudf/cudf/tests/test_reductions.py
+++ b/python/cudf/cudf/tests/test_reductions.py
@@ -1,11 +1,13 @@
 from __future__ import division, print_function
 
 import random
+import re
 from itertools import product
 
 import numpy as np
 import pytest
 
+import cudf
 from cudf.core import Series
 from cudf.tests import utils
 from cudf.tests.utils import NUMERIC_TYPES, gen_rand
@@ -160,3 +162,42 @@ def test_date_minmax():
     np_max = np_casted.max()
     gdf_max = gdf_casted.max()
     assert np_max == gdf_max
+
+
+@pytest.mark.parametrize(
+    "op",
+    ["sum", "product", "std", "var", "median", "kurt", "kurtosis", "skew"],
+)
+def test_datetime_unsupported_reductions(op):
+    gsr = cudf.Series([1, 2, 3, None], dtype="datetime64[ns]")
+    psr = gsr.to_pandas()
+
+    try:
+        getattr(psr, op)()
+    except Exception as e:
+        with pytest.raises(type(e), match=re.escape(str(e))):
+            getattr(gsr, op)()
+
+
+@pytest.mark.parametrize("op", ["product", "var", "kurt", "kurtosis", "skew"])
+def test_timedelta_unsupported_reductions(op):
+    gsr = cudf.Series([1, 2, 3, None], dtype="timedelta64[ns]")
+    psr = gsr.to_pandas()
+
+    try:
+        getattr(psr, op)()
+    except Exception as e:
+        with pytest.raises(type(e), match=re.escape(str(e))):
+            getattr(gsr, op)()
+
+
+@pytest.mark.parametrize("op", ["sum", "product", "std", "var"])
+def test_categorical_reductions(op):
+    gsr = cudf.Series([1, 2, 3, None], dtype="category")
+    psr = gsr.to_pandas()
+
+    try:
+        getattr(psr, op)()
+    except Exception as e:
+        with pytest.raises(type(e), match=re.escape(str(e))):
+            getattr(gsr, op)()

--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
+import re
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -465,3 +467,31 @@ def test_min_count_ops(data, ops, skipna, min_count):
         getattr(psr, ops)(skipna=skipna, min_count=min_count),
         getattr(gsr, ops)(skipna=skipna, min_count=min_count),
     )
+
+
+def test_cov_corr_invalid_dtypes():
+    gsr = Series([1, 2, 3, 4], dtype="datetime64[ns]")
+    psr = gsr.to_pandas()
+
+    try:
+        psr.corr(psr)
+    except Exception as e:
+        with pytest.raises(
+            type(e),
+            match=re.escape(
+                f"cannot perform corr with types {gsr.dtype}, {gsr.dtype}"
+            ),
+        ):
+            gsr.corr(gsr)
+
+    try:
+        psr.cov(psr)
+    except Exception as e:
+        with pytest.raises(
+            type(e),
+            match=re.escape(
+                f"cannot perform covarience with types {gsr.dtype}, "
+                f"{gsr.dtype}"
+            ),
+        ):
+            gsr.cov(gsr)

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1220,3 +1220,28 @@ def test_timedelta_contains(data, dtype, scalar):
     actual = scalar in psr
 
     assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize("op", ["max", "min"])
+@pytest.mark.parametrize(
+    "data",
+    [
+        [],
+        [1, 2, 3, 100],
+        [10, None, 100, None, None],
+        [None, None, None],
+        [1231],
+    ],
+)
+@pytest.mark.parametrize("dtype", dtypeutils.TIMEDELTA_TYPES)
+def test_timedelta_reductions(data, op, dtype):
+    sr = cudf.Series(data, dtype=dtype)
+    psr = sr.to_pandas()
+
+    actual = getattr(sr, op)()
+    expected = getattr(psr, op)()
+
+    if np.isnat(expected.to_numpy()) and np.isnat(actual):
+        assert True
+    else:
+        assert_eq(expected.to_numpy(), actual)

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -442,3 +442,12 @@ def get_time_unit(obj):
 
     time_unit, _ = np.datetime_data(obj.dtype)
     return time_unit
+
+
+def _get_nan_for_dtype(dtype):
+    if pd.api.types.is_datetime64_dtype(
+        dtype
+    ) or pd.api.types.is_timedelta64_dtype(dtype):
+        return dtype.type("nat")
+    else:
+        return np.nan


### PR DESCRIPTION
Fixes: #6132 

This PR:
- [x] Handle returning `np.nan` based on dtype across all APIs.
- [x] Raise informative errors for APIs in unsupported dtypes.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
