### PR TITLE
[REVIEW] Move template param to member var to improve compile of hash/groupby.cu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - PR #6770 Support building decimal columns with Table.TestBuilder
 - PR #6819 Use CMake 3.19 for RMM when building cuDF jar
 - PR #6833 Use settings.xml if existing for internal build
+- PR #6835 Move template param to member var to improve compile of hash/groupby.cu
 
 ## Bug Fixes
 

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -279,27 +279,19 @@ void compute_single_pass_aggs(table_view const& keys,
 
   bool skip_key_rows_with_nulls = keys_have_nulls and include_null_keys == null_policy::EXCLUDE;
 
-  if (skip_key_rows_with_nulls) {
-    auto row_bitmask{cudf::detail::bitmask_and(keys, stream)};
-    thrust::for_each_n(
-      rmm::exec_policy(stream)->on(stream.value()),
-      thrust::make_counting_iterator(0),
-      keys.num_rows(),
-      hash::compute_single_pass_aggs<true, Map>{map,
-                                                keys.num_rows(),
-                                                *d_values,
-                                                *d_sparse_table,
-                                                d_aggs.data().get(),
-                                                static_cast<bitmask_type*>(row_bitmask.data())});
-  } else {
-    thrust::for_each_n(
-      rmm::exec_policy(stream)->on(stream.value()),
-      thrust::make_counting_iterator(0),
-      keys.num_rows(),
-      hash::compute_single_pass_aggs<false, Map>{
-        map, keys.num_rows(), *d_values, *d_sparse_table, d_aggs.data().get(), nullptr});
-  }
-
+  auto row_bitmask =
+    skip_key_rows_with_nulls ? cudf::detail::bitmask_and(keys, stream) : rmm::device_buffer{};
+  thrust::for_each_n(
+    rmm::exec_policy(stream)->on(stream.value()),
+    thrust::make_counting_iterator(0),
+    keys.num_rows(),
+    hash::compute_single_pass_aggs_fn<Map>{map,
+                                           keys.num_rows(),
+                                           *d_values,
+                                           *d_sparse_table,
+                                           d_aggs.data().get(),
+                                           static_cast<bitmask_type*>(row_bitmask.data()),
+                                           skip_key_rows_with_nulls});
   // Add results back to sparse_results cache
   auto sparse_result_cols = sparse_table.release();
   for (size_t i = 0; i < aggs.size(); i++) {

--- a/cpp/src/groupby/hash/groupby_kernels.cuh
+++ b/cpp/src/groupby/hash/groupby_kernels.cuh
@@ -57,22 +57,20 @@ namespace hash {
  * rows. In this way, after all rows are aggregated, `output_values` will likely
  * be "sparse", meaning that not all rows contain the result of an aggregation.
  *
- * @tparam skip_rows_with_nulls Indicates if rows in `input_keys` containing
- * null values should be skipped. It `true`, it is assumed `row_bitmask` is a
- * bitmask where bit `i` indicates the presence of a null value in row `i`.
  * @tparam Map The type of the hash map
  */
-template <bool skip_rows_with_nulls, typename Map>
-struct compute_single_pass_aggs {
+template <typename Map>
+struct compute_single_pass_aggs_fn {
   Map map;
   size_type num_keys;
   table_device_view input_values;
   mutable_table_device_view output_values;
   aggregation::Kind const* __restrict__ aggs;
   bitmask_type const* __restrict__ row_bitmask;
+  bool skip_rows_with_nulls;
 
   /**
-   * @brief Construct a new compute_single_pass_aggs functor object
+   * @brief Construct a new compute_single_pass_aggs_fn functor object
    *
    * @param map Hash map object to insert key,value pairs into.
    * @param num_keys The number of rows in input keys table
@@ -84,19 +82,24 @@ struct compute_single_pass_aggs {
    * columns of the `input_values` rows
    * @param row_bitmask Bitmask where bit `i` indicates the presence of a null
    * value in row `i` of input keys. Only used if `skip_rows_with_nulls` is `true`
+   * @param skip_rows_with_nulls Indicates if rows in `input_keys` containing
+   * null values should be skipped. It `true`, it is assumed `row_bitmask` is a
+   * bitmask where bit `i` indicates the presence of a null value in row `i`.
    */
-  compute_single_pass_aggs(Map map,
-                           size_type num_keys,
-                           table_device_view input_values,
-                           mutable_table_device_view output_values,
-                           aggregation::Kind const* aggs,
-                           bitmask_type const* row_bitmask)
+  compute_single_pass_aggs_fn(Map map,
+                              size_type num_keys,
+                              table_device_view input_values,
+                              mutable_table_device_view output_values,
+                              aggregation::Kind const* aggs,
+                              bitmask_type const* row_bitmask,
+                              bool skip_rows_with_nulls)
     : map(map),
       num_keys(num_keys),
       input_values(input_values),
       output_values(output_values),
       aggs(aggs),
-      row_bitmask(row_bitmask)
+      row_bitmask(row_bitmask),
+      skip_rows_with_nulls(skip_rows_with_nulls)
   {
   }
 
@@ -110,8 +113,6 @@ struct compute_single_pass_aggs {
     }
   }
 };
-
-// TODO (dm): variance kernel
 
 }  // namespace hash
 }  // namespace detail


### PR DESCRIPTION
The compile time/size of `cpp/src/groupby/hash/groupby.cu` is one of the top offenders for building libcudf.

Current top 5 slowest compiles:
```
1813479 CMakeFiles/cudf_base.dir/src/sort/sort.cu.o
1805726 CMakeFiles/cudf_base.dir/src/sort/stable_sort.cu.o
1091904 CMakeFiles/cudf_base.dir/src/stream_compaction/drop_duplicates.cu.o
 979061 CMakeFiles/cudf_base.dir/src/groupby/hash/groupby.cu.o  <----
 685116 CMakeFiles/cudf_join.dir/src/join/semi_join.cu.o
...
```
The two sort.cu files may be improved in a later PR. The `drop_duplicates.cu` is being addressed in #6822 

The simple change here is to `compute_single_pass_aggs` functor defined here: https://github.com/rapidsai/cudf/blob/591bead156398635aa39a2c3d7f441d9dfddf39b/cpp/src/groupby/hash/groupby_kernels.cuh#L65-L66
The `skip_rows_with_nulls` template parameter is set to avoid calling (and inlining) `cudf::bit_is_set()`. This function is minimal compared to the `cudf::detail::aggregate_row` function that must be inlined twice to accommodate this template parameter. Simply changing this to a member variable means we still do not incur an extra call to `cudf::bit_is_set()` when appropriate but also means we generate half as much device code for this specific function. The `cudf::detail::aggregate_row` code is quite significant.

This change reduces the compile time for `hash/groupby.cu` from 16 minutes to 9 minutes. This moves it out of the top 5 (for now). This also reduces the size of the libcudf_base.so by ~5MB.

There is no functional changes to any logic. The `gbenchmark/GROUPBY_BENCH` shows no change in performance.
