### PR TITLE
Fix ambiguous constructor compile error with devtoolset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 - PR #6304 Fix span_tests.cu includes
 - PR #6331 Avoids materializing `RangeIndex` during frame concatnation (when not needed)
 - PR #6278 Add filter tests for struct columns
+- PR #6345 Fix ambiguous constructor compile error with devtoolset
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -689,14 +689,16 @@ TEST_F(ParquetWriterTest, MultipleMismatchedSources)
   auto const int5file = create_parquet_file<int>(5);
   {
     auto const float5file = create_parquet_file<float>(5);
+    std::vector<std::string> files{int5file, float5file};
     cudf_io::parquet_reader_options const read_opts =
-      cudf_io::parquet_reader_options::builder(cudf_io::source_info{{int5file, float5file}});
+      cudf_io::parquet_reader_options::builder(cudf_io::source_info{files});
     EXPECT_THROW(cudf_io::read_parquet(read_opts), cudf::logic_error);
   }
   {
     auto const int10file = create_parquet_file<int>(10);
+    std::vector<std::string> files{int5file, int10file};
     cudf_io::parquet_reader_options const read_opts =
-      cudf_io::parquet_reader_options::builder(cudf_io::source_info{{int5file, int10file}});
+      cudf_io::parquet_reader_options::builder(cudf_io::source_info{files});
     EXPECT_THROW(cudf_io::read_parquet(read_opts), cudf::logic_error);
   }
 }


### PR DESCRIPTION
Fixes #6334 

I was able to reproduce the ambiguous constructor build error with devtoolset-7 (based on GCC 7.3.1) and devtoolset-8 (based on GCC 8.3.1).  I can't readily explain why I do not see the error outside of the devtoolset environment with GCC 7.5.0, but it's easy to update the test so all the build environments are happy.