### PR TITLE
Use correct stream in hash_join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - PR #6549 Fix memory_usage calls for list columns
 - PR #6575 Fix JNI RMM initialize with no pool allocator limit
 - PR #6595 Fix JNI build, broken by to_arrow() signature change
+- PR #6603 Use correct stream in hash_join.
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -215,13 +215,13 @@ std::unique_ptr<multimap_type, std::function<void(multimap_type *)>> build_join_
                                           stream);
 
   row_hash hash_build{build_table};
-  rmm::device_scalar<int> failure(0, 0);
+  rmm::device_scalar<int> failure(0, stream);
   constexpr int block_size{DEFAULT_JOIN_BLOCK_SIZE};
   detail::grid_1d config(build_table_num_rows, block_size);
-  build_hash_table<<<config.num_blocks, config.num_threads_per_block, 0, 0>>>(
+  build_hash_table<<<config.num_blocks, config.num_threads_per_block, 0, stream>>>(
     *hash_table, hash_build, build_table_num_rows, failure.data());
   // Check error code from the kernel
-  if (failure.value() == 1) { CUDF_FAIL("Hash Table insert failure."); }
+  if (failure.value(stream) == 1) { CUDF_FAIL("Hash Table insert failure."); }
 
   return hash_table;
 }


### PR DESCRIPTION
The `hash_join` code was using `0` for the stream instead of the provided stream. Not only was this a bug, but it also led to an ambiguous constructor because `rmm::device_scalar<int> failure(0, 0);` was ambiguous. 