### PR TITLE
[REVIEW] Pin conda boost-cpp to 1.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - PR #6157 Fix issue related to `Series.concat` to concat a non-empty and empty series.
 - PR #6226 Add in some JNI checks for null handles
 - PR #6251 Replace remaining calls to RMM `get_default_resource`
+- PR #XXXX Pin libcudf conda recipe to boost 1.72.0
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@
 - PR #6157 Fix issue related to `Series.concat` to concat a non-empty and empty series.
 - PR #6226 Add in some JNI checks for null handles
 - PR #6251 Replace remaining calls to RMM `get_default_resource`
-- PR #XXXX Pin libcudf conda recipe to boost 1.72.0
+- PR #6258 Pin libcudf conda recipe to boost 1.72.0
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - arrow-cpp 1.0.1.*
     - arrow-cpp-proc * cuda
     - flatbuffers
-    - boost-cpp >=1.72.0
+    - boost-cpp 1.72.0.*
     - dlpack
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - arrow-cpp 1.0.1.*
     - arrow-cpp-proc * cuda
     - flatbuffers
-    - boost-cpp 1.72.0.*
+    - boost-cpp 1.72.0
     - dlpack
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}


### PR DESCRIPTION
Conda-forge is currently going through a migration from boost 1.72.0 --> 1.74.0. This has seemed to cause some issues where some builds are getting 1.74 at build time and then 1.72 at runtime and is generally causing issues. Pinning to 1.72.0 for now to stabilize things and will move to 1.74 once the migration is done. 