### PR TITLE
Fix Java HostColumnVector unnecessarily loading native dependencies [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - PR #6607 Fix integer overflow in ORC encoder
 - PR #6617 Fix JNI native dependency load order
 - PR #6629 Fix JNI CMake
+- PR #6633 Fix Java HostColumnVector unnecessarily loading native dependencies
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/java/src/main/java/ai/rapids/cudf/Aggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/Aggregation.java
@@ -25,6 +25,10 @@ import java.util.Arrays;
  * since in all types of aggregation operations.
  */
 public abstract class Aggregation {
+    static {
+        NativeDepsLoader.loadNativeDeps();
+    }
+
     /*
      * This should be kept in sync with AggregationJni.cpp.  Note that the nativeId here is not the
      * same as the C++ cudf::aggregation::Kind.  They are very closely related, but both are

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -36,9 +36,6 @@ public final class HostColumnVector extends HostColumnVectorCore {
    * The size in bytes of an offset entry
    */
   static final int OFFSET_SIZE = DType.INT32.getSizeInBytes();
-  static {
-    NativeDepsLoader.loadNativeDeps();
-  }
 
   private int refCount;
 


### PR DESCRIPTION
This fixes two issues related to Java classes and native dependencies:
- HostColumnVector loads native libraries despite not having any native methods
- Aggregation does not load native libraries yet has native methods
