### PR TITLE
[REVIEW] add instruction for building libboost_filesystem from source [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #5953 Use stable sort when doing a sort groupby
 - PR #5973 Link to the Code of Conduct in CONTRIBUTING.md
 - PR #6354 Perform shallow clone of external projects
+- PR #6388 Add documentation for building `libboost_filesystem.a` from source
 - PR #5917 Just use `None` for `strides` in `Buffer`
 - PR #6015 Upgrade CUB/Thrust to the latest commit
 - PR #5971 Add cuStreamz README for basic installation and use

--- a/java/README.md
+++ b/java/README.md
@@ -54,8 +54,17 @@ Build the native code first, and make sure the a JDK is installed and available.
 
 When building libcudf, make sure you install boost first:
 ```bash
-# Install Boost C++ for Ubuntu 16.04/18.04
-$ sudo apt install libboost-filesystem-dev
+# Install Boost C++ for Ubuntu 16.04/18.04/20.04
+sudo apt install libboost-filesystem-dev
+```
+or for a smaller installation footprint (Boost is a large library), build it from the source:
+```bash
+wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
+tar xvf boost_1_74_0.tar.bz2
+cd boost_1_74_0
+./bootstrap.sh --with-libraries=filesystem
+./b2 cxxflags=-fPIC link=static
+sudo cp stage/lib/libboost_filesystem.a /usr/local/lib/
 ```
 and pass in the cmake options
 `-DARROW_STATIC_LIB=ON -DBoost_USE_STATIC_LIBS=ON` so that Apache Arrow and Boost libraries are


### PR DESCRIPTION
In case anyone is picky about their environment. :)
```console
$ sudo apt install libboost-filesystem-dev
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  libboost-filesystem1.71-dev libboost-filesystem1.71.0 libboost-system1.71-dev libboost-system1.71.0 libboost1.71-dev
Suggested packages:
  libboost1.71-doc libboost-atomic1.71-dev libboost-chrono1.71-dev libboost-container1.71-dev libboost-context1.71-dev libboost-contract1.71-dev libboost-coroutine1.71-dev libboost-date-time1.71-dev
  libboost-exception1.71-dev libboost-fiber1.71-dev libboost-graph1.71-dev libboost-graph-parallel1.71-dev libboost-iostreams1.71-dev libboost-locale1.71-dev libboost-log1.71-dev libboost-math1.71-dev
  libboost-mpi1.71-dev libboost-mpi-python1.71-dev libboost-numpy1.71-dev libboost-program-options1.71-dev libboost-python1.71-dev libboost-random1.71-dev libboost-regex1.71-dev libboost-serialization1.71-dev
  libboost-stacktrace1.71-dev libboost-test1.71-dev libboost-thread1.71-dev libboost-timer1.71-dev libboost-type-erasure1.71-dev libboost-wave1.71-dev libboost1.71-tools-dev libmpfrc++-dev libntl-dev
The following NEW packages will be installed:
  libboost-filesystem-dev libboost-filesystem1.71-dev libboost-filesystem1.71.0 libboost-system1.71-dev libboost-system1.71.0 libboost1.71-dev
0 upgraded, 6 newly installed, 0 to remove and 0 not upgraded.
Need to get 9,981 kB of archives.
After this operation, 147 MB of additional disk space will be used.
Do you want to continue? [Y/n]
```
@andygrove @jlowe 
