### PR TITLE
[REVIEW] Remove 2nd type-dispatcher call from cudf::reduce for simple operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - PR #6609 Support fixed-point decimal for HostColumnVector
 - PR #6705 Add nested type support to Java table serialization
 - PR #6709 Raise informative error while converting a pandas dataframe with duplicate columns
+- PR #6727 Remove 2nd type-dispatcher call from cudf::reduce
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/detail/copy.hpp
+++ b/cpp/include/cudf/detail/copy.hpp
@@ -162,5 +162,14 @@ std::unique_ptr<table> sample(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
   cudaStream_t stream                 = 0);
 
+/**
+ * @copydoc cudf::get_element
+ *
+ * @param[in] stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::unique_ptr<scalar> get_element(column_view const& input,
+                                    size_type index,
+                                    cudaStream_t stream,
+                                    rmm::mr::device_memory_resource* mr);
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/reduction.hpp
+++ b/cpp/include/cudf/reduction.hpp
@@ -42,25 +42,29 @@ enum class scan_type : bool { INCLUSIVE, EXCLUSIVE };
  * If the column is empty, the member `is_valid()` of the output scalar
  * will contain `false`.
  *
- * @throws cudf::logic_error if reduction is called for non-arithmetic output
+ * @throw cudf::logic_error if reduction is called for non-arithmetic output
  * type and operator other than `min` and `max`.
- * @throws cudf::logic_error if input column data type is not convertible to
+ * @throw cudf::logic_error if input column data type is not convertible to
  * output data type.
+ * @throw cudf::logic_error if `min` or `max` reduction is called and the
+ * output type does not match the input column data type.
+ *
  * If the input column has arithmetic type, output_dtype can be any arithmetic
  * type. For `mean`, `var` and `std` ops, a floating point output type must be
  * specified. If the input column has non-arithmetic type
  *   eg.(timestamp, string...), the same type must be specified.
  *
- * @param[in] col Input column view
- * @param[in] agg unique_ptr of the aggregation operator applied by the reduction
- * @param[in] output_dtype  The computation and output precision.
- * @param[in] mr Device memory resource used to allocate the returned scalar's device memory
- * @returns  cudf::scalar the result value
  * If the reduction fails, the member is_valid of the output scalar
  * will contain `false`.
+ *
+ * @param col Input column view
+ * @param agg Aggregation operator applied by the reduction
+ * @param output_dtype  The computation and output precision.
+ * @param mr Device memory resource used to allocate the returned scalar's device memory
+ * @returns Output scalar with reduce result.
  */
 std::unique_ptr<scalar> reduce(
-  const column_view &col,
+  column_view const &col,
   std::unique_ptr<aggregation> const &agg,
   data_type output_dtype,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());

--- a/cpp/src/reductions/all.cu
+++ b/cpp/src/reductions/all.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// The translation unit for reduction `max`
 
 #include <cudf/detail/reduction_functions.hpp>
-#include "simple.cuh"
+#include <reductions/simple.cuh>
 
-std::unique_ptr<cudf::scalar> cudf::reduction::all(column_view const& col,
-                                                   cudf::data_type const output_dtype,
-                                                   rmm::mr::device_memory_resource* mr,
-                                                   cudaStream_t stream)
+namespace cudf {
+namespace reduction {
+
+std::unique_ptr<cudf::scalar> all(column_view const& col,
+                                  cudf::data_type const output_dtype,
+                                  rmm::mr::device_memory_resource* mr,
+                                  cudaStream_t stream)
 {
   CUDF_EXPECTS(output_dtype == cudf::data_type(cudf::type_id::BOOL8),
-               "all() operation can be applied with output type `bool8` only");
-  return cudf::reduction::min(col, cudf::data_type(cudf::type_id::BOOL8), mr, stream);
+               "all() operation can be applied with output type `BOOL8` only");
+  return cudf::type_dispatcher(col.type(),
+                               simple::bool_result_element_dispatcher<cudf::reduction::op::min>{},
+                               col,
+                               mr,
+                               stream);
 }
+
+}  // namespace reduction
+}  // namespace cudf

