### PR TITLE
Use simplified `rmm::exec_policy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - PR #6922 Fix N/A detection for empty fields in CSV reader
 - PR #6912 Fix rmm_mode=managed parameter for gtests
+- PR #6942 Fix cudf::merge gtest for dictionary columns
 
 
 # cuDF 0.17.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #6275 Update to official libcu++ on Github
 - PR #6838 Fix `columns` & `index` handling in dataframe constructor
 - PR #6750 Remove **kwargs from string/categorical methods
+- PR #6939 Use simplified `rmm::exec_policy`
 
 ## Bug Fixes
 

--- a/cpp/docs/TRANSITIONGUIDE.md
+++ b/cpp/docs/TRANSITIONGUIDE.md
@@ -155,7 +155,7 @@ namespace detail{
         RMM_ALLOC(...,stream);
         CUDA_TRY(cudaMemcpyAsync(...,stream.value()));
         kernel<<<..., stream>>>(...);
-        thrust::algorithm(rmm::exec_policy(stream)->on(stream), ...);
+        thrust::algorithm(rmm::exec_policy(stream), ...);
         stream.synchronize();
         RMM_FREE(...,stream);
     }

--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -19,8 +19,8 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
 
 namespace cudf {
 /**

--- a/cpp/include/cudf/detail/aggregation/aggregation.cuh
+++ b/cpp/include/cudf/detail/aggregation/aggregation.cuh
@@ -24,6 +24,7 @@
 #include <cudf/table/table_device_view.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -423,10 +424,7 @@ struct identity_initializer {
   std::enable_if_t<is_supported<T, k>(), void> operator()(mutable_column_view const& col,
                                                           rmm::cuda_stream_view stream)
   {
-    thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
-                 col.begin<T>(),
-                 col.end<T>(),
-                 get_identity<T, k>());
+    thrust::fill(rmm::exec_policy(stream), col.begin<T>(), col.end<T>(), get_identity<T, k>());
   }
 
   template <typename T, aggregation::Kind k>

--- a/cpp/include/cudf/detail/copy_if.cuh
+++ b/cpp/include/cudf/detail/copy_if.cuh
@@ -283,7 +283,7 @@ struct scatter_gather_functor {
   {
     rmm::device_uvector<cudf::size_type> indices(output_size, stream);
 
-    thrust::copy_if(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::copy_if(rmm::exec_policy(stream),
                     thrust::counting_iterator<cudf::size_type>(0),
                     thrust::counting_iterator<cudf::size_type>(input.size()),
                     indices.begin(),

--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -34,8 +34,9 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <algorithm>
 
@@ -125,7 +126,7 @@ void gather_helper(InputItr source_itr,
 {
   using map_type = typename std::iterator_traits<MapIterator>::value_type;
   if (nullify_out_of_bounds) {
-    thrust::gather_if(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::gather_if(rmm::exec_policy(stream),
                       gather_map_begin,
                       gather_map_end,
                       gather_map_begin,
@@ -133,11 +134,8 @@ void gather_helper(InputItr source_itr,
                       target_itr,
                       bounds_checker<map_type>{0, source_size});
   } else {
-    thrust::gather(rmm::exec_policy(stream)->on(stream.value()),
-                   gather_map_begin,
-                   gather_map_end,
-                   source_itr,
-                   target_itr);
+    thrust::gather(
+      rmm::exec_policy(stream), gather_map_begin, gather_map_end, source_itr, target_itr);
   }
 }
 

--- a/cpp/include/cudf/detail/groupby/sort_helper.hpp
+++ b/cpp/include/cudf/detail/groupby/sort_helper.hpp
@@ -21,8 +21,8 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
 
 namespace cudf {
 namespace groupby {

--- a/cpp/include/cudf/detail/indexalator.cuh
+++ b/cpp/include/cudf/detail/indexalator.cuh
@@ -314,7 +314,7 @@ struct input_indexalator : base_indexalator<input_indexalator> {
  * Example output iterator usage.
  * @code
  *  auto result_itr = indexalator_factory::create_output_iterator(indices->mutable_view());
- *  thrust::lower_bound(rmm::exec_policy(stream)->on(stream),
+ *  thrust::lower_bound(rmm::exec_policy(stream),
  *                      input->begin<Element>(),
  *                      input->end<Element>(),
  *                      values->begin<Element>(),

--- a/cpp/include/cudf/detail/reduction.cuh
+++ b/cpp/include/cudf/detail/reduction.cuh
@@ -20,10 +20,10 @@
 
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_reduce.cuh>
 
@@ -209,7 +209,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
   // compute the result value from intermediate value in device
   using ScalarType = cudf::scalar_type_t<OutputType>;
   auto result      = new ScalarType(OutputType{0}, true, stream, mr);
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      intermediate_result.data(),
                      1,
                      [dres = result->data(), cop, valid_count, ddof] __device__(auto i) {

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -30,6 +30,7 @@
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -69,7 +70,7 @@ auto scatter_to_gather(MapIterator scatter_map_begin,
 
   // Convert scatter map to a gather map
   thrust::scatter(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<MapValueType>(0),
     thrust::make_counting_iterator<MapValueType>(std::distance(scatter_map_begin, scatter_map_end)),
     scatter_map_begin,
@@ -94,7 +95,7 @@ struct column_scatterer_impl {
 
     // NOTE use source.begin + scatter rows rather than source.end in case the
     // scatter map is smaller than the number of source rows
-    thrust::scatter(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::scatter(rmm::exec_policy(stream),
                     source.begin<Type>(),
                     source.begin<Type>() + cudf::distance(scatter_map_begin, scatter_map_end),
                     scatter_map_begin,
@@ -180,7 +181,7 @@ struct column_scatterer_impl<dictionary32, MapIterator> {
     auto source_itr  = indexalator_factory::make_input_iterator(source_view.indices());
     auto new_indices = std::make_unique<column>(target_view.get_indices_annotated(), stream, mr);
     auto target_itr  = indexalator_factory::make_output_iterator(new_indices->mutable_view());
-    thrust::scatter(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::scatter(rmm::exec_policy(stream),
                     source_itr,
                     source_itr + std::distance(scatter_map_begin, scatter_map_end),
                     scatter_map_begin,
@@ -262,8 +263,7 @@ std::unique_ptr<table> scatter(
     auto bounds      = bounds_checker<MapType>{begin, end};
     CUDF_EXPECTS(
       std::distance(scatter_map_begin, scatter_map_end) ==
-        thrust::count_if(
-          rmm::exec_policy(stream)->on(stream.value()), scatter_map_begin, scatter_map_end, bounds),
+        thrust::count_if(rmm::exec_policy(stream), scatter_map_begin, scatter_map_end, bounds),
       "Scatter map index out of bounds");
   }
 

--- a/cpp/include/cudf/detail/unary.hpp
+++ b/cpp/include/cudf/detail/unary.hpp
@@ -20,6 +20,7 @@
 #include <cudf/unary.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -54,7 +55,7 @@ std::unique_ptr<column> true_if(
   auto output_mutable_view = output->mutable_view();
   auto output_data         = output_mutable_view.data<bool>();
 
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()), begin, end, output_data, p);
+  thrust::transform(rmm::exec_policy(stream), begin, end, output_data, p);
 
   return output;
 }

--- a/cpp/include/cudf/lists/detail/gather.cuh
+++ b/cpp/include/cudf/lists/detail/gather.cuh
@@ -21,6 +21,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/transform_scan.h>
 
@@ -82,7 +83,7 @@ gather_data make_gather_data(cudf::lists_column_view const& source_column,
   // generate the compacted outgoing offsets.
   auto count_iter = thrust::make_counting_iterator<int32_t>(0);
   thrust::transform_exclusive_scan(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     count_iter,
     count_iter + offset_count,
     dst_offsets_v.begin<int32_t>(),
@@ -106,7 +107,7 @@ gather_data make_gather_data(cudf::lists_column_view const& source_column,
 
   // generate the base offsets
   rmm::device_uvector<int32_t> base_offsets = rmm::device_uvector<int32_t>(output_count, stream);
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     gather_map,
                     gather_map + output_count,
                     base_offsets.data(),

--- a/cpp/include/cudf/lists/detail/scatter.cuh
+++ b/cpp/include/cudf/lists/detail/scatter.cuh
@@ -28,6 +28,7 @@
 #include <cudf/types.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
 
@@ -148,7 +149,7 @@ rmm::device_uvector<unbound_list_view> list_vector_from_column(
 
   auto vector = rmm::device_uvector<unbound_list_view>(n_rows, stream, mr);
 
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(n_rows),
                     vector.begin(),
@@ -233,7 +234,7 @@ void print(std::string const& msg, column_view const& col, rmm::cuda_stream_view
 
   std::cout << msg << " = [";
   thrust::for_each_n(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     col.size(),
     [c = col.template data<int32_t>()] __device__(auto const& i) { printf("%d,", c[i]); });
@@ -246,7 +247,7 @@ void print(std::string const& msg,
 {
   std::cout << msg << " == [";
 
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      scatter.size(),
                      [s = scatter.begin()] __device__(auto const& i) {
@@ -420,7 +421,7 @@ struct list_child_constructor {
     };
 
     // For each list-row, copy underlying elements to the child column.
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        list_vector.size(),
                        copy_child_values_for_list_index);
@@ -490,7 +491,7 @@ struct list_child_constructor {
         });
     };
 
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        list_vector.size(),
                        populate_string_views);
@@ -581,7 +582,7 @@ struct list_child_constructor {
         });
     };
 
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        list_vector.size(),
                        populate_child_list_views);
@@ -780,7 +781,7 @@ std::unique_ptr<column> scatter(
                                                mr);
 
   // Scatter.
-  thrust::scatter(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::scatter(rmm::exec_policy(stream),
                   source_vector.begin(),
                   source_vector.end(),
                   scatter_map_begin,

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -21,7 +21,6 @@
 
 #include <cudf/fixed_point/fixed_point.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -372,7 +372,8 @@ class fixed_point_scalar : public scalar {
    */
   T fixed_point_value(rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
   {
-    return T{_data.value(stream), numeric::scale_type{type().scale()}};
+    using namespace numeric;
+    return T{scaled_integer<rep_type>{_data.value(stream), scale_type{type().scale()}}};
   }
 
   /**

--- a/cpp/include/cudf/strings/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/strings/detail/copy_if_else.cuh
@@ -23,6 +23,7 @@
 #include <cudf/strings/strings_column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace strings {
@@ -62,7 +63,6 @@ std::unique_ptr<cudf::column> copy_if_else(
   auto strings_count = std::distance(lhs_begin, lhs_end);
   if (strings_count == 0) return make_empty_strings_column(stream, mr);
 
-  auto execpol = rmm::exec_policy(stream);
   // create null mask
   auto valid_mask = cudf::detail::valid_if(
     thrust::make_counting_iterator<size_type>(0),
@@ -97,7 +97,7 @@ std::unique_ptr<cudf::column> copy_if_else(
   auto d_chars      = chars_column->mutable_view().template data<char>();
   // fill in chars
   thrust::for_each_n(
-    execpol->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     [lhs_begin, rhs_begin, filter_fn, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/include/cudf/strings/detail/copy_range.cuh
+++ b/cpp/include/cudf/strings/detail/copy_range.cuh
@@ -24,6 +24,7 @@
 #include <cudf/types.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -187,7 +188,7 @@ std::unique_ptr<column> copy_range(
     // copy to the chars column
 
     auto p_chars = (p_chars_column->mutable_view()).template data<char>();
-    thrust::for_each(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each(rmm::exec_policy(stream),
                      thrust::make_counting_iterator(0),
                      thrust::make_counting_iterator(target.size()),
                      [source_value_begin,

--- a/cpp/include/cudf/strings/detail/scatter.cuh
+++ b/cpp/include/cudf/strings/detail/scatter.cuh
@@ -23,6 +23,7 @@
 #include <cudf/strings/strings_column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace strings {
@@ -71,8 +72,7 @@ std::unique_ptr<column> scatter(
   rmm::device_vector<string_view> target_vector =
     create_string_vector_from_column(target, stream.value());
   // do the scatter
-  thrust::scatter(
-    rmm::exec_policy(stream)->on(stream.value()), begin, end, scatter_map, target_vector.begin());
+  thrust::scatter(rmm::exec_policy(stream), begin, end, scatter_map, target_vector.begin());
 
   // build offsets column
   auto offsets_column = child_offsets_from_string_vector(target_vector, stream, mr);

--- a/cpp/include/cudf/strings/detail/utilities.cuh
+++ b/cpp/include/cudf/strings/detail/utilities.cuh
@@ -18,8 +18,8 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/scan.h>
 
@@ -59,7 +59,7 @@ std::unique_ptr<column> make_offsets_child_column(
   // Rather than manually computing the final offset using values in device memory,
   // we use inclusive-scan on a shifted output (d_offsets+1) and then set the first
   // offset values to zero manually.
-  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()), begin, end, d_offsets + 1);
+  thrust::inclusive_scan(rmm::exec_policy(stream), begin, end, d_offsets + 1);
   CUDA_TRY(cudaMemsetAsync(d_offsets, 0, sizeof(int32_t), stream.value()));
   return offsets_column;
 }

--- a/cpp/include/cudf/strings/detail/utilities.hpp
+++ b/cpp/include/cudf/strings/detail/utilities.hpp
@@ -18,8 +18,8 @@
 #include <cudf/column/column.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
 
 namespace cudf {
 namespace strings {

--- a/cpp/include/cudf/strings/strings_column_view.hpp
+++ b/cpp/include/cudf/strings/strings_column_view.hpp
@@ -18,8 +18,8 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
 
 /**
  * @file

--- a/cpp/include/cudf/utilities/span.hpp
+++ b/cpp/include/cudf/utilities/span.hpp
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/device_vector.h>

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -34,6 +34,7 @@
 
 #include <rmm/device_buffer.hpp>
 
+#include <thrust/copy.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 

--- a/cpp/include/cudf_test/timestamp_utilities.cuh
+++ b/cpp/include/cudf_test/timestamp_utilities.cuh
@@ -19,11 +19,8 @@
 #include <cudf/wrappers/timestamps.hpp>
 #include <cudf_test/column_wrapper.hpp>
 
-#include <thrust/device_vector.h>
 #include <thrust/logical.h>
 #include <thrust/sequence.h>
-
-#include <rmm/thrust_rmm_allocator.h>
 
 namespace cudf {
 namespace test {
@@ -31,7 +28,7 @@ using time_point_ms =
   cuda::std::chrono::time_point<cuda::std::chrono::system_clock, cuda::std::chrono::milliseconds>;
 
 /**
- * @brief Creates a `thrust::device_vector` with ascending timestamps in the
+ * @brief Creates a `fixed_width_column_wrapper` with ascending timestamps in the
  * range `[start, stop)`.
  *
  * The period is inferred from `count` and difference between `start`

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -24,10 +24,10 @@
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
+#include <rmm/device_vector.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/binary_search.h>

--- a/cpp/src/column/column_device_view.cu
+++ b/cpp/src/column/column_device_view.cu
@@ -18,7 +18,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 
 #include <numeric>

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -29,6 +29,8 @@
 #include <cudf/table/table_device_view.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
 #include <thrust/transform_scan.h>
@@ -274,10 +276,7 @@ std::unique_ptr<column> for_each_concatenate(std::vector<column_view> const& vie
 
   auto count = 0;
   for (auto& v : views) {
-    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
-                 v.begin<T>(),
-                 v.end<T>(),
-                 m_view.begin<T>() + count);
+    thrust::copy(rmm::exec_policy(stream), v.begin<T>(), v.end<T>(), m_view.begin<T>() + count);
     count += v.size();
   }
 

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -25,7 +25,7 @@
 #include <cudf/utilities/bit.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/discard_iterator.h>
 
@@ -789,7 +789,7 @@ std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& in
 
   // compute sizes of each column in each partition, including alignment.
   thrust::transform(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_t>(0),
     thrust::make_counting_iterator<size_t>(num_bufs),
     d_dst_buf_info,
@@ -862,7 +862,7 @@ std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& in
     auto values = thrust::make_transform_iterator(thrust::make_counting_iterator(0),
                                                   buf_size_functor{d_dst_buf_info});
 
-    thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::reduce_by_key(rmm::exec_policy(stream),
                           keys,
                           keys + num_bufs,
                           values,
@@ -876,7 +876,7 @@ std::vector<contiguous_split_result> contiguous_split(cudf::table_view const& in
                                                 split_key_functor{static_cast<int>(num_src_bufs)});
     auto values = thrust::make_transform_iterator(thrust::make_counting_iterator(0),
                                                   buf_size_functor{d_dst_buf_info});
-    thrust::exclusive_scan_by_key(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::exclusive_scan_by_key(rmm::exec_policy(stream),
                                   keys,
                                   keys + num_bufs,
                                   values,

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -66,7 +66,7 @@ std::unique_ptr<table> sample(table_view const& input,
       data_type{type_id::INT32}, num_rows, mask_state::UNALLOCATED, stream.value());
     auto gather_map_mutable_view = gather_map->mutable_view();
     // Shuffle all the row indices
-    thrust::shuffle_copy(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::shuffle_copy(rmm::exec_policy(stream),
                          thrust::counting_iterator<size_type>(0),
                          thrust::counting_iterator<size_type>(num_rows),
                          gather_map_mutable_view.begin<size_type>(),

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -27,6 +27,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/copy.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -105,8 +106,7 @@ struct shift_functor {
         return out_of_bounds(size, src_idx) ? *fill : input.element<Type>(src_idx);
       };
 
-    thrust::transform(
-      rmm::exec_policy(stream)->on(stream.value()), index_begin, index_end, data, func_value);
+    thrust::transform(rmm::exec_policy(stream), index_begin, index_end, data, func_value);
 
     return output;
   }

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -26,8 +26,8 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace datetime {
@@ -146,7 +146,7 @@ struct launch_functor {
   typename std::enable_if_t<cudf::is_timestamp_t<Timestamp>::value, void> operator()(
     rmm::cuda_stream_view stream) const
   {
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       input.begin<Timestamp>(),
                       input.end<Timestamp>(),
                       output.begin<OutputColT>(),
@@ -219,7 +219,7 @@ struct add_calendrical_months_functor {
   typename std::enable_if_t<cudf::is_timestamp_t<Timestamp>::value, void> operator()(
     rmm::cuda_stream_view stream) const
   {
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       timestamp_column.begin<Timestamp>(),
                       timestamp_column.end<Timestamp>(),
                       months_column.begin<int16_t>(),

--- a/cpp/src/dictionary/add_keys.cu
+++ b/cpp/src/dictionary/add_keys.cu
@@ -28,7 +28,6 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf {

--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -26,6 +26,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
 #include <thrust/transform_scan.h>
@@ -158,7 +159,7 @@ struct dispatch_compute_indices {
     auto result_itr =
       cudf::detail::indexalator_factory::make_output_iterator(result->mutable_view());
     // new indices values are computed by matching the concatenated keys to the new key set
-    thrust::lower_bound(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::lower_bound(rmm::exec_policy(stream),
                         new_keys_view->begin<Element>(),
                         new_keys_view->end<Element>(),
                         all_itr,
@@ -236,7 +237,7 @@ std::unique_ptr<column> concatenate(std::vector<column_view> const& columns,
                                                      });
   // the indices offsets (pair.second) are for building the map
   thrust::lower_bound(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     children_offsets.begin() + 1,
     children_offsets.end(),
     indices_itr,

--- a/cpp/src/dictionary/detail/merge.cu
+++ b/cpp/src/dictionary/detail/merge.cu
@@ -23,6 +23,7 @@
 #include <cudf/dictionary/dictionary_factories.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace dictionary {
@@ -46,7 +47,7 @@ std::unique_ptr<column> merge(dictionary_column_view const& lcol,
     cudf::detail::indexalator_factory::make_output_iterator(indices_column->mutable_view());
 
   // merge the input indices columns into the output column
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     row_order.begin(),
                     row_order.end(),
                     output_iter,

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -27,6 +27,7 @@
 #include <cudf/table/table_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
@@ -59,7 +60,6 @@ std::unique_ptr<column> remove_keys_fn(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto const keys_view    = dictionary_column.keys();
-  auto execpol            = rmm::exec_policy(stream);
   auto const indices_type = dictionary_column.indices().type();
   auto const max_size     = dictionary_column.size();
 
@@ -69,7 +69,7 @@ std::unique_ptr<column> remove_keys_fn(
   auto map_itr =
     cudf::detail::indexalator_factory::make_output_iterator(map_indices->mutable_view());
   // init to max to identify new nulls
-  thrust::fill(execpol->on(stream.value()),
+  thrust::fill(rmm::exec_policy(stream),
                map_itr,
                map_itr + keys_view.size(),
                max_size);  // all valid indices are less than this value
@@ -81,7 +81,7 @@ std::unique_ptr<column> remove_keys_fn(
       auto positions = make_fixed_width_column(
         indices_type, keys_view.size(), cudf::mask_state::UNALLOCATED, stream);
       auto itr = cudf::detail::indexalator_factory::make_output_iterator(positions->mutable_view());
-      thrust::sequence(execpol->on(stream.value()), itr, itr + keys_view.size());
+      thrust::sequence(rmm::exec_policy(stream), itr, itr + keys_view.size());
       return positions;
     }();
     // copy the non-removed keys ( keys_to_keep_fn(idx)==true )
@@ -95,7 +95,7 @@ std::unique_ptr<column> remove_keys_fn(
       cudf::detail::indexalator_factory::make_input_iterator(keys_positions->view());
     // build indices mapper
     // Example scatter([0,1,2][0,2,4][max,max,max,max,max]) => [0,max,1,max,2]
-    thrust::scatter(execpol->on(stream.value()),
+    thrust::scatter(rmm::exec_policy(stream),
                     positions_itr,
                     positions_itr + filtered_view.size(),
                     filtered_itr,
@@ -176,8 +176,7 @@ std::unique_ptr<column> remove_unused_keys(
   auto const matches = [&] {
     // build keys index to verify against indices values
     rmm::device_uvector<uint32_t> keys_positions(keys_size, stream);
-    thrust::sequence(
-      rmm::exec_policy(stream)->on(stream.value()), keys_positions.begin(), keys_positions.end());
+    thrust::sequence(rmm::exec_policy(stream), keys_positions.begin(), keys_positions.end());
     // wrap the indices for comparison in contains()
     column_view keys_positions_view(data_type{type_id::UINT32}, keys_size, keys_positions.data());
     return cudf::detail::contains(keys_positions_view, indices_view, stream, mr);

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -27,8 +27,8 @@
 #include <cudf/dictionary/dictionary_factories.hpp>
 #include <cudf/stream_compaction.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
 #include <algorithm>
@@ -74,7 +74,7 @@ struct dispatch_compute_indices {
                                       mr);
     auto result_itr =
       cudf::detail::indexalator_factory::make_output_iterator(result->mutable_view());
-    thrust::lower_bound(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::lower_bound(rmm::exec_policy(stream),
                         new_keys_view->begin<Element>(),
                         new_keys_view->end<Element>(),
                         dictionary_itr,

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -28,8 +28,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 
 #include <thrust/binary_search.h>
@@ -86,14 +87,11 @@ struct compute_offsets {
                    "count should not have values larger than size_type's limit.");
     }
     rmm::device_vector<cudf::size_type> offsets(p_column->size());
-    thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
-                           p_column->begin<T>(),
-                           p_column->end<T>(),
-                           offsets.begin());
+    thrust::inclusive_scan(
+      rmm::exec_policy(stream), p_column->begin<T>(), p_column->end<T>(), offsets.begin());
     if (check_count == true) {
       CUDF_EXPECTS(
-        thrust::is_sorted(
-          rmm::exec_policy(stream)->on(stream.value()), offsets.begin(), offsets.end()) == true,
+        thrust::is_sorted(rmm::exec_policy(stream), offsets.begin(), offsets.end()) == true,
         "count has negative values or the resulting table has more \
                     rows than size_type's limit.");
     }
@@ -128,7 +126,7 @@ std::unique_ptr<table> repeat(table_view const& input_table,
 
   size_type output_size{offsets.back()};
   rmm::device_vector<size_type> indices(output_size);
-  thrust::upper_bound(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::upper_bound(rmm::exec_policy(stream),
                       offsets.begin(),
                       offsets.end(),
                       thrust::make_counting_iterator(0),

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -24,6 +24,7 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -74,7 +75,7 @@ struct sequence_functor {
     // not using thrust::sequence because it requires init and step to be passed as
     // constants, not iterators. to do that we would have to retrieve the scalar values off the gpu,
     // which is undesirable from a performance perspective.
-    thrust::tabulate(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::tabulate(rmm::exec_policy(stream),
                      result_device_view->begin<T>(),
                      result_device_view->end<T>(),
                      tabulator<T>{n_init, n_step});
@@ -111,7 +112,7 @@ struct sequence_functor {
     // not using thrust::sequence because it requires init and step to be passed as
     // constants, not iterators. to do that we would have to retrieve the scalar values off the gpu,
     // which is undesirable from a performance perspective.
-    thrust::tabulate(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::tabulate(rmm::exec_policy(stream),
                      result_device_view->begin<T>(),
                      result_device_view->end<T>(),
                      const_tabulator<T>{n_init});

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -243,7 +243,7 @@ class hash_compound_agg_finalizer final : public cudf::detail::aggregation_final
     cudf::detail::initialize_with_identity(var_table_view, {agg.kind}, stream);
 
     thrust::for_each_n(
-      rmm::exec_policy(stream)->on(stream.value()),
+      rmm::exec_policy(stream),
       thrust::make_counting_iterator(0),
       col.size(),
       ::cudf::detail::var_hash_functor<Map>{
@@ -431,7 +431,7 @@ void compute_single_pass_aggs(table_view const& keys,
   auto row_bitmask =
     skip_key_rows_with_nulls ? cudf::detail::bitmask_and(keys, stream) : rmm::device_buffer{};
   thrust::for_each_n(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator(0),
     keys.num_rows(),
     hash::compute_single_pass_aggs_fn<Map>{map,
@@ -467,7 +467,7 @@ std::pair<rmm::device_vector<size_type>, size_type> extract_populated_keys(
   };
 
   auto end_it = thrust::copy_if(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_transform_iterator(map.data(), get_key),
     thrust::make_transform_iterator(map.data() + map.capacity(), get_key),
     populated_keys.begin(),

--- a/cpp/src/groupby/sort/group_count.cu
+++ b/cpp/src/groupby/sort/group_count.cu
@@ -20,6 +20,7 @@
 #include <cudf/types.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
@@ -51,14 +52,14 @@ std::unique_ptr<column> group_count_valid(column_view const& values,
       thrust::make_transform_iterator(cudf::detail::make_validity_iterator(*values_view),
                                       [] __device__(auto b) { return static_cast<size_type>(b); });
 
-    thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::reduce_by_key(rmm::exec_policy(stream),
                           group_labels.begin(),
                           group_labels.end(),
                           bitmask_iterator,
                           thrust::make_discard_iterator(),
                           result->mutable_view().begin<size_type>());
   } else {
-    thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::reduce_by_key(rmm::exec_policy(stream),
                           group_labels.begin(),
                           group_labels.end(),
                           thrust::make_constant_iterator(1),
@@ -81,7 +82,7 @@ std::unique_ptr<column> group_count_all(rmm::device_vector<size_type> const& gro
 
   if (num_groups == 0) { return result; }
 
-  thrust::adjacent_difference(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::adjacent_difference(rmm::exec_policy(stream),
                               group_offsets.begin() + 1,
                               group_offsets.end(),
                               result->mutable_view().begin<size_type>());

--- a/cpp/src/groupby/sort/group_nth_element.cu
+++ b/cpp/src/groupby/sort/group_nth_element.cu
@@ -50,7 +50,7 @@ std::unique_ptr<column> group_nth_element(column_view const &values,
   if (null_handling == null_policy::INCLUDE || !values.has_nulls()) {
     // Returns index of nth value.
     thrust::transform_if(
-      rmm::exec_policy(stream)->on(stream.value()),
+      rmm::exec_policy(stream),
       group_sizes.begin<size_type>(),
       group_sizes.end<size_type>(),
       group_offsets.begin(),
@@ -70,7 +70,7 @@ std::unique_ptr<column> group_nth_element(column_view const &values,
                                       [] __device__(auto b) { return static_cast<size_type>(b); });
     rmm::device_vector<size_type> intra_group_index(values.size());
     // intra group index for valids only.
-    thrust::exclusive_scan_by_key(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::exclusive_scan_by_key(rmm::exec_policy(stream),
                                   group_labels.begin(),
                                   group_labels.end(),
                                   bitmask_iterator,
@@ -79,7 +79,7 @@ std::unique_ptr<column> group_nth_element(column_view const &values,
     rmm::device_vector<size_type> group_count = [&] {
       if (n < 0) {
         rmm::device_vector<size_type> group_count(num_groups);
-        thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
+        thrust::reduce_by_key(rmm::exec_policy(stream),
                               group_labels.begin(),
                               group_labels.end(),
                               bitmask_iterator,
@@ -91,7 +91,7 @@ std::unique_ptr<column> group_nth_element(column_view const &values,
       }
     }();
     // gather the valid index == n
-    thrust::scatter_if(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::scatter_if(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        thrust::make_counting_iterator<size_type>(values.size()),
                        group_labels.begin(),                          // map

--- a/cpp/src/groupby/sort/group_nunique.cu
+++ b/cpp/src/groupby/sort/group_nunique.cu
@@ -21,6 +21,7 @@
 #include <cudf/types.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
@@ -63,7 +64,7 @@ struct nunique_functor {
           return static_cast<size_type>(is_unique);
         });
 
-      thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::reduce_by_key(rmm::exec_policy(stream),
                             group_labels.begin(),
                             group_labels.end(),
                             is_unique_iterator,
@@ -81,7 +82,7 @@ struct nunique_functor {
                            (not equal.operator()<T>(i, i - 1));    // new unique value in sorted
           return static_cast<size_type>(is_unique);
         });
-      thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::reduce_by_key(rmm::exec_policy(stream),
                             group_labels.begin(),
                             group_labels.end(),
                             is_unique_iterator,

--- a/cpp/src/groupby/sort/group_quantiles.cu
+++ b/cpp/src/groupby/sort/group_quantiles.cu
@@ -24,8 +24,9 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/for_each.h>
 
@@ -62,7 +63,7 @@ struct quantiles_functor {
     auto result_view     = mutable_column_device_view::create(result->mutable_view());
 
     // For each group, calculate quantile
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator(0),
                        num_groups,
                        [d_values       = *values_view,

--- a/cpp/src/groupby/sort/group_reductions.hpp
+++ b/cpp/src/groupby/sort/group_reductions.hpp
@@ -19,8 +19,8 @@
 #include <cudf/aggregation.hpp>
 #include <cudf/column/column.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <memory>
 

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -26,8 +26,9 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/discard_iterator.h>
 
@@ -75,7 +76,7 @@ struct reduce_functor {
     auto resultview = mutable_column_device_view::create(result->mutable_view(), stream);
     auto valuesview = column_device_view::create(values, stream);
 
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator(0),
                        values.size(),
                        [d_values     = *valuesview,

--- a/cpp/src/hash/unordered_multiset.cuh
+++ b/cpp/src/hash/unordered_multiset.cuh
@@ -22,6 +22,7 @@
 #include <cudf/detail/utilities/hash_functions.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -85,7 +86,7 @@ class unordered_multiset {
     size_type *d_hash_bins_end   = hash_bins_end.data().get();
     Element *d_hash_data         = hash_data.data().get();
 
-    thrust::for_each(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      thrust::make_counting_iterator<size_type>(col.size()),
                      [d_hash_bins_start, d_col, hasher] __device__(size_t idx) {
@@ -96,17 +97,17 @@ class unordered_multiset {
                        }
                      });
 
-    thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::exclusive_scan(rmm::exec_policy(stream),
                            hash_bins_start.begin(),
                            hash_bins_start.end(),
                            hash_bins_end.begin());
 
-    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::copy(rmm::exec_policy(stream),
                  hash_bins_end.begin(),
                  hash_bins_end.end(),
                  hash_bins_start.begin());
 
-    thrust::for_each(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      thrust::make_counting_iterator<size_type>(col.size()),
                      [d_hash_bins_end, d_hash_data, d_col, hasher] __device__(size_t idx) {

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -28,7 +28,6 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>

--- a/cpp/src/io/csv/csv_gpu.cu
+++ b/cpp/src/io/csv/csv_gpu.cu
@@ -33,6 +33,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/detail/copy.h>
 #include <thrust/transform.h>
@@ -1013,7 +1014,7 @@ size_t __host__ count_blank_rows(const cudf::io::parse_options_view &opts,
   const auto comment  = opts.comment != '\0' ? opts.comment : newline;
   const auto carriage = (opts.skipblanklines && opts.terminator == '\n') ? '\r' : comment;
   return thrust::count_if(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     row_offsets.begin(),
     row_offsets.end(),
     [data = data, newline, comment, carriage] __device__(const uint64_t pos) {
@@ -1032,7 +1033,7 @@ void __host__ remove_blank_rows(cudf::io::parse_options_view const &options,
   const auto comment  = options.comment != '\0' ? options.comment : newline;
   const auto carriage = (options.skipblanklines && options.terminator == '\n') ? '\r' : comment;
   auto new_end        = thrust::remove_if(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     row_offsets.begin(),
     row_offsets.end(),
     [data = data, d_size, newline, comment, carriage] __device__(const uint64_t pos) {

--- a/cpp/src/io/csv/csv_gpu.h
+++ b/cpp/src/io/csv/csv_gpu.h
@@ -21,7 +21,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 
 using cudf::detail::device_span;

--- a/cpp/src/io/csv/durations.cu
+++ b/cpp/src/io/csv/durations.cu
@@ -195,7 +195,7 @@ struct dispatch_from_durations_fn {
     auto chars_view = chars_column->mutable_view();
     auto d_chars    = chars_view.template data<char>();
 
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        strings_count,
                        duration_to_string_fn<T>{d_column, d_new_offsets, d_chars});

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -35,9 +35,8 @@
 #include <cudf/strings/replace.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_buffer.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
@@ -416,7 +415,7 @@ void writer::impl::write_chunked(strings_column_view const& str_column_view,
 
   cudf::string_scalar newline{options_.get_line_terminator()};
   auto p_str_col_w_nl = cudf::strings::join_strings(str_column_view, newline);
-  strings_column_view strings_column{std::move(p_str_col_w_nl->view())};
+  strings_column_view strings_column{p_str_col_w_nl->view()};
 
   auto total_num_bytes      = strings_column.chars_size();
   char const* ptr_all_bytes = strings_column.chars().data<char>();
@@ -479,8 +478,6 @@ void writer::impl::write(table_view const& table,
 
     CUDF_EXPECTS(n_rows_per_chunk >= 8, "write_csv: invalid chunk_rows; must be at least 8");
 
-    auto exec = rmm::exec_policy(stream);
-
     auto num_rows = table.num_rows();
     std::vector<table_view> vector_views;
 
@@ -493,7 +490,7 @@ void writer::impl::write(table_view const& table,
 
       rmm::device_vector<size_type> d_splits(n_chunks, n_rows_per_chunk);
       thrust::inclusive_scan(
-        exec->on(stream.value()), d_splits.begin(), d_splits.end(), d_splits.begin());
+        rmm::exec_policy(stream), d_splits.begin(), d_splits.end(), d_splits.begin());
 
       CUDA_TRY(cudaMemcpyAsync(splits.data(),
                                d_splits.data().get(),

--- a/cpp/src/io/json/json_gpu.cu
+++ b/cpp/src/io/json/json_gpu.cu
@@ -32,6 +32,8 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/detail/copy.h>
 #include <thrust/find.h>
@@ -835,7 +837,7 @@ std::vector<cudf::io::column_type_histogram> detect_data_types(
   if (do_set_null_count) {
     // Set the null count to the row count (all fields assumes to be null).
     thrust::for_each(
-      rmm::exec_policy(stream)->on(stream.value()),
+      rmm::exec_policy(stream),
       d_column_infos.begin(),
       d_column_infos.end(),
       [num_records = row_offsets.size()] __device__(auto &info) { info.null_count = num_records; });

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -34,9 +34,10 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_scalar.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/optional.h>
 
@@ -114,7 +115,7 @@ col_map_ptr_type create_col_names_hash_map(column_view column_name_hashes,
 {
   auto key_col_map{col_map_type::create(column_name_hashes.size(), stream)};
   auto const column_data = column_name_hashes.data<uint32_t>();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      column_name_hashes.size(),
                      [map = *key_col_map, column_data] __device__(size_type idx) mutable {
@@ -327,7 +328,7 @@ void reader::impl::set_record_starts(rmm::cuda_stream_view stream)
   // Previous call stores the record pinput_file.typeositions as encountered by all threads
   // Sort the record positions as subsequent processing may require filtering
   // certain rows or other processing on specific records
-  thrust::sort(rmm::exec_policy()->on(stream.value()), rec_starts_.begin(), rec_starts_.end());
+  thrust::sort(rmm::exec_policy(stream), rec_starts_.begin(), rec_starts_.end());
 
   auto filtered_count = prefilter_count;
   if (allow_newlines_in_strings_) {
@@ -345,7 +346,7 @@ void reader::impl::set_record_starts(rmm::cuda_stream_view stream)
     }
 
     rec_starts_ = h_rec_starts;
-    thrust::sort(rmm::exec_policy()->on(stream.value()), rec_starts_.begin(), rec_starts_.end());
+    thrust::sort(rmm::exec_policy(stream), rec_starts_.begin(), rec_starts_.end());
   }
 
   // Exclude the ending newline as it does not precede a record start
@@ -384,7 +385,7 @@ void reader::impl::upload_data_to_device(rmm::cuda_stream_view stream)
     // Adjust row start positions to account for the data subcopy
     start_offset = h_rec_starts.front();
     rec_starts_.resize(h_rec_starts.size());
-    thrust::transform(rmm::exec_policy()->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       rec_starts_.begin(),
                       rec_starts_.end(),
                       thrust::make_constant_iterator(start_offset),

--- a/cpp/src/io/orc/dict_enc.cu
+++ b/cpp/src/io/orc/dict_enc.cu
@@ -19,8 +19,8 @@
 
 #include <io/utilities/block_utils.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
@@ -473,7 +473,7 @@ void BuildStripeDictionaries(StripeDictionary *stripes,
       const nvstrdesc_s *str_data =
         static_cast<const nvstrdesc_s *>(stripes_host[i].column_data_base);
       // NOTE: Requires the --expt-extended-lambda nvcc flag
-      thrust::sort(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::sort(rmm::exec_policy(stream),
                    p,
                    p + stripes_host[i].num_strings,
                    [str_data] __device__(const uint32_t &lhs, const uint32_t &rhs) {

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -28,9 +28,9 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <algorithm>
 #include <array>

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -24,9 +24,9 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <algorithm>
 #include <cstring>

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -27,10 +27,10 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <algorithm>
 #include <array>

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -28,11 +28,11 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <algorithm>
 #include <cstring>

--- a/cpp/src/io/utilities/column_buffer.hpp
+++ b/cpp/src/io/utilities/column_buffer.hpp
@@ -30,9 +30,9 @@
 
 #include <cudf_test/column_utilities.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/device_vector.hpp>
 
 namespace cudf {
 namespace io {

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -3,8 +3,8 @@
 #include <thrust/device_vector.h>
 #include <thrust/pair.h>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/device_buffer.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <cudf/io/types.hpp>
 

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -20,7 +20,7 @@
 #include <cudf/io/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/device_vector.hpp>
 
 using cudf::detail::device_span;
 

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -20,6 +20,8 @@
 #include <cudf/detail/gather.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <numeric>
 
@@ -148,7 +150,7 @@ get_left_join_indices_complement(rmm::device_vector<size_type> &right_indices,
   // right_indices will be JoinNoneValue, i.e. -1. This if path should
   // produce exactly the same result as the else path but will be faster.
   if (left_table_row_count == 0) {
-    thrust::sequence(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::sequence(rmm::exec_policy(stream),
                      right_indices_complement.begin(),
                      right_indices_complement.end(),
                      0);
@@ -160,7 +162,7 @@ get_left_join_indices_complement(rmm::device_vector<size_type> &right_indices,
 
     // invalid_index_map[index_ptr[i]] = 0 for i = 0 to right_table_row_count
     // Thus specifying that those locations are valid
-    thrust::scatter_if(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::scatter_if(rmm::exec_policy(stream),
                        thrust::make_constant_iterator(0),
                        thrust::make_constant_iterator(0) + right_indices.size(),
                        right_indices.begin(),      // Index locations
@@ -171,7 +173,7 @@ get_left_join_indices_complement(rmm::device_vector<size_type> &right_indices,
     size_type end_counter   = static_cast<size_type>(right_table_row_count);
 
     // Create list of indices that have been marked as invalid
-    size_type indices_count = thrust::copy_if(rmm::exec_policy(stream)->on(stream.value()),
+    size_type indices_count = thrust::copy_if(rmm::exec_policy(stream),
                                               thrust::make_counting_iterator(begin_counter),
                                               thrust::make_counting_iterator(end_counter),
                                               invalid_index_map.begin(),

--- a/cpp/src/join/hash_join.cuh
+++ b/cpp/src/join/hash_join.cuh
@@ -25,6 +25,8 @@
 #include <cudf/table/table_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/sequence.h>
 
@@ -183,13 +185,9 @@ inline std::pair<rmm::device_vector<size_type>, rmm::device_vector<size_type>>
 get_trivial_left_join_indices(table_view const& left, rmm::cuda_stream_view stream)
 {
   rmm::device_vector<size_type> left_indices(left.num_rows());
-  thrust::sequence(
-    rmm::exec_policy(stream)->on(stream.value()), left_indices.begin(), left_indices.end(), 0);
+  thrust::sequence(rmm::exec_policy(stream), left_indices.begin(), left_indices.end(), 0);
   rmm::device_vector<size_type> right_indices(left.num_rows());
-  thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
-               right_indices.begin(),
-               right_indices.end(),
-               JoinNoneValue);
+  thrust::fill(rmm::exec_policy(stream), right_indices.begin(), right_indices.end(), JoinNoneValue);
   return std::make_pair(std::move(left_indices), std::move(right_indices));
 }
 

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -26,6 +26,8 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -128,7 +130,7 @@ std::unique_ptr<cudf::table> left_semi_anti_join(
                                                 equality_build);
   auto hash_table     = *hash_table_ptr;
 
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      right_num_rows,
                      [hash_table] __device__(size_type idx) mutable {
@@ -147,7 +149,7 @@ std::unique_ptr<cudf::table> left_semi_anti_join(
 
   // gather_map_end will be the end of valid data in gather_map
   auto gather_map_end = thrust::copy_if(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(left_num_rows),
     gather_map.begin(),

--- a/cpp/src/lists/copying/concatenate.cu
+++ b/cpp/src/lists/copying/concatenate.cu
@@ -25,6 +25,7 @@
 #include <cudf/lists/lists_column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <memory>
 
@@ -69,7 +70,7 @@ std::unique_ptr<column> merge_offsets(std::vector<lists_column_view> const& colu
                                                       : 0);
       column_device_view offsets(c.offsets(), nullptr, nullptr);
       thrust::transform(
-        rmm::exec_policy(stream)->on(stream.value()),
+        rmm::exec_policy(stream),
         offsets.begin<size_type>() + c.offset(),
         offsets.begin<size_type>() + c.offset() + c.size() + 1,
         d_merged_offsets.begin<size_type>() + count,

--- a/cpp/src/lists/copying/copying.cu
+++ b/cpp/src/lists/copying/copying.cu
@@ -18,6 +18,7 @@
 #include <cudf/lists/lists_column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 
@@ -50,11 +51,10 @@ std::unique_ptr<cudf::column> copy_slice(lists_column_view const& lists,
   auto end_offset   = cudf::detail::get_value<size_type>(lists.offsets(), end, stream);
 
   rmm::device_uvector<cudf::size_type> out_offsets(offsets_count, stream);
-  auto execpol = rmm::exec_policy(stream);
 
   // Compute the offsets column of the result:
   thrust::transform(
-    execpol->on(stream.value()),
+    rmm::exec_policy(stream),
     offsets_data + start,
     offsets_data + end + 1,  // size of offsets column is 1 greater than slice length
     out_offsets.data(),

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -83,13 +83,13 @@ std::unique_ptr<column> extract_list_element(lists_column_view lists_column,
   // build the gather map using the offsets and the provided index
   auto const d_column = column_device_view::create(annotated_offsets, stream);
   if (index < 0)
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(gather_map->size()),
                       d_gather_map,
                       map_index_fn<false>{*d_column, index, child_column.size()});
   else
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(gather_map->size()),
                       d_gather_map,

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -24,8 +24,9 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_device_view.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -193,7 +194,6 @@ rmm::device_vector<index_type> generate_merged_indices(
 
   rmm::device_vector<order> d_column_order(column_order);
 
-  auto exec_pol = rmm::exec_policy(stream);
   if (nullable) {
     rmm::device_vector<null_order> d_null_precedence(null_precedence);
 
@@ -202,7 +202,7 @@ rmm::device_vector<index_type> generate_merged_indices(
                                                         *rhs_device_view,
                                                         d_column_order.data().get(),
                                                         d_null_precedence.data().get());
-    thrust::merge(exec_pol->on(stream.value()),
+    thrust::merge(rmm::exec_policy(stream),
                   left_begin_zip_iterator,
                   left_end_zip_iterator,
                   right_begin_zip_iterator,
@@ -212,7 +212,7 @@ rmm::device_vector<index_type> generate_merged_indices(
   } else {
     auto ineq_op = detail::row_lexicographic_tagged_comparator<false>(
       *lhs_device_view, *rhs_device_view, d_column_order.data().get());
-    thrust::merge(exec_pol->on(stream.value()),
+    thrust::merge(rmm::exec_policy(stream),
                   left_begin_zip_iterator,
                   left_end_zip_iterator,
                   right_begin_zip_iterator,
@@ -279,13 +279,11 @@ struct column_merger {
     auto const d_lcol = lcol.data<Type>();
     auto const d_rcol = rcol.data<Type>();
 
-    auto exe_pol = rmm::exec_policy(stream);
-
     // capture lcol, rcol
     // and "gather" into merged_view.data()[indx_merged]
     // from lcol or rcol, depending on side;
     //
-    thrust::transform(exe_pol->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       row_order_.begin(),
                       row_order_.end(),
                       merged_view.begin<Type>(),

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -26,11 +26,10 @@
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
-#include <thrust/device_vector.h>
-#include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -94,8 +93,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
 
   if (num_partitions == nrows) {
     VectorT<cudf::size_type> partition_offsets(num_partitions, cudf::size_type{0});
-    auto exec = rmm::exec_policy(stream);
-    thrust::sequence(exec->on(stream.value()), partition_offsets.begin(), partition_offsets.end());
+    thrust::sequence(rmm::exec_policy(stream), partition_offsets.begin(), partition_offsets.end());
 
     auto uniq_tbl = cudf::detail::gather(input,
                                          rotated_iter_begin,
@@ -123,8 +121,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
     // fall in the interval [0, nrows):
     //(this relies on a _stable_ copy_if())
     //
-    auto exec = rmm::exec_policy(stream);
-    thrust::copy_if(exec->on(stream.value()),
+    thrust::copy_if(rmm::exec_policy(stream),
                     rotated_iter_begin,
                     rotated_iter_begin + num_partitions,
                     d_row_indices.begin(),
@@ -153,7 +150,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
     // offsets (part 2: compute partition offsets):
     //
     VectorT<cudf::size_type> partition_offsets(num_partitions, cudf::size_type{0});
-    thrust::exclusive_scan(exec->on(stream.value()),
+    thrust::exclusive_scan(rmm::exec_policy(stream),
                            nedges_iter_begin,
                            nedges_iter_begin + num_partitions,
                            partition_offsets.begin());

--- a/cpp/src/reductions/nth_element.cu
+++ b/cpp/src/reductions/nth_element.cu
@@ -22,6 +22,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
 
@@ -43,15 +44,13 @@ std::unique_ptr<cudf::scalar> cudf::reduction::nth_element(column_view const& co
                                       [] __device__(auto b) { return static_cast<size_type>(b); });
     rmm::device_uvector<size_type> null_skipped_index(col.size(), stream);
     // null skipped index for valids only.
-    thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::inclusive_scan(rmm::exec_policy(stream),
                            bitmask_iterator,
                            bitmask_iterator + col.size(),
                            null_skipped_index.begin());
 
-    auto n_pos          = thrust::upper_bound(rmm::exec_policy(stream)->on(stream.value()),
-                                     null_skipped_index.begin(),
-                                     null_skipped_index.end(),
-                                     n);
+    auto n_pos = thrust::upper_bound(
+      rmm::exec_policy(stream), null_skipped_index.begin(), null_skipped_index.end(), n);
     auto null_skipped_n = n_pos - null_skipped_index.begin();
     return cudf::detail::get_element(col, null_skipped_n, stream, mr);
   } else {

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -33,6 +33,7 @@
 #include <cudf/types.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -136,8 +137,7 @@ std::unique_ptr<cudf::column> clamp_string_column(strings_column_view const& inp
       }
     };
 
-  auto exec = rmm::exec_policy(stream);
-  thrust::for_each_n(exec->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      input.size(),
                      copy_transformer);
@@ -189,7 +189,7 @@ std::enable_if_t<cudf::is_fixed_width<T>(), std::unique_ptr<cudf::column>> clamp
 
   if (input.has_nulls()) {
     auto input_pair_iterator = make_pair_iterator<T, true>(*input_device_view);
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       input_pair_iterator,
                       input_pair_iterator + input.size(),
                       scalar_zip_itr,
@@ -197,7 +197,7 @@ std::enable_if_t<cudf::is_fixed_width<T>(), std::unique_ptr<cudf::column>> clamp
                       trans);
   } else {
     auto input_pair_iterator = make_pair_iterator<T, false>(*input_device_view);
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       input_pair_iterator,
                       input_pair_iterator + input.size(),
                       scalar_zip_itr,

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -184,7 +184,7 @@ struct normalize_nans_and_zeros_kernel_forwarder {
                   cudf::mutable_column_device_view out,
                   rmm::cuda_stream_view stream)
   {
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator(0),
                       thrust::make_counting_iterator(in.size()),
                       out.head<T>(),

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -309,7 +309,7 @@ struct replace_nulls_scalar_kernel_forwarder {
     auto device_in   = cudf::column_device_view::create(input);
 
     auto func = replace_nulls_functor<Type>{s1.data()};
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       input.data<Type>(),
                       input.data<Type>() + input.size(),
                       cudf::detail::make_validity_iterator(*device_in),

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -23,6 +23,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -57,14 +58,14 @@ struct byte_list_conversion {
     size_type mask     = sizeof(T) - 1;
 
     if (configuration == flip_endianness::YES) {
-      thrust::for_each(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::for_each(rmm::exec_policy(stream),
                        thrust::make_counting_iterator(0),
                        thrust::make_counting_iterator(num_bytes),
                        [d_chars, d_data, mask] __device__(auto index) {
                          d_chars[index] = d_data[index + mask - ((index & mask) << 1)];
                        });
     } else {
-      thrust::copy_n(rmm::exec_policy(stream)->on(stream.value()), d_data, num_bytes, d_chars);
+      thrust::copy_n(rmm::exec_policy(stream), d_data, num_bytes, d_chars);
     }
 
     auto begin          = thrust::make_constant_iterator(cudf::size_of(input_column.type()));

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -45,13 +45,11 @@
 #include <jit/rolling_jit_detail.hpp.jit>
 #include <jit/types.hpp.jit>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_scalar.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <thrust/binary_search.h>
-#include <thrust/detail/execution_policy.h>
-#include <thrust/execution_policy.h>
 #include <thrust/find.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -29,6 +29,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <type_traits>
 
@@ -217,11 +218,8 @@ std::unique_ptr<column> round_with(column_view const& input,
   auto out_view = result->mutable_view();
   T const n     = std::pow(10, std::abs(decimal_places));
 
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
-                    input.begin<T>(),
-                    input.end<T>(),
-                    out_view.begin<T>(),
-                    Functor{n});
+  thrust::transform(
+    rmm::exec_policy(stream), input.begin<T>(), input.end<T>(), out_view.begin<T>(), Functor{n});
 
   return result;
 }
@@ -257,7 +255,7 @@ std::unique_ptr<column> round_with(column_view const& input,
   auto out_view = result->mutable_view();
   Type const n  = std::pow(10, std::abs(decimal_places + input.type().scale()));
 
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     input.begin<Type>(),
                     input.end<Type>(),
                     out_view.begin<Type>(),

--- a/cpp/src/search/search.cu
+++ b/cpp/src/search/search.cu
@@ -29,6 +29,7 @@
 #include <hash/unordered_multiset.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
 
@@ -48,7 +49,7 @@ void launch_search(DataIterator it_data,
                    rmm::cuda_stream_view stream)
 {
   if (find_first) {
-    thrust::lower_bound(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::lower_bound(rmm::exec_policy(stream),
                         it_data,
                         it_data + data_size,
                         it_vals,
@@ -56,7 +57,7 @@ void launch_search(DataIterator it_data,
                         it_output,
                         comp);
   } else {
-    thrust::upper_bound(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::upper_bound(rmm::exec_policy(stream),
                         it_data,
                         it_data + data_size,
                         it_vals,
@@ -156,14 +157,14 @@ struct contains_scalar_dispatch {
     auto s           = static_cast<const ScalarType*>(&value);
 
     if (col.has_nulls()) {
-      auto found_iter = thrust::find(rmm::exec_policy(stream)->on(stream.value()),
+      auto found_iter = thrust::find(rmm::exec_policy(stream),
                                      d_col->pair_begin<Type, true>(),
                                      d_col->pair_end<Type, true>(),
                                      thrust::make_pair(s->value(), true));
 
       return found_iter != d_col->pair_end<Type, true>();
     } else {
-      auto found_iter = thrust::find(rmm::exec_policy(stream)->on(stream.value()),  //
+      auto found_iter = thrust::find(rmm::exec_policy(stream),  //
                                      d_col->begin<Type>(),
                                      d_col->end<Type>(),
                                      s->value());
@@ -237,10 +238,8 @@ struct multi_contains_dispatch {
     mutable_column_view result_view = result.get()->mutable_view();
 
     if (needles.is_empty()) {
-      thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
-                   result_view.begin<bool>(),
-                   result_view.end<bool>(),
-                   false);
+      thrust::fill(
+        rmm::exec_policy(stream), result_view.begin<bool>(), result_view.end<bool>(), false);
       return result;
     }
 
@@ -251,7 +250,7 @@ struct multi_contains_dispatch {
     auto d_haystack     = *d_haystack_ptr;
 
     if (haystack.has_nulls()) {
-      thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::transform(rmm::exec_policy(stream),
                         thrust::make_counting_iterator<size_type>(0),
                         thrust::make_counting_iterator<size_type>(haystack.size()),
                         result_view.begin<bool>(),
@@ -260,7 +259,7 @@ struct multi_contains_dispatch {
                                  device_hash_set.contains(d_haystack.element<Element>(index));
                         });
     } else {
-      thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::transform(rmm::exec_policy(stream),
                         thrust::make_counting_iterator<size_type>(0),
                         thrust::make_counting_iterator<size_type>(haystack.size()),
                         result_view.begin<bool>(),

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -21,8 +21,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -41,7 +42,7 @@ auto is_sorted(cudf::table_view const& in,
   auto ineq_op = row_lexicographic_comparator<has_nulls>(
     *in_d, *in_d, d_column_order.data().get(), d_null_precedence.data().get());
 
-  auto sorted = thrust::is_sorted(rmm::exec_policy(stream)->on(stream.value()),
+  auto sorted = thrust::is_sorted(rmm::exec_policy(stream),
                                   thrust::make_counting_iterator(0),
                                   thrust::make_counting_iterator(in.num_rows()),
                                   ineq_op);

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -22,8 +22,9 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/sequence.h>
 
@@ -58,7 +59,7 @@ std::unique_ptr<column> sorted_order(table_view input,
 
   auto device_table = table_device_view::create(input, stream);
 
-  thrust::sequence(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::sequence(rmm::exec_policy(stream),
                    mutable_indices_view.begin<size_type>(),
                    mutable_indices_view.end<size_type>(),
                    0);
@@ -70,12 +71,12 @@ std::unique_ptr<column> sorted_order(table_view input,
     auto comparator = row_lexicographic_comparator<true>(
       *device_table, *device_table, d_column_order.data().get(), d_null_precedence.data().get());
     if (stable) {
-      thrust::stable_sort(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::stable_sort(rmm::exec_policy(stream),
                           mutable_indices_view.begin<size_type>(),
                           mutable_indices_view.end<size_type>(),
                           comparator);
     } else {
-      thrust::sort(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::sort(rmm::exec_policy(stream),
                    mutable_indices_view.begin<size_type>(),
                    mutable_indices_view.end<size_type>(),
                    comparator);
@@ -84,12 +85,12 @@ std::unique_ptr<column> sorted_order(table_view input,
     auto comparator = row_lexicographic_comparator<false>(
       *device_table, *device_table, d_column_order.data().get());
     if (stable) {
-      thrust::stable_sort(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::stable_sort(rmm::exec_policy(stream),
                           mutable_indices_view.begin<size_type>(),
                           mutable_indices_view.end<size_type>(),
                           comparator);
     } else {
-      thrust::sort(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::sort(rmm::exec_policy(stream),
                    mutable_indices_view.begin<size_type>(),
                    mutable_indices_view.end<size_type>(),
                    comparator);

--- a/cpp/src/stream_compaction/distinct_count.cu
+++ b/cpp/src/stream_compaction/distinct_count.cu
@@ -25,9 +25,11 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
-#include <rmm/cuda_stream_view.hpp>
 #include <vector>
 
 namespace cudf {
@@ -52,7 +54,7 @@ cudf::size_type distinct_count(table_view const& keys,
     row_equality_comparator<true> comp(
       *device_input_table, *device_input_table, nulls_equal == null_equality::EQUAL);
     return thrust::count_if(
-      rmm::exec_policy(stream)->on(stream.value()),
+      rmm::exec_policy(stream),
       thrust::counting_iterator<cudf::size_type>(0),
       thrust::counting_iterator<cudf::size_type>(keys.num_rows()),
       [sorted_row_index, comp] __device__(cudf::size_type i) {
@@ -62,7 +64,7 @@ cudf::size_type distinct_count(table_view const& keys,
     row_equality_comparator<false> comp(
       *device_input_table, *device_input_table, nulls_equal == null_equality::EQUAL);
     return thrust::count_if(
-      rmm::exec_policy(stream)->on(stream.value()),
+      rmm::exec_policy(stream),
       thrust::counting_iterator<cudf::size_type>(0),
       thrust::counting_iterator<cudf::size_type>(keys.num_rows()),
       [sorted_row_index, comp] __device__(cudf::size_type i) {
@@ -121,7 +123,7 @@ struct has_nans {
   {
     auto input_device_view = cudf::column_device_view::create(input, stream);
     auto device_view       = *input_device_view;
-    auto count             = thrust::count_if(rmm::exec_policy(stream)->on(stream.value()),
+    auto count             = thrust::count_if(rmm::exec_policy(stream),
                                   thrust::counting_iterator<cudf::size_type>(0),
                                   thrust::counting_iterator<cudf::size_type>(input.size()),
                                   check_for_nan<T>(device_view));

--- a/cpp/src/stream_compaction/drop_duplicates.cu
+++ b/cpp/src/stream_compaction/drop_duplicates.cu
@@ -29,9 +29,12 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>
-#include <rmm/cuda_stream_view.hpp>
+
 #include <vector>
 
 namespace cudf {
@@ -97,7 +100,7 @@ OutputIterator unique_copy(InputIterator first,
 {
   size_type const last_index = thrust::distance(first, last) - 1;
   return thrust::copy_if(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     first,
     last,
     thrust::counting_iterator<size_type>(0),

--- a/cpp/src/strings/case.cu
+++ b/cpp/src/strings/case.cu
@@ -31,6 +31,7 @@
 #include <strings/utilities.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace strings {
@@ -140,7 +141,6 @@ std::unique_ptr<column> convert_case(strings_column_view const& strings,
   auto strings_count = strings.size();
   if (strings_count == 0) return detail::make_empty_strings_column(stream, mr);
 
-  auto execpol         = rmm::exec_policy(stream);
   auto strings_column  = column_device_view::create(strings.parent(), stream);
   auto d_column        = *strings_column;
   size_type null_count = strings.null_count();
@@ -170,7 +170,7 @@ std::unique_ptr<column> convert_case(strings_column_view const& strings,
   auto d_chars    = chars_view.data<char>();
 
   thrust::for_each_n(
-    execpol->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     upper_lower_fn<ExecuteOp>{

--- a/cpp/src/strings/char_types/char_types.cu
+++ b/cpp/src/strings/char_types/char_types.cu
@@ -58,7 +58,7 @@ std::unique_ptr<column> all_characters_of_type(
   // get the static character types table
   auto d_flags = detail::get_character_flags_table();
   // set the output values by checking the character types for each string
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -201,7 +201,7 @@ std::unique_ptr<column> is_integer(
                                      stream,
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings.size()),
                     d_results,
@@ -222,7 +222,7 @@ bool all_integer(strings_column_view const& strings, rmm::cuda_stream_view strea
       if (d_column.is_null(idx)) return false;
       return string::is_integer(d_column.element<string_view>(idx));
     });
-  return thrust::all_of(rmm::exec_policy(stream)->on(stream.value()),
+  return thrust::all_of(rmm::exec_policy(stream),
                         transformer_itr,
                         transformer_itr + strings.size(),
                         thrust::identity<bool>());
@@ -244,7 +244,7 @@ std::unique_ptr<column> is_float(
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
   // check strings for valid float chars
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings.size()),
                     d_results,
@@ -265,7 +265,7 @@ bool all_float(strings_column_view const& strings, rmm::cuda_stream_view stream)
       if (d_column.is_null(idx)) return false;
       return string::is_float(d_column.element<string_view>(idx));
     });
-  return thrust::all_of(rmm::exec_policy(stream)->on(stream.value()),
+  return thrust::all_of(rmm::exec_policy(stream),
                         transformer_itr,
                         transformer_itr + strings.size(),
                         thrust::identity<bool>());

--- a/cpp/src/strings/contains.cu
+++ b/cpp/src/strings/contains.cu
@@ -27,6 +27,7 @@
 #include <strings/utilities.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace strings {
@@ -90,22 +91,21 @@ std::unique_ptr<column> contains_util(
   auto d_results = results->mutable_view().data<bool>();
 
   // fill the output column
-  auto execpol    = rmm::exec_policy(stream);
   int regex_insts = d_prog.insts_counts();
   if ((regex_insts > MAX_STACK_INSTS) || (regex_insts <= RX_SMALL_INSTS))
-    thrust::transform(execpol->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_count),
                       d_results,
                       contains_fn<RX_STACK_SMALL>{d_prog, d_column, beginning_only});
   else if (regex_insts <= RX_MEDIUM_INSTS)
-    thrust::transform(execpol->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_count),
                       d_results,
                       contains_fn<RX_STACK_MEDIUM>{d_prog, d_column, beginning_only});
   else
-    thrust::transform(execpol->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_count),
                       d_results,
@@ -211,22 +211,21 @@ std::unique_ptr<column> count_re(
   auto d_results = results->mutable_view().data<int32_t>();
 
   // fill the output column
-  auto execpol    = rmm::exec_policy(stream);
   int regex_insts = d_prog.insts_counts();
   if ((regex_insts > MAX_STACK_INSTS) || (regex_insts <= RX_SMALL_INSTS))
-    thrust::transform(execpol->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_count),
                       d_results,
                       count_fn<RX_STACK_SMALL>{d_prog, d_column});
   else if (regex_insts <= RX_MEDIUM_INSTS)
-    thrust::transform(execpol->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_count),
                       d_results,
                       count_fn<RX_STACK_MEDIUM>{d_prog, d_column});
   else
-    thrust::transform(execpol->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_count),
                       d_results,

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -27,8 +27,8 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <strings/utilities.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
@@ -61,7 +61,7 @@ std::unique_ptr<column> to_booleans(strings_column_view const& strings,
   auto results_view = results->mutable_view();
   auto d_results    = results_view.data<bool>();
 
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -133,7 +133,7 @@ std::unique_ptr<column> from_booleans(column_view const& booleans,
     create_chars_child_column(strings_count, booleans.null_count(), bytes, stream, mr);
   auto chars_view = chars_column->mutable_view();
   auto d_chars    = chars_view.data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      [d_column, d_true, d_false, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -383,7 +383,7 @@ struct dispatch_to_timestamps_fn {
     auto d_results = results_view.data<T>();
     parse_datetime<T> pfn{
       d_strings, d_items, compiler.items_count(), units, compiler.subsecond_precision()};
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(results_view.size()),
                       d_results,
@@ -578,7 +578,7 @@ std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& strings,
 
   format_compiler compiler(format.c_str(), stream);
   thrust::transform(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(strings_count),
     d_results,
@@ -850,7 +850,7 @@ struct dispatch_from_timestamps_fn {
                   rmm::cuda_stream_view stream) const
   {
     datetime_formatter<T> pfn{d_timestamps, d_format_items, items_count, units, d_offsets, d_chars};
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<cudf::size_type>(0),
                        d_timestamps.size(),
                        pfn);

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -432,7 +432,7 @@ struct dispatch_from_durations_fn {
     auto chars_view = chars_column->mutable_view();
     auto d_chars    = chars_view.template data<char>();
 
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        strings_count,
                        duration_to_string_fn<T>{
@@ -683,7 +683,7 @@ struct dispatch_to_durations_fn {
     auto d_items   = compiler.compiled_format_items();
     auto d_results = results_view.data<T>();
     parse_duration<T> pfn{d_strings, d_items, compiler.items_count()};
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(results_view.size()),
                       d_results,

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -27,8 +27,8 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <strings/utilities.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
@@ -151,7 +151,7 @@ struct dispatch_to_floats_fn {
                   rmm::cuda_stream_view stream) const
   {
     auto d_results = output_column.data<FloatType>();
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_column.size()),
                       d_results,
@@ -485,7 +485,7 @@ struct dispatch_from_floats_fn {
       detail::create_chars_child_column(strings_count, floats.null_count(), bytes, stream, mr);
     auto chars_view = chars_column->mutable_view();
     auto d_chars    = chars_view.template data<char>();
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        strings_count,
                        float_to_string_fn<FloatType>{d_column, d_offsets, d_chars});

--- a/cpp/src/strings/convert/convert_hex.cu
+++ b/cpp/src/strings/convert/convert_hex.cu
@@ -26,8 +26,8 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <strings/utilities.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/logical.h>
@@ -96,7 +96,7 @@ struct dispatch_hex_to_integers_fn {
                   rmm::cuda_stream_view stream) const
   {
     auto d_results = output_column.data<IntegerType>();
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_column.size()),
                       d_results,
@@ -159,7 +159,7 @@ std::unique_ptr<column> is_hex(strings_column_view const& strings,
                                      stream,
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings.size()),
                     d_results,

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -29,8 +29,8 @@
 #include <strings/convert/utilities.cuh>
 #include <strings/utilities.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
@@ -69,7 +69,7 @@ struct dispatch_to_integers_fn {
                   rmm::cuda_stream_view stream) const
   {
     auto d_results = output_column.data<IntegerType>();
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_column.size()),
                       d_results,
@@ -198,7 +198,7 @@ struct dispatch_from_integers_fn {
       detail::create_chars_child_column(strings_count, integers.null_count(), bytes, stream, mr);
     auto chars_view = chars_column->mutable_view();
     auto d_chars    = chars_view.template data<char>();
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        strings_count,
                        integer_to_string_fn<IntegerType>{d_column, d_new_offsets, d_chars});

--- a/cpp/src/strings/convert/convert_ipv4.cu
+++ b/cpp/src/strings/convert/convert_ipv4.cu
@@ -89,7 +89,7 @@ std::unique_ptr<column> ipv4_to_integers(
                                      mr);
   auto d_results = results->mutable_view().data<int64_t>();
   // fill output column with ipv4 integers
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -194,7 +194,7 @@ std::unique_ptr<column> integers_to_ipv4(
   auto chars_column =
     create_chars_child_column(strings_count, integers.null_count(), bytes, stream, mr);
   auto d_chars = chars_column->mutable_view().data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      integers_to_ipv4_fn{d_column, d_offsets, d_chars});
@@ -222,7 +222,7 @@ std::unique_ptr<column> is_ipv4(strings_column_view const& strings,
                                      stream,
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings.size()),
                     d_results,

--- a/cpp/src/strings/convert/convert_urls.cu
+++ b/cpp/src/strings/convert/convert_urls.cu
@@ -138,7 +138,7 @@ std::unique_ptr<column> url_encode(
                               stream,
                               mr);
   auto d_chars = chars_column->mutable_view().data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      url_encoder_fn{d_strings, d_offsets, d_chars});
@@ -242,7 +242,7 @@ std::unique_ptr<column> url_decode(
                               stream,
                               mr);
   auto d_chars = chars_column->mutable_view().data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      url_decoder_fn{d_strings, d_offsets, d_chars});

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -26,6 +26,7 @@
 #include <cudf/table/table_device_view.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
 #include <thrust/for_each.h>
@@ -93,12 +94,12 @@ auto create_strings_device_views(std::vector<column_view> const& views,
   // error: the default constructor of "cudf::column_device_view" cannot be
   // referenced -- it is a deleted function
   auto d_partition_offsets = rmm::device_vector<size_t>(views.size() + 1);
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     device_views_ptr,
                     device_views_ptr + views.size(),
                     std::next(d_partition_offsets.begin()),
                     chars_size_transform{});
-  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::inclusive_scan(rmm::exec_policy(stream),
                          d_partition_offsets.cbegin(),
                          d_partition_offsets.cend(),
                          d_partition_offsets.begin());

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/strings_column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/sequence.h>
 
@@ -64,11 +65,11 @@ std::unique_ptr<cudf::column> copy_slice(strings_column_view const& strings,
                                stream,
                                mr);
   }
+
   // do the gather instead
-  auto execpol = rmm::exec_policy(stream);
   // build indices
   rmm::device_vector<size_type> indices(strings_count);
-  thrust::sequence(execpol->on(stream.value()), indices.begin(), indices.end(), start, step);
+  thrust::sequence(rmm::exec_policy(stream), indices.begin(), indices.end(), start, step);
   // create a column_view as a wrapper of these indices
   column_view indices_view(
     data_type{type_id::INT32}, strings_count, indices.data().get(), nullptr, 0);

--- a/cpp/src/strings/extract.cu
+++ b/cpp/src/strings/extract.cu
@@ -89,26 +89,26 @@ std::unique_ptr<table> extract(
 
   // build a result column for each group
   std::vector<std::unique_ptr<column>> results;
-  auto execpol     = rmm::exec_policy(stream);
   auto regex_insts = d_prog.insts_counts();
+
   for (int32_t column_index = 0; column_index < groups; ++column_index) {
     rmm::device_vector<string_index_pair> indices(strings_count);
     string_index_pair* d_indices = indices.data().get();
 
     if ((regex_insts > MAX_STACK_INSTS) || (regex_insts <= RX_SMALL_INSTS))
-      thrust::transform(execpol->on(stream.value()),
+      thrust::transform(rmm::exec_policy(stream),
                         thrust::make_counting_iterator<size_type>(0),
                         thrust::make_counting_iterator<size_type>(strings_count),
                         d_indices,
                         extract_fn<RX_STACK_SMALL>{d_prog, d_strings, column_index});
     else if (regex_insts <= RX_MEDIUM_INSTS)
-      thrust::transform(execpol->on(stream.value()),
+      thrust::transform(rmm::exec_policy(stream),
                         thrust::make_counting_iterator<size_type>(0),
                         thrust::make_counting_iterator<size_type>(strings_count),
                         d_indices,
                         extract_fn<RX_STACK_MEDIUM>{d_prog, d_strings, column_index});
     else
-      thrust::transform(execpol->on(stream.value()),
+      thrust::transform(rmm::exec_policy(stream),
                         thrust::make_counting_iterator<size_type>(0),
                         thrust::make_counting_iterator<size_type>(strings_count),
                         d_indices,

--- a/cpp/src/strings/filling/fill.cu
+++ b/cpp/src/strings/filling/fill.cu
@@ -84,7 +84,7 @@ std::unique_ptr<column> fill(
   // fill the chars column
   auto d_chars = chars_column->mutable_view().data<char>();
   thrust::for_each_n(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     [d_strings, begin, end, d_value, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/src/strings/filter_chars.cu
+++ b/cpp/src/strings/filter_chars.cu
@@ -27,6 +27,7 @@
 #include <strings/utilities.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/find.h>
 
@@ -122,7 +123,6 @@ std::unique_ptr<column> filter_characters(
     });
   rmm::device_vector<char_range> table(htable);  // copy filter table to device memory
 
-  auto execpol        = rmm::exec_policy(stream);
   auto strings_column = column_device_view::create(strings.parent(), stream);
   auto d_strings      = *strings_column;
 
@@ -142,7 +142,7 @@ std::unique_ptr<column> filter_characters(
   auto chars_column = strings::detail::create_chars_child_column(
     strings_count, strings.null_count(), bytes, stream, mr);
   ffn.d_chars = chars_column->mutable_view().data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<cudf::size_type>(0),
                      strings_count,
                      ffn);

--- a/cpp/src/strings/find.cu
+++ b/cpp/src/strings/find.cu
@@ -26,6 +26,7 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/transform.h>
 
@@ -77,7 +78,7 @@ std::unique_ptr<column> find_fn(strings_column_view const& strings,
   auto results_view = results->mutable_view();
   auto d_results    = results_view.data<int32_t>();
   // set the position values by evaluating the passed function
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -208,7 +209,7 @@ std::unique_ptr<column> contains_fn(strings_column_view const& strings,
   auto results_view = results->mutable_view();
   auto d_results    = results_view.data<bool>();
   // set the bool values by evaluating the passed function
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -263,7 +264,7 @@ std::unique_ptr<column> contains_fn(strings_column_view const& strings,
   auto d_results    = results_view.data<bool>();
   // set the bool values by evaluating the passed function
   thrust::transform(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(strings.size()),
     d_results,

--- a/cpp/src/strings/find_multiple.cu
+++ b/cpp/src/strings/find_multiple.cu
@@ -23,6 +23,7 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/transform.h>
 
@@ -57,7 +58,7 @@ std::unique_ptr<column> find_multiple(
   auto results_view = results->mutable_view();
   auto d_results    = results_view.data<int32_t>();
   // fill output column with position values
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(total_count),
                     d_results,

--- a/cpp/src/strings/replace/replace.cu
+++ b/cpp/src/strings/replace/replace.cu
@@ -126,7 +126,7 @@ std::unique_ptr<column> replace(strings_column_view const& strings,
     create_chars_child_column(strings_count, strings.null_count(), bytes, stream, mr);
   auto d_chars = chars_column->mutable_view().data<char>();
   thrust::for_each_n(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     replace_fn<two_pass::EXECUTE_OP>{d_strings, d_target, d_repl, maxrepl, d_offsets, d_chars});
@@ -214,7 +214,7 @@ std::unique_ptr<column> replace_slice(strings_column_view const& strings,
   auto chars_view = chars_column->mutable_view();
   auto d_chars    = chars_view.data<char>();
   thrust::for_each_n(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     replace_slice_fn<two_pass::EXECUTE_OP>{d_strings, d_repl, start, stop, d_offsets, d_chars});
@@ -321,7 +321,7 @@ std::unique_ptr<column> replace(strings_column_view const& strings,
     create_chars_child_column(strings_count, strings.null_count(), bytes, stream, mr);
   auto d_chars = chars_column->mutable_view().data<char>();
   thrust::for_each_n(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     replace_multi_fn<two_pass::EXECUTE_OP>{d_strings, d_targets, d_repls, d_offsets, d_chars});
@@ -364,7 +364,7 @@ std::unique_ptr<column> replace_nulls(strings_column_view const& strings,
   auto chars_column = strings::detail::create_chars_child_column(
     strings_count, strings.null_count(), bytes, stream, mr);
   auto d_chars = chars_column->mutable_view().data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      [d_strings, d_repl, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/src/strings/sorting/sorting.cu
+++ b/cpp/src/strings/sorting/sorting.cu
@@ -20,8 +20,9 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
@@ -37,15 +38,14 @@ std::unique_ptr<cudf::column> sort(strings_column_view strings,
                                    rmm::cuda_stream_view stream,
                                    rmm::mr::device_memory_resource* mr)
 {
-  auto execpol        = rmm::exec_policy(stream);
   auto strings_column = column_device_view::create(strings.parent(), stream);
   auto d_column       = *strings_column;
 
   // sort the indices of the strings
   size_type num_strings = strings.size();
   rmm::device_vector<size_type> indices(num_strings);
-  thrust::sequence(execpol->on(stream.value()), indices.begin(), indices.end());
-  thrust::sort(execpol->on(stream.value()),
+  thrust::sequence(rmm::exec_policy(stream), indices.begin(), indices.end());
+  thrust::sort(rmm::exec_policy(stream),
                indices.begin(),
                indices.end(),
                [d_column, stype, order, null_order] __device__(size_type lhs, size_type rhs) {

--- a/cpp/src/strings/split/partition.cu
+++ b/cpp/src/strings/split/partition.cu
@@ -25,6 +25,7 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <vector>
 
@@ -191,7 +192,7 @@ std::unique_ptr<table> partition(
   partition_fn partitioner(
     *strings_column, d_delimiter, left_indices, delim_indices, right_indices);
 
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      partitioner);
@@ -217,7 +218,7 @@ std::unique_ptr<table> rpartition(
     right_indices(strings_count);
   rpartition_fn partitioner(
     *strings_column, d_delimiter, left_indices, delim_indices, right_indices);
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      partitioner);

--- a/cpp/src/strings/split/split_record.cu
+++ b/cpp/src/strings/split/split_record.cu
@@ -232,15 +232,13 @@ std::unique_ptr<column> split_record_fn(strings_column_view const& strings,
   auto offsets       = make_numeric_column(
     data_type{type_id::INT32}, strings_count + 1, mask_state::UNALLOCATED, stream, mr);
   auto d_offsets = offsets->mutable_view().data<int32_t>();
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator(0),
                     thrust::make_counting_iterator(strings_count),
                     d_offsets,
                     counter);
-  thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
-                         d_offsets,
-                         d_offsets + strings_count + 1,
-                         d_offsets);
+  thrust::exclusive_scan(
+    rmm::exec_policy(stream), d_offsets, d_offsets + strings_count + 1, d_offsets);
 
   // last entry is the total number of tokens to be generated
   auto total_tokens = cudf::detail::get_value<int32_t>(offsets->view(), strings_count, stream);
@@ -248,10 +246,8 @@ std::unique_ptr<column> split_record_fn(strings_column_view const& strings,
   rmm::device_vector<string_index_pair> tokens(total_tokens);
   reader.d_token_offsets = d_offsets;
   reader.d_tokens        = tokens.data().get();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
-                     thrust::make_counting_iterator<size_type>(0),
-                     strings_count,
-                     reader);
+  thrust::for_each_n(
+    rmm::exec_policy(stream), thrust::make_counting_iterator<size_type>(0), strings_count, reader);
   // convert the index-pairs into one big strings column
   auto strings_output = make_strings_column(tokens.begin(), tokens.end(), stream, mr);
   // create a lists column using the offsets and the strings columns

--- a/cpp/src/strings/strings_column_view.cu
+++ b/cpp/src/strings/strings_column_view.cu
@@ -21,6 +21,7 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/for_each.h>
 #include <thrust/transform.h>
@@ -147,7 +148,7 @@ std::pair<rmm::device_vector<char>, rmm::device_vector<size_type>> create_offset
   rmm::device_vector<size_type> offsets(count + 1);
   // normalize the offset values for the column offset
   thrust::transform(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     d_offsets,
     d_offsets + count + 1,
     offsets.begin(),

--- a/cpp/src/strings/substring.cu
+++ b/cpp/src/strings/substring.cu
@@ -129,7 +129,7 @@ std::unique_ptr<column> slice_strings(
   auto chars_column = strings::detail::create_chars_child_column(
     strings_count, strings.null_count(), bytes, stream, mr);
   auto d_chars = chars_column->mutable_view().data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      substring_fn{d_column, d_start, d_stop, d_step, d_new_offsets, d_chars});
@@ -230,7 +230,7 @@ std::unique_ptr<column> compute_substrings_from_fn(column_device_view const& d_c
     cudf::strings::detail::create_chars_child_column(strings_count, null_count, bytes, stream, mr);
   auto chars_view = chars_column->mutable_view();
   auto d_chars    = chars_view.template data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<cudf::size_type>(0),
                      strings_count,
                      substring_from_fn{d_column, starts, stops, d_new_offsets, d_chars});
@@ -262,7 +262,7 @@ void compute_substring_indices(column_device_view const& d_column,
   auto strings_count = d_column.size();
 
   thrust::for_each_n(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     [delim_itr, delimiter_count, start_char_pos, end_char_pos, d_column] __device__(size_type idx) {

--- a/cpp/src/strings/utilities.cuh
+++ b/cpp/src/strings/utilities.cuh
@@ -88,7 +88,7 @@ auto make_strings_children(
   // This is called twice -- once for offsets and once for chars.
   // Reducing the number of places size_and_exec_fn is inlined speeds up compile time.
   auto for_each_fn = [strings_count, stream](SizeAndExecuteFunction& size_and_exec_fn) {
-    thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each_n(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        strings_count,
                        size_and_exec_fn);
@@ -96,10 +96,8 @@ auto make_strings_children(
 
   // Compute the offsets values
   for_each_fn(size_and_exec_fn);
-  thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
-                         d_offsets,
-                         d_offsets + strings_count + 1,
-                         d_offsets);
+  thrust::exclusive_scan(
+    rmm::exec_policy(stream), d_offsets, d_offsets + strings_count + 1, d_offsets);
 
   // Now build the chars column
   std::unique_ptr<column> chars_column = create_chars_child_column(

--- a/cpp/src/text/detokenize.cu
+++ b/cpp/src/text/detokenize.cu
@@ -107,13 +107,13 @@ struct token_row_offsets_fn {
   {
     index_changed_fn<T> pfn{row_indices.data<T>(), sorted_indices.template data<int32_t>()};
     auto const output_count =
-      thrust::count_if(rmm::exec_policy(stream)->on(stream.value()),
+      thrust::count_if(rmm::exec_policy(stream),
                        thrust::make_counting_iterator<cudf::size_type>(0),
                        thrust::make_counting_iterator<cudf::size_type>(tokens_counts),
                        pfn);
     auto tokens_offsets =
       std::make_unique<rmm::device_uvector<cudf::size_type>>(output_count + 1, stream);
-    thrust::copy_if(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::copy_if(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(tokens_counts),
                     tokens_offsets->begin(),
@@ -179,7 +179,7 @@ std::unique_ptr<cudf::column> detokenize(cudf::strings_column_view const& string
     cudf::strings::detail::create_chars_child_column(output_count, 0, total_bytes, stream, mr);
   auto d_chars = chars_column->mutable_view().data<char>();
   thrust::for_each_n(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     output_count,
     detokenizer_fn{

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -26,6 +26,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
@@ -166,8 +167,8 @@ std::unique_ptr<cudf::column> edit_distance(cudf::strings_column_view const& str
                                                stream,
                                                mr);
   auto d_results = results->mutable_view().data<int32_t>();
-  auto execpol   = rmm::exec_policy(stream);
-  thrust::transform(execpol->on(stream.value()),
+
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(strings_count),
                     d_results,
@@ -183,10 +184,9 @@ std::unique_ptr<cudf::column> edit_distance(cudf::strings_column_view const& str
 
   // get the total size of the temporary compute buffer
   size_t compute_size =
-    thrust::reduce(execpol->on(stream.value()), d_results, d_results + strings_count, size_t{0});
+    thrust::reduce(rmm::exec_policy(stream), d_results, d_results + strings_count, size_t{0});
   // convert sizes to offsets in-place
-  thrust::exclusive_scan(
-    execpol->on(stream.value()), d_results, d_results + strings_count, d_results);
+  thrust::exclusive_scan(rmm::exec_policy(stream), d_results, d_results + strings_count, d_results);
   // create the temporary compute buffer
   rmm::device_uvector<int16_t> compute_buffer(compute_size, stream);
   auto d_buffer = compute_buffer.data();
@@ -195,7 +195,7 @@ std::unique_ptr<cudf::column> edit_distance(cudf::strings_column_view const& str
   // - on input, d_results is the offset to the working section of d_buffer for each row
   // - on output, d_results is the calculated edit distance for that row
   thrust::for_each_n(
-    execpol->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     strings_count,
     edit_distance_levenshtein_algorithm{d_strings, d_targets, d_buffer, d_results});
@@ -219,7 +219,6 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
   // create device column of the input strings column
   auto strings_column = cudf::column_device_view::create(strings.parent(), stream);
   auto d_strings      = *strings_column;
-  auto execpol        = rmm::exec_policy(stream);
 
   // Calculate the size of the compute-buffer.
   // We only need memory for half the size of the output matrix since the edit distance calculation
@@ -229,7 +228,7 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
   auto d_offsets = offsets.data();
   CUDA_TRY(cudaMemsetAsync(d_offsets, 0, n_upper * sizeof(cudf::size_type), stream.value()));
   thrust::for_each_n(
-    execpol->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     strings_count * strings_count,
     [d_strings, d_offsets, strings_count] __device__(cudf::size_type idx) {
@@ -247,10 +246,9 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
 
   // get the total size for the compute buffer
   size_t compute_size =
-    thrust::reduce(execpol->on(stream.value()), offsets.begin(), offsets.end(), size_t{0});
+    thrust::reduce(rmm::exec_policy(stream), offsets.begin(), offsets.end(), size_t{0});
   // convert sizes to offsets in-place
-  thrust::exclusive_scan(
-    execpol->on(stream.value()), offsets.begin(), offsets.end(), offsets.begin());
+  thrust::exclusive_scan(rmm::exec_policy(stream), offsets.begin(), offsets.end(), offsets.begin());
   // create the compute buffer
   rmm::device_uvector<int16_t> compute_buffer(compute_size, stream);
   auto d_buffer = compute_buffer.data();
@@ -264,7 +262,7 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
                                                mr);
   auto d_results = results->mutable_view().data<int32_t>();
   thrust::for_each_n(
-    execpol->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     strings_count * strings_count,
     edit_distance_matrix_levenshtein_algorithm{d_strings, d_buffer, d_offsets, d_results});
@@ -277,7 +275,7 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
                                                       stream,
                                                       mr);
   thrust::transform_exclusive_scan(
-    execpol->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<int32_t>(0),
     thrust::make_counting_iterator<int32_t>(strings_count + 1),
     offsets_column->mutable_view().data<int32_t>(),

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -184,7 +184,7 @@ std::unique_ptr<cudf::column> normalize_spaces(
   auto d_chars = chars_column->mutable_view().data<char>();
 
   // copy tokens to the chars buffer
-  thrust::for_each_n(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::for_each_n(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<cudf::size_type>(0),
                      strings_count,
                      normalize_spaces_fn{d_strings, d_offsets, d_chars});
@@ -247,7 +247,7 @@ std::unique_ptr<cudf::column> normalize_characters(cudf::strings_column_view con
 
   // build the chars output data: convert the 4-byte code-point values into UTF-8 chars
   thrust::for_each_n(
-    rmm::exec_policy(stream)->on(stream.value()),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     strings_count,
     codepoint_to_utf8_fn{*strings_column, cp_chars, cp_offsets, d_offsets, d_chars});

--- a/cpp/src/text/stemmer.cu
+++ b/cpp/src/text/stemmer.cu
@@ -110,7 +110,7 @@ std::unique_ptr<cudf::column> is_letter(cudf::strings_column_view const& strings
                                   mr);
   // set values into output column
   auto strings_column = cudf::column_device_view::create(strings.parent(), stream);
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(strings.size()),
                     results->mutable_view().data<bool>(),
@@ -219,7 +219,7 @@ std::unique_ptr<cudf::column> porter_stemmer_measure(cudf::strings_column_view c
                                   mr);
   // compute measures into output column
   auto strings_column = cudf::column_device_view::create(strings.parent(), stream);
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(strings.size()),
                     results->mutable_view().data<int32_t>(),

--- a/cpp/src/text/subword/load_hash_file.cu
+++ b/cpp/src/text/subword/load_hash_file.cu
@@ -50,7 +50,7 @@ const codepoint_metadata_type* get_codepoint_metadata(rmm::cuda_stream_view stre
     codepoint_metadata_type* table =
       static_cast<codepoint_metadata_type*>(rmm::mr::get_current_device_resource()->allocate(
         codepoint_metadata_size * sizeof(codepoint_metadata_type), stream));
-    thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::fill(rmm::exec_policy(stream),
                  table + cp_section1_end,
                  table + codepoint_metadata_size,
                  codepoint_metadata_default_value);
@@ -83,7 +83,7 @@ const aux_codepoint_data_type* get_aux_codepoint_data(rmm::cuda_stream_view stre
     aux_codepoint_data_type* table =
       static_cast<aux_codepoint_data_type*>(rmm::mr::get_current_device_resource()->allocate(
         aux_codepoint_data_size * sizeof(aux_codepoint_data_type), stream));
-    thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::fill(rmm::exec_policy(stream),
                  table + aux_section1_end,
                  table + aux_codepoint_data_size,
                  aux_codepoint_default_value);

--- a/cpp/src/transform/encode.cu
+++ b/cpp/src/transform/encode.cu
@@ -27,7 +27,8 @@
 #include <cudf/utilities/bit.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <numeric>
 
@@ -58,8 +59,8 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<column>> encode(
       cudf::count_unset_bits(reinterpret_cast<bitmask_type*>(mask.data()), 0, num_rows);
 
     rmm::device_vector<cudf::size_type> gather_map(num_rows);
-    auto execpol = rmm::exec_policy(stream);
-    thrust::transform(execpol->on(stream.value()),
+
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<cudf::size_type>(0),
                       thrust::make_counting_iterator<cudf::size_type>(num_rows),
                       gather_map.begin(),

--- a/cpp/src/transform/mask_to_bools.cu
+++ b/cpp/src/transform/mask_to_bools.cu
@@ -24,6 +24,7 @@
 #include <cudf/utilities/bit.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -43,7 +44,7 @@ std::unique_ptr<column> mask_to_bools(bitmask_type const* bitmask,
   if (length > 0) {
     auto mutable_view = out_col->mutable_view();
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       thrust::make_counting_iterator<cudf::size_type>(begin_bit),
                       thrust::make_counting_iterator<cudf::size_type>(end_bit),
                       mutable_view.begin<bool>(),

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -25,8 +25,8 @@
 #include <cudf/unary.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace detail {
@@ -211,7 +211,7 @@ struct dispatch_unary_cast_to {
 
     mutable_column_view output_mutable = *output;
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       input.begin<SourceT>(),
                       input.end<SourceT>(),
                       output_mutable.begin<TargetT>(),
@@ -241,7 +241,7 @@ struct dispatch_unary_cast_to {
     using DeviceT    = device_storage_type_t<SourceT>;
     auto const scale = numeric::scale_type{input.type().scale()};
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       input.begin<DeviceT>(),
                       input.end<DeviceT>(),
                       output_mutable.begin<TargetT>(),
@@ -271,7 +271,7 @@ struct dispatch_unary_cast_to {
     using DeviceT    = device_storage_type_t<TargetT>;
     auto const scale = numeric::scale_type{type.scale()};
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       input.begin<SourceT>(),
                       input.end<SourceT>(),
                       output_mutable.begin<DeviceT>(),
@@ -318,7 +318,7 @@ struct dispatch_unary_cast_to {
 
     mutable_column_view output_mutable = *temporary;
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       input.begin<SourceDeviceT>(),
                       input.end<SourceDeviceT>(),
                       output_mutable.begin<TargetDeviceT>(),

--- a/cpp/src/unary/math_ops.cu
+++ b/cpp/src/unary/math_ops.cu
@@ -294,7 +294,7 @@ std::unique_ptr<column> unary_op_with(column_view const& input,
   auto out_view = result->mutable_view();
   Type const n  = std::pow(10, -input.type().scale());
 
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     input.begin<Type>(),
                     input.end<Type>(),
                     out_view.begin<Type>(),
@@ -323,11 +323,7 @@ std::unique_ptr<cudf::column> transform_fn(InputIterator begin,
   if (size == 0) return output;
 
   auto output_view = output->mutable_view();
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
-                    begin,
-                    end,
-                    output_view.begin<OutputType>(),
-                    UFN{});
+  thrust::transform(rmm::exec_policy(stream), begin, end, output_view.begin<OutputType>(), UFN{});
   return output;
 }
 

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -23,8 +23,8 @@
 #include <cudf/unary.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace unary {
@@ -65,11 +65,8 @@ struct launcher {
         rmm::device_buffer{input.null_mask(), bitmask_allocation_size_bytes(input.size())},
         input.null_count());
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
-                      input.begin<T>(),
-                      input.end<T>(),
-                      output_view.begin<Tout>(),
-                      F{});
+    thrust::transform(
+      rmm::exec_policy(stream), input.begin<T>(), input.end<T>(), output_view.begin<Tout>(), F{});
 
     CHECK_CUDA(stream.value());
 

--- a/cpp/tests/column/column_device_view_test.cu
+++ b/cpp/tests/column/column_device_view_test.cu
@@ -26,6 +26,7 @@
 #include <cudf/types.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 struct ColumnDeviceViewTest : public cudf::test::BaseFixture {
 };
@@ -39,8 +40,8 @@ TEST_F(ColumnDeviceViewTest, Sample)
   auto input_device_view = cudf::column_device_view::create(input, stream);
   auto output_device_view =
     cudf::mutable_column_device_view::create(output->mutable_view(), stream);
-  auto exec = rmm::exec_policy(stream);
-  EXPECT_NO_THROW(thrust::copy(exec->on(stream.value()),
+
+  EXPECT_NO_THROW(thrust::copy(rmm::exec_policy(stream),
                                input_device_view->begin<T>(),
                                input_device_view->end<T>(),
                                output_device_view->begin<T>()));
@@ -57,8 +58,8 @@ TEST_F(ColumnDeviceViewTest, MismatchingType)
   auto input_device_view = cudf::column_device_view::create(input, stream);
   auto output_device_view =
     cudf::mutable_column_device_view::create(output->mutable_view(), stream);
-  auto exec = rmm::exec_policy(stream);
-  EXPECT_THROW(thrust::copy(exec->on(stream.value()),
+
+  EXPECT_THROW(thrust::copy(rmm::exec_policy(stream),
                             input_device_view->begin<T>(),
                             input_device_view->end<T>(),
                             output_device_view->begin<int64_t>()),

--- a/cpp/tests/fixed_point/fixed_point_tests.cu
+++ b/cpp/tests/fixed_point/fixed_point_tests.cu
@@ -15,6 +15,7 @@
  */
 
 #include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -26,12 +27,13 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
+#include <rmm/exec_policy.hpp>
+
 #include <algorithm>
 #include <limits>
 #include <numeric>
 #include <type_traits>
 #include <vector>
-#include "cudf_test/column_utilities.hpp"
 
 using namespace numeric;
 
@@ -507,7 +509,7 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
   thrust::device_vector<decimal32> vec1(1000, decimal32{1, scale_type{-2}});
 
   auto const sum = thrust::reduce(
-    rmm::exec_policy(0)->on(0), std::cbegin(vec1), std::cend(vec1), decimal32{0, scale_type{-2}});
+    rmm::exec_policy(), std::cbegin(vec1), std::cend(vec1), decimal32{0, scale_type{-2}});
 
   EXPECT_EQ(static_cast<int32_t>(sum), 1000);
 
@@ -523,7 +525,7 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
   std::iota(std::begin(vec2), std::end(vec2), 1);
 
   auto const res1 = thrust::reduce(
-    rmm::exec_policy(0)->on(0), std::cbegin(vec1), std::cend(vec1), decimal32{0, scale_type{-2}});
+    rmm::exec_policy(), std::cbegin(vec1), std::cend(vec1), decimal32{0, scale_type{-2}});
 
   auto const res2 = std::accumulate(std::cbegin(vec2), std::cend(vec2), 0);
 
@@ -531,11 +533,8 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
 
   thrust::device_vector<int32_t> vec3(1000);
 
-  thrust::transform(rmm::exec_policy(0)->on(0),
-                    std::cbegin(vec1),
-                    std::cend(vec1),
-                    std::begin(vec3),
-                    cast_to_int32_fn{});
+  thrust::transform(
+    rmm::exec_policy(), std::cbegin(vec1), std::cend(vec1), std::begin(vec3), cast_to_int32_fn{});
 
   thrust::host_vector<int32_t> vec3_host = vec3;
 

--- a/cpp/tests/hash_map/map_test.cu
+++ b/cpp/tests/hash_map/map_test.cu
@@ -19,10 +19,9 @@
 #include <cudf/types.hpp>
 #include <cudf_test/base_fixture.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_vector.hpp>
 
-#include <thrust/device_vector.h>
 #include <thrust/logical.h>
 
 #include <gtest/gtest.h>

--- a/cpp/tests/io/comp/decomp_test.cu
+++ b/cpp/tests/io/comp/decomp_test.cu
@@ -15,12 +15,13 @@
  */
 
 #include <io/comp/gpuinflate.h>
+
 #include <cudf_test/base_fixture.hpp>
 
 #include <vector>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/device_buffer.hpp>
+#include <rmm/device_vector.hpp>
 
 /**
  * @brief Base test fixture for decompression

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -40,6 +40,7 @@
 #include <string>
 #include <vector>
 
+#include <thrust/execution_policy.h>
 #include <thrust/find.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <cudf/strings/convert/convert_datetime.hpp>

--- a/cpp/tests/merge/merge_dictionary_test.cpp
+++ b/cpp/tests/merge/merge_dictionary_test.cpp
@@ -102,34 +102,34 @@ TEST_F(MergeDictionaryTest, Merge2Columns)
 
 TEST_F(MergeDictionaryTest, WithNulls)
 {
-  cudf::test::fixed_width_column_wrapper<int8_t> left_w1({1, 2, 0, 4, 4, 5, 5},
-                                                         {1, 1, 0, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int8_t> left_w1({1, 2, 2, 4, 4, 5, 0},
+                                                         {1, 1, 1, 1, 1, 1, 0});
   auto left1 = cudf::dictionary::encode(left_w1);
-  cudf::test::fixed_width_column_wrapper<int64_t> left_w2({1000, 1000, 800, 0, 500, 500, 100},
-                                                          {1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int64_t> left_w2({1000, 1000, 800, 500, 500, 100, 0},
+                                                          {1, 1, 1, 1, 1, 1, 0});
   auto left2 = cudf::dictionary::encode(left_w2);
   cudf::table_view left_view{{left1->view(), left2->view()}};
 
-  cudf::test::fixed_width_column_wrapper<int8_t> right_w1({1, 1, 2, 0, 4, 5}, {1, 1, 1, 0, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int8_t> right_w1({1, 1, 2, 4, 5, 0}, {1, 1, 1, 1, 1, 0});
   auto right1 = cudf::dictionary::encode(right_w1);
-  cudf::test::fixed_width_column_wrapper<int64_t> right_w2({1000, 800, 800, 400, 0, 100},
-                                                           {1, 1, 1, 1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<int64_t> right_w2({1000, 800, 800, 400, 100, 0},
+                                                           {1, 1, 1, 1, 1, 0});
   auto right2 = cudf::dictionary::encode(right_w2);
   cudf::table_view right_view{{right1->view(), right2->view()}};
 
   std::vector<cudf::size_type> key_cols{0, 1};
   std::vector<cudf::order> column_order{cudf::order::ASCENDING, cudf::order::DESCENDING};
-  std::vector<cudf::null_order> null_precedence{};
+  std::vector<cudf::null_order> null_precedence{cudf::null_order::AFTER, cudf::null_order::BEFORE};
 
   auto result   = cudf::merge({left_view, right_view}, key_cols, column_order, null_precedence);
   auto decoded1 = cudf::dictionary::decode(result->get_column(0).view());
   auto decoded2 = cudf::dictionary::decode(result->get_column(1).view());
 
   cudf::test::fixed_width_column_wrapper<int8_t> expected_1(
-    {1, 1, 1, 2, 0, 2, 0, 4, 4, 4, 5, 5, 5}, {1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1});
+    {1, 1, 1, 2, 2, 2, 4, 4, 4, 5, 5, 0, 0}, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0});
   cudf::test::fixed_width_column_wrapper<int64_t> expected_2(
-    {1000, 1000, 800, 1000, 800, 800, 400, 0, 0, 500, 500, 100, 100},
-    {1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1});
+    {1000, 1000, 800, 1000, 800, 800, 500, 500, 400, 100, 100, 0, 0},
+    {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_1, decoded1->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_2, decoded2->view());
 

--- a/cpp/tests/merge/merge_string_test.cpp
+++ b/cpp/tests/merge/merge_string_test.cpp
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
+#include <cudf/column/column_factories.hpp>
+#include <cudf/merge.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
-#include <cudf_test/base_fixture.hpp>
-
-#include <rmm/thrust_rmm_allocator.h>
-#include <cudf/column/column_factories.hpp>
-#include <cudf/merge.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
+
+#include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>

--- a/cpp/tests/merge/merge_test.cpp
+++ b/cpp/tests/merge/merge_test.cpp
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+#include <cudf/column/column_factories.hpp>
 #include <cudf/merge.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>

--- a/cpp/tests/merge/merge_test.cpp
+++ b/cpp/tests/merge/merge_test.cpp
@@ -14,29 +14,21 @@
  * limitations under the License.
  */
 
+#include <cudf/merge.hpp>
+#include <cudf/sorting.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf_test/base_fixture.hpp>
-
-#include <rmm/thrust_rmm_allocator.h>
-#include <cudf/column/column_factories.hpp>
-#include <cudf/merge.hpp>
-#include <cudf/utilities/type_dispatcher.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <algorithm>
-#include <cassert>
-#include <initializer_list>
-#include <limits>
-#include <memory>
-#include <vector>
+#include <rmm/thrust_rmm_allocator.h>
 
-#include <gtest/gtest.h>
+#include <vector>
 
 template <typename T>
 class MergeTest_ : public cudf::test::BaseFixture {
@@ -693,6 +685,43 @@ TYPED_TEST(MergeTest_, NMerge1KeyColumns)
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_column_view1, output_column_view1);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_column_view2, output_column_view2);
+}
+
+class MergeTest : public cudf::test::BaseFixture {
+};
+
+TEST_F(MergeTest, KeysWithNulls)
+{
+  cudf::size_type nrows = 13200;  // Ensures that thrust::merge uses more than one tile/block
+  auto data_iter        = thrust::make_counting_iterator<int32_t>(0);
+  auto valids1          = cudf::test::make_counting_transform_iterator(
+    0, [](auto row) { return (row % 10 == 0) ? false : true; });
+  cudf::test::fixed_width_column_wrapper<int32_t> data1(data_iter, data_iter + nrows, valids1);
+  auto valids2 = cudf::test::make_counting_transform_iterator(
+    0, [](auto row) { return (row % 15 == 0) ? false : true; });
+  cudf::test::fixed_width_column_wrapper<int32_t> data2(data_iter, data_iter + nrows, valids2);
+  auto all_data = cudf::concatenate({data1, data2});
+
+  std::vector<cudf::order> column_orders{cudf::order::ASCENDING, cudf::order::DESCENDING};
+  std::vector<cudf::null_order> null_precedences{cudf::null_order::AFTER, cudf::null_order::BEFORE};
+
+  for (auto co : column_orders)
+    for (auto np : null_precedences) {
+      std::vector<cudf::order> column_order{co};
+      std::vector<cudf::null_order> null_precedence{np};
+      auto sorted1 =
+        cudf::sort(cudf::table_view({data1}), column_order, null_precedence)->release();
+      auto col1 = sorted1.front()->view();
+      auto sorted2 =
+        cudf::sort(cudf::table_view({data2}), column_order, null_precedence)->release();
+      auto col2 = sorted2.front()->view();
+
+      auto result = cudf::merge(
+        {cudf::table_view({col1}), cudf::table_view({col2})}, {0}, column_order, null_precedence);
+      auto sorted_all =
+        cudf::sort(cudf::table_view({all_data->view()}), column_order, null_precedence);
+      CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_all->view().column(0), result->view().column(0));
+    }
 }
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/partitioning/round_robin_test.cpp
+++ b/cpp/tests/partitioning/round_robin_test.cpp
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
+#include <cudf/column/column_factories.hpp>
+#include <cudf/partitioning.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
-#include <cudf_test/base_fixture.hpp>
-
-#include <rmm/thrust_rmm_allocator.h>
-#include <cudf/column/column_factories.hpp>
-#include <cudf/partitioning.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
+
+#include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -1072,7 +1072,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionProduct)
     auto const scale    = scale_type{i};
     auto const column   = fp_wrapper{{1, 2, 3, 1, 2, 3}, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
-    auto const expected = decimalXX{36, scale};
+    auto const expected = decimalXX{scaled_integer<RepType>{36, scale_type{i * 6}}};
 
     auto const result        = cudf::reduce(column, cudf::make_product_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());
@@ -1091,23 +1091,14 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionSum)
   for (int i = -3; i <= 0; ++i) {
     auto const scale = scale_type{i};
 
-    auto const ZERO  = decimalXX{0, scale};
-    auto const ONE   = decimalXX{1, scale};
-    auto const TWO   = decimalXX{2, scale};
-    auto const THREE = decimalXX{3, scale};
-    auto const FOUR  = decimalXX{4, scale};
-    auto const TEN   = decimalXX{10, scale};
-
-    auto const in       = std::vector<decimalXX>{ONE, TWO, THREE, FOUR};
     auto const column   = fp_wrapper{{1, 2, 3, 4}, scale};
-    auto const expected = std::accumulate(in.cbegin(), in.cend(), ZERO, std::plus<decimalXX>());
+    auto const expected = decimalXX{scaled_integer<RepType>{10, scale}};
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
     auto const result        = cudf::reduce(column, cudf::make_sum_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
-    EXPECT_EQ(result_scalar->fixed_point_value(), TEN);
   }
 }
 
@@ -1146,7 +1137,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionSumFractional)
     auto const scale    = scale_type{i};
     auto const column   = fp_wrapper{{111, 222, 333}, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
-    auto const expected = decimalXX{666, scale};
+    auto const expected = decimalXX{scaled_integer<RepType>{666, scale}};
 
     auto const result        = cudf::reduce(column, cudf::make_sum_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());
@@ -1169,7 +1160,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionSumLarge)
     auto const column         = fp_wrapper{values.cbegin(), values.cend(), scale};
     auto const out_type       = static_cast<cudf::column_view>(column).type();
     auto const expected_value = std::accumulate(values.cbegin(), values.cend(), RepType{0});
-    auto const expected       = decimalXX{expected_value, scale};
+    auto const expected       = decimalXX{scaled_integer<RepType>{expected_value, scale}};
 
     auto const result        = cudf::reduce(column, cudf::make_sum_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());
@@ -1187,7 +1178,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionMin)
 
   for (int i = -3; i <= 0; ++i) {
     auto const scale    = scale_type{i};
-    auto const ONE      = decimalXX{1, scale};
+    auto const ONE      = decimalXX{scaled_integer<RepType>{1, scale}};
     auto const column   = fp_wrapper{{1, 2, 3, 4}, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
@@ -1228,7 +1219,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionMax)
 
   for (int i = -3; i <= 0; ++i) {
     auto const scale    = scale_type{i};
-    auto const FOUR     = decimalXX{4, scale};
+    auto const FOUR     = decimalXX{scaled_integer<RepType>{4, scale}};
     auto const column   = fp_wrapper{{1, 2, 3, 4}, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
@@ -1251,7 +1242,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionMaxLarge)
     auto f = cudf::test::make_counting_transform_iterator(0, [](auto e) { return e % 43; });
     auto const column   = fp_wrapper{f, f + 5000, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
-    auto const expected = decimalXX{42, scale};
+    auto const expected = decimalXX{scaled_integer<RepType>{42, scale}};
 
     auto const result        = cudf::reduce(column, cudf::make_max_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());

--- a/cpp/tests/scalar/scalar_device_view_test.cu
+++ b/cpp/tests/scalar/scalar_device_view_test.cu
@@ -23,6 +23,8 @@
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <rmm/device_vector.hpp>
+
 #include <thrust/sequence.h>
 #include <random>
 

--- a/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
@@ -198,13 +198,13 @@ TEST_F(ApplyBooleanMask, FixedPointLargeColumnTest)
 
   std::vector<int32_t> expect_dec32_data;
   std::vector<int64_t> expect_dec64_data;
-  thrust::copy_if(thrust::host,
+  thrust::copy_if(thrust::seq,
                   dec32_data.cbegin(),
                   dec32_data.cend(),
                   mask_data.cbegin(),
                   std::back_inserter(expect_dec32_data),
                   thrust::identity<bool>());
-  thrust::copy_if(thrust::host,
+  thrust::copy_if(thrust::seq,
                   dec64_data.cbegin(),
                   dec64_data.cend(),
                   mask_data.cbegin(),

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -25,6 +25,7 @@
 #include <cudf/table/table_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <vector>
 
@@ -46,7 +47,7 @@ void row_comparison(cudf::table_view input1,
   auto comparator = cudf::row_lexicographic_comparator<false>(
     *device_table_1, *device_table_2, d_column_order.data().get());
 
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     thrust::make_counting_iterator(0),
                     thrust::make_counting_iterator(input1.num_rows()),
                     thrust::make_counting_iterator(0),

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -25,7 +25,7 @@
 #include <cudf/table/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/bit.hpp>
-#include "cudf/utilities/type_dispatcher.hpp"
+#include <cudf/utilities/type_dispatcher.hpp>
 
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -33,6 +33,8 @@
 #include <cudf_test/detail/column_utilities.hpp>
 
 #include <jit/type.h>
+
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/equal.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -516,7 +518,7 @@ std::string nested_offsets_to_string(NestedColumnView const& c, std::string cons
   // normalize the offset values for the column offset
   size_type const* d_offsets = offsets.head<size_type>() + c.offset();
   thrust::transform(
-    rmm::exec_policy(0)->on(0),
+    rmm::exec_policy(),
     d_offsets,
     d_offsets + output_size,
     shifted_offsets.begin(),

--- a/cpp/tests/utilities_tests/span_tests.cu
+++ b/cpp/tests/utilities_tests/span_tests.cu
@@ -20,8 +20,8 @@
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/device_buffer.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <cstddef>
 #include <cstring>

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -36,7 +36,7 @@ nvidia-docker run -it cudf-build:10.1-devel-centos7 bash
 You can download the cuDF repo in the docker container or you can mount it into the container.
 Here I choose to download again in the container.
 ```bash
-git clone --recursive https://github.com/rapidsai/cudf.git -b branch-0.17
+git clone --recursive https://github.com/rapidsai/cudf.git -b branch-0.18
 ```
 
 ### Build cuDF jar
@@ -49,5 +49,5 @@ scl enable devtoolset-7 "java/ci/build-in-docker.sh"
 
 ### The output
 
-You can find the cuDF jar in java/target/ like cudf-0.17-SNAPSHOT-cuda10-1.jar.
+You can find the cuDF jar in java/target/ like cudf-0.18-SNAPSHOT-cuda10-1.jar.
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ai.rapids</groupId>
     <artifactId>cudf</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.18-SNAPSHOT</version>
 
     <name>cudfjni</name>
     <description>


### PR DESCRIPTION
Updates libcudf to use the new, simplified `rmm::exec_policy` and include the new refactored headers `rmm/exec_policy.hpp` and `rmm/device_vector.hpp`

The new `exec_policy` can be passed directly to Thrust, no longer any need to call `rmm::exec_policy(stream)->on(stream)`.

Depends on rapidsai/rmm#647