### PR TITLE
[REVIEW] fix uint32_t undefined errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@
 - PR #6824 Fix JNI build
 - PR #6826 Fix resource management in Java ColumnBuilder
 - PR #6830 Fix categorical scalar insertion
+- PR #6844 Fix uint32_t undefined errors
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/cpp/src/io/orc/orc_common.h
+++ b/cpp/src/io/orc/orc_common.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace cudf {
 namespace io {
 namespace orc {

--- a/cpp/src/text/subword/detail/codepoint_metadata.ah
+++ b/cpp/src/text/subword/detail/codepoint_metadata.ah
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // this file is included only by data_normalizer.cu
 // this is the metadata for every unicode code point value
 // it is broken into pieces since only 10% of the values are unique

--- a/cpp/src/text/subword/detail/cp_data.h
+++ b/cpp/src/text/subword/detail/cp_data.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 constexpr uint32_t NEW_CP_MASK = 0x1fffff;
 
 constexpr uint32_t MULTICHAR_SHIFT = 23;

--- a/cpp/src/text/subword/detail/hash_utils.cuh
+++ b/cpp/src/text/subword/detail/hash_utils.cuh
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace nvtext {
 namespace detail {
 


### PR DESCRIPTION
Newer gcc compilers seem to be unhappy about not including `cstdint`:
```console
/home/rou/src/cudf/cpp/src/io/orc/orc_common.h(24): error: identifier "uint32_t" is undefined
```