### PR TITLE
[REVIEW] Native code for string-map lookups for cudf-java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #6171 Java and Jni support for Struct columns
 - PR #6125 Add support for `Series.mode` and `DataFrame.mode`
 - PR #6262 Add nth_element series aggregation with null handling
+- PR #6315 Native code for string-map lookups, for cudf-java
 
 ## Improvements
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -351,6 +351,7 @@
                                     <arg value="-DLOGGING_LEVEL=${LOGGING_LEVEL}" />
                                     <arg value="-DCMAKE_CXX_FLAGS=${cxx.flags}"/>
                                     <arg value="-DCMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}"/>
+                                    <arg value="-DGPU_ARCHS=ALL"/>
                                 </exec>
                                 <exec dir="${native.build.path}"
                                       failonerror="true"

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -49,9 +49,50 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=deprecated-declarations")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
-#set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode=arch=compute_60,code=sm_60")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_70,code=compute_70")
+# Auto-detect available GPU compute architectures
+set(GPU_ARCHS "ALL" CACHE STRING
+  "List of GPU architectures (semicolon-separated) to be compiled for. Pass 'ALL' if you want to compile for all supported GPU architectures. Empty string means to auto-detect the GPUs on the current system")
+
+if("${GPU_ARCHS}" STREQUAL "")
+  include(cmake/EvalGpuArchs.cmake)
+  evaluate_gpu_archs(GPU_ARCHS)
+endif()
+
+if("${GPU_ARCHS}" STREQUAL "ALL")
+  
+  # Check for embedded vs workstation architectures
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    # This is being built for Linux4Tegra or SBSA ARM64
+    set(GPU_ARCHS "62")
+    if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
+      set(GPU_ARCHS "${GPU_ARCHS};72")
+    endif()
+    if((CUDA_VERSION_MAJOR EQUAL 11) OR (CUDA_VERSION_MAJOR GREATER 11))
+      set(GPU_ARCHS "${GPU_ARCHS};75;80")
+    endif()
+
+  else()
+    # This is being built for an x86 or x86_64 architecture
+    set(GPU_ARCHS "60")
+    if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
+      set(GPU_ARCHS "${GPU_ARCHS};70")
+    endif()
+    if((CUDA_VERSION_MAJOR EQUAL 10) OR (CUDA_VERSION_MAJOR GREATER 10))
+      set(GPU_ARCHS "${GPU_ARCHS};75")
+    endif()
+    if((CUDA_VERSION_MAJOR EQUAL 11) OR (CUDA_VERSION_MAJOR GREATER 11))
+      set(GPU_ARCHS "${GPU_ARCHS};80")
+    endif()
+
+  endif()
+  
+endif()
+message("GPU_ARCHS = ${GPU_ARCHS}")
+
+foreach(arch ${GPU_ARCHS})
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode=arch=compute_${arch},code=sm_${arch}")
+endforeach()
+
 
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr")
 
@@ -217,7 +258,8 @@ set(SOURCE_FILES
     "src/NvtxRangeJni.cpp"
     "src/RmmJni.cpp"
     "src/ScalarJni.cpp"
-    "src/TableJni.cpp")
+    "src/TableJni.cpp"
+    "src/map_lookup.cu")
 add_library(cudfjni SHARED ${SOURCE_FILES})
 
 #Override RPATH for cudfjni

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -49,6 +49,21 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=deprecated-declarations")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
+if(CMAKE_CUDA_COMPILER_VERSION)
+  # Compute the version. from  CMAKE_CUDA_COMPILER_VERSION
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\1" CUDA_VERSION_MAJOR ${CMAKE_CUDA_COMPILER_VERSION})
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\2" CUDA_VERSION_MINOR ${CMAKE_CUDA_COMPILER_VERSION})
+  set(CUDA_VERSION "${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}" CACHE STRING "Version of CUDA as computed from nvcc.")
+  mark_as_advanced(CUDA_VERSION)
+endif()
+
+message(STATUS "CUDA_VERSION_MAJOR: ${CUDA_VERSION_MAJOR}")
+message(STATUS "CUDA_VERSION_MINOR: ${CUDA_VERSION_MINOR}")
+message(STATUS "CUDA_VERSION: ${CUDA_VERSION}")
+
+# Always set this convenience variable
+set(CUDA_VERSION_STRING "${CUDA_VERSION}")
+
 # Auto-detect available GPU compute architectures
 set(GPU_ARCHS "ALL" CACHE STRING
   "List of GPU architectures (semicolon-separated) to be compiled for. Pass 'ALL' if you want to compile for all supported GPU architectures. Empty string means to auto-detect the GPUs on the current system")

