### PR TITLE
Fix JNI RMM initialize with no pool allocator limit [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #6519 Fix end-of-string marking boundary condition in subword-tokenizer
 - PR #6543 Handle `np.nan` values in `isna`/`isnull`/`notna`/`notnull`
 - PR #6549 Fix memory_usage calls for list columns
+- PR #6575 Fix JNI RMM initialize with no pool allocator limit
 
 
 # cuDF 0.16.0 (Date TBD)

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -345,8 +345,9 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(JNIEnv *env, j
     bool use_managed_mem = allocation_mode & 2;
     bool use_arena_alloc = allocation_mode & 4;
     if (use_pool_alloc) {
-      std::size_t pool_limit = (max_pool_size > 0) ? static_cast<std::size_t>(max_pool_size) :
-                                                     std::numeric_limits<std::size_t>::max();
+      auto pool_limit = (max_pool_size > 0) ?
+                            thrust::optional<std::size_t>{static_cast<std::size_t>(max_pool_size)} :
+                            thrust::nullopt;
       if (use_managed_mem) {
         Initialized_resource = rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
             std::make_shared<rmm::mr::managed_memory_resource>(), pool_size, pool_limit);


### PR DESCRIPTION
https://github.com/rapidsai/rmm/pull/601 changed the pool resource initialization so that instead of passing max std::size_t value to indicate no limit, it now uses `thrust::optional<std::size_t>`.  Passing the old value causes startup to fail with an exception like this:
```
ai.rapids.cudf.CudfException: RMM failure at: /home/jlowe/miniconda3/envs/cudf10.1/include/rmm/mr/device/pool_memory_resource.hpp:102: Error, Maximum pool size required to be a multiple of 256 bytes
```

This updates the JNI code to pass `thrust::nullopt` instead of the old default value when there's no specified pool limit.