### PR TITLE
[gpuCI] Auto-merge branch-0.17 to branch-0.18 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@
 - PR #6869 Avoid dependency resolution failure in latest version of pip by explicitly specifying versions for dask and distributed
 - PR #6806 Force install of local conda artifacts
 - PR #6887 Fix typo and `0-d` numpy array handling in binary operation
+- PR #6898 Fix missing clone overrides on derived aggregations
 - PR #6899 Update JNI to new gather boundary check API
 
 

--- a/cpp/include/cudf/detail/aggregation/aggregation.hpp
+++ b/cpp/include/cudf/detail/aggregation/aggregation.hpp
@@ -61,6 +61,11 @@ struct min_aggregation final : aggregation {
       return {this->kind};
   }
   void finalize(aggregation_finalizer& finalizer) override { finalizer.visit(*this); }
+
+  std::unique_ptr<aggregation> clone() const override
+  {
+    return std::make_unique<min_aggregation>(*this);
+  }
 };
 
 /**
@@ -77,6 +82,11 @@ struct max_aggregation final : aggregation {
       return {this->kind};
   }
   void finalize(aggregation_finalizer& finalizer) override { finalizer.visit(*this); }
+
+  std::unique_ptr<aggregation> clone() const override
+  {
+    return std::make_unique<max_aggregation>(*this);
+  }
 };
 
 /**
@@ -173,6 +183,11 @@ struct mean_aggregation final : aggregation {
     return {aggregation::SUM, aggregation::COUNT_VALID};
   }
   void finalize(aggregation_finalizer& finalizer) override { finalizer.visit(*this); }
+
+  std::unique_ptr<aggregation> clone() const override
+  {
+    return std::make_unique<mean_aggregation>(*this);
+  }
 };
 
 /**


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.17` that creates a PR to keep `branch-0.18` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.