### PR TITLE
Remove shared libs from Java sources jar [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - PR #6173 Fix normalize_characters offset logic on sliced strings column
 - PR #6159 Fix issue related to empty `Dataframe` with columns input to `DataFrame.appened`
 - PR #6199 Fix index preservation for dask_cudf parquet
+- PR #6207 Remove shared libs from Java sources jar
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -195,6 +195,9 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <excludeResources>true</excludeResources>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This updates the Java build to exclude the native shared libs from the sources jar.