### PR TITLE
Revert bad CMake changes for JNI [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - PR #6595 Fix JNI build, broken by to_arrow() signature change
 - PR #6603 Use correct stream in hash_join.
 - PR #6617 Fix JNI native dependency load order
+- PR #6629 Fix JNI CMake
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -307,9 +307,6 @@ add_library(cudfjni SHARED ${SOURCE_FILES})
 #Override RPATH for cudfjni
 SET_TARGET_PROPERTIES(cudfjni PROPERTIES BUILD_RPATH "\$ORIGIN")
 
-
-add_executable(row_test "src/to_rows_test.cpp" "src/row_conversion.cu")
-target_link_libraries(row_test ${CUDF_LIBS} ${ARROW_LIBRARY} ${CUDART_LIBRARY} cuda nvrtc)
 ###################################################################################################
 # - build options ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
This fixes some changes to the JNI cmake that were checked in incorrectly.