### PR TITLE
[REVIEW] Avoids materializing `RangeIndex` during frame concatnation (when not needed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@
 - PR #6289 Revert #6206
 - PR #6291 Fix issue related to row-wise operations in `cudf.DataFrame`
 - PR #6304 Fix span_tests.cu includes
-
+- PR #6331 Avoids materializing `RangeIndex` during frame concatnation (when not needed)
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -441,7 +441,9 @@ class Frame(libcudf.table.Table):
         # Reassign the categories for any categorical index cols
         if not isinstance(out._index, cudf.RangeIndex):
             reassign_categories(
-                categories, out._index._data, indices[:first_data_column_position]
+                categories,
+                out._index._data,
+                indices[:first_data_column_position],
             )
             if not isinstance(
                 out._index, cudf.MultiIndex

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -13,7 +13,7 @@ from pandas.api.types import is_dict_like, is_dtype_equal
 import cudf
 from cudf import _lib as libcudf
 from cudf._lib.nvtx import annotate
-from cudf.core.column import as_column, build_categorical_column
+from cudf.core.column import as_column, build_categorical_column, column_empty
 from cudf.utils import utils
 from cudf.utils.dtypes import (
     is_categorical_dtype,
@@ -23,6 +23,7 @@ from cudf.utils.dtypes import (
     min_scalar_type,
     min_signed_type,
 )
+from cudf.core.index import as_index
 
 
 class Frame(libcudf.table.Table):
@@ -236,117 +237,6 @@ class Frame(libcudf.table.Table):
                     result_index_length += len(obj)
                     empty_has_index = empty_has_index or len(obj) > 0
 
-        from cudf.core.column.column import (
-            build_categorical_column,
-            column_empty,
-        )
-        from cudf.core.index import as_index
-
-        # Create a dictionary of the common, non-null columns
-        def get_non_null_cols_and_dtypes(col_idxs, list_of_columns):
-            # A mapping of {idx: np.dtype}
-            dtypes = dict()
-            # A mapping of {idx: [...columns]}, where `[...columns]`
-            # is a list of columns with at least one valid value for each
-            # column name across all input frames
-            non_null_columns = dict()
-            for idx in col_idxs:
-                for cols in list_of_columns:
-                    # Skip columns not in this frame
-                    if idx >= len(cols) or cols[idx] is None:
-                        continue
-                    # Store the first dtype we find for a column, even if it's
-                    # all-null. This ensures we always have at least one dtype
-                    # for each name. This dtype will be overwritten later if a
-                    # non-null Column with the same name is found.
-                    if idx not in dtypes:
-                        dtypes[idx] = cols[idx].dtype
-                    if cols[idx].valid_count > 0:
-                        if idx not in non_null_columns:
-                            non_null_columns[idx] = [cols[idx]]
-                        else:
-                            non_null_columns[idx].append(cols[idx])
-            return non_null_columns, dtypes
-
-        def find_common_dtypes_and_categories(non_null_columns, dtypes):
-            # A mapping of {idx: categories}, where `categories` is a
-            # column of all the unique categorical values from each
-            # categorical column across all input frames
-            categories = dict()
-            for idx, cols in non_null_columns.items():
-                # default to the first non-null dtype
-                dtypes[idx] = cols[0].dtype
-                # If all the non-null dtypes are int/float, find a common dtype
-                if all(is_numerical_dtype(col.dtype) for col in cols):
-                    dtypes[idx] = np.find_common_type(
-                        [col.dtype for col in cols], []
-                    )
-                # If all categorical dtypes, combine the categories
-                elif all(
-                    isinstance(col, cudf.core.column.CategoricalColumn)
-                    for col in cols
-                ):
-                    # Combine and de-dupe the categories
-                    categories[idx] = (
-                        cudf.concat([col.cat().categories for col in cols])
-                        .to_series()
-                        .drop_duplicates(ignore_index=True)
-                        ._column
-                    )
-                    # Set the column dtype to the codes' dtype. The categories
-                    # will be re-assigned at the end
-                    dtypes[idx] = min_scalar_type(len(categories[idx]))
-                # Otherwise raise an error if columns have different dtypes
-                elif not all(
-                    is_dtype_equal(c.dtype, dtypes[idx]) for c in cols
-                ):
-                    raise ValueError("All columns must be the same type")
-            return categories
-
-        def cast_cols_to_common_dtypes(
-            col_idxs, list_of_columns, dtypes, categories
-        ):
-            # Cast all columns to a common dtype, assign combined categories,
-            # and back-fill missing columns with all-null columns
-            for idx in col_idxs:
-                dtype = dtypes[idx]
-                for cols in list_of_columns:
-                    # If column not in this df, fill with an all-null column
-                    if idx >= len(cols) or cols[idx] is None:
-                        n = len(next(x for x in cols if x is not None))
-                        cols[idx] = column_empty(
-                            row_count=n, dtype=dtype, masked=True
-                        )
-                    else:
-                        # If column is categorical, rebase the codes with the
-                        # combined categories, and cast the new codes to the
-                        # min-scalar-sized dtype
-                        if idx in categories:
-                            cols[idx] = (
-                                cols[idx]
-                                .cat()
-                                ._set_categories(
-                                    cols[idx].cat().categories,
-                                    categories[idx],
-                                    is_unique=True,
-                                )
-                                .codes
-                            )
-                        cols[idx] = cols[idx].astype(dtype)
-
-        def reassign_categories(categories, cols, col_idxs):
-            for name, idx in zip(cols, col_idxs):
-                if idx in categories:
-                    cols[name] = build_categorical_column(
-                        categories=categories[idx],
-                        codes=as_column(
-                            cols[name].base_data, dtype=cols[name].dtype
-                        ),
-                        mask=cols[name].base_mask,
-                        offset=cols[name].offset,
-                        size=cols[name].size,
-                    )
-
         # Get a list of the unique table column names
         names = [name for f in objs for name in f._column_names]
         names = OrderedDict.fromkeys(names).keys()
@@ -383,15 +273,15 @@ class Frame(libcudf.table.Table):
         first_data_column_position = len(indices) - len(names)
 
         # Get the non-null columns and their dtypes
-        non_null_cols, dtypes = get_non_null_cols_and_dtypes(indices, columns)
+        non_null_cols, dtypes = _get_non_null_cols_and_dtypes(indices, columns)
 
         # Infer common dtypes between numeric columns
         # and combine CategoricalColumn categories
-        categories = find_common_dtypes_and_categories(non_null_cols, dtypes)
+        categories = _find_common_dtypes_and_categories(non_null_cols, dtypes)
 
         # Cast all columns to a common dtype, assign combined categories,
         # and back-fill missing columns with all-null columns
-        cast_cols_to_common_dtypes(indices, columns, dtypes, categories)
+        _cast_cols_to_common_dtypes(indices, columns, dtypes, categories)
 
         # Construct input tables with the index and data columns in the same
         # order. This strips the given index/column names and replaces the
@@ -434,13 +324,13 @@ class Frame(libcudf.table.Table):
             out._index = cudf.RangeIndex(result_index_length)
 
         # Reassign the categories for any categorical table cols
-        reassign_categories(
+        _reassign_categories(
             categories, out._data, indices[first_data_column_position:]
         )
 
         # Reassign the categories for any categorical index cols
         if not isinstance(out._index, cudf.RangeIndex):
-            reassign_categories(
+            _reassign_categories(
                 categories,
                 out._index._data,
                 indices[:first_data_column_position],
@@ -3301,3 +3191,101 @@ def _get_dictionary_array(array):
         return pa.array([], type=pa.null())
     else:
         return array
+
+
+# Create a dictionary of the common, non-null columns
+def _get_non_null_cols_and_dtypes(col_idxs, list_of_columns):
+    # A mapping of {idx: np.dtype}
+    dtypes = dict()
+    # A mapping of {idx: [...columns]}, where `[...columns]`
+    # is a list of columns with at least one valid value for each
+    # column name across all input frames
+    non_null_columns = dict()
+    for idx in col_idxs:
+        for cols in list_of_columns:
+            # Skip columns not in this frame
+            if idx >= len(cols) or cols[idx] is None:
+                continue
+            # Store the first dtype we find for a column, even if it's
+            # all-null. This ensures we always have at least one dtype
+            # for each name. This dtype will be overwritten later if a
+            # non-null Column with the same name is found.
+            if idx not in dtypes:
+                dtypes[idx] = cols[idx].dtype
+            if cols[idx].valid_count > 0:
+                if idx not in non_null_columns:
+                    non_null_columns[idx] = [cols[idx]]
+                else:
+                    non_null_columns[idx].append(cols[idx])
+    return non_null_columns, dtypes
+
+
+def _find_common_dtypes_and_categories(non_null_columns, dtypes):
+    # A mapping of {idx: categories}, where `categories` is a
+    # column of all the unique categorical values from each
+    # categorical column across all input frames
+    categories = dict()
+    for idx, cols in non_null_columns.items():
+        # default to the first non-null dtype
+        dtypes[idx] = cols[0].dtype
+        # If all the non-null dtypes are int/float, find a common dtype
+        if all(is_numerical_dtype(col.dtype) for col in cols):
+            dtypes[idx] = np.find_common_type([col.dtype for col in cols], [])
+        # If all categorical dtypes, combine the categories
+        elif all(
+            isinstance(col, cudf.core.column.CategoricalColumn) for col in cols
+        ):
+            # Combine and de-dupe the categories
+            categories[idx] = (
+                cudf.concat([col.cat().categories for col in cols])
+                .to_series()
+                .drop_duplicates(ignore_index=True)
+                ._column
+            )
+            # Set the column dtype to the codes' dtype. The categories
+            # will be re-assigned at the end
+            dtypes[idx] = min_scalar_type(len(categories[idx]))
+        # Otherwise raise an error if columns have different dtypes
+        elif not all(is_dtype_equal(c.dtype, dtypes[idx]) for c in cols):
+            raise ValueError("All columns must be the same type")
+    return categories
+
+
+def _cast_cols_to_common_dtypes(col_idxs, list_of_columns, dtypes, categories):
+    # Cast all columns to a common dtype, assign combined categories,
+    # and back-fill missing columns with all-null columns
+    for idx in col_idxs:
+        dtype = dtypes[idx]
+        for cols in list_of_columns:
+            # If column not in this df, fill with an all-null column
+            if idx >= len(cols) or cols[idx] is None:
+                n = len(next(x for x in cols if x is not None))
+                cols[idx] = column_empty(row_count=n, dtype=dtype, masked=True)
+            else:
+                # If column is categorical, rebase the codes with the
+                # combined categories, and cast the new codes to the
+                # min-scalar-sized dtype
+                if idx in categories:
+                    cols[idx] = (
+                        cols[idx]
+                        .cat()
+                        ._set_categories(
+                            cols[idx].cat().categories,
+                            categories[idx],
+                            is_unique=True,
+                        )
+                        .codes
+                    )
+                cols[idx] = cols[idx].astype(dtype)
+
+
+def _reassign_categories(categories, cols, col_idxs):
+    for name, idx in zip(cols, col_idxs):
+        if idx in categories:
+            cols[name] = build_categorical_column(
+                categories=categories[idx],
+                codes=as_column(cols[name].base_data, dtype=cols[name].dtype),
+                mask=cols[name].base_mask,
+                offset=cols[name].offset,
+                size=cols[name].size,
+            )

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -23,7 +23,6 @@ from cudf.utils.dtypes import (
     min_scalar_type,
     min_signed_type,
 )
-from cudf.core.index import as_index
 
 
 class Frame(libcudf.table.Table):
@@ -290,7 +289,7 @@ class Frame(libcudf.table.Table):
         for cols in columns:
             table_index = None
             if 1 == first_data_column_position:
-                table_index = as_index(cols[0])
+                table_index = cudf.core.index.as_index(cols[0])
             elif first_data_column_position > 1:
                 table_index = libcudf.table.Table(
                     data=dict(
@@ -338,7 +337,9 @@ class Frame(libcudf.table.Table):
             if not isinstance(
                 out._index, cudf.MultiIndex
             ) and is_categorical_dtype(out._index._values.dtype):
-                out = out.set_index(as_index(out.index._values))
+                out = out.set_index(
+                    cudf.core.index.as_index(out.index._values)
+                )
 
         # Reassign index and column names
         if isinstance(objs[0].columns, pd.MultiIndex):
@@ -346,8 +347,9 @@ class Frame(libcudf.table.Table):
         else:
             out.columns = names
 
-        out._index.name = objs[0]._index.name
-        out._index.names = objs[0]._index.names
+        if not ignore_index:
+            out._index.name = objs[0]._index.name
+            out._index.names = objs[0]._index.names
 
         return out
 

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -439,13 +439,14 @@ class Frame(libcudf.table.Table):
         )
 
         # Reassign the categories for any categorical index cols
-        reassign_categories(
-            categories, out._index._data, indices[:first_data_column_position]
-        )
-        if not isinstance(
-            out._index, cudf.MultiIndex
-        ) and is_categorical_dtype(out._index._values.dtype):
-            out = out.set_index(as_index(out.index._values))
+        if not isinstance(out._index, cudf.RangeIndex):
+            reassign_categories(
+                categories, out._index._data, indices[:first_data_column_position]
+            )
+            if not isinstance(
+                out._index, cudf.MultiIndex
+            ) and is_categorical_dtype(out._index._values.dtype):
+                out = out.set_index(as_index(out.index._values))
 
         # Reassign index and column names
         if isinstance(objs[0].columns, pd.MultiIndex):


### PR DESCRIPTION
Closes #6249 