### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@
 - PR #6335 Fix conda commands for outdated python version
 - PR #6378 Fix index handling in `fillna` and incorrect pytests
 - PR #6380 Avoid problematic column-index check in dask_cudf.read_parquet test
+- PR #6402 Update JNI build to pull fixed nvcomp commit
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
+++ b/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
@@ -22,7 +22,7 @@ include(ExternalProject)
 
 ExternalProject_Add(nvcomp
     GIT_REPOSITORY  https://github.com/NVIDIA/nvcomp.git
-    GIT_TAG         branch-1.1
+    GIT_TAG         9ee396c2d7f0d5f6a8146b7e74f88f2ad012c010
     GIT_SHALLOW     true
     SOURCE_DIR      "${NVCOMP_ROOT}/nvcomp"
     BINARY_DIR      "${NVCOMP_ROOT}/build"


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.