### PR TITLE
Add support for scatter() on lists-of-struct columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #6768 Add support for scatter() on list columns
 - PR #6796 Add create_metadata_file in dask_cudf
 - PR #6765 Cupy fallback for __array_function__ and __array_ufunc__ for cudf.Series
+- PR #6817 Add support for scatter() on lists-of-struct columns
 
 ## Improvements
 

--- a/cpp/include/cudf/lists/detail/scatter.cuh
+++ b/cpp/include/cudf/lists/detail/scatter.cuh
@@ -627,19 +627,19 @@ struct list_child_constructor {
     rmm::cuda_stream_view stream,
     rmm::mr::device_memory_resource* mr) const
   {
-    auto source_column_device_view =
+    auto const source_column_device_view =
       column_device_view::create(source_lists_column_view.parent(), stream);
-    auto target_column_device_view =
+    auto const target_column_device_view =
       column_device_view::create(target_lists_column_view.parent(), stream);
-    auto source_lists = cudf::detail::lists_column_device_view(*source_column_device_view);
-    auto target_lists = cudf::detail::lists_column_device_view(*target_column_device_view);
+    auto const source_lists = cudf::detail::lists_column_device_view(*source_column_device_view);
+    auto const target_lists = cudf::detail::lists_column_device_view(*target_column_device_view);
 
-    auto source_structs = source_lists_column_view.child();
-    auto target_structs = target_lists_column_view.child();
+    auto const source_structs = source_lists_column_view.child();
+    auto const target_structs = target_lists_column_view.child();
 
-    auto num_child_rows = get_num_child_rows(list_offsets, stream);
+    auto const num_child_rows = get_num_child_rows(list_offsets, stream);
 
-    auto num_struct_members =
+    auto const num_struct_members =
       std::distance(source_structs.child_begin(), source_structs.child_end());
     std::vector<std::unique_ptr<column>> child_columns;
     child_columns.reserve(num_struct_members);
@@ -658,7 +658,7 @@ struct list_child_constructor {
                                      mr);
     };
 
-    auto iter_source_member_as_list = thrust::make_transform_iterator(
+    auto const iter_source_member_as_list = thrust::make_transform_iterator(
       thrust::make_counting_iterator<cudf::size_type>(0), [&](auto child_idx) {
         return project_member_as_list(
           source_structs.child(child_idx),
@@ -668,7 +668,7 @@ struct list_child_constructor {
           source_lists_column_view.null_count());
       });
 
-    auto iter_target_member_as_list = thrust::make_transform_iterator(
+    auto const iter_target_member_as_list = thrust::make_transform_iterator(
       thrust::make_counting_iterator<cudf::size_type>(0), [&](auto child_idx) {
         return project_member_as_list(
           target_structs.child(child_idx),

--- a/cpp/tests/copying/scatter_list_tests.cu
+++ b/cpp/tests/copying/scatter_list_tests.cu
@@ -484,17 +484,14 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
     "nine", "nine", "nine", "nine", 
     "eight", "eight", "eight"
   };
+  // clang-format on
 
   auto source_structs = structs_column_wrapper{{source_numerics, source_strings}};
 
-  auto source_lists = cudf::make_lists_column(
-    2, 
-    offsets_column{0, 4, 7}.release(), 
-    source_structs.release(), 
-    0, 
-    {}
-  );
+  auto source_lists =
+    cudf::make_lists_column(2, offsets_column{0, 4, 7}.release(), source_structs.release(), 0, {});
 
+  // clang-format off
   auto target_ints    = numerics_column{
     0, 0, 
     1, 1, 
@@ -505,23 +502,19 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
   };
 
   auto target_strings = strings_column_wrapper{
-    "zero", "zero", 
-    "one", "one", 
-    "two", "two", 
+    "zero",  "zero", 
+    "one",   "one", 
+    "two",   "two", 
     "three", "three", 
-    "four", "four", 
-    "five", "five"
+    "four",  "four", 
+    "five",  "five"
   };
+  // clang-format on
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
-    6, 
-    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), 
-    target_structs.release(), 
-    0, 
-    {}
-  );
+    6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
 
   auto scatter_map = offsets_column{2, 0};
 
@@ -529,6 +522,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
                                       scatter_map,
                                       cudf::table_view({target_lists->view()}));
 
+  // clang-format off
   auto expected_numerics = numerics_column{
     8, 8, 8, 
     1, 1, 
@@ -577,17 +571,14 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
     }, 
     make_counting_transform_iterator(0, [](auto i) { return i != 5; })
   };
+  // clang-format on
 
   auto source_structs = structs_column_wrapper{{source_numerics, source_strings}};
 
-  auto source_lists = cudf::make_lists_column(
-    2,
-    offsets_column{0, 4, 7}.release(),
-    source_structs.release(),
-    0,
-    {}
-  );
+  auto source_lists =
+    cudf::make_lists_column(2, offsets_column{0, 4, 7}.release(), source_structs.release(), 0, {});
 
+  // clang-format off
   auto target_ints    = numerics_column{
     0, 0, 
     1, 1, 
@@ -605,15 +596,12 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
     "four", "four", 
     "five", "five"
   };
+  // clang-format on
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
-    6,
-    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(),
-    target_structs.release(),
-    0,
-    {});
+    6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
   // clang-format on
 
   auto scatter_map = offsets_column{2, 0};
