### PR TITLE
Update nested JNI builder so we can do it incrementally. [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - PR #6705 Add nested type support to Java table serialization
 - PR #6709 Raise informative error while converting a pandas dataframe with duplicate columns
 - PR #6727 Remove 2nd type-dispatcher call from cudf::reduce
+- PR #6749 Update nested JNI builder so we can do it incrementally
 
 ## Bug Fixes
 


### PR DESCRIPTION
This updates and exposes some APIs to make it simpler to build nested types on the CPU before sending the data to the GPU for processing.