### PR TITLE
[REVIEW] Create cudf::detail::byte_cast for cudf::byte_cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #6544 Remove `fixed_point` precise round
 - PR #6555 Adapt JNI build to libcudf composition of multiple libraries
 - PR #6564 Load JNI library dependencies with a thread pool
+- PR #6573 Create `cudf::detail::byte_cast` for `cudf::byte_cast`
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/reshape.hpp
+++ b/cpp/include/cudf/reshape.hpp
@@ -73,7 +73,7 @@ std::unique_ptr<table> tile(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Configures if byte casting flips endianness
+ * @brief Configures whether byte casting flips endianness
  */
 enum class flip_endianness : bool { NO, YES };
 
@@ -86,15 +86,15 @@ enum class flip_endianness : bool { NO, YES };
  * return        = [[0x00, 0x00, 0x21, 0xe3], [0x00, 0x00, 0x01, 0x35]]
  * ```
  *
- * @param input_column column to be converted to lists of bytes.
- * @param configuration configuration retain or flip the endianness of a row.
+ * @param input_column Column to be converted to lists of bytes.
+ * @param endian_configuration Whether to retain or flip the endianness of the elements.
  * @param mr Device memory resource used to allocate the returned column's device memory.
  *
  * @return The column containing the lists of bytes.
  */
 std::unique_ptr<column> byte_cast(
   column_view const& input_column,
-  flip_endianness configuration,
+  flip_endianness endian_configuration,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/reshape.hpp
+++ b/cpp/include/cudf/reshape.hpp
@@ -72,10 +72,8 @@ std::unique_ptr<table> tile(
   size_type count,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
-/** @} */  // end of group
-
-/*
- * Configures if byte casting flips endianness
+/**
+ * @brief Configures if byte casting flips endianness
  */
 enum class flip_endianness : bool { NO, YES };
 
@@ -91,14 +89,14 @@ enum class flip_endianness : bool { NO, YES };
  * @param input_column column to be converted to lists of bytes.
  * @param configuration configuration retain or flip the endianness of a row.
  * @param mr Device memory resource used to allocate the returned column's device memory.
- * @param stream CUDA stream used for device memory operations and kernel launches.
  *
  * @return The column containing the lists of bytes.
  */
 std::unique_ptr<column> byte_cast(
   column_view const& input_column,
   flip_endianness configuration,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
-  cudaStream_t stream                 = 0);
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/** @} */  // end of group
 
 }  // namespace cudf

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -22,6 +22,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 namespace cudf {
+namespace detail {
 namespace {
 struct byte_list_conversion {
   /**
@@ -107,9 +108,23 @@ std::unique_ptr<column> byte_cast(column_view const& input_column,
                                   rmm::mr::device_memory_resource* mr,
                                   cudaStream_t stream)
 {
-  CUDF_FUNC_RANGE();
   return type_dispatcher(
     input_column.type(), byte_list_conversion{}, input_column, configuration, mr, stream);
+}
+
+}  // namespace detail
+
+/**
+ * @copydoc cudf::byte_cast(input_column,flip_endianess,rmm::mr::device_memory_resource)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::unique_ptr<column> byte_cast(column_view const& input_column,
+                                  flip_endianness configuration,
+                                  rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::byte_cast(input_column, configuration, mr, 0);
 }
 
 }  // namespace cudf

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -109,12 +109,12 @@ std::unique_ptr<cudf::column> byte_list_conversion::operator()<string_view>(
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<column> byte_cast(column_view const& input_column,
-                                  flip_endianness configuration,
+                                  flip_endianness endian_configuration,
                                   rmm::mr::device_memory_resource* mr,
                                   cudaStream_t stream)
 {
   return type_dispatcher(
-    input_column.type(), byte_list_conversion{}, input_column, configuration, mr, stream);
+    input_column.type(), byte_list_conversion{}, input_column, endian_configuration, mr, stream);
 }
 
 }  // namespace detail
@@ -123,11 +123,11 @@ std::unique_ptr<column> byte_cast(column_view const& input_column,
  * @copydoc cudf::byte_cast(input_column,flip_endianess,rmm::mr::device_memory_resource)
  */
 std::unique_ptr<column> byte_cast(column_view const& input_column,
-                                  flip_endianness configuration,
+                                  flip_endianness endian_configuration,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::byte_cast(input_column, configuration, mr, cudaStreamDefault);
+  return detail::byte_cast(input_column, endian_configuration, mr, cudaStreamDefault);
 }
 
 }  // namespace cudf

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -103,6 +103,11 @@ std::unique_ptr<cudf::column> byte_list_conversion::operator()<string_view>(
 }
 }  // namespace
 
+/**
+ * @copydoc cudf::byte_cast(input_column,flip_endianess,rmm::mr::device_memory_resource)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
 std::unique_ptr<column> byte_cast(column_view const& input_column,
                                   flip_endianness configuration,
                                   rmm::mr::device_memory_resource* mr,
@@ -116,15 +121,13 @@ std::unique_ptr<column> byte_cast(column_view const& input_column,
 
 /**
  * @copydoc cudf::byte_cast(input_column,flip_endianess,rmm::mr::device_memory_resource)
- *
- * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<column> byte_cast(column_view const& input_column,
                                   flip_endianness configuration,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::byte_cast(input_column, configuration, mr, 0);
+  return detail::byte_cast(input_column, configuration, mr, cudaStreamDefault);
 }
 
 }  // namespace cudf


### PR DESCRIPTION
Found this when I noticed a doxygen error in `reshape.hpp`
https://github.com/rapidsai/cudf/blob/47a3d32cc343293c5240c1c60f0dcd3ef7e26691/cpp/include/cudf/reshape.hpp#L75
This line should be right before the end bracket for the `namespace cudf` line so the `cudf::byte_cast` appears in the correct doxygen group.

Noticed that `cudf::byte_cast` includes a `cudaStream_t` parameter unlike all the other APIs in this header file. This PR creates the appropriate `cudf::detail::byte_cast` and move the `cudaStream_t` parameter to that call per the coding guidelines here:
https://github.com/rapidsai/cudf/blob/branch-0.17/cpp/docs/TRANSITIONGUIDE.md#streams
