### PR TITLE
Preemptive fix for possible dask_cudf.read_parquet CI failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 - PR #6331 Avoids materializing `RangeIndex` during frame concatnation (when not needed)
 - PR #6278 Add filter tests for struct columns
 - PR #6335 Fix conda commands for outdated python version
+- PR #6380 Avoid problematic column-index check in dask_cudf.read_parquet test
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
@@ -252,6 +252,9 @@ def test_roundtrip_from_dask_partitioned(tmpdir, parts, daskcudf, metadata):
             partition_on=parts,
         )
     try:
+        # Preemptive change for dask/dask#6534.
+        # TODO: Update `CudfEngine` to leverage pyarrow.dataset
+        # API after dask/dask#6534 is merged.
         df_read = dd.read_parquet(tmpdir, engine="pyarrow-legacy")
     except ValueError:
         df_read = dd.read_parquet(tmpdir, engine="pyarrow")

--- a/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
@@ -254,6 +254,8 @@ def test_roundtrip_from_dask_partitioned(tmpdir, parts, daskcudf, metadata):
     df_read = dd.read_parquet(tmpdir, engine="pyarrow")
     gdf_read = dask_cudf.read_parquet(tmpdir)
 
+    # TODO: Avoid column selection after `CudfEngine`
+    # can be aligned with dask/dask#6534
     columns = list(df_read.columns)
     assert set(df_read.columns) == set(gdf_read.columns)
     dd.assert_eq(

--- a/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
@@ -251,7 +251,10 @@ def test_roundtrip_from_dask_partitioned(tmpdir, parts, daskcudf, metadata):
             write_metadata_file=metadata,
             partition_on=parts,
         )
-    df_read = dd.read_parquet(tmpdir, engine="pyarrow")
+    try:
+        df_read = dd.read_parquet(tmpdir, engine="pyarrow-legacy")
+    except ValueError:
+        df_read = dd.read_parquet(tmpdir, engine="pyarrow")
     gdf_read = dask_cudf.read_parquet(tmpdir)
 
     dd.assert_eq(


### PR DESCRIPTION
Trivial/minor change to a single `dask_cudf.read_parquet` test.

**Motivation**:

As [dask#6534](https://github.com/dask/dask/pull/6534) nears a "merge-ready" state, I am doing my best to avoid future compatibility problems between dask_cudf and post-6534 dask.  That PR will most likely change the default `"pyarrow"` engine from `ArrowEngine` to `ArrowDatasetEngine`.  That change should not break any `dask_cudf.read_parquet` functionality, but it **will**  (likely) affect the behavior of `dask.dataframe.read_parquet(.., engine="pyarrow")`.  More specifically, the order that hive-partitioned columns are appended to the final DataFrame may differ.

This PR simply avoids the column-index check in one test (`test_roundtrip_from_dask_partitioned`), since it is expected to fail after dask#6534 is merged.  Note that I will be following up with an additional PR to actually use the new `ArrowDatasetEngine`  functionality after it becomes available.  **This PR is only meant to avoid temporary (but predictable) CI pain.**

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
