### PR TITLE
[REVIEW]Handle index when dispatching __array_function__ and __array_ufunc__ to cupy for cudf.Series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - PR #6829 Enable workaround to write categorical columns in csv
 - PR #6819 Use CMake 3.19 for RMM when building cuDF jar
 - PR #6833 Use settings.xml if existing for internal build
+- PR #6839 Handle index when dispatching __array_function__ and __array_ufunc__ to cupy for cudf.Series
 
 ## Bug Fixes
 

--- a/python/cudf/cudf/tests/test_array_function.py
+++ b/python/cudf/cudf/tests/test_array_function.py
@@ -119,7 +119,7 @@ def test_array_func_missing_cudf_multi_index(func):
 
 
 @pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
-def test_output_func_with_unalligned_index():
+def test_list_input_array_func():
     ar = np.array([1, 2, 3])
 
     s = cudf.Series(ar)

--- a/python/cudf/cudf/tests/test_array_function.py
+++ b/python/cudf/cudf/tests/test_array_function.py
@@ -119,9 +119,13 @@ def test_array_func_missing_cudf_multi_index(func):
 
 
 @pytest.mark.skipif(missing_arrfunc_cond, reason=missing_arrfunc_reason)
-def test_list_input_array_func():
+def test_output_func_with_unalligned_index():
     ar = np.array([1, 2, 3])
+
     s = cudf.Series(ar)
-    expect = np.concatenate([ar, ar, ar])
-    got = np.concatenate([s, s, s])
-    assert_eq(expect, got.to_array())
+    with pytest.raises(TypeError):
+        np.concatenate([s, s, s])
+
+    s = cudf.Series(ar, index=[1, 2, 3])
+    with pytest.raises(TypeError):
+        np.concatenate([s, s, s])

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -80,7 +80,7 @@ def test_error_with_null_cudf_series(func):
 
 
 @pytest.mark.parametrize(
-    "func", [lambda x: np.absolute(x), lambda x: np.sign(x)],
+    "func", [np.absolute,  np.sign],
 )
 def test_ufunc_cudf_series_with_index(func):
     data = [-1, 2, 3, 0]

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -80,7 +80,7 @@ def test_error_with_null_cudf_series(func):
 
 
 @pytest.mark.parametrize(
-    "func", [np.absolute,  np.sign],
+    "func", [np.absolute, np.sign],
 )
 def test_ufunc_cudf_series_with_index(func):
     data = [-1, 2, 3, 0]

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -64,7 +64,18 @@ def test_ufunc_cudf_series_cupy_array(np_ar_tup, func):
 def test_error_with_null_cudf_series(func):
     s_1 = cudf.Series([1, 2])
     s_2 = cudf.Series([1, None])
+
+    # this thows a value error
+    # because of nulls in cudf.Series
     with pytest.raises(ValueError):
+        func(s_1, s_2)
+
+    s_1 = cudf.Series([1, 2])
+    s_2 = cudf.Series([1, 2, None])
+
+    # this throws a type-error because
+    # indexes are not aligned
+    with pytest.raises(TypeError):
         func(s_1, s_2)
 
 

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -10,13 +10,7 @@ from cudf.tests.utils import assert_eq
     "np_ar_tup", [(np.random.random(100), np.random.random(100))]
 )
 @pytest.mark.parametrize(
-    "func",
-    [
-        lambda x, y: np.greater(x, y),
-        lambda x, y: np.less(x, y),
-        lambda x, y: np.less_equal(x, y),
-        lambda x, y: np.subtract(x, y),
-    ],
+    "func", [np.greater, np.less, np.less_equal, np.subtract],
 )
 def test_ufunc_cudf_series(np_ar_tup, func):
     x, y = np_ar_tup[0], np_ar_tup[1]
@@ -33,12 +27,7 @@ def test_ufunc_cudf_series(np_ar_tup, func):
     "np_ar_tup", [(np.random.random(100), np.random.random(100))]
 )
 @pytest.mark.parametrize(
-    "func",
-    [
-        lambda x, y: np.greater(x, y),
-        lambda x, y: np.less(x, y),
-        lambda x, y: np.less_equal(x, y),
-    ],
+    "func", [np.greater, np.less, np.less_equal],
 )
 def test_ufunc_cudf_series_cupy_array(np_ar_tup, func):
     x, y = np_ar_tup[0], np_ar_tup[1]
@@ -54,12 +43,7 @@ def test_ufunc_cudf_series_cupy_array(np_ar_tup, func):
 
 
 @pytest.mark.parametrize(
-    "func",
-    [
-        lambda x, y: np.greater(x, y),
-        lambda x, y: np.less(x, y),
-        lambda x, y: np.less_equal(x, y),
-    ],
+    "func", [np.greater, np.less, np.less_equal],
 )
 def test_error_with_null_cudf_series(func):
     s_1 = cudf.Series([1, 2])
@@ -73,9 +57,11 @@ def test_error_with_null_cudf_series(func):
     s_1 = cudf.Series([1, 2])
     s_2 = cudf.Series([1, 2, None])
 
-    # this throws a type-error because
-    # indexes are not aligned
-    with pytest.raises(TypeError):
+    # this throws a value-error if indexes are not aligned
+    # following pandas behavior for ufunc numpy dispatching
+    with pytest.raises(
+        ValueError, match="Can only compare identically-labeled Series objects"
+    ):
         func(s_1, s_2)
 
 
