### PR TITLE
[REVIEW] fix array out-of-bound errors in Orc writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 - PR #6137 Fix issue where `np.nan` is being return instead of `NAT` for datetime/duration types
 - PR #6298 Fix gcc-9 compilation error in dictionary/remove_keys.cu
 - PR #6172 Fix slice issue with empty column
+- PR #6342 Fix array out-of-bound errors in Orc writer
 - PR #6154 Warnings on row-wise op only when non-numeric columns are found.
 - PR #6150 Fix issue related to inferring `datetime64` format with UTC timezone in string data
 - PR #6179 `make_elements` copies to `iterator` without adjusting `size`

--- a/cpp/src/io/csv/csv_common.h
+++ b/cpp/src/io/csv/csv_common.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 class SerialTrieNode;
 
 namespace cudf {

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -866,9 +866,9 @@ void writer::impl::write_index_stream(int32_t stripe_id,
     if (record[0] >= 0) {
       record[0] += chunk.strm_len[type];
       while ((record[1] >= 0) && (static_cast<size_t>(record[0]) >= compression_blocksize_) &&
-             (record[3] + 3 + comp_out[record[1]].bytes_written < static_cast<size_t>(record[4]))) {
+             (record[2] + 3 + comp_out[record[1]].bytes_written < static_cast<size_t>(record[3]))) {
         record[0] -= compression_blocksize_;
-        record[3] += 3 + comp_out[record[1]].bytes_written;
+        record[2] += 3 + comp_out[record[1]].bytes_written;
         record[1] += 1;
       }
     }

--- a/cpp/src/strings/char_types/is_flags.h
+++ b/cpp/src/strings/char_types/is_flags.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 //
 // 8-bit flag for each code-point.
 //


### PR DESCRIPTION
Fixes #6333 

gcc-10 also complained about the missing includes.

@OlivierNV