### PR TITLE
[REVIEW] Fix compilation error with GCC 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - PR #6157 Fix issue related to `Series.concat` to concat a non-empty and empty series.
 - PR #6226 Add in some JNI checks for null handles
 - PR #6251 Replace remaining calls to RMM `get_default_resource`
+- PR #6259 Fix compiler error with GCC 8
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@
 - PR #6157 Fix issue related to `Series.concat` to concat a non-empty and empty series.
 - PR #6226 Add in some JNI checks for null handles
 - PR #6251 Replace remaining calls to RMM `get_default_resource`
-- PR #6259 Fix compiler error with GCC 8
+- PR #6259 Fix compilation error with GCC 8
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/cpp/benchmarks/common/generate_benchmark_input.cpp
+++ b/cpp/benchmarks/common/generate_benchmark_input.cpp
@@ -43,18 +43,20 @@ auto deterministic_engine(unsigned seed) { return std::mt19937{seed}; }
 template <typename T>
 T get_distribution_mean(distribution_params<T> const& dist)
 {
-  if (dist.id == distribution_id::NORMAL || dist.id == distribution_id::UNIFORM) {
-    return (dist.lower_bound / 2.) + (dist.upper_bound / 2.);
-  }
-  if (dist.id == distribution_id::GEOMETRIC) {
-    auto const range_size = dist.lower_bound < dist.upper_bound
-                              ? dist.upper_bound - dist.lower_bound
-                              : dist.lower_bound - dist.upper_bound;
-    auto const p = geometric_dist_p(range_size);
-    if (dist.lower_bound < dist.upper_bound)
-      return dist.lower_bound + (1. / p);
-    else
-      return dist.lower_bound - (1. / p);
+  switch (dist.id) {
+    case distribution_id::NORMAL:
+    case distribution_id::UNIFORM: return (dist.lower_bound / 2.) + (dist.upper_bound / 2.);
+    case distribution_id::GEOMETRIC: {
+      auto const range_size = dist.lower_bound < dist.upper_bound
+                                ? dist.upper_bound - dist.lower_bound
+                                : dist.lower_bound - dist.upper_bound;
+      auto const p = geometric_dist_p(range_size);
+      if (dist.lower_bound < dist.upper_bound)
+        return dist.lower_bound + (1. / p);
+      else
+        return dist.lower_bound - (1. / p);
+    }
+    default: CUDF_FAIL("Unsupported distribution type.");
   }
 }
 


### PR DESCRIPTION
Issue #6000

Code added in https://github.com/rapidsai/cudf/pull/6174 has a missing return statement that generates an error when compiling with GCC 8.4.

Added a CUDF_FAIL if the type does not match any valid distribution and rewrote the function to use switch statement.