--- a/java/src/main/native/cmake/EvalGpuArchs.cmake
+++ b/java/src/main/native/cmake/EvalGpuArchs.cmake
@@ -1,0 +1,62 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function(evaluate_gpu_archs gpu_archs)
+  set(eval_file ${PROJECT_BINARY_DIR}/eval_gpu_archs.cu)
+  set(eval_exe ${PROJECT_BINARY_DIR}/eval_gpu_archs)
+  set(error_file ${PROJECT_BINARY_DIR}/eval_gpu_archs.stderr.log)
+  file(WRITE ${eval_file}
+    "
+#include <cstdio>
+#include <set>
+#include <string>
+using namespace std;
+int main(int argc, char** argv) {
+  set<string> archs;
+  int nDevices;
+  if((cudaGetDeviceCount(&nDevices) == cudaSuccess) && (nDevices > 0)) {
+    for(int dev=0;dev<nDevices;++dev) {
+      char buff[32];
+      cudaDeviceProp prop;
+      if(cudaGetDeviceProperties(&prop, dev) != cudaSuccess) continue;
+      sprintf(buff, \"%d%d\", prop.major, prop.minor);
+      archs.insert(buff);
+    }
+  }
+  if(archs.empty()) {
+    printf(\"ALL\");
+  } else {
+    bool first = true;
+    for(const auto& arch : archs) {
+      printf(first? \"%s\" : \";%s\", arch.c_str());
+      first = false;
+    }
+  }
+  printf(\"\\n\");
+  return 0;
+}
+")
+  execute_process(
+    COMMAND ${CMAKE_CUDA_COMPILER}
+      -std=c++11
+      -o ${eval_exe}
+      --run
+      ${eval_file}
+    OUTPUT_VARIABLE __gpu_archs
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_FILE ${error_file})
+  message("Auto detection of gpu-archs: ${__gpu_archs}")
+  set(${gpu_archs} ${__gpu_archs} PARENT_SCOPE)
+endfunction(evaluate_gpu_archs)

--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/gather.hpp>
+#include <cudf/detail/utilities/cuda.cuh>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/scalar/scalar_device_view.cuh>
+#include <cudf/structs/structs_column_view.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+namespace cudf {
+namespace {
+
+void __device__ search_each_list(size_type list_index,
+                                 column_device_view input,
+                                 mutable_column_device_view output,
+                                 string_scalar_device_view lookup_key)
+{
+  if (input.is_null(list_index)) {               // List row is null.
+    output.element<size_type>(list_index) = -1;  // Not found.
+    return;
+  }
+
+  auto offsets{input.child(0)};
+  auto start_index{offsets.element<size_type>(list_index)};
+  auto end_index{offsets.element<size_type>(list_index + 1)};
+
+  auto key_column{input.child(1).child(0)};
+
+  for (size_type list_element_index{start_index}; list_element_index < end_index;
+       ++list_element_index) {
+    if (!key_column.is_null(list_element_index) &&
+        key_column.element<string_view>(list_element_index) == lookup_key.value()) {
+      output.element<size_type>(list_index) = list_element_index;
+      return;
+    }
+  }
+
+  output.element<size_type>(list_index) = -1;  // Not found.
+}
+
+template <int block_size>
+__launch_bounds__(block_size) __global__ void gpu_find_first(column_device_view input,
+                                                             mutable_column_device_view output,
+                                                             string_scalar_device_view lookup_key)
+{
+  size_type i      = blockIdx.x * block_size + threadIdx.x;
+  size_type stride = block_size * gridDim.x;
+
+  auto active_threads = __ballot_sync(0xffffffff, i < input.size());
+
+  while (i < input.size()) {
+    search_each_list(i, input, output, lookup_key);
+    i += stride;
+    active_threads = __ballot_sync(active_threads, i < input.size());
+  }
+}
+
+std::unique_ptr<column> get_gather_map_for_map_values(column_view const& input,
+                                                      string_scalar& lookup_key,
+                                                      rmm::mr::device_memory_resource* mr,
+                                                      cudaStream_t stream)
+{
+  constexpr size_type block_size{256};
+  cudf::detail::grid_1d grid{input.size(), block_size};
+
+  auto input_device_view = cudf::column_device_view::create(input, stream);
+  auto lookup_key_device_view{get_scalar_device_view(lookup_key)};
+  auto gather_map = make_numeric_column(
+    data_type{cudf::type_to_id<size_type>()}, input.size(), mask_state::ALL_VALID, stream, mr);
+  auto output_view = mutable_column_device_view::create(gather_map->mutable_view(), stream);
+
+  gpu_find_first<block_size><<<grid.num_blocks, block_size, 0, stream>>>(
+    *input_device_view, *output_view, lookup_key_device_view);
+
+  CHECK_CUDA(stream);
+
+  return std::move(gather_map);
+}
+
+}  // namespace
+
+namespace jni {
+std::unique_ptr<column> map_lookup(column_view const& map_column,
+                                   string_scalar lookup_key,
+                                   rmm::mr::device_memory_resource* mr,
+                                   cudaStream_t stream)
+{
+  // Defensive checks.
+  CUDF_EXPECTS(map_column.type().id() == type_id::LIST, "Expected LIST<STRUCT<key,value>>.");
+
+  lists_column_view lcv{map_column};
+  auto structs_column = lcv.get_sliced_child(stream);
+
+  CUDF_EXPECTS(structs_column.type().id() == type_id::STRUCT, "Expected LIST<STRUCT<key,value>>.");
+
+  structs_column_view scv{structs_column};
+  CUDF_EXPECTS(structs_column.num_children() == 2, "Expected LIST<STRUCT<key,value>>.");
+  CUDF_EXPECTS(structs_column.child(0).type().id() == type_id::STRING,
+               "Expected LIST<STRUCT<key,value>>.");
+  CUDF_EXPECTS(structs_column.child(1).type().id() == type_id::STRING,
+               "Expected LIST<STRUCT<key,value>>.");
+
+  // Two-pass plan: construct gather map, and then gather() on structs_column.child(1). Plan A.
+  // Can do in one pass perhaps, but that's Plan B.
+
+  auto gather_map = get_gather_map_for_map_values(map_column, lookup_key, mr, stream);
+
+  // Gather map is now available.
+
+  auto values_column    = structs_column.child(1);
+  auto table_for_gather = table_view{std::vector<cudf::column_view>{values_column}};
+
+  auto gathered_table = cudf::detail::gather(table_for_gather,
+                                             gather_map->view(),
+                                             detail::out_of_bounds_policy::IGNORE,
+                                             detail::negative_index_policy::NOT_ALLOWED,
+                                             mr,
+                                             stream);
+
+  return std::make_unique<cudf::column>(std::move(gathered_table->get_column(0)));
+}
+} // namespace jni;
+} // namespace cudf;

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+
+namespace cudf {
+
+namespace jni {
+
+  std::unique_ptr<column> map_lookup(
+    column_view const& map_column,
+    string_scalar lookup_key,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
+    cudaStream_t stream                 = 0);
+
+} // namespace jni;
+
+} // namespace cudf;

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -37,6 +37,7 @@ namespace jni {
    * @param map_column The input "map" column to be searched. Must be of
    *                   type list_view<struct_view<string_view, string_view>>.
    * @param lookup_key The search key, whose value is to be returned for each list row
+   * @param has_nulls  Whether the input column might contain null list-rows, or null keys.
    * @param mr         The device memory resource to be used for allocations
    * @param stream     The CUDA stream
    * @return           A string_view column with the value from the first match in each list.
@@ -47,6 +48,7 @@ namespace jni {
   std::unique_ptr<column> map_lookup(
     column_view const& map_column,
     string_scalar lookup_key,
+    bool has_nulls                      = true,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
     cudaStream_t stream                 = 0);
 

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -22,6 +22,28 @@ namespace cudf {
 
 namespace jni {
 
+  /**
+   * @brief Looks up a "map" column by specified key, and returns a column of string values.
+   * 
+   * The map-column is represented as follows:
+   * 
+   *  list_view<struct_view< string_view, string_view > >. 
+   *                         <---KEY--->  <--VALUE-->
+   * 
+   * The string_view struct members are the key and value, respectively.
+   * For each row in the input list column, the value corresponding to the first match
+   * of the specified lookup_key is returned. If the key is not found, a null is returned.
+   * 
+   * @param map_column The input "map" column to be searched. Must be of
+   *                   type list_view<struct_view<string_view, string_view>>.
+   * @param lookup_key The search key, whose value is to be returned for each list row
+   * @param mr         The device memory resource to be used for allocations
+   * @param stream     The CUDA stream
+   * @return           A string_view column with the value from the first match in each list.
+   *                   A null row is returned for any row where the lookup_key is not found.
+   * @throw cudf::logic_error If the input column is not of type 
+   *                          list_view<struct_view<string_view, string_view>>
+   */
   std::unique_ptr<column> map_lookup(
     column_view const& map_column,
     string_scalar lookup_key,


### PR DESCRIPTION
Native code in `cudf/java` to support looking up a Map column `map<string, string>`. This is very specific to looking up string maps. (The Java bindings for this will follow.)

For some minimal context: A Spark `map<string, string>` column will be represented as a `list_view<struct_view<string_view, string_view>>`. The code in this commit should allow one to look up a "map column" by a `string_view` scalar value, to receive a column of `string_view`, with nulls where the map-row does not contain the key.

Peripherally, I have modified the `java/src/main/native/CMakeLists.txt` for how GPU architectures are detected, bringing it in line with what `libcudf` does.