@@ -95,11 +81,15 @@ def test_ufunc_cudf_series_with_index(func):
 
 
 @pytest.mark.parametrize(
-    "func", [lambda x, y: np.greater(x, y), lambda x, y: np.logaddexp(x, y)],
+    "func", [np.greater, np.logaddexp],
 )
 def test_ufunc_cudf_series_with_nonaligned_index(func):
     cudf_s1 = cudf.Series(data=[-1, 2, 3, 0], index=[2, 3, 1, 0])
     cudf_s2 = cudf.Series(data=[-1, 2, 3, 0], index=[3, 1, 0, 2])
 
-    with pytest.raises(TypeError):
+    # this throws a value-error if indexes are not aligned
+    # following pandas behavior for ufunc numpy dispatching
+    with pytest.raises(
+        ValueError, match="Can only compare identically-labeled Series objects"
+    ):
         func(cudf_s1, cudf_s2)

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -508,9 +508,8 @@ def _cast_to_appropriate_cudf_type(val, index=None):
         if (index is None) or (len(index) == len(val)):
             return cudf.Series(val, index=index)
         else:
-            # if index is not None and is of a different
-            # length as val cupy dispatching behaviour
-            # is undefined
+            # if index is not None and is of a different length
+            # than the index cupy dispatching behaviour is undefined
             return NotImplemented
     else:
         return NotImplemented
@@ -518,8 +517,8 @@ def _cast_to_appropriate_cudf_type(val, index=None):
 
 def _get_cupy_compatible_args_index(args, ser_index=None):
     """
-     This function returns cupy function compatible arguments and index
-     if its not possible it return None
+     This function returns cupy compatible arguments and output index
+     if conversion is not possible it returns None
     """
 
     casted_ls = []
@@ -527,7 +526,7 @@ def _get_cupy_compatible_args_index(args, ser_index=None):
         if isinstance(arg, cp.ndarray):
             casted_ls.append(arg)
         elif isinstance(arg, cudf.Series):
-            if _are_indices_alligned(ser_index, arg.index):
+            if _are_indexes_alligned(ser_index, arg.index):
                 ser_index = arg.index
                 casted_ls.append(arg.values)
             else:
@@ -536,14 +535,14 @@ def _get_cupy_compatible_args_index(args, ser_index=None):
         elif isinstance(arg, Sequence):
             # we dont handle list of inputs for functions as
             # these form inputs for functions like
-            # np.concatenate, vstack which have abiguity around index allignment
+            # np.concatenate, vstack have abiguity around index allignment
             return None, ser_index
         else:
             casted_ls.append(arg)
     return casted_ls, ser_index
 
 
-def _are_indices_alligned(index_1, index_2=None):
+def _are_indexes_alligned(index_1, index_2=None):
     if index_1:
         return index_1.equals(index_2)
     else:

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -523,7 +523,7 @@ def _get_cupy_compatible_args_index(args, ser_index=None):
         if isinstance(arg, cp.ndarray):
             casted_ls.append(arg)
         elif isinstance(arg, cudf.Series):
-            ## check if indexes can be aligned
+            # check if indexes can be aligned
             if (ser_index is None) or (ser_index.equals(arg.index)):
                 ser_index = arg.index
                 casted_ls.append(arg.values)

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -528,8 +528,11 @@ def _get_cupy_compatible_args_index(args, ser_index=None):
                 ser_index = arg.index
                 casted_ls.append(arg.values)
             else:
-                # dont dispatch if the index does not line up
-                return None, ser_index
+                # this throws a value-error if indexes are not aligned
+                # following pandas behavior for ufunc numpy dispatching
+                raise ValueError(
+                    "Can only compare identically-labeled Series objects"
+                )
         elif isinstance(arg, Sequence):
             # we dont handle list of inputs for functions as
             # these form inputs for functions like


### PR DESCRIPTION
This pr adds index handling when dispatching to cupy functions with `__ufunc__` and `__array_function__` for cudf.Series.  

This PR does the following: 

- [x] Adds index handling for `__ufunc__` and `__array_function` (when being dispatched to `cupy`)
- [x] Adds test to ensure the same results as pandas with aligned index  
- [x] Adds tests for appropriate errors non-aligned index 
- [x] Removs support for `list` inputs  (should not have been supported initially too) 


Please note that I am unsure how to handle `list` inputs here. 
The problem being solved here is below:

With this **PR #6839** we get the correct index when we do the following:
```python
>>> cudf_s1 = cudf.Series(data=[-1, 2, 3, 0], index=[2, 3, 1, 0])
>>> cudf_s2 = cudf.Series(data=[-1, -2, 3, 0], index=[2, 3, 1, 0])
>>> o = np.logaddexp(cudf_s1, cudf_s2)
>>> o.index
Int64Index([2, 3, 1, 0], dtype='int64')
>>> print(o)
2   -0.306853
3    2.018150
1    3.693147
0    0.693147
dtype: float64
```
On **Master** we get:
```python
>>> cudf_s1 = cudf.Series(data=[-1, 2, 3, 0], index=[2, 3, 1, 0])
>>> cudf_s2 = cudf.Series(data=[-1, -2, 3, 0], index=[2, 3, 1, 0])
>>> o = np.logaddexp(cudf_s1, cudf_s2)
>>> o.index
RangeIndex(start=0, stop=4, step=1)
>>> print(o)
0   -0.306853
1    2.018150
2    3.693147
3    0.693147
dtype: float64
````