### PR TITLE
[REVIEW] Make getter for host CV children public [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@
 - PR #6438 Fetch nvcomp v1.1.0 for JNI build
 - PR #6379 Add list hashing functionality to MD5
 - PR #6498 Add helper method to ColumnBuilder with some nits
+- PR #6531 Make getter for host CV children public
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
@@ -121,7 +121,7 @@ public class HostColumnVectorCore implements ColumnViewAccess<HostMemoryBuffer> 
   /**
    * Returns the list of child host column vectors for a given host side column
    */
-  List<HostColumnVectorCore> getNestedChildren() {
+  public List<HostColumnVectorCore> getNestedChildren() {
     return children;
   }
 


### PR DESCRIPTION
Minor change to expose nested children at Host column vector level.