### PR TITLE
Remove repo URL from Java build-info [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@
 - PR #6445 Add `dlpack` to run section of libcudf conda recipe to fix downstream build issues
 - PR #6450 Make java Column Builder row agnostic
 - PR #6309 Make all CI `.sh` scripts have a consistent set of permissions
+- PR #6491 Remove repo URL from Java build-info
 
 # cuDF 0.15.0 (26 Aug 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@
 - PR #6491 Remove repo URL from Java build-info
 - PR #6462 Bug fixes for ColumnBuilder
 
+
 # cuDF 0.15.0 (26 Aug 2020)
 
 ## New Features

--- a/java/buildscripts/build-info
+++ b/java/buildscripts/build-info
@@ -26,7 +26,6 @@ echo_build_properties() {
   echo revision=$(git rev-parse HEAD)
   echo branch=$(git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  echo url=$(git config --get remote.origin.url)
 }
 
 echo_build_properties $1


### PR DESCRIPTION
Issue #6490 

**Describe the bug
There is an offensive word in the cuDF java binaries.

Steps/Code to reproduce bug
Our cuDF java binaries are built from the source code of nvspark/cudf Gitlab repo, which is the down-stream of this GitHub rapidsai/cudf.

When building cuDF java binaries, the build-info is collected via the script java/buildscripts/build-info.

In this build-info (an example showing as below), the down-stream repo URL contains the offensive word.

version=0.16-SNAPSHOT
user=
revision=9ec5093e18dcea3978931288d14f0476b58347ae
branch=HEAD
date=2020-09-27T03:53:03Z
url=https://gitlab-master.nvidia.com/nvspark/cudf.git
This build-info will be packaged into the cuDF binaries, and be released onto public maven repo.

Expected behavior
cuDF java binaries should not have any offensive word.

Remove down-stream repo URL from build-info.