### PR TITLE
[REVIEW] Add error message for unsupported `axis` parameter in DataFrame APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - PR #6617 Fix JNI native dependency load order
 - PR #6629 Fix JNI CMake
 - PR #6633 Fix Java HostColumnVector unnecessarily loading native dependencies
+- PR #6640 Add error message for unsupported `axis` parameter in DataFrame APIs
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5467,6 +5467,9 @@ class DataFrame(Frame, Serializable):
         Single    5
         dtype: int64
         """
+        if axis not in (0, "index", None):
+            raise NotImplementedError("Only axis=0 is currently supported.")
+
         return self._apply_support_method(
             "count",
             axis=axis,
@@ -5768,6 +5771,9 @@ class DataFrame(Frame, Serializable):
         2  1  7
         3  1  7
         """
+        if axis not in (0, "index", None):
+            raise NotImplementedError("Only axis=0 is currently supported.")
+
         return self._apply_support_method(
             "cummin", axis=axis, skipna=skipna, *args, **kwargs
         )
@@ -5802,6 +5808,9 @@ class DataFrame(Frame, Serializable):
         2  3   9
         3  4  10
         """
+        if axis not in (0, "index", None):
+            raise NotImplementedError("Only axis=0 is currently supported.")
+
         return self._apply_support_method(
             "cummax", axis=axis, skipna=skipna, *args, **kwargs
         )
@@ -5837,6 +5846,9 @@ class DataFrame(Frame, Serializable):
         2   6  24
         3  10  34
         """
+        if axis not in (0, "index", None):
+            raise NotImplementedError("Only axis=0 is currently supported.")
+
         return self._apply_support_method(
             "cumsum", axis=axis, skipna=skipna, *args, **kwargs
         )
@@ -5871,6 +5883,9 @@ class DataFrame(Frame, Serializable):
         2   6   504
         3  24  5040
         """
+        if axis not in (0, "index", None):
+            raise NotImplementedError("Only axis=0 is currently supported.")
+
         return self._apply_support_method(
             "cumprod", axis=axis, skipna=skipna, *args, **kwargs
         )
@@ -6163,6 +6178,9 @@ class DataFrame(Frame, Serializable):
         b   -1.2
         dtype: float64
         """
+        if axis not in (0, "index", None):
+            raise NotImplementedError("Only axis=0 is currently supported.")
+
         if numeric_only not in (None, True):
             msg = "Kurtosis only supports int, float, and bool dtypes."
             raise NotImplementedError(msg)
@@ -6209,6 +6227,9 @@ class DataFrame(Frame, Serializable):
         b   -0.37037
         dtype: float64
         """
+        if axis not in (0, "index", None):
+            raise NotImplementedError("Only axis=0 is currently supported.")
+
         if numeric_only not in (None, True):
             msg = "Skew only supports int, float, and bool dtypes."
             raise NotImplementedError(msg)
@@ -6355,27 +6376,30 @@ class DataFrame(Frame, Serializable):
 
             level = kwargs.pop("level", None)
             if level not in (None,):
-                msg = "Row-wise operations currently do not "
-                "support `level`."
-                raise NotImplementedError(msg)
+                raise NotImplementedError(
+                    "Row-wise operations currently do not support `level`."
+                )
 
             numeric_only = kwargs.pop("numeric_only", None)
             if numeric_only not in (None, True):
-                msg = "Row-wise operations currently do not "
-                "support `numeric_only=False`."
-                raise NotImplementedError(msg)
+                raise NotImplementedError(
+                    "Row-wise operations currently do not "
+                    "support `numeric_only=False`."
+                )
 
             min_count = kwargs.pop("min_count", None)
             if min_count not in (None, 0):
-                msg = "Row-wise operations currently do not "
-                "support `min_count`."
-                raise NotImplementedError(msg)
+                raise NotImplementedError(
+                    "Row-wise operations currently do not "
+                    "support `min_count`."
+                )
 
             bool_only = kwargs.pop("bool_only", None)
             if bool_only not in (None, True):
-                msg = "Row-wise operations currently do not "
-                "support `bool_only`."
-                raise NotImplementedError(msg)
+                raise NotImplementedError(
+                    "Row-wise operations currently do not "
+                    "support `bool_only`."
+                )
 
             prepared, mask, common_dtype = self._prepare_for_rowwise_op(
                 method, skipna

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -7889,3 +7889,25 @@ def test_dataframe_to_pandas_nullable_dtypes(df, expected_pdf):
     actual_pdf = df.to_pandas(nullable=True)
 
     assert_eq(actual_pdf, expected_pdf)
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        "count",
+        "cummin",
+        "cummax",
+        "cummax",
+        "cumprod",
+        "kurt",
+        "kurtosis",
+        "skew",
+    ],
+)
+def test_dataframe_axis1_unsupported_ops(op):
+    df = gd.DataFrame({"a": [1, 2, 3], "b": [8, 9, 10]})
+
+    with pytest.raises(
+        NotImplementedError, match="Only axis=0 is currently supported."
+    ):
+        getattr(df, op)(axis=1)


### PR DESCRIPTION
Fixes: #6639 

This PR adds parameter validation to raise error when `axis=1` for some of the dataframe APIs that rely on cupy. This also has changes to fix where the strings of other errors were being truncated.


<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
