### PR TITLE
[REVIEW] fix gcc-9 compile error on ColumnVectorJni.cpp [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - PR #6150 Fix issue related to inferring `datetime64` format with UTC timezone in string data
 - PR #6179 `make_elements` copies to `iterator` without adjusting `size`
 - PR #6182 Fix cmake build of arrow
+- PR #6288 Fix gcc-9 compilation error with `ColumnVectorJni.cpp`
 - PR #6173 Fix normalize_characters offset logic on sliced strings column
 - PR #6159 Fix issue related to empty `Dataframe` with columns input to `DataFrame.appened`
 - PR #6199 Fix index preservation for dask_cudf parquet

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -1365,6 +1365,8 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeNumChildren(JNI
         return static_cast<jint>(column->num_children() - 1);
       } else if (column->type().id() == cudf::type_id::STRUCT) {
         return static_cast<jint>(column->num_children());
+      } else {
+        return 0;
       }
     }
     CATCH_STD(env, 0);


### PR DESCRIPTION
Current code causes a gcc-9 compilation error:
```bash
     [exec] /home/rou/src/cudf/java/src/main/native/src/ColumnVectorJni.cpp: In function ‘jint Java_ai_rapids_cudf_ColumnVector_getNativeNumChildren(JNIEnv*, jobject, jlong)’:
     [exec] /home/rou/src/cudf/java/src/main/native/src/ColumnVectorJni.cpp:1374:1: error: control reaches end of non-void function [-Werror=return-type]
     [exec]  1374 | }
     [exec]       | ^
     [exec] cc1plus: all warnings being treated as errors
     [exec] CMakeFiles/cudfjni.dir/build.make:107: recipe for target 'CMakeFiles/cudfjni.dir/src/ColumnVectorJni.cpp.o' failed
     [exec] make[2]: *** [CMakeFiles/cudfjni.dir/src/ColumnVectorJni.cpp.o] Error 1
     [exec] CMakeFiles/Makefile2:94: recipe for target 'CMakeFiles/cudfjni.dir/all' failed
     [exec] make[1]: *** [CMakeFiles/cudfjni.dir/all] Error 2
     [exec] Makefile:102: recipe for target 'all' failed
     [exec] make: *** [all] Error 2
```

@kuhushukla @revans2 