@@ -646,17 +634,13 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
     },
     make_counting_transform_iterator(0, [](auto i) { return i != 1; })
   };
+  // clang-format on
 
   auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
 
   auto expected_lists = cudf::make_lists_column(
-    6,
-    offsets_column{0, 3, 5, 9, 11, 13, 15}.release(),
-    expected_structs.release(),
-    0,
-    {});
+    6, offsets_column{0, 3, 5, 9, 11, 13, 15}.release(), expected_structs.release(), 0, {});
 
-  // clang-format on
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }
 
@@ -683,19 +667,16 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
     }, 
     make_counting_transform_iterator(0, [](auto i) { return i != 5; })
   };
+  // clang-format on
 
-  auto source_structs = structs_column_wrapper{
-    {source_numerics, source_strings},
-    make_counting_transform_iterator(0, [](auto i) { return i != 1; })
-  };
+  auto source_structs =
+    structs_column_wrapper{{source_numerics, source_strings},
+                           make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
 
   auto source_lists =
-    cudf::make_lists_column(2,
-                            offsets_column{0, 4, 7}.release(),
-                            source_structs.release(),
-                            0,
-                            {});
+    cudf::make_lists_column(2, offsets_column{0, 4, 7}.release(), source_structs.release(), 0, {});
 
+  // clang-format off
   auto target_ints    = numerics_column{
     0, 0, 
     1, 1, 
@@ -713,15 +694,12 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
     "four",  "four", 
     "five",  "five"
   };
+  // clang-format on
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
-    6,
-    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(),
-    target_structs.release(),
-    0,
-    {});
+    6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
 
   auto scatter_map = offsets_column{2, 0};
 
@@ -729,6 +707,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
                                       scatter_map,
                                       cudf::table_view({target_lists->view()}));
 
+  // clang-format off
   auto expected_numerics = numerics_column{
     {
       8, 8, 8, 
@@ -752,17 +731,13 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
     },
     make_counting_transform_iterator(0, [](auto i) { return (i != 1) && (i != 6); })
   };
+  // clang-format on
 
   auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
 
   auto expected_lists = cudf::make_lists_column(
-    6,
-    offsets_column{0, 3, 5, 9, 11, 13, 15}.release(),
-    expected_structs.release(),
-    0,
-    {});
+    6, offsets_column{0, 3, 5, 9, 11, 13, 15}.release(), expected_structs.release(), 0, {});
 
-  // clang-format on
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }
 
@@ -789,18 +764,16 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
     }, 
     make_counting_transform_iterator(0, [](auto i) { return i != 5; })
   };
+  // clang-format on
 
   auto source_structs =
     structs_column_wrapper{{source_numerics, source_strings},
                            make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
 
-  auto source_lists =
-    cudf::make_lists_column(3,
-                            offsets_column{0, 4, 7, 7}.release(),
-                            source_structs.release(),
-                            0,
-                            {});
+  auto source_lists = cudf::make_lists_column(
+    3, offsets_column{0, 4, 7, 7}.release(), source_structs.release(), 0, {});
 
+  // clang-format off
   auto target_ints    = numerics_column{
     0, 0, 
     1, 1, 
@@ -811,22 +784,19 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
   };
 
   auto target_strings = strings_column_wrapper{
-    "zero", "zero", 
-    "one", "one", 
-    "two", "two", 
+    "zero",  "zero", 
+    "one",   "one", 
+    "two",   "two", 
     "three", "three", 
-    "four", "four", 
-    "five", "five"
+    "four",  "four", 
+    "five",  "five"
   };
+  // clang-format on
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
-    6,
-    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(),
-    target_structs.release(),
-    0,
-    {});
+    6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
 
   auto scatter_map = offsets_column{2, 0, 4};
 
