### PR TITLE
WIP: Use `pandas.util.testing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - PR #6163 Use `Column.full` instead of `scalar_broadcast_to` or `cupy.zeros`
 - PR #6176 Fix cmake warnings for GoogleTest, GoogleBenchmark, and Arrow external projects
 - PR #6149 Update to Arrow v1.0.1
+- PR #6349 Use `pandas.utils.testing`
 - PR #6201 Expose libcudf test utilities headers for external project use.
 - PR #6174 Data profile support in random data generator; Expand cuIO benchmarks
 - PR #6189 Avoid deprecated pyarrow.compat for parquet

--- a/python/cudf/cudf/testing/testing.py
+++ b/python/cudf/cudf/testing/testing.py
@@ -575,7 +575,7 @@ def assert_frame_equal(
         obj=f"{obj}.index",
     )
 
-    pd.testing.assert_index_equal(
+    pd.util.testing.assert_index_equal(
         left.columns,
         right.columns,
         exact=check_column_type,

--- a/python/cudf/cudf/tests/test_testing.py
+++ b/python/cudf/cudf/tests/test_testing.py
@@ -32,7 +32,7 @@ def test_basic_assert_index_equal(
 
     kind = None
     try:
-        pd.testing.assert_index_equal(
+        pd.util.testing.assert_index_equal(
             p_left,
             p_right,
             exact=exact,
@@ -90,7 +90,7 @@ def test_basic_assert_series_equal(
 
     kind = None
     try:
-        pd.testing.assert_series_equal(
+        pd.util.testing.assert_series_equal(
             p_left,
             p_right,
             check_names=check_names,
@@ -157,7 +157,7 @@ def test_basic_assert_frame_equal(
 
     kind = None
     try:
-        pd.testing.assert_frame_equal(
+        pd.util.testing.assert_frame_equal(
             p_left,
             p_right,
             check_exact=check_exact,
@@ -200,7 +200,7 @@ def test_datetime_like_compaibility(rdata, check_datetimelike_compat):
 
     kind = None
     try:
-        pd.testing.assert_series_equal(
+        pd.util.testing.assert_series_equal(
             psr1, psr2, check_datetimelike_compat=check_datetimelike_compat
         )
     except BaseException as e:
@@ -235,7 +235,7 @@ def test_multiindex_equal(rdata):
 
     kind = None
     try:
-        pd.testing.assert_index_equal(pidx1, pidx2)
+        pd.util.testing.assert_index_equal(pidx1, pidx2)
     except BaseException as e:
         kind = type(e)
 
@@ -260,7 +260,7 @@ def test_series_different_type_cases(dtype, check_exact, check_dtype):
 
     kind = None
     try:
-        pd.testing.assert_series_equal(
+        pd.util.testing.assert_series_equal(
             psr1, psr2, check_exact=check_exact, check_dtype=check_dtype
         )
     except BaseException as e:
@@ -290,7 +290,7 @@ def test_range_index_and_int_index_eqaulity(index, exact):
 
     kind = None
     try:
-        pd.testing.assert_index_equal(pidx1, pidx2, exact=exact)
+        pd.util.testing.assert_index_equal(pidx1, pidx2, exact=exact)
     except BaseException as e:
         kind = type(e)
 


### PR DESCRIPTION
`pandas.testing` is deprecated. The preferred way forward is to use `pandas.util.testing`. So this updates cuDF usage accordingly.