### PR TITLE
Use CMake 3.19 for RMM when building cuDF jar [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - PR #6780 Move `cudf::cast` tests to separate test file
 - PR #6789 Rename `unary_op` to `unary_operator`
 - PR #6770 Support building decimal columns with Table.TestBuilder
+- PR #6819 Use CMake 3.19 for RMM when building cuDF jar
 
 ## Bug Fixes
 

--- a/java/ci/Dockerfile.centos7
+++ b/java/ci/Dockerfile.centos7
@@ -26,8 +26,7 @@ FROM nvidia/cuda:$CUDA_VERSION-devel-centos7
 ### Install basic requirements
 RUN yum install -y centos-release-scl
 RUN yum install -y devtoolset-7 epel-release
-RUN yum install -y cmake3 git zlib-devel maven tar wget patch && \
-    ln -s /usr/bin/cmake3 /usr/bin/cmake
+RUN yum install -y git zlib-devel maven tar wget patch
 
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir /usr/local/rapids && mkdir /rapids && chmod 777 /usr/local/rapids && chmod 777 /rapids

--- a/java/ci/Dockerfile.centos7
+++ b/java/ci/Dockerfile.centos7
@@ -36,3 +36,6 @@ RUN cd /rapids/ && wget https://dl.bintray.com/boostorg/release/1.72.0/source/bo
    tar zxf boost_1_72_0.tar.gz && \
    cd boost_1_72_0 && \
    scl enable devtoolset-7 "./bootstrap.sh --prefix=/usr && ./b2 install --with-filesystem threading=multi link=static cxxflags=-fPIC; exit 0"
+
+RUN cd /usr/local/ && wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.tar.gz && \
+   tar zxf cmake-3.19.0-Linux-x86_64.tar.gz

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -48,7 +48,6 @@ export PARALLEL_LEVEL=4
 export SKIP_JAVA_TESTS=true
 export BUILD_CPP_TESTS=OFF
 export OUT=out
-export ENABLE_PTDS=OFF
 
 scl enable devtoolset-7 "java/ci/build-in-docker.sh"
 ```

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -44,11 +44,6 @@ git clone --recursive https://github.com/rapidsai/cudf.git -b branch-0.17
 ```bash
 cd cudf
 export WORKSPACE=`pwd`
-export PARALLEL_LEVEL=4
-export SKIP_JAVA_TESTS=true
-export BUILD_CPP_TESTS=OFF
-export OUT=out
-
 scl enable devtoolset-7 "java/ci/build-in-docker.sh"
 ```
 

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -22,7 +22,7 @@ gcc --version
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 SKIP_JAVA_TESTS=${SKIP_JAVA_TESTS:-true}
 BUILD_CPP_TESTS=${BUILD_CPP_TESTS:-OFF}
-ENABLE_PTDS=${ENABLE_PTDS:-OFF}
+ENABLE_PTDS=${ENABLE_PTDS:-ON}
 RMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL:-OFF}
 OUT=${OUT:-out}
 
@@ -50,6 +50,9 @@ export CUDACXX=/usr/local/cuda/bin/nvcc
 export RMM_ROOT=$INSTALL_PREFIX
 export DLPACK_ROOT=$INSTALL_PREFIX
 export LIBCUDF_KERNEL_CACHE_PATH=/rapids
+
+# add cmake 3.19 to PATH
+export PATH=/usr/local/cmake-3.19.0-Linux-x86_64/bin:$PATH
 
 cd /rapids/
 git clone --recurse-submodules https://github.com/rapidsai/rmm.git -b branch-$RMM_VERSION

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -65,9 +65,6 @@ echo "RMM SHA: `git rev-parse HEAD`"
 cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DBUILD_TESTS=$BUILD_CPP_TESTS
 make -j$PARALLEL_LEVEL install
 
-# Install spdlog headers from RMM build
-(cd /rapids/rmm/build/_deps/spdlog-src && find include/spdlog | cpio -pmdv $INSTALL_PREFIX)
-
 mkdir -p /rapids/dlpack/build
 cd /rapids/dlpack/build
 echo "DLPACK SHA: `git rev-parse HEAD`"


### PR DESCRIPTION
Update Dockerfile to install CMake 3.19 as RMM required 3.18+
Add cmake into PATH in build script
Change PTDS default ON