### PR TITLE
[REVIEW] Small fixes and improvements to java Arrow IPC [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PR #6103 Small refactor of `print_differences`
 - PR #6124 Fix gcc-9 compilation errors on tests
 - PR #6141 Fix typo in custreamz README that was a result of recent changes
+- PR #6143 General improvements for java arrow IPC.
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/ArrowIPCOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowIPCOptions.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package ai.rapids.cudf;
+
+/**
+ * Options for reading data in Arrow IPC format
+ */
+public class ArrowIPCOptions {
+
+  public interface NeedGpu {
+    /**
+     * A callback to indicate that we are about to start putting data on the GPU.
+     */
+    void needTheGpu();
+  }
+
+  public static ArrowIPCOptions DEFAULT = new ArrowIPCOptions(new Builder());
+
+  private final NeedGpu callback;
+
+  private ArrowIPCOptions(Builder builder) {
+    this.callback = builder.callback;
+  }
+
+  public NeedGpu getCallback() {
+    return callback;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private NeedGpu callback = null;
+
+    public Builder withCallback(NeedGpu callback) {
+      this.callback = callback;
+      return this;
+    }
+
+    public ArrowIPCOptions build() {
+      return new ArrowIPCOptions(this);
+    }
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/ArrowIPCOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowIPCOptions.java
@@ -47,10 +47,14 @@ public class ArrowIPCOptions {
   }
 
   public static class Builder {
-    private NeedGpu callback = null;
+    private NeedGpu callback = () -> {};
 
     public Builder withCallback(NeedGpu callback) {
-      this.callback = callback;
+      if (callback == null) {
+        this.callback = () -> {};
+      } else {
+        this.callback = callback;
+      }
       return this;
     }
 

--- a/java/src/main/java/ai/rapids/cudf/ArrowIPCWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowIPCWriterOptions.java
@@ -51,7 +51,7 @@ public class ArrowIPCWriterOptions extends WriterOptions {
 
   public static class Builder extends WriterBuilder<Builder> {
     private long size = -1;
-    private DoneOnGpu callback = null;
+    private DoneOnGpu callback = (ignored) -> {};
 
     public Builder withMaxChunkSize(long size) {
       this.size = size;
@@ -59,7 +59,11 @@ public class ArrowIPCWriterOptions extends WriterOptions {
     }
 
     public Builder withCallback(DoneOnGpu callback) {
-      this.callback = callback;
+      if (callback == null) {
+        this.callback = (ignored) -> {};
+      } else {
+        this.callback = callback;
+      }
       return this;
     }
 

--- a/java/src/main/java/ai/rapids/cudf/ArrowIPCWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowIPCWriterOptions.java
@@ -23,7 +23,46 @@ package ai.rapids.cudf;
  */
 public class ArrowIPCWriterOptions extends WriterOptions {
 
+  public interface DoneOnGpu {
+    /**
+     * A callback to indicate that the table is off of the GPU
+     * and may be closed, even if all of the data is not yet written.
+     * @param table the table that can be closed.
+     */
+    void doneWithTheGpu(Table table);
+  }
+
+  private final long size;
+  private final DoneOnGpu callback;
+
+  private ArrowIPCWriterOptions(Builder builder) {
+    super(builder);
+    this.size = builder.size;
+    this.callback = builder.callback;
+  }
+
+  public long getMaxChunkSize() {
+    return size;
+  }
+
+  public DoneOnGpu getCallback() {
+    return callback;
+  }
+
   public static class Builder extends WriterBuilder<Builder> {
+    private long size = -1;
+    private DoneOnGpu callback = null;
+
+    public Builder withMaxChunkSize(long size) {
+      this.size = size;
+      return this;
+    }
+
+    public Builder withCallback(DoneOnGpu callback) {
+      this.callback = callback;
+      return this;
+    }
+
     public ArrowIPCWriterOptions build() {
       return new ArrowIPCWriterOptions(this);
     }
@@ -33,9 +72,5 @@ public class ArrowIPCWriterOptions extends WriterOptions {
 
   public static Builder builder() {
     return new Builder();
-  }
-
-  private ArrowIPCWriterOptions(Builder builder) {
-    super(builder);
   }
 }

--- a/java/src/main/java/ai/rapids/cudf/StreamedTableReader.java
+++ b/java/src/main/java/ai/rapids/cudf/StreamedTableReader.java
@@ -29,6 +29,14 @@ public interface StreamedTableReader extends AutoCloseable {
      */
     Table getNextIfAvailable() throws CudfException;
 
+    /**
+     * Get the next table if available.
+     * @param rowTarget the target number of rows to read (this is really just best effort).
+     * @return the next Table or null if done reading tables.
+     * @throws CudfException on any error.
+     */
+    Table getNextIfAvailable(int rowTarget) throws CudfException;
+
     @Override
     void close() throws CudfException;
 }

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -353,11 +353,21 @@ public final class Table implements AutoCloseable {
                                                       HostBufferConsumer consumer);
 
   /**
+   * Convert a cudf table to an arrow table handle.
+   * @param handle the handle to the writer.
+   * @param tableHandle the table to convert
+   */
+  private static native long convertCudfToArrowTable(long handle,
+                                                     long tableHandle);
+
+  /**
    * Write out a table to an open handle.
    * @param handle the handle to the writer.
-   * @param table the table to write out.
+   * @param arrowHandle the arrow table to write out.
    */
-  private static native void writeArrowIPCChunk(long handle, long table);
+  private static native void writeArrowIPCArrowChunk(long handle,
+                                                     long arrowHandle,
+                                                     long maxChunkSize);
 
   /**
    * Finish writing out Arrow IPC.
@@ -382,9 +392,22 @@ public final class Table implements AutoCloseable {
   /**
    * Read the next chunk/table of data.
    * @param handle the handle that is holding the data.
-   * @return the pointers to the columns for the table, or null if the data is done being read.
+   * @param rowTarget the number of rows to read.
+   * @return a pointer to an arrow table handle.
    */
-  private static native long[] readArrowIPCChunk(long handle);
+  private static native long readArrowIPCChunkToArrowTable(long handle, int rowTarget);
+
+  /**
+   * Close the arrow table handle returned by readArrowIPCChunkToArrowTable or
+   * convertCudfToArrowTable
+   */
+  private static native void closeArrowTable(long arrowHandle);
+
+  /**
+   * Convert an arrow table handle as returned by readArrowIPCChunkToArrowTable to
+   * cudf table handles.
+   */
+  private static native long[] convertArrowTableToCudf(long arrowHandle);
 
   /**
    * Finish reading the data.  We are done.
@@ -894,21 +917,29 @@ public final class Table implements AutoCloseable {
   }
 
   private static class ArrowIPCTableWriter implements TableWriter {
+    private final ArrowIPCWriterOptions.DoneOnGpu callback;
     private long handle;
-    HostBufferConsumer consumer;
+    private HostBufferConsumer consumer;
+    private long maxChunkSize;
 
-    private ArrowIPCTableWriter(ArrowIPCWriterOptions options, File outputFile) {
+    private ArrowIPCTableWriter(ArrowIPCWriterOptions options,
+                                File outputFile) {
+      this.callback = options.getCallback();
       this.consumer = null;
+      this.maxChunkSize = options.getMaxChunkSize();
       this.handle = writeArrowIPCFileBegin(
               options.getColumnNames(),
               outputFile.getAbsolutePath());
     }
 
-    private ArrowIPCTableWriter(ArrowIPCWriterOptions options, HostBufferConsumer consumer) {
+    private ArrowIPCTableWriter(ArrowIPCWriterOptions options,
+                                HostBufferConsumer consumer) {
+      this.callback = options.getCallback();
+      this.consumer = consumer;
+      this.maxChunkSize = options.getMaxChunkSize();
       this.handle = writeArrowIPCBufferBegin(
               options.getColumnNames(),
               consumer);
-      this.consumer = consumer;
     }
 
     @Override
@@ -916,7 +947,15 @@ public final class Table implements AutoCloseable {
       if (handle == 0) {
         throw new IllegalStateException("Writer was already closed");
       }
-      writeArrowIPCChunk(handle, table.nativeHandle);
+      long arrowHandle = convertCudfToArrowTable(handle, table.nativeHandle);
+      try {
+        if (callback != null) {
+          callback.doneWithTheGpu(table);
+        }
+        writeArrowIPCArrowChunk(handle, arrowHandle, maxChunkSize);
+      } finally {
+        closeArrowTable(arrowHandle);
+      }
     }
 
     @Override
@@ -964,11 +1003,21 @@ public final class Table implements AutoCloseable {
     }
 
     // Called From JNI
-    public long readInto(long dstAddress, long maxAmount) {
-      long realMaxAmount = Math.min(maxAmount, buffer.length);
-      long amountRead = provider.readInto(buffer, realMaxAmount);
-      buffer.copyToMemory(dstAddress, amountRead);
-      return amountRead;
+    public long readInto(long dstAddress, long amount) {
+      long totalRead = 0;
+      long amountLeft = amount;
+      while (amountLeft > 0) {
+        long amountToCopy = Math.min(amountLeft, buffer.length);
+        long amountRead = provider.readInto(buffer, amountToCopy);
+        buffer.copyToMemory(totalRead + dstAddress, amountRead);
+        amountLeft -= amountRead;
+        totalRead += amountRead;
+        if (amountRead < amountToCopy) {
+          // EOF
+          amountLeft = 0;
+        }
+      }
+      return totalRead;
     }
 
     @Override
@@ -986,27 +1035,43 @@ public final class Table implements AutoCloseable {
   }
 
   private static class ArrowIPCStreamedTableReader implements StreamedTableReader {
+    private final ArrowIPCOptions.NeedGpu callback;
     private long handle;
     private ArrowReaderWrapper provider;
 
-    private ArrowIPCStreamedTableReader(File inputFile) {
+    private ArrowIPCStreamedTableReader(ArrowIPCOptions options, File inputFile) {
       this.provider = null;
       this.handle = readArrowIPCFileBegin(
               inputFile.getAbsolutePath());
+      this.callback = options.getCallback();
     }
 
-    private ArrowIPCStreamedTableReader(HostBufferProvider provider) {
+    private ArrowIPCStreamedTableReader(ArrowIPCOptions options, HostBufferProvider provider) {
       this.provider = new ArrowReaderWrapper(provider);
       this.handle = readArrowIPCBufferBegin(this.provider);
+      this.callback = options.getCallback();
     }
 
     @Override
     public Table getNextIfAvailable() throws CudfException {
-      long[] columns = readArrowIPCChunk(handle);
-      if (columns == null) {
-        return null;
+      // In this case rowTarget is the minimum number of rows to read.
+      return getNextIfAvailable(1);
+    }
+
+    @Override
+    public Table getNextIfAvailable(int rowTarget) throws CudfException {
+      long arrowTableHandle = readArrowIPCChunkToArrowTable(handle, rowTarget);
+      try {
+        if (arrowTableHandle == 0) {
+          return null;
+        }
+        if (callback !=  null) {
+          callback.needTheGpu();
+        }
+        return new Table(convertArrowTableToCudf(arrowTableHandle));
+      } finally {
+        closeArrowTable(arrowTableHandle);
       }
-      return new Table(columns);
     }
 
     @Override
@@ -1024,11 +1089,32 @@ public final class Table implements AutoCloseable {
 
   /**
    * Get a reader that will return tables.
+   * @param options options for reading.
+   * @param inputFile the file to read the Arrow IPC formatted data from
+   * @return a reader.
+   */
+  public static StreamedTableReader readArrowIPCChunked(ArrowIPCOptions options, File inputFile) {
+    return new ArrowIPCStreamedTableReader(options, inputFile);
+  }
+
+  /**
+   * Get a reader that will return tables.
    * @param inputFile the file to read the Arrow IPC formatted data from
    * @return a reader.
    */
   public static StreamedTableReader readArrowIPCChunked(File inputFile) {
-    return new ArrowIPCStreamedTableReader(inputFile);
+    return readArrowIPCChunked(ArrowIPCOptions.DEFAULT, inputFile);
+  }
+
+  /**
+   * Get a reader that will return tables.
+   * @param options options for reading.
+   * @param provider what will provide the data being read.
+   * @return a reader.
+   */
+  public static StreamedTableReader readArrowIPCChunked(ArrowIPCOptions options,
+                                                        HostBufferProvider provider) {
+    return new ArrowIPCStreamedTableReader(options, provider);
   }
 
   /**
@@ -1037,7 +1123,7 @@ public final class Table implements AutoCloseable {
    * @return a reader.
    */
   public static StreamedTableReader readArrowIPCChunked(HostBufferProvider provider) {
-    return new ArrowIPCStreamedTableReader(provider);
+    return readArrowIPCChunked(ArrowIPCOptions.DEFAULT, provider);
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -364,6 +364,11 @@ public final class Table implements AutoCloseable {
    * Write out a table to an open handle.
    * @param handle the handle to the writer.
    * @param arrowHandle the arrow table to write out.
+   * @param maxChunkSize the maximum number of rows that could
+   *                     be written out in a single chunk.  Generally this setting will be
+   *                     followed unless for some reason the arrow table is not a single group.
+   *                     This can happen when reading arrow data, but not when converting from
+   *                     cudf.
    */
   private static native void writeArrowIPCArrowChunk(long handle,
                                                      long arrowHandle,
@@ -949,9 +954,7 @@ public final class Table implements AutoCloseable {
       }
       long arrowHandle = convertCudfToArrowTable(handle, table.nativeHandle);
       try {
-        if (callback != null) {
-          callback.doneWithTheGpu(table);
-        }
+        callback.doneWithTheGpu(table);
         writeArrowIPCArrowChunk(handle, arrowHandle, maxChunkSize);
       } finally {
         closeArrowTable(arrowHandle);
@@ -1065,9 +1068,7 @@ public final class Table implements AutoCloseable {
         if (arrowTableHandle == 0) {
           return null;
         }
-        if (callback !=  null) {
-          callback.needTheGpu();
-        }
+        callback.needTheGpu();
         return new Table(convertArrowTableToCudf(arrowTableHandle));
       } finally {
         closeArrowTable(arrowTableHandle);


### PR DESCRIPTION
This does a number of different things around the arrow IPC format for java.

It fixes a bug where we could not read more than a 10MB buffer.
It adds in a few more APIs to be able to better batch reading and writing data.
It provides callbacks to let you know when it needs the GPU and when it no longer needs the GPU to better deal with concurreny.
