### PR TITLE
[REVIEW] Parquet reader bounds checking error fix. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 - PR #6159 Fix issue related to empty `Dataframe` with columns input to `DataFrame.appened`
 - PR #6199 Fix index preservation for dask_cudf parquet
 - PR #6207 Remove shared libs from Java sources jar
-
+- PR #6217 Fixed missing bounds checking when storing validity in parquet reader
 
 # cuDF 0.15.0 (26 Aug 2020)
 

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -1310,7 +1310,9 @@ static __device__ void gpuUpdateValidityOffsetsAndRowIndices(int32_t target_inpu
 
       // increment count of valid values, count of total values, and validity mask
       if (!t) {
-        if (pni->valid_map != nullptr) { store_validity(pni, warp_valid_mask, warp_value_count); }
+        if (pni->valid_map != nullptr && in_row_bounds) {
+          store_validity(pni, warp_valid_mask, warp_value_count);
+        }
         pni->valid_count += warp_valid_count;
         pni->value_count += warp_value_count;
       }


### PR DESCRIPTION
Fixes  

https://github.com/rapidsai/cudf/issues/6200

We weren't respecting row bound capping (skip rows / num rows) when writing out validity bits in the kernel.  Kind of surprised this didn't show up more frequently.  :shrug:

**Please don't merge this until we get confirmation from @williamBlazing that it fixes his issue.**  It seems to have cleared it up for everyone else.
