### PR TITLE
Use settings.xml if existing for internal build [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 - PR #6789 Rename `unary_op` to `unary_operator`
 - PR #6770 Support building decimal columns with Table.TestBuilder
 - PR #6819 Use CMake 3.19 for RMM when building cuDF jar
+- PR #6833 Use settings.xml if existing for internal build
 
 ## Bug Fixes
 

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -88,7 +88,7 @@ fi
 
 if [ -f $WORKSPACE/java/ci/settings.xml ]; then
     # Build with an internal settings.xml
-    BUILD_ARG="$BUILD_ARG -s ci/settings.xml"
+    BUILD_ARG="$BUILD_ARG -s $WORKSPACE/javaci/settings.xml"
 fi
 
 cd $WORKSPACE/java

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -88,7 +88,7 @@ fi
 
 if [ -f $WORKSPACE/java/ci/settings.xml ]; then
     # Build with an internal settings.xml
-    BUILD_ARG="$BUILD_ARG -s $WORKSPACE/javaci/settings.xml"
+    BUILD_ARG="$BUILD_ARG -s $WORKSPACE/java/ci/settings.xml"
 fi
 
 cd $WORKSPACE/java

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -86,6 +86,11 @@ if [ "$SIGN_FILE" == true ]; then
     BUILD_ARG="$BUILD_ARG -Prelease"
 fi
 
+if [ -f $WORKSPACE/java/ci/settings.xml ]; then
+    # Build with an internal settings.xml
+    BUILD_ARG="$BUILD_ARG -s ci/settings.xml"
+fi
+
 cd $WORKSPACE/java
 mvn -B clean package $BUILD_ARG
 


### PR DESCRIPTION
For the internal cudf jar building, we'll use a settings.xml to define the maven repo.
Use the settings.xml if it exists in ci.
No change for the external build.
