### PR TITLE
[REVIEW] Fix the java build now that cub has moved locations [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #6143 General improvements for java arrow IPC.
 - PR #6176 Fix cmake warnings for GoogleTest, GoogleBenchmark, and Arrow external projects
 - PR #6149 Update to Arrow v1.0.1
+- PR #6186 Update JNI to look for cub in new location
 
 ## Bug Fixes
 

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -115,8 +115,8 @@ find_path(THRUST_INCLUDE "thrust"
           "$ENV{CONDA_PREFIX}/include")
 
 find_path(CUB_INCLUDE "cub"
-    HINTS "$ENV{CUDF_ROOT}/_deps/cub-src"
-          "${CUDF_CPP_BUILD_DIR}/_deps/cub-src"
+    HINTS "$ENV{CUDF_ROOT}/_deps/thrust-src"
+          "${CUDF_CPP_BUILD_DIR}/_deps/thrust-src"
           "$ENV{CONDA_PREFIX}/include")
 
 find_path(LIBCUDACXX_INCLUDE "simt"


### PR DESCRIPTION
#6182 fixes some issues with going to 1.0.1 for arrow, but it also looks like cub changed locations by default in the build.  This updates the java cmake to look in the new location by default.