### PR TITLE
Fix JNI native dependency load order [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - PR #6596 Fix memory usage calculation
 - PR #6595 Fix JNI build, broken by to_arrow() signature change
 - PR #6603 Use correct stream in hash_join.
+- PR #6617 Fix JNI native dependency load order
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -56,11 +56,11 @@ public class NativeDepsLoader {
   private static final String[][] loadOrder = new String[][]{
       new String[]{
           "nvcomp",
-          "cudf_base",
-          "cudf_comms"
+          "cudf_base"
       },
       new String[]{
           "cudf_ast",
+          "cudf_comms",
           "cudf_hash",
           "cudf_interop",
           "cudf_io",


### PR DESCRIPTION
This changes the JNI native dependency load order to always load libcudf_base.so before loading libcudf_comms.so.

When built with some toolchains, libcudf_comms.so has an explicit dependency on libcudf_base.so whereas with other toolchains it does not.  The JNI code currently loads libcudf_base.so and libcudf_comms.so in parallel, but this only works when building with a toolchain smart enough to realize libcudf_comms.so does not need libcudf_base.so despite linking against it.
