### PR TITLE
Update JNI to new RMM cuda_stream_view API [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - PR #6597 Use thread-local to track CUDA device in JNI
 - PR #6599 Replace `size()==0` with `empty()`, `is_empty()`
 - PR #6514 Initial work for decimal type in Java/JNI
+- PR #6612 Update JNI to new RMM cuda_stream_view API
 
 ## Bug Fixes
 


### PR DESCRIPTION
This fixes the JNI build by updating to the new device memory resource API that uses `rmm::cuda_stream_view` instead of `cudaStream_t` directly.