### PR TITLE
Remove remaining calls to RMM get_default_resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - PR #6212 Update codeowners file
 - PR #6157 Fix issue related to `Series.concat` to concat a non-empty and empty series.
 - PR #6226 Add in some JNI checks for null handles
+- PR #6251 Replace remaining calls to RMM `get_default_resource`
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/cpp/include/cudf/io/avro.hpp
+++ b/cpp/include/cudf/io/avro.hpp
@@ -23,7 +23,7 @@
 
 #include "types.hpp"
 
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 #include <cudf/io/writers.hpp>
 #include <cudf/table/table_view.hpp>
@@ -215,6 +215,6 @@ class avro_reader_options_builder {
  */
 table_with_metadata read_avro(
   avro_reader_options const& options,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 }  // namespace io
 }  // namespace cudf

--- a/cpp/include/cudf/io/detail/avro.hpp
+++ b/cpp/include/cudf/io/detail/avro.hpp
@@ -45,7 +45,7 @@ class reader {
    */
   explicit reader(std::vector<std::string> const &filepaths,
                   avro_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
   /**
    * @brief Constructor from an array of datasources
@@ -56,7 +56,7 @@ class reader {
    */
   explicit reader(std::vector<std::unique_ptr<cudf::io::datasource>> &&sources,
                   avro_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
   /**
    * @brief Destructor explicitly-declared to avoid inlined in header

--- a/cpp/include/cudf/io/detail/json.hpp
+++ b/cpp/include/cudf/io/detail/json.hpp
@@ -53,7 +53,7 @@ class reader {
    */
   explicit reader(std::vector<std::string> const &filepaths,
                   json_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
   /**
    * @brief Constructor from an array of datasources
@@ -64,7 +64,7 @@ class reader {
    */
   explicit reader(std::vector<std::unique_ptr<cudf::io::datasource>> &&sources,
                   json_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
   /**
    * @brief Destructor explicitly-declared to avoid inlined in header

--- a/cpp/include/cudf/io/detail/parquet.hpp
+++ b/cpp/include/cudf/io/detail/parquet.hpp
@@ -44,7 +44,7 @@ class reader {
    */
   explicit reader(std::vector<std::string> const& filepaths,
                   parquet_reader_options const& options,
-                  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
    * @brief Constructor from an array of datasources
@@ -55,7 +55,7 @@ class reader {
    */
   explicit reader(std::vector<std::unique_ptr<cudf::io::datasource>>&& sources,
                   parquet_reader_options const& options,
-                  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
    * @brief Destructor explicitly-declared to avoid inlined in header
@@ -91,7 +91,7 @@ class writer {
    */
   explicit writer(std::unique_ptr<cudf::io::data_sink> sink,
                   parquet_writer_options const& options,
-                  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
    * @brief Destructor explicitly-declared to avoid inlined in header

--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -23,7 +23,7 @@
 
 #include "types.hpp"
 
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
@@ -312,7 +312,7 @@ class json_reader_options_builder {
  */
 table_with_metadata read_json(
   json_reader_options const& options,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace io
 }  // namespace cudf

--- a/cpp/include/cudf/io/parquet.hpp
+++ b/cpp/include/cudf/io/parquet.hpp
@@ -26,7 +26,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 #include <iostream>
 #include <memory>
@@ -339,7 +339,7 @@ class parquet_reader_options_builder {
  */
 table_with_metadata read_parquet(
   parquet_reader_options const& options,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Class to build `parquet_writer_options`.
@@ -600,7 +600,7 @@ class parquet_writer_options_builder {
 
 std::unique_ptr<std::vector<uint8_t>> write_parquet(
   parquet_writer_options const& options,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Merges multiple raw metadata blobs that were previously created by write_parquet
@@ -813,7 +813,7 @@ struct pq_chunked_state;
  */
 std::shared_ptr<pq_chunked_state> write_parquet_chunked_begin(
   chunked_parquet_writer_options const& options,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Write a single table as a subtable of a larger logical parquet file/table.

--- a/cpp/include/cudf/strings/translate.hpp
+++ b/cpp/include/cudf/strings/translate.hpp
@@ -19,6 +19,8 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <vector>
 
 namespace cudf {
@@ -93,7 +95,7 @@ std::unique_ptr<column> filter_characters(
   std::vector<std::pair<cudf::char_utf8, cudf::char_utf8>> characters_to_filter,
   filter_type keep_characters         = filter_type::KEEP,
   string_scalar const& replacement    = string_scalar(""),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of doxygen group
 }  // namespace strings

--- a/cpp/src/interop/to_arrow.cpp
+++ b/cpp/src/interop/to_arrow.cpp
@@ -27,6 +27,8 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 namespace cudf {
 namespace detail {
 namespace {
@@ -218,7 +220,7 @@ std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::dictionary32>(
   std::unique_ptr<column> dict_indices =
     cast(cudf::dictionary_column_view(input).get_indices_annotated(),
          cudf::data_type{type_id::INT32},
-         rmm::mr::get_default_resource(),
+         rmm::mr::get_current_device_resource(),
          stream);
   auto indices = dispatch_to_arrow{}.operator()<int32_t>(
     dict_indices->view(), dict_indices->type().id(), ar_mr, stream);

--- a/cpp/src/transform/encode.cu
+++ b/cpp/src/transform/encode.cu
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
@@ -9,6 +25,9 @@
 #include <cudf/detail/transform.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/bit.hpp>
+
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <numeric>
 
 namespace cudf {
@@ -34,7 +53,7 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<column>> encode(
 
     auto num_rows = keys_table->num_rows();
     auto mask =
-      cudf::detail::bitmask_and(keys_table->view(), rmm::mr::get_default_resource(), stream);
+      cudf::detail::bitmask_and(keys_table->view(), rmm::mr::get_current_device_resource(), stream);
     auto num_rows_with_nulls =
       cudf::count_unset_bits(reinterpret_cast<bitmask_type*>(mask.data()), 0, num_rows);
 


### PR DESCRIPTION
Fixes #6250 

Replace remaining calls to RMM `get_default_resource` with `get_current_device_resource`