### PR TITLE
Replace a misspelled reference to `master` branch with `main` branch in a comment in changelog.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,8 +112,10 @@
 - PR #6264 Remove include statement for missing rmm/mr/device/default_memory_resource.hpp file
 - PR #6281 Fix unreachable code warning in datetime.cuh
 - PR #6286 Fix `read_csv` `int32` overflow 
+- PR #6310 Replace a misspelled reference to `master` branch with `main` branch in a comment in changelog.sh
 - PR #6289 Revert #6206
 - PR #6304 Fix span_tests.cu includes
+
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/ci/checks/changelog.sh
+++ b/ci/checks/changelog.sh
@@ -13,7 +13,7 @@ git checkout --force --quiet current-pr-branch
 # Ignore errors during searching
 set +e
 
-# Get list of modified files between matster and PR branch
+# Get list of modified files between main and PR branch
 CHANGELOG=`git diff --name-only main...current-pr-branch | grep CHANGELOG.md`
 # Check if CHANGELOG has PR ID
 PRNUM=`cat CHANGELOG.md | grep "$PR_ID"`


### PR DESCRIPTION
I'm pretty sure this typo exists in all the other RAPIDS repos too.