@@ -834,6 +804,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
                                       scatter_map,
                                       cudf::table_view({target_lists->view()}));
 
+  // clang-format off
   auto expected_numerics = numerics_column{
     {
       8, 8, 8, 
@@ -855,17 +826,13 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
     },
     make_counting_transform_iterator(0, [](auto i) { return (i != 1) && (i != 6); })
   };
+  // clang-format on
 
   auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
 
   auto expected_lists = cudf::make_lists_column(
-    6,
-    offsets_column{0, 3, 5, 9, 11, 11, 13}.release(),
-    expected_structs.release(),
-    0,
-    {});
+    6, offsets_column{0, 3, 5, 9, 11, 11, 13}.release(), expected_structs.release(), 0, {});
 
-  // clang-format on
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }
 
@@ -887,11 +854,12 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
 
   auto source_strings = strings_column_wrapper{
     {
-      "nine", "nine", "nine", "nine", 
+      "nine",  "nine",  "nine", "nine", 
       "eight", "eight", "eight"
     }, 
     make_counting_transform_iterator(0, [](auto i) { return i != 5; })
   };
+  // clang-format on
 
   auto source_structs =
     structs_column_wrapper{{source_numerics, source_strings},
@@ -907,6 +875,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
     1,
     detail::make_null_mask(source_list_null_mask_begin, source_list_null_mask_begin + 3));
 
+  // clang-format off
   auto target_ints    = numerics_column{
     0, 0, 
     1, 1, 
@@ -923,15 +892,12 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
     "four",  "four", 
     "five",  "five"
   };
+  // clang-format on
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
-    6,
-    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(),
-    target_structs.release(),
-    0,
-    {});
+    6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
 
   auto scatter_map = offsets_column{2, 0, 4};
 
@@ -939,6 +905,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
                                       scatter_map,
                                       cudf::table_view({target_lists->view()}));
 
+  // clang-format off
   auto expected_numerics = numerics_column{
     {
       8, 8, 8, 
@@ -953,13 +920,14 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
   auto expected_strings = strings_column_wrapper{
     {
       "eight", "eight", "eight",
-      "one", "one",
-      "nine", "nine", "nine", "nine",
+      "one",   "one",
+      "nine",  "nine",  "nine", "nine",
       "three", "three",
-      "five", "five"
+      "five",  "five"
     },
     make_counting_transform_iterator(0, [](auto i) { return i != 1 && i != 6; })
   };
+  // clang-format on
 
   auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
 
@@ -973,6 +941,5 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
     1,
     detail::make_null_mask(expected_lists_null_mask_begin, expected_lists_null_mask_begin + 6));
 
-  // clang-format on
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }

--- a/cpp/tests/copying/scatter_list_tests.cu
+++ b/cpp/tests/copying/scatter_list_tests.cu
@@ -470,68 +470,86 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfLists)
 TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
 {
   using namespace cudf::test;
-  using T = TypeParam;
+  using T               = TypeParam;
+  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = fixed_width_column_wrapper<T>;
 
-  auto source_numerics = fixed_width_column_wrapper<T>{9, 9, 9, 9, 8, 8, 8};
+  // clang-format off
+  auto source_numerics = numerics_column{
+    9, 9, 9, 9, 
+    8, 8, 8
+  };
 
-  auto source_strings =
-    strings_column_wrapper{"nine", "nine", "nine", "nine", "eight", "eight", "eight"};
+  auto source_strings = strings_column_wrapper{
+    "nine", "nine", "nine", "nine", 
+    "eight", "eight", "eight"
+  };
 
   auto source_structs = structs_column_wrapper{{source_numerics, source_strings}};
 
-  auto source_lists =
-    cudf::make_lists_column(2,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7}.release(),
-                            source_structs.release(),
-                            0,
-                            {});
+  auto source_lists = cudf::make_lists_column(
+    2, 
+    offsets_column{0, 4, 7}.release(), 
+    source_structs.release(), 
+    0, 
+    {}
+  );
 
-  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_ints    = numerics_column{
+    0, 0, 
+    1, 1, 
+    2, 2, 
+    3, 3, 
+    4, 4, 
+    5, 5
+  };
+
   auto target_strings = strings_column_wrapper{
-    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+    "zero", "zero", 
+    "one", "one", 
+    "two", "two", 
+    "three", "three", 
+    "four", "four", 
+    "five", "five"
+  };
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
-    6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
-    target_structs.release(),
-    0,
-    {});
+    6, 
+    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), 
+    target_structs.release(), 
+    0, 
+    {}
+  );
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+  auto scatter_map = offsets_column{2, 0};
 
   auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
                                       scatter_map,
                                       cudf::table_view({target_lists->view()}));
 
