### PR TITLE
Update JNI to new gather boundary check API [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,8 @@
 - PR #6869 Avoid dependency resolution failure in latest version of pip by explicitly specifying versions for dask and distributed
 - PR #6806 Force install of local conda artifacts
 - PR #6887 Fix typo and `0-d` numpy array handling in binary operation
+- PR #6899 Update JNI to new gather boundary check API
+
 
 # cuDF 0.16.0 (21 Oct 2020)
 

--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -158,7 +158,7 @@ std::unique_ptr<column> map_lookup(column_view const &map_column, string_scalar 
   auto table_for_gather = table_view{std::vector<cudf::column_view>{values_column}};
 
   auto gathered_table = cudf::detail::gather(
-      table_for_gather, gather_map->view(), detail::out_of_bounds_policy::IGNORE,
+      table_for_gather, gather_map->view(), out_of_bounds_policy::NULLIFY,
       detail::negative_index_policy::NOT_ALLOWED, stream, mr);
 
   return std::make_unique<cudf::column>(std::move(gathered_table->get_column(0)));


### PR DESCRIPTION
#6875 updated the gather bounds checking enums which broke the `map_lookup` code in the JNI.  This updates the code to use the new API.
