### PR TITLE
[REVIEW] Remove unnecessary memory-resource parameter in cudf::contains API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - PR #6149 Update to Arrow v1.0.1
 - PR #6184 Add cuda 11 dev environment.yml
 - PR #6186 Update JNI to look for cub in new location
+- PR #6194 Remove unnecessary memory-resource parameter in `cudf::contains` API
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/detail/search.hpp
+++ b/cpp/include/cudf/detail/search.hpp
@@ -57,10 +57,7 @@ std::unique_ptr<column> upper_bound(
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-bool contains(column_view const& col,
-              scalar const& value,
-              rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
-              cudaStream_t stream                 = 0);
+bool contains(column_view const& col, scalar const& value, cudaStream_t stream = 0);
 
 /**
  * @copydoc cudf::contains(column_view const&, column_view const&,

--- a/cpp/include/cudf/search.hpp
+++ b/cpp/include/cudf/search.hpp
@@ -130,13 +130,10 @@ std::unique_ptr<column> upper_bound(
  *
  * @param col      A column object
  * @param value    A scalar value to search for in `col`
- * @param mr       Device memory resource to use for device memory allocation
  *
  * @return bool    If `value` is found in `column` true, else false.
  */
-bool contains(column_view const& col,
-              scalar const& value,
-              rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+bool contains(column_view const& col, scalar const& value);
 
 /**
  * @brief  Returns a new column of type bool identifying for each element of @p haystack column,


### PR DESCRIPTION
Closes #6193 
The `cudf::contains()` that accepts a `cudf::scalar` does not require a memory-resource since it only returns a `bool`.

No python/cython code updates are required.