-  auto expected_numerics =
-    fixed_width_column_wrapper<T>{8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 5, 5};
+  auto expected_numerics = numerics_column{
+    8, 8, 8, 
+    1, 1, 
+    9, 9, 9, 9, 
+    3, 3, 4, 4, 5, 5
+  };
 
-  auto expected_strings = strings_column_wrapper{"eight",
-                                                 "eight",
-                                                 "eight",
-                                                 "one",
-                                                 "one",
-                                                 "nine",
-                                                 "nine",
-                                                 "nine",
-                                                 "nine",
-                                                 "three",
-                                                 "three",
-                                                 "four",
-                                                 "four",
-                                                 "five",
-                                                 "five"};
+  auto expected_strings = strings_column_wrapper{
+    "eight", "eight", "eight",
+    "one", "one",
+    "nine", "nine", "nine", "nine",
+    "three", "three",
+    "four", "four",
+    "five", "five"
+  };
+  // clang-format on
 
   auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
 
   auto expected_lists = cudf::make_lists_column(
-    6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 15}.release(),
-    expected_structs.release(),
-    0,
-    {});
+    6, offsets_column{0, 3, 5, 9, 11, 13, 15}.release(), expected_structs.release(), 0, {});
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }
@@ -539,159 +557,238 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
 TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
 {
   using namespace cudf::test;
-  using T = TypeParam;
+  using T               = TypeParam;
+  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = fixed_width_column_wrapper<T>;
 
-  auto source_numerics =
-    fixed_width_column_wrapper<T>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+  // clang-format off
+  auto source_numerics = numerics_column{
+    { 
+      9, 9, 9, 9, 
+      8, 8, 8    
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return i != 3; })
+  };
 
   auto source_strings = strings_column_wrapper{
-    {"nine", "nine", "nine", "nine", "eight", "eight", "eight"}, {1, 1, 1, 1, 1, 0, 1}};
+    {
+      "nine",  "nine",  "nine", "nine", 
+      "eight", "eight", "eight"
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return i != 5; })
+  };
 
   auto source_structs = structs_column_wrapper{{source_numerics, source_strings}};
 
-  auto source_lists =
-    cudf::make_lists_column(2,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7}.release(),
-                            source_structs.release(),
-                            0,
-                            {});
+  auto source_lists = cudf::make_lists_column(
+    2,
+    offsets_column{0, 4, 7}.release(),
+    source_structs.release(),
+    0,
+    {}
+  );
 
-  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_ints    = numerics_column{
+    0, 0, 
+    1, 1, 
+    2, 2, 
+    3, 3, 
+    4, 4, 
+    5, 5
+  };
+
   auto target_strings = strings_column_wrapper{
-    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+    "zero", "zero", 
+    "one",  "one", 
+    "two",  "two", 
+    "three","three", 
+    "four", "four", 
+    "five", "five"
+  };
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
+    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(),
     target_structs.release(),
     0,
     {});
+  // clang-format on
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+  auto scatter_map = offsets_column{2, 0};
 
   auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
                                       scatter_map,
                                       cudf::table_view({target_lists->view()}));
 
-  auto expected_numerics = fixed_width_column_wrapper<T>{
-    {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 5, 5}, {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}};
+  // clang-format off
+  auto expected_numerics = numerics_column{
+    {
+      8, 8, 8, 
+      1, 1, 
+      9, 9, 9, 9, 
+      3, 3, 
+      4, 4, 
+      5, 5
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return i != 8; })
+  };
 
-  auto expected_strings =
-    strings_column_wrapper{{"eight",
-                            "eight",
-                            "eight",
-                            "one",
-                            "one",
-                            "nine",
-                            "nine",
-                            "nine",
-                            "nine",
-                            "three",
-                            "three",
-                            "four",
-                            "four",
-                            "five",
-                            "five"},
-                           make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+  auto expected_strings = strings_column_wrapper{
+    {
+      "eight", "eight", "eight",
+      "one",   "one",
+      "nine",  "nine",  "nine", "nine",
+      "three", "three",
+      "four",  "four",
+      "five",  "five"
+    },
+    make_counting_transform_iterator(0, [](auto i) { return i != 1; })
+  };
 
   auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
 
   auto expected_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 15}.release(),
+    offsets_column{0, 3, 5, 9, 11, 13, 15}.release(),
     expected_structs.release(),
     0,
     {});
 
