### PR TITLE
[REVIEW] Fix contiguous split of null string columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@
 
 - PR #6853 Fix contiguous split of null string columns
 
+
 # cuDF 0.16.0 (21 Oct 2020)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,6 @@
 - PR #6830 Fix categorical scalar insertion
 - PR #6854 Fix the parameter order of writeParquetBufferBegin
 - PR #6855 Fix `.str.replace_with_backrefs` docs examples
-
 - PR #6853 Fix contiguous split of null string columns
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@
 - PR #6854 Fix the parameter order of writeParquetBufferBegin
 - PR #6855 Fix `.str.replace_with_backrefs` docs examples
 
+- PR #6853 Fix contiguous split of null string columns
 
 # cuDF 0.16.0 (21 Oct 2020)
 

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -435,16 +435,20 @@ std::pair<src_buf_info*, size_type> buf_info_functor::operator()<cudf::string_vi
                           parent_offset_index,
                           false,
                           col.offset());
-  current++;
-  offset_stack_pos += offset_depth;
 
-  // since we are crossing an offset boundary, our offset_depth and parent_offset_index go up.
-  offset_depth++;
-  parent_offset_index = offset_col - head;
+  // prevent appending buf_info for non-exist chars buffer
+  if (scv.chars_size() > 0) {
+    current++;
+    offset_stack_pos += offset_depth;
 
-  // info for the chars buffer
-  *current = src_buf_info(
-    type_id::INT8, nullptr, offset_stack_pos, parent_offset_index, false, col.offset());
+    // since we are crossing an offset boundary, our offset_depth and parent_offset_index go up.
+    offset_depth++;
+    parent_offset_index = offset_col - head;
+
+    // info for the chars buffer
+    *current = src_buf_info(
+      type_id::INT8, nullptr, offset_stack_pos, parent_offset_index, false, col.offset());
+  }
 
   return {current + 1, offset_stack_pos + offset_depth};
 }
@@ -598,9 +602,10 @@ BufInfo build_output_columns(InputIter begin,
         return std::make_pair(ptr, size);
       }
       // Parent columns w/o data (e.g., strings, lists) don't have an associated `dst_buf_info`,
-      // therefore, use the first child's info. their num_rows value will be correct (also see
-      // comment above)
-      return std::make_pair(static_cast<uint8_t const*>(nullptr), current_info->num_rows);
+      // therefore, use the first child's info if it has at least one child. Their num_rows value
+      // will be correct (also see comment above)
+      auto const size = (src.num_children() == 0) ? 0 : current_info->num_rows;
+      return std::make_pair(static_cast<uint8_t const*>(nullptr), size);
     }();
     auto children = std::vector<column_view>{};
     children.reserve(src.num_children());


### PR DESCRIPTION
This PR attempts to address #6842, which may be caused by multiple reasons.
For now, one certain problem is contiguous splitting on null (fully invalid) string columns, which only contains single child column (offset column). This PR is about to fix this problem with below changes:
1.  Skip non-exist chars buffer for string column views when `setup_source_buf_info`.
2. Adapt size computing for empty leaf columns when`build_output_columns`.
3. Provide specialized test case for null string columns, which will fail without above changes.
