### PR TITLE
Fix JNI build broken by to_arrow signature change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - PR #6543 Handle `np.nan` values in `isna`/`isnull`/`notna`/`notnull`
 - PR #6549 Fix memory_usage calls for list columns
 - PR #6575 Fix JNI RMM initialize with no pool allocator limit
+- PR #6595 Fix JNI build, broken by to_arrow() signature change
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1190,7 +1190,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_convertCudfToArrowTable(JNIEnv
   try {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<std::shared_ptr<arrow::Table>> result(new std::shared_ptr<arrow::Table>(nullptr));
-    *result = cudf::to_arrow(*tview, state->column_names);
+    auto column_metadata = std::vector<cudf::column_metadata>{};
+    column_metadata.reserve(state->column_names.size());
+    std::transform(
+      std::begin(state->column_names),
+      std::end(state->column_names),
+      std::back_inserter(column_metadata),
+      [](auto const& column_name) { return cudf::column_metadata{column_name}; }
+    );
+    *result = cudf::to_arrow(*tview, column_metadata);
     if (!result->get()) {
       return 0;
     }


### PR DESCRIPTION
#6430  added struct_type support to to_arrow()/from_arrow().
The change in signature broke cudf/jni code.

```     [exec] /home/mithunr/workspace/dev/cudf/01/java/src/main/native/src/TableJni.cpp: In function ‘jlong Java_ai_rapids_cudf_Table_convertCudfToArrowTable(JNIEnv*, jclass, jlong, jlong)’:
     [exec] /home/mithunr/workspace/dev/cudf/01/java/src/main/native/src/TableJni.cpp:1193:45: error: invalid initialization of reference of type ‘const std::vector<cudf::column_metadata>&’ fr
om expression of type ‘std::vector<std::__cxx11::basic_string<char> >’
     [exec]      *result = cudf::to_arrow(*tview, state->column_names);
     [exec]                                       ~~~~~~~^~~~~~~~~~~~
     [exec] In file included from /home/mithunr/workspace/dev/cudf/01/java/src/main/native/src/TableJni.cpp:24:
     [exec] /home/mithunr/workspace/dev/cudf/01/java/src/main/native/../../../../cpp/include/cudf/interop.hpp:113:31: note: in passing argument 2 of ‘std::shared_ptr<arrow::Table> cudf::to_arr
ow(cudf::table_view, const std::vector<cudf::column_metadata>&, arrow::MemoryPool*)’
     [exec]  std::shared_ptr<arrow::Table> to_arrow(table_view input,
     [exec]                                ^~~~~~~~
```

This commit aims to fix that break.
