### PR TITLE
[REVIEW] Implement `cudf::round` `decimal32` & `decimal64` (`HALF_UP` and `HALF_EVEN`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - PR #6460 Add is_timestamp format check API
 - PR #6647 Implement `cudf::round` floating point and integer types (`HALF_EVEN`)
 - PR #6562 Implement `cudf::round` floating point and integer types (`HALF_UP`)
+- PR #6685 Implement `cudf::round` `decimal32` & `decimal64` (`HALF_UP` and `HALF_EVEN`)
 - PR #6528 Enable `fixed_point` binary operations
 - PR #6460 Add is_timestamp format check API
 - PR #6568 Add function to create hashed vocabulary file from raw vocabulary

--- a/cpp/include/cudf/round.hpp
+++ b/cpp/include/cudf/round.hpp
@@ -39,8 +39,8 @@ enum class rounding_method : int32_t { HALF_UP, HALF_EVEN };
  * @brief Rounds all the values in a column to the specified number of decimal places.
  *
  * `cudf::round` currently supports HALF_UP and HALF_EVEN rounding for integer, floating point and
- * `decimal32` and `decimal64` numbers. For `decimal32` and `decimal64` numbers, the
- * `numeric::scale` is set the `-decimal_places` rounded to.
+ * `decimal32` and `decimal64` numbers. For `decimal32` and `decimal64` numbers, negated
+ * `numeric::scale` is equivalent to `decimal_places`.
  *
  * Example:
  * ```

--- a/cpp/include/cudf/round.hpp
+++ b/cpp/include/cudf/round.hpp
@@ -38,8 +38,9 @@ enum class rounding_method : int32_t { HALF_UP, HALF_EVEN };
 /**
  * @brief Rounds all the values in a column to the specified number of decimal places.
  *
- * `cudf::round` currently supports HALF_UP and HALF_EVEN rounding for integer and floating point
- * numbers.
+ * `cudf::round` currently supports HALF_UP and HALF_EVEN rounding for integer, floating point and
+ * `decimal32` and `decimal64` numbers. For `decimal32` and `decimal64` numbers, the
+ * `numeric::scale` is set the `-decimal_places` rounded to.
  *
  * Example:
  * ```

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -343,7 +343,7 @@ std::unique_ptr<column> round(column_view const& input,
   CUDF_EXPECTS(cudf::is_numeric(input.type()) || cudf::is_fixed_point(input.type()),
                "Only integral/floating point/fixed point currently supported.");
 
-  if (input.size() == 0) {
+  if (input.is_empty()) {
     if (is_fixed_point(input.type())) {
       auto const type = data_type{input.type().id(), numeric::scale_type{-decimal_places}};
       return std::make_unique<cudf::column>(type, 0, rmm::device_buffer{});

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -343,8 +343,13 @@ std::unique_ptr<column> round(column_view const& input,
   CUDF_EXPECTS(cudf::is_numeric(input.type()) || cudf::is_fixed_point(input.type()),
                "Only integral/floating point/fixed point currently supported.");
 
-  // TODO when fixed_point supported, have to adjust type
-  if (input.size() == 0) return empty_like(input);
+  if (input.size() == 0) {
+    if (is_fixed_point(input.type())) {
+      auto const type = data_type{input.type().id(), numeric::scale_type{-decimal_places}};
+      return std::make_unique<cudf::column>(type, 0, rmm::device_buffer{});
+    }
+    return empty_like(input);
+  }
 
   return type_dispatcher(
     input.type(), round_type_dispatcher{}, input, decimal_places, method, stream, mr);

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -77,13 +77,13 @@ template <typename T>
 struct half_up_zero {
   T n;  // unused in the decimal_places = 0 case
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     return generic_round(e);
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     assert(false);  // Should never get here. Just for compilation
     return U{};
@@ -94,7 +94,7 @@ template <typename T>
 struct half_up_positive {
   T n;
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     T integer_part;
     T const fractional_part = generic_modf(e, &integer_part);
@@ -102,7 +102,7 @@ struct half_up_positive {
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     assert(false);  // Should never get here. Just for compilation
     return U{};
@@ -113,13 +113,13 @@ template <typename T>
 struct half_up_negative {
   T n;
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     return generic_round(e / n) * n;
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     auto const down = (e / n) * n;  // result from rounding down
     return down + generic_sign(e) * (generic_abs(e - down) >= n / 2 ? n : 0);
@@ -130,13 +130,13 @@ template <typename T>
 struct half_even_zero {
   T n;  // unused in the decimal_places = 0 case
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     return generic_round_half_even(e);
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     assert(false);  // Should never get here. Just for compilation
     return U{};
@@ -147,7 +147,7 @@ template <typename T>
 struct half_even_positive {
   T n;
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     T integer_part;
     T const fractional_part = generic_modf(e, &integer_part);
@@ -155,7 +155,7 @@ struct half_even_positive {
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     assert(false);  // Should never get here. Just for compilation
     return U{};
@@ -166,13 +166,13 @@ template <typename T>
 struct half_even_negative {
   T n;
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     return generic_round_half_even(e / n) * n;
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ T operator()(T e)
+  __device__ U operator()(U e)
   {
     auto const down_over_n = e / n;            // use this to determine HALF_EVEN case
     auto const down        = down_over_n * n;  // result from rounding down

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -138,7 +138,7 @@ struct half_up_negative {
   template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
   __device__ DeviceType operator()(DeviceType e)
   {
-    return e;  // TODO
+    return half_up_negative<DeviceType, DeviceType>{n}(e) / n;
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -242,7 +242,7 @@ std::unique_ptr<column> round_with(column_view const& input,
 
   // if rounding to more precision that fixed_point is capable of, just need to rescale
   // note: decimal_places has the opposite sign of numeric::scale_type (therefore have to negate)
-  if (is_fixed_point(input.type()) && input.type().scale() > -decimal_places) {
+  if (input.type().scale() > -decimal_places) {
     // TODO replace this cudf::binary_operation with a cudf::cast or cudf::rescale when available
     auto const diff   = input.type().scale() - (-decimal_places);
     auto const scalar = cudf::make_fixed_point_scalar<T>(std::pow(10, diff), scale_type{-diff});
@@ -251,12 +251,8 @@ std::unique_ptr<column> round_with(column_view const& input,
 
   auto const result_type = data_type{input.type().id(), scale_type{-decimal_places}};
 
-  auto result = cudf::make_fixed_width_column(result_type,  //
-                                              input.size(),
-                                              copy_bitmask(input, stream, mr),
-                                              input.null_count(),
-                                              stream,
-                                              mr);
+  auto result = cudf::make_fixed_width_column(
+    result_type, input.size(), copy_bitmask(input, stream, mr), input.null_count(), stream, mr);
 
   auto out_view = result->mutable_view();
   Type const n  = std::pow(10, std::abs(decimal_places + input.type().scale()));

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -73,147 +73,106 @@ constexpr inline auto is_supported_round_type()
   return (cudf::is_numeric<T>() && not std::is_same<T, bool>::value) || cudf::is_fixed_point<T>();
 }
 
-// clang-format off
-template <typename T, typename DeviceType> struct half_up_negative;
-template <typename T, typename DeviceType> struct half_even_negative;
-// clang-format on
-
-template <typename T, typename DeviceType>
+template <typename T>
 struct half_up_zero {
-  DeviceType n;  // unused in the decimal_places = 0 case
+  T n;  // unused in the decimal_places = 0 case
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     return generic_round(e);
   }
 
-  template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
-  {
-    return half_up_negative<DeviceType, DeviceType>{n}(e) / n;
-  }
-
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     assert(false);  // Should never get here. Just for compilation
     return U{};
   }
 };
 
-template <typename T, typename DeviceType>
+template <typename T>
 struct half_up_positive {
-  DeviceType n;
+  T n;
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
-    DeviceType integer_part;
-    DeviceType const fractional_part = generic_modf(e, &integer_part);
+    T integer_part;
+    T const fractional_part = generic_modf(e, &integer_part);
     return integer_part + generic_round(fractional_part * n) / n;
   }
 
-  template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
-  {
-    return half_up_negative<DeviceType, DeviceType>{n}(e) / n;
-  }
-
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     assert(false);  // Should never get here. Just for compilation
     return U{};
   }
 };
 
-template <typename T, typename DeviceType>
+template <typename T>
 struct half_up_negative {
-  DeviceType n;
+  T n;
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     return generic_round(e / n) * n;
   }
 
-  template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
-  {
-    return half_up_negative<DeviceType, DeviceType>{n}(e) / n;
-  }
-
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     auto const down = (e / n) * n;  // result from rounding down
     return down + generic_sign(e) * (generic_abs(e - down) >= n / 2 ? n : 0);
   }
 };
 
-template <typename T, typename DeviceType>
+template <typename T>
 struct half_even_zero {
-  DeviceType n;  // unused in the decimal_places = 0 case
+  T n;  // unused in the decimal_places = 0 case
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     return generic_round_half_even(e);
   }
 
-  template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
-  {
-    return half_even_negative<DeviceType, DeviceType>{n}(e) / n;
-  }
-
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     assert(false);  // Should never get here. Just for compilation
     return U{};
   }
 };
 
-template <typename T, typename DeviceType>
+template <typename T>
 struct half_even_positive {
-  DeviceType n;
+  T n;
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
-    DeviceType integer_part;
-    DeviceType const fractional_part = generic_modf(e, &integer_part);
+    T integer_part;
+    T const fractional_part = generic_modf(e, &integer_part);
     return integer_part + generic_round_half_even(fractional_part * n) / n;
   }
 
-  template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
-  {
-    return half_even_negative<DeviceType, DeviceType>{n}(e) / n;
-  }
-
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     assert(false);  // Should never get here. Just for compilation
     return U{};
   }
 };
 
-template <typename T, typename DeviceType>
+template <typename T>
 struct half_even_negative {
-  DeviceType n;
+  T n;
   template <typename U = T, typename std::enable_if_t<cudf::is_floating_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     return generic_round_half_even(e / n) * n;
   }
 
-  template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
-  {
-    return half_even_negative<DeviceType, DeviceType>{n}(e) / n;
-  }
-
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
-  __device__ DeviceType operator()(DeviceType e)
+  __device__ T operator()(T e)
   {
     auto const down_over_n = e / n;            // use this to determine HALF_EVEN case
     auto const down        = down_over_n * n;  // result from rounding down
@@ -223,8 +182,20 @@ struct half_even_negative {
   }
 };
 
+template <typename T>
+struct half_up_fixed_point {
+  T n;
+  __device__ T operator()(T e) { return half_up_negative<T>{n}(e) / n; }
+};
+
+template <typename T>
+struct half_even_fixed_point {
+  T n;
+  __device__ T operator()(T e) { return half_even_negative<T>{n}(e) / n; }
+};
+
 template <typename T,
-          template <typename, typename>
+          template <typename>
           typename RoundFunctor,
           typename std::enable_if_t<not cudf::is_fixed_point<T>()>* = nullptr>
 std::unique_ptr<column> round_with(column_view const& input,
@@ -232,7 +203,7 @@ std::unique_ptr<column> round_with(column_view const& input,
                                    cudaStream_t stream,
                                    rmm::mr::device_memory_resource* mr)
 {
-  using Functor = RoundFunctor<T, T>;
+  using Functor = RoundFunctor<T>;
 
   if (decimal_places >= 0 && std::is_integral<T>::value)
     return std::make_unique<cudf::column>(input, stream, mr);
@@ -257,7 +228,7 @@ std::unique_ptr<column> round_with(column_view const& input,
 }
 
 template <typename T,
-          template <typename, typename>
+          template <typename>
           typename RoundFunctor,
           typename std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
 std::unique_ptr<column> round_with(column_view const& input,
@@ -266,8 +237,8 @@ std::unique_ptr<column> round_with(column_view const& input,
                                    rmm::mr::device_memory_resource* mr)
 {
   using namespace numeric;
-  using Type    = device_storage_type_t<T>;
-  using Functor = RoundFunctor<T, Type>;
+  using Type                   = device_storage_type_t<T>;
+  using FixedPointRoundFunctor = RoundFunctor<Type>;
 
   // if rounding to more precision that fixed_point is capable of, just need to rescale
   // note: decimal_places has the opposite sign of numeric::scale_type (therefore have to negate)
@@ -288,14 +259,13 @@ std::unique_ptr<column> round_with(column_view const& input,
                                               mr);
 
   auto out_view = result->mutable_view();
-  // Type const n = std::pow(10, -decimal_places - input.type().scale())
-  Type const n = std::pow(10, std::abs(decimal_places + input.type().scale()));
+  Type const n  = std::pow(10, std::abs(decimal_places + input.type().scale()));
 
   thrust::transform(rmm::exec_policy(stream)->on(stream),
                     input.begin<Type>(),
                     input.end<Type>(),
                     out_view.begin<Type>(),
-                    Functor{n});
+                    FixedPointRoundFunctor{n});
 
   return result;
 }
@@ -319,13 +289,15 @@ struct round_type_dispatcher {
     // clang-format off
     switch (method) {
       case cudf::rounding_method::HALF_UP:
-        if      (decimal_places == 0) return round_with<T, half_up_zero    >(input, decimal_places, stream, mr);
-        else if (decimal_places >  0) return round_with<T, half_up_positive>(input, decimal_places, stream, mr);
-        else                          return round_with<T, half_up_negative>(input, decimal_places, stream, mr);
+        if      (is_fixed_point<T>()) return round_with<T, half_up_fixed_point>(input, decimal_places, stream, mr);
+        else if (decimal_places == 0) return round_with<T, half_up_zero       >(input, decimal_places, stream, mr);
+        else if (decimal_places >  0) return round_with<T, half_up_positive   >(input, decimal_places, stream, mr);
+        else                          return round_with<T, half_up_negative   >(input, decimal_places, stream, mr);
       case cudf::rounding_method::HALF_EVEN:
-        if      (decimal_places == 0) return round_with<T, half_even_zero    >(input, decimal_places, stream, mr);
-        else if (decimal_places >  0) return round_with<T, half_even_positive>(input, decimal_places, stream, mr);
-        else                          return round_with<T, half_even_negative>(input, decimal_places, stream, mr);
+        if      (is_fixed_point<T>()) return round_with<T, half_even_fixed_point>(input, decimal_places, stream, mr);
+        else if (decimal_places == 0) return round_with<T, half_even_zero       >(input, decimal_places, stream, mr);
+        else if (decimal_places >  0) return round_with<T, half_even_positive   >(input, decimal_places, stream, mr);
+        else                          return round_with<T, half_even_negative   >(input, decimal_places, stream, mr);
       default: CUDF_FAIL("Undefined rounding method");
     }
     // clang-format on

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -240,7 +240,7 @@ std::unique_ptr<column> round_with(column_view const& input,
   using Type                   = device_storage_type_t<T>;
   using FixedPointRoundFunctor = RoundFunctor<Type>;
 
-  // if rounding to more precision that fixed_point is capable of, just need to rescale
+  // if rounding to more precision than fixed_point is capable of, just need to rescale
   // note: decimal_places has the opposite sign of numeric::scale_type (therefore have to negate)
   if (input.type().scale() > -decimal_places) {
     // TODO replace this cudf::binary_operation with a cudf::cast or cudf::rescale when available

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -73,6 +73,11 @@ constexpr inline auto is_supported_round_type()
   return (cudf::is_numeric<T>() && not std::is_same<T, bool>::value) || cudf::is_fixed_point<T>();
 }
 
+// clang-format off
+template <typename T, typename DeviceType> struct half_up_negative;
+template <typename T, typename DeviceType> struct half_even_negative;
+// clang-format on
+
 template <typename T, typename DeviceType>
 struct half_up_zero {
   DeviceType n;  // unused in the decimal_places = 0 case
@@ -85,7 +90,7 @@ struct half_up_zero {
   template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
   __device__ DeviceType operator()(DeviceType e)
   {
-    return e;  // TODO
+    return half_up_negative<DeviceType, DeviceType>{n}(e) / n;
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>
@@ -95,11 +100,6 @@ struct half_up_zero {
     return U{};
   }
 };
-
-// clang-format off
-template <typename T, typename DeviceType> struct half_up_negative;
-template <typename T, typename DeviceType> struct half_even_negative;
-// clang-format on
 
 template <typename T, typename DeviceType>
 struct half_up_positive {

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -96,8 +96,10 @@ struct half_up_zero {
   }
 };
 
-template <typename T, typename DeviceType>
-struct half_up_negative;
+// clang-format off
+template <typename T, typename DeviceType> struct half_up_negative;
+template <typename T, typename DeviceType> struct half_even_negative;
+// clang-format on
 
 template <typename T, typename DeviceType>
 struct half_up_positive {
@@ -184,7 +186,7 @@ struct half_even_positive {
   template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
   __device__ DeviceType operator()(DeviceType e)
   {
-    return e;  // TODO
+    return half_even_negative<DeviceType, DeviceType>{n}(e) / n;
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -209,7 +209,7 @@ struct half_even_negative {
   template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
   __device__ DeviceType operator()(DeviceType e)
   {
-    return e;  // TODO
+    return half_even_negative<DeviceType, DeviceType>{n}(e) / n;
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -208,12 +208,8 @@ std::unique_ptr<column> round_with(column_view const& input,
   if (decimal_places >= 0 && std::is_integral<T>::value)
     return std::make_unique<cudf::column>(input, stream, mr);
 
-  auto result = cudf::make_fixed_width_column(input.type(),  //
-                                              input.size(),
-                                              copy_bitmask(input, stream, mr),
-                                              input.null_count(),
-                                              stream,
-                                              mr);
+  auto result = cudf::make_fixed_width_column(
+    input.type(), input.size(), copy_bitmask(input, stream, mr), input.null_count(), stream, mr);
 
   auto out_view = result->mutable_view();
   T const n     = std::pow(10, std::abs(decimal_places));

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -161,7 +161,7 @@ struct half_even_zero {
   template <typename U = T, typename std::enable_if_t<cudf::is_fixed_point<U>()>* = nullptr>
   __device__ DeviceType operator()(DeviceType e)
   {
-    return e;  // TODO
+    return half_even_negative<DeviceType, DeviceType>{n}(e) / n;
   }
 
   template <typename U = T, typename std::enable_if_t<std::is_integral<U>::value>* = nullptr>

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -142,6 +142,48 @@ TYPED_TEST(RoundTestsFixedPointTypes, EmptyFixedPointTypeTest)
   EXPECT_EQ(result->view().type(), expected_type);
 }
 
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestNegHalfUp)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{14, 15, 16, 24, 25, 26}, scale_type{2}};
+  auto const expected = fp_wrapper{{1, 2, 2, 2, 3, 3}, scale_type{3}};
+  auto const result   = cudf::round(input, -3, cudf::rounding_method::HALF_UP);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestNegHalfUp2)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{14, 15, 16, 24, 25, 26}, scale_type{3}};
+  auto const expected = fp_wrapper{{1, 2, 2, 2, 3, 3}, scale_type{4}};
+  auto const result   = cudf::round(input, -4, cudf::rounding_method::HALF_UP);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfNegUp3)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{1, 2, 3}, scale_type{2}};
+  auto const expected = fp_wrapper{{10, 20, 30}, scale_type{1}};
+  auto const result   = cudf::round(input, -1, cudf::rounding_method::HALF_UP);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 TYPED_TEST(RoundTestsFloatingPointTypes, SimpleFloatingPointTestHalfUp0)
 {
   using fw_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -51,12 +51,9 @@ TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUp)
 
   auto const input    = fp_wrapper{{1140, 1150, 1160}, scale_type{-3}};
   auto const expected = fp_wrapper{{11, 12, 12}, scale_type{-1}};
+  auto const result   = cudf::round(input, 1, cudf::rounding_method::HALF_UP);
 
-  EXPECT_THROW(cudf::round(input, 1, cudf::rounding_method::HALF_UP), cudf::logic_error);
-
-  // enable in follow up PR
-  // auto const result   = cudf::round(col, 1, cudf::rounding_method::HALF_UP);
-  // CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
 TYPED_TEST(RoundTestsFloatingPointTypes, SimpleFloatingPointTestHalfUp0)

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -49,9 +49,23 @@ TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUpZero)
   using RepType    = cudf::device_storage_type_t<decimalXX>;
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
 
-  auto const input    = fp_wrapper{{1140, 1150, 1160}, scale_type{-2}};
-  auto const expected = fp_wrapper{{11, 12, 12}, scale_type{0}};
+  auto const input    = fp_wrapper{{1140, 1150, 1160, 1240, 1250, 1260}, scale_type{-2}};
+  auto const expected = fp_wrapper{{11, 12, 12, 12, 13, 13}, scale_type{0}};
   auto const result   = cudf::round(input);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfEvenZero)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{1140, 1150, 1160, 1240, 1250, 1260}, scale_type{-2}};
+  auto const expected = fp_wrapper{{11, 12, 12, 12, 12, 13}, scale_type{0}};
+  auto const result   = cudf::round(input, 0, cudf::rounding_method::HALF_EVEN);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -56,6 +56,34 @@ TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUp)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUp2)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{114, 115, 116}, scale_type{-2}};
+  auto const expected = fp_wrapper{{11, 12, 12}, scale_type{-1}};
+  auto const result   = cudf::round(input, 1, cudf::rounding_method::HALF_UP);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUp3)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{1, 2, 3}, scale_type{1}};
+  auto const expected = fp_wrapper{{100, 200, 300}, scale_type{-1}};
+  auto const result   = cudf::round(input, 1, cudf::rounding_method::HALF_UP);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 TYPED_TEST(RoundTestsFloatingPointTypes, SimpleFloatingPointTestHalfUp0)
 {
   using fw_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -184,6 +184,48 @@ TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfNegUp3)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestNegHalfEven)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{14, 15, 16, 24, 25, 26}, scale_type{2}};
+  auto const expected = fp_wrapper{{1, 2, 2, 2, 2, 3}, scale_type{3}};
+  auto const result   = cudf::round(input, -3, cudf::rounding_method::HALF_EVEN);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestNegHalfEven2)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{14, 15, 16, 24, 25, 26}, scale_type{3}};
+  auto const expected = fp_wrapper{{1, 2, 2, 2, 2, 3}, scale_type{4}};
+  auto const result   = cudf::round(input, -4, cudf::rounding_method::HALF_EVEN);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfNegEven3)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{1, 2, 3}, scale_type{2}};
+  auto const expected = fp_wrapper{{10, 20, 30}, scale_type{1}};
+  auto const result   = cudf::round(input, -1, cudf::rounding_method::HALF_EVEN);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 TYPED_TEST(RoundTestsFloatingPointTypes, SimpleFloatingPointTestHalfUp0)
 {
   using fw_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -84,6 +84,48 @@ TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUp3)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfEven)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{1140, 1150, 1160, 1240, 1250, 1260}, scale_type{-3}};
