### PR TITLE
Disable Jitify log printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ## Bug Fixes
 
+ - PR #6509 Disable JITIFY log printing
+
 
 # cuDF 0.16.0 (Date TBD)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -631,6 +631,9 @@ set_target_properties(cudf PROPERTIES BUILD_RPATH "\$ORIGIN")
 ###################################################################################################
 # - jitify ----------------------------------------------------------------------------------------
 
+# Disable Jitify log printing. See https://github.com/NVIDIA/jitify/issues/79
+target_compile_definitions(cudf PRIVATE JITIFY_PRINT_LOG=0)
+
 # Creates executable stringify and uses it to convert types.h to c-str for use in JIT code
 add_executable(stringify "${JITIFY_INCLUDE_DIR}/stringify.cpp")
 execute_process(WORKING_DIRECTORY ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
Fixes #6117 

Sets `JITIFY_PRINT_LOG` to zero via cmake, since by default jitify prints its log to `stdout`, which can corrupt application data generated on `stdout`.

See also https://github.com/NVIDIA/jitify/issues/79

