### PR TITLE
[REVIEW] add dlpack to libcudf conda run section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@
 - PR #6424 Check for null data in close for ColumnBuilder
 - PR #6426 Fix `RuntimeError` when `np.bool_` is passed as `header` in `to_csv`
 - PR #6443 Make java apis getList and getStruct public
+- PR #XXXX Add `dlpack` to run section of libcudf conda recipe to fix downstream build issues
+
 
 # cuDF 0.15.0 (26 Aug 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,7 +182,7 @@
 - PR #6424 Check for null data in close for ColumnBuilder
 - PR #6426 Fix `RuntimeError` when `np.bool_` is passed as `header` in `to_csv`
 - PR #6443 Make java apis getList and getStruct public
-- PR #XXXX Add `dlpack` to run section of libcudf conda recipe to fix downstream build issues
+- PR #6445 Add `dlpack` to run section of libcudf conda recipe to fix downstream build issues
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -31,12 +31,13 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
     - arrow-cpp 1.0.1.*
     - arrow-cpp-proc * cuda
-    - boost-cpp 1.72.0
+    - boost-cpp 1.72.0.*
     - dlpack
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - arrow-cpp-proc * cuda
     - {{ pin_compatible('boost-cpp', max_pin='x.x.x') }}
+    - {{ pin_compatible('dlpack', max_pin='x.x') }}
 
 test:
   commands:

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -29,9 +29,9 @@ requirements:
   host:
     - librmm {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
-    - arrow-cpp 1.0.1.*
+    - arrow-cpp 1.0.1
     - arrow-cpp-proc * cuda
-    - boost-cpp 1.72.0.*
+    - boost-cpp 1.72.0
     - dlpack
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}


### PR DESCRIPTION
Downstream users developing against libcudf will need the dlpack headers in order to properly compile code that uses certain libcudf headers. We may want to split into a `libcudf-dev` package in the future, but until we do that we should enforce a `run` requirement on dlpack to make sure that downstream packages that build against libcudf have the necessary headers.

cc @jakirkham 