### PR TITLE
[REVIEW] fix uses of dangerous default values in Python code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,9 +167,8 @@
 - PR #6335 Fix conda commands for outdated python version
 - PR #6378 Fix index handling in `fillna` and incorrect pytests
 - PR #6380 Avoid problematic column-index check in dask_cudf.read_parquet test
-- PR #6410 Fix uses of dangerous default values in Python code
 - PR #6402 Update JNI build to pull fixed nvcomp commit
-
+- PR #6410 Fix uses of dangerous default values in Python code
 
 # cuDF 0.15.0 (26 Aug 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@
 - PR #6335 Fix conda commands for outdated python version
 - PR #6378 Fix index handling in `fillna` and incorrect pytests
 - PR #6380 Avoid problematic column-index check in dask_cudf.read_parquet test
+- PR #6410 Fix uses of dangerous default values in Python code
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -13,7 +13,7 @@ from cudf.utils.utils import (
 
 
 class ColumnAccessor(MutableMapping):
-    def __init__(self, data={}, multiindex=False, level_names=None):
+    def __init__(self, data=None, multiindex=False, level_names=None):
         """
         Parameters
         ----------
@@ -27,6 +27,7 @@ class ColumnAccessor(MutableMapping):
             For a non-hierarchical index, a tuple of size 1
             may be passe.
         """
+        data = data or {}
         # TODO: we should validate the keys of `data`
         if isinstance(data, ColumnAccessor):
             multiindex = multiindex or data.multiindex

--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -27,7 +27,8 @@ class ColumnAccessor(MutableMapping):
             For a non-hierarchical index, a tuple of size 1
             may be passe.
         """
-        data = data or {}
+        if data is None:
+            data = {}
         # TODO: we should validate the keys of `data`
         if isinstance(data, ColumnAccessor):
             multiindex = multiindex or data.multiindex

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4177,8 +4177,8 @@ class DataFrame(Frame, Serializable):
         # can't use `annotate` decorator here as we inspect the calling
         # environment.
         with annotate("QUERY", color="purple", domain="cudf_python"):
-            if local_dir is None:
-                local_dir = {}
+            if local_dict is None:
+                local_dict = {}
 
             if self.empty:
                 return self.copy()

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4174,11 +4174,12 @@ class DataFrame(Frame, Serializable):
                         datetimes
         1 2018-10-08T00:00:00.000
         """
-        if local_dir is None:
-            local_dir = {}
         # can't use `annotate` decorator here as we inspect the calling
         # environment.
         with annotate("QUERY", color="purple", domain="cudf_python"):
+            if local_dir is None:
+                local_dir = {}
+
             if self.empty:
                 return self.copy()
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4110,7 +4110,7 @@ class DataFrame(Frame, Serializable):
             win_type=win_type,
         )
 
-    def query(self, expr, local_dict={}):
+    def query(self, expr, local_dict=None):
         """
         Query with a boolean expression using Numba to compile a GPU kernel.
 
@@ -4174,6 +4174,7 @@ class DataFrame(Frame, Serializable):
                         datetimes
         1 2018-10-08T00:00:00.000
         """
+        local_dir = local_dir or {}
         # can't use `annotate` decorator here as we inspect the calling
         # environment.
         with annotate("QUERY", color="purple", domain="cudf_python"):
@@ -4282,7 +4283,7 @@ class DataFrame(Frame, Serializable):
         func,
         incols,
         outcols,
-        kwargs={},
+        kwargs=None,
         pessimistic_nulls=True,
         chunks=None,
         blkct=None,
@@ -4328,6 +4329,7 @@ class DataFrame(Frame, Serializable):
         --------
         DataFrame.apply_rows
         """
+        kwargs = kwargs or {}
         if chunks is None:
             raise ValueError("*chunks* must be defined")
         return applyutils.apply_chunks(

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4174,7 +4174,8 @@ class DataFrame(Frame, Serializable):
                         datetimes
         1 2018-10-08T00:00:00.000
         """
-        local_dir = local_dir or {}
+        if local_dir is None:
+            local_dir = {}
         # can't use `annotate` decorator here as we inspect the calling
         # environment.
         with annotate("QUERY", color="purple", domain="cudf_python"):
@@ -4329,7 +4330,8 @@ class DataFrame(Frame, Serializable):
         --------
         DataFrame.apply_rows
         """
-        kwargs = kwargs or {}
+        if kwargs is None:
+            kwargs = {}
         if chunks is None:
             raise ValueError("*chunks* must be defined")
         return applyutils.apply_chunks(

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -483,7 +483,7 @@ def get_dummies(
     prefix_sep="_",
     dummy_na=False,
     columns=None,
-    cats={},
+    cats=None,
     sparse=False,
     drop_first=False,
     dtype="uint8",
@@ -552,6 +552,7 @@ def get_dummies(
     2      0      0      1       0
     3      0      0      0       1
     """
