### PR TITLE
Avoid gather when copying strings view from start of strings column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - PR #6770 Support building decimal columns with Table.TestBuilder
 - PR #6819 Use CMake 3.19 for RMM when building cuDF jar
 - PR #6833 Use settings.xml if existing for internal build
+- PR #6837 Avoid gather when copying strings view from start of strings column
 
 ## Bug Fixes
 

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -17,7 +17,9 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/gather.hpp>
+#include <cudf/detail/get_value.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
+#include <cudf/detail/null_mask.hpp>
 #include <cudf/strings/copying.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/strings_column_view.hpp>
@@ -42,6 +44,38 @@ std::unique_ptr<cudf::column> copy_slice(strings_column_view const& strings,
   if (end < 0 || end > strings_count) end = strings_count;
   CUDF_EXPECTS(((start >= 0) && (start < end)), "Invalid start parameter value.");
   strings_count = cudf::util::round_up_safe<size_type>((end - start), step);
+  if (start == 0 && strings.offset() == 0) {
+    // slice starts at the beginning, so do not need a gather to adjust offsets
+    auto offsets_column = make_numeric_column(
+      data_type{type_id::INT32},
+      strings.size() + 1,
+      mask_state::UNALLOCATED,
+      stream,
+      mr);
+    auto offsets_view = offsets_column->mutable_view();
+    CUDA_TRY(cudaMemcpyAsync(offsets_view.data<size_type>(),
+                             strings.offsets().data<size_type>(),
+                             (strings.size() + 1) * sizeof(size_type),
+                             cudaMemcpyDeviceToDevice,
+                             stream));
+    auto validity = cudf::detail::copy_bitmask(strings.null_mask(), 0, strings.size(), stream, mr);
+    auto data_size =
+      cudf::detail::get_value<size_type>(offsets_column->view(), strings.size(), stream);
+    auto chars_column = create_chars_child_column(strings.size(), 0, data_size, mr, stream);
+    auto chars_view  = chars_column->mutable_view();
+    CUDA_TRY(cudaMemcpyAsync(chars_view.data<char>(),
+                             strings.chars().data<char>(),
+                             data_size,
+                             cudaMemcpyDeviceToDevice,
+                             stream));
+    return make_strings_column(strings.size(),
+                               std::move(offsets_column),
+                               std::move(chars_column),
+                               UNKNOWN_NULL_COUNT,
+                               std::move(validity),
+                               stream,
+                               mr);
+  }
   //
   auto execpol = rmm::exec_policy(stream);
   // build indices

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -16,10 +16,11 @@
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/get_value.cuh>
-#include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/strings/copying.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/strings_column_view.hpp>
@@ -44,39 +45,24 @@ std::unique_ptr<cudf::column> copy_slice(strings_column_view const& strings,
   if (end < 0 || end > strings_count) end = strings_count;
   CUDF_EXPECTS(((start >= 0) && (start < end)), "Invalid start parameter value.");
   strings_count = cudf::util::round_up_safe<size_type>((end - start), step);
-  if (start == 0 && strings.offset() == 0) {
-    // slice starts at the beginning, so do not need a gather to adjust offsets
-    auto offsets_column = make_numeric_column(
-      data_type{type_id::INT32},
-      strings.size() + 1,
-      mask_state::UNALLOCATED,
-      stream,
-      mr);
-    auto offsets_view = offsets_column->mutable_view();
-    CUDA_TRY(cudaMemcpyAsync(offsets_view.data<size_type>(),
-                             strings.offsets().data<size_type>(),
-                             (strings.size() + 1) * sizeof(size_type),
-                             cudaMemcpyDeviceToDevice,
-                             stream));
-    auto validity = cudf::detail::copy_bitmask(strings.null_mask(), 0, strings.size(), stream, mr);
+  if (start == 0 && strings.offset() == 0 && step == 1) {
+    // sliced at the beginning and copying every step, so no need to gather
+    auto offsets_column = std::make_unique<cudf::column>(
+      cudf::slice(strings.offsets(), {0, strings_count + 1}).front(), stream, mr);
     auto data_size =
-      cudf::detail::get_value<size_type>(offsets_column->view(), strings.size(), stream);
-    auto chars_column = create_chars_child_column(strings.size(), 0, data_size, mr, stream);
-    auto chars_view  = chars_column->mutable_view();
-    CUDA_TRY(cudaMemcpyAsync(chars_view.data<char>(),
-                             strings.chars().data<char>(),
-                             data_size,
-                             cudaMemcpyDeviceToDevice,
-                             stream));
-    return make_strings_column(strings.size(),
+      cudf::detail::get_value<size_type>(offsets_column->view(), strings_count, stream);
+    auto chars_column = std::make_unique<cudf::column>(
+      cudf::slice(strings.chars(), {0, data_size}).front(), stream, mr);
+    auto null_mask = cudf::detail::copy_bitmask(strings.null_mask(), 0, strings_count, stream, mr);
+    return make_strings_column(strings_count,
                                std::move(offsets_column),
                                std::move(chars_column),
                                UNKNOWN_NULL_COUNT,
-                               std::move(validity),
+                               std::move(null_mask),
                                stream,
                                mr);
   }
-  //
+  // do the gather instead
   auto execpol = rmm::exec_policy(stream);
   // build indices
   rmm::device_vector<size_type> indices(strings_count);

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -158,7 +158,7 @@ TEST_F(ReplaceNullsStringsTest, ReplaceNone)
   std::unique_ptr<cudf::column> result;
   ASSERT_NO_THROW(result = cudf::replace_nulls(input_w, replacement_w, mr()));
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, expected_w);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, expected_w);
 }
 
 TEST_F(ReplaceNullsStringsTest, SimpleReplaceScalar)


### PR DESCRIPTION
Fixes #6803 

This optimizes string slice copying in the case where the string column view starts at offset 0.  In that case the offset values do not need to be modified, and all the column buffers can be copied.