--- a/cpp/src/reductions/any.cu
+++ b/cpp/src/reductions/any.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,24 @@
 // The translation unit for reduction `max`
 
 #include <cudf/detail/reduction_functions.hpp>
-#include "simple.cuh"
+#include <reductions/simple.cuh>
 
-std::unique_ptr<cudf::scalar> cudf::reduction::any(column_view const& col,
-                                                   cudf::data_type const output_dtype,
-                                                   rmm::mr::device_memory_resource* mr,
-                                                   cudaStream_t stream)
+namespace cudf {
+namespace reduction {
+
+std::unique_ptr<cudf::scalar> any(column_view const& col,
+                                  cudf::data_type const output_dtype,
+                                  rmm::mr::device_memory_resource* mr,
+                                  cudaStream_t stream)
 {
   CUDF_EXPECTS(output_dtype == cudf::data_type(cudf::type_id::BOOL8),
                "any() operation can be applied with output type `bool8` only");
-  return cudf::reduction::max(col, cudf::data_type(cudf::type_id::BOOL8), mr, stream);
+  return cudf::type_dispatcher(col.type(),
+                               simple::bool_result_element_dispatcher<cudf::reduction::op::max>{},
+                               col,
+                               mr,
+                               stream);
 }
+
+}  // namespace reduction
+}  // namespace cudf

--- a/cpp/src/reductions/max.cu
+++ b/cpp/src/reductions/max.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// The translation unit for reduction `max`
 
 #include <cudf/detail/reduction_functions.hpp>
-#include "simple.cuh"
+#include <reductions/simple.cuh>
 
-std::unique_ptr<cudf::scalar> cudf::reduction::max(column_view const& col,
-                                                   cudf::data_type const output_dtype,
-                                                   rmm::mr::device_memory_resource* mr,
-                                                   cudaStream_t stream)
+namespace cudf {
+namespace reduction {
+
+std::unique_ptr<cudf::scalar> max(column_view const& col,
+                                  cudf::data_type const output_dtype,
+                                  rmm::mr::device_memory_resource* mr,
+                                  cudaStream_t stream)
 {
-  using reducer = cudf::reduction::simple::element_type_dispatcher<cudf::reduction::op::max>;
-  return cudf::type_dispatcher(col.type(), reducer(), col, output_dtype, mr, stream);
+  CUDF_EXPECTS(col.type() == output_dtype, "max() operation requires matching output type");
+  return cudf::type_dispatcher(
+    col.type(), simple::same_element_type_dispatcher<cudf::reduction::op::max>{}, col, mr, stream);
 }
+
+}  // namespace reduction
+}  // namespace cudf

--- a/cpp/src/reductions/min.cu
+++ b/cpp/src/reductions/min.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// The translation unit for reduction `min`
 
 #include <cudf/detail/reduction_functions.hpp>
-#include "simple.cuh"
+#include <reductions/simple.cuh>
 
-std::unique_ptr<cudf::scalar> cudf::reduction::min(column_view const& col,
-                                                   data_type const output_dtype,
-                                                   rmm::mr::device_memory_resource* mr,
-                                                   cudaStream_t stream)
+namespace cudf {
+namespace reduction {
+
+std::unique_ptr<cudf::scalar> min(column_view const& col,
+                                  data_type const output_dtype,
+                                  rmm::mr::device_memory_resource* mr,
+                                  cudaStream_t stream)
 {
-  using reducer = cudf::reduction::simple::element_type_dispatcher<cudf::reduction::op::min>;
-  return cudf::type_dispatcher(col.type(), reducer(), col, output_dtype, mr, stream);
+  CUDF_EXPECTS(col.type() == output_dtype, "min() operation requires matching output type");
+  return cudf::type_dispatcher(
+    col.type(), simple::same_element_type_dispatcher<cudf::reduction::op::min>{}, col, mr, stream);
 }
+
+}  // namespace reduction
+}  // namespace cudf

--- a/cpp/src/reductions/product.cu
+++ b/cpp/src/reductions/product.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// The translation unit for reduction `product`
 
 #include <cudf/detail/reduction_functions.hpp>
-#include "simple.cuh"
+#include <reductions/simple.cuh>
 
