### PR TITLE
Fix rmm_mode=managed parameter for gtests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Bug Fixes
 
+- PR #6912 Fix rmm_mode=managed parameter for gtests
+
+
 # cuDF 0.17.0 (Date TBD)
 
 ## New Features

--- a/cpp/include/cudf_test/base_fixture.hpp
+++ b/cpp/include/cudf_test/base_fixture.hpp
@@ -243,7 +243,7 @@ inline std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(
   if (allocation_mode == "binning") return make_binning();
   if (allocation_mode == "cuda") return make_cuda();
   if (allocation_mode == "pool") return make_pool();
-  if (allocation_mode == "managed") make_managed();
+  if (allocation_mode == "managed") return make_managed();
   CUDF_FAIL("Invalid RMM allocation mode: " + allocation_mode);
 }
 


### PR DESCRIPTION
When using parameter `--rmm_mode=managed` for gtests `Invalid RMM allocation mode: managed` exception is thrown.
The logic in `include/cudf_test/base_fixture.hpp` is just missing a return statement.