### PR TITLE
[FIX] README: fix conda commands for outdated python version [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@
 - PR #6291 Fix issue related to row-wise operations in `cudf.DataFrame`
 - PR #6304 Fix span_tests.cu includes
 - PR #6278 Add filter tests for struct columns
+- PR #6335 Fix conda commands for outdated python version
 
 
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
     cudf python=3.7 cudatoolkit=10.2
 ```
 
-Note: cuDF is supported only on Linux, and with Python versions 3.7.
+Note: cuDF is supported only on Linux, and with Python versions 3.7 and later.
 
 See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS and version info. 
 

--- a/README.md
+++ b/README.md
@@ -69,23 +69,24 @@ conda install -c rapidsai -c nvidia -c numba -c conda-forge \
     cudf=0.13 python=3.6 cudatoolkit=10.2
 
 ```
+Note: cuDF stable is supported only on Linux, and with Python versions 3.6 or 3.7.
 
 For the nightly version of `cudf` :
 ```bash
 # for CUDA 10.0
 conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
-    cudf python=3.6 cudatoolkit=10.0
+    cudf python=3.7 cudatoolkit=10.0
 
 # or, for CUDA 10.1
 conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
-    cudf python=3.6 cudatoolkit=10.1
+    cudf python=3.7 cudatoolkit=10.1
 
 # or, for CUDA 10.2
 conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
-    cudf python=3.6 cudatoolkit=10.2
+    cudf python=3.7 cudatoolkit=10.2
 ```
 
-Note: cuDF is supported only on Linux, and with Python versions 3.6 or 3.7.
+Note: cuDF nightly is supported only on Linux, and with Python versions 3.7 or 3.8.
 
 See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS and version info. 
 

--- a/README.md
+++ b/README.md
@@ -56,27 +56,19 @@ cuDF can be installed with conda ([miniconda](https://conda.io/miniconda.html), 
 
 For `cudf version == 0.13` :
 ```bash
-# for CUDA 10.0
+# for CUDA 10.1
 conda install -c rapidsai -c nvidia -c numba -c conda-forge \
-    cudf=0.13 python=3.6 cudatoolkit=10.0
-
-# or, for CUDA 10.1
-conda install -c rapidsai -c nvidia -c numba -c conda-forge \
-    cudf=0.13 python=3.6 cudatoolkit=10.1
+    cudf=0.13 python=3.7 cudatoolkit=10.1
 
 # or, for CUDA 10.2
 conda install -c rapidsai -c nvidia -c numba -c conda-forge \
-    cudf=0.13 python=3.6 cudatoolkit=10.2
+    cudf=0.13 python=3.7 cudatoolkit=10.2
 
 ```
 
 For the nightly version of `cudf` :
 ```bash
-# for CUDA 10.0
-conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
-    cudf python=3.7 cudatoolkit=10.0
-
-# or, for CUDA 10.1
+# for CUDA 10.1
 conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
     cudf python=3.7 cudatoolkit=10.1
 
@@ -85,7 +77,7 @@ conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
     cudf python=3.7 cudatoolkit=10.2
 ```
 
-Note: cuDF is supported only on Linux, and with Python versions 3.6 or 3.7 (only with 3.7 in nightly version).
+Note: cuDF is supported only on Linux, and with Python versions 3.7.
 
 See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS and version info. 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ conda install -c rapidsai -c nvidia -c numba -c conda-forge \
     cudf=0.13 python=3.6 cudatoolkit=10.2
 
 ```
-Note: cuDF stable is supported only on Linux, and with Python versions 3.6 or 3.7.
+Note: the nightly version of cuDF is supported only on Linux, and with Python versions 3.6 or 3.7.
 
 For the nightly version of `cudf` :
 ```bash
@@ -86,7 +86,7 @@ conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
     cudf python=3.7 cudatoolkit=10.2
 ```
 
-Note: cuDF nightly is supported only on Linux, and with Python versions 3.7 or 3.8.
+Note: the nightly version of cuDF is supported only on Linux, and with Python versions 3.7.
 
 See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS and version info. 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ conda install -c rapidsai -c nvidia -c numba -c conda-forge \
     cudf=0.13 python=3.6 cudatoolkit=10.2
 
 ```
-Note: the nightly version of cuDF is supported only on Linux, and with Python versions 3.6 or 3.7.
 
 For the nightly version of `cudf` :
 ```bash
@@ -86,7 +85,7 @@ conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
     cudf python=3.7 cudatoolkit=10.2
 ```
 
-Note: the nightly version of cuDF is supported only on Linux, and with Python versions 3.7.
+Note: cuDF is supported only on Linux, and with Python versions 3.6 or 3.7 (only with 3.7 in nightly version).
 
 See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS and version info. 
 


### PR DESCRIPTION
I failed to install the nightly version of cudf via conda command provided in README; `conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge cudf python=3.6 cudatoolkit=10.2`. And I installed it successfully with `python 3.7`.
According to error log (which partially pasted below), it seems that the nightly version of cudf requires` python[version='>=3.7,<3.8.0a0']`.
So, I am trying to fix conda commands with this PR.  

```
Package libffi conflicts for:
certifi -> python[version='>=3.8,<3.9.0a0'] -> libffi[version='3.2.*|>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.2.1,<3.3a0']
libffi
cudf -> python[version='>=3.7,<3.8.0a0'] -> libffi[version='>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.2.1,<3.3a0']
setuptools -> python[version='>=3.6,<3.7.0a0'] -> libffi[version='3.2.*|>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.2.1,<3.3a0']
python=3.6 -> libffi[version='3.2.*|>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.2.1,<3.3a0']
pip -> python[version='>=3'] -> libffi[version='3.2.*|>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.2.1,<3.3a0']

Package readline conflicts for:
pip -> python[version='>=3'] -> readline[version='6.2.*|7.0|>=7.0,<8.0a0|>=8.0,<9.0a0|7.*|7.0.*']
cudf -> python[version='>=3.7,<3.8.0a0'] -> readline[version='>=7.0,<8.0a0|>=8.0,<9.0a0']
setuptools -> python[version='>=3.6,<3.7.0a0'] -> readline[version='6.2.*|7.0|>=7.0,<8.0a0|>=8.0,<9.0a0|7.*|7.0.*']
readline
python=3.6 -> sqlite[version='>=3.23.1,<4.0a0'] -> readline=7.0
sqlite -> readline[version='6.2.*|7.0|7.0.*|>=7.0,<8.0a0|>=8.0,<9.0a0']
certifi -> python[version='>=3.8,<3.9.0a0'] -> readline[version='6.2.*|7.0|>=7.0,<8.0a0|>=8.0,<9.0a0|7.*|7.0.*']
python=3.6 -> readline[version='6.2.*|7.0|>=7.0,<8.0a0|>=8.0,<9.0a0|7.*']
```
