### PR TITLE
remove individual size tracking from JNI tracking resource adaptor [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Improvements
 
+- PR #6292 Remove individual size tracking from JNI tracking resource adaptor
 - PR #5946 Add cython and python support for libcudf `to_arrow` and `from_arrow`
 - PR #5919 Remove max_strings and max_chars from nvtext::subword_tokenize
 - PR #5956 Add/Update tests for cuStreamz

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -36,7 +36,7 @@ using rmm::mr::logging_resource_adaptor;
 namespace {
 
 // Alignment to which the RMM memory resource will round allocation sizes
-constexpr std::size_t RMM_ALLOC_SIZE_ALIGNMENT = 512;
+constexpr std::size_t RMM_ALLOC_SIZE_ALIGNMENT = 256;
 
 constexpr char const *RMM_EXCEPTION_CLASS = "ai/rapids/cudf/RmmException";
 

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -26,7 +26,6 @@
 #include <rmm/mr/device/owning_wrapper.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
-#include <unordered_map>
 
 #include "cudf_jni_apis.hpp"
 
@@ -100,10 +99,7 @@ private:
     resource->deallocate(p, size, stream);
 
     if (p) {
-        total_allocated -= size;
-      } else {
-        // Untracked size, may be an allocation from before resource was installed.
-      }
+      total_allocated -= size;
     }
   }
 

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -95,6 +95,8 @@ private:
   }
 
   void do_deallocate(void *p, std::size_t size, cudaStream_t stream) override {
+    size = (size + size_align - 1) / size_align * size_align;
+    
     resource->deallocate(p, size, stream);
 
     if (p) {


### PR DESCRIPTION
remove the size_map and the related mutex since https://github.com/rapidsai/rmm/issues/302 had been closed
