### PR TITLE
Fix issue reading parquet files containing lists with multiple row groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@
 - PR #6309 Make all CI `.sh` scripts have a consistent set of permissions
 - PR #6491 Remove repo URL from Java build-info
 - PR #6462 Bug fixes for ColumnBuilder
+- PR #6497 Fixes a data corruption issue reading list columns from Parquet files with multiple row groups.
 
 
 # cuDF 0.15.0 (26 Aug 2020)

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -1729,7 +1729,9 @@ struct chunk_row_output_iter {
 };
 
 struct start_offset_output_iterator {
-  PageInfo *p;
+  PageInfo *pages;
+  int *page_indices;
+  int cur_index;
   int src_col_schema;
   int nesting_depth;
   int empty               = 0;
@@ -1741,21 +1743,21 @@ struct start_offset_output_iterator {
 
   start_offset_output_iterator operator+ __host__ __device__(int i)
   {
-    return start_offset_output_iterator{p + i, src_col_schema, nesting_depth};
+    return start_offset_output_iterator{
+      pages, page_indices, cur_index + i, src_col_schema, nesting_depth};
   }
 
-  void operator++ __host__ __device__() { p++; }
+  void operator++ __host__ __device__() { cur_index++; }
 
-  reference operator[] __device__(int i) { return dereference(p + i); }
-  reference operator*__device__() { return dereference(p); }
+  reference operator[] __device__(int i) { return dereference(cur_index + i); }
+  reference operator*__device__() { return dereference(cur_index); }
 
  private:
-  reference __device__ dereference(PageInfo *p)
+  reference __device__ dereference(int index)
   {
-    if (p->src_col_schema != src_col_schema || p->flags & PAGEINFO_FLAGS_DICTIONARY) {
-      return empty;
-    }
-    return p->nesting[nesting_depth].page_start_value;
+    PageInfo const &p = pages[page_indices[index]];
+    if (p.src_col_schema != src_col_schema || p.flags & PAGEINFO_FLAGS_DICTIONARY) { return empty; }
+    return p.nesting[nesting_depth].page_start_value;
   }
 };
 
@@ -1803,6 +1805,40 @@ cudaError_t PreprocessColumnData(hostdevice_vector<PageInfo> &pages,
   // back, this value will get overwritten later on).
   pages.device_to_host(stream, true);
 
+  // ordering of pages is by input column schema, repeated across row groups.  so
+  // if we had 3 columns, each with 2 pages, and 1 row group, our schema values might look like
+  //
+  // 1, 1, 2, 2, 3, 3
+  //
+  // However, if we had more than one row group, the pattern would be
+  //
+  // 1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3
+  // ^ row group 0     |
+  //                   ^ row group 1
+  //
+  // To use exclusive_scan_by_key, the ordering we actually want is
+  //
+  // 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3
+  //
+  // We also need to preserve key-relative page ordering, so we need to use a stable sort.
+  thrust::device_vector<int> page_keys(pages.size());
+  thrust::device_vector<int> page_index(pages.size());
+  {
+    thrust::transform(rmm::exec_policy(stream)->on(stream),
+                      pages.device_ptr(),
+                      pages.device_ptr() + pages.size(),
+                      page_keys.begin(),
+                      [] __device__(PageInfo const &page) { return page.src_col_schema; });
+
+    thrust::sequence(rmm::exec_policy(stream)->on(stream), page_index.begin(), page_index.end());
+    int *keys = page_keys.data().get();
+    thrust::stable_sort_by_key(rmm::exec_policy(stream)->on(stream),
+                               keys,
+                               keys + pages.size(),
+                               page_index.data().get(),
+                               thrust::less<int>());
+  }
+
   // compute output column sizes by examining the pages of the -input- columns
   for (size_t idx = 0; idx < input_columns.size(); idx++) {
     auto const &input_col = input_columns[idx];
@@ -1814,15 +1850,18 @@ cudaError_t PreprocessColumnData(hostdevice_vector<PageInfo> &pages,
       auto &out_buf = (*cols)[input_col.nesting[l_idx]];
       cols          = &out_buf.children;
 
+      // size iterator. indexes pages by sorted order
       auto size_input = thrust::make_transform_iterator(
-        pages.device_ptr(), [src_col_schema, l_idx] __device__(PageInfo const &page) {
+        page_index.begin(),
+        [src_col_schema, l_idx, pages = pages.device_ptr()] __device__(int index) {
+          auto const &page = pages[index];
           if (page.src_col_schema != src_col_schema || page.flags & PAGEINFO_FLAGS_DICTIONARY) {
             return 0;
           }
           return page.nesting[l_idx].size;
         });
 
-      // column size
+      // compute column size.
       // for struct columns, higher levels of the output columns are shared between input
       // columns. so don't compute any given level more than once.
       if (out_buf.size == 0) {
@@ -1836,16 +1875,16 @@ cudaError_t PreprocessColumnData(hostdevice_vector<PageInfo> &pages,
         out_buf.create(size, stream, mr);
       }
 
-      // per-page start offset
-      auto key_input = thrust::make_transform_iterator(
-        pages.device_ptr(), [] __device__(PageInfo const &page) { return page.src_col_schema; });
-      thrust::exclusive_scan_by_key(
-        rmm::exec_policy(stream)->on(stream),
-        key_input,
-        key_input + pages.size(),
-        size_input,
-        start_offset_output_iterator{
-          pages.device_ptr(), static_cast<int>(src_col_schema), static_cast<int>(l_idx)});
+      // compute per-page start offset
+      thrust::exclusive_scan_by_key(rmm::exec_policy(stream)->on(stream),
+                                    page_keys.begin(),
+                                    page_keys.begin() + pages.size(),
+                                    size_input,
+                                    start_offset_output_iterator{pages.device_ptr(),
+                                                                 page_index.data().get(),
+                                                                 0,
+                                                                 static_cast<int>(src_col_schema),
+                                                                 static_cast<int>(l_idx)});
     }
   }
 

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -903,8 +903,8 @@ def test_parquet_reader_list_large_mixed(tmpdir):
 
 
 def test_parquet_reader_list_large_multi_rowgroup(tmpdir):
-    # > 800 row groups
-    num_rows = 2_000_000
+    # > 40 row groups
+    num_rows = 100000
     num_docs = num_rows / 2
     num_categories = 1_000
     row_group_size = 1000
@@ -935,8 +935,8 @@ def test_parquet_reader_list_large_multi_rowgroup(tmpdir):
 
 
 def test_parquet_reader_list_large_multi_rowgroup_nulls(tmpdir):
-    # 200 row groups
-    num_rows = 200000
+    # 25 row groups
+    num_rows = 25000
     row_group_size = 1000
 
     expect = cudf.DataFrame(

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -901,6 +901,55 @@ def test_parquet_reader_list_large_mixed(tmpdir):
     assert_eq(expect, got, check_dtype=False)
 
 
+def test_parquet_reader_list_large_multi_rowgroup(tmpdir):
+    # > 800 row groups
+    num_rows = 2_000_000
+    num_docs = num_rows / 2
+    num_categories = 1_000
+    row_group_size = 1000
+
+    # generate a random pairing of doc: category
+    documents = cudf.DataFrame(
+        {
+            "document_id": np.random.randint(num_docs, size=num_rows),
+            "category_id": np.random.randint(num_categories, size=num_rows),
+        }
+    )
+
+    # group categories by document_id to create a list column
+    expect = documents.groupby("document_id").agg({"category_id": ["collect"]})
+    expect.columns = expect.columns.get_level_values(0)
+    expect.reset_index(inplace=True)
+
+    # round trip the dataframe to/from parquet
+    fname = tmpdir.join(
+        "test_parquet_reader_list_large_multi_rowgroup.parquet"
+    )
+    expect.to_pandas().to_parquet(fname)
+    got = cudf.read_parquet(fname)
+
+    assert_eq(expect, got)
+
+
+def test_parquet_reader_list_large_multi_rowgroup_nulls(tmpdir):
+    # 200 row groups
+    num_rows = 200000
+    row_group_size = 1000
+
+    expect = cudf.DataFrame(
+        {"a": list_gen(int_gen, 0, num_rows, 3, 2, include_validity=True)}
+    )
+
+    # round trip the dataframe to/from parquet
+    fname = tmpdir.join(
+        "test_parquet_reader_list_large_multi_rowgroup_nulls.parquet"
+    )
+    expect.to_pandas().to_parquet(fname, row_group_size=row_group_size)
+    assert os.path.exists(fname)
+    got = cudf.read_parquet(fname)
+    assert_eq(expect, got)
+
+
 @pytest.mark.parametrize("skip", range(0, 128))
 def test_parquet_reader_list_skiprows(skip, tmpdir):
     num_rows = 128

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 import pytest
 from packaging import version
 from pyarrow import parquet as pq
+import cupy
 
 import cudf
 from cudf.io.parquet import ParquetWriter, merge_parquet_filemetadata
@@ -908,11 +909,13 @@ def test_parquet_reader_list_large_multi_rowgroup(tmpdir):
     num_categories = 1_000
     row_group_size = 1000
 
+    cupy.random.seed(0)
+
     # generate a random pairing of doc: category
     documents = cudf.DataFrame(
         {
-            "document_id": np.random.randint(num_docs, size=num_rows),
-            "category_id": np.random.randint(num_categories, size=num_rows),
+            "document_id": cupy.random.randint(num_docs, size=num_rows),
+            "category_id": cupy.random.randint(num_categories, size=num_rows),
         }
     )
 

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -925,7 +925,7 @@ def test_parquet_reader_list_large_multi_rowgroup(tmpdir):
     fname = tmpdir.join(
         "test_parquet_reader_list_large_multi_rowgroup.parquet"
     )
-    expect.to_pandas().to_parquet(fname)
+    expect.to_pandas().to_parquet(fname, row_group_size=row_group_size)
     got = cudf.read_parquet(fname)
 
     assert_eq(expect, got)


### PR DESCRIPTION
Fixes : https://github.com/rapidsai/cudf/issues/6477

Core issue was the order in which pages were being visited when doing an exclusive_scan_by_key at the end of the preprocess step.

Tests added.