### PR TITLE
[REVIEW] Enable copy_if for fixed-point decimal columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - PR #6780 Move `cudf::cast` tests to separate test file
 - PR #6789 Rename `unary_op` to `unary_operator`
 - PR #6770 Support building decimal columns with Table.TestBuilder
+- PR #6805 Enable copy_if for fixed-point decimal columns
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #6768 Add support for scatter() on list columns
 - PR #6796 Add create_metadata_file in dask_cudf
 - PR #6765 Cupy fallback for __array_function__ and __array_ufunc__ for cudf.Series
+- PR #6805 Implement `cudf::detail::copy_if` for `decimal32` and `decimal64`
 
 ## Improvements
 
@@ -97,7 +98,6 @@
 - PR #6780 Move `cudf::cast` tests to separate test file
 - PR #6789 Rename `unary_op` to `unary_operator`
 - PR #6770 Support building decimal columns with Table.TestBuilder
-- PR #6805 Implement `cudf::detail::copy_if` for `decimal32` and `decimal64`
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@
 - PR #6780 Move `cudf::cast` tests to separate test file
 - PR #6789 Rename `unary_op` to `unary_operator`
 - PR #6770 Support building decimal columns with Table.TestBuilder
-- PR #6805 Enable copy_if for fixed-point decimal columns
+- PR #6805 Implement `cudf::detail::copy_if` for `decimal32` and `decimal64`
 
 ## Bug Fixes
 

--- a/cpp/include/cudf/detail/copy_if.cuh
+++ b/cpp/include/cudf/detail/copy_if.cuh
@@ -203,8 +203,7 @@ __launch_bounds__(block_size) __global__
 // Dispatch functor which performs the scatter for fixed column types and gather for other
 template <typename Filter, int block_size>
 struct scatter_gather_functor {
-  template <typename T,
-            std::enable_if_t<cudf::is_fixed_width<T>()>* = nullptr>
+  template <typename T, std::enable_if_t<cudf::is_fixed_width<T>()>* = nullptr>
   std::unique_ptr<cudf::column> operator()(
     cudf::column_view const& input,
     cudf::size_type const& output_size,
@@ -220,7 +219,7 @@ struct scatter_gather_functor {
 
     bool has_valid = input.nullable();
 
-    using Type = cudf::device_storage_type_t<T>;
+    using Type   = cudf::device_storage_type_t<T>;
     auto scatter = (has_valid) ? scatter_kernel<Type, Filter, block_size, true>
                                : scatter_kernel<Type, Filter, block_size, false>;
 

--- a/cpp/include/cudf/detail/copy_if.cuh
+++ b/cpp/include/cudf/detail/copy_if.cuh
@@ -204,7 +204,7 @@ __launch_bounds__(block_size) __global__
 template <typename Filter, int block_size>
 struct scatter_gather_functor {
   template <typename T,
-            std::enable_if_t<cudf::is_fixed_width<T>() and !cudf::is_fixed_point<T>()>* = nullptr>
+            std::enable_if_t<cudf::is_fixed_width<T>()>* = nullptr>
   std::unique_ptr<cudf::column> operator()(
     cudf::column_view const& input,
     cudf::size_type const& output_size,
@@ -220,8 +220,9 @@ struct scatter_gather_functor {
 
     bool has_valid = input.nullable();
 
-    auto scatter = (has_valid) ? scatter_kernel<T, Filter, block_size, true>
-                               : scatter_kernel<T, Filter, block_size, false>;
+    using Type = cudf::device_storage_type_t<T>;
+    auto scatter = (has_valid) ? scatter_kernel<Type, Filter, block_size, true>
+                               : scatter_kernel<Type, Filter, block_size, false>;
 
     cudf::detail::grid_1d grid{input.size(), block_size, per_thread};
 
@@ -273,19 +274,6 @@ struct scatter_gather_functor {
 
     // There will be only one column
     return std::make_unique<cudf::column>(std::move(output_table->get_column(0)));
-  }
-
-  template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(
-    cudf::column_view const& input,
-    cudf::size_type const& output_size,
-    cudf::size_type const* block_offsets,
-    Filter filter,
-    cudf::size_type per_thread,
-    rmm::cuda_stream_view stream,
-    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
-  {
-    CUDF_FAIL("fixed_point type not supported for this operation yet");
   }
 };
 

--- a/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
@@ -198,12 +198,16 @@ TEST_F(ApplyBooleanMask, FixedPointLargeColumnTest)
 
   std::vector<int32_t> expect_dec32_data;
   std::vector<int64_t> expect_dec64_data;
-  for (int i = 0; i < mask_data.size(); ++i) {
-    if (mask_data[i]) {
-      expect_dec32_data.push_back(dec32_data[i]);
-      expect_dec64_data.push_back(dec64_data[i]);
-    }
-  }
+  thrust::copy_if(dec32_data.cbegin(),
+                  dec32_data.cend(),
+                  mask_data.cbegin(),
+                  std::back_inserter(expect_dec32_data),
+                  thrust::identity());
+  thrust::copy_if(dec64_data.cbegin(),
+                  dec64_data.cend(),
+                  mask_data.cbegin(),
+                  std::back_inserter(expect_dec64_data),
+                  thrust::identity());
 
   decimal32_wrapper expect_col32(
     expect_dec32_data.begin(), expect_dec32_data.end(), numeric::scale_type{-3});

--- a/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
@@ -198,12 +198,14 @@ TEST_F(ApplyBooleanMask, FixedPointLargeColumnTest)
 
   std::vector<int32_t> expect_dec32_data;
   std::vector<int64_t> expect_dec64_data;
-  thrust::copy_if(dec32_data.cbegin(),
+  thrust::copy_if(thrust::host,
+                  dec32_data.cbegin(),
                   dec32_data.cend(),
                   mask_data.cbegin(),
                   std::back_inserter(expect_dec32_data),
                   thrust::identity<bool>());
-  thrust::copy_if(dec64_data.cbegin(),
+  thrust::copy_if(thrust::host,
+                  dec64_data.cbegin(),
                   dec64_data.cend(),
                   mask_data.cbegin(),
                   std::back_inserter(expect_dec64_data),

--- a/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
@@ -202,12 +202,12 @@ TEST_F(ApplyBooleanMask, FixedPointLargeColumnTest)
                   dec32_data.cend(),
                   mask_data.cbegin(),
                   std::back_inserter(expect_dec32_data),
-                  thrust::identity());
+                  thrust::identity<bool>());
   thrust::copy_if(dec64_data.cbegin(),
                   dec64_data.cend(),
                   mask_data.cbegin(),
                   std::back_inserter(expect_dec64_data),
-                  thrust::identity());
+                  thrust::identity<bool>());
 
   decimal32_wrapper expect_col32(
     expect_dec32_data.begin(), expect_dec32_data.end(), numeric::scale_type{-3});

--- a/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
@@ -169,7 +169,7 @@ TEST_F(ApplyBooleanMask, FixedPointColumnTest)
 
 TEST_F(ApplyBooleanMask, FixedPointLargeColumnTest)
 {
-  cudf::size_type num_rows = 10000;
+  cudf::size_type const num_rows = 10000;
 
   using decimal32_wrapper = cudf::test::fixed_point_column_wrapper<int32_t>;
   using decimal64_wrapper = cudf::test::fixed_point_column_wrapper<int64_t>;


### PR DESCRIPTION
This PR resolves a part of https://github.com/rapidsai/cudf/issues/3556.

This PR attempts to enable `copy_if` for fixed-point decimal columns, in order to support filtering table which includes decimal columns.  