### PR TITLE
[REVIEW] Fix `build.sh` when `PARALLEL_LEVEL` env variable isn't set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,7 @@
 - PR #6304 Fix span_tests.cu includes
 - PR #6331 Avoids materializing `RangeIndex` during frame concatnation (when not needed)
 - PR #6278 Add filter tests for struct columns
-- PR #XXXX Fix `build.sh` when `PARALLEL_LEVEL` environment variable isn't set
+- PR #6397 Fix `build.sh` when `PARALLEL_LEVEL` environment variable isn't set
 - PR #6345 Fix ambiguous constructor compile error with devtoolset
 - PR #6335 Fix conda commands for outdated python version
 - PR #6380 Avoid problematic column-index check in dask_cudf.read_parquet test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@
 - PR #6304 Fix span_tests.cu includes
 - PR #6331 Avoids materializing `RangeIndex` during frame concatnation (when not needed)
 - PR #6278 Add filter tests for struct columns
+- PR #XXXX Fix `build.sh` when `PARALLEL_LEVEL` environment variable isn't set
 - PR #6345 Fix ambiguous constructor compile error with devtoolset
 - PR #6335 Fix conda commands for outdated python version
 - PR #6380 Avoid problematic column-index check in dask_cudf.read_parquet test

--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ BUILD_PER_THREAD_DEFAULT_STREAM=OFF
 #  FIXME: if INSTALL_PREFIX is not set, check PREFIX, then check
 #         CONDA_PREFIX, but there is no fallback from there!
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX}}}
-PARALLEL_LEVEL=${PARALLEL_LEVEL:=""}
+PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
 
 function hasArg {
     (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")


### PR DESCRIPTION
Currently if `PARALLEL_LEVEL` is not set, it defaults to an empty string. Later in the script this causes a command to look like: `python setup.py build_ext --inplace -j` which isn't allowed as for Python you need to add a number of threads after `-j`.

To fix this, defaulting `PARALLEL_LEVEL` to the output of `nproc` which should be the default behavior of passing `-j` anyway.