### PR TITLE
[REVIEW] remove unused variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 - PR #6369 Add dictionary support to `cudf::find_and_replace`
 - PR #6377 Update ci/local/README.md
 - PR #6383 Removed `move.pxd`, use standard library `move`
+- PR #6400 Removed unused variables
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -7309,7 +7309,7 @@ def _get_union_of_indices(indexes):
 def _get_union_of_series_names(series_list):
     names_list = []
     unnamed_count = 0
-    for idx, series in enumerate(series_list):
+    for series in series_list:
         if series.name is None:
             names_list.append(f"Unnamed {unnamed_count}")
             unnamed_count += 1

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1047,7 +1047,7 @@ class Frame(libcudf.table.Table):
             frame._copy_categories(self, include_index=keep_index)
 
         if npartitions:
-            for i in range(npartitions - len(result)):
+            for _ in range(npartitions - len(result)):
                 result.append(self._empty_like(keep_index))
 
         return result
@@ -1321,7 +1321,7 @@ class Frame(libcudf.table.Table):
 
         copy_data = self._data.copy(deep=True)
 
-        for name, col in copy_data.items():
+        for name in copy_data.keys():
             if name in value and value[name] is not None:
                 copy_data[name] = copy_data[name].fillna(value[name],)
 

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -67,7 +67,7 @@ class GroupBy(Serializable):
             raise
 
     def __iter__(self):
-        group_names, offsets, grouped_keys, grouped_values = self._grouped()
+        group_names, offsets, _, grouped_values = self._grouped()
         if isinstance(group_names, cudf.Index):
             group_names = group_names.to_pandas()
         for i, name in enumerate(group_names):

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -680,7 +680,7 @@ class MultiIndex(Index):
             # Pandas returns an empty Series with a tuple as name
             # the one expected result column
             series_name = []
-            for idx, code in enumerate(index._source_data.columns):
+            for code in index._source_data.columns:
                 series_name.append(index._source_data[code][0])
             result = cudf.Series([])
             result.name = tuple(series_name)

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -447,7 +447,7 @@ def melt(
 
     # Step 2: add variable
     var_cols = []
-    for i, var in enumerate(value_vars):
+    for i, _ in enumerate(value_vars):
         var_cols.append(
             cudf.Series(cudf.core.column.full(N, i, dtype=np.int8))
         )

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -977,7 +977,7 @@ class Series(Frame, Serializable):
         return self.to_string()
 
     def __repr__(self):
-        width, height = get_terminal_size()
+        _, height = get_terminal_size()
         max_rows = (
             height
             if get_option("display.max_rows") == 0

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -98,7 +98,7 @@ def write_to_dataset(
             raise ValueError("No data left to save outside partition columns")
 
         #  Loop through the partition groups
-        for i, sub_df in enumerate(
+        for _, sub_df in enumerate(
             _get_partition_groups(
                 df, partition_cols, preserve_index=preserve_index
             )


### PR DESCRIPTION
Hello from Chicago 👋 

I've been getting familiar with `cudf` recently. I wanted to contribute back to this project, so I ran `pylint` over this project's Python code. A lot of the warnings from that linter are subjective style things that I think are best ignored or left to maintainers, but I did find a few small warnings that I think should be fixed.

This PR proposes removing a few unused variables. I think this makes the affected code a little easier to read, and reduces the risk of name conflicts between variables.

I specifically am proposing fixing these warnings:

```text
python/cudf/cudf/core/dataframe.py:7312:8: W0612: Unused variable 'idx' (unused-variable)
python/cudf/cudf/core/reshape.py:450:11: W0612: Unused variable 'var' (unused-variable)
python/cudf/cudf/core/series.py:980:8: W0612: Unused variable 'width' (unused-variable)
python/cudf/cudf/core/frame.py:1050:16: W0612: Unused variable 'i' (unused-variable)
python/cudf/cudf/core/frame.py:1324:18: W0612: Unused variable 'col' (unused-variable)
python/cudf/cudf/core/multiindex.py:683:16: W0612: Unused variable 'idx' (unused-variable)
python/cudf/cudf/core/groupby/groupby.py:70:30: W0612: Unused variable 'grouped_keys' (unused-variable)
python/cudf/cudf/io/parquet.py:101:12: W0612: Unused variable 'i' (unused-variable)
```

which can be reproduced like this:

```shell
pylint python/ | grep unused-variable
```

Thank you for your time and consideration.