+  // clang-format on
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
 {
   using namespace cudf::test;
-  using T = TypeParam;
+  using T               = TypeParam;
+  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = fixed_width_column_wrapper<T>;
 
-  auto source_numerics =
-    fixed_width_column_wrapper<T>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+  // clang-format off
+  auto source_numerics = numerics_column{
+    {
+      9, 9, 9, 9, 
+      8, 8, 8
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return i != 3; })
+  };
 
   auto source_strings = strings_column_wrapper{
-    {"nine", "nine", "nine", "nine", "eight", "eight", "eight"}, {1, 1, 1, 1, 1, 0, 1}};
+    {
+      "nine",  "nine",  "nine", "nine", 
+      "eight", "eight", "eight"
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return i != 5; })
+  };
 
-  auto source_structs =
-    structs_column_wrapper{{source_numerics, source_strings},
-                           make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+  auto source_structs = structs_column_wrapper{
+    {source_numerics, source_strings},
+    make_counting_transform_iterator(0, [](auto i) { return i != 1; })
+  };
 
   auto source_lists =
     cudf::make_lists_column(2,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7}.release(),
+                            offsets_column{0, 4, 7}.release(),
                             source_structs.release(),
                             0,
                             {});
 
-  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_ints    = numerics_column{
+    0, 0, 
+    1, 1, 
+    2, 2, 
+    3, 3, 
+    4, 4, 
+    5, 5
+  };
+
   auto target_strings = strings_column_wrapper{
-    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+    "zero",  "zero", 
+    "one",   "one", 
+    "two",   "two", 
+    "three", "three", 
+    "four",  "four", 
+    "five",  "five"
+  };
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
+    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(),
     target_structs.release(),
     0,
     {});
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+  auto scatter_map = offsets_column{2, 0};
 
   auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
                                       scatter_map,
                                       cudf::table_view({target_lists->view()}));
 
-  auto expected_numerics = fixed_width_column_wrapper<T>{
-    {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 5, 5}, {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1}};
+  auto expected_numerics = numerics_column{
+    {
+      8, 8, 8, 
+      1, 1, 
+      9, 9, 9, 9, 
+      3, 3, 
+      4, 4, 
+      5, 5
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return (i != 6) && (i != 8); })
+  };
 
   auto expected_strings = strings_column_wrapper{
-    {"eight",
-     "eight",
-     "eight",
-     "one",
-     "one",
-     "nine",
-     "nine",
-     "nine",
-     "nine",
-     "three",
-     "three",
-     "four",
-     "four",
-     "five",
-     "five"},
-    make_counting_transform_iterator(0, [](auto i) { return i != 1 && i != 6; })};
+    {
+      "eight", "eight", "eight",
+      "one",   "one",
+      "nine",  "nine",  "nine", "nine",
+      "three", "three",
+      "four",  "four",
+      "five",  "five"
+    },
+    make_counting_transform_iterator(0, [](auto i) { return (i != 1) && (i != 6); })
+  };
 
   auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
 
   auto expected_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 15}.release(),
+    offsets_column{0, 3, 5, 9, 11, 13, 15}.release(),
     expected_structs.release(),
     0,
     {});
 
+  // clang-format on
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
 {
   using namespace cudf::test;
-  using T = TypeParam;
+  using T               = TypeParam;
+  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = fixed_width_column_wrapper<T>;
 
-  auto source_numerics =
-    fixed_width_column_wrapper<T>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+  // clang-format off
+  auto source_numerics = numerics_column{
+    {
+      9, 9, 9, 9, 
+      8, 8, 8
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return i != 3; })
+  };
 
   auto source_strings = strings_column_wrapper{
-    {"nine", "nine", "nine", "nine", "eight", "eight", "eight"}, {1, 1, 1, 1, 1, 0, 1}};
+    {
+      "nine",  "nine",  "nine", "nine", 
+      "eight", "eight", "eight"
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return i != 5; })
+  };
 
   auto source_structs =
     structs_column_wrapper{{source_numerics, source_strings},
@@ -699,71 +796,102 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
 
   auto source_lists =
     cudf::make_lists_column(3,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+                            offsets_column{0, 4, 7, 7}.release(),
                             source_structs.release(),
                             0,
                             {});
 
-  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_ints    = numerics_column{
+    0, 0, 
+    1, 1, 
+    2, 2, 
+    3, 3, 
+    4, 4, 
+    5, 5
+  };
+
   auto target_strings = strings_column_wrapper{
-    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+    "zero", "zero", 
+    "one", "one", 
+    "two", "two", 
+    "three", "three", 
+    "four", "four", 
+    "five", "five"
+  };
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
+    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(),
     target_structs.release(),
     0,
     {});
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+  auto scatter_map = offsets_column{2, 0, 4};
 
   auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
                                       scatter_map,
                                       cudf::table_view({target_lists->view()}));
 
