### PR TITLE
Implement `cudf::clamp` for `decimal32` and `decimal64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #6685 Implement `cudf::round` `decimal32` & `decimal64` (`HALF_UP` and `HALF_EVEN`)
 - PR #6711 Implement `cudf::cast` for `decimal32/64` to/from integer and floating point
 - PR #6729 Implement `cudf::cast` for `decimal32/64` to/from different `type_id`
+- PR #6792 Implement `cudf::clamp` for `decimal32` and `decimal64`
 - PR #6528 Enable `fixed_point` binary operations
 - PR #6460 Add is_timestamp format check API
 - PR #6568 Add function to create hashed vocabulary file from raw vocabulary

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -848,7 +848,7 @@ struct pair_accessor {
    */
   pair_accessor(column_device_view const& _col) : col{_col}
   {
-    CUDF_EXPECTS(data_type(type_to_id<T>()) == col.type(), "the data type mismatch");
+    CUDF_EXPECTS(type_id_matches_device_storage_type<T>(col.type().id()), "the data type mismatch");
     if (has_nulls) { CUDF_EXPECTS(_col.nullable(), "Unexpected non-nullable column."); }
   }
 

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -191,7 +191,8 @@ struct scalar_value_accessor {
   scalar_value_accessor(scalar const& scalar_value)
     : dscalar(get_scalar_device_view(static_cast<ScalarType&>(const_cast<scalar&>(scalar_value))))
   {
-    CUDF_EXPECTS(data_type(type_to_id<Element>()) == scalar_value.type(), "the data type mismatch");
+    CUDF_EXPECTS(type_id_matches_device_storage_type<Element>(scalar_value.type().id()),
+                 "the data type mismatch");
   }
 
   /**
@@ -294,7 +295,8 @@ struct scalar_pair_accessor : public scalar_value_accessor<Element> {
 template <typename Element, bool = false>
 auto inline make_pair_iterator(scalar const& scalar_value)
 {
-  CUDF_EXPECTS(data_type(type_to_id<Element>()) == scalar_value.type(), "the data type mismatch");
+  CUDF_EXPECTS(type_id_matches_device_storage_type<Element>(scalar_value.type().id()),
+               "the data type mismatch");
   return thrust::make_transform_iterator(thrust::make_constant_iterator<size_type>(0),
                                          scalar_pair_accessor<Element>{scalar_value});
 }

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -245,12 +245,14 @@ struct dispatch_clamp {
   {
     CUDF_EXPECTS(lo.type() == input.type(), "mismatching types of scalar and input");
 
-    auto lo_itr         = make_pair_iterator<T>(lo);
-    auto hi_itr         = make_pair_iterator<T>(hi);
-    auto lo_replace_itr = make_pair_iterator<T>(lo_replace);
-    auto hi_replace_itr = make_pair_iterator<T>(hi_replace);
+    using Type = device_storage_type_t<T>;
 
-    return clamp<T>(input, lo_itr, lo_replace_itr, hi_itr, hi_replace_itr, mr, stream);
+    auto lo_itr         = make_pair_iterator<Type>(lo);
+    auto hi_itr         = make_pair_iterator<Type>(hi);
+    auto lo_replace_itr = make_pair_iterator<Type>(lo_replace);
+    auto hi_replace_itr = make_pair_iterator<Type>(hi_replace);
+
+    return clamp<Type>(input, lo_itr, lo_replace_itr, hi_itr, hi_replace_itr, mr, stream);
   }
 };
 
@@ -265,32 +267,6 @@ std::unique_ptr<column> dispatch_clamp::operator()<cudf::list_view>(
   cudaStream_t stream)
 {
   CUDF_FAIL("clamp for list_view not supported");
-}
-
-template <>
-std::unique_ptr<column> dispatch_clamp::operator()<numeric::decimal32>(
-  column_view const& input,
-  scalar const& lo,
-  scalar const& lo_replace,
-  scalar const& hi,
-  scalar const& hi_replace,
-  rmm::mr::device_memory_resource* mr,
-  cudaStream_t stream)
-{
-  CUDF_FAIL("clamp for decimal32 not supported");
-}
-
-template <>
-std::unique_ptr<column> dispatch_clamp::operator()<numeric::decimal64>(
-  column_view const& input,
-  scalar const& lo,
-  scalar const& lo_replace,
-  scalar const& hi,
-  scalar const& hi_replace,
-  rmm::mr::device_memory_resource* mr,
-  cudaStream_t stream)
-{
-  CUDF_FAIL("clamp for decimal64 not supported");
 }
 
 template <>

--- a/cpp/tests/replace/clamp_test.cpp
+++ b/cpp/tests/replace/clamp_test.cpp
@@ -23,7 +23,6 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/type_lists.hpp>
-#include "cudf/utilities/error.hpp"
 
 #include <gtest/gtest.h>
 
@@ -605,6 +604,27 @@ TYPED_TEST(FixedPointTest, ZeroScale)
   auto const hi       = cudf::make_fixed_point_scalar<decimalXX>(8, scale);
   auto const input    = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, scale};
   auto const expected = fp_wrapper{{2, 2, 2, 3, 4, 5, 6, 7, 8, 8, 8}, scale};
+  auto const result   = cudf::clamp(input, *lo, *hi);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTest, LargeTest)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const scale = scale_type{-3};
+  auto const lo    = cudf::make_fixed_point_scalar<decimalXX>(1000, scale);
+  auto const hi    = cudf::make_fixed_point_scalar<decimalXX>(2000, scale);
+
+  auto begin          = thrust::make_counting_iterator(-1000);
+  auto clamp          = [](int e) { return e < 1000 ? 1000 : e > 2000 ? 2000 : e; };
+  auto begin2         = cudf::test::make_counting_transform_iterator(-1000, clamp);
+  auto const input    = fp_wrapper{begin, begin + 5000, scale};
+  auto const expected = fp_wrapper{begin2, begin2 + 5000, scale};
   auto const result   = cudf::clamp(input, *lo, *hi);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());

--- a/cpp/tests/replace/clamp_test.cpp
+++ b/cpp/tests/replace/clamp_test.cpp
@@ -586,4 +586,27 @@ TEST_F(ClampDictionaryTest, WithReplace)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, decoded->view());
 }
 
+template <typename T>
+struct FixedPointTest : public cudf::test::BaseFixture {
+};
+
+TYPED_TEST_CASE(FixedPointTest, cudf::test::FixedPointTypes);
+
+TYPED_TEST(FixedPointTest, ZeroScale)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const scale    = scale_type{0};
+  auto const lo       = cudf::make_fixed_point_scalar<decimalXX>(2, scale);
+  auto const hi       = cudf::make_fixed_point_scalar<decimalXX>(8, scale);
+  auto const input    = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, scale};
+  auto const expected = fp_wrapper{{2, 2, 2, 3, 4, 5, 6, 7, 8, 8, 8}, scale};
+  auto const result   = cudf::clamp(input, *lo, *hi);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
This PR resolves a part of https://github.com/rapidsai/cudf/issues/3556.

**To Do List:**
* [x] `clamp`
   * [x] Implementation
   * [x] Basic unit tests
   * [x] Comprehensive unit tests
   * [x] Add test for different scaled column / scalars