### PR TITLE
[REVIEW] Remove cxx11 abi handling from CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PR #6195 Update JNI to use parquet options builder
 - PR #6190 Avoid reading full csv files for metadata in dask_cudf
 - PR #6197 Remove librmm dependency for libcudf
+- PR #XXXX Remove CXX11 ABI handling from CMake
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 - PR #6195 Update JNI to use parquet options builder
 - PR #6190 Avoid reading full csv files for metadata in dask_cudf
 - PR #6197 Remove librmm dependency for libcudf
-- PR #XXXX Remove CXX11 ABI handling from CMake
+- PR #6209 Remove CXX11 ABI handling from CMake
 
 ## Bug Fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,8 +174,7 @@ $ cd build                                                                # ente
 
 # CMake options:
 # -DCMAKE_INSTALL_PREFIX set to the install path for your libraries or $CONDA_PREFIX if you're using Anaconda, i.e. -DCMAKE_INSTALL_PREFIX=/install/path or -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
-# -DCMAKE_CXX11_ABI set to ON or OFF depending on the ABI version you want, defaults to ON. When turned ON, ABI compability for C++11 is used. When OFF, pre-C++11 ABI compability is used.
-$ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_CXX11_ABI=ON      # configure cmake ...
+$ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX                           # configure cmake ...
 $ make -j                                                                 # compile the libraries librmm.so, libcudf.so ... '-j' will start a parallel job using the number of physical cores available on your system
 $ make install                                                            # install the libraries librmm.so, libcudf.so to the CMAKE_INSTALL_PREFIX
 ```
@@ -234,9 +233,6 @@ $ ./build.sh libcudf -g                # compile and install libcudf for debug
 $ PARALLEL_LEVEL=4 ./build.sh libcudf  # compile and install libcudf limiting parallel build jobs to 4 (make -j4)
 $ ./build.sh libcudf -n                # compile libcudf but do not install
 ```
-
-- The `build.sh` script can be customized to support other features:
-  - **ABI version:** The cmake `-DCMAKE_CXX11_ABI` option can be set to ON or OFF depending on the ABI version you want, defaults to ON. When turned ON, ABI compability for C++11 is used. When OFF, pre-C++11 ABI compability is used.
 
 Done! You are ready to develop for the cuDF OSS project.
 

--- a/build.sh
+++ b/build.sh
@@ -149,7 +149,6 @@ if buildAll || hasArg libcudf; then
     mkdir -p ${LIB_BUILD_DIR}
     cd ${LIB_BUILD_DIR}
     cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
-          -DCMAKE_CXX11_ABI=ON \
           ${GPU_ARCH} \
           -DUSE_NVTX=${BUILD_NVTX} \
           -DBUILD_BENCHMARKS=${BUILD_BENCHMARKS} \

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - dlpack
     - arrow-cpp-proc * cuda
-    - {{ pin_compatible('boost-cpp', max_pin='x.x') }}
+    - {{ pin_compatible('boost-cpp', max_pin='x.x.x') }}
 
 test:
   commands:

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - dlpack
     - arrow-cpp-proc * cuda
-    - boost-cpp >=1.72.0
+    - {{ pin_compatible('boost-cpp', max_pin='x.x') }}
 
 test:
   commands:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -52,16 +52,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 
     # Suppress parentheses warning which causes gmock to fail
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-parentheses")
-
-    option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" ON)
-    if(CMAKE_CXX11_ABI)
-        message(STATUS "CUDF: Enabling the GLIBCXX11 ABI")
-    else()
-        message(STATUS "CUDF: Disabling the GLIBCXX11 ABI")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D_GLIBCXX_USE_CXX11_ABI=0")
-    endif(CMAKE_CXX11_ABI)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
 if(CMAKE_CUDA_COMPILER_VERSION)

--- a/cpp/cmake/Modules/ConfigureArrow.cmake
+++ b/cpp/cmake/Modules/ConfigureArrow.cmake
@@ -24,14 +24,6 @@ set(ARROW_CMAKE_ARGS " -DARROW_WITH_LZ4=OFF"
     " -DARROW_HDFS=OFF"
     " -DCMAKE_VERBOSE_MAKEFILE=ON")
 
