### PR TITLE
Add JNI bindings to nvcomp [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #6171 Java and Jni support for Struct columns
 - PR #6125 Add support for `Series.mode` and `DataFrame.mode`
 - PR #6262 Add nth_element series aggregation with null handling
+- PR #6301 Add JNI bindings to nvcomp
 
 ## Improvements
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -395,6 +395,14 @@
                                 fail("Could not find cudf as a dependency of libcudfjni out> $sout err> $serr")
                             }
 
+                            def libnvcomp = ~/libnvcomp\\.so\\s+=>\\s+(.*)libnvcomp.*\\.so\\s+.*/
+                            def nvcompm = libnvcomp.matcher(sout)
+                            if (nvcompm.find()) {
+                                pom.properties['native.nvcomp.path'] = nvcompm.group(1)
+                            } else {
+                                fail("Could not find nvcomp as a dependency of libcudfjni out> $sout err> $serr")
+                            }
+
                             def libcudart = ~/libcudart\\.so\\.(.*)\\s+=>.*/
                             def cm = libcudart.matcher(sout)
                             if (cm.find()) {
@@ -476,6 +484,13 @@
                                     <directory>${native.cudf.path}</directory>
                                     <includes>
                                         <include>libcudf.so</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <!--Set by groovy script-->
+                                    <directory>${native.nvcomp.path}</directory>
+                                    <includes>
+                                        <include>libnvcomp.so</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -88,7 +88,7 @@ public class Cuda {
       streamWaitEvent(getStream(), event.getEvent());
     }
 
-    long getStream() {
+    public long getStream() {
       return cleaner == null ? 0 : cleaner.stream;
     }
 

--- a/java/src/main/java/ai/rapids/cudf/HostMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/HostMemoryBuffer.java
@@ -286,8 +286,10 @@ public class HostMemoryBuffer extends MemoryBuffer {
 
   /**
    * Copy a set of bytes to an array from the buffer starting at offset.
-   * @param dstOffset the offset from the address to start copying to
-   * @param dst       the data to be copied.
+   * @param dst       destination byte array
+   * @param dstOffset starting offset within the destination array
+   * @param srcOffset starting offset within this buffer
+   * @param len       number of bytes to copy
    */
   public final void getBytes(byte[] dst, long dstOffset, long srcOffset, long len) {
     assert len >= 0;
@@ -404,6 +406,22 @@ public class HostMemoryBuffer extends MemoryBuffer {
     long requestedAddress = this.address + offset;
     addressOutOfBoundsCheck(requestedAddress, 8, "getLong");
     UnsafeMemoryAccessor.setLong(requestedAddress, value);
+  }
+
+  /**
+   * Copy a set of longs to an array from the buffer starting at offset.
+   * @param dst       destination long array
+   * @param dstIndex  starting index within the destination array
+   * @param srcOffset starting offset within this buffer
+   * @param count     number of longs to copy
+   */
+  public final void getLongs(long[] dst, long dstIndex, long srcOffset, int count) {
+    assert count >= 0;
+    assert count <= dst.length - dstIndex;
+    assert srcOffset >= 0;
+    long requestedAddress = this.address + srcOffset;
+    addressOutOfBoundsCheck(requestedAddress, count * 8L, "getLongs");
+    UnsafeMemoryAccessor.getLongs(dst, dstIndex, requestedAddress, count);
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -32,6 +32,7 @@ import java.net.URL;
 public class NativeDepsLoader {
   private static final Logger log = LoggerFactory.getLogger(NativeDepsLoader.class);
   private static final String[] loadOrder = new String[] {
+      "nvcomp",
       "cudf",
       "cudfjni"
   };

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -314,7 +314,7 @@ public class Rmm {
    * @param stream The stream in which to synchronize this command.
    * @return Returned pointer to the allocated memory
    */
-  static DeviceMemoryBuffer alloc(long size, Cuda.Stream stream) {
+  public static DeviceMemoryBuffer alloc(long size, Cuda.Stream stream) {
     long s = stream == null ? 0 : stream.getStream();
     return new DeviceMemoryBuffer(allocInternal(size, s), size, stream);
   }

--- a/java/src/main/java/ai/rapids/cudf/UnsafeMemoryAccessor.java
+++ b/java/src/main/java/ai/rapids/cudf/UnsafeMemoryAccessor.java
@@ -211,6 +211,19 @@ class UnsafeMemoryAccessor {
   }
 
   /**
+   * Copy out an array of longs.
+   * @param dst       where to write the data
+   * @param dstIndex  index into values to start writing at.
+   * @param address   src memory address
+   * @param count     the number of longs to copy
+   * @throws IndexOutOfBoundsException
+   */
+  public static void getLongs(long[] dst, long dstIndex, long address, int count) {
+    copyMemory(null, address,
+        dst, UnsafeMemoryAccessor.LONG_ARRAY_OFFSET + (dstIndex * 8), count * 8);
+  }
+
+  /**
    * Returns the Short value at this address
    * @param address - memory address
    * @return - value

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Compressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Compressor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf.nvcomp;
+
+import ai.rapids.cudf.BaseDeviceMemoryBuffer;
+import ai.rapids.cudf.Cuda;
+import ai.rapids.cudf.HostMemoryBuffer;
+
+public class BatchedLZ4Compressor {
+
+  public static long getTempSize(BaseDeviceMemoryBuffer[] inputs, long chunkSize) {
+    int numBuffers = inputs.length;
+    long[] inputAddrs = new long[numBuffers];
+    long[] inputSizes = new long[numBuffers];
+    for (int i = 0; i < numBuffers; ++i) {
+      BaseDeviceMemoryBuffer buffer = inputs[i];
+      inputAddrs[i] = buffer.getAddress();
+      inputSizes[i] = buffer.getLength();
+    }
+    return NvcompJni.batchedLZ4CompressGetTempSize(inputAddrs, inputSizes, chunkSize);
+  }
+
+  public static long[] getOutputSizes(BaseDeviceMemoryBuffer[] inputs, long chunkSize,
+                                      BaseDeviceMemoryBuffer tempBuffer) {
+    int numBuffers = inputs.length;
+    long[] inputAddrs = new long[numBuffers];
+    long[] inputSizes = new long[numBuffers];
+    for (int i = 0; i < numBuffers; ++i) {
+      BaseDeviceMemoryBuffer buffer = inputs[i];
+      inputAddrs[i] = buffer.getAddress();
+      inputSizes[i] = buffer.getLength();
+    }
+    return NvcompJni.batchedLZ4CompressGetOutputSize(inputAddrs, inputSizes, chunkSize,
+        tempBuffer.getAddress(), tempBuffer.getLength());
+  }
+
+  public static void compressAsync(HostMemoryBuffer compressedSizesOutputBuffer,
+                                   BaseDeviceMemoryBuffer[] inputs, long chunkSize,
+                                   BaseDeviceMemoryBuffer tempBuffer,
+                                   BaseDeviceMemoryBuffer[] outputs, Cuda.Stream stream) {
+    int numBuffers = inputs.length;
+    if (outputs.length != numBuffers) {
+      throw new IllegalArgumentException("buffer count mismatch, " + numBuffers + " inputs and " +
+          outputs.length + " outputs");
+    }
+    if (compressedSizesOutputBuffer.getLength() < numBuffers * 8) {
+      throw new IllegalArgumentException("compressed output size buffer must be able to hold " +
+          "at least 8 bytes per buffer, size is only " + compressedSizesOutputBuffer.getLength());
+    }
+
+    long[] inputAddrs = new long[numBuffers];
+    long[] inputSizes = new long[numBuffers];
+    for (int i = 0; i < numBuffers; ++i) {
+      BaseDeviceMemoryBuffer buffer = inputs[i];
+      inputAddrs[i] = buffer.getAddress();
+      inputSizes[i] = buffer.getLength();
+    }
+
+    long[] outputAddrs = new long[numBuffers];
+    long[] outputSizes = new long[numBuffers];
+    for (int i = 0; i < numBuffers; ++i) {
+      BaseDeviceMemoryBuffer buffer = outputs[i];
+      outputAddrs[i] = buffer.getAddress();
+      outputSizes[i] = buffer.getLength();
+    }
+
+    NvcompJni.batchedLZ4CompressAsync(compressedSizesOutputBuffer.getAddress(),
+        inputAddrs, inputSizes, chunkSize, tempBuffer.getAddress(), tempBuffer.getLength(),
+        outputAddrs, outputSizes, stream.getStream());
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Compressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Compressor.java
@@ -54,6 +54,9 @@ public class BatchedLZ4Compressor {
    * @return amount in bytes of temporary storage space required to compress the batch
    */
   public static long getTempSize(BaseDeviceMemoryBuffer[] inputs, long chunkSize) {
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("Illegal chunk size: " + chunkSize);
+    }
     int numBuffers = inputs.length;
     long[] inputAddrs = new long[numBuffers];
     long[] inputSizes = new long[numBuffers];
@@ -74,6 +77,9 @@ public class BatchedLZ4Compressor {
    */
   public static long[] getOutputSizes(BaseDeviceMemoryBuffer[] inputs, long chunkSize,
                                       BaseDeviceMemoryBuffer tempBuffer) {
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("Illegal chunk size: " + chunkSize);
+    }
     int numBuffers = inputs.length;
     long[] inputAddrs = new long[numBuffers];
     long[] inputSizes = new long[numBuffers];
@@ -102,6 +108,9 @@ public class BatchedLZ4Compressor {
                                    BaseDeviceMemoryBuffer[] inputs, long chunkSize,
                                    BaseDeviceMemoryBuffer tempBuffer,
                                    BaseDeviceMemoryBuffer[] outputs, Cuda.Stream stream) {
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("Illegal chunk size: " + chunkSize);
+    }
     int numBuffers = inputs.length;
     if (outputs.length != numBuffers) {
       throw new IllegalArgumentException("buffer count mismatch, " + numBuffers + " inputs and " +
@@ -143,6 +152,9 @@ public class BatchedLZ4Compressor {
    */
   public static BatchedCompressionResult compress(BaseDeviceMemoryBuffer[] inputs, long chunkSize,
                                                   Cuda.Stream stream) {
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("Illegal chunk size: " + chunkSize);
+    }
     int numBuffers = inputs.length;
     long[] inputAddrs = new long[numBuffers];
     long[] inputSizes = new long[numBuffers];

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Decompressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Decompressor.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf.nvcomp;
+
+import ai.rapids.cudf.Cuda;
+import ai.rapids.cudf.BaseDeviceMemoryBuffer;
+import ai.rapids.cudf.MemoryCleaner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** LZ4 decompressor that operates on multiple input buffers in a batch */
+public class BatchedLZ4Decompressor {
+  private static final Logger log = LoggerFactory.getLogger(Decompressor.class);
+
+  public static BatchedMetadata getMetadata(BaseDeviceMemoryBuffer[] inputs, Cuda.Stream stream) {
+    long[] inputAddrs = new long[inputs.length];
+    long[] inputSizes = new long[inputs.length];
+    for (int i = 0; i < inputs.length; ++i) {
+      BaseDeviceMemoryBuffer buffer = inputs[i];
+      inputAddrs[i] = buffer.getAddress();
+      inputSizes[i] = buffer.getLength();
+    }
+    return new BatchedMetadata(NvcompJni.batchedLZ4DecompressGetMetadata(
+        inputAddrs, inputSizes, stream.getStream()));
+  }
+
+  public static long getTempSize(BatchedMetadata metadata) {
+    return NvcompJni.batchedLZ4DecompressGetTempSize(metadata.getMetadata());
+  }
+
+  public static long[] getOutputSizes(BatchedMetadata metadata, int numOutputs) {
+    return NvcompJni.batchedLZ4DecompressGetOutputSize(metadata.getMetadata(), numOutputs);
+  }
+
+  public static void decompressAsync(BaseDeviceMemoryBuffer[] inputs,
+                                     BaseDeviceMemoryBuffer tempBuffer, BatchedMetadata metadata,
+                                     BaseDeviceMemoryBuffer[] outputs, Cuda.Stream stream) {
+    int numBuffers = inputs.length;
+    if (outputs.length != numBuffers) {
+      throw new IllegalArgumentException("buffer count mismatch, " + numBuffers + " inputs and " +
+          outputs.length + " outputs");
+    }
+
+    long[] inputAddrs = new long[numBuffers];
+    long[] inputSizes = new long[numBuffers];
+    for (int i = 0; i < numBuffers; ++i) {
+      BaseDeviceMemoryBuffer buffer = inputs[i];
+      inputAddrs[i] = buffer.getAddress();
+      inputSizes[i] = buffer.getLength();
+    }
+
+    long[] outputAddrs = new long[numBuffers];
+    long[] outputSizes = new long[numBuffers];
+    for (int i = 0; i < numBuffers; ++i) {
+      BaseDeviceMemoryBuffer buffer = outputs[i];
+      outputAddrs[i] = buffer.getAddress();
+      outputSizes[i] = buffer.getLength();
+    }
+
+    NvcompJni.batchedLZ4DecompressAsync(inputAddrs, inputSizes,
+        tempBuffer.getAddress(), tempBuffer.getLength(), metadata.getMetadata(),
+        outputAddrs, outputSizes, stream.getStream());
+  }
+
+
+  /** Opaque metadata object for batched LZ4 decompression */
+  public static class BatchedMetadata implements AutoCloseable {
+    private final BatchedMetadataCleaner cleaner;
+    private final long id;
+    private boolean closed = false;
+
+    BatchedMetadata(long metadata) {
+      this.cleaner = new BatchedMetadataCleaner(metadata);
+      this.id = cleaner.id;
+      MemoryCleaner.register(this, cleaner);
+      cleaner.addRef();
+    }
+
+    long getMetadata() {
+      return cleaner.metadata;
+    }
+
+    public boolean isLZ4Metadata() {
+      return NvcompJni.isLZ4Metadata(getMetadata());
+    }
+
+    @Override
+    public void close() {
+      if (!closed) {
+        cleaner.delRef();
+      } else {
+        cleaner.logRefCountDebug("double free " + this);
+        throw new IllegalStateException("Close called too many times " + this);
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "LZ4 BATCHED METADATA (ID: " + id + " " +
+          Long.toHexString(cleaner.metadata) + ")";
+    }
+
+    private static class BatchedMetadataCleaner extends MemoryCleaner.Cleaner {
+      private long metadata;
+
+      BatchedMetadataCleaner(long metadata) {
+        this.metadata = metadata;
+      }
+
+      @Override
+      protected boolean cleanImpl(boolean logErrorIfNotClean) {
+        boolean neededCleanup = false;
+        long address = metadata;
+        if (metadata != 0) {
+          try {
+            NvcompJni.batchedLZ4DecompressDestroyMetadata(metadata);
+          } finally {
+            // Always mark the resource as freed even if an exception is thrown.
+            // We cannot know how far it progressed before the exception, and
+            // therefore it is unsafe to retry.
+            metadata = 0;
+          }
+          neededCleanup = true;
+        }
+        if (neededCleanup && logErrorIfNotClean) {
+          log.error("LZ4 BATCHED METADATA WAS LEAKED (Address: " + Long.toHexString(address) + ")");
+          logRefCountDebug("Leaked event");
+        }
+        return neededCleanup;
+      }
+
+      @Override
+      public boolean isClean() {
+        return metadata != 0;
+      }
+    }
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/CompressionType.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/CompressionType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf.nvcomp;
+
+/** Enumeration of data types that can be compressed. */
+public enum CompressionType {
+  CHAR(0),
+  UCHAR(1),
+  SHORT(2),
+  USHORT(3),
+  INT(4),
+  UINT(5),
+  LONGLONG(6),
+  ULONGLONG(7);
+
+  final int nativeId;
+
+  CompressionType(int nativeId) {
+    this.nativeId = nativeId;
+  }
+
+  public final int toNativeId() {
+    return nativeId;
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
@@ -26,20 +26,44 @@ import org.slf4j.LoggerFactory;
 public class Decompressor {
   private static final Logger log = LoggerFactory.getLogger(Decompressor.class);
 
+  /**
+   * Get the metadata associated with a compressed buffer
+   * @param buffer compressed data buffer
+   * @param stream CUDA stream to use
+   * @return opaque metadata object
+   */
   public static Metadata getMetadata(BaseDeviceMemoryBuffer buffer, Cuda.Stream stream) {
     long metadata = NvcompJni.decompressGetMetadata(buffer.getAddress(), buffer.getLength(),
         stream.getStream());
     return new Metadata(metadata);
   }
 
+  /**
+   * Get the amount of temporary storage space required to decompress a buffer.
+   * @param metadata metadata retrieved from the compressed data
+   * @return amount in bytes of temporary storage space required to decompress
+   */
   public static long getTempSize(Metadata metadata) {
     return NvcompJni.decompressGetTempSize(metadata.getMetadata());
   }
 
+  /**
+   * Get the amount of output storage space required to hold the uncompressed data.
+   * @param metadata metadata retrieved from the compressed data
+   * @return amount in bytes of output storage space required to decompress
+   */
   public static long getOutputSize(Metadata metadata) {
     return NvcompJni.decompressGetOutputSize(metadata.getMetadata());
   }
 
+  /**
+   * Asynchronously decompress a buffer.
+   * @param input      compressed data buffer
+   * @param tempBuffer temporary storage buffer
+   * @param metadata   metadata retrieved from compressed data
+   * @param output     output storage buffer
+   * @param stream     CUDA stream to use
+   */
   public static void decompressAsync(BaseDeviceMemoryBuffer input, BaseDeviceMemoryBuffer tempBuffer,
       Metadata metadata, BaseDeviceMemoryBuffer output, Cuda.Stream stream) {
     NvcompJni.decompressAsync(
@@ -50,6 +74,11 @@ public class Decompressor {
         stream.getStream());
   }
 
+  /**
+   * Determine if a buffer is data compressed with LZ4.
+   * @param buffer data to examine
+   * @return true if the data is LZ4 compressed
+   */
   public static boolean isLZ4Data(BaseDeviceMemoryBuffer buffer) {
     return NvcompJni.isLZ4Data(buffer.getAddress(), buffer.getLength());
   }
@@ -72,6 +101,10 @@ public class Decompressor {
       return cleaner.metadata;
     }
 
+    /**
+     * Determine if this metadata is associated with LZ4-compressed data
+     * @return true if the metadata is associated with LZ4-compressed data
+     */
     public boolean isLZ4Metadata() {
       return NvcompJni.isLZ4Metadata(getMetadata());
     }

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf.nvcomp;
+
+import ai.rapids.cudf.Cuda;
+import ai.rapids.cudf.BaseDeviceMemoryBuffer;
+import ai.rapids.cudf.MemoryCleaner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Generic single-buffer decompressor interface */
+public class Decompressor {
+  private static final Logger log = LoggerFactory.getLogger(Decompressor.class);
+
+  public static Metadata getMetadata(BaseDeviceMemoryBuffer buffer, Cuda.Stream stream) {
+    long metadata = NvcompJni.decompressGetMetadata(buffer.getAddress(), buffer.getLength(),
+        stream.getStream());
+    return new Metadata(metadata);
+  }
+
+  public static long getTempSize(Metadata metadata) {
+    return NvcompJni.decompressGetTempSize(metadata.getMetadata());
+  }
+
+  public static long getOutputSize(Metadata metadata) {
+    return NvcompJni.decompressGetOutputSize(metadata.getMetadata());
+  }
+
+  public static void decompressAsync(BaseDeviceMemoryBuffer input, BaseDeviceMemoryBuffer tempBuffer,
+      Metadata metadata, BaseDeviceMemoryBuffer output, Cuda.Stream stream) {
+    NvcompJni.decompressAsync(
+        input.getAddress(), input.getLength(),
+        tempBuffer.getAddress(), tempBuffer.getLength(),
+        metadata.getMetadata(),
+        output.getAddress(), output.getLength(),
+        stream.getStream());
+  }
+
+  public static boolean isLZ4Data(BaseDeviceMemoryBuffer buffer) {
+    return NvcompJni.isLZ4Data(buffer.getAddress(), buffer.getLength());
+  }
+
+
+  /** Opaque metadata object for single-buffer decompression */
+  public static class Metadata implements AutoCloseable {
+    private final MetadataCleaner cleaner;
+    private final long id;
+    private boolean closed = false;
+
+    Metadata(long metadata) {
+      this.cleaner = new MetadataCleaner(metadata);
+      this.id = cleaner.id;
+      MemoryCleaner.register(this, cleaner);
+      cleaner.addRef();
+    }
+
+    long getMetadata() {
+      return cleaner.metadata;
+    }
+
+    public boolean isLZ4Metadata() {
+      return NvcompJni.isLZ4Metadata(getMetadata());
+    }
+
+    @Override
+    public void close() {
+      if (!closed) {
+        cleaner.delRef();
+      } else {
+        cleaner.logRefCountDebug("double free " + this);
+        throw new IllegalStateException("Close called too many times " + this);
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "DECOMPRESSOR METADATA (ID: " + id + " " +
+          Long.toHexString(cleaner.metadata) + ")";
+    }
+
+    private static class MetadataCleaner extends MemoryCleaner.Cleaner {
+      private long metadata;
+
+      MetadataCleaner(long metadata) {
+        this.metadata = metadata;
+      }
+
+      @Override
+      protected boolean cleanImpl(boolean logErrorIfNotClean) {
+        boolean neededCleanup = false;
+        long address = metadata;
+        if (metadata != 0) {
+          try {
+            NvcompJni.decompressDestroyMetadata(metadata);
+          } finally {
+            // Always mark the resource as freed even if an exception is thrown.
+            // We cannot know how far it progressed before the exception, and
+            // therefore it is unsafe to retry.
+            metadata = 0;
+          }
+          neededCleanup = true;
+        }
+        if (neededCleanup && logErrorIfNotClean) {
+          log.error("DECOMPRESSOR METADATA WAS LEAKED (Address: " +
+              Long.toHexString(address) + ")");
+          logRefCountDebug("Leaked event");
+        }
+        return neededCleanup;
+      }
+
+      @Override
+      public boolean isClean() {
+        return metadata != 0;
+      }
+    }
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/LZ4Compressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/LZ4Compressor.java
@@ -32,6 +32,9 @@ public class LZ4Compressor {
    */
   public static long getTempSize(BaseDeviceMemoryBuffer input, CompressionType inputType,
                                  long chunkSize) {
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("Illegal chunk size: " + chunkSize);
+    }
     return NvcompJni.lz4CompressGetTempSize(input.getAddress(), input.getLength(),
         inputType.nativeId, chunkSize);
   }
@@ -46,6 +49,9 @@ public class LZ4Compressor {
    */
   public static long getOutputSize(BaseDeviceMemoryBuffer input, CompressionType inputType,
                                    long chunkSize, BaseDeviceMemoryBuffer tempBuffer) {
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("Illegal chunk size: " + chunkSize);
+    }
     return NvcompJni.lz4CompressGetOutputSize(input.getAddress(), input.getLength(),
         inputType.nativeId, chunkSize, tempBuffer.getAddress(), tempBuffer.getLength(), false);
   }
@@ -63,6 +69,9 @@ public class LZ4Compressor {
   public static long compress(BaseDeviceMemoryBuffer input, CompressionType inputType,
                               long chunkSize, BaseDeviceMemoryBuffer tempBuffer,
                               BaseDeviceMemoryBuffer output, Cuda.Stream stream) {
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("Illegal chunk size: " + chunkSize);
+    }
     return NvcompJni.lz4Compress(input.getAddress(), input.getLength(), inputType.nativeId,
         chunkSize, tempBuffer.getAddress(), tempBuffer.getLength(),
         output.getAddress(), output.getLength(), stream.getStream());
@@ -84,6 +93,9 @@ public class LZ4Compressor {
                                    BaseDeviceMemoryBuffer input, CompressionType inputType,
                                    long chunkSize, BaseDeviceMemoryBuffer tempBuffer,
                                    BaseDeviceMemoryBuffer output, Cuda.Stream stream) {
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("Illegal chunk size: " + chunkSize);
+    }
     if (compressedSizeOutputBuffer.getLength() < 8) {
       throw new IllegalArgumentException("compressed output size buffer must be able to hold " +
           "at least 8 bytes, size is only " + compressedSizeOutputBuffer.getLength());

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/LZ4Compressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/LZ4Compressor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf.nvcomp;
+
+import ai.rapids.cudf.Cuda;
+import ai.rapids.cudf.BaseDeviceMemoryBuffer;
+import ai.rapids.cudf.HostMemoryBuffer;
+
+/** Single-buffer compressor implementing LZ4 */
+public class LZ4Compressor {
+
+  public static long getTempSize(BaseDeviceMemoryBuffer input, CompressionType inputType,
+                                 long chunkSize) {
+    return NvcompJni.lz4CompressGetTempSize(input.getAddress(), input.getLength(),
+        inputType.nativeId, chunkSize);
+  }
+
+  public static long getOutputSize(BaseDeviceMemoryBuffer input, CompressionType inputType,
+                                   long chunkSize, BaseDeviceMemoryBuffer tempBuffer) {
+    return NvcompJni.lz4CompressGetOutputSize(input.getAddress(), input.getLength(),
+        inputType.nativeId, chunkSize, tempBuffer.getAddress(), tempBuffer.getLength(), false);
+  }
+
+  public static long compress(BaseDeviceMemoryBuffer input, CompressionType inputType,
+                              long chunkSize, BaseDeviceMemoryBuffer tempBuffer,
+                              BaseDeviceMemoryBuffer output, Cuda.Stream stream) {
+    return NvcompJni.lz4Compress(input.getAddress(), input.getLength(), inputType.nativeId,
+        chunkSize, tempBuffer.getAddress(), tempBuffer.getLength(),
+        output.getAddress(), output.getLength(), stream.getStream());
+  }
+
+  public static void compressAsync(HostMemoryBuffer compressedSizeOutputBuffer,
+                                   BaseDeviceMemoryBuffer input, CompressionType inputType,
+                                   long chunkSize, BaseDeviceMemoryBuffer tempBuffer,
+                                   BaseDeviceMemoryBuffer output, Cuda.Stream stream) {
+    if (compressedSizeOutputBuffer.getLength() < 8) {
+      throw new IllegalArgumentException("compressed output size buffer must be able to hold " +
+          "at least 8 bytes, size is only " + compressedSizeOutputBuffer.getLength());
+    }
+    NvcompJni.lz4CompressAsync(compressedSizeOutputBuffer.getAddress(),
+        input.getAddress(), input.getLength(), inputType.nativeId, chunkSize,
+        tempBuffer.getAddress(), tempBuffer.getLength(), output.getAddress(), output.getLength(),
+        stream.getStream());
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/Nvcomp.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/Nvcomp.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf.nvcomp;
+
+import ai.rapids.cudf.NativeDepsLoader;
+
+/** Raw JNI interface to the nvcomp library. */
+public class Nvcomp {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+  /**
+   * Extracts the metadata from the input on the device and copies
+   * it to the host. Note that the result must be released with a
+   * call to decompressDestroyMetadata
+   * @param inPtr device address of the compressed data
+   * @param inSize size of the compressed data in bytes
+   * @param stream address of CUDA stream that will be used for synchronization
+   * @return address of the metadata on the host
+   */
+  public static native long decompressGetMetadata(long inPtr, long inSize, long stream);
+
+  /**
+   * Destroys the metadata object and frees the associated memory.
+   * @param metadataPtr address of the metadata object
+   */
+  public static native void decompressDestroyMetadata(long metadataPtr);
+
+  /**
+   * Computes the temporary storage size needed to decompress.
+   * This over-estimates the needed storage considerably.
+   * @param metadataPtr address of the metadata object
+   * @return the number of temporary storage bytes needed to decompress
+   */
+  public static native long decompressGetTempSize(long metadataPtr);
+
+  /**
+   * Computes the decompressed size of the data.  Gets this from the
+   * metadata contained in the compressed data.
+   * @param metadataPtr address of the metadata object
+   * @return the size of the decompressed data in bytes
+   */
+  public static native long decompressGetOutputSize(long metadataPtr);
+
+  /**
+   * Perform asynchronous decompression using the specified CUDA stream.
+   * The input, temporary, and output buffers must all be in GPU-accessible
+   * memory.
+   * @param inPtr device address of the compressed buffer
+   * @param inSize size of the compressed data in bytes
+   * @param tempPtr device address of the temporary decompression storage buffer
+   * @param tempSize size of the temporary decompression storage buffer
+   * @param metadataPtr address of the metadata object
+   * @param outPtr device address of the buffer to use for uncompressed output
+   * @param outSize size of the uncompressed output buffer in bytes
+   * @param stream CUDA stream to use
+   */
+  public static native void decompressAsync(
+      long inPtr,
+      long inSize,
+      long tempPtr,
+      long tempSize,
+      long metadataPtr,
+      long outPtr,
+      long outSize,
+      long stream);
+
+  /**
+   * Determine if data is compressed with the nvcomp LZ4 compressor.
+   * @param inPtr device address of the compressed data
+   * @param inSize size of the compressed data in bytes
+   * @return true if the data is compressed with the nvcomp LZ4 compressor
+   */
+  public static native boolean isLZ4Data(long inPtr, long inSize);
+
+  /**
+   * Determine if the metadata corresponds to data compressed with the nvcomp LZ4 compressor.
+   * @param metadataPtr address of the metadata object
+   * @return true if the metadata describes data compressed with the nvcomp LZ4 compressor.
+   */
+  public static native boolean isLZ4Metadata(long metadataPtr);
+
+  /**
+   * Calculate the temporary buffer size needed for LZ4 compression.
+   * @param inPtr device address of the uncompressed data
+   * @param inSize size of the uncompressed data in bytes
+   * @param inputType type of uncompressed data
+   * @param chunkSize size of an LZ4 chunk in bytes
+   * @return number of temporary storage bytes needed to compress
+   */
+  public static native long lz4CompressGetTempSize(
+      long inPtr,
+      long inSize,
+      int inputType,
+      long chunkSize);
+
+  /**
+   * Calculate the output buffer size for LZ4 compression. The output
+   * size can be an estimated upper bound or the exact value.
+   * @param inPtr device address of the uncompressed data
+   * @param inSize size of the uncompressed data in bytes
+   * @param inputType type of uncompressed data
+   * @param chunkSize size of an LZ4 chunk in bytes
+   * @param tempPtr device address of the temporary storage buffer
+   * @param tempSize size of the temporary storage buffer in bytes
+   * @param computeExactSize set to true to compute the exact output size
+   * @return output buffer size in bytes. If computeExactSize is true then
+   * this is an exact size otherwise it is a maximum, worst-case size of the
+   * compressed data.
+   */
+  public static native long lz4CompressGetOutputSize(
+      long inPtr,
+      long inSize,
+      int inputType,
+      long chunkSize,
+      long tempPtr,
+      long tempSize,
+      boolean computeExactSize);
+
+  /**
+   * Perform cascaded compression synchronously using the specified CUDA
+   * stream.
+   * @param inPtr device address of the uncompressed data
+   * @param inSize size of the uncompressed data in bytes
+   * @param inputType type of uncompressed data
+   * @param chunkSize size of an LZ4 chunk in bytes
+   * @param tempPtr device address of the temporary compression storage buffer
+   * @param tempSize size of the temporary storage buffer in bytes
+   * @param outPtr device address of the output buffer
+   * @param outSize size of the output buffer in bytes
+   * @param stream CUDA stream to use
+   * @return size of the compressed output in bytes
+   */
+  public static native long lz4Compress(
+      long inPtr,
+      long inSize,
+      int inputType,
+      long chunkSize,
+      long tempPtr,
+      long tempSize,
+      long outPtr,
+      long outSize,
+      long stream);
+
+  /**
+   * Perform cascaded compression synchronously using the specified CUDA
+   * stream.
+   * @param compressedSizeOutputPtr address of a 64-bit integer to update with
+   *                                the resulting compressed size of the data.
+   *                                For the operation to be truly asynchronous
+   *                                this should point to pinned host memory.
+   * @param inPtr device address of the uncompressed data
+   * @param inSize size of the uncompressed data in bytes
+   * @param inputType type of uncompressed data
+   * @param chunkSize size of an LZ4 chunk in bytes
+   * @param tempPtr device address of the temporary compression storage buffer
+   * @param tempSize size of the temporary storage buffer in bytes
+   * @param outPtr device address of the output buffer
+   * @param outSize size of the output buffer in bytes
+   * @param stream CUDA stream to use
+   */
+  public static native void lz4CompressAsync(
+      long compressedSizeOutputPtr,
+      long inPtr,
+      long inSize,
+      int inputType,
+      long chunkSize,
+      long tempPtr,
+      long tempSize,
+      long outPtr,
+      long outSize,
+      long stream);
+
+  /**
+   * Calculate the temporary buffer size needed for cascaded compression.
+   * @param inPtr device address of the uncompressed data
+   * @param inSize size of the uncompressed data in bytes
+   * @param inputType type of uncompressed data
+   * @param numRLEs number of Run Length Encoding layers to use
+   * @param numDeltas number of delta layers to use
+   * @param useBitPacking set to true if bit-packing should be used
+   * @return number of temporary storage bytes needed to compress
+   */
+  static native long cascadedCompressGetTempSize(
+      long inPtr,
+      long inSize,
+      int inputType,
+      int numRLEs,
+      int numDeltas,
+      boolean useBitPacking);
+
+  /**
+   * Calculate the output buffer size for cascaded compression. The output
+   * size can be an estimated upper bound or the exact value.
+   * @param inPtr device address of the uncompressed data
+   * @param inSize size of the uncompressed data in bytes
+   * @param inputType type of uncompressed data
+   * @param numRLEs number of Run Length Encoding layers to use
+   * @param numDeltas number of delta layers to use
+   * @param useBitPacking set to true if bit-packing should be used
+   * @param tempPtr device address of the temporary compression storage buffer
+   * @param tempSize size of the temporary storage buffer in bytes
+   * @param computeExactSize set to true to compute the exact output size
+   * @return output buffer size in bytes. If computeExactSize is true then
+   * this is an exact size otherwise it is a maximum, worst-case size of the
+   * compressed data.
+   */
+  static native long cascadedCompressGetOutputSize(
+      long inPtr,
+      long inSize,
+      int inputType,
+      int numRLEs,
+      int numDeltas,
+      boolean useBitPacking,
+      long tempPtr,
+      long tempSize,
+      boolean computeExactSize);
+
+  /**
+   * Perform cascaded compression synchronously using the specified CUDA
+   * stream.
+   * @param inPtr device address of the uncompressed data
+   * @param inSize size of the uncompressed data in bytes
+   * @param inputType type of uncompressed data
+   * @param numRLEs number of Run Length Encoding layers to use
+   * @param numDeltas number of delta layers to use
+   * @param useBitPacking set to true if bit-packing should be used
+   * @param tempPtr device address of the temporary compression storage buffer
+   * @param tempSize size of the temporary storage buffer in bytes
+   * @param outPtr device address of the output buffer
+   * @param outSize size of the output buffer in bytes
+   * @param stream CUDA stream to use
+   * @return size of the compressed output in bytes
+   */
+  static native long cascadedCompress(
+      long inPtr,
+      long inSize,
+      int inputType,
+      int numRLEs,
+      int numDeltas,
+      boolean useBitPacking,
+      long tempPtr,
+      long tempSize,
+      long outPtr,
+      long outSize,
+      long stream);
+
+  /**
+   * Perform cascaded compression asynchronously using the specified CUDA
+   * stream. Note if the compressedSizeOutputPtr argument points to paged
+   * memory then this may synchronize in practice due to limitations of
+   * copying from the device to paged memory.
+   * @param compressedSizeOutputPtr address of a 64-bit integer to update with
+   *                                the resulting compressed size of the data.
+   *                                For the operation to be truly asynchronous
+   *                                this should point to pinned host memory.
+   * @param inPtr device address of the uncompressed data
+   * @param inSize size of the uncompressed data in bytes
+   * @param inputType type of uncompressed data
+   * @param numRLEs number of Run Length Encoding layers to use
+   * @param numDeltas number of delta layers to use
+   * @param useBitPacking set to true if bit-packing should be used
+   * @param tempPtr device address of the temporary compression storage buffer
+   * @param tempSize size of the temporary storage buffer in bytes
+   * @param outPtr device address of the output buffer
+   * @param outSize size of the output buffer in bytes
+   * @param stream CUDA stream to use
+   */
+  static native void cascadedCompressAsync(
+      long compressedSizeOutputPtr,
+      long inPtr,
+      long inSize,
+      int inputType,
+      int numRLEs,
+      int numDeltas,
+      boolean useBitPacking,
+      long tempPtr,
+      long tempSize,
+      long outPtr,
+      long outSize,
+      long stream);
+}

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/NvcompCudaException.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/NvcompCudaException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf.nvcomp;
+
+/** Exception thrown from nvcomp indicating a CUDA error occurred. */
+public class NvcompCudaException extends NvcompException {
+  NvcompCudaException(String message) {
+    super(message);
+  }
+
+  NvcompCudaException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/NvcompException.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/NvcompException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf.nvcomp;
+
+/** Base class for all nvcomp-specific exceptions */
+public class NvcompException extends RuntimeException {
+  NvcompException(String message) {
+    super(message);
+  }
+
+  NvcompException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/NvcompJni.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/NvcompJni.java
@@ -19,7 +19,7 @@ package ai.rapids.cudf.nvcomp;
 import ai.rapids.cudf.NativeDepsLoader;
 
 /** Raw JNI interface to the nvcomp library. */
-public class Nvcomp {
+class NvcompJni {
   static {
     NativeDepsLoader.loadNativeDeps();
   }
@@ -33,13 +33,13 @@ public class Nvcomp {
    * @param stream address of CUDA stream that will be used for synchronization
    * @return address of the metadata on the host
    */
-  public static native long decompressGetMetadata(long inPtr, long inSize, long stream);
+  static native long decompressGetMetadata(long inPtr, long inSize, long stream);
 
   /**
    * Destroys the metadata object and frees the associated memory.
    * @param metadataPtr address of the metadata object
    */
-  public static native void decompressDestroyMetadata(long metadataPtr);
+  static native void decompressDestroyMetadata(long metadataPtr);
 
   /**
    * Computes the temporary storage size needed to decompress.
@@ -47,7 +47,7 @@ public class Nvcomp {
    * @param metadataPtr address of the metadata object
    * @return the number of temporary storage bytes needed to decompress
    */
-  public static native long decompressGetTempSize(long metadataPtr);
+  static native long decompressGetTempSize(long metadataPtr);
 
   /**
    * Computes the decompressed size of the data.  Gets this from the
@@ -55,7 +55,7 @@ public class Nvcomp {
    * @param metadataPtr address of the metadata object
    * @return the size of the decompressed data in bytes
    */
-  public static native long decompressGetOutputSize(long metadataPtr);
+  static native long decompressGetOutputSize(long metadataPtr);
 
   /**
    * Perform asynchronous decompression using the specified CUDA stream.
@@ -70,7 +70,7 @@ public class Nvcomp {
    * @param outSize size of the uncompressed output buffer in bytes
    * @param stream CUDA stream to use
    */
-  public static native void decompressAsync(
+  static native void decompressAsync(
       long inPtr,
       long inSize,
       long tempPtr,
@@ -86,14 +86,14 @@ public class Nvcomp {
    * @param inSize size of the compressed data in bytes
    * @return true if the data is compressed with the nvcomp LZ4 compressor
    */
-  public static native boolean isLZ4Data(long inPtr, long inSize);
+  static native boolean isLZ4Data(long inPtr, long inSize);
 
   /**
    * Determine if the metadata corresponds to data compressed with the nvcomp LZ4 compressor.
    * @param metadataPtr address of the metadata object
    * @return true if the metadata describes data compressed with the nvcomp LZ4 compressor.
    */
-  public static native boolean isLZ4Metadata(long metadataPtr);
+  static native boolean isLZ4Metadata(long metadataPtr);
 
   /**
    * Calculate the temporary buffer size needed for LZ4 compression.
@@ -103,7 +103,7 @@ public class Nvcomp {
    * @param chunkSize size of an LZ4 chunk in bytes
    * @return number of temporary storage bytes needed to compress
    */
-  public static native long lz4CompressGetTempSize(
+  static native long lz4CompressGetTempSize(
       long inPtr,
       long inSize,
       int inputType,
@@ -123,7 +123,7 @@ public class Nvcomp {
    * this is an exact size otherwise it is a maximum, worst-case size of the
    * compressed data.
    */
-  public static native long lz4CompressGetOutputSize(
+  static native long lz4CompressGetOutputSize(
       long inPtr,
       long inSize,
       int inputType,
@@ -146,7 +146,7 @@ public class Nvcomp {
    * @param stream CUDA stream to use
    * @return size of the compressed output in bytes
    */
-  public static native long lz4Compress(
+  static native long lz4Compress(
       long inPtr,
       long inSize,
       int inputType,
@@ -175,7 +175,7 @@ public class Nvcomp {
    * @param outSize size of the output buffer in bytes
    * @param stream CUDA stream to use
    */
-  public static native void lz4CompressAsync(
+  static native void lz4CompressAsync(
       long compressedSizeOutputPtr,
       long inPtr,
       long inSize,
@@ -195,7 +195,7 @@ public class Nvcomp {
    * @param stream CUDA stream to use
    * @return handle to the batched decompress metadata on the host
    */
-  public static native long batchedLZ4DecompressGetMetadata(
+  static native long batchedLZ4DecompressGetMetadata(
       long[] inPtrs,
       long[] inSizes,
       long stream);
@@ -204,7 +204,7 @@ public class Nvcomp {
    * Destroys batched metadata and frees the underlying host memory.
    * @param batchedMetadata handle to the batched decompress metadata
    */
-  public static native void batchedLZ4DecompressDestroyMetadata(long batchedMetadata);
+  static native void batchedLZ4DecompressDestroyMetadata(long batchedMetadata);
 
   /**
    * Computes the temporary storage size in bytes needed to decompress
@@ -212,7 +212,7 @@ public class Nvcomp {
    * @param batchedMetadata handle to the batched metadata
    * @return number of temporary storage bytes needed to decompress the batch
    */
-  public static native long batchedLZ4DecompressGetTempSize(long batchedMetadata);
+  static native long batchedLZ4DecompressGetTempSize(long batchedMetadata);
 
   /**
    * Computes the decompressed size of each chunk in the batch.
@@ -221,7 +221,7 @@ public class Nvcomp {
    * @return Array of corresponding output sizes needed to decompress
    * each buffer in the batch.
    */
-  public static native long[] batchedLZ4DecompressGetOutputSize(
+  static native long[] batchedLZ4DecompressGetOutputSize(
       long batchedMetadata,
       long numOutputs);
 
@@ -236,7 +236,7 @@ public class Nvcomp {
    * @param outSizes corresponding byte sizes of the uncompressed output buffers
    * @param stream CUDA stream to use
    */
-  public static native void batchedLZ4DecompressAsync(
+  static native void batchedLZ4DecompressAsync(
       long[] inPtrs,
       long[] inSizes,
       long tempPtr,
@@ -253,7 +253,7 @@ public class Nvcomp {
    * @param chunkSize size of an LZ4 chunk in bytes
    * @return The size of required temporary workspace in bytes to compress the batch.
    */
-  public static native long batchedLZ4CompressGetTempSize(
+  static native long batchedLZ4CompressGetTempSize(
       long[] inPtrs,
       long[] inSizes,
       long chunkSize);
@@ -268,7 +268,7 @@ public class Nvcomp {
    * @return array of corresponding sizes in bytes of the output buffers needed
    * to compress the buffers in the batch.
    */
-  public static native long[] batchedLZ4CompressGetOutputSize(
+  static native long[] batchedLZ4CompressGetOutputSize(
       long[] inPtrs,
       long[] inSizes,
       long chunkSize,
@@ -294,7 +294,7 @@ public class Nvcomp {
    * @param outSizes corresponding sizes in bytes of the output buffers
    * @param stream CUDA stream to use
    */
-  public static native void batchedLZ4CompressAsync(
+  static native void batchedLZ4CompressAsync(
       long compressedSizesOutPtr,
       long[] inPtrs,
       long[] inSizes,

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -182,12 +182,25 @@ else()
 endif(JNI_FOUND)
 
 ###################################################################################################
+# - nvcomp ----------------------------------------------------------------------------------------
+
+include(ConfigureNvcomp)
+if(NVCOMP_FOUND)
+    message(STATUS "nvcomp compression library found in ${NVCOMP_ROOT}")
+else()
+    message(FATAL_ERROR "nvcomp compression library not found.")
+endif(NVCOMP_FOUND)
+
+add_library(nvcomp STATIC IMPORTED ${NVCOMP_LIB})
+
+###################################################################################################
 # - include paths ---------------------------------------------------------------------------------
 
 include_directories("${THRUST_INCLUDE}"
                     "${CUB_INCLUDE}"
                     "${LIBCUDACXX_INCLUDE}"
                     "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
+                    "${NVCOMP_INCLUDE_DIR}"
                     "${CMAKE_BINARY_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/include"
                     "${SPDLOG_INCLUDE}"
@@ -214,6 +227,7 @@ set(SOURCE_FILES
     "src/CudaJni.cpp"
     "src/ColumnVectorJni.cpp"
     "src/HostMemoryBufferNativeUtilsJni.cpp"
+    "src/NvcompJni.cpp"
     "src/NvtxRangeJni.cpp"
     "src/RmmJni.cpp"
     "src/ScalarJni.cpp"
@@ -259,4 +273,4 @@ target_compile_definitions(cudfjni PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOG
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(cudfjni cudf ${ARROW_LIBRARY} ${CUDART_LIBRARY} cuda nvrtc)
+target_link_libraries(cudfjni cudf ${ARROW_LIBRARY} ${NVCOMP_LIB} ${CUDART_LIBRARY} cuda nvrtc)

--- a/java/src/main/native/cmake/Modules/ConfigureNvcomp.cmake
+++ b/java/src/main/native/cmake/Modules/ConfigureNvcomp.cmake
@@ -1,0 +1,80 @@
+#=============================================================================
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+set(NVCOMP_ROOT "${CMAKE_BINARY_DIR}/nvcomp")
+
+set(NVCOMP_CMAKE_ARGS "-DUSE_RMM=ON -DCUB_DIR=${CUB_INCLUDE}")
+
+if(NOT CMAKE_CXX11_ABI)
+    message(STATUS "NVCOMP: Disabling the GLIBCXX11 ABI")
+    list(APPEND NVCOMP_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
+    list(APPEND NVCOMP_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
+elseif(CMAKE_CXX11_ABI)
+    message(STATUS "NVCOMP: Enabling the GLIBCXX11 ABI")
+    list(APPEND NVCOMP_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
+    list(APPEND NVCOMP_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
+endif(NOT CMAKE_CXX11_ABI)
+
+configure_file("${CMAKE_SOURCE_DIR}/cmake/Templates/Nvcomp.CMakeLists.txt.cmake"
+               "${NVCOMP_ROOT}/CMakeLists.txt")
+
+file(MAKE_DIRECTORY "${NVCOMP_ROOT}/build")
+
+execute_process(COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR} .
+                RESULT_VARIABLE NVCOMP_CONFIG
+                WORKING_DIRECTORY ${NVCOMP_ROOT})
+
+if(NVCOMP_CONFIG)
+    message(FATAL_ERROR "Configuring nvcomp failed: " ${NVCOMP_CONFIG})
+endif(NVCOMP_CONFIG)
+
+set(PARALLEL_BUILD -j)
+if($ENV{PARALLEL_LEVEL})
+    set(NUM_JOBS $ENV{PARALLEL_LEVEL})
+    set(PARALLEL_BUILD "${PARALLEL_BUILD}${NUM_JOBS}")
+endif($ENV{PARALLEL_LEVEL})
+
+if(${NUM_JOBS})
+    if(${NUM_JOBS} EQUAL 1)
+        message(STATUS "NVCOMP BUILD: Enabling Sequential CMake build")
+    elseif(${NUM_JOBS} GREATER 1)
+        message(STATUS "NVCOMP BUILD: Enabling Parallel CMake build with ${NUM_JOBS} jobs")
+    endif(${NUM_JOBS} EQUAL 1)
+else()
+    message(STATUS "NVCOMP BUILD: Enabling Parallel CMake build with all threads")
+endif(${NUM_JOBS})
+
+execute_process(COMMAND ${CMAKE_COMMAND} --build .. -- ${PARALLEL_BUILD}
+                RESULT_VARIABLE NVCOMP_BUILD
+                WORKING_DIRECTORY ${NVCOMP_ROOT}/build)
+
+if(NVCOMP_BUILD)
+    message(FATAL_ERROR "Building nvcomp failed: " ${NVCOMP_BUILD})
+endif(NVCOMP_BUILD)
+
+message(STATUS "nvcomp build completed at: " ${NVCOMP_ROOT}/build)
+
+set(NVCOMP_INCLUDE_DIR "${NVCOMP_ROOT}/build/include")
+set(NVCOMP_LIBRARY_DIR "${NVCOMP_ROOT}/build/lib")
+
+find_library(NVCOMP_LIB nvcomp
+    NO_DEFAULT_PATH
+    HINTS "${NVCOMP_LIBRARY_DIR}")
+
+if(NVCOMP_LIB)
+    message(STATUS "nvcomp library: " ${NVCOMP_LIB})
+    set(NVCOMP_FOUND TRUE)
+endif(NVCOMP_LIB)

--- a/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
+++ b/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
@@ -22,7 +22,7 @@ include(ExternalProject)
 
 ExternalProject_Add(nvcomp
     GIT_REPOSITORY  https://github.com/NVIDIA/nvcomp.git
-    GIT_TAG         v1.0.0
+    GIT_TAG         b694e5b72b2a7c4bbadadc425eae42a336d02f3d
     GIT_SHALLOW     true
     SOURCE_DIR      "${NVCOMP_ROOT}/nvcomp"
     BINARY_DIR      "${NVCOMP_ROOT}/build"

--- a/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
+++ b/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
@@ -1,0 +1,32 @@
+#=============================================================================
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+cmake_minimum_required(VERSION 3.12)
+
+project(nvcomp)
+
+include(ExternalProject)
+
+ExternalProject_Add(nvcomp
+    GIT_REPOSITORY  https://github.com/NVIDIA/nvcomp.git
+    GIT_TAG         v1.0.0
+    GIT_SHALLOW     true
+    SOURCE_DIR      "${NVCOMP_ROOT}/nvcomp"
+    BINARY_DIR      "${NVCOMP_ROOT}/build"
+    INSTALL_DIR     "${NVCOMP_ROOT}/install"
+    CMAKE_ARGS      ${NVCOMP_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${NVCOMP_ROOT}/install
+    BUILD_COMMAND   ${CMAKE_COMMAND} --build . --target nvcomp
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping nvcomp install step.")

--- a/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
+++ b/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
@@ -22,7 +22,7 @@ include(ExternalProject)
 
 ExternalProject_Add(nvcomp
     GIT_REPOSITORY  https://github.com/NVIDIA/nvcomp.git
-    GIT_TAG         b694e5b72b2a7c4bbadadc425eae42a336d02f3d
+    GIT_TAG         branch-1.1
     GIT_SHALLOW     true
     SOURCE_DIR      "${NVCOMP_ROOT}/nvcomp"
     BINARY_DIR      "${NVCOMP_ROOT}/build"

--- a/java/src/main/native/src/NvcompJni.cpp
+++ b/java/src/main/native/src/NvcompJni.cpp
@@ -139,8 +139,8 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressGetTempSize(JNIEnv *env, jclass,
     nvcompLZ4FormatOpts opts{};
     opts.chunk_size = chunk_size;
     size_t temp_size;
-    auto status = LZ4CompressGetTempSize(reinterpret_cast<void *>(in_ptr), in_size,
-                                         comp_type, &opts, &temp_size);
+    auto status = nvcompLZ4CompressGetTempSize(reinterpret_cast<void *>(in_ptr), in_size,
+                                               comp_type, &opts, &temp_size);
     check_nvcomp_status(env, status);
     return temp_size;
   } CATCH_STD(env, 0);
@@ -158,10 +158,10 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressGetOutputSize(JNIEnv *env, jclass,
     nvcompLZ4FormatOpts opts{};
     opts.chunk_size = chunk_size;
     size_t out_size;
-    auto status = LZ4CompressGetOutputSize(reinterpret_cast<void *>(in_ptr), in_size,
-                                           comp_type, &opts,
-                                           reinterpret_cast<void *>(temp_ptr), temp_size,
-                                           &out_size, compute_exact);
+    auto status = nvcompLZ4CompressGetOutputSize(reinterpret_cast<void *>(in_ptr), in_size,
+                                                 comp_type, &opts,
+                                                 reinterpret_cast<void *>(temp_ptr), temp_size,
+                                                 &out_size, compute_exact);
     check_nvcomp_status(env, status);
     return out_size;
   } CATCH_STD(env, 0);
@@ -181,11 +181,11 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4Compress(JNIEnv *env, jclass,
     opts.chunk_size = chunk_size;
     auto stream = reinterpret_cast<cudaStream_t>(jstream);
     size_t compressed_size = out_size;
-    auto status = LZ4CompressAsync(reinterpret_cast<void *>(in_ptr), in_size,
-                                   comp_type, &opts,
-                                   reinterpret_cast<void *>(temp_ptr), temp_size,
-                                   reinterpret_cast<void *>(out_ptr), &compressed_size,
-                                   stream);
+    auto status = nvcompLZ4CompressAsync(reinterpret_cast<void *>(in_ptr), in_size,
+                                         comp_type, &opts,
+                                         reinterpret_cast<void *>(temp_ptr), temp_size,
+                                         reinterpret_cast<void *>(out_ptr), &compressed_size,
+                                         stream);
     check_nvcomp_status(env, status);
     if (cudaStreamSynchronize(stream) != cudaSuccess) {
       JNI_THROW_NEW(env, NVCOMP_CUDA_ERROR_CLASS, "Error synchronizing stream", 0);
@@ -210,11 +210,11 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressAsync(JNIEnv *env, jclass,
     auto stream = reinterpret_cast<cudaStream_t>(jstream);
     auto compressed_size_ptr = reinterpret_cast<size_t *>(compressed_output_ptr);
     *compressed_size_ptr = out_size;
-    auto status = LZ4CompressAsync(reinterpret_cast<void *>(in_ptr), in_size,
-                                   comp_type, &opts,
-                                   reinterpret_cast<void *>(temp_ptr), temp_size,
-                                   reinterpret_cast<void *>(out_ptr), compressed_size_ptr,
-                                   stream);
+    auto status = nvcompLZ4CompressAsync(reinterpret_cast<void *>(in_ptr), in_size,
+                                         comp_type, &opts,
+                                         reinterpret_cast<void *>(temp_ptr), temp_size,
+                                         reinterpret_cast<void *>(out_ptr), compressed_size_ptr,
+                                         stream);
     check_nvcomp_status(env, status);
   } CATCH_STD(env, );
 }

--- a/java/src/main/native/src/NvcompJni.cpp
+++ b/java/src/main/native/src/NvcompJni.cpp
@@ -51,9 +51,9 @@ void check_nvcomp_status(JNIEnv *env, nvcompError_t status) {
 extern "C" {
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressGetMetadata(JNIEnv *env, jclass,
-                                                        jlong in_ptr, jlong in_size,
-                                                        jlong jstream) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_decompressGetMetadata(JNIEnv *env, jclass,
+                                                           jlong in_ptr, jlong in_size,
+                                                           jlong jstream) {
   try {
     cudf::jni::auto_set_device(env);
     void *metadata_ptr;
@@ -66,8 +66,8 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressGetMetadata(JNIEnv *env, jclass,
 }
 
 JNIEXPORT void JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressDestroyMetadata(JNIEnv *env, jclass,
-                                                            jlong metadata_ptr) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_decompressDestroyMetadata(JNIEnv *env, jclass,
+                                                               jlong metadata_ptr) {
   try {
     cudf::jni::auto_set_device(env);
     nvcompDecompressDestroyMetadata(reinterpret_cast<void *>(metadata_ptr));
@@ -75,7 +75,8 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressDestroyMetadata(JNIEnv *env, jclass,
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressGetTempSize(JNIEnv *env, jclass, jlong metadata_ptr) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_decompressGetTempSize(JNIEnv *env, jclass,
+                                                           jlong metadata_ptr) {
   try {
     cudf::jni::auto_set_device(env);
     size_t temp_size;
@@ -86,7 +87,8 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressGetTempSize(JNIEnv *env, jclass, jlo
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressGetOutputSize(JNIEnv *env, jclass, jlong metadata_ptr) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_decompressGetOutputSize(JNIEnv *env, jclass,
+                                                             jlong metadata_ptr) {
   try {
     cudf::jni::auto_set_device(env);
     size_t out_size;
@@ -97,10 +99,11 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressGetOutputSize(JNIEnv *env, jclass, j
 }
 
 JNIEXPORT void JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressAsync(JNIEnv *env, jclass, jlong in_ptr, jlong in_size,
-                                                  jlong temp_ptr, jlong temp_size,
-                                                  jlong metadata_ptr,
-                                                  jlong out_ptr, jlong out_size, jlong jstream) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_decompressAsync(JNIEnv *env, jclass,
+                                                     jlong in_ptr, jlong in_size,
+                                                     jlong temp_ptr, jlong temp_size,
+                                                     jlong metadata_ptr,
+                                                     jlong out_ptr, jlong out_size, jlong jstream) {
   try {
     cudf::jni::auto_set_device(env);
     auto stream = reinterpret_cast<cudaStream_t>(jstream);
@@ -114,7 +117,7 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressAsync(JNIEnv *env, jclass, jlong in_
 }
 
 JNIEXPORT jboolean JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_isLZ4Data(JNIEnv *env, jclass, jlong in_ptr, jlong in_size) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_isLZ4Data(JNIEnv *env, jclass, jlong in_ptr, jlong in_size) {
   try {
     cudf::jni::auto_set_device(env);
     return LZ4IsData(reinterpret_cast<void *>(in_ptr), in_size);
@@ -122,7 +125,7 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_isLZ4Data(JNIEnv *env, jclass, jlong in_ptr, j
 }
 
 JNIEXPORT jboolean JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_isLZ4Metadata(JNIEnv *env, jclass, jlong metadata_ptr) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_isLZ4Metadata(JNIEnv *env, jclass, jlong metadata_ptr) {
   try {
     cudf::jni::auto_set_device(env);
     return LZ4IsMetadata(reinterpret_cast<void *>(metadata_ptr));
@@ -130,9 +133,9 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_isLZ4Metadata(JNIEnv *env, jclass, jlong metad
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressGetTempSize(JNIEnv *env, jclass,
-                                                         jlong in_ptr, jlong in_size,
-                                                         jint input_type, jlong chunk_size) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_lz4CompressGetTempSize(JNIEnv *env, jclass,
+                                                            jlong in_ptr, jlong in_size,
+                                                            jint input_type, jlong chunk_size) {
   try {
     cudf::jni::auto_set_device(env);
     auto comp_type = static_cast<nvcompType_t>(input_type);
@@ -147,11 +150,11 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressGetTempSize(JNIEnv *env, jclass,
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressGetOutputSize(JNIEnv *env, jclass,
-                                                           jlong in_ptr, jlong in_size,
-                                                           jint input_type, jlong chunk_size,
-                                                           jlong temp_ptr, jlong temp_size,
-                                                           jboolean compute_exact) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_lz4CompressGetOutputSize(JNIEnv *env, jclass,
+                                                              jlong in_ptr, jlong in_size,
+                                                              jint input_type, jlong chunk_size,
+                                                              jlong temp_ptr, jlong temp_size,
+                                                              jboolean compute_exact) {
   try {
     cudf::jni::auto_set_device(env);
     auto comp_type = static_cast<nvcompType_t>(input_type);
@@ -168,12 +171,12 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressGetOutputSize(JNIEnv *env, jclass,
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4Compress(JNIEnv *env, jclass,
-                                              jlong in_ptr, jlong in_size,
-                                              jint input_type, jlong chunk_size,
-                                              jlong temp_ptr, jlong temp_size,
-                                              jlong out_ptr, jlong out_size,
-                                              jlong jstream) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_lz4Compress(JNIEnv *env, jclass,
+                                                 jlong in_ptr, jlong in_size,
+                                                 jint input_type, jlong chunk_size,
+                                                 jlong temp_ptr, jlong temp_size,
+                                                 jlong out_ptr, jlong out_size,
+                                                 jlong jstream) {
   try {
     cudf::jni::auto_set_device(env);
     auto comp_type = static_cast<nvcompType_t>(input_type);
@@ -195,13 +198,13 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4Compress(JNIEnv *env, jclass,
 }
 
 JNIEXPORT void JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressAsync(JNIEnv *env, jclass,
-                                                   jlong compressed_output_ptr,
-                                                   jlong in_ptr, jlong in_size,
-                                                   jint input_type, jlong chunk_size,
-                                                   jlong temp_ptr, jlong temp_size,
-                                                   jlong out_ptr, jlong out_size,
-                                                   jlong jstream) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_lz4CompressAsync(JNIEnv *env, jclass,
+                                                      jlong compressed_output_ptr,
+                                                      jlong in_ptr, jlong in_size,
+                                                      jint input_type, jlong chunk_size,
+                                                      jlong temp_ptr, jlong temp_size,
+                                                      jlong out_ptr, jlong out_size,
+                                                      jlong jstream) {
   try {
     cudf::jni::auto_set_device(env);
     auto comp_type = static_cast<nvcompType_t>(input_type);
@@ -220,10 +223,10 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressAsync(JNIEnv *env, jclass,
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressGetMetadata(JNIEnv* env, jclass,
-                                                                  jlongArray in_ptrs,
-                                                                  jlongArray in_sizes,
-                                                                  jlong jstream) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4DecompressGetMetadata(JNIEnv* env, jclass,
+                                                                     jlongArray in_ptrs,
+                                                                     jlongArray in_sizes,
+                                                                     jlong jstream) {
   try {
     cudf::jni::auto_set_device(env);
 
@@ -247,8 +250,8 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressGetMetadata(JNIEnv* env, j
 }
 
 JNIEXPORT void JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressDestroyMetadata(JNIEnv* env, jclass,
-                                                                      jlong metadata_ptr) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4DecompressDestroyMetadata(JNIEnv* env, jclass,
+                                                                         jlong metadata_ptr) {
   try {
     cudf::jni::auto_set_device(env);
     nvcompBatchedLZ4DecompressDestroyMetadata(reinterpret_cast<void*>(metadata_ptr));
@@ -256,8 +259,8 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressDestroyMetadata(JNIEnv* en
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressGetTempSize(JNIEnv* env, jclass,
-                                                                  jlong metadata_ptr) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4DecompressGetTempSize(JNIEnv* env, jclass,
+                                                                     jlong metadata_ptr) {
   try {
     cudf::jni::auto_set_device(env);
     size_t temp_size;
@@ -269,9 +272,9 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressGetTempSize(JNIEnv* env, j
 }
 
 JNIEXPORT jlongArray JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressGetOutputSize(JNIEnv* env, jclass,
-                                                                    jlong metadata_ptr,
-                                                                    jint num_outputs) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4DecompressGetOutputSize(JNIEnv* env, jclass,
+                                                                       jlong metadata_ptr,
+                                                                       jint num_outputs) {
   try {
     cudf::jni::auto_set_device(env);
     std::vector<size_t> sizes(num_outputs);
@@ -287,15 +290,15 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressGetOutputSize(JNIEnv* env,
 }
 
 JNIEXPORT void JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressAsync(JNIEnv* env, jclass,
-                                                            jlongArray in_ptrs,
-                                                            jlongArray in_sizes,
-                                                            jlong temp_ptr,
-                                                            jlong temp_size,
-                                                            jlong metadata_ptr,
-                                                            jlongArray out_ptrs,
-                                                            jlongArray out_sizes,
-                                                            jlong jstream) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4DecompressAsync(JNIEnv* env, jclass,
+                                                               jlongArray in_ptrs,
+                                                               jlongArray in_sizes,
+                                                               jlong temp_ptr,
+                                                               jlong temp_size,
+                                                               jlong metadata_ptr,
+                                                               jlongArray out_ptrs,
+                                                               jlongArray out_sizes,
+                                                               jlong jstream) {
   try {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<void const> input_ptrs(env, in_ptrs);
@@ -335,10 +338,10 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4DecompressAsync(JNIEnv* env, jclass,
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4CompressGetTempSize(JNIEnv* env, jclass,
-                                                                jlongArray in_ptrs,
-                                                                jlongArray in_sizes,
-                                                                jlong chunk_size) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4CompressGetTempSize(JNIEnv* env, jclass,
+                                                                   jlongArray in_ptrs,
+                                                                   jlongArray in_sizes,
+                                                                   jlong chunk_size) {
   try {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<void const> input_ptrs(env, in_ptrs);
@@ -362,12 +365,12 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4CompressGetTempSize(JNIEnv* env, jcl
 }
 
 JNIEXPORT jlongArray JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4CompressGetOutputSize(JNIEnv* env, jclass,
-                                                                  jlongArray in_ptrs,
-                                                                  jlongArray in_sizes,
-                                                                  jlong chunk_size,
-                                                                  jlong temp_ptr,
-                                                                  jlong temp_size) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4CompressGetOutputSize(JNIEnv* env, jclass,
+                                                                     jlongArray in_ptrs,
+                                                                     jlongArray in_sizes,
+                                                                     jlong chunk_size,
+                                                                     jlong temp_ptr,
+                                                                     jlong temp_size) {
   try {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<void const> input_ptrs(env, in_ptrs);
@@ -397,16 +400,16 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4CompressGetOutputSize(JNIEnv* env, j
 }
 
 JNIEXPORT void JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4CompressAsync(JNIEnv* env, jclass,
-                                                          jlong compressed_sizes_out_ptr,
-                                                          jlongArray in_ptrs,
-                                                          jlongArray in_sizes,
-                                                          jlong chunk_size,
-                                                          jlong temp_ptr,
-                                                          jlong temp_size,
-                                                          jlongArray out_ptrs,
-                                                          jlongArray out_sizes,
-                                                          jlong jstream) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4CompressAsync(JNIEnv* env, jclass,
+                                                             jlong compressed_sizes_out_ptr,
+                                                             jlongArray in_ptrs,
+                                                             jlongArray in_sizes,
+                                                             jlong chunk_size,
+                                                             jlong temp_ptr,
+                                                             jlong temp_size,
+                                                             jlongArray out_ptrs,
+                                                             jlongArray out_sizes,
+                                                             jlong jstream) {
   try {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<void const> input_ptrs(env, in_ptrs);
@@ -448,10 +451,10 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_batchedLZ4CompressAsync(JNIEnv* env, jclass,
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompressGetTempSize(JNIEnv *env, jclass,
-                                                              jlong in_ptr, jlong in_size,
-                                                              jint input_type, jint num_rles,
-                                                              jint num_deltas, jboolean use_bp) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_cascadedCompressGetTempSize(JNIEnv *env, jclass,
+                                                                 jlong in_ptr, jlong in_size,
+                                                                 jint input_type, jint num_rles,
+                                                                 jint num_deltas, jboolean use_bp) {
   try {
     cudf::jni::auto_set_device(env);
     auto comp_type = static_cast<nvcompType_t>(input_type);
@@ -468,12 +471,12 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompressGetTempSize(JNIEnv *env, jclas
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompressGetOutputSize(JNIEnv *env, jclass,
-                                                                jlong in_ptr, jlong in_size,
-                                                                jint input_type, jint num_rles,
-                                                                jint num_deltas, jboolean use_bp,
-                                                                jlong temp_ptr, jlong temp_size,
-                                                                jboolean compute_exact) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_cascadedCompressGetOutputSize(JNIEnv *env, jclass,
+                                                                   jlong in_ptr, jlong in_size,
+                                                                   jint input_type, jint num_rles,
+                                                                   jint num_deltas, jboolean use_bp,
+                                                                   jlong temp_ptr, jlong temp_size,
+                                                                   jboolean compute_exact) {
   try {
     cudf::jni::auto_set_device(env);
     auto comp_type = static_cast<nvcompType_t>(input_type);
@@ -492,13 +495,13 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompressGetOutputSize(JNIEnv *env, jcl
 }
 
 JNIEXPORT jlong JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompress(JNIEnv *env, jclass,
-                                                   jlong in_ptr, jlong in_size,
-                                                   jint input_type, jint num_rles,
-                                                   jint num_deltas, jboolean use_bp,
-                                                   jlong temp_ptr, jlong temp_size,
-                                                   jlong out_ptr, jlong out_size,
-                                                   jlong jstream) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_cascadedCompress(JNIEnv *env, jclass,
+                                                      jlong in_ptr, jlong in_size,
+                                                      jint input_type, jint num_rles,
+                                                      jint num_deltas, jboolean use_bp,
+                                                      jlong temp_ptr, jlong temp_size,
+                                                      jlong out_ptr, jlong out_size,
+                                                      jlong jstream) {
   try {
     cudf::jni::auto_set_device(env);
     auto comp_type = static_cast<nvcompType_t>(input_type);
@@ -522,14 +525,14 @@ Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompress(JNIEnv *env, jclass,
 }
 
 JNIEXPORT void JNICALL
-Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompressAsync(JNIEnv *env, jclass,
-                                                        jlong compressed_output_ptr,
-                                                        jlong in_ptr, jlong in_size,
-                                                        jint input_type, jint num_rles,
-                                                        jint num_deltas, jboolean use_bp,
-                                                        jlong temp_ptr, jlong temp_size,
-                                                        jlong out_ptr, jlong out_size,
-                                                        jlong jstream) {
+Java_ai_rapids_cudf_nvcomp_NvcompJni_cascadedCompressAsync(JNIEnv *env, jclass,
+                                                           jlong compressed_output_ptr,
+                                                           jlong in_ptr, jlong in_size,
+                                                           jint input_type, jint num_rles,
+                                                           jint num_deltas, jboolean use_bp,
+                                                           jlong temp_ptr, jlong temp_size,
+                                                           jlong out_ptr, jlong out_size,
+                                                           jlong jstream) {
   try {
     cudf::jni::auto_set_device(env);
     auto comp_type = static_cast<nvcompType_t>(input_type);

--- a/java/src/main/native/src/NvcompJni.cpp
+++ b/java/src/main/native/src/NvcompJni.cpp
@@ -22,8 +22,8 @@
 
 namespace {
 
-constexpr char const *NVCOMP_ERROR_CLASS = "com/nvidia/nvcomp/NvcompException";
-constexpr char const *NVCOMP_CUDA_ERROR_CLASS = "com/nvidia/nvcomp/NvcompCudaException";
+constexpr char const *NVCOMP_ERROR_CLASS = "ai/rapids/cudf/nvcomp/NvcompException";
+constexpr char const *NVCOMP_CUDA_ERROR_CLASS = "ai/rapids/cudf/nvcomp/NvcompCudaException";
 constexpr char const *ILLEGAL_ARG_CLASS = "java/lang/IllegalArgumentException";
 constexpr char const *UNSUPPORTED_CLASS = "java/lang/UnsupportedOperationException";
 

--- a/java/src/main/native/src/NvcompJni.cpp
+++ b/java/src/main/native/src/NvcompJni.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cascaded.h>
+#include <lz4.h>
+#include <nvcomp.h>
+
+#include "cudf_jni_apis.hpp"
+
+namespace {
+
+constexpr char const *NVCOMP_ERROR_CLASS = "com/nvidia/nvcomp/NvcompException";
+constexpr char const *NVCOMP_CUDA_ERROR_CLASS = "com/nvidia/nvcomp/NvcompCudaException";
+constexpr char const *ILLEGAL_ARG_CLASS = "java/lang/IllegalArgumentException";
+constexpr char const *UNSUPPORTED_CLASS = "java/lang/UnsupportedOperationException";
+
+void check_nvcomp_status(JNIEnv *env, nvcompError_t status) {
+  switch (status) {
+    case nvcompSuccess:
+      break;
+    case nvcompErrorInvalidValue:
+      cudf::jni::throw_java_exception(env, ILLEGAL_ARG_CLASS, "nvcomp invalid value");
+      break;
+    case nvcompErrorNotSupported:
+      cudf::jni::throw_java_exception(env, UNSUPPORTED_CLASS, "nvcomp unsupported");
+      break;
+    case nvcompErrorCudaError:
+      cudf::jni::throw_java_exception(env, NVCOMP_CUDA_ERROR_CLASS, "nvcomp CUDA error");
+      break;
+    default:
+      cudf::jni::throw_java_exception(env, NVCOMP_ERROR_CLASS, "nvcomp unknown error");
+      break;
+  }
+}
+
+} // anonymous namespace
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressGetMetadata(JNIEnv *env, jclass,
+                                                        jlong in_ptr, jlong in_size,
+                                                        jlong jstream) {
+  try {
+    cudf::jni::auto_set_device(env);
+    void *metadata_ptr;
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    auto status = nvcompDecompressGetMetadata(reinterpret_cast<void *>(in_ptr), in_size,
+                                              &metadata_ptr, stream);
+    check_nvcomp_status(env, status);
+    return reinterpret_cast<jlong>(metadata_ptr);
+  } CATCH_STD(env, 0);
+}
+
+JNIEXPORT void JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressDestroyMetadata(JNIEnv *env, jclass,
+                                                            jlong metadata_ptr) {
+  try {
+    cudf::jni::auto_set_device(env);
+    nvcompDecompressDestroyMetadata(reinterpret_cast<void *>(metadata_ptr));
+  } CATCH_STD(env, );
+}
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressGetTempSize(JNIEnv *env, jclass, jlong metadata_ptr) {
+  try {
+    cudf::jni::auto_set_device(env);
+    size_t temp_size;
+    auto status = nvcompDecompressGetTempSize(reinterpret_cast<void *>(metadata_ptr), &temp_size);
+    check_nvcomp_status(env, status);
+    return temp_size;
+  } CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressGetOutputSize(JNIEnv *env, jclass, jlong metadata_ptr) {
+  try {
+    cudf::jni::auto_set_device(env);
+    size_t out_size;
+    auto status = nvcompDecompressGetOutputSize(reinterpret_cast<void *>(metadata_ptr), &out_size);
+    check_nvcomp_status(env, status);
+    return out_size;
+  } CATCH_STD(env, 0);
+}
+
+JNIEXPORT void JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_decompressAsync(JNIEnv *env, jclass, jlong in_ptr, jlong in_size,
+                                                  jlong temp_ptr, jlong temp_size,
+                                                  jlong metadata_ptr,
+                                                  jlong out_ptr, jlong out_size, jlong jstream) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    auto status = nvcompDecompressAsync(reinterpret_cast<void *>(in_ptr), in_size,
+                                        reinterpret_cast<void *>(temp_ptr), temp_size,
+                                        reinterpret_cast<void *>(metadata_ptr),
+                                        reinterpret_cast<void *>(out_ptr), out_size,
+                                        stream);
+    check_nvcomp_status(env, status);
+  } CATCH_STD(env, );
+}
+
+JNIEXPORT jboolean JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_isLZ4Data(JNIEnv *env, jclass, jlong in_ptr, jlong in_size) {
+  try {
+    cudf::jni::auto_set_device(env);
+    return LZ4IsData(reinterpret_cast<void *>(in_ptr), in_size);
+  } CATCH_STD(env, 0)
+}
+
+JNIEXPORT jboolean JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_isLZ4Metadata(JNIEnv *env, jclass, jlong metadata_ptr) {
+  try {
+    cudf::jni::auto_set_device(env);
+    return LZ4IsMetadata(reinterpret_cast<void *>(metadata_ptr));
+  } CATCH_STD(env, 0)
+}
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressGetTempSize(JNIEnv *env, jclass,
+                                                         jlong in_ptr, jlong in_size,
+                                                         jint input_type, jlong chunk_size) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto comp_type = static_cast<nvcompType_t>(input_type);
+    nvcompLZ4FormatOpts opts{};
+    opts.chunk_size = chunk_size;
+    size_t temp_size;
+    auto status = LZ4CompressGetTempSize(reinterpret_cast<void *>(in_ptr), in_size,
+                                         comp_type, &opts, &temp_size);
+    check_nvcomp_status(env, status);
+    return temp_size;
+  } CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressGetOutputSize(JNIEnv *env, jclass,
+                                                           jlong in_ptr, jlong in_size,
+                                                           jint input_type, jlong chunk_size,
+                                                           jlong temp_ptr, jlong temp_size,
+                                                           jboolean compute_exact) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto comp_type = static_cast<nvcompType_t>(input_type);
+    nvcompLZ4FormatOpts opts{};
+    opts.chunk_size = chunk_size;
+    size_t out_size;
+    auto status = LZ4CompressGetOutputSize(reinterpret_cast<void *>(in_ptr), in_size,
+                                           comp_type, &opts,
+                                           reinterpret_cast<void *>(temp_ptr), temp_size,
+                                           &out_size, compute_exact);
+    check_nvcomp_status(env, status);
+    return out_size;
+  } CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4Compress(JNIEnv *env, jclass,
+                                              jlong in_ptr, jlong in_size,
+                                              jint input_type, jlong chunk_size,
+                                              jlong temp_ptr, jlong temp_size,
+                                              jlong out_ptr, jlong out_size,
+                                              jlong jstream) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto comp_type = static_cast<nvcompType_t>(input_type);
+    nvcompLZ4FormatOpts opts{};
+    opts.chunk_size = chunk_size;
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    size_t compressed_size = out_size;
+    auto status = LZ4CompressAsync(reinterpret_cast<void *>(in_ptr), in_size,
+                                   comp_type, &opts,
+                                   reinterpret_cast<void *>(temp_ptr), temp_size,
+                                   reinterpret_cast<void *>(out_ptr), &compressed_size,
+                                   stream);
+    check_nvcomp_status(env, status);
+    if (cudaStreamSynchronize(stream) != cudaSuccess) {
+      JNI_THROW_NEW(env, NVCOMP_CUDA_ERROR_CLASS, "Error synchronizing stream", 0);
+    }
+    return compressed_size;
+  } CATCH_STD(env, 0);
+}
+
+JNIEXPORT void JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_lz4CompressAsync(JNIEnv *env, jclass,
+                                                   jlong compressed_output_ptr,
+                                                   jlong in_ptr, jlong in_size,
+                                                   jint input_type, jlong chunk_size,
+                                                   jlong temp_ptr, jlong temp_size,
+                                                   jlong out_ptr, jlong out_size,
+                                                   jlong jstream) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto comp_type = static_cast<nvcompType_t>(input_type);
+    nvcompLZ4FormatOpts opts{};
+    opts.chunk_size = chunk_size;
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    auto compressed_size_ptr = reinterpret_cast<size_t *>(compressed_output_ptr);
+    *compressed_size_ptr = out_size;
+    auto status = LZ4CompressAsync(reinterpret_cast<void *>(in_ptr), in_size,
+                                   comp_type, &opts,
+                                   reinterpret_cast<void *>(temp_ptr), temp_size,
+                                   reinterpret_cast<void *>(out_ptr), compressed_size_ptr,
+                                   stream);
+    check_nvcomp_status(env, status);
+  } CATCH_STD(env, );
+}
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompressGetTempSize(JNIEnv *env, jclass,
+                                                              jlong in_ptr, jlong in_size,
+                                                              jint input_type, jint num_rles,
+                                                              jint num_deltas, jboolean use_bp) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto comp_type = static_cast<nvcompType_t>(input_type);
+    nvcompCascadedFormatOpts opts{};
+    opts.num_RLEs = num_rles;
+    opts.num_deltas = num_deltas;
+    opts.use_bp = use_bp;
+    size_t temp_size;
+    auto status = nvcompCascadedCompressGetTempSize(reinterpret_cast<void *>(in_ptr), in_size,
+                                                    comp_type, &opts, &temp_size);
+    check_nvcomp_status(env, status);
+    return temp_size;
+  } CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompressGetOutputSize(JNIEnv *env, jclass,
+                                                                jlong in_ptr, jlong in_size,
+                                                                jint input_type, jint num_rles,
+                                                                jint num_deltas, jboolean use_bp,
+                                                                jlong temp_ptr, jlong temp_size,
+                                                                jboolean compute_exact) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto comp_type = static_cast<nvcompType_t>(input_type);
+    nvcompCascadedFormatOpts opts{};
+    opts.num_RLEs = num_rles;
+    opts.num_deltas = num_deltas;
+    opts.use_bp = use_bp;
+    size_t out_size;
+    auto status = nvcompCascadedCompressGetOutputSize(reinterpret_cast<void *>(in_ptr), in_size,
+                                                      comp_type, &opts,
+                                                      reinterpret_cast<void *>(temp_ptr), temp_size,
+                                                      &out_size, compute_exact);
+    check_nvcomp_status(env, status);
+    return out_size;
+  } CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompress(JNIEnv *env, jclass,
+                                                   jlong in_ptr, jlong in_size,
+                                                   jint input_type, jint num_rles,
+                                                   jint num_deltas, jboolean use_bp,
+                                                   jlong temp_ptr, jlong temp_size,
+                                                   jlong out_ptr, jlong out_size,
+                                                   jlong jstream) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto comp_type = static_cast<nvcompType_t>(input_type);
+    nvcompCascadedFormatOpts opts{};
+    opts.num_RLEs = num_rles;
+    opts.num_deltas = num_deltas;
+    opts.use_bp = use_bp;
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    size_t compressed_size = out_size;
+    auto status = nvcompCascadedCompressAsync(reinterpret_cast<void *>(in_ptr), in_size,
+                                              comp_type, &opts,
+                                              reinterpret_cast<void *>(temp_ptr), temp_size,
+                                              reinterpret_cast<void *>(out_ptr), &compressed_size,
+                                              stream);
+    check_nvcomp_status(env, status);
+    if (cudaStreamSynchronize(stream) != cudaSuccess) {
+      JNI_THROW_NEW(env, NVCOMP_CUDA_ERROR_CLASS, "Error synchronizing stream", 0);
+    }
+    return compressed_size;
+  } CATCH_STD(env, 0);
+}
+
+JNIEXPORT void JNICALL
+Java_ai_rapids_cudf_nvcomp_Nvcomp_cascadedCompressAsync(JNIEnv *env, jclass,
+                                                        jlong compressed_output_ptr,
+                                                        jlong in_ptr, jlong in_size,
+                                                        jint input_type, jint num_rles,
+                                                        jint num_deltas, jboolean use_bp,
+                                                        jlong temp_ptr, jlong temp_size,
+                                                        jlong out_ptr, jlong out_size,
+                                                        jlong jstream) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto comp_type = static_cast<nvcompType_t>(input_type);
+    nvcompCascadedFormatOpts opts{};
+    opts.num_RLEs = num_rles;
+    opts.num_deltas = num_deltas;
+    opts.use_bp = use_bp;
+    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    auto compressed_size_ptr = reinterpret_cast<size_t *>(compressed_output_ptr);
+    *compressed_size_ptr = out_size;
+    auto status = nvcompCascadedCompressAsync(reinterpret_cast<void *>(in_ptr), in_size,
+                                              comp_type, &opts,
+                                              reinterpret_cast<void *>(temp_ptr), temp_size,
+                                              reinterpret_cast<void *>(out_ptr),
+                                              compressed_size_ptr, stream);
+    check_nvcomp_status(env, status);
+  } CATCH_STD(env, );
+}
+
+} // extern "C"

--- a/java/src/test/java/ai/rapids/cudf/HostMemoryBufferTest.java
+++ b/java/src/test/java/ai/rapids/cudf/HostMemoryBufferTest.java
@@ -106,6 +106,18 @@ public class HostMemoryBufferTest extends CudfTestBase {
   }
 
   @Test
+  public void testGetLongs() {
+    try (HostMemoryBuffer hostMemoryBuffer = HostMemoryBuffer.allocate(16)) {
+      hostMemoryBuffer.setLong(0, 3);
+      hostMemoryBuffer.setLong(DType.INT64.sizeInBytes, 10);
+      long[] results = new long[2];
+      hostMemoryBuffer.getLongs(results, 0, 0, 2);
+      assertEquals(3, results[0]);
+      assertEquals(10, results[1]);
+    }
+  }
+
+  @Test
   public void testGetLength() {
     try (HostMemoryBuffer hostMemoryBuffer = HostMemoryBuffer.allocate(16)) {
       long length = hostMemoryBuffer.getLength();

--- a/java/src/test/java/ai/rapids/cudf/UnsafeMemoryAccessorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/UnsafeMemoryAccessorTest.java
@@ -75,4 +75,24 @@ public class UnsafeMemoryAccessorTest {
       UnsafeMemoryAccessor.free(address);
     }
   }
+
+  @Test
+  public void testGetLongs() {
+    int numLongs = 257;
+    long address = UnsafeMemoryAccessor.allocate(numLongs * 8);
+    for (int i = 0; i < numLongs; ++i) {
+      UnsafeMemoryAccessor.setLong(address + (i * 8), i);
+    }
+    long[] result = new long[numLongs ];
+    UnsafeMemoryAccessor.getLongs(result, 0, address, numLongs);
+    for (int i = 0; i < numLongs; ++i) {
+      assertEquals(i, result[i]);
+    }
+    UnsafeMemoryAccessor.getLongs(result, 1,
+        address + ((numLongs - 1) * 8), 1);
+    for (int i = 0; i < numLongs; ++i) {
+      long expected = (i == 1) ? numLongs - 1 : i;
+      assertEquals(expected, result[i]);
+    }
+  }
 }

--- a/java/src/test/java/ai/rapids/cudf/UnsafeMemoryAccessorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/UnsafeMemoryAccessorTest.java
@@ -83,7 +83,7 @@ public class UnsafeMemoryAccessorTest {
     for (int i = 0; i < numLongs; ++i) {
       UnsafeMemoryAccessor.setLong(address + (i * 8), i);
     }
-    long[] result = new long[numLongs ];
+    long[] result = new long[numLongs];
     UnsafeMemoryAccessor.getLongs(result, 0, address, numLongs);
     for (int i = 0; i < numLongs; ++i) {
       assertEquals(i, result[i]);

--- a/java/src/test/java/ai/rapids/cudf/nvcomp/NvcompTest.java
+++ b/java/src/test/java/ai/rapids/cudf/nvcomp/NvcompTest.java
@@ -72,7 +72,8 @@ public class NvcompTest {
         for (int i = 0; i < numBuffers; ++i) {
           compressedBuffers[i] = DeviceMemoryBuffer.allocate(outputSizes[i]);
         }
-        try (HostMemoryBuffer compressedSizesBuffer = HostMemoryBuffer.allocate(8 * numBuffers)) {
+        long sizesBufferSize = BatchedLZ4Compressor.getCompressedSizesBufferSize(numBuffers);
+        try (HostMemoryBuffer compressedSizesBuffer = HostMemoryBuffer.allocate(sizesBufferSize)) {
           BatchedLZ4Compressor.compressAsync(compressedSizesBuffer, originalBuffers, chunkSize,
               tempBuffer, compressedBuffers, Cuda.DEFAULT_STREAM);
           Cuda.DEFAULT_STREAM.sync();

--- a/java/src/test/java/ai/rapids/cudf/nvcomp/NvcompTest.java
+++ b/java/src/test/java/ai/rapids/cudf/nvcomp/NvcompTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf.nvcomp;
+
+import ai.rapids.cudf.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class NvcompTest {
+  private static final Logger log = LoggerFactory.getLogger(ColumnVector.class);
+
+  @Test
+  void testLZ4RoundTripSync() {
+    lz4RoundTrip(false);
+  }
+
+  @Test
+  void testLZ4RoundTripAsync() {
+    lz4RoundTrip(true);
+  }
+
+  private void lz4RoundTrip(boolean useAsync) {
+    final long chunk_size = 64 * 1024;
+    final int numElements = 10 * 1024 * 1024 + 1;
+    long[] data = new long[numElements];
+    for (int i = 0; i < numElements; ++i) {
+      data[i] = i;
+    }
+
+    DeviceMemoryBuffer tempBuffer = null;
+    DeviceMemoryBuffer compressedBuffer = null;
+    DeviceMemoryBuffer uncompressedBuffer = null;
+    try (ColumnVector v = ColumnVector.fromLongs(data)) {
+      BaseDeviceMemoryBuffer inputBuffer = v.getDeviceBufferFor(BufferType.DATA);
+      log.debug("Uncompressed size is {}", inputBuffer.getLength());
+
+      long tempSize = Nvcomp.lz4CompressGetTempSize(
+          inputBuffer.getAddress(),
+          inputBuffer.getLength(),
+          CompressionType.CHAR.nativeId,
+          chunk_size);
+
+      log.debug("Using {} temporary space for lz4 compression", tempSize);
+      tempBuffer = DeviceMemoryBuffer.allocate(tempSize);
+
+      long outSize = Nvcomp.lz4CompressGetOutputSize(
+          inputBuffer.getAddress(),
+          inputBuffer.getLength(),
+          CompressionType.CHAR.nativeId,
+          chunk_size,
+          tempBuffer.getAddress(),
+          tempBuffer.getLength(),
+          false);
+      log.debug("Inexact lz4 compressed size estimate is {}", outSize);
+
+      compressedBuffer = DeviceMemoryBuffer.allocate(outSize);
+
+      long startTime = System.nanoTime();
+      long compressedSize;
+      if (useAsync) {
+        try (HostMemoryBuffer tempHostBuffer = HostMemoryBuffer.allocate(8)) {
+          Nvcomp.lz4CompressAsync(
+              tempHostBuffer.getAddress(),
+              inputBuffer.getAddress(),
+              inputBuffer.getLength(),
+              CompressionType.CHAR.nativeId,
+              chunk_size,
+              tempBuffer.getAddress(),
+              tempBuffer.getLength(),
+              compressedBuffer.getAddress(),
+              compressedBuffer.getLength(),
+              0);
+          Cuda.DEFAULT_STREAM.sync();
+          compressedSize = tempHostBuffer.getLong(0);
+        }
+      } else {
+        compressedSize = Nvcomp.lz4Compress(
+            inputBuffer.getAddress(),
+            inputBuffer.getLength(),
+            CompressionType.CHAR.nativeId,
+            chunk_size,
+            tempBuffer.getAddress(),
+            tempBuffer.getLength(),
+            compressedBuffer.getAddress(),
+            compressedBuffer.getLength(),
+            0);
+      }
+      double duration = (System.nanoTime() - startTime) / 1000.0;
+      log.info("Compressed with lz4 to {} in {} us", compressedSize, duration);
+
+      tempBuffer.close();
+      tempBuffer = null;
+
+      Assertions.assertTrue(Nvcomp.isLZ4Data(compressedBuffer.getAddress(), compressedSize));
+
+      long metadata = Nvcomp.decompressGetMetadata(
+          compressedBuffer.getAddress(),
+          compressedBuffer.getLength(),
+          0);
+      try {
+        Assertions.assertTrue(Nvcomp.isLZ4Metadata(metadata));
+        tempSize = Nvcomp.decompressGetTempSize(metadata);
+
+        log.debug("Using {} temporary space for lz4 compression", tempSize);
+        tempBuffer = DeviceMemoryBuffer.allocate(tempSize);
+
+        outSize = Nvcomp.decompressGetOutputSize(metadata);
+        Assertions.assertEquals(inputBuffer.getLength(), outSize);
+
+        uncompressedBuffer = DeviceMemoryBuffer.allocate(outSize);
+
+        Nvcomp.decompressAsync(
+            compressedBuffer.getAddress(),
+            compressedSize,
+            tempBuffer.getAddress(),
+            tempBuffer.getLength(),
+            metadata,
+            uncompressedBuffer.getAddress(),
+            uncompressedBuffer.getLength(),
+            0);
+
+        try (ColumnVector v2 = new ColumnVector(
+            DType.INT64,
+            numElements,
+            Optional.empty(),
+            uncompressedBuffer,
+            null,
+            null);
+             HostColumnVector hv2 = v2.copyToHost()) {
+          uncompressedBuffer = null;
+          for (int i = 0; i < numElements; ++i) {
+            long val = hv2.getLong(i);
+            if (val != i) {
+              Assertions.fail("Expected " + i + " at " + i + " found " + val);
+            }
+          }
+        }
+      } finally {
+        Nvcomp.decompressDestroyMetadata(metadata);
+      }
+    } finally {
+      if (tempBuffer != null) {
+        tempBuffer.close();
+      }
+      if (compressedBuffer != null) {
+        compressedBuffer.close();
+      }
+      if (uncompressedBuffer != null) {
+        uncompressedBuffer.close();
+      }
+    }
+  }
+
+  @Test
+  void testCascadedRoundTripSync() {
+    cascadedRoundTrip(false);
+  }
+
+  @Test
+  void testCascadedRoundTripAsync() {
+    cascadedRoundTrip(true);
+  }
+
+  private void cascadedRoundTrip(boolean useAsync) {
+    final int numElements = 10 * 1024 * 1024 + 1;
+    final int numRunLengthEncodings = 2;
+    final int numDeltas = 1;
+    final boolean useBitPacking = true;
+    int[] data = new int[numElements];
+    for (int i = 0; i < numElements; ++i) {
+      data[i] = i;
+    }
+
+    DeviceMemoryBuffer tempBuffer = null;
+    DeviceMemoryBuffer compressedBuffer = null;
+    DeviceMemoryBuffer uncompressedBuffer = null;
+    try (ColumnVector v = ColumnVector.fromInts(data)) {
+      BaseDeviceMemoryBuffer inputBuffer = v.getDeviceBufferFor(BufferType.DATA);
+      log.debug("Uncompressed size is " + inputBuffer.getLength());
+
+      long tempSize = Nvcomp.cascadedCompressGetTempSize(
+          inputBuffer.getAddress(),
+          inputBuffer.getLength(),
+          CompressionType.INT.nativeId,
+          numRunLengthEncodings,
+          numDeltas,
+          useBitPacking);
+
+      log.debug("Using {} temporary space for cascaded compression", tempSize);
+      tempBuffer = DeviceMemoryBuffer.allocate(tempSize);
+
+      long outSize = Nvcomp.cascadedCompressGetOutputSize(
+          inputBuffer.getAddress(),
+          inputBuffer.getLength(),
+          CompressionType.INT.nativeId,
+          numRunLengthEncodings,
+          numDeltas,
+          useBitPacking,
+          tempBuffer.getAddress(),
+          tempBuffer.getLength(),
+          false);
+      log.debug("Inexact cascaded compressed size estimate is {}", outSize);
+
+      compressedBuffer = DeviceMemoryBuffer.allocate(outSize);
+
+      long startTime = System.nanoTime();
+      long compressedSize;
+      if (useAsync) {
+        try (HostMemoryBuffer tempHostBuffer = HostMemoryBuffer.allocate(8)) {
+          Nvcomp.cascadedCompressAsync(
+              tempHostBuffer.getAddress(),
+              inputBuffer.getAddress(),
+              inputBuffer.getLength(),
+              CompressionType.INT.nativeId,
+              numRunLengthEncodings,
+              numDeltas,
+              useBitPacking,
+              tempBuffer.getAddress(),
+              tempBuffer.getLength(),
+              compressedBuffer.getAddress(),
+              compressedBuffer.getLength(),
+              0);
+          Cuda.DEFAULT_STREAM.sync();
+          compressedSize = tempHostBuffer.getLong(0);
+        }
+      } else {
+        compressedSize = Nvcomp.cascadedCompress(
+            inputBuffer.getAddress(),
+            inputBuffer.getLength(),
+            CompressionType.INT.nativeId,
+            numRunLengthEncodings,
+            numDeltas,
+            useBitPacking,
+            tempBuffer.getAddress(),
+            tempBuffer.getLength(),
+            compressedBuffer.getAddress(),
+            compressedBuffer.getLength(),
+            0);
+      }
+
+      double duration = (System.nanoTime() - startTime) / 1000.0;
+      log.debug("Compressed with cascaded to {} in {} us", compressedSize, duration);
+
+      tempBuffer.close();
+      tempBuffer = null;
+
+      long metadata = Nvcomp.decompressGetMetadata(
+          compressedBuffer.getAddress(),
+          compressedBuffer.getLength(),
+          0);
+      try {
+        tempSize = Nvcomp.decompressGetTempSize(metadata);
+
+        log.debug("Using {} temporary space for cascaded compression", tempSize);
+        tempBuffer = DeviceMemoryBuffer.allocate(tempSize);
+
+        outSize = Nvcomp.decompressGetOutputSize(metadata);
+        Assertions.assertEquals(inputBuffer.getLength(), outSize);
+
+        uncompressedBuffer = DeviceMemoryBuffer.allocate(outSize);
+
+        Nvcomp.decompressAsync(
+            compressedBuffer.getAddress(),
+            compressedSize,
+            tempBuffer.getAddress(),
+            tempBuffer.getLength(),
+            metadata,
+            uncompressedBuffer.getAddress(),
+            uncompressedBuffer.getLength(),
+            0);
+
+        try (ColumnVector v2 = new ColumnVector(
+            DType.INT32,
+            numElements,
+            Optional.empty(),
+            uncompressedBuffer,
+            null,
+            null)) {
+          uncompressedBuffer = null;
+          try (ColumnVector compare = v2.equalTo(v);
+               Scalar compareAll = compare.all()) {
+            Assertions.assertTrue(compareAll.getBoolean());
+          }
+        }
+      } finally {
+        Nvcomp.decompressDestroyMetadata(metadata);
+      }
+    } finally {
+      if (tempBuffer != null) {
+        tempBuffer.close();
+      }
+      if (compressedBuffer != null) {
+        compressedBuffer.close();
+      }
+      if (uncompressedBuffer != null) {
+        uncompressedBuffer.close();
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds JNI bindings to the nvcomp compression library.  It also adds:
- a `getLongs` utility method for `HostMemoryBuffer`
- expose ability to get the underlying raw handle of a CUDA stream
- expose `MemoryCleaner` for implementing other objects with leak-checking semantics on garbage collection
- expose allocating a `DeviceMemoryBuffer` on a CUDA stream

Ideally these bindings would be hosted in the nvcomp repo and produce a standalone nvcomp jar artifact, but in the short-term it was deemed better to place them with cudf for now.  The nvcomp bindings need Java definitions for concepts like `HostMemoryBuffer`, `DeviceMemoryBuffer`, CUDA streams, etc. that already exist in the cudf bindings.