-  auto expected_numerics = fixed_width_column_wrapper<T>{{8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 5, 5},
-                                                         {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1}};
+  auto expected_numerics = numerics_column{
+    {
+      8, 8, 8, 
+      1, 1, 
+      9, 9, 9, 9, 
+      3, 3, 
+      5, 5
+    },
+    make_counting_transform_iterator(0, [](auto i) { return (i != 6) && (i != 8); })
+  };
 
   auto expected_strings = strings_column_wrapper{
-    {"eight",
-     "eight",
-     "eight",
-     "one",
-     "one",
-     "nine",
-     "nine",
-     "nine",
-     "nine",
-     "three",
-     "three",
-     "five",
-     "five"},
-    make_counting_transform_iterator(0, [](auto i) { return i != 1 && i != 6; })};
+    {
+      "eight", "eight", "eight",
+      "one",   "one",
+      "nine",  "nine",  "nine", "nine",
+      "three", "three",
+      "five",  "five"
+    },
+    make_counting_transform_iterator(0, [](auto i) { return (i != 1) && (i != 6); })
+  };
 
   auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
 
   auto expected_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 11, 13}.release(),
+    offsets_column{0, 3, 5, 9, 11, 11, 13}.release(),
     expected_structs.release(),
     0,
     {});
 
+  // clang-format on
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
 {
   using namespace cudf::test;
-  using T = TypeParam;
+  using T               = TypeParam;
+  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = fixed_width_column_wrapper<T>;
 
-  auto source_numerics =
-    fixed_width_column_wrapper<T>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+  // clang-format off
+  auto source_numerics = numerics_column{
+    {
+      9, 9, 9, 9, 
+      8, 8, 8
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return i != 3; })
+  };
 
   auto source_strings = strings_column_wrapper{
-    {"nine", "nine", "nine", "nine", "eight", "eight", "eight"}, {1, 1, 1, 1, 1, 0, 1}};
+    {
+      "nine", "nine", "nine", "nine", 
+      "eight", "eight", "eight"
+    }, 
+    make_counting_transform_iterator(0, [](auto i) { return i != 5; })
+  };
 
   auto source_structs =
     structs_column_wrapper{{source_numerics, source_strings},
@@ -774,48 +902,64 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
 
   auto source_lists = cudf::make_lists_column(
     3,
-    fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+    offsets_column{0, 4, 7, 7}.release(),
     source_structs.release(),
     1,
     detail::make_null_mask(source_list_null_mask_begin, source_list_null_mask_begin + 3));
 
-  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_ints    = numerics_column{
+    0, 0, 
+    1, 1, 
+    2, 2, 
+    3, 3, 
+    4, 4, 
+    5, 5
+  };
   auto target_strings = strings_column_wrapper{
-    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+    "zero",  "zero", 
+    "one",   "one", 
+    "two",   "two", 
+    "three", "three", 
+    "four",  "four", 
+    "five",  "five"
+  };
 
   auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
+    offsets_column{0, 2, 4, 6, 8, 10, 12}.release(),
     target_structs.release(),
     0,
     {});
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+  auto scatter_map = offsets_column{2, 0, 4};
 
   auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
                                       scatter_map,
                                       cudf::table_view({target_lists->view()}));
 
-  auto expected_numerics = fixed_width_column_wrapper<T>{{8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 5, 5},
-                                                         {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1}};
+  auto expected_numerics = numerics_column{
+    {
+      8, 8, 8, 
+      1, 1, 
+      9, 9, 9, 9, 
+      3, 3, 
+      5, 5
+    },
+    make_counting_transform_iterator(0, [](auto i) { return (i != 6) && (i != 8); })
+  };
 
   auto expected_strings = strings_column_wrapper{
-    {"eight",
-     "eight",
-     "eight",
-     "one",
-     "one",
-     "nine",
-     "nine",
-     "nine",
-     "nine",
-     "three",
-     "three",
-     "five",
-     "five"},
-    make_counting_transform_iterator(0, [](auto i) { return i != 1 && i != 6; })};
+    {
+      "eight", "eight", "eight",
+      "one", "one",
+      "nine", "nine", "nine", "nine",
+      "three", "three",
+      "five", "five"
+    },
+    make_counting_transform_iterator(0, [](auto i) { return i != 1 && i != 6; })
+  };
 
   auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
 
