### PR TITLE
Fix compile error in type_dispatch_benchmark.cu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@
 - PR #6854 Fix the parameter order of writeParquetBufferBegin
 - PR #6855 Fix `.str.replace_with_backrefs` docs examples
 - PR #6853 Fix contiguous split of null string columns
+- PR #6861 Fix compile error in type_dispatch_benchmark.cu
 
 
 # cuDF 0.16.0 (21 Oct 2020)

--- a/cpp/benchmarks/type_dispatcher/type_dispatcher_benchmark.cu
+++ b/cpp/benchmarks/type_dispatcher/type_dispatcher_benchmark.cu
@@ -88,15 +88,12 @@ __global__ void host_dispatching_kernel(mutable_column_device_view source_column
 template <FunctorType functor_type>
 struct ColumnHandle {
   template <typename ColumnType>
-  void operator()(mutable_column_device_view source_column,
-                  int work_per_thread,
-                  rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+  void operator()(mutable_column_device_view source_column, int work_per_thread)
   {
     cudf::detail::grid_1d grid_config{source_column.size(), block_size};
     int grid_size = grid_config.num_blocks;
     // Launch the kernel.
-    host_dispatching_kernel<functor_type, ColumnType>
-      <<<grid_size, block_size, 0, stream.value()>>>(source_column);
+    host_dispatching_kernel<functor_type, ColumnType><<<grid_size, block_size>>>(source_column);
   }
 };
 


### PR DESCRIPTION
Compile error for `type_dispatch_benchmark.cu`

```
[40+16+94=149] Building CUDA object benchmarks/CMake...H.dir/type_dispatcher/type_dispatcher_benchmark.cu.o
FAILED: benchmarks/CMakeFiles/TYPE_DISPATCHER_BENCH.dir/type_dispatcher/type_dispatcher_benchmark.cu.o 
/usr/local/cuda/bin/nvcc -forward-unknown-to-host-compiler -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_ -Igoogletest/install/include -Igooglebenchmark/install/include -I_deps/thrust-src -I_deps/jitify-src -I_deps/libcudacxx-src/include -I/usr/local/cuda/targets/x86_64-linux/include -Iinclude -I../include -I../ -I../src -I../thirdparty/dlpack/include -I/conda/envs/rapids/include -I../benchmarks -Xcompiler -Wno-parentheses -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_70,code=compute_70 --expt-extended-lambda --expt-relaxed-constexpr -Werror=cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-error=deprecated-declarations -Xcompiler -Wno-deprecated-declarations -DBOOST_NO_CXX14_CONSTEXPR -O3 -DNDEBUG -Xcompiler=-fPIE   -DJITIFY_USE_CACHE -DCUDF_VERSION=0.17.0 -std=c++14 -MD -MT benchmarks/CMakeFiles/TYPE_DISPATCHER_BENCH.dir/type_dispatcher/type_dispatcher_benchmark.cu.o -MF benchmarks/CMakeFiles/TYPE_DISPATCHER_BENCH.dir/type_dispatcher/type_dispatcher_benchmark.cu.o.d -x cu -c ../benchmarks/type_dispatcher/type_dispatcher_benchmark.cu -o benchmarks/CMakeFiles/TYPE_DISPATCHER_BENCH.dir/type_dispatcher/type_dispatcher_benchmark.cu.o
../include/cudf/utilities/type_dispatcher.hpp(393): error: identifier "rmm::cuda_stream_default" is undefined in device code

../include/cudf/utilities/type_dispatcher.hpp(396): error: identifier "rmm::cuda_stream_default" is undefined in device code

```

Looks like this may have been introduced with the `cudaStream_t` to `rmm::cuda_stream_view` conversion.

Removed unused stream parameter from type-dispatcher benchmark source.