### PR TITLE
Refactor DeviceColumnViewAccess to avoid JNI returning an array [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #6413 Replace Python NVTX package with conda-forge source
 - PR #6442 Remove deprecated `DataFrame.from_gpu_matrix`, `DataFrame.to_gpu_matrix`, `DataFrame.add_column` APIs and method parameters
 - PR #6504 Update Java bindings version to 0.17-SNAPSHOT
+- PR #6527 Refactor DeviceColumnViewAccess to avoid JNI returning an array
 
 ## Bug Fixes
 


### PR DESCRIPTION
This updates Java's `ColumnVector` JNI interface to create separate address and length accessors for the data, validity, and offset buffers.  The original API returned the address and length in a `long[]` which causes the JNI to callback into the JVM to create the array.  Even though it's more JNI calls, it turns out to be more efficient to access the address and length separately, as it avoids the JNI->JVM callback and avoids temporary object creation.

This also updates `DeviceColumnViewAccess` to be a static class since it really has no reason to reach back into the parent class instance.  Everything it needs can be provided via static method calls using the view handle associated with it.

Using a microbenchmark that stresses table metadata creation in the plugin, which in turn hammers `DeviceColumnViewAccess` for the data, validity, and offset buffers for each column, the benchmark time dropped from 64 seconds to 33 seconds with this change.