### PR TITLE
Fix resource management in Java ColumnBuilder [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@
 - PR #6787 Update java reduction APIs to reflect C++ changes
 - PR #6794 Fix AVRO reader issues with empty input
 - PR #6824 Fix JNI build
-- PR #6824 Fix resource management in Java ColumnBuilder
+- PR #6826 Fix resource management in Java ColumnBuilder
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@
 - PR #6787 Update java reduction APIs to reflect C++ changes
 - PR #6794 Fix AVRO reader issues with empty input
 - PR #6824 Fix JNI build
+- PR #6824 Fix resource management in Java ColumnBuilder
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2895,7 +2895,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
       BaseDeviceMemoryBuffer offsets = getOffsets();
       BaseDeviceMemoryBuffer data = null;
       DType type = this.type;
-      Long rows = this.rows;
+      long rows = this.rows;
       if (!type.isNestedType()) {
         data = getData();
       }
@@ -2923,21 +2923,18 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
           needsCleanup = false;
           return ret;
         } else {
-          HostMemoryBuffer hOffset = null;
-          HostMemoryBuffer hValid = null;
-          HostMemoryBuffer hData = null;
           if (data != null) {
-            hData = HostMemoryBuffer.allocate(data.length);
-            hData.copyFromDeviceBuffer(data);
+            hostDataBuffer = HostMemoryBuffer.allocate(data.length);
+            hostDataBuffer.copyFromDeviceBuffer(data);
           }
 
           if (valid != null) {
-            hValid = HostMemoryBuffer.allocate(valid.getLength());
-            hValid.copyFromDeviceBuffer(valid);
+            hostValidityBuffer = HostMemoryBuffer.allocate(valid.getLength());
+            hostValidityBuffer.copyFromDeviceBuffer(valid);
           }
           if (offsets != null) {
-            hOffset = HostMemoryBuffer.allocate(offsets.getLength());
-            hOffset.copyFromDeviceBuffer(offsets);
+            hostOffsetsBuffer = HostMemoryBuffer.allocate(offsets.getLength());
+            hostOffsetsBuffer.copyFromDeviceBuffer(offsets);
           }
           List<HostColumnVectorCore> children = new ArrayList<>();
           for (int i = 0; i < getNumChildren(); i++) {
@@ -2946,7 +2943,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
             }
           }
           HostColumnVector ret = new HostColumnVector(type, rows, Optional.of(nullCount),
-              hData, hValid, hOffset, children);
+              hostDataBuffer, hostValidityBuffer, hostOffsetsBuffer, children);
+          needsCleanup = false;
           return ret;
         }
       } finally {

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -282,22 +282,25 @@ public final class HostColumnVector extends HostColumnVectorCore {
   }
 
   public static<T> HostColumnVector fromLists(DataType dataType, List<T>... values) {
-    ColumnBuilder cb = new ColumnBuilder(dataType, values.length);
-    cb.appendLists(values);
-    return cb.build();
+    try (ColumnBuilder cb = new ColumnBuilder(dataType, values.length)) {
+      cb.appendLists(values);
+      return cb.build();
+    }
   }
 
   public static HostColumnVector fromStructs(DataType dataType,
                                              List<StructData> values) {
-    ColumnBuilder cb = new ColumnBuilder(dataType, values.size());
-    cb.appendStructValues(values);
-    return cb.build();
+    try (ColumnBuilder cb = new ColumnBuilder(dataType, values.size())) {
+      cb.appendStructValues(values);
+      return cb.build();
+    }
   }
 
   public static HostColumnVector fromStructs(DataType dataType, StructData... values) {
-    ColumnBuilder cb = new ColumnBuilder(dataType, values.length);
-    cb.appendStructValues(values);
-    return cb.build();
+    try (ColumnBuilder cb = new ColumnBuilder(dataType, values.length)) {
+      cb.appendStructValues(values);
+      return cb.build();
+    }
   }
 
   /**
@@ -794,6 +797,7 @@ public final class HostColumnVector extends HostColumnVectorCore {
       }
       HostColumnVector hostColumnVector = new HostColumnVector(type, rows, Optional.of(nullCount), data, valid, offsets,
           hostColumnVectorCoreList);
+      built = true;
       return hostColumnVector;
     }
 
@@ -1198,6 +1202,9 @@ public final class HostColumnVector extends HostColumnVectorCore {
         if (offsets != null) {
           offsets.close();
           offsets = null;
+        }
+        for (ColumnBuilder childBuilder : childBuilders) {
+          childBuilder.close();
         }
         built = true;
       }


### PR DESCRIPTION
Fixes the following issues in `ColumnBuilder`:
- The builder is `AutoCloseable` but cannot be closed after a column is built
- Some column building code uses builders without a try-with-resources to close them safely on exception
