### PR TITLE
Update java reduction APIs to reflect C++ changes [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@
 - PR #6742 Fix concat bug in dask_cudf Series/Index creation
 - PR #6632 Fix DataFrame initialization from list of dicts
 - PR #6767 Fix sort order of parameters in `test_scalar_invalid_implicit_conversion` pytest
+- PR #6787 Update java reduction APIs to reflect C++ changes
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/java/src/test/java/ai/rapids/cudf/ReductionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ReductionTest.java
@@ -17,6 +17,7 @@
  */
 package ai.rapids.cudf;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -368,6 +369,45 @@ class ReductionTest extends CudfTestBase {
     try (Scalar expected = buildExpectedScalar(op, DType.TIMESTAMP_NANOSECONDS, expectedObject);
          ColumnVector v = ColumnVector.timestampNanoSecondsFromBoxedLongs(values);
          Scalar result = v.reduce(op, expected.getType())) {
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  void testWithSetOutputType() {
+    try (Scalar expected = Scalar.fromLong(1 * 2 * 3 * 4L);
+         ColumnVector cv = ColumnVector.fromBytes(new byte[]{1, 2, 3, 4});
+         Scalar result = cv.product(DType.INT64)) {
+      assertEquals(expected, result);
+    }
+
+    try (Scalar expected = Scalar.fromLong(1 + 2 + 3 + 4L);
+         ColumnVector cv = ColumnVector.fromBytes(new byte[]{1, 2, 3, 4});
+         Scalar result = cv.sum(DType.INT64)) {
+      assertEquals(expected, result);
+    }
+
+    try (Scalar expected = Scalar.fromLong((1*1L) + (2*2L) + (3*3L) + (4*4L));
+         ColumnVector cv = ColumnVector.fromBytes(new byte[]{1, 2, 3, 4});
+         Scalar result = cv.sumOfSquares(DType.INT64)) {
+      assertEquals(expected, result);
+    }
+
+    try (Scalar expected = Scalar.fromFloat((1 + 2 + 3 + 4f)/4);
+         ColumnVector cv = ColumnVector.fromBytes(new byte[]{1, 2, 3, 4});
+         Scalar result = cv.mean(DType.FLOAT32)) {
+      assertEquals(expected, result);
+    }
+
+    try (Scalar expected = Scalar.fromFloat(1.666667f);
+         ColumnVector cv = ColumnVector.fromBytes(new byte[]{1, 2, 3, 4});
+         Scalar result = cv.variance(DType.FLOAT32)) {
+      assertEquals(expected, result);
+    }
+
+    try (Scalar expected = Scalar.fromFloat(1.2909945f);
+         ColumnVector cv = ColumnVector.fromBytes(new byte[]{1, 2, 3, 4});
+         Scalar result = cv.standardDeviation(DType.FLOAT32)) {
       assertEquals(expected, result);
     }
   }


### PR DESCRIPTION
Recently #6717 changed some of the output formats that a reduction can support.  This updates the java APIs to clean that up.

This also fixes #6783 but only as a temporary work around.