### PR TITLE
[REVIEW] support contiguous split of fixed-point decimal column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - PR #6748 Add Java API to concatenate serialized tables to ContiguousTable
 - PR #6734 Binary operations support for decimal type in cudf Java
 - PR #6761 Add Java/JNI bindings for round
+- PR #6762 Support contiguous split of fixed-point decimal column
 
 ## Bug Fixes
 

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -187,20 +187,11 @@ struct column_split_info {
  * a source table.
  */
 struct column_buffer_size_functor {
-  template <typename T, typename std::enable_if_t<!cudf::is_fixed_point<T>()>* = nullptr>
+  template <typename T>
   size_t operator()(column_view const& c, column_split_info& split_info)
   {
-    split_info.data_buf_size = cudf::util::round_up_safe(c.size() * sizeof(T), split_align);
-    split_info.validity_buf_size =
-      (c.has_nulls() ? cudf::bitmask_allocation_size_bytes(c.size(), split_align) : 0);
-    return split_info.data_buf_size + split_info.validity_buf_size;
-  }
-
-  template <typename T, typename std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
-  size_t operator()(column_view const& c, column_split_info& split_info)
-  {
-    using RepType            = typename T::rep;
-    split_info.data_buf_size = cudf::util::round_up_safe(c.size() * sizeof(RepType), split_align);
+    using Type               = cudf::device_storage_type_t<T>;
+    split_info.data_buf_size = cudf::util::round_up_safe(c.size() * sizeof(Type), split_align);
     split_info.validity_buf_size =
       (c.has_nulls() ? cudf::bitmask_allocation_size_bytes(c.size(), split_align) : 0);
     return split_info.data_buf_size + split_info.validity_buf_size;
@@ -221,7 +212,7 @@ size_t column_buffer_size_functor::operator()<string_view>(column_view const& c,
  * Used for copying each column in a source table into one contiguous buffer of memory.
  */
 struct column_copy_functor {
-  template <typename T, typename std::enable_if_t<!cudf::is_fixed_point<T>()>* = nullptr>
+  template <typename T>
   void operator()(column_view const& in,
                   column_split_info const& split_info,
                   char*& dst,
@@ -248,52 +239,13 @@ struct column_copy_functor {
     cudf::detail::grid_1d grid{num_els, block_size, 1};
 
     // output copied column
+    using Type = cudf::device_storage_type_t<T>;
     mutable_column_view mcv{in.type(), in.size(), data, validity, in.null_count()};
     if (in.has_nulls()) {
-      copy_in_place_kernel<block_size, T, true><<<grid.num_blocks, block_size, 0, 0>>>(
+      copy_in_place_kernel<block_size, Type, true><<<grid.num_blocks, block_size, 0, 0>>>(
         *column_device_view::create(in), *mutable_column_device_view::create(mcv));
     } else {
-      copy_in_place_kernel<block_size, T, false><<<grid.num_blocks, block_size, 0, 0>>>(
-        *column_device_view::create(in), *mutable_column_device_view::create(mcv));
-    }
-
-    out_cols.push_back(mcv);
-  }
-
-  template <typename T, typename std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
-  void operator()(column_view const& in,
-                  column_split_info const& split_info,
-                  char*& dst,
-                  std::vector<column_view>& out_cols)
-  {
-    // outgoing pointers
-    char* data             = dst;
-    bitmask_type* validity = split_info.validity_buf_size == 0
-                               ? nullptr
-                               : reinterpret_cast<bitmask_type*>(dst + split_info.data_buf_size);
-
-    // increment working buffer
-    dst += (split_info.data_buf_size + split_info.validity_buf_size);
-
-    // no work to do
-    if (in.is_empty()) {
-      out_cols.push_back(column_view{in.type(), 0, nullptr});
-      return;
-    }
-
-    // custom copy kernel (which could probably just be an in-place copy() function in cudf).
-    cudf::size_type num_els  = cudf::util::round_up_safe(in.size(), cudf::detail::warp_size);
-    constexpr int block_size = 256;
-    cudf::detail::grid_1d grid{num_els, block_size, 1};
-
-    // output copied column
-    using RepType = typename T::rep;
-    mutable_column_view mcv{in.type(), in.size(), data, validity, in.null_count()};
-    if (in.has_nulls()) {
-      copy_in_place_kernel<block_size, RepType, true><<<grid.num_blocks, block_size, 0, 0>>>(
-        *column_device_view::create(in), *mutable_column_device_view::create(mcv));
-    } else {
-      copy_in_place_kernel<block_size, RepType, false><<<grid.num_blocks, block_size, 0, 0>>>(
+      copy_in_place_kernel<block_size, Type, false><<<grid.num_blocks, block_size, 0, 0>>>(
         *column_device_view::create(in), *mutable_column_device_view::create(mcv));
     }
 

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -795,9 +795,19 @@ TEST_F(ContiguousSplitTableCornerCases, MixedColumnTypes)
   auto c4    = cudf::test::fixed_width_column_wrapper<int>(iter4, iter4 + 10, valids);
   cols.push_back(c4.release());
 
+  auto iter5 = cudf::test::make_counting_transform_iterator(30, [](auto i) { return (i); });
+  auto c5 =
+    cudf::test::fixed_point_column_wrapper<int32_t>(iter5, iter5 + 10, numeric::scale_type{1});
+  cols.push_back(c5.release());
+
+  auto iter6 = cudf::test::make_counting_transform_iterator(40, [](auto i) { return (i); });
+  auto c6 =
+    cudf::test::fixed_point_column_wrapper<int32_t>(iter6, iter6 + 10, numeric::scale_type{-2});
+  cols.push_back(c6.release());
+
   auto tbl = cudf::table(std::move(cols));
 
-  std::vector<cudf::size_type> splits{5};
+  std::vector<cudf::size_type> splits{7};
 
   auto result   = cudf::contiguous_split(tbl, splits);
   auto expected = cudf::split(tbl, splits);


### PR DESCRIPTION
This PR is about to support contiguous split of fixed-point decimal column through implementing specialized dispatching branches for fixed-point types.