### PR TITLE
[REVIEW] Fix intermittent error in ORC writer tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - PR #6259 Fix compilation error with GCC 8
 - PR #6258 Pin libcudf conda recipe to boost 1.72.0
 - PR #6264 Remove include statement for missing rmm/mr/device/default_memory_resource.hpp file
+- PR #6283 Fix intermittent errors in ORC writer tests
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/cpp/src/io/csv/csv_gpu.cu
+++ b/cpp/src/io/csv/csv_gpu.cu
@@ -872,7 +872,7 @@ __global__ void __launch_bounds__(rowofs_block_dim) gather_row_offsets_gpu(uint6
   using warp_reduce      = typename cub::WarpReduce<uint32_t>;
   using half_warp_reduce = typename cub::WarpReduce<uint32_t, 16>;
   __shared__ union {
-    typename warp_reduce::TempStorage full[rowofs_block_dim / 32];
+    typename warp_reduce::TempStorage full;
     typename half_warp_reduce::TempStorage half[rowofs_block_dim / 32];
   } temp_storage;
 
@@ -974,8 +974,7 @@ __global__ void __launch_bounds__(rowofs_block_dim) gather_row_offsets_gpu(uint6
     if (!(t & 0xf)) { ctxtree[t >> 4] = rows_out_of_range; }
     __syncthreads();
     if (t < 32) {
-      rows_out_of_range =
-        warp_reduce(temp_storage.full[threadIdx.x / 32]).Sum(static_cast<uint32_t>(ctxtree[t]));
+      rows_out_of_range = warp_reduce(temp_storage.full).Sum(static_cast<uint32_t>(ctxtree[t]));
       if (t == 0) { row_ctx[blockIdx.x] = rows_out_of_range; }
     }
   } else {

--- a/cpp/src/io/orc/stripe_enc.cu
+++ b/cpp/src/io/orc/stripe_enc.cu
@@ -355,8 +355,8 @@ static __device__ uint32_t IntegerRLE(
   using warp_reduce      = cub::WarpReduce<T>;
   using half_warp_reduce = cub::WarpReduce<T, 16>;
   __shared__ union {
-    typename warp_reduce::TempStorage full[2 * block_size];
-    typename half_warp_reduce::TempStorage half[2 * block_size];
+    typename warp_reduce::TempStorage full[2 * block_size / 32];
+    typename half_warp_reduce::TempStorage half[2 * block_size / 32];
   } temp_storage;
   uint8_t *dst     = s->chunk.streams[cid] + s->strm_pos[cid];
   uint32_t out_cnt = 0;

--- a/cpp/src/io/orc/stripe_enc.cu
+++ b/cpp/src/io/orc/stripe_enc.cu
@@ -409,7 +409,7 @@ static __device__ uint32_t IntegerRLE(
         intrle_minmax(vmax, vmin);
       }
       vmin = warp_reduce(temp_storage.full[t / 32]).Reduce(vmin, cub::Min());
-      vmax = warp_reduce(temp_storage.full[t / 32 + block_size]).Reduce(vmax, cub::Max());
+      vmax = warp_reduce(temp_storage.full[(t + block_size) / 32]).Reduce(vmax, cub::Max());
       if (!(t & 0x1f)) {
         s->u.intrle.scratch.u64[(t >> 5) * 2 + 0] = vmin;
         s->u.intrle.scratch.u64[(t >> 5) * 2 + 1] = vmax;


### PR DESCRIPTION
PR #6206 introduced an intermittent failure in ORC writer tests.

Root cause: `TempStorage` in multiple places has incorrect size for the number of warps performing reduction using the storage. Also, `TempStorage` is reused without inter-warp synchronization in a few places.

Fix: Correct `TempStorage` size, add warp synchronization.