### PR TITLE
Parallelize child column construction in scatter() for lists columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #6638 Add support for `pipe` API
 - PR #6675 Add DecimalDtype to cuDF
 - PR #6739 Add Java bindings for is_timestamp
+- PR #6768 Add support for scatter() on list columns
 
 ## Improvements
 

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -129,7 +129,7 @@ struct column_scatterer_impl<list_view, MapIterator> {
                                      cudaStream_t stream) const
   {
     return cudf::lists::detail::scatter(
-      source, scatter_map_begin, scatter_map_end, target, mr, stream);
+      source, scatter_map_begin, scatter_map_end, target, stream, mr);
   }
 };
 

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -25,6 +25,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
 #include <cudf/strings/detail/scatter.cuh>
+#include <cudf/lists/detail/scatter.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/utilities/traits.hpp>
 
@@ -115,6 +116,19 @@ struct column_scatterer_impl<string_view, MapIterator> {
     auto const begin         = source_vector.begin();
     auto const end           = begin + std::distance(scatter_map_begin, scatter_map_end);
     return strings::detail::scatter(begin, end, scatter_map_begin, target, mr, stream);
+  }
+};
+
+template <typename MapIterator>
+struct column_scatterer_impl<list_view, MapIterator> {
+  std::unique_ptr<column> operator()(column_view const& source,
+                                     MapIterator scatter_map_begin,
+                                     MapIterator scatter_map_end,
+                                     column_view const& target,
+                                     rmm::mr::device_memory_resource* mr,
+                                     cudaStream_t stream) const
+  {
+    return cudf::lists::detail::scatter(source, scatter_map_begin, scatter_map_end, target, mr, stream);
   }
 };
 

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -24,8 +24,8 @@
 #include <cudf/dictionary/detail/update_keys.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
-#include <cudf/strings/detail/scatter.cuh>
 #include <cudf/lists/detail/scatter.cuh>
+#include <cudf/strings/detail/scatter.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/utilities/traits.hpp>
 
@@ -128,7 +128,8 @@ struct column_scatterer_impl<list_view, MapIterator> {
                                      rmm::mr::device_memory_resource* mr,
                                      cudaStream_t stream) const
   {
-    return cudf::lists::detail::scatter(source, scatter_map_begin, scatter_map_end, target, mr, stream);
+    return cudf::lists::detail::scatter(
+      source, scatter_map_begin, scatter_map_end, target, mr, stream);
   }
 };
 