-if(NOT CMAKE_CXX11_ABI)
-  message(STATUS "ARROW: Disabling the GLIBCXX11 ABI")
-  list(APPEND ARROW_CMAKE_ARGS " -DARROW_TENSORFLOW=ON")
-elseif(CMAKE_CXX11_ABI)
-  message(STATUS "ARROW: Enabling the GLIBCXX11 ABI")
-  list(APPEND ARROW_CMAKE_ARGS " -DARROW_TENSORFLOW=OFF")
-endif(NOT CMAKE_CXX11_ABI)
-
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Templates/Arrow.CMakeLists.txt.cmake"
     "${ARROW_ROOT}/CMakeLists.txt")
 

--- a/cpp/cmake/Modules/ConfigureGoogleBenchmark.cmake
+++ b/cpp/cmake/Modules/ConfigureGoogleBenchmark.cmake
@@ -4,16 +4,6 @@ set(GBENCH_CMAKE_ARGS " -DCMAKE_BUILD_TYPE=Release")
                      #" -Dgtest_build_samples=ON" 
                      #" -DCMAKE_VERBOSE_MAKEFILE=ON")
 
-if(NOT CMAKE_CXX11_ABI)
-    message(STATUS "GBENCH: Disabling the GLIBCXX11 ABI")
-    list(APPEND GBENCH_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-    list(APPEND GBENCH_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-elseif(CMAKE_CXX11_ABI)
-    message(STATUS "GBENCH: Enabling the GLIBCXX11 ABI")
-    list(APPEND GBENCH_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-    list(APPEND GBENCH_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-endif(NOT CMAKE_CXX11_ABI)
-
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake"
                "${GBENCH_ROOT}/CMakeLists.txt")
 

--- a/cpp/cmake/Modules/ConfigureGoogleTest.cmake
+++ b/cpp/cmake/Modules/ConfigureGoogleTest.cmake
@@ -4,16 +4,6 @@ set(GTEST_CMAKE_ARGS "")
                      #" -Dgtest_build_samples=ON" 
                      #" -DCMAKE_VERBOSE_MAKEFILE=ON")
 
-if(NOT CMAKE_CXX11_ABI)
-    message(STATUS "GTEST: Disabling the GLIBCXX11 ABI")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-elseif(CMAKE_CXX11_ABI)
-    message(STATUS "GTEST: Enabling the GLIBCXX11 ABI")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-endif(NOT CMAKE_CXX11_ABI)
-
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Templates/GoogleTest.CMakeLists.txt.cmake"
                "${GTEST_ROOT}/CMakeLists.txt")
 

--- a/cpp/libcudf_kafka/cmake/Modules/ConfigureGoogleTest.cmake
+++ b/cpp/libcudf_kafka/cmake/Modules/ConfigureGoogleTest.cmake
@@ -1,18 +1,6 @@
 set(GTEST_ROOT "${CMAKE_BINARY_DIR}/googletest")
 
 set(GTEST_CMAKE_ARGS "")
-                     #" -Dgtest_build_samples=ON" 
-                     #" -DCMAKE_VERBOSE_MAKEFILE=ON")
-
-if(NOT CMAKE_CXX11_ABI)
-    message(STATUS "GTEST: Disabling the GLIBCXX11 ABI")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-elseif(CMAKE_CXX11_ABI)
-    message(STATUS "GTEST: Enabling the GLIBCXX11 ABI")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-endif(NOT CMAKE_CXX11_ABI)
 
 configure_file("${CMAKE_SOURCE_DIR}/cmake/Templates/GoogleTest.CMakeLists.txt.cmake"
                "${GTEST_ROOT}/CMakeLists.txt")


### PR DESCRIPTION
We historically had a CMake variable to control the cxx11 ABI as we used to build against old ABI projects in Ubuntu, which by default uses the new ABI. This removes this option from the CMake as its no longer used.

If someone absolutely needs the old ABI they can still manually pass in compilers flags via variables like `CMAKE_C_FLAGS`, `CMAKE_CXX_FLAGS`, `CMAKE_CUDA_FLAGS`, etc.