@@ -824,10 +968,11 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
 
   auto expected_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 11, 13}.release(),
+    offsets_column{0, 3, 5, 9, 11, 11, 13}.release(),
     expected_structs.release(),
     1,
     detail::make_null_mask(expected_lists_null_mask_begin, expected_lists_null_mask_begin + 6));
 
+  // clang-format on
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }

--- a/cpp/tests/copying/scatter_list_tests.cu
+++ b/cpp/tests/copying/scatter_list_tests.cu
@@ -466,3 +466,368 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfLists)
       make_counting_transform_iterator(0, [](auto i) { return i != 4; })},
     ret->get_column(0));
 }
+
+TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
+{
+  using namespace cudf::test;
+  using T = TypeParam;
+
+  auto source_numerics = fixed_width_column_wrapper<T>{9, 9, 9, 9, 8, 8, 8};
+
+  auto source_strings =
+    strings_column_wrapper{"nine", "nine", "nine", "nine", "eight", "eight", "eight"};
+
+  auto source_structs = structs_column_wrapper{{source_numerics, source_strings}};
+
+  auto source_lists =
+    cudf::make_lists_column(2,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7}.release(),
+                            source_structs.release(),
+                            0,
+                            {});
+
+  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_strings = strings_column_wrapper{
+    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+
+  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+
+  auto target_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
+    target_structs.release(),
+    0,
+    {});
+
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+
+  auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
+                                      scatter_map,
+                                      cudf::table_view({target_lists->view()}));
+
+  auto expected_numerics =
+    fixed_width_column_wrapper<T>{8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 5, 5};
+
+  auto expected_strings = strings_column_wrapper{"eight",
+                                                 "eight",
+                                                 "eight",
+                                                 "one",
+                                                 "one",
+                                                 "nine",
+                                                 "nine",
+                                                 "nine",
+                                                 "nine",
+                                                 "three",
+                                                 "three",
+                                                 "four",
+                                                 "four",
+                                                 "five",
+                                                 "five"};
+
+  auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
+
+  auto expected_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 15}.release(),
+    expected_structs.release(),
+    0,
+    {});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
+}
+
+TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
+{
+  using namespace cudf::test;
+  using T = TypeParam;
+
+  auto source_numerics =
+    fixed_width_column_wrapper<T>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+
+  auto source_strings = strings_column_wrapper{
+    {"nine", "nine", "nine", "nine", "eight", "eight", "eight"}, {1, 1, 1, 1, 1, 0, 1}};
+
+  auto source_structs = structs_column_wrapper{{source_numerics, source_strings}};
+
+  auto source_lists =
+    cudf::make_lists_column(2,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7}.release(),
+                            source_structs.release(),
+                            0,
+                            {});
+
+  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_strings = strings_column_wrapper{
+    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+
+  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+
+  auto target_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
+    target_structs.release(),
+    0,
+    {});
+
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+
+  auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
+                                      scatter_map,
+                                      cudf::table_view({target_lists->view()}));
+
+  auto expected_numerics = fixed_width_column_wrapper<T>{
+    {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 5, 5}, {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}};
+
+  auto expected_strings =
+    strings_column_wrapper{{"eight",
+                            "eight",
+                            "eight",
+                            "one",
+                            "one",
+                            "nine",
+                            "nine",
+                            "nine",
+                            "nine",
+                            "three",
+                            "three",
+                            "four",
+                            "four",
+                            "five",
+                            "five"},
+                           make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+
+  auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
+
+  auto expected_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 15}.release(),
+    expected_structs.release(),
+    0,
+    {});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
+}
+
+TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
+{
+  using namespace cudf::test;
+  using T = TypeParam;
+
+  auto source_numerics =
+    fixed_width_column_wrapper<T>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+
+  auto source_strings = strings_column_wrapper{
+    {"nine", "nine", "nine", "nine", "eight", "eight", "eight"}, {1, 1, 1, 1, 1, 0, 1}};
+
+  auto source_structs =
+    structs_column_wrapper{{source_numerics, source_strings},
+                           make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+
+  auto source_lists =
+    cudf::make_lists_column(2,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7}.release(),
+                            source_structs.release(),
+                            0,
+                            {});
+
+  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_strings = strings_column_wrapper{
+    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+
+  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+
+  auto target_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
+    target_structs.release(),
+    0,
+    {});
+
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+
+  auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
+                                      scatter_map,
+                                      cudf::table_view({target_lists->view()}));
+
+  auto expected_numerics = fixed_width_column_wrapper<T>{
+    {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 5, 5}, {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1}};
+
+  auto expected_strings = strings_column_wrapper{
+    {"eight",
+     "eight",
+     "eight",
+     "one",
+     "one",
+     "nine",
+     "nine",
+     "nine",
+     "nine",
+     "three",
+     "three",
+     "four",
+     "four",
+     "five",
+     "five"},
+    make_counting_transform_iterator(0, [](auto i) { return i != 1 && i != 6; })};
+
+  auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
+
+  auto expected_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 15}.release(),
+    expected_structs.release(),
+    0,
+    {});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
+}
+
+TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
+{
+  using namespace cudf::test;
+  using T = TypeParam;
+
+  auto source_numerics =
+    fixed_width_column_wrapper<T>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+
+  auto source_strings = strings_column_wrapper{
+    {"nine", "nine", "nine", "nine", "eight", "eight", "eight"}, {1, 1, 1, 1, 1, 0, 1}};
+
+  auto source_structs =
+    structs_column_wrapper{{source_numerics, source_strings},
+                           make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+
+  auto source_lists =
+    cudf::make_lists_column(3,
+                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+                            source_structs.release(),
+                            0,
+                            {});
+
+  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_strings = strings_column_wrapper{
+    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+
+  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+
+  auto target_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
+    target_structs.release(),
+    0,
+    {});
+
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+
+  auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
+                                      scatter_map,
+                                      cudf::table_view({target_lists->view()}));
+
+  auto expected_numerics = fixed_width_column_wrapper<T>{{8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 5, 5},
+                                                         {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1}};
+
+  auto expected_strings = strings_column_wrapper{
+    {"eight",
+     "eight",
+     "eight",
+     "one",
+     "one",
+     "nine",
+     "nine",
+     "nine",
+     "nine",
+     "three",
+     "three",
+     "five",
+     "five"},
+    make_counting_transform_iterator(0, [](auto i) { return i != 1 && i != 6; })};
+
+  auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
+
+  auto expected_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 11, 13}.release(),
+    expected_structs.release(),
+    0,
+    {});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
+}
+
+TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
+{
+  using namespace cudf::test;
+  using T = TypeParam;
+
+  auto source_numerics =
+    fixed_width_column_wrapper<T>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+
+  auto source_strings = strings_column_wrapper{
+    {"nine", "nine", "nine", "nine", "eight", "eight", "eight"}, {1, 1, 1, 1, 1, 0, 1}};
+
+  auto source_structs =
+    structs_column_wrapper{{source_numerics, source_strings},
+                           make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+
+  auto source_list_null_mask_begin =
+    make_counting_transform_iterator(0, [](auto i) { return i != 2; });
+
+  auto source_lists = cudf::make_lists_column(
+    3,
+    fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+    source_structs.release(),
+    1,
+    detail::make_null_mask(source_list_null_mask_begin, source_list_null_mask_begin + 3));
+
+  auto target_ints    = fixed_width_column_wrapper<T>{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  auto target_strings = strings_column_wrapper{
+    "zero", "zero", "one", "one", "two", "two", "three", "three", "four", "four", "five", "five"};
+
+  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+
+  auto target_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 6, 8, 10, 12}.release(),
+    target_structs.release(),
+    0,
+    {});
+
+  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+
+  auto scatter_result = cudf::scatter(cudf::table_view({source_lists->view()}),
+                                      scatter_map,
+                                      cudf::table_view({target_lists->view()}));
+
+  auto expected_numerics = fixed_width_column_wrapper<T>{{8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 5, 5},
+                                                         {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1}};
+
+  auto expected_strings = strings_column_wrapper{
+    {"eight",
+     "eight",
+     "eight",
+     "one",
+     "one",
+     "nine",
+     "nine",
+     "nine",
+     "nine",
+     "three",
+     "three",
+     "five",
+     "five"},
+    make_counting_transform_iterator(0, [](auto i) { return i != 1 && i != 6; })};
+
+  auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
+
+  auto expected_lists_null_mask_begin =
+    make_counting_transform_iterator(0, [](auto i) { return i != 4; });
+
+  auto expected_lists = cudf::make_lists_column(
+    6,
+    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 11, 13}.release(),
+    expected_structs.release(),
+    1,
+    detail::make_null_mask(expected_lists_null_mask_begin, expected_lists_null_mask_begin + 6));
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
+}


### PR DESCRIPTION
Addendum to https://github.com/rapidsai/cudf/pull/6768, to support scatter on columns of type `list<struct>`.

Depends on #6768.

The hard part was the tests.

~(This branch is based off of that in #6768, and shows all commits from that PR. Only the last 4 commits are material to `struct_view` support.)~