### PR TITLE
Update build to fetch nvcomp v1.1.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - PR #6400 Removed unused variables
 - PR #6409 Allow CuPy 8.x
 - PR #6407 Add RMM_LOGGING_LEVEL flag to Java docker build
+- PR #6438 Fetch nvcomp v1.1.0 for JNI build
 
 ## Bug Fixes
 

--- a/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
+++ b/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
@@ -22,7 +22,7 @@ include(ExternalProject)
 
 ExternalProject_Add(nvcomp
     GIT_REPOSITORY  https://github.com/NVIDIA/nvcomp.git
-    GIT_TAG         9ee396c2d7f0d5f6a8146b7e74f88f2ad012c010
+    GIT_TAG         v1.1.0
     GIT_SHALLOW     true
     SOURCE_DIR      "${NVCOMP_ROOT}/nvcomp"
     BINARY_DIR      "${NVCOMP_ROOT}/build"


### PR DESCRIPTION
When nvcomp pushed new commits to branch-1.1 it broke the JNI build since shallow clones are not allowed on arbitrary commits.  This updates the JNI build to fetch the v1.1.0 tag from nvcomp.