+    cats = cats or {}
     if sparse:
         raise NotImplementedError("sparse is not supported yet")
 

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -552,7 +552,8 @@ def get_dummies(
     2      0      0      1       0
     3      0      0      0       1
     """
-    cats = cats or {}
+    if cats is None:
+        cats = {}
     if sparse:
         raise NotImplementedError("sparse is not supported yet")
 

--- a/python/cudf/cudf/datasets.py
+++ b/python/cudf/cudf/datasets.py
@@ -12,7 +12,7 @@ def timeseries(
     start="2000-01-01",
     end="2000-01-31",
     freq="1s",
-    dtypes={"name": "category", "id": int, "x": float, "y": float},
+    dtypes=None,
     seed=None,
 ):
     """ Create timeseries dataframe with random data
@@ -25,7 +25,9 @@ def timeseries(
         End of time series
     dtypes : dict
         Mapping of column names to types.
-        Valid types include {float, int, str, 'category'}
+        Valid types include {float, int, str, 'category'}.
+        If none is provided, this defaults to
+        ``{"name": "category", "id": int, "x": float, "y": float}``
     freq : string
         String like '2s' or '1H' or '12W' for the time series frequency
     seed : int (optional)
@@ -43,6 +45,7 @@ def timeseries(
     2000-01-01 00:00:03  1016   Yvonne  0.620456  0.767270
     2000-01-01 00:00:04   998   Ursula  0.684902 -0.463278
     """
+    dtypes = dtypes or {"name": "category", "id": int, "x": float, "y": float}
 
     index = pd.DatetimeIndex(
         pd.date_range(start, end, freq=freq, name="timestamp")
@@ -58,7 +61,7 @@ def timeseries(
 
 
 def randomdata(
-    nrows=10, dtypes={"id": int, "x": float, "y": float}, seed=None
+    nrows=10, dtypes=None, seed=None
 ):
     """ Create a dataframe with random data
 
@@ -69,6 +72,8 @@ def randomdata(
     dtypes : dict
         Mapping of column names to types.
         Valid types include {float, int, str, 'category'}
+        If none is provided, this defaults to
+        ``{"id": int, "x": float, "y": float}``
     seed : int (optional)
         Randomstate seed
 
@@ -84,6 +89,7 @@ def randomdata(
     3  1002 0.9280495300010041  0.5137701393017848
     4   976 0.9089527839187654  0.9881063385586304
     """
+    dtypes = dtypes or {"id": int, "x": float, "y": float}
     state = np.random.RandomState(seed)
     columns = dict((k, make[dt](nrows, state)) for k, dt in dtypes.items())
     df = pd.DataFrame(columns, columns=sorted(columns))

--- a/python/cudf/cudf/datasets.py
+++ b/python/cudf/cudf/datasets.py
@@ -9,11 +9,7 @@ __all__ = ["timeseries", "randomdata"]
 # TODO:
 # change default of name from category to str type when nvstring are merged
 def timeseries(
-    start="2000-01-01",
-    end="2000-01-31",
-    freq="1s",
-    dtypes=None,
-    seed=None,
+    start="2000-01-01", end="2000-01-31", freq="1s", dtypes=None, seed=None,
 ):
     """ Create timeseries dataframe with random data
 
@@ -61,9 +57,7 @@ def timeseries(
     return cudf.from_pandas(df)
 
 
-def randomdata(
-    nrows=10, dtypes=None, seed=None
-):
+def randomdata(nrows=10, dtypes=None, seed=None):
     """ Create a dataframe with random data
 
     Parameters

--- a/python/cudf/cudf/datasets.py
+++ b/python/cudf/cudf/datasets.py
@@ -45,7 +45,8 @@ def timeseries(
     2000-01-01 00:00:03  1016   Yvonne  0.620456  0.767270
     2000-01-01 00:00:04   998   Ursula  0.684902 -0.463278
     """
-    dtypes = dtypes or {"name": "category", "id": int, "x": float, "y": float}
+    if dtypes is None:
+        dtypes = {"name": "category", "id": int, "x": float, "y": float}
 
     index = pd.DatetimeIndex(
         pd.date_range(start, end, freq=freq, name="timestamp")
@@ -89,7 +90,8 @@ def randomdata(
     3  1002 0.9280495300010041  0.5137701393017848
     4   976 0.9089527839187654  0.9881063385586304
     """
-    dtypes = dtypes or {"id": int, "x": float, "y": float}
+    if dtypes is None:
+        dtypes = {"id": int, "x": float, "y": float}
     state = np.random.RandomState(seed)
     columns = dict((k, make[dt](nrows, state)) for k, dt in dtypes.items())
     df = pd.DataFrame(columns, columns=sorted(columns))

--- a/python/cudf/cudf/tests/dataset_generator.py
+++ b/python/cudf/cudf/tests/dataset_generator.py
@@ -72,10 +72,10 @@ class Parameters:
     """
 
     def __init__(
-        self, num_rows=2048, column_parameters=[], seed=None,
+        self, num_rows=2048, column_parameters=None, seed=None,
     ):
         self.num_rows = num_rows
-        self.column_parameters = column_parameters
+        self.column_parameters = column_parameters or []
         self.seed = seed
 
 
@@ -170,7 +170,7 @@ def _generate_column(column_params, num_rows):
 def generate(
     path,
     parameters,
-    format={"name": "parquet", "row_group_size": 64},
+    format=None,
     use_threads=True,
 ):
     """
@@ -185,7 +185,7 @@ def generate(
     format : Dict
         Format to write
     """
-
+    format = format or {"name": "parquet", "row_group_size": 64}
     df = get_dataframe(parameters, use_threads)
 
     # Write

--- a/python/cudf/cudf/tests/dataset_generator.py
+++ b/python/cudf/cudf/tests/dataset_generator.py
@@ -170,10 +170,7 @@ def _generate_column(column_params, num_rows):
 
 
 def generate(
-    path,
-    parameters,
-    format=None,
-    use_threads=True,
+    path, parameters, format=None, use_threads=True,
 ):
     """
     Generate dataset using given parameters and write to given format

--- a/python/cudf/cudf/tests/dataset_generator.py
+++ b/python/cudf/cudf/tests/dataset_generator.py
@@ -75,7 +75,9 @@ class Parameters:
         self, num_rows=2048, column_parameters=None, seed=None,
     ):
         self.num_rows = num_rows
-        self.column_parameters = column_parameters or []
+        if column_parameters is None:
+            column_parameters = []
+        self.column_parameters = column_parameters
         self.seed = seed
 
 
@@ -185,7 +187,8 @@ def generate(
     format : Dict
         Format to write
     """
-    format = format or {"name": "parquet", "row_group_size": 64}
+    if format is None:
+        format = {"name": "parquet", "row_group_size": 64}
     df = get_dataframe(parameters, use_threads)
 
     # Write

--- a/python/cudf/cudf/tests/test_s3.py
+++ b/python/cudf/cudf/tests/test_s3.py
@@ -36,7 +36,8 @@ def ensure_safe_environment_variables():
 
 @contextmanager
 def s3_context(bucket, files=None):
-    files = files or {}
+    if files is None:
+        files = {}
     with ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,
         # see https://github.com/spulec/moto/issues/1924 & 1952

--- a/python/cudf/cudf/tests/test_s3.py
+++ b/python/cudf/cudf/tests/test_s3.py
@@ -35,7 +35,8 @@ def ensure_safe_environment_variables():
 
 
 @contextmanager
-def s3_context(bucket, files={}):
+def s3_context(bucket, files=None):
+    files = files or {}
     with ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,
         # see https://github.com/spulec/moto/issues/1924 & 1952

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -323,7 +323,8 @@ def to_flat_dict(d):
     """
 
     def _inner(d, parents=None):
-        parents = parents or []
+        if parents is None:
+            parents = []
         for k, v in d.items():
             if not isinstance(v, d.__class__):
                 if parents:

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -322,7 +322,8 @@ def to_flat_dict(d):
     with tuple keys.
     """
 
-    def _inner(d, parents=[]):
+    def _inner(d, parents=None):
+        parents = parents or []
         for k, v in d.items():
             if not isinstance(v, d.__class__):
                 if parents:

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -125,8 +125,9 @@ class DataFrame(_Frame, dd.core.DataFrame):
         meta = assigner(self._meta, k, dd.core.make_meta(v))
         return self.map_partitions(assigner, k, v, meta=meta)
 
-    def apply_rows(self, func, incols, outcols, kwargs={}, cache_key=None):
+    def apply_rows(self, func, incols, outcols, kwargs=None, cache_key=None):
         import uuid
+        kwargs = kwargs or {}
 
         if cache_key is None:
             cache_key = uuid.uuid4()

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -127,7 +127,8 @@ class DataFrame(_Frame, dd.core.DataFrame):
 
     def apply_rows(self, func, incols, outcols, kwargs=None, cache_key=None):
         import uuid
-        kwargs = kwargs or {}
+        if kwargs is None:
+            kwargs = {}
 
         if cache_key is None:
             cache_key = uuid.uuid4()

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -127,6 +127,7 @@ class DataFrame(_Frame, dd.core.DataFrame):
 
     def apply_rows(self, func, incols, outcols, kwargs=None, cache_key=None):
         import uuid
+
         if kwargs is None:
             kwargs = {}
 

--- a/python/dask_cudf/dask_cudf/io/orc.py
+++ b/python/dask_cudf/dask_cudf/io/orc.py
@@ -14,7 +14,8 @@ import cudf
 
 def _read_orc_stripe(fs, path, stripe, columns, kwargs=None):
     """Pull out specific columns from specific stripe"""
-    kwargs = kwargs or {}
+    if kwargs is None:
+        kwargs = {}
     with fs.open(path, "rb") as f:
         df_stripe = cudf.read_orc(
             f, stripes=[stripe], columns=columns, **kwargs

--- a/python/dask_cudf/dask_cudf/io/orc.py
+++ b/python/dask_cudf/dask_cudf/io/orc.py
@@ -12,8 +12,9 @@ from dask.dataframe.io.utils import _get_pyarrow_dtypes
 import cudf
 
 
-def _read_orc_stripe(fs, path, stripe, columns, kwargs={}):
+def _read_orc_stripe(fs, path, stripe, columns, kwargs=None):
     """Pull out specific columns from specific stripe"""
+    kwargs = kwargs or {}
     with fs.open(path, "rb") as f:
         df_stripe = cudf.read_orc(
             f, stripes=[stripe], columns=columns, **kwargs


### PR DESCRIPTION
Following up on #6400 ...I'm starting to get familiar with `cudf`, and wanted to contribute back. Using `pylint`, I think I've found another class of minor issue that could lead to bugs in this project's Python code.

There are several places in this project where functions use mutable types like dictionaries and lists as default values. This is a dangerous practice, because when you use such literals as defaults, Python creates them and stores them one time.

For example:

```python
import uuid

def do_stuff(d={}):
    d[str(uuid.uuid4())] = "hello"
    return d

do_stuff()
# {'c31f11a0-5d55-42d2-96a6-7d847a0f2e3e': 'hello'}

do_stuff()
# {'c31f11a0-5d55-42d2-96a6-7d847a0f2e3e': 'hello', '748bc289-3d2b-4a3f-b39a-f4b551c28cfa': 'hello'}

do_stuff()
# {'c31f11a0-5d55-42d2-96a6-7d847a0f2e3e': 'hello', '748bc289-3d2b-4a3f-b39a-f4b551c28cfa': 'hello', '4f74165a-1e3c-4f87-a5d2-255c0c67fdc4': 'hello'}

```

This PR proposes fixing those cases

## Note for reviewers

I chose to fix cases like this by defaulting those arguments to `None` and then immediately replacing them, like this

```python
def do_stuff(d=None):
    d = d or None
    d[str(uuid.uuid4())] = "hello"
    return d
```

If you think that is too weird or makes the documentation confusing, an alternative way to make these safe would be to use `deepcopy()`

```python
from copy import deepcopy

def do_stuff(d={}):
    d = deepcopy(d)
    d[str(uuid.uuid4())] = "hello"
    return d
```

This will makes those calls slightly slower and give them a slightly larger memory footprint, but they would make the function signature a slightly more informative source of documentaiton.

I'd be happy to change to `deepcopy()` if you'd prefer.

## How to identify these cases

You can find the instances fixes in this PR by running

```shell
pylint python/ | grep dangerous-default
```

```text
python/cudf/cudf/datasets.py:11:0: W0102: Dangerous default value {} as argument (dangerous-default-value)
python/cudf/cudf/datasets.py:60:0: W0102: Dangerous default value {} as argument (dangerous-default-value)
python/cudf/cudf/utils/utils.py:325:4: W0102: Dangerous default value [] as argument (dangerous-default-value)
python/cudf/cudf/core/dataframe.py:4113:4: W0102: Dangerous default value {} as argument (dangerous-default-value)
python/cudf/cudf/core/dataframe.py:4280:4: W0102: Dangerous default value {} as argument (dangerous-default-value)
python/cudf/cudf/core/column_accessor.py:16:4: W0102: Dangerous default value {} as argument (dangerous-default-value)
python/cudf/cudf/core/reshape.py:480:0: W0102: Dangerous default value {} as argument (dangerous-default-value)
python/cudf/cudf/tests/test_s3.py:38:0: W0102: Dangerous default value {} as argument (dangerous-default-value)
python/cudf/cudf/tests/dataset_generator.py:74:4: W0102: Dangerous default value [] as argument (dangerous-default-value)
python/cudf/cudf/tests/dataset_generator.py:170:0: W0102: Dangerous default value {} as argument (dangerous-default-value)
python/dask_cudf/dask_cudf/core.py:128:4: W0102: Dangerous default value {} as argument (dangerous-default-value)
python/dask_cudf/dask_cudf/io/orc.py:15:0: W0102: Dangerous default value {} as argument (dangerous-default-value)
```

Thanks for your time and consideration!