### PR TITLE
[REVIEW] Support fixed-point decimal for HostColumnVector [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #6622 Update `to_pandas` api docs
 - PR #6623 Add operator overloading to column and clean up error messages
 - PR #6635 Add cudf::test::dictionary_column_wrapper class
+- PR #6609 Support fixed-point decimal for HostColumnVector
 
 ## Bug Fixes
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -3799,9 +3799,9 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
   }
 
   /**
-   * Create a new vector from the given values.  This API supports inline nulls,
-   * but is much slower than building from primitive array of unscaledValue.
-   * Notice all input BigDecimals should share same scale.
+   * Create a new string vector from the given values.  This API
+   * supports inline nulls. This is really intended to be used only for testing as
+   * it is slow and memory intensive to translate between java strings and UTF8 strings.
    */
   public static ColumnVector fromStrings(String... values) {
     try (HostColumnVector host = HostColumnVector.fromStrings(values)) {

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -3790,8 +3790,8 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
   /**
    * Create a new vector from the given values.  This API supports inline nulls.
    */
-  public static ColumnVector fromBigDecimals(BigDecimal... values) {
-    try (HostColumnVector hcv = HostColumnVector.fromBigDecimals(values)) {
+  public static ColumnVector fromDecimals(BigDecimal... values) {
+    try (HostColumnVector hcv = HostColumnVector.fromDecimals(values)) {
       return hcv.copyToDevice();
     }
   }

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -3822,8 +3822,11 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
   }
 
   /**
-   * Create a new vector from the given values.  This API supports inline nulls, but it is inefficient.
-   * Notice all input BigDecimals should share same scale.
+   * Create a new vector from the given values.  This API supports inline nulls,
+   * but is much slower than building from primitive array of unscaledValues.
+   * Notice:
+   *  1. All input BigDecimals should share same scale.
+   *  2. The scale will be zero if all input values are null.
    */
   public static ColumnVector fromDecimals(BigDecimal... values) {
     try (HostColumnVector hcv = HostColumnVector.fromDecimals(values)) {

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -3799,13 +3800,13 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
   }
 
   /**
-   * Create a new decimal vector from double floats with scale and decimal type.
+   * Create a new decimal vector from double floats with specific DecimalType and RoundingMode.
    * All doubles will be rescaled according to [[scale]]. Then the integral part of rescaled double will be put to ColumnVector.
    * If any overflow occurs in extracting integral part, an IllegalArgumentException will be thrown.
    * Compared with scale of [[java.math.BigDecimal]], the scale here represents the opposite meaning.
    */
-  public static ColumnVector decimalFromDoubles(DType.DTypeEnum type, int scale, double... values) {
-    try (HostColumnVector host = HostColumnVector.decimalFromDoubles(type, scale, values)) {
+  public static ColumnVector decimalFromDoubles(DType type, RoundingMode mode, double... values) {
+    try (HostColumnVector host = HostColumnVector.decimalFromDoubles(type, mode, values)) {
       return host.copyToDevice();
     }
   }

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -24,6 +24,7 @@ import ai.rapids.cudf.WindowOptions.FrameType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -3783,6 +3784,15 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
   public static ColumnVector fromStrings(String... values) {
     try (HostColumnVector host = HostColumnVector.fromStrings(values)) {
       return host.copyToDevice();
+    }
+  }
+
+  /**
+   * Create a new vector from the given values.  This API supports inline nulls.
+   */
+  public static ColumnVector fromBigDecimals(BigDecimal... values) {
+    try (HostColumnVector hcv = HostColumnVector.fromBigDecimals(values)) {
+      return hcv.copyToDevice();
     }
   }
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -3801,8 +3801,9 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
 
   /**
    * Create a new decimal vector from double floats with specific DecimalType and RoundingMode.
-   * All doubles will be rescaled according to [[scale]]. Then the integral part of rescaled double will be put to ColumnVector.
+   * All doubles will be rescaled if necessary, according to scale of input DecimalType and RoundingMode.
    * If any overflow occurs in extracting integral part, an IllegalArgumentException will be thrown.
+   * This API is inefficient because of slow double -> decimal conversion, so it is mainly for testing.
    * Compared with scale of [[java.math.BigDecimal]], the scale here represents the opposite meaning.
    */
   public static ColumnVector decimalFromDoubles(DType type, RoundingMode mode, double... values) {

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -3799,6 +3799,18 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
   }
 
   /**
+   * Create a new decimal vector from double floats with scale and decimal type.
+   * All doubles will be rescaled according to [[scale]]. Then the integral part of rescaled double will be put to ColumnVector.
+   * If any overflow occurs in extracting integral part, an IllegalArgumentException will be thrown.
+   * Compared with scale of [[java.math.BigDecimal]], the scale here represents the opposite meaning.
+   */
+  public static ColumnVector decimalFromDoubles(DType.DTypeEnum type, int scale, double... values) {
+    try (HostColumnVector host = HostColumnVector.decimalFromDoubles(type, scale, values)) {
+      return host.copyToDevice();
+    }
+  }
+
+  /**
    * Create a new string vector from the given values.  This API
    * supports inline nulls. This is really intended to be used only for testing as
    * it is slow and memory intensive to translate between java strings and UTF8 strings.

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -3777,9 +3777,31 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
   }
 
   /**
-   * Create a new string vector from the given values.  This API
-   * supports inline nulls. This is really intended to be used only for testing as
-   * it is slow and memory intensive to translate between java strings and UTF8 strings.
+   * Create a new decimal vector from unscaled values (int array) and scale.
+   * The created vector is of type DType.DECIMAL32, whose max precision is 9.
+   * Compared with scale of [[java.math.BigDecimal]], the scale here represents the opposite meaning.
+   */
+  public static ColumnVector decimalFromInts(int scale, int... values) {
+    try (HostColumnVector host = HostColumnVector.decimalFromInts(scale, values)) {
+      return host.copyToDevice();
+    }
+  }
+
+  /**
+   * Create a new decimal vector from unscaled values (long array) and scale.
+   * The created vector is of type DType.DECIMAL64, whose max precision is 18.
+   * Compared with scale of [[java.math.BigDecimal]], the scale here represents the opposite meaning.
+   */
+  public static ColumnVector decimalFromLongs(int scale, long... values) {
+    try (HostColumnVector host = HostColumnVector.decimalFromLongs(scale, values)) {
+      return host.copyToDevice();
+    }
+  }
+
+  /**
+   * Create a new vector from the given values.  This API supports inline nulls,
+   * but is much slower than building from primitive array of unscaledValue.
+   * Notice all input BigDecimals should share same scale.
    */
   public static ColumnVector fromStrings(String... values) {
     try (HostColumnVector host = HostColumnVector.fromStrings(values)) {
@@ -3788,7 +3810,8 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
   }
 
   /**
-   * Create a new vector from the given values.  This API supports inline nulls.
+   * Create a new vector from the given values.  This API supports inline nulls, but it is inefficient.
+   * Notice all input BigDecimals should share same scale.
    */
   public static ColumnVector fromDecimals(BigDecimal... values) {
     try (HostColumnVector hcv = HostColumnVector.fromDecimals(values)) {

--- a/java/src/main/java/ai/rapids/cudf/DType.java
+++ b/java/src/main/java/ai/rapids/cudf/DType.java
@@ -92,6 +92,8 @@ public final class DType {
     }
 
     public int getNativeId() { return nativeId; }
+
+    public static boolean isDecimalType(DTypeEnum dt) { return DType.DECIMALS.contains(dt); }
   }
 
   final DTypeEnum typeId;
@@ -368,7 +370,7 @@ public final class DType {
    *       DType.DECIMAL32,
    *       DType.DECIMAL64
    */
-  public boolean isDecimalType() { return DECIMALS.contains(this.typeId); }
+  public boolean isDecimalType() { return DTypeEnum.isDecimalType(this.typeId); }
 
   /**
    * Returns true for duration types
@@ -434,7 +436,7 @@ public final class DType {
       DTypeEnum.UINT32,
       DTypeEnum.DURATION_DAYS,
       DTypeEnum.TIMESTAMP_DAYS,
-      // The unscaledValue of DECIMAL64 is of type INT32, which means it can be fetched by getInt.
+      // The unscaledValue of DECIMAL32 is of type INT32, which means it can be fetched by getInt.
       DTypeEnum.DECIMAL32
   );
 

--- a/java/src/main/java/ai/rapids/cudf/DType.java
+++ b/java/src/main/java/ai/rapids/cudf/DType.java
@@ -21,8 +21,8 @@ import java.util.Objects;
 
 public final class DType {
 
-  public static final int DECIMAL32_MAX_PRECISION = 10;
-  public static final int DECIMAL64_MAX_PRECISION = 19;
+  public static final int DECIMAL32_MAX_PRECISION = 9;
+  public static final int DECIMAL64_MAX_PRECISION = 18;
 
   /* enum representing various types. Whenever a new non-decimal type is added please make sure
   below sections are updated as well:

--- a/java/src/main/java/ai/rapids/cudf/DType.java
+++ b/java/src/main/java/ai/rapids/cudf/DType.java
@@ -231,7 +231,7 @@ public final class DType {
    * @return DType
    */
   public static DType create(DTypeEnum dt) {
-    if (dt == DTypeEnum.DECIMAL32 || dt == DTypeEnum.DECIMAL64) {
+    if (DType.DECIMALS.contains(dt)) {
       throw new IllegalArgumentException("Could not create a Decimal DType without scale");
     }
     return DType.fromNative(dt.nativeId, 0);
@@ -247,7 +247,7 @@ public final class DType {
    * @return DType
    */
   public static DType create(DTypeEnum dt, int scale) {
-    if (dt != DTypeEnum.DECIMAL32 && dt != DTypeEnum.DECIMAL64) {
+    if (!DType.DECIMALS.contains(dt)) {
       throw new IllegalArgumentException("Could not create a non-Decimal DType with scale");
     }
     return DType.fromNative(dt.nativeId, scale);
@@ -319,7 +319,8 @@ public final class DType {
    *       DType.INT32,
    *       DType.UINT32,
    *       DType.DURATION_DAYS,
-   *       DType.TIMESTAMP_DAYS
+   *       DType.TIMESTAMP_DAYS,
+   *       DType.DECIMAL32
    */
   public boolean isBackedByInt() {
     return INTS.contains(this.typeId);
@@ -337,7 +338,8 @@ public final class DType {
    *       DType.TIMESTAMP_SECONDS,
    *       DType.TIMESTAMP_MILLISECONDS,
    *       DType.TIMESTAMP_MICROSECONDS,
-   *       DType.TIMESTAMP_NANOSECONDS
+   *       DType.TIMESTAMP_NANOSECONDS,
+   *       DType.DECIMAL64
    */
   public boolean isBackedByLong() {
     return LONGS.contains(this.typeId);
@@ -422,14 +424,18 @@ public final class DType {
       DTypeEnum.TIMESTAMP_SECONDS,
       DTypeEnum.TIMESTAMP_MILLISECONDS,
       DTypeEnum.TIMESTAMP_MICROSECONDS,
-      DTypeEnum.TIMESTAMP_NANOSECONDS
+      DTypeEnum.TIMESTAMP_NANOSECONDS,
+      // The unscaledValue of DECIMAL64 is of type INT64, which means it can be fetched by getLong.
+      DTypeEnum.DECIMAL64
   );
 
   private static final EnumSet<DTypeEnum> INTS = EnumSet.of(
       DTypeEnum.INT32,
       DTypeEnum.UINT32,
       DTypeEnum.DURATION_DAYS,
-      DTypeEnum.TIMESTAMP_DAYS
+      DTypeEnum.TIMESTAMP_DAYS,
+      // The unscaledValue of DECIMAL64 is of type INT32, which means it can be fetched by getInt.
+      DTypeEnum.DECIMAL32
   );
 
   private static final EnumSet<DTypeEnum> SHORTS = EnumSet.of(

--- a/java/src/main/java/ai/rapids/cudf/DType.java
+++ b/java/src/main/java/ai/rapids/cudf/DType.java
@@ -93,7 +93,7 @@ public final class DType {
 
     public int getNativeId() { return nativeId; }
 
-    public static boolean isDecimalType(DTypeEnum dt) { return DType.DECIMALS.contains(dt); }
+    public boolean isDecimalType() { return DType.DECIMALS.contains(this); }
   }
 
   final DTypeEnum typeId;
@@ -370,7 +370,7 @@ public final class DType {
    *       DType.DECIMAL32,
    *       DType.DECIMAL64
    */
-  public boolean isDecimalType() { return DTypeEnum.isDecimalType(this.typeId); }
+  public boolean isDecimalType() { return this.typeId.isDecimalType(); }
 
   /**
    * Returns true for duration types

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -541,8 +541,10 @@ public final class HostColumnVector extends HostColumnVectorCore {
 
   /**
    * Create a new vector from the given values.  This API supports inline nulls,
-   * but is much slower than building from primitive array of unscaledValue.
-   * Notice all input BigDecimals should share same scale.
+   * but is much slower than building from primitive array of unscaledValues.
+   * Notice:
+   *  1. All input BigDecimals should share same scale.
+   *  2. The scale will be zero if all input values are null.
    */
   public static HostColumnVector fromDecimals(BigDecimal... values) {
     // Try to fetch the element with max precision. Fill with ZERO if inputs is empty.

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -1070,7 +1070,6 @@ public final class HostColumnVector extends HostColumnVectorCore {
 
     public final ColumnBuilder append(BigDecimal value) {
       growBuffersAndRows(false, currentIndex * type.getSizeInBytes() + type.getSizeInBytes());
-      assert type.isDecimalType();
       assert currentIndex < rows;
       // Rescale input decimal with UNNECESSARY policy, which accepts no precision loss.
       BigInteger unscaledVal = value.setScale(-type.getScale(), RoundingMode.UNNECESSARY).unscaledValue();

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -451,10 +451,6 @@ public final class HostColumnVector extends HostColumnVectorCore {
    * Compared with scale of [[java.math.BigDecimal]], the scale here represents the opposite meaning.
    */
   public static HostColumnVector decimalFromInts(int scale, int... values) {
-    if (-scale > DType.DECIMAL32_MAX_PRECISION) {
-      throw new IllegalArgumentException(
-          "Scale " + scale + " exceeds the max precision of DECIMAL32: " + DType.DECIMAL32_MAX_PRECISION);
-    }
     return build(DType.create(DType.DTypeEnum.DECIMAL32, scale), values.length, (b) -> b.appendUnscaledDecimalArray(values));
   }
 
@@ -464,10 +460,6 @@ public final class HostColumnVector extends HostColumnVectorCore {
    * Compared with scale of [[java.math.BigDecimal]], the scale here represents the opposite meaning.
    */
   public static HostColumnVector decimalFromLongs(int scale, long... values) {
-    if (-scale > DType.DECIMAL64_MAX_PRECISION) {
-      throw new IllegalArgumentException(
-          "Scale " + scale + " exceeds the max precision of DECIMAL64: " + DType.DECIMAL64_MAX_PRECISION);
-    }
     return build(DType.create(DType.DTypeEnum.DECIMAL64, scale), values.length, (b) -> b.appendUnscaledDecimalArray(values));
   }
 
@@ -1266,8 +1258,11 @@ public final class HostColumnVector extends HostColumnVectorCore {
     }
 
     public final Builder appendUnscaledDecimal(int value) {
-      assert type.typeId == DType.DTypeEnum.DECIMAL32;
+      assert type.isDecimalType();
       assert currentIndex < rows;
+      if (type.typeId == DType.DTypeEnum.DECIMAL64) {
+        return appendUnscaledDecimal((long) value);
+      }
       data.setInt(currentIndex * type.getSizeInBytes(), value);
       currentIndex++;
       return this;

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -470,7 +470,7 @@ public final class HostColumnVector extends HostColumnVectorCore {
 
   /**
    * Create a new decimal vector from double floats with specific DecimalType and RoundingMode.
-   * All doubles will be rescaled according to [[scale]] and cast an integral value.
+   * All doubles will be rescaled if necessary, according to scale of input DecimalType and RoundingMode.
    * If any overflow occurs in extracting integral part, an IllegalArgumentException will be thrown.
    * This API is inefficient because of slow double -> decimal conversion, so it is mainly for testing.
    * Compared with scale of [[java.math.BigDecimal]], the scale here represents the opposite meaning.

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -940,9 +940,8 @@ public final class HostColumnVector extends HostColumnVectorCore {
         childBuilder.append((Byte) listElement);
       } else if (listElement instanceof Short) {
         childBuilder.append((Short) listElement);
-      // TODO: support decimal type as a child of nested type
-      // } else if (listElement instanceof BigDecimal) {
-      //  childBuilder.append((BigDecimal) listElement);
+       } else if (listElement instanceof BigDecimal) {
+        childBuilder.append((BigDecimal) listElement);
       } else if (listElement instanceof List) {
         childBuilder.append((List) listElement);
       } else if (listElement instanceof StructData) {

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
@@ -536,6 +536,8 @@ public class HostColumnVectorCore implements ColumnViewAccess<HostMemoryBuffer> 
       case INT16: return offHeap.data.getShort(rowOffset);
       case BOOL8: return offHeap.data.getBoolean(rowOffset);
       case STRING: return getString(rowIndex);
+      case DECIMAL32: return BigDecimal.valueOf(offHeap.data.getInt(rowOffset), -type.getScale());
+      case DECIMAL64: return BigDecimal.valueOf(offHeap.data.getLong(rowOffset), -type.getScale());
       default: throw new UnsupportedOperationException("Do not support " + type);
     }
   }

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
@@ -21,6 +21,7 @@ package ai.rapids.cudf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -369,6 +370,23 @@ public class HostColumnVectorCore implements ColumnViewAccess<HostMemoryBuffer> 
     assert type.equals(DType.BOOL8) : type + " is not a supported boolean type.";
     assertsForGet(index);
     return offHeap.data.getBoolean(index * type.getSizeInBytes());
+  }
+
+  /**
+   * Get the BigDecimal value at index.
+   */
+  public BigDecimal getBigDecimal(long index) {
+    assert type.isDecimalType() : type + " is not a supported decimal type.";
+    assertsForGet(index);
+    if (type.typeId == DType.DTypeEnum.DECIMAL32) {
+      int unscaledValue = offHeap.data.getInt(index * type.getSizeInBytes());
+      return BigDecimal.valueOf(unscaledValue, -type.getScale());
+    } else if (type.typeId == DType.DTypeEnum.DECIMAL64) {
+      long unscaledValue = offHeap.data.getLong(index * type.getSizeInBytes());
+      return BigDecimal.valueOf(unscaledValue, -type.getScale());
+    } else {
+      throw new IllegalStateException(type + " is not a supported decimal type.");
+    }
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
@@ -375,7 +375,7 @@ public class HostColumnVectorCore implements ColumnViewAccess<HostMemoryBuffer> 
   /**
    * Get the BigDecimal value at index.
    */
-  public BigDecimal getBigDecimal(long index) {
+  public final BigDecimal getBigDecimal(long index) {
     assert type.isDecimalType() : type + " is not a supported decimal type.";
     assertsForGet(index);
     if (type.typeId == DType.DTypeEnum.DECIMAL32) {

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -216,19 +216,11 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
   }
 
   public static Scalar fromDecimal(int scale, int unscaledValue) {
-    if (-scale > DType.DECIMAL32_MAX_PRECISION) {
-      throw new IllegalArgumentException(
-          "Scale " + scale + " exceeds the max precision of DECIMAL32: " + DType.DECIMAL32_MAX_PRECISION);
-    }
     long handle = makeDecimal32Scalar(unscaledValue, scale, true);
     return new Scalar(DType.create(DType.DTypeEnum.DECIMAL32, scale), handle);
   }
 
   public static Scalar fromDecimal(int scale, long unscaledValue) {
-    if (-scale > DType.DECIMAL64_MAX_PRECISION) {
-      throw new IllegalArgumentException(
-          "Scale " + scale + " exceeds the max precision of DECIMAL64: " + DType.DECIMAL64_MAX_PRECISION);
-    }
     long handle = makeDecimal64Scalar(unscaledValue, scale, true);
     return new Scalar(DType.create(DType.DTypeEnum.DECIMAL64, scale), handle);
   }

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -215,6 +215,24 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
     return new Scalar(DType.FLOAT32, makeFloat32Scalar(value, true));
   }
 
+  public static Scalar fromDecimal(int scale, int unscaledValue) {
+    if (-scale > DType.DECIMAL32_MAX_PRECISION) {
+      throw new IllegalArgumentException(
+          "Scale " + scale + " exceeds the max precision of DECIMAL32: " + DType.DECIMAL32_MAX_PRECISION);
+    }
+    long handle = makeDecimal32Scalar(unscaledValue, scale, true);
+    return new Scalar(DType.create(DType.DTypeEnum.DECIMAL32, scale), handle);
+  }
+
+  public static Scalar fromDecimal(int scale, long unscaledValue) {
+    if (-scale > DType.DECIMAL64_MAX_PRECISION) {
+      throw new IllegalArgumentException(
+          "Scale " + scale + " exceeds the max precision of DECIMAL64: " + DType.DECIMAL64_MAX_PRECISION);
+    }
+    long handle = makeDecimal64Scalar(unscaledValue, scale, true);
+    return new Scalar(DType.create(DType.DTypeEnum.DECIMAL64, scale), handle);
+  }
+
   public static Scalar fromFloat(Float value) {
     if (value == null) {
       return Scalar.fromNull(DType.FLOAT32);
@@ -233,7 +251,7 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
     return Scalar.fromDouble(value.doubleValue());
   }
 
-  public static Scalar fromBigDecimal(BigDecimal value) {
+  public static Scalar fromDecimal(BigDecimal value) {
     if (value == null) {
       return Scalar.fromNull(DType.create(DType.DTypeEnum.DECIMAL64, 0));
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -21,6 +21,7 @@ package ai.rapids.cudf;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -2962,6 +2963,28 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testListOfListsCvDecimals() {
+    List<BigDecimal> list1 = Arrays.asList(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2), BigDecimal.valueOf(3.3));
+    List<BigDecimal> list2 = Arrays.asList(BigDecimal.valueOf(4.4), BigDecimal.valueOf(5.5), BigDecimal.valueOf(6.6));
+    List<BigDecimal> list3 = Arrays.asList(BigDecimal.valueOf(10.1), BigDecimal.valueOf(20.2), BigDecimal.valueOf(30.3));
+    List<List<BigDecimal>> mainList1 = new ArrayList<>();
+    mainList1.add(list1);
+    mainList1.add(list2);
+    List<List<BigDecimal>> mainList2 = new ArrayList<>();
+    mainList2.add(list3);
+
+    HostColumnVector.BasicType basicType = new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL32, -1));
+    try(ColumnVector res = ColumnVector.fromLists(new HostColumnVector.ListType(true,
+        new HostColumnVector.ListType(true, basicType)), mainList1, mainList2);
+        HostColumnVector hcv = res.copyToHost()) {
+      List<List<BigDecimal>> ret1 = hcv.getList(0);
+      List<List<BigDecimal>> ret2 = hcv.getList(1);
+      assertEquals(mainList1, ret1, "Lists don't match");
+      assertEquals(mainList2, ret2, "Lists don't match");
+    }
+  }
+
+  @Test
   void testConcatLists() {
     List<Integer> list1 = Arrays.asList(0, 1, 2, 3);
     List<Integer> list2 = Arrays.asList(6, 2, 4, 5);
@@ -3043,6 +3066,34 @@ public class ColumnVectorTest extends CudfTestBase {
     try(ColumnVector expected = ColumnVector.fromLists(
         new HostColumnVector.ListType(true,
             new HostColumnVector.BasicType(true, DType.INT32)),
+        val1, val2, val3, val4, val5, val6);
+        HostColumnVector hostColumnVector = expected.copyToHost()) {
+      List<String> ret1 = hostColumnVector.getList(0);
+      List<String> ret2 = hostColumnVector.getList(1);
+      List<String> ret3 = hostColumnVector.getList(2);
+      List<String> ret4 = hostColumnVector.getList(3);
+      List<String> ret5 = hostColumnVector.getList(4);
+      List<String> ret6 = hostColumnVector.getList(5);
+      assertEquals(val1, ret1, "Lists don't match");
+      assertEquals(val2, ret2, "Lists don't match");
+      assertEquals(val3, ret3, "Lists don't match");
+      assertEquals(val4, ret4, "Lists don't match");
+      assertEquals(val5, ret5, "Lists don't match");
+      assertEquals(val6, ret6, "Lists don't match");
+    }
+  }
+
+  @Test
+  void testHcvOfDecimals() {
+    List<BigDecimal> val1 = Arrays.asList(BigDecimal.ONE, BigDecimal.TEN);
+    List<BigDecimal> val2 = Arrays.asList(BigDecimal.ZERO);
+    List<BigDecimal> val3 = null;
+    List<BigDecimal> val4 = Arrays.asList();
+    List<BigDecimal> val5 = Arrays.asList(BigDecimal.valueOf(123), BigDecimal.valueOf(100));
+    List<BigDecimal> val6 = Arrays.asList(BigDecimal.valueOf(100000), BigDecimal.valueOf(20000));
+    try(ColumnVector expected = ColumnVector.fromLists(
+        new HostColumnVector.ListType(true,
+            new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL32, 0))),
         val1, val2, val3, val4, val5, val6);
         HostColumnVector hostColumnVector = expected.copyToHost()) {
       List<String> ret1 = hostColumnVector.getList(0);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -778,7 +778,7 @@ public class ColumnVectorTest extends CudfTestBase {
         }
 
         try (ColumnVector c = ColumnVector.fromScalar(s, 0)) {
-          if (type == DType.DTypeEnum.DECIMAL32 || type == DType.DTypeEnum.DECIMAL64) {
+          if (DType.DTypeEnum.isDecimalType(type)) {
             assertEquals(DType.create(type, mockScale), c.getType());
           } else {
             assertEquals(DType.create(type), c.getType());
@@ -806,7 +806,7 @@ public class ColumnVectorTest extends CudfTestBase {
   void testFromScalar() {
     final int rowCount = 4;
     for (DType.DTypeEnum type : DType.DTypeEnum.values()) {
-      if(type == DType.DTypeEnum.DECIMAL32 || type == DType.DTypeEnum.DECIMAL64) {
+      if(DType.DTypeEnum.isDecimalType(type)) {
         continue;
       }
       Scalar s = null;
@@ -976,7 +976,7 @@ public class ColumnVectorTest extends CudfTestBase {
         continue;
       }
       DType dType;
-      if (type == DType.DTypeEnum.DECIMAL32 || type == DType.DTypeEnum.DECIMAL64) {
+      if (DType.DTypeEnum.isDecimalType(type)) {
         dType = DType.create(type, -8);
       } else {
         dType = DType.create(type);

--- a/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
@@ -1,12 +1,32 @@
+/*
+ *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package ai.rapids.cudf;
 
+import ai.rapids.cudf.HostColumnVector.Builder;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DecimalColumnVectorTest extends CudfTestBase {
   private final Random rdSeed = new Random();
@@ -66,7 +86,7 @@ public class DecimalColumnVectorTest extends CudfTestBase {
 
   @Test
   public void testOverrunningTheBuffer() {
-    try (HostColumnVector.Builder builder = HostColumnVector.builder(DType.create(DType.DTypeEnum.DECIMAL32, 4), 3)) {
+    try (Builder builder = HostColumnVector.builder(DType.create(DType.DTypeEnum.DECIMAL32, 4), 3)) {
       assertThrows(AssertionError.class,
           () -> builder.append(decimal32Zoo[0]).appendNull().appendBoxed(decimal32Zoo[1], decimal32Zoo[2]).build());
     }
@@ -111,7 +131,7 @@ public class DecimalColumnVectorTest extends CudfTestBase {
         for (int dstPrefilledSize = 0; dstPrefilledSize < dstSize; dstPrefilledSize++) {
           final int srcSize = dstSize - dstPrefilledSize;
           for (int sizeOfDataNotToAdd = 0; sizeOfDataNotToAdd <= dstPrefilledSize; sizeOfDataNotToAdd++) {
-            try (HostColumnVector.Builder dst = HostColumnVector.builder(decType, dstSize);
+            try (Builder dst = HostColumnVector.builder(decType, dstSize);
                  HostColumnVector src = HostColumnVector.build(decType, srcSize, (b) -> {
                    for (int i = 0; i < srcSize; i++) {
                      if (random.nextBoolean()) {
@@ -121,7 +141,7 @@ public class DecimalColumnVectorTest extends CudfTestBase {
                      }
                    }
                  });
-                 HostColumnVector.Builder gtBuilder = HostColumnVector.builder(decType, dstPrefilledSize)) {
+                 Builder gtBuilder = HostColumnVector.builder(decType, dstPrefilledSize)) {
               assertEquals(dstSize, srcSize + dstPrefilledSize);
               //add the first half of the prefilled list
               for (int i = 0; i < dstPrefilledSize - sizeOfDataNotToAdd; i++) {

--- a/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *  Copyright (c) 2020, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
@@ -86,15 +86,8 @@ public class DecimalColumnVectorTest extends CudfTestBase {
   public void testAddingNullValues() {
     try (HostColumnVector cv = HostColumnVector.fromDecimals(decimal64Zoo)) {
       int nullCount = 0;
-      int index = 0;
-      for (BigDecimal dec : decimal64Zoo) {
-        if (dec == null) {
-          assertTrue(cv.isNull(index));
-          nullCount++;
-        } else {
-          assertFalse(cv.isNull(index));
-        }
-        index++;
+      for (int i = 0; i < decimal64Zoo.length; ++i) {
+        assertEquals(decimal64Zoo[i] == null, cv.isNull(i));
       }
       assertEquals(nullCount > 0, cv.hasNulls());
       assertEquals(nullCount, cv.getNullCount());

--- a/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
@@ -205,7 +205,7 @@ public class DecimalColumnVectorTest extends CudfTestBase {
                      if (rdSeed.nextBoolean()) {
                        b.appendNull();
                      } else {
-                       b.append(BigDecimal.valueOf(rdSeed.nextInt(), -decType.getScale()));
+                       b.append(BigDecimal.valueOf(rdSeed.nextInt() / 10, -decType.getScale()));
                      }
                    }
                  });
@@ -217,8 +217,8 @@ public class DecimalColumnVectorTest extends CudfTestBase {
                   dst.appendNull();
                   gtBuilder.appendNull();
                 } else {
-                  BigDecimal a = BigDecimal.valueOf(rdSeed.nextInt(), -decType.getScale());
-                  dst.append(a);
+                  BigDecimal a = BigDecimal.valueOf(rdSeed.nextInt() / 10, -decType.getScale());
+                  dst.appendUnscaledDecimal(a.unscaledValue().intValueExact());
                   gtBuilder.append(a);
                 }
               }

--- a/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
@@ -1,0 +1,167 @@
+package ai.rapids.cudf;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DecimalColumnVectorTest extends CudfTestBase {
+  private final Random rdSeed = new Random();
+
+  private final BigDecimal[] decimal32Zoo = new BigDecimal[]{
+    BigDecimal.valueOf(rdSeed.nextInt(1000000000), 4),
+    BigDecimal.valueOf(rdSeed.nextInt(1000000000), 4),
+    BigDecimal.valueOf(rdSeed.nextInt(1000000000), 4),
+  };
+
+  private final BigDecimal[] decimal64Zoo = new BigDecimal[]{
+    BigDecimal.valueOf(rdSeed.nextLong(), 10),
+    BigDecimal.valueOf(rdSeed.nextLong(), 10),
+    null,
+    BigDecimal.valueOf(rdSeed.nextLong(), 10),
+  };
+
+  @Test
+  public void testCreateColumnVectorBuilder() {
+    try (ColumnVector decColumnVector = ColumnVector.build(DType.create(DType.DTypeEnum.DECIMAL32, -5), 3,
+        (b) -> b.append(BigDecimal.valueOf(123456789, 5)))) {
+      assertFalse(decColumnVector.hasNulls());
+    }
+    try (ColumnVector decColumnVector = ColumnVector.build(DType.create(DType.DTypeEnum.DECIMAL64, -10), 3,
+        (b) -> b.append(BigDecimal.valueOf(1023040506070809L, 10)))) {
+      assertFalse(decColumnVector.hasNulls());
+    }
+  }
+
+  @Test
+  public void testUpperIndexOutOfBoundsException() {
+    try (HostColumnVector decColumnVector = HostColumnVector.fromBigDecimals(decimal32Zoo)) {
+      assertThrows(AssertionError.class, () -> decColumnVector.getBigDecimal(3));
+      assertFalse(decColumnVector.hasNulls());
+    }
+  }
+
+  @Test
+  public void testLowerIndexOutOfBoundsException() {
+    try (HostColumnVector doubleColumnVector = HostColumnVector.fromBigDecimals(decimal32Zoo)) {
+      assertFalse(doubleColumnVector.hasNulls());
+      assertThrows(AssertionError.class, () -> doubleColumnVector.getBigDecimal(-1));
+    }
+  }
+
+  @Test
+  public void testAddingNullValues() {
+    try (HostColumnVector cv = HostColumnVector.fromBigDecimals(decimal64Zoo)) {
+      assertTrue(cv.hasNulls());
+      assertEquals(1, cv.getNullCount());
+      assertFalse(cv.isNull(0));
+      assertFalse(cv.isNull(1));
+      assertTrue(cv.isNull(2));
+      assertFalse(cv.isNull(3));
+    }
+  }
+
+  @Test
+  public void testOverrunningTheBuffer() {
+    try (HostColumnVector.Builder builder = HostColumnVector.builder(DType.create(DType.DTypeEnum.DECIMAL32, 4), 3)) {
+      assertThrows(AssertionError.class,
+          () -> builder.append(decimal32Zoo[0]).appendNull().appendBoxed(decimal32Zoo[1], decimal32Zoo[2]).build());
+    }
+  }
+
+  @Test
+  public void testDecimalValidation() {
+    assertThrows(AssertionError.class,
+        () -> HostColumnVector.fromBigDecimals(BigDecimal.valueOf(123, 1), BigDecimal.valueOf(123, 2)));
+    assertThrows(AssertionError.class,
+        () -> HostColumnVector.fromBigDecimals(new BigDecimal("12345678901234567890")));
+  }
+
+  @Test
+  public void testDecimalSpecifics() {
+    try (HostColumnVector cv = HostColumnVector.fromBigDecimals(decimal32Zoo)) {
+      assertEquals(DType.DTypeEnum.DECIMAL32, cv.getType().typeId);
+      assertEquals(-4, cv.getType().getScale());
+      assertFalse(cv.hasNulls());
+      assertEquals(decimal32Zoo[0], cv.getBigDecimal(0));
+      assertEquals(decimal32Zoo[1], cv.getBigDecimal(1));
+      assertEquals(decimal32Zoo[2], cv.getBigDecimal(2));
+    }
+    try (HostColumnVector cv = HostColumnVector.fromBigDecimals(decimal64Zoo)) {
+      assertEquals(DType.DTypeEnum.DECIMAL64, cv.getType().typeId);
+      assertEquals(-10, cv.getType().getScale());
+      assertTrue(cv.hasNulls());
+      assertEquals(decimal64Zoo[0], cv.getBigDecimal(0));
+      assertEquals(decimal64Zoo[1], cv.getBigDecimal(1));
+      assertThrows(AssertionError.class, () -> cv.getBigDecimal(2));
+      assertEquals(decimal64Zoo[3], cv.getBigDecimal(3));
+    }
+  }
+
+  @Test
+  public void testAppendVector() {
+    Random random = new Random(192312989128L);
+    for (DType decType : new DType[]{
+        DType.create(DType.DTypeEnum.DECIMAL32, -6),
+        DType.create(DType.DTypeEnum.DECIMAL64, -10)}) {
+      for (int dstSize = 1; dstSize <= 100; dstSize++) {
+        for (int dstPrefilledSize = 0; dstPrefilledSize < dstSize; dstPrefilledSize++) {
+          final int srcSize = dstSize - dstPrefilledSize;
+          for (int sizeOfDataNotToAdd = 0; sizeOfDataNotToAdd <= dstPrefilledSize; sizeOfDataNotToAdd++) {
+            try (HostColumnVector.Builder dst = HostColumnVector.builder(decType, dstSize);
+                 HostColumnVector src = HostColumnVector.build(decType, srcSize, (b) -> {
+                   for (int i = 0; i < srcSize; i++) {
+                     if (random.nextBoolean()) {
+                       b.appendNull();
+                     } else {
+                       b.append(BigDecimal.valueOf(random.nextInt(), -decType.getScale()));
+                     }
+                   }
+                 });
+                 HostColumnVector.Builder gtBuilder = HostColumnVector.builder(decType, dstPrefilledSize)) {
+              assertEquals(dstSize, srcSize + dstPrefilledSize);
+              //add the first half of the prefilled list
+              for (int i = 0; i < dstPrefilledSize - sizeOfDataNotToAdd; i++) {
+                if (random.nextBoolean()) {
+                  dst.appendNull();
+                  gtBuilder.appendNull();
+                } else {
+                  BigDecimal a = BigDecimal.valueOf(random.nextInt(), -decType.getScale());
+                  dst.append(a);
+                  gtBuilder.append(a);
+                }
+              }
+              // append the src vector
+              dst.append(src);
+              try (HostColumnVector dstVector = dst.build();
+                   HostColumnVector gt = gtBuilder.build()) {
+                for (int i = 0; i < dstPrefilledSize - sizeOfDataNotToAdd; i++) {
+                  assertEquals(gt.isNull(i), dstVector.isNull(i));
+                  if (!gt.isNull(i)) {
+                    assertEquals(gt.getBigDecimal(i), dstVector.getBigDecimal(i));
+                  }
+                }
+                for (int i = dstPrefilledSize - sizeOfDataNotToAdd, j = 0; i < dstSize - sizeOfDataNotToAdd && j < srcSize; i++, j++) {
+                  assertEquals(src.isNull(j), dstVector.isNull(i));
+                  if (!src.isNull(j)) {
+                    assertEquals(src.getBigDecimal(j), dstVector.getBigDecimal(i));
+                  }
+                }
+                if (dstVector.hasValidityVector()) {
+                  long maxIndex =
+                      BitVectorHelper.getValidityAllocationSizeInBytes(dstVector.getRowCount()) * 8;
+                  for (long i = dstSize - sizeOfDataNotToAdd; i < maxIndex; i++) {
+                    assertFalse(dstVector.isNullExtendedRange(i));
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/java/src/test/java/ai/rapids/cudf/ScalarTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ScalarTest.java
@@ -21,7 +21,6 @@ package ai.rapids.cudf;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.math.MathContext;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -134,12 +133,20 @@ public class ScalarTest extends CudfTestBase {
         BigDecimal.valueOf(12345678, 2),
         BigDecimal.valueOf(1234567890123L, 6),
     };
-    for (BigDecimal bigDec: bigDecimals) {
-      try (Scalar s = Scalar.fromBigDecimal(bigDec)) {
-        assertEquals(DType.fromJavaBigDecimal(bigDec), s.getType());
+    for (BigDecimal dec: bigDecimals) {
+      try (Scalar s = Scalar.fromDecimal(dec)) {
+        assertEquals(DType.fromJavaBigDecimal(dec), s.getType());
         assertTrue(s.isValid());
-        assertEquals(bigDec.unscaledValue().longValueExact(), s.getLong());
-        assertEquals(bigDec, s.getBigDecimal());
+        assertEquals(dec.unscaledValue().longValueExact(), s.getLong());
+        assertEquals(dec, s.getBigDecimal());
+      }
+      try (Scalar s = Scalar.fromDecimal(-dec.scale(), dec.unscaledValue().intValueExact())) {
+        assertEquals(dec, s.getBigDecimal());
+      } catch (java.lang.ArithmeticException ex) {
+        try (Scalar s = Scalar.fromDecimal(-dec.scale(), dec.unscaledValue().longValueExact())) {
+          assertEquals(dec, s.getBigDecimal());
+          assertTrue(s.getType().isBackedByLong());
+        }
       }
     }
   }

--- a/java/src/test/java/ai/rapids/cudf/ScalarTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ScalarTest.java
@@ -49,7 +49,7 @@ public class ScalarTest extends CudfTestBase {
   public void testNull() {
     for (DType.DTypeEnum dataType : DType.DTypeEnum.values()) {
       DType type;
-      if (DType.DTypeEnum.isDecimalType(dataType)) {
+      if (dataType.isDecimalType()) {
         type = DType.create(dataType, -3);
       } else {
         type = DType.create(dataType);

--- a/java/src/test/java/ai/rapids/cudf/ScalarTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ScalarTest.java
@@ -49,7 +49,7 @@ public class ScalarTest extends CudfTestBase {
   public void testNull() {
     for (DType.DTypeEnum dataType : DType.DTypeEnum.values()) {
       DType type;
-      if (dataType == DType.DTypeEnum.DECIMAL32 || dataType == DType.DTypeEnum.DECIMAL64) {
+      if (DType.DTypeEnum.isDecimalType(dataType)) {
         type = DType.create(dataType, -3);
       } else {
         type = DType.create(dataType);


### PR DESCRIPTION
This PR supports decimal fetching/appending for (Host)ColumnVector.  In specific, with this PR, we are able to get/append `java.math.BigDecimal` from/to ColumnVector. This is a minimum work to provide essential interface for the plugin-side development.
* Considering `java.math.BigDecimal` is a boxed type,  this PR only implemented `Builder.appendBoxed` method for BigDecimal (left `Builder.appendArray` unsupported).
* Each BigDecimal will be verified before appending to HostColumnVector.Builder, which ensures:
   * All scales in same HostColumnVector are consistent.
   * Transfer BigDecimal to cuDF::fixed_point without any precison loss. If any overflow occurs, corresponding exception will be thrown.
* Decimal types can be used as basic type of nested types. 