### PR TITLE
Update JNI to use ORC options builder [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - PR #6204 Add dockerfile and script to build cuDF jar
 - PR #6245 Split up replace.cu into multiple source files
 - PR #6218 increase visiblity/consistency for cuio reader writer private member variable names.
+- PR #6265 Update JNI to use ORC options builder
 
 ## Bug Fixes
 


### PR DESCRIPTION
This fixes the JNI build by updating to the ORC options builder APIs added in #6138.