### PR TITLE
Add JNI wrapper for the cuFile API (GDS) [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - PR #6847 Add a cmake find module for cuFile in JNI code
 - PR #6902 Implement `DataFrame.quantile` for `datetime` and `timedelta` data types
-- PR #6940 Add JNI wrapper for the cuFile API (GDS)
 - PR #6814 Implement `cudf::reduce` for `decimal32` and `decimal64` (part 1)
 - PR #6929 Add `Index.set_names` api
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - PR #6902 Implement `DataFrame.quantile` for `datetime` and `timedelta` data types
+- PR #6940 Add JNI wrapper for the cuFile API (GDS)
 
 ## Improvements
 

--- a/java/README.md
+++ b/java/README.md
@@ -119,3 +119,16 @@ then build the jar:
 cd src/cudf/java
 mvn clean install -DPER_THREAD_DEFAULT_STREAM=ON
 ```
+
+## GPUDirect Storage (GDS)
+
+The JNI code can be built with *GPUDirect Storage* (GDS) support, which enables direct copying 
+between GPU device buffers and supported filesystems (see
+https://docs.nvidia.com/gpudirect-storage/).
+
+To enable GDS support, first make sure GDS is installed (see
+https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/index.html), then run:  
+```shell script
+cd src/cudf/java
+mvn clean install -DUSE_GDS=ON
+```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -138,7 +138,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <junit.version>5.7.0</junit.version>
+        <junit.version>5.4.2</junit.version>
         <ai.rapids.refcount.debug>false</ai.rapids.refcount.debug>
         <native.build.path>${basedir}/target/cmake-build</native.build.path>
         <skipNativeCopy>false</skipNativeCopy>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -138,7 +138,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <junit.version>5.4.2</junit.version>
+        <junit.version>5.7.0</junit.version>
         <ai.rapids.refcount.debug>false</ai.rapids.refcount.debug>
         <native.build.path>${basedir}/target/cmake-build</native.build.path>
         <skipNativeCopy>false</skipNativeCopy>
@@ -147,6 +147,7 @@
         <CUDA_STATIC_RUNTIME>OFF</CUDA_STATIC_RUNTIME>
         <PER_THREAD_DEFAULT_STREAM>OFF</PER_THREAD_DEFAULT_STREAM>
         <RMM_LOGGING_LEVEL>INFO</RMM_LOGGING_LEVEL>
+        <USE_GDS>OFF</USE_GDS>
         <native.build.path>${project.build.directory}/cmake-build</native.build.path>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
@@ -157,6 +158,28 @@
             <properties>
                 <cxx.flags>-Wno-deprecated-declarations</cxx.flags>
             </properties>
+        </profile>
+        <profile>
+            <id>no-cufile</id>
+            <activation>
+                <property>
+                    <name>USE_GDS</name>
+                    <value>!ON</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/CuFile*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>release</id>
@@ -349,6 +372,7 @@
                                     <arg value="-DCUDA_STATIC_RUNTIME=${CUDA_STATIC_RUNTIME}" />
                                     <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}" />
                                     <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
+                                    <arg value="-DUSE_GDS=${USE_GDS}" />
                                     <arg value="-DCMAKE_CXX_FLAGS=${cxx.flags}"/>
                                     <arg value="-DCMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}"/>
                                     <arg value="-DCUDF_CPP_BUILD_DIR=${CUDF_CPP_BUILD_DIR}"/>
@@ -479,6 +503,7 @@
                                     <directory>${native.build.path}</directory>
                                     <includes>
                                         <include>libcudfjni.so</include>
+                                        <include>libcufilejni.so</include>
                                     </includes>
                                 </resource>
                                 <resource>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -160,7 +160,7 @@
             </properties>
         </profile>
         <profile>
-            <id>no-cufile</id>
+            <id>no-cufile-tests</id>
             <activation>
                 <property>
                     <name>USE_GDS</name>
@@ -174,7 +174,7 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <exclude>**/CuFile*.java</exclude>
+                                <exclude>**/CuFileTest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -23,6 +23,14 @@ import java.io.File;
 
 /**
  * JNI wrapper for accessing the cuFile API.
+ * <p>
+ * Using this wrapper requires GPUDirect Storage (GDS)/cuFile to be installed in the target
+ * environment, and the jar to be built with `USE_GDS=ON`. Otherwise it will throw an exception when
+ * loading.
+ * <p>
+ * The Java APIs are experimental and subject to change.
+ *
+ * @see <a href="https://docs.nvidia.com/gpudirect-storage/">GDS documentation</a>
  */
 public class CuFile {
   private static final Logger log = LoggerFactory.getLogger(CuFile.class);
@@ -57,9 +65,11 @@ public class CuFile {
   private static native void destroyDriver(long pointer);
 
   /**
-   * Copy a device buffer to a given file path.
+   * Copy a device buffer to a given file path synchronously.
+   * <p>
+   * This method is NOT thread safe if the path points to the same file on disk.
    *
-   * @param path The file path to copy to.
+   * @param path   The file path to copy to.
    * @param buffer The device buffer to copy from.
    * @param append Whether to append to the file.
    * @return The file offset from which the buffer was appended.
@@ -69,10 +79,12 @@ public class CuFile {
   }
 
   /**
-   * Copy a file into a device buffer.
+   * Copy a file into a device buffer synchronously.
+   * <p>
+   * This method is NOT thread safe if the path points to the same file on disk.
    *
-   * @param buffer The device buffer to copy into.
-   * @param path The file path to copy from.
+   * @param buffer     The device buffer to copy into.
+   * @param path       The file path to copy from.
    * @param fileOffset The file offset from which to copy the content.
    */
   public static void copyFileToDeviceBuffer(DeviceMemoryBuffer buffer, File path, long fileOffset) {

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -21,6 +21,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
+/**
+ * JNI wrapper for accessing the cuFile API.
+ */
 public class CuFile {
   private static final Logger log = LoggerFactory.getLogger(CuFile.class);
   private static boolean initialized = false;
@@ -53,10 +56,25 @@ public class CuFile {
 
   private static native void destroyDriver(long pointer);
 
+  /**
+   * Copy a device buffer to a given file path.
+   *
+   * @param path The file path to copy to.
+   * @param buffer The device buffer to copy from.
+   * @param append Whether to append to the file.
+   * @return The file offset from which the buffer was appended.
+   */
   public static long copyDeviceBufferToFile(File path, DeviceMemoryBuffer buffer, boolean append) {
     return copyToFile(path.getAbsolutePath(), buffer.getAddress(), buffer.getLength(), append);
   }
 
+  /**
+   * Copy a file into a device buffer.
+   *
+   * @param buffer The device buffer to copy into.
+   * @param path The file path to copy from.
+   * @param fileOffset The file offset from which to copy the content.
+   */
   public static void copyFileToDeviceBuffer(DeviceMemoryBuffer buffer, File path, long fileOffset) {
     copyFromFile(buffer.getAddress(), buffer.getLength(), path.getAbsolutePath(), fileOffset);
   }

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -57,12 +57,11 @@ public class CuFile {
     return copyToFile(path.getAbsolutePath(), buffer.getAddress(), buffer.getLength(), append);
   }
 
-  public static long copyFileToDeviceBuffer(DeviceMemoryBuffer buffer, File path) {
-    copyFromFile(buffer.getAddress(), buffer.getLength(), path.getAbsolutePath());
-    return 0;
+  public static void copyFileToDeviceBuffer(DeviceMemoryBuffer buffer, File path, long fileOffset) {
+    copyFromFile(buffer.getAddress(), buffer.getLength(), path.getAbsolutePath(), fileOffset);
   }
 
   private static native long copyToFile(String path, long address, long length, boolean append);
 
-  private static native void copyFromFile(long address, long length, String path);
+  private static native void copyFromFile(long address, long length, String path, long fileOffset);
 }

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -65,21 +65,44 @@ public class CuFile {
   private static native void destroyDriver(long pointer);
 
   /**
-   * Copy a device buffer to a given file path synchronously.
+   * Check if the libcufilejni library is loaded.
+   *
+   * @return true if the libcufilejni library has been successfully loaded.
+   */
+  public static boolean libraryLoaded() {
+    return initialized;
+  }
+
+  /**
+   * Write a device buffer to a given file path synchronously.
+   * <p>
+   * This method is NOT thread safe if the path points to the same file on disk.
+   *
+   * @param path        The file path to copy to.
+   * @param file_offset The file offset from which to write the buffer.
+   * @param buffer      The device buffer to copy from.
+   * @return The file offset from which the buffer was appended.
+   */
+  public static void writeDeviceBufferToFile(File path, long file_offset,
+                                             BaseDeviceMemoryBuffer buffer) {
+    writeToFile(path.getAbsolutePath(), file_offset, buffer.getAddress(), buffer.getLength());
+  }
+
+  /**
+   * Append a device buffer to a given file path synchronously.
    * <p>
    * This method is NOT thread safe if the path points to the same file on disk.
    *
    * @param path   The file path to copy to.
    * @param buffer The device buffer to copy from.
-   * @param append Whether to append to the file.
    * @return The file offset from which the buffer was appended.
    */
-  public static long copyDeviceBufferToFile(File path, DeviceMemoryBuffer buffer, boolean append) {
-    return copyToFile(path.getAbsolutePath(), buffer.getAddress(), buffer.getLength(), append);
+  public static long appendDeviceBufferToFile(File path, BaseDeviceMemoryBuffer buffer) {
+    return appendToFile(path.getAbsolutePath(), buffer.getAddress(), buffer.getLength());
   }
 
   /**
-   * Copy a file into a device buffer synchronously.
+   * Read a file into a device buffer synchronously.
    * <p>
    * This method is NOT thread safe if the path points to the same file on disk.
    *
@@ -87,11 +110,14 @@ public class CuFile {
    * @param path       The file path to copy from.
    * @param fileOffset The file offset from which to copy the content.
    */
-  public static void copyFileToDeviceBuffer(DeviceMemoryBuffer buffer, File path, long fileOffset) {
-    copyFromFile(buffer.getAddress(), buffer.getLength(), path.getAbsolutePath(), fileOffset);
+  public static void readFileToDeviceBuffer(BaseDeviceMemoryBuffer buffer, File path,
+                                            long fileOffset) {
+    readFromFile(buffer.getAddress(), buffer.getLength(), path.getAbsolutePath(), fileOffset);
   }
 
-  private static native long copyToFile(String path, long address, long length, boolean append);
+  private static native void writeToFile(String path, long file_offset, long address, long length);
 
-  private static native void copyFromFile(long address, long length, String path, long fileOffset);
+  private static native long appendToFile(String path, long address, long length);
+
+  private static native void readFromFile(long address, long length, String path, long fileOffset);
 }

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public class CuFile {
+  private static final Logger log = LoggerFactory.getLogger(CuFile.class);
+  private static boolean initialized = false;
+
+  static {
+    initialize();
+  }
+
+  /**
+   * Load the native libraries needed for libcufilejni, if not loaded already; open the cuFile
+   * driver, and add a shutdown hook to close it.
+   */
+  private static synchronized void initialize() {
+    if (!initialized) {
+      try {
+        NativeDepsLoader.loadNativeDeps(new String[]{"cufilejni"});
+        open();
+        Runtime.getRuntime().addShutdownHook(new Thread(CuFile::close));
+        initialized = true;
+      } catch (Throwable t) {
+        log.error("Could not load cuFile jni library...", t);
+      }
+    }
+  }
+
+  private static native void open();
+
+  private static native void close();
+
+  public static long copyDeviceBufferToFile(File path, DeviceMemoryBuffer buffer) {
+    copyToFile(path.getAbsolutePath(), buffer.getAddress(), buffer.getLength());
+    return 0;
+  }
+
+  public static long copyFileToDeviceBuffer(DeviceMemoryBuffer buffer, File path) {
+    copyFromFile(buffer.getAddress(), buffer.getLength(), path.getAbsolutePath());
+    return 0;
+  }
+
+  private static native void copyToFile(String path, long address, long length);
+
+  private static native void copyFromFile(long address, long length, String path);
+}

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -289,8 +289,7 @@ include_directories("${THRUST_INCLUDE}"
                     "${JNI_INCLUDE_DIRS}"
                     "${CUDF_INCLUDE}"
                     "${RMM_INCLUDE}"
-                    "${ARROW_INCLUDE}"
-                    "$<$<BOOL:${cuFile_FOUND}>:${cuFile_INCLUDE_DIRS}>")
+                    "${ARROW_INCLUDE}")
 
 ###################################################################################################
 # - library paths ---------------------------------------------------------------------------------
@@ -320,6 +319,12 @@ add_library(cudfjni SHARED ${SOURCE_FILES})
 
 #Override RPATH for cudfjni
 SET_TARGET_PROPERTIES(cudfjni PROPERTIES BUILD_RPATH "\$ORIGIN")
+
+if(USE_GDS)
+    add_library(cufilejni SHARED "src/CuFileJni.cpp")
+    target_include_directories(cufilejni PRIVATE "${cuFile_INCLUDE_DIRS}")
+    target_link_libraries(cufilejni PRIVATE "${cuFile_LIBRARIES}")
+endif(USE_GDS)
 
 ###################################################################################################
 # - build options ---------------------------------------------------------------------------------

--- a/java/src/main/native/src/CuFileJni.cpp
+++ b/java/src/main/native/src/CuFileJni.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+
+#include <cufile.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cudf/utilities/error.hpp>
+
+namespace cufile {
+namespace jni {
+
+//
+// cuda driver error description
+//
+static const char *GetCuErrorString(CUresult cu_result) {
+  const char *description;
+  if (cuGetErrorName(cu_result, &description) != CUDA_SUCCESS)
+    description = "unknown cuda error";
+  return description;
+}
+
+//
+// cuFile APIs return both cuFile specific error codes as well as POSIX error codes
+// for ease, the below template can be used for getting the error description depending
+// on its type.
+
+// POSIX
+template <typename T,
+          typename std::enable_if<std::is_integral<T>::value, std::nullptr_t>::type = nullptr>
+std::string cuFileGetErrorString(T status) {
+  status = std::abs(status);
+  return IS_CUFILE_ERR(status) ? std::string(CUFILE_ERRSTR(status)) :
+                                 std::string(std::strerror(status));
+}
+
+// CUfileError_t
+template <typename T,
+          typename std::enable_if<!std::is_integral<T>::value, std::nullptr_t>::type = nullptr>
+std::string cuFileGetErrorString(T status) {
+  std::string error = cuFileGetErrorString(static_cast<int>(status.err));
+  if (IS_CUDA_ERR(status)) {
+    error.append(".").append(GetCuErrorString(status.cu_err));
+  }
+  return error;
+}
+
+class cufile_driver {
+public:
+  cufile_driver() {
+    auto const status = cuFileDriverOpen();
+    if (status.err != CU_FILE_SUCCESS) {
+      CUDF_FAIL("Failed to initialize cuFile driver: " + cuFileGetErrorString(status));
+    }
+  }
+
+  // Disable copy (and move) semantics.
+  cufile_driver(cufile_driver const &) = delete;
+  cufile_driver &operator=(cufile_driver const &) = delete;
+
+  ~cufile_driver() { cuFileDriverClose(); }
+};
+
+class cufile_buffer {
+public:
+  cufile_buffer(void *device_pointer, std::size_t size)
+      : device_pointer_{device_pointer}, size_{size} {
+    auto const status = cuFileBufRegister(device_pointer_, size_, 0);
+    if (status.err != CU_FILE_SUCCESS) {
+      CUDF_FAIL("Failed to register cuFile buffer: " + cuFileGetErrorString(status));
+    }
+  }
+
+  // Disable copy (and move) semantics.
+  cufile_buffer(cufile_buffer const &) = delete;
+  cufile_buffer &operator=(cufile_buffer const &) = delete;
+
+  ~cufile_buffer() { cuFileBufDeregister(device_pointer_); }
+
+  void *device_pointer() const { return device_pointer_; }
+  std::size_t size() const { return size_; }
+
+private:
+  void *device_pointer_;
+  std::size_t size_;
+};
+
+class cufile_file {
+public:
+  cufile_file(std::string const &path) {
+    file_descriptor_ = open(path.c_str(), O_CREAT | O_RDWR | O_DIRECT, 0644);
+    if (file_descriptor_ < 0) {
+      CUDF_FAIL("Failed to open file: " + cuFileGetErrorString(errno));
+    }
+    CUfileDescr_t cufile_descriptor{CU_FILE_HANDLE_TYPE_OPAQUE_FD, file_descriptor_};
+    auto const status = cuFileHandleRegister(&cufile_handle_, &cufile_descriptor);
+    if (status.err != CU_FILE_SUCCESS) {
+      close(file_descriptor_);
+      CUDF_FAIL("Failed to register cuFile handle: " + cuFileGetErrorString(status));
+    }
+  }
+
+  // Disable copy (and move) semantics.
+  cufile_file(cufile_file const &) = delete;
+  cufile_file &operator=(cufile_file const &) = delete;
+
+  ~cufile_file() {
+    cuFileHandleDeregister(cufile_handle_);
+    close(file_descriptor_);
+  }
+
+  std::size_t read(cufile_buffer *buffer) {
+    auto const status = cuFileRead(cufile_handle_, buffer->device_pointer(), buffer->size(), 0, 0);
+
+    if (status < 0) {
+      if (IS_CUFILE_ERR(status)) {
+        CUDF_FAIL("Failed to read file into buffer: " + cuFileGetErrorString(status));
+      } else {
+        CUDF_FAIL("Failed to read file into buffer: " + cuFileGetErrorString(errno));
+      }
+    }
+
+    return static_cast<std::size_t>(status);
+  }
+
+  std::size_t write(cufile_buffer const &buffer) {
+    auto const status = cuFileWrite(cufile_handle_, buffer.device_pointer(), buffer.size(), 0, 0);
+
+    if (status < 0) {
+      if (IS_CUFILE_ERR(status)) {
+        CUDF_FAIL("Failed to write buffer to file: " + cuFileGetErrorString(status));
+      } else {
+        CUDF_FAIL("Failed to write buffer to file: " + cuFileGetErrorString(errno));
+      }
+    }
+
+    return static_cast<std::size_t>(status);
+  }
+
+private:
+  int file_descriptor_;
+  CUfileHandle_t cufile_handle_;
+};
+
+} // namespace jni
+} // namespace cufile

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -27,7 +27,7 @@ public class CuFileTest extends CudfTestBase {
          HostMemoryBuffer dest = HostMemoryBuffer.allocate(16);) {
       orig.setLong(0, 123456789);
       from.copyFromHostBuffer(orig);
-      CuFile.copyDeviceBufferToFile(tempFile, from);
+      CuFile.copyDeviceBufferToFile(tempFile, from, false);
       CuFile.copyFileToDeviceBuffer(to, tempFile);
       dest.copyFromDeviceBuffer(to);
       assertEquals(123456789, dest.getLong(0));

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -27,8 +27,8 @@ public class CuFileTest extends CudfTestBase {
          HostMemoryBuffer dest = HostMemoryBuffer.allocate(16);) {
       orig.setLong(0, 123456789);
       from.copyFromHostBuffer(orig);
-      CuFile.copyDeviceBufferToFile(tempFile, from, false);
-      CuFile.copyFileToDeviceBuffer(to, tempFile, 0);
+      CuFile.writeDeviceBufferToFile(tempFile, 0, from);
+      CuFile.readFileToDeviceBuffer(to, tempFile, 0);
       dest.copyFromDeviceBuffer(to);
       assertEquals(123456789, dest.getLong(0));
     }
@@ -43,17 +43,17 @@ public class CuFileTest extends CudfTestBase {
          HostMemoryBuffer dest = HostMemoryBuffer.allocate(16);) {
       orig.setLong(0, 123456789);
       from.copyFromHostBuffer(orig);
-      CuFile.copyDeviceBufferToFile(tempFile, from, true);
+      CuFile.appendDeviceBufferToFile(tempFile, from);
 
       orig.setLong(0, 987654321);
       from.copyFromHostBuffer(orig);
-      CuFile.copyDeviceBufferToFile(tempFile, from, true);
+      CuFile.appendDeviceBufferToFile(tempFile, from);
 
-      CuFile.copyFileToDeviceBuffer(to, tempFile, 0);
+      CuFile.readFileToDeviceBuffer(to, tempFile, 0);
       dest.copyFromDeviceBuffer(to);
       assertEquals(123456789, dest.getLong(0));
 
-      CuFile.copyFileToDeviceBuffer(to, tempFile, 16);
+      CuFile.readFileToDeviceBuffer(to, tempFile, 16);
       dest.copyFromDeviceBuffer(to);
       assertEquals(987654321, dest.getLong(0));
     }

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -28,9 +28,34 @@ public class CuFileTest extends CudfTestBase {
       orig.setLong(0, 123456789);
       from.copyFromHostBuffer(orig);
       CuFile.copyDeviceBufferToFile(tempFile, from, false);
-      CuFile.copyFileToDeviceBuffer(to, tempFile);
+      CuFile.copyFileToDeviceBuffer(to, tempFile, 0);
       dest.copyFromDeviceBuffer(to);
       assertEquals(123456789, dest.getLong(0));
+    }
+  }
+
+  @Test
+  public void testAppendToFile() {
+    File tempFile = new File(tempDir, "tempFile");
+    try (HostMemoryBuffer orig = HostMemoryBuffer.allocate(16);
+         DeviceMemoryBuffer from = DeviceMemoryBuffer.allocate(16);
+         DeviceMemoryBuffer to = DeviceMemoryBuffer.allocate(16);
+         HostMemoryBuffer dest = HostMemoryBuffer.allocate(16);) {
+      orig.setLong(0, 123456789);
+      from.copyFromHostBuffer(orig);
+      CuFile.copyDeviceBufferToFile(tempFile, from, false);
+
+      orig.setLong(0, 987654321);
+      from.copyFromHostBuffer(orig);
+      CuFile.copyDeviceBufferToFile(tempFile, from, true);
+
+      CuFile.copyFileToDeviceBuffer(to, tempFile, 0);
+      dest.copyFromDeviceBuffer(to);
+      assertEquals(123456789, dest.getLong(0));
+
+      CuFile.copyFileToDeviceBuffer(to, tempFile, 16);
+      dest.copyFromDeviceBuffer(to);
+      assertEquals(987654321, dest.getLong(0));
     }
   }
 }

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -43,7 +43,7 @@ public class CuFileTest extends CudfTestBase {
          HostMemoryBuffer dest = HostMemoryBuffer.allocate(16);) {
       orig.setLong(0, 123456789);
       from.copyFromHostBuffer(orig);
-      CuFile.copyDeviceBufferToFile(tempFile, from, false);
+      CuFile.copyDeviceBufferToFile(tempFile, from, true);
 
       orig.setLong(0, 987654321);
       from.copyFromHostBuffer(orig);

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -1,0 +1,36 @@
+package ai.rapids.cudf;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CuFileTest extends CudfTestBase {
+  @TempDir File tempDir;
+
+  @AfterEach
+  void tearDown() {
+    if (PinnedMemoryPool.isInitialized()) {
+      PinnedMemoryPool.shutdown();
+    }
+  }
+
+  @Test
+  public void testCopyToFile() {
+    File tempFile = new File(tempDir, "tempFile");
+    try (HostMemoryBuffer orig = HostMemoryBuffer.allocate(16);
+         DeviceMemoryBuffer from = DeviceMemoryBuffer.allocate(16);
+         DeviceMemoryBuffer to = DeviceMemoryBuffer.allocate(16);
+         HostMemoryBuffer dest = HostMemoryBuffer.allocate(16);) {
+      orig.setLong(0, 123456789);
+      from.copyFromHostBuffer(orig);
+      CuFile.copyDeviceBufferToFile(tempFile, from);
+      CuFile.copyFileToDeviceBuffer(to, tempFile);
+      dest.copyFromDeviceBuffer(to);
+      assertEquals(123456789, dest.getLong(0));
+    }
+  }
+}


### PR DESCRIPTION
This adds a `libcufilejni.so` that's by default not built nor loaded. The unit tests are controlled similarly.

Tested locally with the corresponding spark-rapids plugin changes.

@jlowe @revans2 @abellina 