### PR TITLE
[REVIEW] Add helper method to ColumnBuilder with some nits [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@
 - PR #6407 Add RMM_LOGGING_LEVEL flag to Java docker build
 - PR #6438 Fetch nvcomp v1.1.0 for JNI build
 - PR #6379 Add list hashing functionality to MD5
-- PR #     Add helper method to ColumnBuilder with some nits
+- PR #6498 Add helper method to ColumnBuilder with some nits
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@
 - PR #6407 Add RMM_LOGGING_LEVEL flag to Java docker build
 - PR #6438 Fetch nvcomp v1.1.0 for JNI build
 - PR #6379 Add list hashing functionality to MD5
+- PR #     Add helper method to ColumnBuilder with some nits
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.Consumer;
 
 /**
@@ -1023,8 +1024,17 @@ public final class HostColumnVector extends HostColumnVectorCore {
       return childBuilders.get(index);
     }
 
+    /**
+     * Finish and create the immutable ColumnVector, copied to the device.
+     */
+    public final ColumnVector buildAndPutOnDevice() {
+      try (HostColumnVector tmp = build()) {
+        return tmp.copyToDevice();
+      }
+    }
+
     @Override
-    public void close() throws Exception {
+    public void close() {
       if (!built) {
         if (data != null) {
           data.close();
@@ -1040,6 +1050,25 @@ public final class HostColumnVector extends HostColumnVectorCore {
         }
         built = true;
       }
+    }
+
+    @Override
+    public String toString() {
+      StringJoiner sj = new StringJoiner(",");
+      for (ColumnBuilder cb : childBuilders) {
+        sj.add(cb.toString());
+      }
+      return "ColumnBuilder{" +
+          "type=" + type +
+          ", children=" + sj.toString() +
+          ", data=" + data +
+          ", valid=" + valid +
+          ", currentIndex=" + currentIndex +
+          ", nullCount=" + nullCount +
+          ", estimatedRows=" + estimatedRows +
+          ", populatedRows=" + rows +
+          ", built=" + built +
+          '}';
     }
   }
 


### PR DESCRIPTION
Adds the identical method that old builder has for building columns to the new ColumnBuilder, plus a `toString` and some nits.