### PR TITLE
[REVIEW] Remove include statement for missing rmm/mr/device/default_memory_resource.hpp file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 - PR #6251 Replace remaining calls to RMM `get_default_resource`
 - PR #6259 Fix compilation error with GCC 8
 - PR #6258 Pin libcudf conda recipe to boost 1.72.0
+- PR #6264 Remove include statement for missing rmm/mr/device/default_memory_resource.hpp file
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/cpp/include/cudf/io/orc.hpp
+++ b/cpp/include/cudf/io/orc.hpp
@@ -17,12 +17,9 @@
 #pragma once
 
 #include <cudf/io/types.hpp>
-
 #include <cudf/io/writers.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
-
-#include <rmm/mr/device/default_memory_resource.hpp>
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
The deprecated entries from `rmm/mr/device/default_memory_resource.hpp` have been removed along with the file itself.
Only one file was left including it (cpp/include/cudf/io/orc.hpp> and thus causing CI build failures today.

This PR removes the include statement which is no longer needed in order to fix the builds.