### PR TITLE
Fix JNI build [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
 - PR #6767 Fix sort order of parameters in `test_scalar_invalid_implicit_conversion` pytest
 - PR #6787 Update java reduction APIs to reflect C++ changes
 - PR #6794 Fix AVRO reader issues with empty input
+- PR #6824 Fix JNI build
 
 
 # cuDF 0.16.0 (21 Oct 2020)


### PR DESCRIPTION
This fixes the JNI build after #6648.  The JNI data_sink was updated to use RMM stream views before the data_sink API was updated.