### PR TITLE
[REVIEW] remove unnecessary std::move() call [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 - PR #6154 Warnings on row-wise op only when non-numeric columns are found.
 - PR #6150 Fix issue related to inferring `datetime64` format with UTC timezone in string data
 - PR #6179 `make_elements` copies to `iterator` without adjusting `size`
+- PR #6387 Remove extra `std::move` call in java/src/main/native/src/map_lookup.cu
 - PR #6182 Fix cmake build of arrow
 - PR #6288 Fix gcc-9 compilation error with `ColumnVectorJni.cpp`
 - PR #6173 Fix normalize_characters offset logic on sliced strings column

--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -125,7 +125,7 @@ std::unique_ptr<column> get_gather_map_for_map_values(column_view const& input,
 
   CHECK_CUDA(stream);
 
-  return std::move(gather_map);
+  return gather_map;
 }
 
 }  // namespace


### PR DESCRIPTION
Newer gcc versions complain about this:
```console
     [exec] [ 91%] Building CUDA object CMakeFiles/cudfjni.dir/src/map_lookup.cu.o
     [exec] /home/rou/src/cudf/java/src/main/native/src/map_lookup.cu: In instantiation of ‘std::unique_ptr<cudf::column> cudf::_GLOBAL__N__57_tmpxft_00012f16_00000000_10_map_lookup_compute_80_cpp1_ii_ab7b9cf2::get_gather_map_for_map_values(const cudf::column_view&, cudf::string_scalar&, rmm::mr::device_memory_resource*, cudaStream_t) [with bool has_nulls = true; cudaStream_t = CUstream_st*]’:
     [exec] /home/rou/src/cudf/java/src/main/native/src/map_lookup.cu:158:104:   required from here
     [exec] /home/rou/src/cudf/java/src/main/native/src/map_lookup.cu:128:28: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
     [exec]   128 |   return std::move(gather_map);
     [exec]       |                            ^
     [exec] /home/rou/src/cudf/java/src/main/native/src/map_lookup.cu:128:28: note: remove ‘std::move’ call
     [exec] /home/rou/src/cudf/java/src/main/native/src/map_lookup.cu: In instantiation of ‘std::unique_ptr<cudf::column> cudf::_GLOBAL__N__57_tmpxft_00012f16_00000000_10_map_lookup_compute_80_cpp1_ii_ab7b9cf2::get_gather_map_for_map_values(const cudf::column_view&, cudf::string_scalar&, rmm::mr::device_memory_resource*, cudaStream_t) [with bool has_nulls = false; cudaStream_t = CUstream_st*]’:
     [exec] /home/rou/src/cudf/java/src/main/native/src/map_lookup.cu:158:182:   required from here
     [exec] /home/rou/src/cudf/java/src/main/native/src/map_lookup.cu:128:28: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
     [exec] /home/rou/src/cudf/java/src/main/native/src/map_lookup.cu:128:28: note: remove ‘std::move’ call
     [exec] cc1plus: all warnings being treated as errors
     [exec] make[2]: *** [CMakeFiles/cudfjni.dir/build.make:212: CMakeFiles/cudfjni.dir/src/map_lookup.cu.o] Error 1
     [exec] make[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/cudfjni.dir/all] Error 2
     [exec] make: *** [Makefile:103: all] Error 2
```
@mythrocks 