-std::unique_ptr<cudf::scalar> cudf::reduction::product(column_view const& col,
-                                                       cudf::data_type const output_dtype,
-                                                       rmm::mr::device_memory_resource* mr,
-                                                       cudaStream_t stream)
+namespace cudf {
+namespace reduction {
+
+std::unique_ptr<cudf::scalar> product(column_view const& col,
+                                      cudf::data_type const output_dtype,
+                                      rmm::mr::device_memory_resource* mr,
+                                      cudaStream_t stream)
 {
-  using reducer = cudf::reduction::simple::element_type_dispatcher<cudf::reduction::op::product>;
-  return cudf::type_dispatcher(col.type(), reducer(), col, output_dtype, mr, stream);
+  return cudf::type_dispatcher(col.type(),
+                               simple::element_type_dispatcher<cudf::reduction::op::product>{},
+                               col,
+                               output_dtype,
+                               mr,
+                               stream);
 }
+
+}  // namespace reduction
+}  // namespace cudf

--- a/cpp/src/reductions/simple.cuh
+++ b/cpp/src/reductions/simple.cuh
@@ -17,31 +17,30 @@
 #pragma once
 
 #include <cudf/detail/reduction.cuh>
-
+#include <cudf/detail/utilities/cuda.cuh>
+#include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
-#include "cudf/structs/struct_view.hpp"
 
 namespace cudf {
 namespace reduction {
 namespace simple {
-/** --------------------------------------------------------------------------*
+/**
  * @brief Reduction for 'sum', 'product', 'min', 'max', 'sum of squares'
  * which directly compute the reduction by a single step reduction call
  *
- * @param[in] col    input column view
- * @param[in] mr Device memory resource used to allocate the returned scalar's device memory
- * @param[in] CUDA stream used for device memory operations and kernel launches.
- * @returns   Output scalar in device memory
- *
- * @tparam ElementType  the input column cudf dtype
- * @tparam ResultType   the output cudf dtype
+ * @tparam ElementType  the input column data-type
+ * @tparam ResultType   the output data-type
  * @tparam Op           the operator of cudf::reduction::op::
- * ----------------------------------------------------------------------------**/
+
+ * @param col Input column of data to reduce
+ * @param mr Device memory resource used to allocate the returned scalar's device memory
+ * @param stream Used for device memory operations and kernel launches.
+ * @return Output scalar in device memory
+ */
 template <typename ElementType, typename ResultType, typename Op>
 std::unique_ptr<scalar> simple_reduction(column_view const& col,
-                                         data_type const output_dtype,
                                          rmm::mr::device_memory_resource* mr,
                                          cudaStream_t stream)
 {
@@ -65,41 +64,59 @@ std::unique_ptr<scalar> simple_reduction(column_view const& col,
   return result;
 };
 
-// @brief result type dispatcher for simple reduction (a.k.a. sum, prod, min...)
-template <typename ElementType, typename Op>
-struct result_type_dispatcher {
+/**
+ * @brief Convert a numeric scalar to another numeric scalar.
+ *
+ * The input value and validity are cast to the output scalar.
+ *
+ * @tparam InputType The type of the input scalar to copy from
+ * @tparam OutputType The output scalar type to copy to
+ */
+template <typename InputType, typename OutputType>
+struct assign_scalar_fn {
+  __device__ void operator()()
+  {
+    d_output.set_value(static_cast<OutputType>(d_input.value()));
+    d_output.set_valid(d_input.is_valid());
+  }
+
+  cudf::numeric_scalar_device_view<InputType> d_input;
+  cudf::numeric_scalar_device_view<OutputType> d_output;
+};
+
+/**
+ * @brief A type-dispatcher functor for converting a numeric scalar.
+ *
+ * The InputType is known and the dispatch is on the ResultType
+ * which is the output numeric scalar type.
+ *
+ * @tparam InputType The scalar type to convert from
+ */
+template <typename InputType>
+struct cast_numeric_scalar_fn {
  private:
   template <typename ResultType>
   static constexpr bool is_supported_v()
   {
-    // for single step reductions,
-    // the available combination of input and output dtypes are
-    //  - same dtypes (including cudf::wrappers)
-    //  - any arithmetic dtype to any arithmetic dtype
-    //  - bool to/from any arithmetic dtype
-    //  - fixed_point to fixed_point
-    return cudf::is_convertible<ElementType, ResultType>::value &&
-           (std::is_arithmetic<ResultType>::value ||
-            std::is_same<Op, cudf::reduction::op::min>::value ||
-            std::is_same<Op, cudf::reduction::op::max>::value) &&
-           !cudf::is_fixed_point<ResultType>() &&
-           !std::is_same<ResultType, cudf::list_view>::value &&
-           !std::is_same<ResultType, cudf::struct_view>::value;
+    return cudf::is_convertible<InputType, ResultType>::value && cudf::is_numeric<ResultType>();
   }
 
  public:
   template <typename ResultType, std::enable_if_t<is_supported_v<ResultType>()>* = nullptr>
-  std::unique_ptr<scalar> operator()(column_view const& col,
-                                     data_type const output_dtype,
+  std::unique_ptr<scalar> operator()(numeric_scalar<InputType>* input,
                                      rmm::mr::device_memory_resource* mr,
                                      cudaStream_t stream)
   {
-    return simple_reduction<ElementType, ResultType, Op>(col, output_dtype, mr, stream);
+    auto d_input  = cudf::get_scalar_device_view(*input);
+    auto result   = std::make_unique<numeric_scalar<ResultType>>(ResultType{}, true, stream, mr);
+    auto d_output = cudf::get_scalar_device_view(*result);
+    cudf::detail::device_single_thread(assign_scalar_fn<InputType, ResultType>{d_input, d_output},
+                                       stream);
+    return result;
   }
 
   template <typename ResultType, std::enable_if_t<not is_supported_v<ResultType>()>* = nullptr>
-  std::unique_ptr<scalar> operator()(column_view const& col,
-                                     data_type const output_dtype,
+  std::unique_ptr<scalar> operator()(numeric_scalar<InputType>* input,
                                      rmm::mr::device_memory_resource* mr,
                                      cudaStream_t stream)
   {
@@ -107,44 +124,139 @@ struct result_type_dispatcher {
   }
 };
 
-// @brief input column element for simple reduction (a.k.a. sum, prod, min...)
+/**
+ * @brief Call reduce and return a scalar of type bool.
+ *
+ * This is used by operations any() and all().
+ *
+ * @tparam Op The reduce operation to execute on the column.
+ */
 template <typename Op>
-struct element_type_dispatcher {
+struct bool_result_element_dispatcher {
  private:
-  // return true if ElementType is arithmetic type or bool, or
-  // Op is DeviceMin or DeviceMax for wrapper (non-arithmetic) types
   template <typename ElementType>
   static constexpr bool is_supported_v()
   {
-    // disable only for string ElementType except for operators min, max
-    return !((std::is_same<ElementType, cudf::string_view>::value &&
-              !(std::is_same<Op, cudf::reduction::op::min>::value ||
-                std::is_same<Op, cudf::reduction::op::max>::value))
-             // disable for list/struct views
-             || std::is_same<ElementType, cudf::list_view>::value ||
+    return std::is_arithmetic<ElementType>();
+  }
+
+ public:
+  template <typename ElementType, std::enable_if_t<is_supported_v<ElementType>()>* = nullptr>
+  std::unique_ptr<scalar> operator()(column_view const& col,
+                                     rmm::mr::device_memory_resource* mr,
+                                     cudaStream_t stream)
+  {
+    return cudf::reduction::simple::simple_reduction<ElementType, bool, Op>(col, mr, stream);
+  }
+
+  template <typename ElementType, std::enable_if_t<not is_supported_v<ElementType>()>* = nullptr>
+  std::unique_ptr<scalar> operator()(column_view const& col,
+                                     rmm::mr::device_memory_resource* mr,
+                                     cudaStream_t stream)
+  {
+    CUDF_FAIL("Reduction operator not supported for this type");
+  }
+};
+
+/**
+ * @brief Call reduce and return a scalar of type matching the input column.
+ *
+ * This is used by operations min() and max().
+ *
+ * @tparam Op The reduce operation to execute on the column.
+ */
+template <typename Op>
+struct same_element_type_dispatcher {
+ private:
+  template <typename ElementType>
+  static constexpr bool is_supported_v()
+  {
+    return !(cudf::is_fixed_point<ElementType>() ||
+             std::is_same<ElementType, cudf::list_view>::value ||
              std::is_same<ElementType, cudf::struct_view>::value);
   }
 
  public:
   template <typename ElementType, std::enable_if_t<is_supported_v<ElementType>()>* = nullptr>
   std::unique_ptr<scalar> operator()(column_view const& col,
-                                     data_type const output_dtype,
                                      rmm::mr::device_memory_resource* mr,
                                      cudaStream_t stream)
   {
-    return cudf::type_dispatcher(
-      output_dtype, result_type_dispatcher<ElementType, Op>(), col, output_dtype, mr, stream);
+    return cudf::reduction::simple::simple_reduction<ElementType, ElementType, Op>(col, mr, stream);
   }
 
   template <typename ElementType, std::enable_if_t<not is_supported_v<ElementType>()>* = nullptr>
   std::unique_ptr<scalar> operator()(column_view const& col,
-                                     data_type const output_dtype,
                                      rmm::mr::device_memory_resource* mr,
                                      cudaStream_t stream)
   {
-    CUDF_FAIL(
-      "Reduction operators other than `min` and `max`"
-      " are not supported for non-arithmetic types");
+    CUDF_FAIL("Reduction operator `max` not supported for this type");
+  }
+};
+
+/**
+ * @brief Call reduce and return a scalar of the type specified.
+ *
+ * This is used by operations sum(), product(), and sum_of_squares().
+ * It only supports numeric types. If the output type is not the
+ * same as the input type, an extra cast operation may incur.
+ *
+ * @tparam Op The reduce operation to execute on the column.
+ */
+template <typename Op>
+struct element_type_dispatcher {
+  template <typename ElementType,
+            typename std::enable_if_t<std::is_floating_point<ElementType>::value>* = nullptr>
+  std::unique_ptr<scalar> operator()(column_view const& col,
+                                     data_type const output_type,
+                                     rmm::mr::device_memory_resource* mr,
+                                     cudaStream_t stream)
+  {
+    if (output_type == col.type())
+      return cudf::reduction::simple::simple_reduction<ElementType, ElementType, Op>(
+        col, mr, stream);
+    auto result =
+      cudf::reduction::simple::simple_reduction<ElementType, double, Op>(col, mr, stream);
+    if (output_type == result->type()) return result;
+    // this will cast the result to the output_type
+    return cudf::type_dispatcher(output_type,
+                                 simple::cast_numeric_scalar_fn<double>{},
+                                 static_cast<numeric_scalar<double>*>(result.get()),
+                                 mr,
+                                 stream);
+  }
+
+  template <typename ElementType,
+            typename std::enable_if_t<std::is_integral<ElementType>::value>* = nullptr>
+  std::unique_ptr<scalar> operator()(column_view const& col,
+                                     data_type const output_type,
+                                     rmm::mr::device_memory_resource* mr,
+                                     cudaStream_t stream)
+  {
+    if (output_type == col.type())
+      return cudf::reduction::simple::simple_reduction<ElementType, ElementType, Op>(
+        col, mr, stream);
+    auto result =
+      cudf::reduction::simple::simple_reduction<ElementType, int64_t, Op>(col, mr, stream);
+    if (output_type == result->type()) return result;
+    // this will cast the result to the output_type
+    return cudf::type_dispatcher(output_type,
+                                 simple::cast_numeric_scalar_fn<int64_t>{},
+                                 static_cast<numeric_scalar<int64_t>*>(result.get()),
+                                 mr,
+                                 stream);
+    return result;
+  }
+
+  template <typename ElementType,
+            typename std::enable_if_t<!std::is_floating_point<ElementType>::value and
+                                      !std::is_integral<ElementType>::value>* = nullptr>
+  std::unique_ptr<scalar> operator()(column_view const& col,
+                                     data_type const output_type,
+                                     rmm::mr::device_memory_resource* mr,
+                                     cudaStream_t stream)
+  {
+    CUDF_FAIL("Reduction operator not supported for this type");
   }
 };
 

--- a/cpp/src/reductions/sum.cu
+++ b/cpp/src/reductions/sum.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// The translation unit for reduction `sum`
 
 #include <cudf/detail/reduction_functions.hpp>
-#include "simple.cuh"
+#include <reductions/simple.cuh>
 
-std::unique_ptr<cudf::scalar> cudf::reduction::sum(column_view const& col,
-                                                   cudf::data_type const output_dtype,
-                                                   rmm::mr::device_memory_resource* mr,
-                                                   cudaStream_t stream)
+namespace cudf {
+namespace reduction {
+
+std::unique_ptr<cudf::scalar> sum(column_view const& col,
+                                  cudf::data_type const output_dtype,
+                                  rmm::mr::device_memory_resource* mr,
+                                  cudaStream_t stream)
 {
-  using reducer = cudf::reduction::simple::element_type_dispatcher<cudf::reduction::op::sum>;
-  return cudf::type_dispatcher(col.type(), reducer(), col, output_dtype, mr, stream);
+  return cudf::type_dispatcher(col.type(),
+                               simple::element_type_dispatcher<cudf::reduction::op::sum>{},
+                               col,
+                               output_dtype,
+                               mr,
+                               stream);
 }
+
+}  // namespace reduction
+}  // namespace cudf

--- a/cpp/src/reductions/sum_of_squares.cu
+++ b/cpp/src/reductions/sum_of_squares.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// The translation unit for reduction `sum of squares`
 
 #include <cudf/detail/reduction_functions.hpp>
-#include "simple.cuh"
+#include <reductions/simple.cuh>
 
-std::unique_ptr<cudf::scalar> cudf::reduction::sum_of_squares(column_view const& col,
-                                                              cudf::data_type const output_dtype,
-                                                              rmm::mr::device_memory_resource* mr,
-                                                              cudaStream_t stream)
+namespace cudf {
+namespace reduction {
+
+std::unique_ptr<cudf::scalar> sum_of_squares(column_view const& col,
+                                             cudf::data_type const output_dtype,
+                                             rmm::mr::device_memory_resource* mr,
+                                             cudaStream_t stream)
 {
-  using reducer =
-    cudf::reduction::simple::element_type_dispatcher<cudf::reduction::op::sum_of_squares>;
-  return cudf::type_dispatcher(col.type(), reducer(), col, output_dtype, mr, stream);
+  return cudf::type_dispatcher(
+    col.type(),
+    simple::element_type_dispatcher<cudf::reduction::op::sum_of_squares>{},
+    col,
+    output_dtype,
+    mr,
+    stream);
 }
+
+}  // namespace reduction
+}  // namespace cudf


### PR DESCRIPTION
Closes #6717 

This PR removes the 2nd type-dispatch from the simple reduce operations: `any()`, `all()`, `min()`, `max()`, `sum()`, `product()`, and `sum_of_squares()`. It is replaced with logic using either the same type as the input column type or a hardcoded type as follows:

- `any()` and `all()` expect only `BOOL8` as the output type
- `min()` and `max()` expect the output type to match the column input type
- `sum()`, `product()`, and `sum_of_squares()` allow any output type but may incur an extra scalar cast operation

The cast operation is only required if the output type does not match the input type or if the output type is not `INT64` for integer columns or `FLOAT64` for floating point columns. The extra cast only applies to `sum()`, `product()`, and `sum_of_squares()` ops.

This change improves the compile time for these operations as follows. Times are from ninja_log output and are in seconds.
| source | baseline | this PR |
| --- | --- | --- |
| max() | 440 | 89 |
| min() | 424 | 89 |
| product() | 331 | 75 |
| sum() | 322 | 71 |
| sum-of-squares() | 319 | 77 |

Also, the overall size of the `libcudf_reductions.so` file is reduced from `88 MB` to `50 MB`.
The gbenchmarks results for reductions did not change since the benchmarks had already been coded with the above restrictions.