--- a/cpp/include/cudf/lists/detail/scatter.cuh
+++ b/cpp/include/cudf/lists/detail/scatter.cuh
@@ -1,0 +1,769 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cinttypes>
+#include <cuda_runtime.h>
+#include <cudf/types.hpp>
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/valid_if.cuh>
+#include <cudf/lists/list_device_view.cuh>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <thrust/binary_search.h>
+
+namespace cudf {
+namespace lists {
+namespace detail {
+
+namespace {
+
+/**
+ * @brief Holder for a list row's positional information, without
+ *        also holding a reference to the list column.
+ * 
+ * Analogous to the list_view, this class is default constructable,
+ * and can thus be stored in rmm::device_vector. It is used to represent
+ * the results of a `scatter()` operation; a device_vector may hold 
+ * several instances of unbound_list_view, each with a flag indicating 
+ * whether it came from the scatter source or target. Each instance
+ * may later be "bound" to the appropriate source/target column, to
+ * reconstruct the list_view.
+ */
+struct unbound_list_view
+{
+  /**
+   * @brief Flag type, indicating whether this list row originated from
+   *        the source or target column, in `scatter()`.
+   */
+  enum label_t : bool {SOURCE, TARGET};
+
+  using lists_column_device_view = cudf::detail::lists_column_device_view;
+  using list_device_view = cudf::list_device_view;
+
+  unbound_list_view() = default;
+  unbound_list_view(unbound_list_view const&) = default;
+  unbound_list_view(unbound_list_view &&) = default;
+  unbound_list_view& operator = (unbound_list_view const&) = default;
+  unbound_list_view& operator = (unbound_list_view &&) = default;
+
+  /**
+   * @brief (__device__) Constructor, for use from `scatter()`.
+   * 
+   * @param scatter_source_label Whether the row came from source or target
+   * @param lists_column The actual source/target lists column
+   * @param row_index Index of the row in lists_column that this instance represents
+   */
+  CUDA_DEVICE_CALLABLE unbound_list_view(label_t scatter_source_label,
+                                          cudf::detail::lists_column_device_view const& lists_column,
+                                          size_type const& row_index)
+    : _label{scatter_source_label},
+      _row_index{row_index}
+  {
+    _size = list_device_view{lists_column, row_index}.size();
+  }
+
+  /**
+   * @brief (__device__) Constructor, for use when constructing the child column
+   *        of a scattered list column
+   * 
+   * @param scatter_source_label Whether the row came from source or target
+   * @param row_index Index of the row that this instance represents in the source/target column
+   * @param size The number of elements in this list row
+   */
+  CUDA_DEVICE_CALLABLE unbound_list_view(label_t scatter_source_label,
+                                          size_type const& row_index,
+                                          size_type const& size)
+    : _label{scatter_source_label},
+      _row_index{row_index},
+      _size{size}
+  {}
+
+  /**
+   * @brief Returns number of elements in this list-row.
+   */
+  CUDA_DEVICE_CALLABLE size_type size() const { return _size; }
+
+  /**
+   * @brief Returns whether this row came from the `scatter()` source or target
+   */
+  CUDA_DEVICE_CALLABLE label_t label() const { return _label; }
+
+  /**
+   * @brief Returns the index in the source/target column
+   */
+  CUDA_DEVICE_CALLABLE size_type row_index() const { return _row_index; }
+
+  /**
+   * @brief Binds to source/target column (depending on SOURCE/TARGET labels),
+   *        to produce a bound list_view.
+   * 
+   * @param scatter_source Source column for the scatter operation
+   * @param scatter_target Target column for the scatter operation
+   * @return A (bound) list_view for the row that this object represents
+   */
+  CUDA_DEVICE_CALLABLE list_device_view bind_to_column(
+    lists_column_device_view const& scatter_source,
+    lists_column_device_view const& scatter_target) const 
+  {
+    return list_device_view(_label == SOURCE? scatter_source : scatter_target, _row_index);
+  }
+
+  private:
+
+    // Note: Cannot store reference to list column, because of storage in device_vector.
+    // Only keep track of whether this list row came from the source or target of scatter.
+
+    label_t _label {SOURCE}; // Whether this list row came from the scatter source or target. 
+    size_type _row_index{};  // Row index in the Lists column.
+    size_type _size{};       // Number of elements in *this* list row.
+};
+
+rmm::device_vector<unbound_list_view> list_vector_from_column(
+  unbound_list_view::label_t label,
+  cudf::detail::lists_column_device_view const& lists_column,
+  cudaStream_t stream
+)
+{
+  auto n_rows = lists_column.size();
+
+  auto vector = rmm::device_vector<unbound_list_view>(n_rows);
+
+  thrust::for_each_n(
+    rmm::exec_policy(stream)->on(stream),
+    thrust::make_counting_iterator<size_type>(0),
+    n_rows,
+    [
+      label,
+      lists_column,
+      output = vector.data().get()
+    ] __device__ (size_type row_index)
+    {
+      output[row_index] = unbound_list_view{label, lists_column, row_index};
+    }
+  );
+
+  return vector;
+}
+
+/**
+ * @brief Utility function to fetch the number of rows in a lists column's
+ *        child column, given its offsets column.
+ *        (This is simply the last value in the offsets column.)
+ * 
+ * @param list_offsets Offsets child of a lists column
+ * @param stream The cuda-stream to synchronize on, when reading from device memory
+ * @return int32_t The last element in the list_offsets column, indicating
+ *         the number of rows in the lists-column's child.
+ */
+int32_t get_num_child_rows(cudf::column_view const& list_offsets, cudaStream_t stream)
+{
+  // Number of rows in child-column == last offset value.
+  int32_t num_child_rows{};
+  CUDA_TRY(cudaMemcpyAsync(&num_child_rows, 
+                            list_offsets.data<int32_t>()+list_offsets.size()-1, 
+                            sizeof(int32_t), 
+                            cudaMemcpyDeviceToHost, 
+                            stream));
+  CUDA_TRY(cudaStreamSynchronize(stream));  
+  return num_child_rows;
+}
+
+/**
+ * @brief Constructs null mask for a scattered list's child column
+ * 
+ * @param parent_list_vector Vector of unbound_list_view, for parent lists column
+ * @param parent_list_offsets List column offsets for parent lists column
+ * @param source_lists Source lists column for scatter operation
+ * @param target_lists Target lists column for scatter operation
+ * @param num_child_rows Number of rows in child column
+ * @param mr Device memory resource used to allocate child column's null mask
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @return std::pair<rmm::device_buffer, size_type> Child column's null mask and null row count
+ */
+std::pair<rmm::device_buffer, size_type> 
+construct_child_nullmask(rmm::device_vector<unbound_list_view> const& parent_list_vector,
+                         column_view const& parent_list_offsets,
+                         cudf::detail::lists_column_device_view const& source_lists,
+                         cudf::detail::lists_column_device_view const& target_lists,
+                         size_type num_child_rows,
+                         rmm::mr::device_memory_resource* mr,
+                         cudaStream_t stream) 
+{
+  auto is_valid_predicate = [
+    d_list_vector = parent_list_vector.data().get(),
+    d_offsets = parent_list_offsets.template data<size_type>(),
+    d_offsets_size = parent_list_offsets.size(),
+    source_lists,
+    target_lists
+  ] __device__ (auto const& i) {
+
+    auto list_start = thrust::upper_bound(thrust::seq,
+                                          d_offsets,
+                                          d_offsets + d_offsets_size,
+                                          i) - 1;
+    auto list_index = list_start - d_offsets;
+    auto element_index = i - *list_start;
+
+    auto list_row = d_list_vector[list_index];
+    return !list_row.bind_to_column(source_lists, target_lists).is_null(element_index);
+  };
+
+  return cudf::detail::valid_if(
+    thrust::make_counting_iterator<size_type>(0),
+    thrust::make_counting_iterator<size_type>(num_child_rows),
+    is_valid_predicate,
+    stream,
+    mr
+  );
+}
+
+#ifndef NDEBUG
+void print(std::string const& msg, column_view const& col, cudaStream_t stream)
+{
+  if (col.type().id() != type_id::INT32)
+  {
+    std::cout << "[Cannot print non-INT32 column.]" << std::endl;
+    return;
+  }
+
+  std::cout << msg << " = [";
+  thrust::for_each_n(
+    rmm::exec_policy(stream)->on(stream),
+    thrust::make_counting_iterator<size_type>(0),
+    col.size(),
+    [c = col.template data<int32_t>()]__device__(auto const& i) {
+      printf("%d,", c[i]);
+    }
+  );
+  std::cout << "]" << std::endl;
+}
+
+void print(std::string const& msg, rmm::device_vector<unbound_list_view> const& scatter, cudaStream_t stream)
+{
+  std::cout << msg << " == [";
+
+  thrust::for_each_n(
+    rmm::exec_policy(stream)->on(stream),
+    thrust::make_counting_iterator<size_type>(0),
+    scatter.size(),
+    [s = scatter.data().get()] __device__ (auto const& i) {
+      auto si = s[i];
+      printf("%s[%d](%d), ", (si.label() == unbound_list_view::SOURCE? "S":"T"), si.row_index(), si.size());
+    }
+  );
+  std::cout << "]" << std::endl;
+}
+#endif // NDEBUG
+
+/**
+ * @brief (type_dispatch endpoint) Functor that constructs the child column result
+ *        of `scatter()`ing a list column.
+ * 
+ * The protocol is as follows:
+ * 
+ * Inputs:
+ *  1. list_vector:  A device_vector of unbound_list_view, with each element
+ *                   indicating the position, size, and which column the list
+ *                   row came from.
+ *  2. list_offsets: The offsets column for the (outer) lists column, each offset
+ *                   marking the beginning of a list row.
+ *  3. source_list:  The lists-column that is the source of the scatter().
+ *  4. target_list:  The lists-column that is the target of the scatter().
+ *  
+ * Output: A (possibly non-list) child column, which may be used in combination
+ *         with list_offsets to fully construct the outer list.
+ * 
+ * Example:
+ * 
+ * Consider the following scatter operation of two `list<int>` columns:
+ * 
+ * 1. Source:      [{9,9,9,9}, {8,8,8}], i.e.
+ *    a. Child:    [9,9,9,9,8,8,8]
+ *    b. Offsets:  [0,      4,    7]
+ * 
+ * 2. Target:      [{1,1}, {2,2}, {3,3}], i.e.
+ *    a. Child:    [1,1,2,2,3,3]
+ *    b. Offsets:  [0,  2,  4,  6]
+ * 
+ * 3. Scatter-map: [2, 0]
+ * 
+ * 4. Expected output: [{8,8,8}, {2,2}, {9,9,9,9}], i.e.
+ *    a. Child:        [8,8,8,2,2,9,9,9,9]  <--- THIS
+ *    b. Offsets:      [0,    3,  5,     9]
+ * 
+ * It is the Expected Child column above that list_child_constructor attempts
+ * to construct.
+ * 
+ * `list_child_constructor` expects to be called with the `Source`/`Target`
+ * lists columns, along with the following:
+ * 
+ * 1. list_vector: [ S[1](3), T[1](2), S[0](4) ]
+ *    Each unbound_list_view (e.g. S[1](3)) indicates:
+ *      a. Which column the row is bound to: S == Source, T == Target
+ *      b. The list index. E.g. S[1] indicates the 2nd list row of the Source column.
+ *      c. The row size.   E.g. S[1](3) indicates that the row has 3 elements.
+ * 
+ * 2. list_offsets: [0, 3, 5, 9]
+ *    The caller may construct this with an `inclusive_scan()` on `list_vector` 
+ *    element sizes.
+ */
+struct list_child_constructor
+{
+  private: 
+  /**
+   * @brief Function to determine what types are supported as child column types,
+   *        when scattering lists.
+   * 
+   * @tparam T The data type of the child column of the list being scattered.
+   */
+  template <typename T>
+  struct is_supported_child_type
+  {
+    static const bool value = cudf::is_fixed_width<T>()
+                           || std::is_same<T, string_view>::value
+                           || std::is_same<T, list_view>::value;
+  };
+
+  public:
+
+  /**
+   * @brief SFINAE catch-all, for unsupported child column types.
+   */
+  template <typename T> 
+  std::enable_if_t<!is_supported_child_type<T>::value, std::unique_ptr<column>> operator()(
+    rmm::device_vector<unbound_list_view> const& list_vector, 
+    cudf::column_view const& list_offsets,
+    cudf::lists_column_view const& source_list,
+    cudf::lists_column_view const& target_list,
+    rmm::mr::device_memory_resource* mr,
+    cudaStream_t stream) const
+  {
+    CUDF_FAIL("list_child_constructor unsupported!");
+  }
+
+  /**
+   * @brief Implementation for fixed_width child column types.
+   */
+  template <typename T>
+  std::enable_if_t<cudf::is_fixed_width<T>(), std::unique_ptr<column>> operator()(
+    rmm::device_vector<unbound_list_view> const& list_vector, 
+    cudf::column_view const& list_offsets,
+    cudf::lists_column_view const& source_lists_column_view,
+    cudf::lists_column_view const& target_lists_column_view,
+    rmm::mr::device_memory_resource* mr,
+    cudaStream_t stream) const
+  {
+    auto source_column_device_view = column_device_view::create(source_lists_column_view.parent(), stream);
+    auto target_column_device_view = column_device_view::create(target_lists_column_view.parent(), stream);
+    auto source_lists = cudf::detail::lists_column_device_view(*source_column_device_view);
+    auto target_lists = cudf::detail::lists_column_device_view(*target_column_device_view);
+
+    // Number of rows in child-column == last offset value.
+    int32_t num_child_rows{get_num_child_rows(list_offsets, stream)};
+
+    auto child_null_mask = 
+      source_lists_column_view.child().nullable() || target_lists_column_view.child().nullable()
+      ? construct_child_nullmask(list_vector, list_offsets, source_lists, target_lists, num_child_rows, mr, stream)
+      : std::make_pair(rmm::device_buffer{}, 0);
+
+#ifndef NDEBUG
+    print("list_offsets ", list_offsets, stream);
+    print("source_lists.child() ", source_lists_column_view.child(), stream);
+    print("source_lists.offsets() ", source_lists_column_view.offsets(), stream);
+    print("target_lists.child() ", target_lists_column_view.child(), stream);
+    print("target_lists.offsets() ", target_lists_column_view.offsets(), stream);
+    print("scatter_rows ", list_vector, stream);
+#endif // NDEBUG
+
+    // Init child-column.
+    auto child_column = cudf::make_fixed_width_column(
+      cudf::data_type{cudf::type_to_id<T>()},
+      num_child_rows,
+      child_null_mask.first,
+      child_null_mask.second,
+      stream,
+      mr
+    );
+
+    // Function to copy child-values for specified index of unbound_list_view
+    // to the child column.
+    auto copy_child_values_for_list_index = [
+      d_scattered_lists = list_vector.data().get(), // unbound_list_view*
+      d_child_column    = child_column->mutable_view().data<T>(),
+      d_offsets         = list_offsets.template data<int32_t>(),
+      source_lists,
+      target_lists
+    ] __device__ (auto const& row_index) {
+
+      auto unbound_list_row   = d_scattered_lists[row_index];
+      auto actual_list_row    = unbound_list_row.bind_to_column(source_lists, target_lists);
+      auto const& bound_column= (unbound_list_row.label() == unbound_list_view::SOURCE? source_lists : target_lists);
+      auto list_begin_offset  = bound_column.offsets().element<size_type>(unbound_list_row.row_index());
+      auto list_end_offset    = bound_column.offsets().element<size_type>(unbound_list_row.row_index()+1);
+
+#ifndef NDEBUG
+      printf("%d: Unbound == %s[%d](%d), Bound size == %d, calc_begin==%d, calc_end=%d, calc_size=%d\n", 
+             row_index, 
+             (unbound_list_row.label() == unbound_list_view::SOURCE? "S":"T"), 
+             unbound_list_row.row_index(),
+             unbound_list_row.size(),
+             actual_list_row.size(),
+             list_begin_offset,
+             list_end_offset,
+             list_end_offset-list_begin_offset
+      );
+#endif // NDEBUG      
+      
+      // Copy all elements in this list row, to "appropriate" offset in child-column.
+      auto destination_start_offset = d_offsets[row_index];
+      thrust::for_each_n(
+        thrust::seq,
+        thrust::make_counting_iterator<size_type>(0),
+        actual_list_row.size(),
+        [actual_list_row, d_child_column, destination_start_offset] __device__ (auto const& list_element_index)
+        {
+          d_child_column[destination_start_offset + list_element_index] =
+            actual_list_row.template element<T>(list_element_index);
+        }
+      );
+    };
+
+    // For each list-row, copy underlying elements to the child column.
+    thrust::for_each_n(
+      rmm::exec_policy(stream)->on(stream),
+      thrust::make_counting_iterator<size_type>(0),
+      list_vector.size(),
+      copy_child_values_for_list_index
+    );
+
+    return std::make_unique<column>(child_column->view());
+  }
+
+  /**
+   * @brief Implementation for list child columns that contain strings.
+   */
+  template <typename T> 
+  std::enable_if_t<std::is_same<T, string_view>::value, 
+                   std::unique_ptr<column>> 
+  operator()(
+    rmm::device_vector<unbound_list_view> const& list_vector, 
+    cudf::column_view const& list_offsets,
+    cudf::lists_column_view const& source_lists_column_view,
+    cudf::lists_column_view const& target_lists_column_view,
+    rmm::mr::device_memory_resource* mr,
+    cudaStream_t stream) const
+  {
+    auto source_column_device_view = column_device_view::create(source_lists_column_view.parent(), stream);
+    auto target_column_device_view = column_device_view::create(target_lists_column_view.parent(), stream);
+    auto source_lists = cudf::detail::lists_column_device_view(*source_column_device_view);
+    auto target_lists = cudf::detail::lists_column_device_view(*target_column_device_view);
+
+    int32_t num_child_rows{get_num_child_rows(list_offsets, stream)};
+
+    auto string_views = rmm::device_vector<string_view>(num_child_rows);
+
+    auto populate_string_views = [
+      d_scattered_lists = list_vector.data().get(), // unbound_list_view*
+      d_list_offsets    = list_offsets.template data<int32_t>(),
+      d_string_views    = string_views.data().get(),
+      source_lists,
+      target_lists
+    ] __device__ (auto const& row_index) {
+
+      auto unbound_list_view    = d_scattered_lists[row_index];
+      auto actual_list_row       = unbound_list_view.bind_to_column(source_lists, target_lists);
+      auto lists_column          = actual_list_row.get_column();
+      auto lists_offsets_column  = lists_column.offsets();
+      auto child_strings_column  = lists_column.child();
+      auto string_offsets_column = child_strings_column.child(cudf::strings_column_view::offsets_column_index);
+      auto string_chars_column   = child_strings_column.child(cudf::strings_column_view::chars_column_index);
+
+      auto output_start_offset = d_list_offsets[row_index]; // Offset in `string_views` at which string_views are 
+                                                            // to be written for this list row_index.
+      auto input_list_start = lists_offsets_column.template element<int32_t>(unbound_list_view.row_index());
+
+      thrust::for_each_n(
+        thrust::seq,
+        thrust::make_counting_iterator<size_type>(0),
+        actual_list_row.size(),
+        [
+          output_start_offset,
+          d_string_views,
+          input_list_start,
+          d_string_offsets = string_offsets_column.template data<int32_t>(),
+          d_string_chars   = string_chars_column.template data<char>()
+        ] __device__ (auto const& string_idx)
+        {
+          // auto string_offset     = output_start_offset + string_idx;
+          auto string_start_idx  = d_string_offsets[input_list_start + string_idx];
+          auto string_end_idx    = d_string_offsets[input_list_start + string_idx + 1];
+
+          d_string_views[output_start_offset + string_idx] = 
+            string_view{d_string_chars + string_start_idx, string_end_idx - string_start_idx};
+        }
+      );
+    };
+
+    thrust::for_each_n(
+      rmm::exec_policy(stream)->on(stream),
+      thrust::make_counting_iterator<size_type>(0),
+      list_vector.size(),
+      populate_string_views
+    );
+
+    // string_views should now have been populated with source and target references.
+
+    auto string_offsets = cudf::strings::detail::child_offsets_from_string_vector(string_views, mr, stream);
+    auto string_chars   = cudf::strings::detail::child_chars_from_string_vector(string_views, string_offsets->view().data<int32_t>(), 0, mr, stream);
+    auto child_null_mask = 
+      source_lists_column_view.child().nullable() || target_lists_column_view.child().nullable()
+      ? construct_child_nullmask(list_vector, list_offsets, source_lists, target_lists, num_child_rows, mr, stream)
+      : std::make_pair(rmm::device_buffer{}, 0);
+
+    return cudf::make_strings_column(num_child_rows,
+                                     std::move(string_offsets),
+                                     std::move(string_chars),
+                                     child_null_mask.second,  // Null count.
+                                     std::move(child_null_mask.first),   // Null mask.
+                                     stream, 
+                                     mr);
+  }
+
+  /**
+   * @brief (Recursively) Constructs a child column that is itself a list column.
+   */
+  template <typename T>
+  std::enable_if_t<std::is_same<T, list_view>::value, 
+                   std::unique_ptr<column>> 
+  operator() (
+    rmm::device_vector<unbound_list_view> const& list_vector, 
+    cudf::column_view const& list_offsets,
+    cudf::lists_column_view const& source_lists_column_view,
+    cudf::lists_column_view const& target_lists_column_view,
+    rmm::mr::device_memory_resource* mr,
+    cudaStream_t stream) const
+  {
+    auto source_column_device_view = column_device_view::create(source_lists_column_view.parent(), stream);
+    auto target_column_device_view = column_device_view::create(target_lists_column_view.parent(), stream);
+    auto source_lists = cudf::detail::lists_column_device_view(*source_column_device_view);
+    auto target_lists = cudf::detail::lists_column_device_view(*target_column_device_view);
+
+    auto num_child_rows = get_num_child_rows(list_offsets, stream);
+
+    auto child_list_views = rmm::device_vector<unbound_list_view>(num_child_rows);
+
+    // Function to convert from parent list_device_view instances to child list_device_views.
+    // For instance, if a parent list_device_view has 3 elements, it should have 3 corresponding
+    // child list_device_view instances.
+    auto populate_child_list_views = [
+      d_scattered_lists  = list_vector.data().get(),
+      d_list_offsets     = list_offsets.template data<int32_t>(),
+      d_child_list_views = child_list_views.data().get(),
+      source_lists,
+      target_lists
+    ] __device__ (auto const& row_index) {
+
+      auto scattered_row        = d_scattered_lists[row_index];
+      auto label                = scattered_row.label();
+      auto bound_list_row       = scattered_row.bind_to_column(source_lists, target_lists);
+      auto lists_offsets_column = bound_list_row.get_column().offsets();
+
+      auto child_column         = bound_list_row.get_column().child();
+      auto child_offsets        = child_column.child(cudf::lists_column_view::offsets_column_index);
+
+      // For lists row at row_index,
+      //   1. Number of entries in child_list_views == bound_list_row.size().
+      //   2. Offset of the first child list_view   == d_list_offsets[row_index].
+      auto output_start_offset  = d_list_offsets[row_index];
+      auto input_list_start     = lists_offsets_column.template element<int32_t>(scattered_row.row_index());
+
+      thrust::for_each_n(
+        thrust::seq,
+        thrust::make_counting_iterator<size_type>(0),
+        bound_list_row.size(),
+        [
+          input_list_start,
+          output_start_offset,
+          label,
+          d_child_list_views,
+          d_child_offsets = child_offsets.template data<int32_t>()
+        ] __device__ (auto const& child_list_index)
+        {
+          auto child_start_idx = d_child_offsets[input_list_start + child_list_index];
+          auto child_end_idx   = d_child_offsets[input_list_start + child_list_index + 1];
+
+          d_child_list_views[output_start_offset + child_list_index] = 
+            unbound_list_view{label, input_list_start + child_list_index, child_end_idx - child_start_idx};
+        }
+      );
+    };
+
+    thrust::for_each_n(
+      rmm::exec_policy(stream)->on(stream),
+      thrust::make_counting_iterator<size_type>(0),
+      list_vector.size(),
+      populate_child_list_views
+    );
+
+    // child_list_views should now have been populated, with source and target references.
+
+    auto begin = thrust::make_transform_iterator(
+      child_list_views.begin(), 
+      [] __device__ (auto const& row) { return row.size(); }
+    );
+
+    auto child_offsets = cudf::strings::detail::make_offsets_child_column(
+      begin,
+      begin + child_list_views.size(),
+      mr,
+      stream
+    );
+
+    auto child_column = cudf::type_dispatcher(
+      source_lists_column_view.child().child(1).type(),
+      list_child_constructor{},
+      child_list_views,
+      child_offsets->view(),
+      cudf::lists_column_view(source_lists_column_view.child()),
+      cudf::lists_column_view(target_lists_column_view.child()),
+      mr,
+      stream
+    );
+
+    auto child_null_mask = 
+      source_lists_column_view.child().nullable() || target_lists_column_view.child().nullable()
+      ? construct_child_nullmask(list_vector, list_offsets, source_lists, target_lists, num_child_rows, mr, stream)
+      : std::make_pair(rmm::device_buffer{}, 0);
+
+    return cudf::make_lists_column(
+      num_child_rows,
+      std::move(child_offsets),
+      std::move(child_column),
+      child_null_mask.second,            // Null count
+      std::move(child_null_mask.first), // Null mask
+      stream,
+      mr
+    );
+  }
+};
+
+} // namespace;
+
+/**
+ * @brief Scatters lists into a copy of the target column
+ * according to a scatter map.
+ *
+ * The scatter is performed according to the scatter iterator such that row
+ * `scatter_map[i]` of the output column is replaced by the source list-row.
+ * All other rows of the output column equal corresponding rows of the target table.
+ *
+ * If the same index appears more than once in the scatter map, the result is
+ * undefined.
+ *
+ * The caller must update the null mask in the output column.
+ *
+ * @tparam SourceIterator must produce list_view objects
+ * @tparam MapIterator must produce index values within the target column.
+ *
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @return New lists column.
+ */
+template <typename MapIterator>
+std::unique_ptr<column> scatter(
+  column_view const& source,
+  MapIterator scatter_map_begin,
+  MapIterator scatter_map_end,
+  column_view const& target,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
+  cudaStream_t stream                 = 0
+  )
+{
+    auto num_rows = target.size();
+
+    if (num_rows == 0)
+    {
+      return cudf::empty_like(target);
+    }
+
+    auto child_column_type = lists_column_view(target).child().type();
+
+    // TODO: Deep(er) checks that source and target have identical types.
+
+    using lists_column_device_view = cudf::detail::lists_column_device_view;
+    using unbound_list_view = cudf::lists::detail::unbound_list_view;
+
+    auto source_lists_column_view = lists_column_view(source); // Checks that this is a list column.
+    auto source_device_view = column_device_view::create(source, stream);
+    // auto source_lists_column_device_view = lists_column_device_view(*source_device_view);
+    auto source_vector = list_vector_from_column(unbound_list_view::SOURCE, lists_column_device_view(*source_device_view), stream);
+
+    auto target_lists_column_view = lists_column_view(target); // Checks that target is a list column.
+    auto target_device_view = column_device_view::create(target, stream);
+    // auto target_lists_column_device_view = lists_column_device_view(*target_device_view);
+    auto target_vector = list_vector_from_column(unbound_list_view::TARGET, lists_column_device_view(*target_device_view), stream);
+
+    // Scatter.
+    thrust::scatter(
+      rmm::exec_policy(stream)->on(stream),
+      source_vector.begin(),
+      source_vector.end(),
+      scatter_map_begin,
+      target_vector.begin()
+    );
+
+    auto list_size_begin = thrust::make_transform_iterator(target_vector.begin(), [] __device__(unbound_list_view l) { return l.size(); });
+    auto offsets_column = cudf::strings::detail::make_offsets_child_column(
+      list_size_begin,
+      list_size_begin + target.size(),
+      mr,
+      stream
+    );
+
+    auto child_column = cudf::type_dispatcher( 
+      child_column_type, 
+      list_child_constructor{},
+      target_vector,
+      offsets_column->view(),
+      source_lists_column_view,
+      target_lists_column_view,
+      mr,
+      stream
+    );
+
+    rmm::device_buffer null_mask{0, stream, mr};
+    if (target.has_nulls()) {
+      null_mask = copy_bitmask(target, stream, mr);
+    }
+
+    return cudf::make_lists_column(
+      num_rows,
+      std::move(offsets_column),
+      std::move(child_column),
+      cudf::UNKNOWN_NULL_COUNT,
+      std::move(null_mask),
+      stream,
+      mr
+    );
+}
+
+} // namespace detail;
+} // namespace lists;
+} // namespace cudf;

