### PR TITLE
Add cmake command-line setting for spdlog logging level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PR #6195 Update JNI to use parquet options builder
 - PR #6190 Avoid reading full csv files for metadata in dask_cudf
 - PR #6197 Remove librmm dependency for libcudf
+- PR #6215 Add cmake command-line setting for spdlog logging level
 
 ## Bug Fixes
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -764,7 +764,7 @@ if(HT_DEFAULT_ALLOCATOR)
 endif(HT_DEFAULT_ALLOCATOR)
 
 # Set a default logging level if none was specified
-set(DEFAULT_LOGGING_LEVEL OFF)
+set(DEFAULT_LOGGING_LEVEL INFO)
 
 if(NOT LOGGING_LEVEL)
     message(STATUS "Setting logging level to '${DEFAULT_LOGGING_LEVEL}' since none specified.")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -293,12 +293,6 @@ endif(Boost_FOUND)
 ###################################################################################################
 # - RMM -------------------------------------------------------------------------------------------
 
-if(NOT SPDLOG_ACTIVE_LEVEL)
-  set(SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_OFF)
-endif(NOT SPDLOG_ACTIVE_LEVEL)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPDLOG_ACTIVE_LEVEL=${SPDLOG_ACTIVE_LEVEL}")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DSPDLOG_ACTIVE_LEVEL=${SPDLOG_ACTIVE_LEVEL}")
-
 find_path(RMM_INCLUDE "rmm"
           HINTS "$ENV{RMM_ROOT}/include")
 
@@ -778,6 +772,22 @@ if(HT_DEFAULT_ALLOCATOR)
     message(STATUS "Using default allocator for hash tables")
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DHT_DEFAULT_ALLOCATOR")
 endif(HT_DEFAULT_ALLOCATOR)
+
+# Set a default logging level if none was specified
+set(DEFAULT_LOGGING_LEVEL OFF)
+
+if(NOT LOGGING_LEVEL)
+    message(STATUS "Setting logging level to '${DEFAULT_LOGGING_LEVEL}' since none specified.")
+    set(LOGGING_LEVEL "${DEFAULT_LOGGING_LEVEL}" CACHE
+      STRING "Choose the logging level." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE LOGGING_LEVEL PROPERTY STRINGS
+        "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
+else()
+    message(STATUS "Setting logging level to '${LOGGING_LEVEL}'")
+endif(NOT LOGGING_LEVEL)
+
+target_compile_definitions(cudf PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOGGING_LEVEL})
 
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -293,6 +293,12 @@ endif(Boost_FOUND)
 ###################################################################################################
 # - RMM -------------------------------------------------------------------------------------------
 
+if(NOT SPDLOG_ACTIVE_LEVEL)
+  set(SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_OFF)
+endif(NOT SPDLOG_ACTIVE_LEVEL)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPDLOG_ACTIVE_LEVEL=${SPDLOG_ACTIVE_LEVEL}")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DSPDLOG_ACTIVE_LEVEL=${SPDLOG_ACTIVE_LEVEL}")
+
 find_path(RMM_INCLUDE "rmm"
           HINTS "$ENV{RMM_ROOT}/include")
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -146,7 +146,7 @@
         <CMAKE_EXPORT_COMPILE_COMMANDS>OFF</CMAKE_EXPORT_COMPILE_COMMANDS>
         <CUDA_STATIC_RUNTIME>OFF</CUDA_STATIC_RUNTIME>
         <PER_THREAD_DEFAULT_STREAM>OFF</PER_THREAD_DEFAULT_STREAM>
-        <LOGGING_LEVEL>OFF</LOGGING_LEVEL>
+        <LOGGING_LEVEL>INFO</LOGGING_LEVEL>
         <native.build.path>${project.build.directory}/cmake-build</native.build.path>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -147,6 +147,7 @@
         <CMAKE_EXPORT_COMPILE_COMMANDS>OFF</CMAKE_EXPORT_COMPILE_COMMANDS>
         <CUDA_STATIC_RUNTIME>OFF</CUDA_STATIC_RUNTIME>
         <PER_THREAD_DEFAULT_STREAM>OFF</PER_THREAD_DEFAULT_STREAM>
