### PR TITLE
Adapt JNI build to libcudf composition of multiple libraries [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PR #6485 Add File IO to cuIO benchmarks
 - PR #6504 Update Java bindings version to 0.17-SNAPSHOT
 - PR #6527 Refactor DeviceColumnViewAccess to avoid JNI returning an array
+- PR #6555 Adapt JNI build to libcudf composition of multiple libraries
 
 ## Bug Fixes
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -388,7 +388,7 @@
                             def proc = 'ldd ${native.build.path}/libcudfjni.so'.execute()
                             proc.consumeProcessOutput(sout, serr)
                             proc.waitForOrKill(10000)
-                            def libcudf = ~/libcudf\\.so\\s+=>\\s+(.*)libcudf.*\\.so\\s+.*/
+                            def libcudf = ~/libcudf.*\\.so\\s+=>\\s+(.*)libcudf.*\\.so\\s+.*/
                             def cudfm = libcudf.matcher(sout)
                             if (cudfm.find()) {
                                 pom.properties['native.cudf.path'] = cudfm.group(1)
@@ -484,7 +484,18 @@
                                     <!--Set by groovy script-->
                                     <directory>${native.cudf.path}</directory>
                                     <includes>
-                                        <include>libcudf.so</include>
+                                        <include>libcudf_ast.so</include>
+                                        <include>libcudf_base.so</include>
+                                        <include>libcudf_comms.so</include>
+                                        <include>libcudf_hash.so</include>
+                                        <include>libcudf_interop.so</include>
+                                        <include>libcudf_io.so</include>
+                                        <include>libcudf_join.so</include>
+                                        <include>libcudf_merge.so</include>
+                                        <include>libcudf_partitioning.so</include>
+                                        <include>libcudf_reductions.so</include>
+                                        <include>libcudf_replace.so</include>
+                                        <include>libcudf_rolling.so</include>
                                     </includes>
                                 </resource>
                                 <resource>

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -33,7 +33,18 @@ public class NativeDepsLoader {
   private static final Logger log = LoggerFactory.getLogger(NativeDepsLoader.class);
   private static final String[] loadOrder = new String[] {
       "nvcomp",
-      "cudf",
+      "cudf_base",
+      "cudf_ast",
+      "cudf_comms",
+      "cudf_hash",
+      "cudf_interop",
+      "cudf_io",
+      "cudf_join",
+      "cudf_merge",
+      "cudf_partitioning",
+      "cudf_reductions",
+      "cudf_replace",
+      "cudf_rolling",
       "cudfjni"
   };
   private static ClassLoader loader = NativeDepsLoader.class.getClassLoader();

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -180,20 +180,33 @@ find_path(SPDLOG_INCLUDE "spdlog"
 set(CUDF_INCLUDE "${PROJECT_SOURCE_DIR}/../../../../cpp/include"
                  "${PROJECT_SOURCE_DIR}/../../../../cpp/src/")
 
-find_library(CUDF_LIBRARY "cudf"
+set(CUDF_LIBS_HINTS
     HINTS "$ENV{CUDF_ROOT}"
           "$ENV{CUDF_ROOT}/lib"
           "$ENV{CONDA_PREFIX}/lib"
           "${CUDF_CPP_BUILD_DIR}")
 
-message(STATUS "CUDF: CUDF_LIBRARY set to ${CUDF_LIBRARY}")
-message(STATUS "CUDF: CUDF_INCLUDE set to ${CUDF_INCLUDE}")
+# This list of cudf libraries needs to be kept in sync with the lists
+# in pom.xml and NativeDepsLoader.java
+set(CUDF_LIB_BASES
+  "cudf_ast"
+  "cudf_base"
+  "cudf_comms"
+  "cudf_hash"
+  "cudf_interop"
+  "cudf_io"
+  "cudf_join"
+  "cudf_merge"
+  "cudf_partitioning"
+  "cudf_reductions"
+  "cudf_replace"
+  "cudf_rolling")
 
-add_library(cudf SHARED IMPORTED ${CUDF_LIBRARY})
-if (CUDF_INCLUDE AND CUDF_LIBRARY)
-    set_target_properties(cudf PROPERTIES IMPORTED_LOCATION ${CUDF_LIBRARY})
-endif (CUDF_INCLUDE AND CUDF_LIBRARY)
-
+set(CUDF_LIBS "")
+foreach(CUDF_LIB_BASE ${CUDF_LIB_BASES})
+    find_library(LIB_${CUDF_LIB_BASE} ${CUDF_LIB_BASE} REQUIRED HINTS ${CUDF_LIBS_HINTS})
+    list(APPEND CUDF_LIBS ${LIB_${CUDF_LIB_BASE}})
+endforeach()
 
 ###################################################################################################
 # - RMM -------------------------------------------------------------------------------------------
@@ -270,8 +283,7 @@ include_directories("${THRUST_INCLUDE}"
 # - library paths ---------------------------------------------------------------------------------
 
 link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
-                 "${CMAKE_BINARY_DIR}/lib"
-                 "${CUDF_LIBRARY}")
+                 "${CMAKE_BINARY_DIR}/lib")
 
 
 ###################################################################################################
@@ -325,4 +337,4 @@ target_compile_definitions(cudfjni PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(cudfjni cudf ${ARROW_LIBRARY} ${NVCOMP_LIB} ${CUDART_LIBRARY} cuda nvrtc)
+target_link_libraries(cudfjni ${CUDF_LIBS} ${ARROW_LIBRARY} ${NVCOMP_LIB} ${CUDART_LIBRARY} cuda nvrtc)


### PR DESCRIPTION
This fixes the JNI build after libcudf.so became composed of many other shared libraries.