+  auto const expected = fp_wrapper{{11, 12, 12, 12, 12, 13}, scale_type{-1}};
+  auto const result   = cudf::round(input, 1, cudf::rounding_method::HALF_EVEN);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfEven2)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{114, 115, 116, 124, 125, 126}, scale_type{-2}};
+  auto const expected = fp_wrapper{{11, 12, 12, 12, 12, 13}, scale_type{-1}};
+  auto const result   = cudf::round(input, 1, cudf::rounding_method::HALF_EVEN);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfEven3)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{1, 2, 3}, scale_type{1}};
+  auto const expected = fp_wrapper{{100, 200, 300}, scale_type{-1}};
+  auto const result   = cudf::round(input, 1, cudf::rounding_method::HALF_EVEN);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 TYPED_TEST(RoundTestsFloatingPointTypes, SimpleFloatingPointTestHalfUp0)
 {
   using fw_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -42,6 +42,20 @@ TYPED_TEST_CASE(RoundTestsIntegerTypes, IntegerTypes);
 TYPED_TEST_CASE(RoundTestsFixedPointTypes, cudf::test::FixedPointTypes);
 TYPED_TEST_CASE(RoundTestsFloatingPointTypes, cudf::test::FloatingPointTypes);
 
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUpZero)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input    = fp_wrapper{{1140, 1150, 1160}, scale_type{-2}};
+  auto const expected = fp_wrapper{{11, 12, 12}, scale_type{0}};
+  auto const result   = cudf::round(input);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUp)
 {
   using namespace numeric;

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -126,6 +126,22 @@ TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfEven3)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(RoundTestsFixedPointTypes, EmptyFixedPointTypeTest)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input         = fp_wrapper{{}, scale_type{1}};
+  auto const expected      = fp_wrapper{{}, scale_type{-1}};
+  auto const expected_type = cudf::data_type{cudf::type_to_id<decimalXX>(), scale_type{-1}};
+  auto const result        = cudf::round(input, 1, cudf::rounding_method::HALF_UP);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  EXPECT_EQ(result->view().type(), expected_type);
+}
+
 TYPED_TEST(RoundTestsFloatingPointTypes, SimpleFloatingPointTestHalfUp0)
 {
   using fw_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;


### PR DESCRIPTION
This PR is the final of 3 PRs and resolves https://github.com/rapidsai/cudf/issues/3790. 

1. Implement `cudf::round` floating point and integer types (`HALF_UP`) https://github.com/rapidsai/cudf/pull/6562
2. Implement `cudf::round` floating point and integer types (`HALF_EVEN`) https://github.com/rapidsai/cudf/pull/6647
3. Implement `cudf::round` `decimal32` & `decimal64` (`HALF_UP` and `HALF_EVEN`) :arrow_backward: 

The PR to do list is as follows:

* [x] Add code for adjusted type of resulting column
* [x] Add implementation for half_up positive
* [x] Add implementation for half_up zero
* [x] Add implementation for half_up negative
* [x] Add implementation for half_even positive
* [x] Add implementation for half_even zero 
* [x] Add implementation for half_even negative
* [x] Update documentation
* [x] Add basic unit tests
* [x] Add comprehensive unit tests
* [x] Refactor leveraging the factor that EVERY `fixed_point` function object is identical :fire: