### PR TITLE
[REVIEW] Fix end-of-string marking boundary condition in subword-tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Bug Fixes
 
  - PR #6509 Disable JITIFY log printing
+ - PR #6519 Fix end-of-string marking boundary condition in subword-tokenizer
 
 
 # cuDF 0.16.0 (Date TBD)

--- a/cpp/src/text/subword/wordpiece_tokenizer.cu
+++ b/cpp/src/text/subword/wordpiece_tokenizer.cu
@@ -329,7 +329,7 @@ void wordpiece_tokenizer::tokenize(uvector_pair& cps_and_offsets, cudaStream_t s
                                                              device_tokens_per_word.data());
   CHECK_CUDA(stream);
 
-  cudf::detail::grid_1d const grid_mark{static_cast<cudf::size_type>(num_strings),
+  cudf::detail::grid_1d const grid_mark{static_cast<cudf::size_type>(num_strings + 1),
                                         THREADS_PER_BLOCK};
   detail::mark_string_start_and_ends<<<grid_mark.num_blocks,
                                        grid_mark.num_threads_per_block,


### PR DESCRIPTION
Closes #6501 

The `mark_string_start_and_ends` kernel did not have enough threads to set the end-of-string marker for the last string if the number of rows was divisible by `THREADS_PER_BLOCK=64`. The end-of-string marker relies on the trailing offset at `num_strings+1` to work correctly. If the number of strings is not divisible by 64 then extra threads are launched for one block and the logic handles the edge case correctly.