### PR TITLE
Use thread-local to track CUDA device in JNI [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - PR #6581 Add JNI API to check if PTDS is enabled
 
 ## Improvements
-- PR #6430 Add struct type support to `to_arrow` and `from_arrow`
 
+- PR #6430 Add struct type support to `to_arrow` and `from_arrow`
 - PR #6384 Add CSV fuzz tests with varying function parameters
 - PR #6385 Add JSON fuzz tests with varying function parameters
 - PR #6398 Remove function constructor macros in parquet reader
@@ -29,6 +29,7 @@
 - PR #6555 Adapt JNI build to libcudf composition of multiple libraries
 - PR #6564 Load JNI library dependencies with a thread pool
 - PR #6573 Create `cudf::detail::byte_cast` for `cudf::byte_cast`
+- PR #6597 Use thread-local to track CUDA device in JNI
 
 ## Bug Fixes
 

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -21,6 +21,8 @@ namespace {
 /** The CUDA device that should be used by all threads using cudf */
 int Cudf_device{cudaInvalidDeviceId};
 
+thread_local int Thread_device = cudaInvalidDeviceId;
+
 } // anonymous namespace
 
 namespace cudf {
@@ -37,12 +39,10 @@ void set_cudf_device(int device) {
  */
 void auto_set_device(JNIEnv *env) {
   if (Cudf_device != cudaInvalidDeviceId) {
-    int device;
-    cudaError_t cuda_status = cudaGetDevice(&device);
-    jni_cuda_check(env, cuda_status);
-    if (device != Cudf_device) {
-      cuda_status = cudaSetDevice(Cudf_device);
+    if (Thread_device != Cudf_device) {
+      cudaError_t cuda_status = cudaSetDevice(Cudf_device);
       jni_cuda_check(env, cuda_status);
+      Thread_device = Cudf_device;
     }
   }
 }


### PR DESCRIPTION
Looking at a recent Nsight profile of a Java application using cudf, I noticed a lot of CPU samples in `cudaGetDevice`.  This is caused by the `auto_set_device` calls made in each cudf JNI function to ensure each thread is using the same device used when RMM was initialized.  Initially we thought calling `cudaGetDevice` would be "cheap enough", but this is apparently not the case, at least when profiling under Nsight.

This changes the cudf JNI code to track the thread's CUDA device in a thread local rather than needing to call `cudaGetDevice` on each cudf call to obtain it.  This saved 0.5ms per `Table.contiguousSplit` call in a microbenchmark, and I noticed it also significantly reduced the time dilation we've seen in Nsight profiles of cudf Java applications.