### PR TITLE
[REVIEW] ignore list dtypes for select_dtype, similar to pandas

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -6741,7 +6741,7 @@ class DataFrame(Frame, Serializable):
                 # category handling
                 if is_categorical_dtype(i_dtype):
                     include_subtypes.add(i_dtype)
-                elif issubclass(dtype.type, i_dtype):
+                elif type(dtype.type) == type and issubclass(dtype.type, i_dtype):
                     include_subtypes.add(dtype.type)
 
         # exclude all subtypes
@@ -6751,7 +6751,7 @@ class DataFrame(Frame, Serializable):
                 # category handling
                 if is_categorical_dtype(e_dtype):
                     exclude_subtypes.add(e_dtype)
-                elif issubclass(dtype.type, e_dtype):
+                elif type(dtype.type) == type and issubclass(dtype.type, e_dtype):
                     exclude_subtypes.add(dtype.type)
 
         include_all = set(

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2972,6 +2972,17 @@ def test_select_dtype():
         gdf.select_dtypes(include=["int"], exclude=["object"]),
     )
 
+    gdf = gd.DataFrame({'int_col': [0, 1, 2], 'list_col': [[1, 2], [3, 4], [5, 6]]})
+    pdf = gdf.to_pandas()
+    assert_eq(
+        pdf.select_dtypes(include=['int64']).columns,
+        gdf.select_dtypes(include=['int64']).columns
+    )
+    assert_eq(
+        pdf.select_dtypes(exclude=['int64']).columns,
+        gdf.select_dtypes(exclude=['int64']).columns
+    )
+
 
 def test_select_dtype_datetime():
     gdf = gd.datasets.timeseries(

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -248,7 +248,7 @@ def cudf_dtype_from_pydata_dtype(dtype):
 
     if is_categorical_dtype(dtype):
         return cudf.core.dtypes.CategoricalDtype
-    elif dtype in cudf._lib.types.np_to_cudf_types:
+    elif dtype.__hash__ and dtype in cudf._lib.types.np_to_cudf_types:
         return dtype.type
 
     return infer_dtype_from_object(dtype)


### PR DESCRIPTION
Closes #6919 

Prevents select dtypes failure when list dyptes are in dataframe. Follows pandas API.