### PR TITLE
[REVIEW] fix gcc-9 compilation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - PR #6121 Replace calls to get_default_resource with get_current_device_resource
 - PR #6128 Add support for numpy RandomState handling in `sample`
 - PR #6137 Fix issue where `np.nan` is being return instead of `NAT` for datetime/duration types
+- PR #6298 Fix gcc-9 compilation error in dictionary/remove_keys.cu
 - PR #6172 Fix slice issue with empty column
 - PR #6154 Warnings on row-wise op only when non-numeric columns are found.
 - PR #6150 Fix issue related to inferring `datetime64` format with UTC timezone in string data

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -80,7 +80,7 @@ std::unique_ptr<column> remove_keys_fn(
         indices_type, keys_view.size(), cudf::mask_state::UNALLOCATED, stream);
       auto itr = cudf::detail::indexalator_factory::make_output_iterator(positions->mutable_view());
       thrust::sequence(execpol->on(stream), itr, itr + keys_view.size());
-      return positions;
+      return std::move(positions);
     }();
     // copy the non-removed keys ( keys_to_keep_fn(idx)==true )
     auto table_keys =

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -80,7 +80,7 @@ std::unique_ptr<column> remove_keys_fn(
         indices_type, keys_view.size(), cudf::mask_state::UNALLOCATED, stream);
       auto itr = cudf::detail::indexalator_factory::make_output_iterator(positions->mutable_view());
       thrust::sequence(execpol->on(stream), itr, itr + keys_view.size());
-      return std::move(positions);
+      return positions;
     }();
     // copy the non-removed keys ( keys_to_keep_fn(idx)==true )
     auto table_keys =


### PR DESCRIPTION
The `std::move()` call prevents copy elision:
```
/home/rou/src/cudf/cpp/src/dictionary/remove_keys.cu: In instantiation of ‘std::unique_ptr<cudf::column> cudf::dictionary::detail::_GLOBAL__N__46_tmpxft_00004b4a_00000000_7_remove_keys_cpp1_ii_8f7b9da6::remove_keys_fn(const cudf::dictionary_column_view&, KeysKeeper, rmm::mr::device_memory_resource*, cudaStream_t) [with KeysKeeper = __nv_dl_wrapper_t<__nv_dl_tag<std::unique_ptr<cudf::column> (*)(const cudf::dictionary_column_view&, const cudf::column_view&, rmm::mr::device_memory_resource*, CUstream_st*), cudf::dictionary::detail::remove_keys, 1>, const bool*>; cudaStream_t = CUstream_st*]’:
/home/rou/src/cudf/cpp/src/dictionary/remove_keys.cu:160:65:   required from here
/home/rou/src/cudf/cpp/src/dictionary/remove_keys.cu:83:27: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
   83 |       return std::move(positions);
      |                           ^
/home/rou/src/cudf/cpp/src/dictionary/remove_keys.cu:83:27: note: remove ‘std::move’ call
/home/rou/src/cudf/cpp/src/dictionary/remove_keys.cu: In instantiation of ‘std::unique_ptr<cudf::column> cudf::dictionary::detail::_GLOBAL__N__46_tmpxft_00004b4a_00000000_7_remove_keys_cpp1_ii_8f7b9da6::remove_keys_fn(const cudf::dictionary_column_view&, KeysKeeper, rmm::mr::device_memory_resource*, cudaStream_t) [with KeysKeeper = __nv_dl_wrapper_t<__nv_dl_tag<std::unique_ptr<cudf::column> (*)(const cudf::dictionary_column_view&, rmm::mr::device_memory_resource*, CUstream_st*), cudf::dictionary::detail::remove_unused_keys, 1>, const bool*>; cudaStream_t = CUstream_st*]’:
/home/rou/src/cudf/cpp/src/dictionary/remove_keys.cu:186:65:   required from here
/home/rou/src/cudf/cpp/src/dictionary/remove_keys.cu:83:27: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
/home/rou/src/cudf/cpp/src/dictionary/remove_keys.cu:83:27: note: remove ‘std::move’ call
cc1plus: all warnings being treated as errors
CMakeFiles/cudf.dir/build.make:2668: recipe for target 'CMakeFiles/cudf.dir/src/dictionary/remove_keys.cu.o' failed
make[2]: *** [CMakeFiles/cudf.dir/src/dictionary/remove_keys.cu.o] Error 1
CMakeFiles/Makefile2:230: recipe for target 'CMakeFiles/cudf.dir/all' failed
make[1]: *** [CMakeFiles/cudf.dir/all] Error 2
Makefile:148: recipe for target 'all' failed
make: *** [all] Error 2
```

@davidwendt @jrhemstad @kkraus14 