+        <LOGGING_LEVEL>OFF</LOGGING_LEVEL>
         <native.build.path>${project.build.directory}/cmake-build</native.build.path>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
@@ -354,6 +355,7 @@
                                     <arg value="${basedir}/src/main/native"/>
                                     <arg value="-DCUDA_STATIC_RUNTIME=${CUDA_STATIC_RUNTIME}" />
                                     <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}" />
+                                    <arg value="-DLOGGING_LEVEL=${LOGGING_LEVEL}" />
                                     <arg value="-DCMAKE_CXX11_ABI=${cxx11.abi.value}"/>
                                     <arg value="-DCMAKE_CXX_FLAGS=${cxx.flags}"/>
                                     <arg value="-DCMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}"/>

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -240,7 +240,7 @@ if(PER_THREAD_DEFAULT_STREAM)
 endif(PER_THREAD_DEFAULT_STREAM)
 
 # Set a default logging level if none was specified
-set(DEFAULT_LOGGING_LEVEL OFF)
+set(DEFAULT_LOGGING_LEVEL INFO)
 
 if(NOT LOGGING_LEVEL)
     message(STATUS "Setting logging level to '${DEFAULT_LOGGING_LEVEL}' since none specified.")

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -152,6 +152,12 @@ endif (CUDF_INCLUDE AND CUDF_LIBRARY)
 ###################################################################################################
 # - RMM -------------------------------------------------------------------------------------------
 
+if(NOT SPDLOG_ACTIVE_LEVEL)
+  set(SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_OFF)
+endif(NOT SPDLOG_ACTIVE_LEVEL)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPDLOG_ACTIVE_LEVEL=${SPDLOG_ACTIVE_LEVEL}")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DSPDLOG_ACTIVE_LEVEL=${SPDLOG_ACTIVE_LEVEL}")
+
 find_path(RMM_INCLUDE "rmm"
           HINTS "$ENV{RMM_ROOT}/include"
                 "$ENV{RMM_HOME}/include"

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -152,12 +152,6 @@ endif (CUDF_INCLUDE AND CUDF_LIBRARY)
 ###################################################################################################
 # - RMM -------------------------------------------------------------------------------------------
 
-if(NOT SPDLOG_ACTIVE_LEVEL)
-  set(SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_OFF)
-endif(NOT SPDLOG_ACTIVE_LEVEL)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPDLOG_ACTIVE_LEVEL=${SPDLOG_ACTIVE_LEVEL}")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DSPDLOG_ACTIVE_LEVEL=${SPDLOG_ACTIVE_LEVEL}")
-
 find_path(RMM_INCLUDE "rmm"
           HINTS "$ENV{RMM_ROOT}/include"
                 "$ENV{RMM_HOME}/include"
@@ -254,6 +248,22 @@ if(PER_THREAD_DEFAULT_STREAM)
     message(STATUS "Using per-thread default stream")
     add_compile_definitions(CUDA_API_PER_THREAD_DEFAULT_STREAM)
 endif(PER_THREAD_DEFAULT_STREAM)
+
+# Set a default logging level if none was specified
+set(DEFAULT_LOGGING_LEVEL OFF)
+
+if(NOT LOGGING_LEVEL)
+    message(STATUS "Setting logging level to '${DEFAULT_LOGGING_LEVEL}' since none specified.")
+    set(LOGGING_LEVEL "${DEFAULT_LOGGING_LEVEL}" CACHE
+      STRING "Choose the logging level." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE LOGGING_LEVEL PROPERTY STRINGS
+        "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
+else()
+    message(STATUS "Setting logging level to '${LOGGING_LEVEL}'")
+endif(NOT LOGGING_LEVEL)
+
+target_compile_definitions(cudfjni PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOGGING_LEVEL})
 
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------


### PR DESCRIPTION
This adds the ability to configure the spdlog logging level on the cmake command-line, defaulting to no logging.