### PR TITLE
[REVIEW] Fix memory_usage calls for list columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #6509 Disable JITIFY log printing
 - PR #6517 Handle index equality in `Series` and `DataFrame` equality checks
 - PR #6519 Fix end-of-string marking boundary condition in subword-tokenizer
+- PR #6549 Fix memory_usage calls for list columns
 
 
 # cuDF 0.16.0 (Date TBD)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -179,9 +179,9 @@ class ColumnBase(Column, Serializable):
         return bool(libcudf.reduce.reduce("any", self, dtype=np.bool_))
 
     def __sizeof__(self):
-        n = self.data.size if self.data is not None else 0
+        n = self.base_data.size if self.base_data is not None else 0
         if self.nullable:
-            n += self.mask.size
+            n += self.base_mask.size
         for child in self.base_children:
             n += child.__sizeof__()
         return n

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -10,7 +10,6 @@ from cudf.utils.dtypes import is_list_dtype
 class ListColumn(ColumnBase):
     def __init__(
         self,
-        data,
         size,
         dtype,
         mask=None,
@@ -19,7 +18,7 @@ class ListColumn(ColumnBase):
         children=(),
     ):
         super().__init__(
-            data,
+            None,
             size,
             dtype,
             mask=mask,
@@ -69,8 +68,14 @@ class ListColumn(ColumnBase):
             pa_type, len(self), buffers, children=[elements]
         )
 
-    def __sizeof__(self):
-        return sum(child.__sizeof__() for child in self.base_children)
+    def set_base_data(self, value):
+        if value is not None:
+            raise RuntimeError(
+                "ListColumn's do not use data attribute of Column, use "
+                "`set_base_children` instead"
+            )
+        else:
+            super().set_base_data(value)
 
 
 class ListMethods(ColumnMethodsMixin):

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -9,13 +9,7 @@ from cudf.utils.dtypes import is_list_dtype
 
 class ListColumn(ColumnBase):
     def __init__(
-        self,
-        size,
-        dtype,
-        mask=None,
-        offset=0,
-        null_count=None,
-        children=(),
+        self, size, dtype, mask=None, offset=0, null_count=None, children=(),
     ):
         super().__init__(
             None,

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -69,6 +69,9 @@ class ListColumn(ColumnBase):
             pa_type, len(self), buffers, children=[elements]
         )
 
+    def __sizeof__(self):
+        return sum(child.__sizeof__() for child in self.base_children)
+
 
 class ListMethods(ColumnMethodsMixin):
     """

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -4523,20 +4523,6 @@ class StringColumn(column.ColumnBase):
     def str(self, parent=None):
         return StringMethods(self, parent=parent)
 
-    def __sizeof__(self):
-        n = 0
-        if len(self.base_children) == 2:
-            n += (
-                self.base_children[0].__sizeof__()
-                + self.base_children[1].__sizeof__()
-            )
-        if self.base_mask is not None:
-            n += self.base_mask.size
-        return n
-
-    def _memory_usage(self, **kwargs):
-        return self.__sizeof__()
-
     def unary_operator(self, unaryop):
         raise TypeError(
             f"Series of dtype `str` cannot perform the operation: "

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -5185,6 +5185,15 @@ def test_memory_usage_cat():
     assert gdf.set_index("B").index.memory_usage(deep=True) == expected
 
 
+def test_memory_usage_list():
+    df = gd.DataFrame({"A": [[0, 1, 2, 3], [4, 5, 6], [7, 8], [9]]})
+    expected = (
+        df.A._column.offsets._memory_usage()
+        + df.A._column.elements._memory_usage()
+    )
+    assert expected == df.A.memory_usage()
+
+
 @pytest.mark.xfail
 def test_memory_usage_multi():
     rows = int(100)

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -568,6 +568,8 @@ def test_drop(gdf, gddf):
 @pytest.mark.parametrize("deep", [True, False])
 @pytest.mark.parametrize("index", [True, False])
 def test_memory_usage(gdf, gddf, index, deep):
+    gddf = gddf.map_partitions(lambda x: x.copy(deep=True))
+
     dd.assert_eq(
         gdf.memory_usage(deep=deep, index=index),
         gddf.memory_usage(deep=deep, index=index),


### PR DESCRIPTION
memory_usage calls were throwing a ```AttributeError: 'ListDtype' object has no attribute 'itemsize'```
exception when called on list columns. Fix by implementing ```__sizeof__``` for list columns