### PR TITLE
Fix leak warnings in JNI unit tests [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - PR #6687 Fix issue where index name of caller object is being modified in csv writer
 - PR #6692 Fix handling of empty column name in csv writer
 - PR #6693 Fix issue related to `na_values` input in `read_csv`
+- PR #6704 Fix leak warnings in JNI unit tests
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Decompressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Decompressor.java
@@ -178,6 +178,8 @@ public class BatchedLZ4Decompressor {
     public void close() {
       if (!closed) {
         cleaner.delRef();
+        cleaner.clean(false);
+        closed = true;
       } else {
         cleaner.logRefCountDebug("double free " + this);
         throw new IllegalStateException("Close called too many times " + this);

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
@@ -113,6 +113,8 @@ public class Decompressor {
     public void close() {
       if (!closed) {
         cleaner.delRef();
+        cleaner.clean(false);
+        closed = true;
       } else {
         cleaner.logRefCountDebug("double free " + this);
         throw new IllegalStateException("Close called too many times " + this);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -2670,8 +2670,8 @@ public class ColumnVectorTest extends CudfTestBase {
   void testCreateDurationDays() {
     Integer[] days = {100, 10, 23, 1, -1, 0, Integer.MAX_VALUE, null, Integer.MIN_VALUE};
 
-    try (ColumnVector durationDays = ColumnVector.durationDaysFromBoxedInts(days)) {
-      HostColumnVector hc = durationDays.copyToHost();
+    try (ColumnVector durationDays = ColumnVector.durationDaysFromBoxedInts(days);
+         HostColumnVector hc = durationDays.copyToHost()) {
       assertTrue(hc.hasNulls());
       assertEquals(DType.DURATION_DAYS, hc.getType());
       for (int i = 0; i < days.length; i++) {
@@ -2687,8 +2687,8 @@ public class ColumnVectorTest extends CudfTestBase {
   void testCreateDurationSeconds() {
     Long[] secs = {10230L, 10L, 203L, 1L, -1L, 0L, Long.MAX_VALUE, null, Long.MIN_VALUE};
 
-    try (ColumnVector durationSeconds = ColumnVector.durationSecondsFromBoxedLongs(secs)) {
-      HostColumnVector hc = durationSeconds.copyToHost();
+    try (ColumnVector durationSeconds = ColumnVector.durationSecondsFromBoxedLongs(secs);
+         HostColumnVector hc = durationSeconds.copyToHost()) {
       assertTrue(hc.hasNulls());
       assertEquals(DType.DURATION_SECONDS, hc.getType());
       for (int i = 0 ; i < secs.length ; i++) {
@@ -2705,8 +2705,8 @@ public class ColumnVectorTest extends CudfTestBase {
     Long[] ms = {12342340230L, 12112340L, 2230233L, 1L, -1L, 0L, Long.MAX_VALUE, null,
         Long.MIN_VALUE};
 
-    try (ColumnVector durationMs = ColumnVector.durationMilliSecondsFromBoxedLongs(ms)) {
-      HostColumnVector hc = durationMs.copyToHost();
+    try (ColumnVector durationMs = ColumnVector.durationMilliSecondsFromBoxedLongs(ms);
+         HostColumnVector hc = durationMs.copyToHost()) {
       assertTrue(hc.hasNulls());
       assertEquals(DType.DURATION_MILLISECONDS, hc.getType());
       for (int i = 0 ; i < ms.length ; i++) {
@@ -2723,8 +2723,8 @@ public class ColumnVectorTest extends CudfTestBase {
     Long[] us = {1234234230L, 132350L, 289877803L, 1L, -1L, 0L, Long.MAX_VALUE, null,
         Long.MIN_VALUE};
 
-    try (ColumnVector durationUs = ColumnVector.durationMicroSecondsFromBoxedLongs(us)) {
-      HostColumnVector hc = durationUs.copyToHost();
+    try (ColumnVector durationUs = ColumnVector.durationMicroSecondsFromBoxedLongs(us);
+         HostColumnVector hc = durationUs.copyToHost()) {
       assertTrue(hc.hasNulls());
       assertEquals(DType.DURATION_MICROSECONDS, hc.getType());
       for (int i = 0 ; i < us.length ; i++) {
@@ -2741,8 +2741,8 @@ public class ColumnVectorTest extends CudfTestBase {
     Long[] ns = {1234234230L, 198832350L, 289877803L, 1L, -1L, 0L, Long.MAX_VALUE, null,
         Long.MIN_VALUE};
 
-    try (ColumnVector durationNs = ColumnVector.durationNanoSecondsFromBoxedLongs(ns)) {
-      HostColumnVector hc = durationNs.copyToHost();
+    try (ColumnVector durationNs = ColumnVector.durationNanoSecondsFromBoxedLongs(ns);
+         HostColumnVector hc = durationNs.copyToHost()) {
       assertTrue(hc.hasNulls());
       assertEquals(DType.DURATION_NANOSECONDS, hc.getType());
       for (int i = 0 ; i < ns.length ; i++) {
@@ -2798,7 +2798,6 @@ public class ColumnVectorTest extends CudfTestBase {
 
     try(ColumnVector res = ColumnVector.fromLists(new HostColumnVector.ListType(true,
         new HostColumnVector.BasicType(true, DType.STRING)), list1, list2, list3);
-
         HostColumnVector hcv = res.copyToHost()) {
       List<String> ret1 = hcv.getList(0);
       List<String> ret2 = hcv.getList(1);

--- a/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/DecimalColumnVectorTest.java
@@ -141,18 +141,26 @@ public class DecimalColumnVectorTest extends CudfTestBase {
     // precision overflow
     assertThrows(IllegalArgumentException.class, () -> HostColumnVector.fromDecimals(overflowDecimal64));
     assertThrows(IllegalArgumentException.class, () -> {
-      ColumnVector.decimalFromInts(-(DType.DECIMAL32_MAX_PRECISION + 1), unscaledDec32Zoo);
+      try (ColumnVector ignored = ColumnVector.decimalFromInts(
+          -(DType.DECIMAL32_MAX_PRECISION + 1), unscaledDec32Zoo)) {
+      }
     });
     assertThrows(IllegalArgumentException.class, () -> {
-      ColumnVector.decimalFromLongs(-(DType.DECIMAL64_MAX_PRECISION + 1), unscaledDec64Zoo);
+      try (ColumnVector ignored = ColumnVector.decimalFromLongs(
+          -(DType.DECIMAL64_MAX_PRECISION + 1), unscaledDec64Zoo)) {
+      }
     });
     // precision overflow due to rescaling by min scale
     assertThrows(IllegalArgumentException.class, () -> {
-      ColumnVector.fromDecimals(BigDecimal.valueOf(1.23e10), BigDecimal.valueOf(1.2e-7));
+      try (ColumnVector ignored = ColumnVector.fromDecimals(
+          BigDecimal.valueOf(1.23e10), BigDecimal.valueOf(1.2e-7))) {
+      }
     });
     // exactly hit the MAX_PRECISION_DECIMAL64 after rescaling
     assertDoesNotThrow(() -> {
-      ColumnVector.fromDecimals(BigDecimal.valueOf(1.23e10), BigDecimal.valueOf(1.2e-6));
+      try (ColumnVector ignored = ColumnVector.fromDecimals(
+          BigDecimal.valueOf(1.23e10), BigDecimal.valueOf(1.2e-6))) {
+      }
     });
   }
 


### PR DESCRIPTION
Fixes the following resource leaks that were triggering leak warnings on JVM shutdown in the cudf Java unit tests:
- nvcomp decompression metadata objects do not release the underlying resource on `close`
- ColumnVectorTest duration type unit tests do not close a vector copied back to the host for verification
- DecimalColumnVectorTest error checking tests do not close the column vector when the constructor does not throw