--- a/cpp/include/cudf/lists/list_device_view.cuh
+++ b/cpp/include/cudf/lists/list_device_view.cuh
@@ -36,10 +36,9 @@ class list_device_view {
                                         size_type const& row_index)
     : lists_column(lists_column), _row_index(row_index)
   {
-    release_assert(row_index >= 0 && row_index < lists_column.size() && "row_index out of bounds");
-
     column_device_view const& offsets = lists_column.offsets();
-    release_assert(row_index < offsets.size() && "row_index should not have exceeded offset size");
+    release_assert(row_index >= 0 && row_index < lists_column.size() &&
+                   row_index < offsets.size() && "row_index out of bounds");
 
     begin_offset = offsets.element<size_type>(row_index);
     release_assert(begin_offset >= 0 && begin_offset <= lists_column.child().size() &&
@@ -77,7 +76,7 @@ class list_device_view {
   }
 
   /**
-   * @brief Fetches the element at the specified index, within the list row.
+   * @brief Fetches the element at the specified index within the list row.
    *
    * @tparam The type of the list's element.
    * @param The index into the list row

--- a/cpp/include/cudf/lists/list_device_view.cuh
+++ b/cpp/include/cudf/lists/list_device_view.cuh
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cudf/types.hpp>
+#include <cudf/lists/lists_column_device_view.cuh>
+
+namespace cudf {
+
+/**
+ * @brief A non-owning, immutable view of device data that represents
+ * a list of elements of arbitrary type (including further nested lists).
+ *
+ */
+class list_device_view {
+
+    using lists_column_device_view = cudf::detail::lists_column_device_view;
+
+  public:
+
+    list_device_view() = default;
+
+    CUDA_DEVICE_CALLABLE list_device_view(lists_column_device_view const& lists_column, size_type const& idx);
+
+    ~list_device_view() = default;
+
+    /**
+     * @brief Fetches the offset in the list column's child that corresponds to
+     * the element at the specified list index.
+     *
+     * Consider the following lists column:
+     *  [
+     *   [0,1,2],
+     *   [3,4,5],
+     *   [6,7,8]
+     *  ]
+     *
+     * The list's internals would look like:
+     *  offsets: [0, 3, 6, 9]
+     *  child  : [0, 1, 2, 3, 4, 5, 6, 7, 8]
+     *
+     * The second list row (i.e. row_index=1) is [3,4,5].
+     * The third element (i.e. idx=2) of the second list row is 5.
+     *
+     * The offset of this element as stored in the child column (i.e. 5)
+     * may be fetched using this method.
+     */
+    CUDA_DEVICE_CALLABLE size_type element_offset(size_type idx) const;
+
+    /**
+     * @brief Fetches the element at the specified index, within the list row.
+     *
+     * @tparam The type of the list's element.
+     * @param The index into the list row
+     * @return The element at the specified index of the list row.
+     */
+    template <typename T>
+    CUDA_DEVICE_CALLABLE T element(size_type idx) const;
+
+    /**
+     * @brief Checks whether element is null at specified index in the list row.
+     */
+    CUDA_DEVICE_CALLABLE bool is_null(size_type idx) const;
+
+    /**
+     * @brief Checks whether this list row is null.
+     */
+    CUDA_DEVICE_CALLABLE bool is_null() const;
+
+    /**
+     * @brief Fetches the number of elements in this list row.
+     */
+    CUDA_DEVICE_CALLABLE size_type size() const { return _size; }
+
+    /**
+     * @brief Fetches the lists_column_device_view that contains this list.
+     */
+    CUDA_DEVICE_CALLABLE lists_column_device_view const& get_column() const { return lists_column; }
+
+  private:
+
+    lists_column_device_view const& lists_column; 
+    size_type _row_index{};  // Row index in the Lists column vector.
+    size_type _size{};       // Number of elements in *this* list row.
+
+    size_type begin_offset;  // Offset in list_column_device_view where this list begins.
+
+};
+
+CUDA_DEVICE_CALLABLE list_device_view::list_device_view(
+  lists_column_device_view const& lists_column, size_type const& row_index)
+  : lists_column(lists_column), _row_index(row_index)
+{
+  release_assert(row_index >= 0 && row_index < lists_column.size() && "row_index out of bounds");
+
+  column_device_view const& offsets = lists_column.offsets();
+  release_assert(row_index < offsets.size() && "row_index should not have exceeded offset size");
+
+  begin_offset = offsets.element<size_type>(row_index);
+  release_assert(begin_offset >= 0 && begin_offset <= lists_column.child().size() &&
+                 "begin_offset out of bounds.");
+  _size = offsets.element<size_type>(row_index + 1) - begin_offset;
+}
+
+CUDA_DEVICE_CALLABLE size_type list_device_view::element_offset(size_type idx) const
+{
+  release_assert(idx >= 0 && idx < size() && "idx out of bounds");
+  // release_assert(!is_null() && !is_null(idx) && "Cannot read null element.");
+  return begin_offset + idx;
+}
+
+template <typename T>
+CUDA_DEVICE_CALLABLE T list_device_view::element(size_type idx) const
+{
+  return lists_column.child().element<T>(element_offset(idx));
+}
+
+CUDA_DEVICE_CALLABLE bool list_device_view::is_null(size_type idx) const
+{
+  release_assert(idx >= 0 && idx < size() && "Index out of bounds.");
+  auto element_offset = begin_offset + idx;
+  return lists_column.child().is_null(element_offset);
+}
+
+CUDA_DEVICE_CALLABLE bool list_device_view::is_null() const
+{
+  return lists_column.is_null(_row_index);
+}
+
+}  // namespace cudf

--- a/cpp/include/cudf/lists/list_device_view.cuh
+++ b/cpp/include/cudf/lists/list_device_view.cuh
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <cuda_runtime.h>
-#include <cudf/types.hpp>
 #include <cudf/lists/lists_column_device_view.cuh>
+#include <cudf/types.hpp>
 
 namespace cudf {
 
@@ -27,105 +27,99 @@ namespace cudf {
  *
  */
 class list_device_view {
+  using lists_column_device_view = cudf::detail::lists_column_device_view;
 
-    using lists_column_device_view = cudf::detail::lists_column_device_view;
+ public:
+  list_device_view() = default;
 
-  public:
+  CUDA_DEVICE_CALLABLE list_device_view(lists_column_device_view const& lists_column,
+                                        size_type const& row_index)
+    : lists_column(lists_column), _row_index(row_index)
+  {
+    release_assert(row_index >= 0 && row_index < lists_column.size() && "row_index out of bounds");
 
-    list_device_view() = default;
+    column_device_view const& offsets = lists_column.offsets();
+    release_assert(row_index < offsets.size() && "row_index should not have exceeded offset size");
 
-    CUDA_DEVICE_CALLABLE list_device_view(lists_column_device_view const& lists_column, size_type const& row_index)
-      : lists_column(lists_column), _row_index(row_index)
-    {
-      release_assert(row_index >= 0 && row_index < lists_column.size() && "row_index out of bounds");
+    begin_offset = offsets.element<size_type>(row_index);
+    release_assert(begin_offset >= 0 && begin_offset <= lists_column.child().size() &&
+                   "begin_offset out of bounds.");
+    _size = offsets.element<size_type>(row_index + 1) - begin_offset;
+  }
 
-      column_device_view const& offsets = lists_column.offsets();
-      release_assert(row_index < offsets.size() && "row_index should not have exceeded offset size");
+  ~list_device_view() = default;
 
-      begin_offset = offsets.element<size_type>(row_index);
-      release_assert(begin_offset >= 0 && begin_offset <= lists_column.child().size() &&
-                    "begin_offset out of bounds.");
-      _size = offsets.element<size_type>(row_index + 1) - begin_offset;
-    }
+  /**
+   * @brief Fetches the offset in the list column's child that corresponds to
+   * the element at the specified list index.
+   *
+   * Consider the following lists column:
+   *  [
+   *   [0,1,2],
+   *   [3,4,5],
+   *   [6,7,8]
+   *  ]
+   *
+   * The list's internals would look like:
+   *  offsets: [0, 3, 6, 9]
+   *  child  : [0, 1, 2, 3, 4, 5, 6, 7, 8]
+   *
+   * The second list row (i.e. row_index=1) is [3,4,5].
+   * The third element (i.e. idx=2) of the second list row is 5.
+   *
+   * The offset of this element as stored in the child column (i.e. 5)
+   * may be fetched using this method.
+   */
+  CUDA_DEVICE_CALLABLE size_type element_offset(size_type idx) const
+  {
+    release_assert(idx >= 0 && idx < size() && "idx out of bounds");
+    return begin_offset + idx;
+  }
 
-    ~list_device_view() = default;
+  /**
+   * @brief Fetches the element at the specified index, within the list row.
+   *
+   * @tparam The type of the list's element.
+   * @param The index into the list row
+   * @return The element at the specified index of the list row.
+   */
+  template <typename T>
+  CUDA_DEVICE_CALLABLE T element(size_type idx) const
+  {
+    return lists_column.child().element<T>(element_offset(idx));
+  }
 
-    /**
-     * @brief Fetches the offset in the list column's child that corresponds to
-     * the element at the specified list index.
-     *
-     * Consider the following lists column:
-     *  [
-     *   [0,1,2],
-     *   [3,4,5],
-     *   [6,7,8]
-     *  ]
-     *
-     * The list's internals would look like:
-     *  offsets: [0, 3, 6, 9]
-     *  child  : [0, 1, 2, 3, 4, 5, 6, 7, 8]
-     *
-     * The second list row (i.e. row_index=1) is [3,4,5].
-     * The third element (i.e. idx=2) of the second list row is 5.
-     *
-     * The offset of this element as stored in the child column (i.e. 5)
-     * may be fetched using this method.
-     */
-    CUDA_DEVICE_CALLABLE size_type element_offset(size_type idx) const
-    {
-      release_assert(idx >= 0 && idx < size() && "idx out of bounds");
-      return begin_offset + idx;
-    }
+  /**
+   * @brief Checks whether element is null at specified index in the list row.
+   */
+  CUDA_DEVICE_CALLABLE bool is_null(size_type idx) const
+  {
+    release_assert(idx >= 0 && idx < size() && "Index out of bounds.");
+    auto element_offset = begin_offset + idx;
+    return lists_column.child().is_null(element_offset);
+  }
 
-    /**
-     * @brief Fetches the element at the specified index, within the list row.
-     *
-     * @tparam The type of the list's element.
-     * @param The index into the list row
-     * @return The element at the specified index of the list row.
-     */
-    template <typename T>
-    CUDA_DEVICE_CALLABLE T element(size_type idx) const
-    {
-      return lists_column.child().element<T>(element_offset(idx));
-    }
+  /**
+   * @brief Checks whether this list row is null.
+   */
+  CUDA_DEVICE_CALLABLE bool is_null() const { return lists_column.is_null(_row_index); }
 
-    /**
-     * @brief Checks whether element is null at specified index in the list row.
-     */
-    CUDA_DEVICE_CALLABLE bool is_null(size_type idx) const
-    {
-      release_assert(idx >= 0 && idx < size() && "Index out of bounds.");
-      auto element_offset = begin_offset + idx;
-      return lists_column.child().is_null(element_offset);
-    }
+  /**
+   * @brief Fetches the number of elements in this list row.
+   */
+  CUDA_DEVICE_CALLABLE size_type size() const { return _size; }
 
-    /**
-     * @brief Checks whether this list row is null.
-     */
-    CUDA_DEVICE_CALLABLE bool is_null() const
-    {
-      return lists_column.is_null(_row_index);
-    }
+  /**
+   * @brief Fetches the lists_column_device_view that contains this list.
+   */
+  CUDA_DEVICE_CALLABLE lists_column_device_view const& get_column() const { return lists_column; }
 
-    /**
-     * @brief Fetches the number of elements in this list row.
-     */
-    CUDA_DEVICE_CALLABLE size_type size() const { return _size; }
+ private:
+  lists_column_device_view const& lists_column;
+  size_type _row_index{};  // Row index in the Lists column vector.
+  size_type _size{};       // Number of elements in *this* list row.
 
-    /**
-     * @brief Fetches the lists_column_device_view that contains this list.
-     */
-    CUDA_DEVICE_CALLABLE lists_column_device_view const& get_column() const { return lists_column; }
-
-  private:
-
-    lists_column_device_view const& lists_column; 
-    size_type _row_index{};  // Row index in the Lists column vector.
-    size_type _size{};       // Number of elements in *this* list row.
-
-    size_type begin_offset;  // Offset in list_column_device_view where this list begins.
-
+  size_type begin_offset;  // Offset in list_column_device_view where this list begins.
 };
 
 }  // namespace cudf

--- a/cpp/include/cudf/lists/lists_column_device_view.cuh
+++ b/cpp/include/cudf/lists/lists_column_device_view.cuh
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cudf/types.hpp>
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/lists/lists_column_view.hpp>
+
+namespace cudf {
+
+namespace detail {
+
+/**
+ * @brief Given a column-device-view, an instance of this class provides a
+ * wrapper on this compound column for list operations.
+ * Analogous to list_column_view.
+ */
+class lists_column_device_view {
+
+ public:
+
+  ~lists_column_device_view()                               = default;
+  lists_column_device_view(lists_column_device_view const&) = default;
+  lists_column_device_view(lists_column_device_view&&)      = default;
+  lists_column_device_view& operator= (lists_column_device_view const&) = default;
+  lists_column_device_view& operator= (lists_column_device_view &&) = default;
+
+  lists_column_device_view(column_device_view const& underlying_)
+    : underlying(underlying_)
+  {
+    CUDF_EXPECTS(underlying_.type().id() == type_id::LIST, "lists_column_device_view only supports lists");
+  }
+
+  /**
+   * @brief Fetches number of rows in the lists column
+   */
+  CUDA_HOST_DEVICE_CALLABLE cudf::size_type size() const
+  {
+    return underlying.size();
+  }
+
+  /**
+   * @brief Fetches the offsets column of the underlying list column.
+   */
+  CUDA_DEVICE_CALLABLE column_device_view offsets() const 
+  { 
+    return underlying.child(lists_column_view::offsets_column_index); 
+  }
+
+  /**
+   * @brief Fetches the child column of the underlying list column.
+   */
+  CUDA_DEVICE_CALLABLE column_device_view child() const 
+  { 
+    return underlying.child(lists_column_view::child_column_index); 
+  }
+
+  /**
+   * @brief Indicates whether the list column is nullable.
+   */
+  CUDA_DEVICE_CALLABLE bool nullable() const { return underlying.nullable(); }
+
+  /**
+   * @brief Indicates whether the row (i.e. list) at the specified
+   * index is null.
+   */
+  CUDA_DEVICE_CALLABLE bool is_null(size_type idx) const { return underlying.is_null(idx); }
+
+ private:
+
+  column_device_view underlying;
+};
+
+}  // namespace detail
+
+} // namespace cudf;

--- a/cpp/include/cudf/lists/lists_column_device_view.cuh
+++ b/cpp/include/cudf/lists/lists_column_device_view.cuh
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <cuda_runtime.h>
-#include <cudf/types.hpp>
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/lists/lists_column_view.hpp>
+#include <cudf/types.hpp>
 
 namespace cudf {
 
@@ -30,43 +30,38 @@ namespace detail {
  * Analogous to list_column_view.
  */
 class lists_column_device_view {
-
  public:
-
   ~lists_column_device_view()                               = default;
   lists_column_device_view(lists_column_device_view const&) = default;
   lists_column_device_view(lists_column_device_view&&)      = default;
-  lists_column_device_view& operator= (lists_column_device_view const&) = default;
-  lists_column_device_view& operator= (lists_column_device_view &&) = default;
+  lists_column_device_view& operator=(lists_column_device_view const&) = default;
+  lists_column_device_view& operator=(lists_column_device_view&&) = default;
 
-  lists_column_device_view(column_device_view const& underlying_)
-    : underlying(underlying_)
+  lists_column_device_view(column_device_view const& underlying_) : underlying(underlying_)
   {
-    CUDF_EXPECTS(underlying_.type().id() == type_id::LIST, "lists_column_device_view only supports lists");
+    CUDF_EXPECTS(underlying_.type().id() == type_id::LIST,
+                 "lists_column_device_view only supports lists");
   }
 
   /**
    * @brief Fetches number of rows in the lists column
    */
-  CUDA_HOST_DEVICE_CALLABLE cudf::size_type size() const
-  {
-    return underlying.size();
-  }
+  CUDA_HOST_DEVICE_CALLABLE cudf::size_type size() const { return underlying.size(); }
 
   /**
    * @brief Fetches the offsets column of the underlying list column.
    */
-  CUDA_DEVICE_CALLABLE column_device_view offsets() const 
-  { 
-    return underlying.child(lists_column_view::offsets_column_index); 
+  CUDA_DEVICE_CALLABLE column_device_view offsets() const
+  {
+    return underlying.child(lists_column_view::offsets_column_index);
   }
 
   /**
    * @brief Fetches the child column of the underlying list column.
    */
-  CUDA_DEVICE_CALLABLE column_device_view child() const 
-  { 
-    return underlying.child(lists_column_view::child_column_index); 
+  CUDA_DEVICE_CALLABLE column_device_view child() const
+  {
+    return underlying.child(lists_column_view::child_column_index);
   }
 
   /**
@@ -81,10 +76,9 @@ class lists_column_device_view {
   CUDA_DEVICE_CALLABLE bool is_null(size_type idx) const { return underlying.is_null(idx); }
 
  private:
-
   column_device_view underlying;
 };
 
 }  // namespace detail
 
-} // namespace cudf;
+}  // namespace cudf

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -378,6 +378,7 @@ set(COPYING_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/copying/gather_struct_tests.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/copying/detail_gather_tests.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/copying/scatter_tests.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/copying/scatter_list_tests.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/copying/copy_range_tests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/copying/slice_tests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/copying/split_tests.cpp"

--- a/cpp/tests/copying/scatter_list_tests.cu
+++ b/cpp/tests/copying/scatter_list_tests.cu
@@ -1,0 +1,554 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tests/strings/utilities.h>
+#include <cudf/column/column_view.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/scatter.cuh>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/cudf_gtest.hpp>
+#include <cudf_test/table_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <cudf/lists/lists_column_view.hpp>
+
+template <typename T>
+class TypedScatterListsTest : public cudf::test::BaseFixture {
+};
+using FixedWidthTypes= cudf::test::Concat<cudf::test::IntegralTypes,
+                                          cudf::test::FloatingPointTypes,
+                                          cudf::test::DurationTypes,
+                                          cudf::test::TimestampTypes>;
+TYPED_TEST_CASE(TypedScatterListsTest, FixedWidthTypes);
+
+class ScatterListsTest : public cudf::test::BaseFixture {
+};
+
+TYPED_TEST(TypedScatterListsTest, ListsOfFixedWidth)
+{
+    using namespace cudf::test;
+    using T = TypeParam;
+
+    auto src_list_column = lists_column_wrapper<T, int32_t>{
+        {9, 9, 9, 9}, {8, 8, 8}
+    };
+
+    auto target_list_column = lists_column_wrapper<T, int32_t>{
+        {0,0}, {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column}),
+        scatter_map,
+        cudf::table_view({target_list_column}));
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT (
+        ret->get_column(0),
+        lists_column_wrapper<T, int32_t> {{8,8,8}, {1,1}, {9,9,9,9}, {3,3}, {4,4}, {5,5}, {6,6}} 
+    );
+}
+
+TYPED_TEST(TypedScatterListsTest, EmptyListsOfFixedWidth)
+{
+    using namespace cudf::test;
+    using T = TypeParam;
+
+    auto src_child = fixed_width_column_wrapper<T, int32_t> {
+        {9, 9, 9, 9, 8, 8, 8},
+    };
+
+    // One null list row, and one row with nulls.
+    auto src_list_column = cudf::make_lists_column(
+        3,
+        fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+        src_child.release(),
+        0,
+        {}
+    );
+
+    auto target_list_column = lists_column_wrapper<T, int32_t>{
+        {0,0}, {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column->view()}),
+        scatter_map,
+        cudf::table_view({target_list_column}));
+
+    auto expected_child_ints = fixed_width_column_wrapper<T, int32_t> {
+        {8,8,8, 1,1, 9,9,9,9, 3,3, 4,4, 6,6 }
+    };
+    auto expected_lists_column = cudf::make_lists_column(
+        7,
+        fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
+        expected_child_ints.release(), 
+        0, 
+        {}
+    );
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        expected_lists_column->view(),
+        ret->get_column(0)
+    );
+}
+
+TYPED_TEST(TypedScatterListsTest, EmptyListsOfNullableFixedWidth)
+{
+    using namespace cudf::test;
+    using T = TypeParam;
+
+    auto src_child = fixed_width_column_wrapper<T, int32_t> {
+        {9, 9, 9, 9, 8, 8, 8},
+        {1, 1, 1, 0, 1, 1, 1}
+    };
+
+    // One null list row, and one row with nulls.
+    auto src_list_column = cudf::make_lists_column(
+        3,
+        fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+        src_child.release(),
+        0,
+        {}
+    );
+
+    auto target_list_column = lists_column_wrapper<T, int32_t>{
+        {0,0}, {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column->view()}),
+        scatter_map,
+        cudf::table_view({target_list_column}));
+
+    auto expected_child_ints = fixed_width_column_wrapper<T, int32_t> {
+        {8,8,8, 1,1, 9,9,9,9, 3,3, 4,4, 6,6 },
+        {1,1,1, 1,1, 1,1,1,0, 1,1, 1,1, 1,1 }
+    };
+    auto expected_lists_column = cudf::make_lists_column(
+        7,
+        fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
+        expected_child_ints.release(), 
+        0, 
+        {}
+    );
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        expected_lists_column->view(),
+        ret->get_column(0)
+    );
+}
+
+TYPED_TEST(TypedScatterListsTest, NullableListsOfNullableFixedWidth)
+{
+    using namespace cudf::test;
+    using T = TypeParam;
+
+    auto src_child = fixed_width_column_wrapper<T, int32_t> {
+        {9, 9, 9, 9, 8, 8, 8},
+        {1, 1, 1, 0, 1, 1, 1}
+    };
+
+    auto src_list_validity = make_counting_transform_iterator(0, [](auto i) { return i != 2; });
+    // One null list row, and one row with nulls.
+    auto src_list_column = cudf::make_lists_column(
+        3,
+        fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+        src_child.release(),
+        1,
+        detail::make_null_mask(src_list_validity, src_list_validity + 3)
+    );
+
+    auto target_list_column = lists_column_wrapper<T, int32_t>{
+        {0,0}, {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column->view()}),
+        scatter_map,
+        cudf::table_view({target_list_column}));
+
+    auto expected_child_ints = fixed_width_column_wrapper<T, int32_t> {
+        {8,8,8, 1,1, 9,9,9,9, 3,3, 4,4, 6,6 },
+        {1,1,1, 1,1, 1,1,1,0, 1,1, 1,1, 1,1 }
+    };
+
+    auto expected_validity = make_counting_transform_iterator(0, [](auto i) { return i != 5; });
+    auto expected_lists_column = cudf::make_lists_column(
+        7,
+        fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
+        expected_child_ints.release(), 
+        1, 
+        detail::make_null_mask(expected_validity, expected_validity + 7)
+    );
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        expected_lists_column->view(),
+        ret->get_column(0)
+    );
+}
+
+TEST_F(ScatterListsTest, ListsOfStrings)
+{
+    using namespace cudf::test;
+
+    auto src_list_column = lists_column_wrapper<cudf::string_view> {
+        {"all", "the", "leaves", "are", "brown"},
+        {"california", "dreaming"}
+    };
+
+    auto target_list_column = lists_column_wrapper<cudf::string_view> {
+        {"zero"},
+        {"one", "one"},
+        {"two", "two"},
+        {"three", "three", "three"},
+        {"four", "four", "four", "four"}
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 0};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column}),
+        scatter_map,
+        cudf::table_view({target_list_column})
+    );
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        lists_column_wrapper<cudf::string_view>{
+            {"california", "dreaming"},
+            {"one", "one"},
+            {"all", "the", "leaves", "are", "brown"},
+            {"three", "three", "three"},
+            {"four", "four", "four", "four"}
+        },
+        ret->get_column(0)       
+    );
+}
+
+TEST_F(ScatterListsTest, ListsOfNullableStrings)
+{
+    using namespace cudf::test;
+
+    auto src_strings_column = strings_column_wrapper{
+        {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
+        {    1,     1,        1,     0,       1,            0,          1}
+    };
+
+    auto src_list_column = cudf::make_lists_column(
+        2, 
+        fixed_width_column_wrapper<cudf::size_type>{0, 5, 7}.release(),
+        src_strings_column.release(),
+        0,
+        {}
+    );
+
+    auto target_list_column = lists_column_wrapper<cudf::string_view> {
+        {"zero"},
+        {"one", "one"},
+        {"two", "two"},
+        {"three", "three"},
+        {"four", "four"},
+        {"five", "five"}
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 0};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column->view()}),
+        scatter_map,
+        cudf::table_view({target_list_column})
+    );
+
+    auto expected_strings = strings_column_wrapper {
+        {"california", "dreaming", "one", "one", "all", "the", "leaves", "are", "brown", 
+         "three", "three", "four", "four", "five", "five"},
+        make_counting_transform_iterator(0, [](auto i) {return i!=0 && i!=7;})
+    };
+
+    auto expected_lists = cudf::make_lists_column(
+        6,
+        fixed_width_column_wrapper<cudf::size_type>{0,2,4,9,11,13,15}.release(),
+        expected_strings.release(),
+        0,
+        {}
+    );
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        expected_lists->view(),
+        ret->get_column(0)
+    );
+}
+
+TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
+{
+    using namespace cudf::test;
+
+    auto src_strings_column = strings_column_wrapper{
+        {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
+        {    1,     1,        1,     0,       1,            0,          1}
+    };
+
+    auto src_list_column = cudf::make_lists_column(
+        3, 
+        fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
+        src_strings_column.release(),
+        0,
+        {}
+    );
+
+    auto target_list_column = lists_column_wrapper<cudf::string_view> {
+        {"zero"},
+        {"one", "one"},
+        {"two", "two"},
+        {"three", "three"},
+        {"four", "four"},
+        {"five", "five"}
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 4, 0};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column->view()}),
+        scatter_map,
+        cudf::table_view({target_list_column})
+    );
+
+    auto expected_strings = strings_column_wrapper {
+        {"california", "dreaming", 
+         "one", "one", 
+         "all", "the", "leaves", "are", "brown", 
+         "three", "three", 
+         "five", "five"},
+        make_counting_transform_iterator(0, [](auto i) {return i!=0 && i!=7;})
+    };
+
+    auto expected_lists = cudf::make_lists_column(
+        6,
+        fixed_width_column_wrapper<cudf::size_type>{0,2,4,9,11,11,13}.release(),
+        expected_strings.release(),
+        0,
+        {}
+    );
+
+    std::cout << "Expected: " << std::endl; print(expected_lists->view());
+    std::cout << "Received: " << std::endl; print(ret->get_column(0));
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        expected_lists->view(),
+        ret->get_column(0)
+    );
+}
+
+TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
+{
+    using namespace cudf::test;
+
+    auto src_strings_column = strings_column_wrapper{
+        {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
+        {    1,     1,        1,     0,       1,            0,          1}
+    };
+
+    auto src_validity = make_counting_transform_iterator(0, [](auto i) { return i != 1;});
+    auto src_list_column = cudf::make_lists_column(
+        3, 
+        fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
+        src_strings_column.release(),
+        1,
+        detail::make_null_mask(src_validity, src_validity + 3)
+    );
+
+    auto target_list_column = lists_column_wrapper<cudf::string_view> {
+        {"zero"},
+        {"one", "one"},
+        {"two", "two"},
+        {"three", "three"},
+        {"four", "four"},
+        {"five", "five"}
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 4, 0};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column->view()}),
+        scatter_map,
+        cudf::table_view({target_list_column})
+    );
+
+    auto expected_strings = strings_column_wrapper {
+        {"california", "dreaming", 
+         "one", "one", 
+         "all", "the", "leaves", "are", "brown", 
+         "three", "three", 
+         "five", "five"},
+        make_counting_transform_iterator(0, [](auto i) {return i!=0 && i!=7;})
+    };
+
+    auto expected_validity = make_counting_transform_iterator(0, [](auto i) { return i != 4; });
+    auto expected_lists = cudf::make_lists_column(
+        6,
+        fixed_width_column_wrapper<cudf::size_type>{0,2,4,9,11,11,13}.release(),
+        expected_strings.release(),
+        1,
+        detail::make_null_mask(expected_validity, expected_validity+6)
+    );
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        expected_lists->view(),
+        ret->get_column(0)
+    );
+}
+
+TYPED_TEST(TypedScatterListsTest, ListsOfLists)
+{
+    using namespace cudf::test;
+    using T = TypeParam;
+
+    auto src_list_column = lists_column_wrapper<T, int32_t> {
+        { {1,1,1,1}, {2,2,2,2} },
+        { {3,3,3,3}, {4,4,4,4} }
+    };
+
+    auto target_list_column = lists_column_wrapper<T, int32_t> {
+        { {9,9,9}, {8,8,8}, {7,7,7} },
+        { {6,6,6}, {5,5,5}, {4,4,4} },
+        { {3,3,3}, {2,2,2}, {1,1,1} },
+        { {9,9}, {8,8}, {7,7} },
+        { {6,6}, {5,5}, {4,4} },
+        { {3,3}, {2,2}, {1,1} }
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column}),
+        scatter_map,
+        cudf::table_view({target_list_column})
+    );
+
+    auto expected = lists_column_wrapper<T, int32_t> {
+            { {3,3,3,3}, {4,4,4,4} },
+            { {6,6,6}, {5,5,5}, {4,4,4} },
+            { {1,1,1,1}, {2,2,2,2} },
+            { {9,9}, {8,8}, {7,7} },
+            { {6,6}, {5,5}, {4,4} },
+            { {3,3}, {2,2}, {1,1} }
+    };
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        expected,
+        ret->get_column(0)
+    );
+}
+
+TYPED_TEST(TypedScatterListsTest, EmptyListsOfLists)
+{
+    using namespace cudf::test;
+    using T = TypeParam;
+
+    auto src_list_column = lists_column_wrapper<T, int32_t> {
+        { {1,1,1,1}, {2,2,2,2} },
+        { {3,3,3,3}, {} }, 
+        {}
+    };
+
+    auto target_list_column = lists_column_wrapper<T, int32_t> {
+        { {9,9,9}, {8,8,8}, {7,7,7} },
+        { {6,6,6}, {5,5,5}, {4,4,4} },
+        { {3,3,3}, {2,2,2}, {1,1,1} },
+        { {9,9}, {8,8}, {7,7} },
+        { {6,6}, {5,5}, {4,4} },
+        { {3,3}, {2,2}, {1,1} }
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column}),
+        scatter_map,
+        cudf::table_view({target_list_column})
+    );
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        lists_column_wrapper<T, int32_t> {
+            { {3,3,3,3}, {} },
+            { {6,6,6}, {5,5,5}, {4,4,4} },
+            { {1,1,1,1}, {2,2,2,2} },
+            { {9,9}, {8,8}, {7,7} },
+            {  },
+            { {3,3}, {2,2}, {1,1} }
+        },
+        ret->get_column(0)
+    );
+}
+
+TYPED_TEST(TypedScatterListsTest, NullListsOfLists)
+{
+    using namespace cudf::test;
+    using T = TypeParam;
+
+    auto src_list_column = lists_column_wrapper<T, int32_t> {
+        { 
+            { {1,1,1,1}, {2,2,2,2} },
+            { {3,3,3,3}, {} }, 
+            {} 
+        },
+        make_counting_transform_iterator(0, [](auto i) { return i != 2; })
+    };
+
+    auto target_list_column = lists_column_wrapper<T, int32_t> {
+        { {9,9,9}, {8,8,8}, {7,7,7} },
+        { {6,6,6}, {5,5,5}, {4,4,4} },
+        { {3,3,3}, {2,2,2}, {1,1,1} },
+        { {9,9}, {8,8}, {7,7} },
+        { {6,6}, {5,5}, {4,4} },
+        { {3,3}, {2,2}, {1,1} }
+    };
+
+    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+
+    auto ret = cudf::scatter(
+        cudf::table_view({src_list_column}),
+        scatter_map,
+        cudf::table_view({target_list_column})
+    );
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+        lists_column_wrapper<T, int32_t> {
+            { 
+                { {3,3,3,3}, {} },
+                { {6,6,6}, {5,5,5}, {4,4,4} },
+                { {1,1,1,1}, {2,2,2,2} },
+                { {9,9}, {8,8}, {7,7} },
+                {  },
+                { {3,3}, {2,2}, {1,1} }
+            },
+            make_counting_transform_iterator(0, [](auto i) { return i != 4; })
+        },
+        ret->get_column(0)
+    );
+}

--- a/cpp/tests/copying/scatter_list_tests.cu
+++ b/cpp/tests/copying/scatter_list_tests.cu
@@ -33,10 +33,10 @@
 template <typename T>
 class TypedScatterListsTest : public cudf::test::BaseFixture {
 };
-using FixedWidthTypes= cudf::test::Concat<cudf::test::IntegralTypes,
-                                          cudf::test::FloatingPointTypes,
-                                          cudf::test::DurationTypes,
-                                          cudf::test::TimestampTypes>;
+using FixedWidthTypes = cudf::test::Concat<cudf::test::IntegralTypes,
+                                           cudf::test::FloatingPointTypes,
+                                           cudf::test::DurationTypes,
+                                           cudf::test::TimestampTypes>;
 TYPED_TEST_CASE(TypedScatterListsTest, FixedWidthTypes);
 
 class ScatterListsTest : public cudf::test::BaseFixture {
@@ -44,511 +44,425 @@ class ScatterListsTest : public cudf::test::BaseFixture {
 
 TYPED_TEST(TypedScatterListsTest, ListsOfFixedWidth)
 {
-    using namespace cudf::test;
-    using T = TypeParam;
+  using namespace cudf::test;
+  using T = TypeParam;
 
-    auto src_list_column = lists_column_wrapper<T, int32_t>{
-        {9, 9, 9, 9}, {8, 8, 8}
-    };
+  auto src_list_column = lists_column_wrapper<T, int32_t>{{9, 9, 9, 9}, {8, 8, 8}};
 
-    auto target_list_column = lists_column_wrapper<T, int32_t>{
-        {0,0}, {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}
-    };
+  auto target_list_column =
+    lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
 
-    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column}),
-        scatter_map,
-        cudf::table_view({target_list_column}));
+  auto ret = cudf::scatter(
+    cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT (
-        ret->get_column(0),
-        lists_column_wrapper<T, int32_t> {{8,8,8}, {1,1}, {9,9,9,9}, {3,3}, {4,4}, {5,5}, {6,6}} 
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    ret->get_column(0),
+    lists_column_wrapper<T, int32_t>{
+      {8, 8, 8}, {1, 1}, {9, 9, 9, 9}, {3, 3}, {4, 4}, {5, 5}, {6, 6}});
 }
 
 TYPED_TEST(TypedScatterListsTest, EmptyListsOfFixedWidth)
 {
-    using namespace cudf::test;
-    using T = TypeParam;
+  using namespace cudf::test;
+  using T = TypeParam;
 
-    auto src_child = fixed_width_column_wrapper<T, int32_t> {
-        {9, 9, 9, 9, 8, 8, 8},
-    };
+  auto src_child = fixed_width_column_wrapper<T, int32_t>{
+    {9, 9, 9, 9, 8, 8, 8},
+  };
 
-    // One null list row, and one row with nulls.
-    auto src_list_column = cudf::make_lists_column(
-        3,
-        fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
-        src_child.release(),
-        0,
-        {}
-    );
+  // One null list row, and one row with nulls.
+  auto src_list_column =
+    cudf::make_lists_column(3,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+                            src_child.release(),
+                            0,
+                            {});
 
-    auto target_list_column = lists_column_wrapper<T, int32_t>{
-        {0,0}, {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}
-    };
+  auto target_list_column =
+    lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
 
-    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column->view()}),
-        scatter_map,
-        cudf::table_view({target_list_column}));
+  auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
+                           scatter_map,
+                           cudf::table_view({target_list_column}));
 
-    auto expected_child_ints = fixed_width_column_wrapper<T, int32_t> {
-        {8,8,8, 1,1, 9,9,9,9, 3,3, 4,4, 6,6 }
-    };
-    auto expected_lists_column = cudf::make_lists_column(
-        7,
-        fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
-        expected_child_ints.release(), 
-        0, 
-        {}
-    );
+  auto expected_child_ints =
+    fixed_width_column_wrapper<T, int32_t>{{8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 6, 6}};
+  auto expected_lists_column = cudf::make_lists_column(
+    7,
+    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
+    expected_child_ints.release(),
+    0,
+    {});
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        expected_lists_column->view(),
-        ret->get_column(0)
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists_column->view(), ret->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, EmptyListsOfNullableFixedWidth)
 {
-    using namespace cudf::test;
-    using T = TypeParam;
+  using namespace cudf::test;
+  using T = TypeParam;
 
-    auto src_child = fixed_width_column_wrapper<T, int32_t> {
-        {9, 9, 9, 9, 8, 8, 8},
-        {1, 1, 1, 0, 1, 1, 1}
-    };
+  auto src_child =
+    fixed_width_column_wrapper<T, int32_t>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
 
-    // One null list row, and one row with nulls.
-    auto src_list_column = cudf::make_lists_column(
-        3,
-        fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
-        src_child.release(),
-        0,
-        {}
-    );
+  // One null list row, and one row with nulls.
+  auto src_list_column =
+    cudf::make_lists_column(3,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+                            src_child.release(),
+                            0,
+                            {});
 
-    auto target_list_column = lists_column_wrapper<T, int32_t>{
-        {0,0}, {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}
-    };
+  auto target_list_column =
+    lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
 
-    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column->view()}),
-        scatter_map,
-        cudf::table_view({target_list_column}));
+  auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
+                           scatter_map,
+                           cudf::table_view({target_list_column}));
 
-    auto expected_child_ints = fixed_width_column_wrapper<T, int32_t> {
-        {8,8,8, 1,1, 9,9,9,9, 3,3, 4,4, 6,6 },
-        {1,1,1, 1,1, 1,1,1,0, 1,1, 1,1, 1,1 }
-    };
-    auto expected_lists_column = cudf::make_lists_column(
-        7,
-        fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
-        expected_child_ints.release(), 
-        0, 
-        {}
-    );
+  auto expected_child_ints = fixed_width_column_wrapper<T, int32_t>{
+    {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 6, 6}, {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}};
+  auto expected_lists_column = cudf::make_lists_column(
+    7,
+    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
+    expected_child_ints.release(),
+    0,
+    {});
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        expected_lists_column->view(),
-        ret->get_column(0)
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists_column->view(), ret->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, NullableListsOfNullableFixedWidth)
 {
-    using namespace cudf::test;
-    using T = TypeParam;
+  using namespace cudf::test;
+  using T = TypeParam;
 
-    auto src_child = fixed_width_column_wrapper<T, int32_t> {
-        {9, 9, 9, 9, 8, 8, 8},
-        {1, 1, 1, 0, 1, 1, 1}
-    };
+  auto src_child =
+    fixed_width_column_wrapper<T, int32_t>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
 
-    auto src_list_validity = make_counting_transform_iterator(0, [](auto i) { return i != 2; });
-    // One null list row, and one row with nulls.
-    auto src_list_column = cudf::make_lists_column(
-        3,
-        fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
-        src_child.release(),
-        1,
-        detail::make_null_mask(src_list_validity, src_list_validity + 3)
-    );
+  auto src_list_validity = make_counting_transform_iterator(0, [](auto i) { return i != 2; });
+  // One null list row, and one row with nulls.
+  auto src_list_column =
+    cudf::make_lists_column(3,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+                            src_child.release(),
+                            1,
+                            detail::make_null_mask(src_list_validity, src_list_validity + 3));
 
-    auto target_list_column = lists_column_wrapper<T, int32_t>{
-        {0,0}, {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}
-    };
+  auto target_list_column =
+    lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
 
-    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column->view()}),
-        scatter_map,
-        cudf::table_view({target_list_column}));
+  auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
+                           scatter_map,
+                           cudf::table_view({target_list_column}));
 
-    auto expected_child_ints = fixed_width_column_wrapper<T, int32_t> {
-        {8,8,8, 1,1, 9,9,9,9, 3,3, 4,4, 6,6 },
-        {1,1,1, 1,1, 1,1,1,0, 1,1, 1,1, 1,1 }
-    };
+  auto expected_child_ints = fixed_width_column_wrapper<T, int32_t>{
+    {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 6, 6}, {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}};
 
-    auto expected_validity = make_counting_transform_iterator(0, [](auto i) { return i != 5; });
-    auto expected_lists_column = cudf::make_lists_column(
-        7,
-        fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
-        expected_child_ints.release(), 
-        1, 
-        detail::make_null_mask(expected_validity, expected_validity + 7)
-    );
+  auto expected_validity     = make_counting_transform_iterator(0, [](auto i) { return i != 5; });
+  auto expected_lists_column = cudf::make_lists_column(
+    7,
+    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
+    expected_child_ints.release(),
+    1,
+    detail::make_null_mask(expected_validity, expected_validity + 7));
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        expected_lists_column->view(),
-        ret->get_column(0)
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists_column->view(), ret->get_column(0));
 }
 
 TEST_F(ScatterListsTest, ListsOfStrings)
 {
-    using namespace cudf::test;
+  using namespace cudf::test;
 
-    auto src_list_column = lists_column_wrapper<cudf::string_view> {
-        {"all", "the", "leaves", "are", "brown"},
-        {"california", "dreaming"}
-    };
+  auto src_list_column = lists_column_wrapper<cudf::string_view>{
+    {"all", "the", "leaves", "are", "brown"}, {"california", "dreaming"}};
 
-    auto target_list_column = lists_column_wrapper<cudf::string_view> {
-        {"zero"},
-        {"one", "one"},
-        {"two", "two"},
-        {"three", "three", "three"},
-        {"four", "four", "four", "four"}
-    };
+  auto target_list_column =
+    lists_column_wrapper<cudf::string_view>{{"zero"},
+                                            {"one", "one"},
+                                            {"two", "two"},
+                                            {"three", "three", "three"},
+                                            {"four", "four", "four", "four"}};
 
-    auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 0};
+  auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 0};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column}),
-        scatter_map,
-        cudf::table_view({target_list_column})
-    );
+  auto ret = cudf::scatter(
+    cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        lists_column_wrapper<cudf::string_view>{
-            {"california", "dreaming"},
-            {"one", "one"},
-            {"all", "the", "leaves", "are", "brown"},
-            {"three", "three", "three"},
-            {"four", "four", "four", "four"}
-        },
-        ret->get_column(0)       
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    lists_column_wrapper<cudf::string_view>{{"california", "dreaming"},
+                                            {"one", "one"},
+                                            {"all", "the", "leaves", "are", "brown"},
+                                            {"three", "three", "three"},
+                                            {"four", "four", "four", "four"}},
+    ret->get_column(0));
 }
 
 TEST_F(ScatterListsTest, ListsOfNullableStrings)
 {
-    using namespace cudf::test;
+  using namespace cudf::test;
 
-    auto src_strings_column = strings_column_wrapper{
-        {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
-        {    1,     1,        1,     0,       1,            0,          1}
-    };
+  auto src_strings_column = strings_column_wrapper{
+    {"all", "the", "leaves", "are", "brown", "california", "dreaming"}, {1, 1, 1, 0, 1, 0, 1}};
 
-    auto src_list_column = cudf::make_lists_column(
-        2, 
-        fixed_width_column_wrapper<cudf::size_type>{0, 5, 7}.release(),
-        src_strings_column.release(),
-        0,
-        {}
-    );
+  auto src_list_column =
+    cudf::make_lists_column(2,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 5, 7}.release(),
+                            src_strings_column.release(),
+                            0,
+                            {});
 
-    auto target_list_column = lists_column_wrapper<cudf::string_view> {
-        {"zero"},
-        {"one", "one"},
-        {"two", "two"},
-        {"three", "three"},
-        {"four", "four"},
-        {"five", "five"}
-    };
+  auto target_list_column = lists_column_wrapper<cudf::string_view>{{"zero"},
+                                                                    {"one", "one"},
+                                                                    {"two", "two"},
+                                                                    {"three", "three"},
+                                                                    {"four", "four"},
+                                                                    {"five", "five"}};
 
-    auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 0};
+  auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 0};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column->view()}),
-        scatter_map,
-        cudf::table_view({target_list_column})
-    );
+  auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
+                           scatter_map,
+                           cudf::table_view({target_list_column}));
 
-    auto expected_strings = strings_column_wrapper {
-        {"california", "dreaming", "one", "one", "all", "the", "leaves", "are", "brown", 
-         "three", "three", "four", "four", "five", "five"},
-        make_counting_transform_iterator(0, [](auto i) {return i!=0 && i!=7;})
-    };
+  auto expected_strings = strings_column_wrapper{
+    {"california",
+     "dreaming",
+     "one",
+     "one",
+     "all",
+     "the",
+     "leaves",
+     "are",
+     "brown",
+     "three",
+     "three",
+     "four",
+     "four",
+     "five",
+     "five"},
+    make_counting_transform_iterator(0, [](auto i) { return i != 0 && i != 7; })};
 
-    auto expected_lists = cudf::make_lists_column(
-        6,
-        fixed_width_column_wrapper<cudf::size_type>{0,2,4,9,11,13,15}.release(),
-        expected_strings.release(),
-        0,
-        {}
-    );
+  auto expected_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 13, 15}.release(),
+    expected_strings.release(),
+    0,
+    {});
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        expected_lists->view(),
-        ret->get_column(0)
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), ret->get_column(0));
 }
 
 TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
 {
-    using namespace cudf::test;
+  using namespace cudf::test;
 
-    auto src_strings_column = strings_column_wrapper{
-        {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
-        {    1,     1,        1,     0,       1,            0,          1}
-    };
+  auto src_strings_column = strings_column_wrapper{
+    {"all", "the", "leaves", "are", "brown", "california", "dreaming"}, {1, 1, 1, 0, 1, 0, 1}};
 
-    auto src_list_column = cudf::make_lists_column(
-        3, 
-        fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
-        src_strings_column.release(),
-        0,
-        {}
-    );
+  auto src_list_column =
+    cudf::make_lists_column(3,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
+                            src_strings_column.release(),
+                            0,
+                            {});
 
-    auto target_list_column = lists_column_wrapper<cudf::string_view> {
-        {"zero"},
-        {"one", "one"},
-        {"two", "two"},
-        {"three", "three"},
-        {"four", "four"},
-        {"five", "five"}
-    };
+  auto target_list_column = lists_column_wrapper<cudf::string_view>{{"zero"},
+                                                                    {"one", "one"},
+                                                                    {"two", "two"},
+                                                                    {"three", "three"},
+                                                                    {"four", "four"},
+                                                                    {"five", "five"}};
 
-    auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 4, 0};
+  auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 4, 0};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column->view()}),
-        scatter_map,
-        cudf::table_view({target_list_column})
-    );
+  auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
+                           scatter_map,
+                           cudf::table_view({target_list_column}));
 
-    auto expected_strings = strings_column_wrapper {
-        {"california", "dreaming", 
-         "one", "one", 
-         "all", "the", "leaves", "are", "brown", 
-         "three", "three", 
-         "five", "five"},
-        make_counting_transform_iterator(0, [](auto i) {return i!=0 && i!=7;})
-    };
+  auto expected_strings = strings_column_wrapper{
+    {"california",
+     "dreaming",
+     "one",
+     "one",
+     "all",
+     "the",
+     "leaves",
+     "are",
+     "brown",
+     "three",
+     "three",
+     "five",
+     "five"},
+    make_counting_transform_iterator(0, [](auto i) { return i != 0 && i != 7; })};
 
-    auto expected_lists = cudf::make_lists_column(
-        6,
-        fixed_width_column_wrapper<cudf::size_type>{0,2,4,9,11,11,13}.release(),
-        expected_strings.release(),
-        0,
-        {}
-    );
+  auto expected_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 11, 13}.release(),
+    expected_strings.release(),
+    0,
+    {});
 
-    std::cout << "Expected: " << std::endl; print(expected_lists->view());
-    std::cout << "Received: " << std::endl; print(ret->get_column(0));
+  std::cout << "Expected: " << std::endl;
+  print(expected_lists->view());
+  std::cout << "Received: " << std::endl;
+  print(ret->get_column(0));
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        expected_lists->view(),
-        ret->get_column(0)
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), ret->get_column(0));
 }
 
 TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
 {
-    using namespace cudf::test;
+  using namespace cudf::test;
 
-    auto src_strings_column = strings_column_wrapper{
-        {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
-        {    1,     1,        1,     0,       1,            0,          1}
-    };
+  auto src_strings_column = strings_column_wrapper{
+    {"all", "the", "leaves", "are", "brown", "california", "dreaming"}, {1, 1, 1, 0, 1, 0, 1}};
 
-    auto src_validity = make_counting_transform_iterator(0, [](auto i) { return i != 1;});
-    auto src_list_column = cudf::make_lists_column(
-        3, 
-        fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
-        src_strings_column.release(),
-        1,
-        detail::make_null_mask(src_validity, src_validity + 3)
-    );
+  auto src_validity = make_counting_transform_iterator(0, [](auto i) { return i != 1; });
+  auto src_list_column =
+    cudf::make_lists_column(3,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
+                            src_strings_column.release(),
+                            1,
+                            detail::make_null_mask(src_validity, src_validity + 3));
 
-    auto target_list_column = lists_column_wrapper<cudf::string_view> {
-        {"zero"},
-        {"one", "one"},
-        {"two", "two"},
-        {"three", "three"},
-        {"four", "four"},
-        {"five", "five"}
-    };
+  auto target_list_column = lists_column_wrapper<cudf::string_view>{{"zero"},
+                                                                    {"one", "one"},
+                                                                    {"two", "two"},
+                                                                    {"three", "three"},
+                                                                    {"four", "four"},
+                                                                    {"five", "five"}};
 
-    auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 4, 0};
+  auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 4, 0};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column->view()}),
-        scatter_map,
-        cudf::table_view({target_list_column})
-    );
+  auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
+                           scatter_map,
+                           cudf::table_view({target_list_column}));
 
-    auto expected_strings = strings_column_wrapper {
-        {"california", "dreaming", 
-         "one", "one", 
-         "all", "the", "leaves", "are", "brown", 
-         "three", "three", 
-         "five", "five"},
-        make_counting_transform_iterator(0, [](auto i) {return i!=0 && i!=7;})
-    };
+  auto expected_strings = strings_column_wrapper{
+    {"california",
+     "dreaming",
+     "one",
+     "one",
+     "all",
+     "the",
+     "leaves",
+     "are",
+     "brown",
+     "three",
+     "three",
+     "five",
+     "five"},
+    make_counting_transform_iterator(0, [](auto i) { return i != 0 && i != 7; })};
 
-    auto expected_validity = make_counting_transform_iterator(0, [](auto i) { return i != 4; });
-    auto expected_lists = cudf::make_lists_column(
-        6,
-        fixed_width_column_wrapper<cudf::size_type>{0,2,4,9,11,11,13}.release(),
-        expected_strings.release(),
-        1,
-        detail::make_null_mask(expected_validity, expected_validity+6)
-    );
+  auto expected_validity = make_counting_transform_iterator(0, [](auto i) { return i != 4; });
+  auto expected_lists    = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 11, 13}.release(),
+    expected_strings.release(),
+    1,
+    detail::make_null_mask(expected_validity, expected_validity + 6));
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        expected_lists->view(),
-        ret->get_column(0)
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), ret->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, ListsOfLists)
 {
-    using namespace cudf::test;
-    using T = TypeParam;
+  using namespace cudf::test;
+  using T = TypeParam;
 
-    auto src_list_column = lists_column_wrapper<T, int32_t> {
-        { {1,1,1,1}, {2,2,2,2} },
-        { {3,3,3,3}, {4,4,4,4} }
-    };
+  auto src_list_column =
+    lists_column_wrapper<T, int32_t>{{{1, 1, 1, 1}, {2, 2, 2, 2}}, {{3, 3, 3, 3}, {4, 4, 4, 4}}};
 
-    auto target_list_column = lists_column_wrapper<T, int32_t> {
-        { {9,9,9}, {8,8,8}, {7,7,7} },
-        { {6,6,6}, {5,5,5}, {4,4,4} },
-        { {3,3,3}, {2,2,2}, {1,1,1} },
-        { {9,9}, {8,8}, {7,7} },
-        { {6,6}, {5,5}, {4,4} },
-        { {3,3}, {2,2}, {1,1} }
-    };
+  auto target_list_column = lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
+                                                             {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                             {{3, 3, 3}, {2, 2, 2}, {1, 1, 1}},
+                                                             {{9, 9}, {8, 8}, {7, 7}},
+                                                             {{6, 6}, {5, 5}, {4, 4}},
+                                                             {{3, 3}, {2, 2}, {1, 1}}};
 
-    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column}),
-        scatter_map,
-        cudf::table_view({target_list_column})
-    );
+  auto ret = cudf::scatter(
+    cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
-    auto expected = lists_column_wrapper<T, int32_t> {
-            { {3,3,3,3}, {4,4,4,4} },
-            { {6,6,6}, {5,5,5}, {4,4,4} },
-            { {1,1,1,1}, {2,2,2,2} },
-            { {9,9}, {8,8}, {7,7} },
-            { {6,6}, {5,5}, {4,4} },
-            { {3,3}, {2,2}, {1,1} }
-    };
+  auto expected = lists_column_wrapper<T, int32_t>{{{3, 3, 3, 3}, {4, 4, 4, 4}},
+                                                   {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                   {{1, 1, 1, 1}, {2, 2, 2, 2}},
+                                                   {{9, 9}, {8, 8}, {7, 7}},
+                                                   {{6, 6}, {5, 5}, {4, 4}},
+                                                   {{3, 3}, {2, 2}, {1, 1}}};
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        expected,
-        ret->get_column(0)
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, ret->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, EmptyListsOfLists)
 {
-    using namespace cudf::test;
-    using T = TypeParam;
+  using namespace cudf::test;
+  using T = TypeParam;
 
-    auto src_list_column = lists_column_wrapper<T, int32_t> {
-        { {1,1,1,1}, {2,2,2,2} },
-        { {3,3,3,3}, {} }, 
-        {}
-    };
+  auto src_list_column =
+    lists_column_wrapper<T, int32_t>{{{1, 1, 1, 1}, {2, 2, 2, 2}}, {{3, 3, 3, 3}, {}}, {}};
 
-    auto target_list_column = lists_column_wrapper<T, int32_t> {
-        { {9,9,9}, {8,8,8}, {7,7,7} },
-        { {6,6,6}, {5,5,5}, {4,4,4} },
-        { {3,3,3}, {2,2,2}, {1,1,1} },
-        { {9,9}, {8,8}, {7,7} },
-        { {6,6}, {5,5}, {4,4} },
-        { {3,3}, {2,2}, {1,1} }
-    };
+  auto target_list_column = lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
+                                                             {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                             {{3, 3, 3}, {2, 2, 2}, {1, 1, 1}},
+                                                             {{9, 9}, {8, 8}, {7, 7}},
+                                                             {{6, 6}, {5, 5}, {4, 4}},
+                                                             {{3, 3}, {2, 2}, {1, 1}}};
 
-    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column}),
-        scatter_map,
-        cudf::table_view({target_list_column})
-    );
+  auto ret = cudf::scatter(
+    cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        lists_column_wrapper<T, int32_t> {
-            { {3,3,3,3}, {} },
-            { {6,6,6}, {5,5,5}, {4,4,4} },
-            { {1,1,1,1}, {2,2,2,2} },
-            { {9,9}, {8,8}, {7,7} },
-            {  },
-            { {3,3}, {2,2}, {1,1} }
-        },
-        ret->get_column(0)
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    lists_column_wrapper<T, int32_t>{{{3, 3, 3, 3}, {}},
+                                     {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                     {{1, 1, 1, 1}, {2, 2, 2, 2}},
+                                     {{9, 9}, {8, 8}, {7, 7}},
+                                     {},
+                                     {{3, 3}, {2, 2}, {1, 1}}},
+    ret->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, NullListsOfLists)
 {
-    using namespace cudf::test;
-    using T = TypeParam;
+  using namespace cudf::test;
+  using T = TypeParam;
 
-    auto src_list_column = lists_column_wrapper<T, int32_t> {
-        { 
-            { {1,1,1,1}, {2,2,2,2} },
-            { {3,3,3,3}, {} }, 
-            {} 
-        },
-        make_counting_transform_iterator(0, [](auto i) { return i != 2; })
-    };
+  auto src_list_column = lists_column_wrapper<T, int32_t>{
+    {{{1, 1, 1, 1}, {2, 2, 2, 2}}, {{3, 3, 3, 3}, {}}, {}},
+    make_counting_transform_iterator(0, [](auto i) { return i != 2; })};
 
-    auto target_list_column = lists_column_wrapper<T, int32_t> {
-        { {9,9,9}, {8,8,8}, {7,7,7} },
-        { {6,6,6}, {5,5,5}, {4,4,4} },
-        { {3,3,3}, {2,2,2}, {1,1,1} },
-        { {9,9}, {8,8}, {7,7} },
-        { {6,6}, {5,5}, {4,4} },
-        { {3,3}, {2,2}, {1,1} }
-    };
+  auto target_list_column = lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
+                                                             {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                             {{3, 3, 3}, {2, 2, 2}, {1, 1, 1}},
+                                                             {{9, 9}, {8, 8}, {7, 7}},
+                                                             {{6, 6}, {5, 5}, {4, 4}},
+                                                             {{3, 3}, {2, 2}, {1, 1}}};
 
-    auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
 
-    auto ret = cudf::scatter(
-        cudf::table_view({src_list_column}),
-        scatter_map,
-        cudf::table_view({target_list_column})
-    );
+  auto ret = cudf::scatter(
+    cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-        lists_column_wrapper<T, int32_t> {
-            { 
-                { {3,3,3,3}, {} },
-                { {6,6,6}, {5,5,5}, {4,4,4} },
-                { {1,1,1,1}, {2,2,2,2} },
-                { {9,9}, {8,8}, {7,7} },
-                {  },
-                { {3,3}, {2,2}, {1,1} }
-            },
-            make_counting_transform_iterator(0, [](auto i) { return i != 4; })
-        },
-        ret->get_column(0)
-    );
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    lists_column_wrapper<T, int32_t>{
+      {{{3, 3, 3, 3}, {}},
+       {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+       {{1, 1, 1, 1}, {2, 2, 2, 2}},
+       {{9, 9}, {8, 8}, {7, 7}},
+       {},
+       {{3, 3}, {2, 2}, {1, 1}}},
+      make_counting_transform_iterator(0, [](auto i) { return i != 4; })},
+    ret->get_column(0));
 }


### PR DESCRIPTION
This is a followup to #6768 (which adds `scatter()` support for list columns). @harrism advises that [the child-column construction could be a lot faster](https://github.com/rapidsai/cudf/pull/6768#discussion_r523868611):

> This is doing a parallel-for with each thread doing a sequential copy of a range of values to a destination offset. This means your parallelism is limited to the length of list_vector, rather than to the size of child_column. This is important because if you have only k=100 rows in the list column but a total of N=100M elements, you will only use 100 threads and each thread will process 1M elements. This could be suboptimal by a factor of 10-100K or more!

> If you flatten these loops you can get full parallelism. Each thread just has to figure out which row it is part of using a thrust::lower_bound(thrust::seq, ...), and use that to look up the appropriate destination index. Then you can just use a single thrust::transform to avoid having to capture offsets or index the array directly.

> This would use N threads and have work complexity O(N log k). This is fine as long as k << N. You can do better (asymptotically). You can convert the offsets to head flags using a thrust::scatter, and then scan the head flags to get the offset for each thread, and then do your O(N) transform.

> Offsets: [0, 3, 5, 9]
Scatter to head flags (scatter a 1 to each location in offsets) (O(k))
Head flags: [0, 0, 0, 1, 0, 1, 0, 0, 0]
Exclusive scan (O(N)) to get offsets:
Offsets: [0, 0, 0, 1, 1, 2, 2, 2, 2]
Then use the offsets in your transform

> This is O(k) + O(N) + O(N) == O(N), so asymptotically better, but requires 3 thrust calls (kernel launches) instead of 1. So may be slower for small N. For our example above (100, 100M) the scan version could be up to 10x faster than the lower_bound version. But for a lot of short lists the lower_bound version might be faster due to only launching a single kernel.

My initial attempt at this works for columns without empty lists. E.g.
```
Offsets:        [0,       3,    5, 5,      9] // ------> Lists[2] is an empty list.
Head flags:     [0, 0, 0, 1, 0, 1, 0, 0, 0] // -----> Scatter produces the same mapping as with [0,3,5,9].
Inclusive scan: [0, 0, 0, 1, 1, 2, 2, 2, 2] // -----> Scan produces the same output as before.
```
For the above, we should have ideally produced `[0, 0, 0, 1, 1, 3, 3, 3, 3]` to correctly map the children back to the lists. This needs figuring out to support empty lists.