### PR TITLE
[REVIEW] Update CODEOWNERS file [skip-ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ java/              @rapidsai/cudf-java-codeowners
 
 #build/ops code owners
 .github/           @rapidsai/ops-codeowners 
-ci/                @rapidsai/ops-codeowners
+/ci/                @rapidsai/ops-codeowners
 conda/             @rapidsai/ops-codeowners
 **/Dockerfile      @rapidsai/ops-codeowners
 **/.dockerignore   @rapidsai/ops-codeowners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - PR #6159 Fix issue related to empty `Dataframe` with columns input to `DataFrame.appened`
 - PR #6199 Fix index preservation for dask_cudf parquet
 - PR #6207 Remove shared libs from Java sources jar
+- PR #6212 Update codeowners file
 
 
 # cuDF 0.15.0 (26 Aug 2020)


### PR DESCRIPTION
This PR updates the `.github/CODEOWNERS` file so that Ops isn't responsible for `ci/` folders that exist in subdirectories (like the one introduced in #6204, `java/ci`).

The syntax was pulled from the last example in the GitHub docs about the `CODEOWNERS` file here:
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file