### PR TITLE
Implement `cudf::copy_if_else` for `decimal32` and `decimal64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PR #6777 Implement `cudf::unary_operation` for `decimal32` & `decimal64`
 - PR #6729 Implement `cudf::cast` for `decimal32/64` to/from different `type_id`
 - PR #6792 Implement `cudf::clamp` for `decimal32` and `decimal64`
+- PR #6845 Implement `cudf::copy_if_else` for `decimal32` and `decimal64`
 - PR #6528 Enable `fixed_point` binary operations
 - PR #6460 Add is_timestamp format check API
 - PR #6568 Add function to create hashed vocabulary file from raw vocabulary

--- a/cpp/include/cudf/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/detail/copy_if_else.cuh
@@ -151,6 +151,7 @@ __launch_bounds__(block_size) __global__
  * @param rhs         Begin iterator of rhs range
  * @param filter      Function of type `FilterFn` which determines for index `i` where to get the
  *                    corresponding output value from
+ * @param out_type    `cudf::data_type` of the returned column
  * @param mr          Device memory resource used to allocate the returned column's device memory
  * @param stream      CUDA stream used for device memory operations and kernel launches.
  * @return            A new column that contains the values from either `lhs` or `rhs` as determined

--- a/cpp/include/cudf/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/detail/copy_if_else.cuh
@@ -163,6 +163,7 @@ std::unique_ptr<column> copy_if_else(
   LeftIter lhs_end,
   RightIter rhs,
   FilterFn filter,
+  cudf::data_type output_type,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource())
 {
@@ -175,7 +176,7 @@ std::unique_ptr<column> copy_if_else(
   cudf::detail::grid_1d grid{num_els, block_size, 1};
 
   std::unique_ptr<column> out =
-    make_fixed_width_column(data_type(type_to_id<Element>()),
+    make_fixed_width_column(output_type,
                             size,
                             nullable ? mask_state::UNINITIALIZED : mask_state::UNALLOCATED,
                             stream.value(),

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -41,24 +41,30 @@ struct copy_if_else_functor_impl {
                                      rmm::cuda_stream_view stream,
                                      rmm::mr::device_memory_resource* mr)
   {
+    using Type = device_storage_type_t<T>;
+
     if (left_nullable) {
       if (right_nullable) {
-        auto lhs_iter = cudf::detail::make_pair_iterator<T, true>(lhs);
-        auto rhs_iter = cudf::detail::make_pair_iterator<T, true>(rhs);
-        return detail::copy_if_else(true, lhs_iter, lhs_iter + size, rhs_iter, filter, stream, mr);
+        auto lhs_iter = cudf::detail::make_pair_iterator<Type, true>(lhs);
+        auto rhs_iter = cudf::detail::make_pair_iterator<Type, true>(rhs);
+        return detail::copy_if_else(
+          true, lhs_iter, lhs_iter + size, rhs_iter, filter, lhs.type(), stream, mr);
       }
-      auto lhs_iter = cudf::detail::make_pair_iterator<T, true>(lhs);
-      auto rhs_iter = cudf::detail::make_pair_iterator<T, false>(rhs);
-      return detail::copy_if_else(true, lhs_iter, lhs_iter + size, rhs_iter, filter, stream, mr);
+      auto lhs_iter = cudf::detail::make_pair_iterator<Type, true>(lhs);
+      auto rhs_iter = cudf::detail::make_pair_iterator<Type, false>(rhs);
+      return detail::copy_if_else(
+        true, lhs_iter, lhs_iter + size, rhs_iter, filter, lhs.type(), stream, mr);
     }
     if (right_nullable) {
-      auto lhs_iter = cudf::detail::make_pair_iterator<T, false>(lhs);
-      auto rhs_iter = cudf::detail::make_pair_iterator<T, true>(rhs);
-      return detail::copy_if_else(true, lhs_iter, lhs_iter + size, rhs_iter, filter, stream, mr);
+      auto lhs_iter = cudf::detail::make_pair_iterator<Type, false>(lhs);
+      auto rhs_iter = cudf::detail::make_pair_iterator<Type, true>(rhs);
+      return detail::copy_if_else(
+        true, lhs_iter, lhs_iter + size, rhs_iter, filter, lhs.type(), stream, mr);
     }
-    auto lhs_iter = cudf::detail::make_pair_iterator<T, false>(lhs);
-    auto rhs_iter = cudf::detail::make_pair_iterator<T, false>(rhs);
-    return detail::copy_if_else(false, lhs_iter, lhs_iter + size, rhs_iter, filter, stream, mr);
+    auto lhs_iter = cudf::detail::make_pair_iterator<Type, false>(lhs);
+    auto rhs_iter = cudf::detail::make_pair_iterator<Type, false>(rhs);
+    return detail::copy_if_else(
+      false, lhs_iter, lhs_iter + size, rhs_iter, filter, lhs.type(), stream, mr);
   }
 };
 
@@ -130,42 +136,6 @@ struct copy_if_else_functor_impl<struct_view, Left, Right, Filter> {
                                      rmm::mr::device_memory_resource* mr)
   {
     CUDF_FAIL("copy_if_else not supported for struct_view yet");
-  }
-};
-
-/**
- * @brief Specialization of copy_if_else_functor for decimal32.
- */
-template <typename Left, typename Right, typename Filter>
-struct copy_if_else_functor_impl<numeric::decimal32, Left, Right, Filter> {
-  std::unique_ptr<column> operator()(Left const& lhs,
-                                     Right const& rhs,
-                                     size_type size,
-                                     bool left_nullable,
-                                     bool right_nullable,
-                                     Filter filter,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::mr::device_memory_resource* mr)
-  {
-    CUDF_FAIL("copy_if_else not supported for decimal32 yet");
-  }
-};
-
-/**
- * @brief Specialization of copy_if_else_functor for decimal64.
- */
-template <typename Left, typename Right, typename Filter>
-struct copy_if_else_functor_impl<numeric::decimal64, Left, Right, Filter> {
-  std::unique_ptr<column> operator()(Left const& lhs,
-                                     Right const& rhs,
-                                     size_type size,
-                                     bool left_nullable,
-                                     bool right_nullable,
-                                     Filter filter,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::mr::device_memory_resource* mr)
-  {
-    CUDF_FAIL("copy_if_else not supported for decimal64 yet");
   }
 };
 

--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -113,13 +113,17 @@ std::unique_ptr<column> replace_indices(column_view const& input,
   auto const d_input    = *input_view;
   auto predicate        = [d_input] __device__(auto i) { return d_input.is_valid(i); };
 
+  using Element = typename thrust::
+    tuple_element<0, typename thrust::iterator_traits<ReplacementIter>::value_type>::type;
+
   auto input_pair_iterator = make_nullable_index_iterator<true>(input);
+
   return cudf::detail::copy_if_else(true,
                                     input_pair_iterator,
                                     input_pair_iterator + input.size(),
                                     replacement_iter,
                                     predicate,
-                                    input.type(),
+                                    data_type{type_to_id<Element>()},
                                     stream,
                                     mr);
 }

--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -119,6 +119,7 @@ std::unique_ptr<column> replace_indices(column_view const& input,
                                     input_pair_iterator + input.size(),
                                     replacement_iter,
                                     predicate,
+                                    input.type(),
                                     stream,
                                     mr);
 }

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -63,6 +63,7 @@ struct replace_nans_functor {
                             input_pair_iterator + size,
                             replacement_pair_iterator,
                             predicate,
+                            input.type(),
                             stream,
                             mr);
       } else {
@@ -72,6 +73,7 @@ struct replace_nans_functor {
                             input_pair_iterator + size,
                             replacement_pair_iterator,
                             predicate,
+                            input.type(),
                             stream,
                             mr);
       }
@@ -84,6 +86,7 @@ struct replace_nans_functor {
                             input_pair_iterator + size,
                             replacement_pair_iterator,
                             predicate,
+                            input.type(),
                             stream,
                             mr);
       } else {
@@ -93,6 +96,7 @@ struct replace_nans_functor {
                             input_pair_iterator + size,
                             replacement_pair_iterator,
                             predicate,
+                            input.type(),
                             stream,
                             mr);
       }

--- a/cpp/tests/copying/copy_range_tests.cpp
+++ b/cpp/tests/copying/copy_range_tests.cpp
@@ -466,12 +466,12 @@ TEST_F(CopyRangeErrorTestFixture, DTypeMismatch)
 }
 
 template <typename T>
-struct FixedPointTypes : public cudf::test::BaseFixture {
+struct FixedPointTypesCopyRange : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_CASE(FixedPointTypes, cudf::test::FixedPointTypes);
+TYPED_TEST_CASE(FixedPointTypesCopyRange, cudf::test::FixedPointTypes);
 
-TYPED_TEST(FixedPointTypes, FixedPointSimple)
+TYPED_TEST(FixedPointTypesCopyRange, FixedPointSimple)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
@@ -486,7 +486,7 @@ TYPED_TEST(FixedPointTypes, FixedPointSimple)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
-TYPED_TEST(FixedPointTypes, FixedPointLarge)
+TYPED_TEST(FixedPointTypesCopyRange, FixedPointLarge)
 {
   using namespace numeric;
   using namespace cudf::test;
@@ -506,7 +506,7 @@ TYPED_TEST(FixedPointTypes, FixedPointLarge)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
-TYPED_TEST(FixedPointTypes, FixedPointScaleMismatch)
+TYPED_TEST(FixedPointTypesCopyRange, FixedPointScaleMismatch)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;

--- a/cpp/tests/copying/copy_tests.cu
+++ b/cpp/tests/copying/copy_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/copying/copy_tests.cu
+++ b/cpp/tests/copying/copy_tests.cu
@@ -561,3 +561,61 @@ TEST_F(StringsCopyIfElseTest, CopyIfElseScalarScalar)
   cudf::test::strings_column_wrapper expected(h_expected.begin(), h_expected.end(), valids);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
+
+template <typename T>
+struct FixedPointTypes : public cudf::test::BaseFixture {
+};
+
+TYPED_TEST_CASE(FixedPointTypes, cudf::test::FixedPointTypes);
+
+TYPED_TEST(FixedPointTypes, FixedPointSimple)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const mask     = cudf::test::fixed_width_column_wrapper<bool>{0, 1, 1, 1, 0, 0};
+  auto const a        = fp_wrapper{{110, 220, 330, 440, 550, 660}, scale_type{-2}};
+  auto const b        = fp_wrapper{{0, 0, 0, 0, 0, 0}, scale_type{-2}};
+  auto const expected = fp_wrapper{{0, 220, 330, 440, 0, 0}, scale_type{-2}};
+  auto const result   = cudf::copy_if_else(a, b, mask);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTypes, FixedPointLarge)
+{
+  using namespace numeric;
+  using namespace cudf::test;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto a = thrust::make_counting_iterator(-1000);
+  auto b = thrust::make_constant_iterator(0);
+  auto m = make_counting_transform_iterator(-1000, [](int i) { return i > 0; });
+  auto e = make_counting_transform_iterator(-1000, [](int i) { return std::max(0, i); });
+
+  auto const mask     = cudf::test::fixed_width_column_wrapper<bool>(m, m + 2000);
+  auto const A        = fp_wrapper{a, a + 2000, scale_type{-3}};
+  auto const B        = fp_wrapper{b, b + 2000, scale_type{-3}};
+  auto const expected = fp_wrapper{e, e + 2000, scale_type{-3}};
+  auto const result   = cudf::copy_if_else(A, B, mask);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTypes, FixedPointScaleMismatch)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const mask = cudf::test::fixed_width_column_wrapper<bool>{0, 1, 1, 1, 0, 0};
+  auto const a    = fp_wrapper{{110, 220, 330, 440, 550, 660}, scale_type{-2}};
+  auto const b    = fp_wrapper{{0, 0, 0, 0, 0, 0}, scale_type{-1}};
+
+  EXPECT_THROW(cudf::copy_if_else(a, b, mask), cudf::logic_error);
+}


### PR DESCRIPTION
This PR resolves a part of https://github.com/rapidsai/cudf/issues/3556.

**To Do List:**
* [x] Implementation
* [x] Basic unit tests
* [x] Comprehensive unit tests