### PR TITLE
[REVIEW] Make java apis getList and getStruct public [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@
 - PR #6410 Fix uses of dangerous default values in Python code
 - PR #6424 Check for null data in close for ColumnBuilder
 - PR #6426 Fix `RuntimeError` when `np.bool_` is passed as `header` in `to_csv`
+- PR #6443 Make java apis getList and getStruct public
 
 # cuDF 0.15.0 (26 Aug 2020)
 

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
@@ -381,7 +381,7 @@ public class HostColumnVectorCore implements ColumnViewAccess<HostMemoryBuffer> 
   /**
    * WARNING: Strictly for test only. This call is not efficient for production.
    */
-  List getList(long rowIndex) {
+  public List getList(long rowIndex) {
     assert rowIndex < rows;
     assert type == DType.LIST;
     List retList = new ArrayList();
@@ -405,7 +405,7 @@ public class HostColumnVectorCore implements ColumnViewAccess<HostMemoryBuffer> 
   /**
    * WARNING: Strictly for test only. This call is not efficient for production.
    */
-  HostColumnVector.StructData getStruct(int rowIndex) {
+  public HostColumnVector.StructData getStruct(int rowIndex) {
     assert rowIndex < rows;
     assert type == DType.STRUCT;
     List<Object> retList = new ArrayList<>();


### PR DESCRIPTION
Minor fix to expose the list and struct getters (even if inefficient) to assist testing and making it inline with other getters on the host side.