### PR TITLE
[REVIEW] Explicitly set legacy or per-thread default stream in JNI [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PR #6540 Add dictionary support to `cudf::unary_operation`
 - PR #6537 Refactor ORC timezone
 - PR #6527 Refactor DeviceColumnViewAccess to avoid JNI returning an array
+- PR #6690 Explicitly set legacy or per-thread default stream in JNI
 - PR #6545 Pin cmake policies to cmake 3.17 version
 - PR #6556 Add dictionary support to `cudf::inner_join`, `cudf::left_join` and `cudf::full_join`
 - PR #6557 Support nullable timestamp columns in time range window functions

--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -43,7 +43,9 @@ public class Cuda {
     protected boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
       long origAddress = stream;
-      if (stream != CUDA_STREAM_DEFAULT && stream != CUDA_STREAM_LEGACY && stream != CUDA_STREAM_PER_THREAD) {
+      if (stream != CUDA_STREAM_DEFAULT &&
+          stream != CUDA_STREAM_LEGACY &&
+          stream != CUDA_STREAM_PER_THREAD) {
         destroyStream(stream);
         stream = 0;
         neededCleanup = true;

--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -19,6 +19,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Cuda {
+  // This needs to happen first before calling any native methods.
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
   // Defined in driver_types.h in cuda library.
   static final int CPU_DEVICE_ID = -1;
   static final long CUDA_STREAM_DEFAULT = 0;
@@ -27,10 +32,6 @@ public class Cuda {
   private final static long DEFAULT_STREAM_ID = isPtdsEnabled() ? CUDA_STREAM_PER_THREAD : CUDA_STREAM_LEGACY;
   private static final Logger log = LoggerFactory.getLogger(Cuda.class);
   private static Boolean isCompat = null;
-
-  static {
-    NativeDepsLoader.loadNativeDeps();
-  }
 
   private static class StreamCleaner extends MemoryCleaner.Cleaner {
     private long stream;


### PR DESCRIPTION
This should make `nvcomp` use the correct cuda stream.

@jlowe @abellina 