### PR TITLE
Fix cuDF benchmarks build with static Arrow lib and fix rapids-compose cuDF JNI build [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - PR #6708 Apply `na_rep` to column names in csv writer
 - PR #6721 Add missing serialization methods for ListColumn
 - PR #6722 Fix index=False bug in dask_cudf.read_parquet
+- PR #6732 Fix cuDF benchmarks build with static Arrow lib and fix rapids-compose cuDF JNI build
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -58,6 +58,10 @@ include_directories("${CMAKE_BINARY_DIR}/include"
                     "${RMM_INCLUDE}"
                     "${CMAKE_CURRENT_SOURCE_DIR}")
 
+if(CONDA_INCLUDE_DIRS)
+  include_directories("${CONDA_INCLUDE_DIRS}")
+endif(CONDA_INCLUDE_DIRS)
+
 ###################################################################################################
 # - library paths ---------------------------------------------------------------------------------
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -351,6 +351,7 @@
                                     <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
                                     <arg value="-DCMAKE_CXX_FLAGS=${cxx.flags}"/>
                                     <arg value="-DCMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}"/>
+                                    <arg value="-DCUDF_CPP_BUILD_DIR=${CUDF_CPP_BUILD_DIR}"/>
                                     <arg value="-DGPU_ARCHS=ALL"/>
                                 </exec>
                                 <exec dir="${native.build.path}"


### PR DESCRIPTION
The cmakelists for cuDF benchmarks (which are not built by default) failed to compile when
ARROW_STATIC_LIB was enabled. This fixes that failure. 

Also adds a cmake variable passthrough to the cuDF JNI pom.xml to enable building
cuDF JNI bindings when the cuDF build directory is not the default of cudf/cpp/build, 
as is common when using rapids-compose to build from source.
