### PR TITLE
[REVIEW] Add Java bindings for is_timestamp [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #6598 Add strings::contains API with target column parameter
 - PR #6638 Add support for `pipe` API
 - PR #6675 Add DecimalDtype to cuDF
+- PR #6739 Add Java bindings for is_timestamp
 
 ## Improvements
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -1852,6 +1852,40 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
     return castTo(DType.FLOAT64);
   }
 
+  /**
+   * Verifies that a string column can be parsed to timestamps using the provided format
+   * pattern.
+   *
+   * The format pattern can include the following specifiers: "%Y,%y,%m,%d,%H,%I,%p,%M,%S,%f,%z"
+   *
+   * | Specifier | Description |
+   * | :-------: | ----------- |
+   * | \%d | Day of the month: 01-31 |
+   * | \%m | Month of the year: 01-12 |
+   * | \%y | Year without century: 00-99 |
+   * | \%Y | Year with century: 0001-9999 |
+   * | \%H | 24-hour of the day: 00-23 |
+   * | \%I | 12-hour of the day: 01-12 |
+   * | \%M | Minute of the hour: 00-59|
+   * | \%S | Second of the minute: 00-59 |
+   * | \%f | 6-digit microsecond: 000000-999999 |
+   * | \%z | UTC offset with format ±HHMM Example +0500 |
+   * | \%j | Day of the year: 001-366 |
+   * | \%p | Only 'AM', 'PM' or 'am', 'pm' are recognized |
+   *
+   * Other specifiers are not currently supported.
+   * The "%f" supports a precision value to read the numeric digits. Specify the
+   * precision with a single integer value (1-9) as follows:
+   * use "%3f" for milliseconds, "%6f" for microseconds and "%9f" for nanoseconds.
+   *
+   * Any null string entry will result in a corresponding null row in the output column.
+   *
+   * This will return a column of type boolean where a `true` row indicates the corresponding
+   * input string can be parsed correctly with the given format.
+   *
+   * @param format String specifying the timestamp format in strings.
+   * @return New boolean ColumnVector.
+   */
   public ColumnVector isTimestamp(String format) {
     return new ColumnVector(isTimestamp(getNativeView(), format));
   }

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -1852,6 +1852,10 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
     return castTo(DType.FLOAT64);
   }
 
+  public ColumnVector isTimestamp(String format) {
+    return new ColumnVector(isTimestamp(getNativeView(), format));
+  }
+
   /**
    * Cast to TIMESTAMP_DAYS - ColumnVector
    * This method takes the value provided by the ColumnVector and casts to TIMESTAMP_DAYS
@@ -2888,6 +2892,8 @@ public final class ColumnVector implements AutoCloseable, BinaryOperable, Column
   private static native long byteCount(long viewHandle) throws CudfException;
 
   private static native long extractListElement(long nativeView, int index);
+
+  private static native long isTimestamp(long nativeView, String format);
 
   private static native long castTo(long nativeHandle, int type, int scale);
 

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -771,7 +771,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_byteListCast(JNIEnv *en
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isTimestamp(
-    JNIEnv *env, jlong handle, jstring formatObj) {
+    JNIEnv *env, jclass, jlong handle, jstring formatObj) {
   JNI_NULL_CHECK(env, handle, "column is null", 0);
   JNI_NULL_CHECK(env, formatObj, "format is null", 0);
 

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -770,6 +770,24 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_byteListCast(JNIEnv *en
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_isTimestamp(
+    JNIEnv *env, jlong handle, jstring formatObj) {
+  JNI_NULL_CHECK(env, handle, "column is null", 0);
+  JNI_NULL_CHECK(env, formatObj, "format is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::jni::native_jstring format(env, formatObj);
+    cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
+    cudf::strings_column_view strings_column(*column);
+
+    std::unique_ptr<cudf::column> result = cudf::strings::is_timestamp(
+        strings_column, format.get());
+    return reinterpret_cast<jlong>(result.release());
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_stringTimestampToTimestamp(
     JNIEnv *env, jobject j_object, jlong handle, jint time_unit, jstring formatObj) {
   JNI_NULL_CHECK(env, handle, "column is null", 0);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -1910,6 +1910,23 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testIsTimestamp() {
+      final String[] TIMESTAMP_STRINGS = {
+          "2018-07-04 12:00:00",
+          "",
+          "2023-01-25",
+          "2023-01-25 07:32:12",
+          "2018-07-04 12:00:00"
+      };
+
+      try (ColumnVector timestampStrings = ColumnVector.fromStrings(TIMESTAMP_STRINGS);
+           ColumnVector isTimestamp = timestampStrings.isTimestamp("%Y-%m-%d %H:%M:%S");
+           ColumnVector expected = ColumnVector.fromBoxedBooleans(true, false, false, true, true)) {
+          assertColumnsAreEqual(expected, isTimestamp);
+      }
+  }
+
+  @Test
   void testCastTimestampAsString() {
     final String[] TIMES_S_STRING = {
         "2018-07-04 12:00:00",

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -1914,6 +1914,7 @@ public class ColumnVectorTest extends CudfTestBase {
       final String[] TIMESTAMP_STRINGS = {
           "2018-07-04 12:00:00",
           "",
+          null,
           "2023-01-25",
           "2023-01-25 07:32:12",
           "2018-07-04 12:00:00"
@@ -1921,7 +1922,15 @@ public class ColumnVectorTest extends CudfTestBase {
 
       try (ColumnVector timestampStrings = ColumnVector.fromStrings(TIMESTAMP_STRINGS);
            ColumnVector isTimestamp = timestampStrings.isTimestamp("%Y-%m-%d %H:%M:%S");
-           ColumnVector expected = ColumnVector.fromBoxedBooleans(true, false, false, true, true)) {
+           ColumnVector expected = ColumnVector.fromBoxedBooleans(
+               true, false, null, false, true, true)) {
+          assertColumnsAreEqual(expected, isTimestamp);
+      }
+
+      try (ColumnVector timestampStrings = ColumnVector.fromStrings(TIMESTAMP_STRINGS);
+           ColumnVector isTimestamp = timestampStrings.isTimestamp("%Y-%m-%d");
+           ColumnVector expected = ColumnVector.fromBoxedBooleans(
+                   true, false, null, true, true, true)) {
           assertColumnsAreEqual(expected, isTimestamp);
       }
   }


### PR DESCRIPTION
This PR simply adds Java bindings for the `is_timestamp` method, along with a unit test.