### PR TITLE
Fix cudf::merge gtest for dictionary columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Bug Fixes
 
 - PR #6912 Fix rmm_mode=managed parameter for gtests
+- PR #6942 Fix cudf::merge gtest for dictionary columns
 
 
 # cuDF 0.17.0 (Date TBD)

--- a/cpp/tests/merge/merge_dictionary_test.cpp
+++ b/cpp/tests/merge/merge_dictionary_test.cpp
@@ -102,34 +102,34 @@ TEST_F(MergeDictionaryTest, Merge2Columns)
 
 TEST_F(MergeDictionaryTest, WithNulls)
 {
-  cudf::test::fixed_width_column_wrapper<int8_t> left_w1({1, 2, 0, 4, 4, 5, 5},
-                                                         {1, 1, 0, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int8_t> left_w1({1, 2, 2, 4, 4, 5, 0},
+                                                         {1, 1, 1, 1, 1, 1, 0});
   auto left1 = cudf::dictionary::encode(left_w1);
-  cudf::test::fixed_width_column_wrapper<int64_t> left_w2({1000, 1000, 800, 0, 500, 500, 100},
-                                                          {1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int64_t> left_w2({1000, 1000, 800, 500, 500, 100, 0},
+                                                          {1, 1, 1, 1, 1, 1, 0});
   auto left2 = cudf::dictionary::encode(left_w2);
   cudf::table_view left_view{{left1->view(), left2->view()}};
 
-  cudf::test::fixed_width_column_wrapper<int8_t> right_w1({1, 1, 2, 0, 4, 5}, {1, 1, 1, 0, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int8_t> right_w1({1, 1, 2, 4, 5, 0}, {1, 1, 1, 1, 1, 0});
   auto right1 = cudf::dictionary::encode(right_w1);
-  cudf::test::fixed_width_column_wrapper<int64_t> right_w2({1000, 800, 800, 400, 0, 100},
-                                                           {1, 1, 1, 1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<int64_t> right_w2({1000, 800, 800, 400, 100, 0},
+                                                           {1, 1, 1, 1, 1, 0});
   auto right2 = cudf::dictionary::encode(right_w2);
   cudf::table_view right_view{{right1->view(), right2->view()}};
 
   std::vector<cudf::size_type> key_cols{0, 1};
   std::vector<cudf::order> column_order{cudf::order::ASCENDING, cudf::order::DESCENDING};
-  std::vector<cudf::null_order> null_precedence{};
+  std::vector<cudf::null_order> null_precedence{cudf::null_order::AFTER, cudf::null_order::BEFORE};
 
   auto result   = cudf::merge({left_view, right_view}, key_cols, column_order, null_precedence);
   auto decoded1 = cudf::dictionary::decode(result->get_column(0).view());
   auto decoded2 = cudf::dictionary::decode(result->get_column(1).view());
 
   cudf::test::fixed_width_column_wrapper<int8_t> expected_1(
-    {1, 1, 1, 2, 0, 2, 0, 4, 4, 4, 5, 5, 5}, {1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1});
+    {1, 1, 1, 2, 2, 2, 4, 4, 4, 5, 5, 0, 0}, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0});
   cudf::test::fixed_width_column_wrapper<int64_t> expected_2(
-    {1000, 1000, 800, 1000, 800, 800, 400, 0, 0, 500, 500, 100, 100},
-    {1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1});
+    {1000, 1000, 800, 1000, 800, 800, 500, 500, 400, 100, 100, 0, 0},
+    {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_1, decoded1->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_2, decoded2->view());
 

--- a/cpp/tests/merge/merge_test.cpp
+++ b/cpp/tests/merge/merge_test.cpp
@@ -14,29 +14,21 @@
  * limitations under the License.
  */
 
+#include <cudf/merge.hpp>
+#include <cudf/sorting.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf_test/base_fixture.hpp>
-
-#include <rmm/thrust_rmm_allocator.h>
-#include <cudf/column/column_factories.hpp>
-#include <cudf/merge.hpp>
-#include <cudf/utilities/type_dispatcher.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <algorithm>
-#include <cassert>
-#include <initializer_list>
-#include <limits>
-#include <memory>
-#include <vector>
+#include <rmm/thrust_rmm_allocator.h>
 
-#include <gtest/gtest.h>
+#include <vector>
 
 template <typename T>
 class MergeTest_ : public cudf::test::BaseFixture {
@@ -693,6 +685,43 @@ TYPED_TEST(MergeTest_, NMerge1KeyColumns)
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_column_view1, output_column_view1);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_column_view2, output_column_view2);
+}
+
+class MergeTest : public cudf::test::BaseFixture {
+};
+
+TEST_F(MergeTest, KeysWithNulls)
+{
+  cudf::size_type nrows = 13200;  // Ensures that thrust::merge uses more than one tile/block
+  auto data_iter        = thrust::make_counting_iterator<int32_t>(0);
+  auto valids1          = cudf::test::make_counting_transform_iterator(
+    0, [](auto row) { return (row % 10 == 0) ? false : true; });
+  cudf::test::fixed_width_column_wrapper<int32_t> data1(data_iter, data_iter + nrows, valids1);
+  auto valids2 = cudf::test::make_counting_transform_iterator(
+    0, [](auto row) { return (row % 15 == 0) ? false : true; });
+  cudf::test::fixed_width_column_wrapper<int32_t> data2(data_iter, data_iter + nrows, valids2);
+  auto all_data = cudf::concatenate({data1, data2});
+
+  std::vector<cudf::order> column_orders{cudf::order::ASCENDING, cudf::order::DESCENDING};
+  std::vector<cudf::null_order> null_precedences{cudf::null_order::AFTER, cudf::null_order::BEFORE};
+
+  for (auto co : column_orders)
+    for (auto np : null_precedences) {
+      std::vector<cudf::order> column_order{co};
+      std::vector<cudf::null_order> null_precedence{np};
+      auto sorted1 =
+        cudf::sort(cudf::table_view({data1}), column_order, null_precedence)->release();
+      auto col1 = sorted1.front()->view();
+      auto sorted2 =
+        cudf::sort(cudf::table_view({data2}), column_order, null_precedence)->release();
+      auto col2 = sorted2.front()->view();
+
+      auto result = cudf::merge(
+        {cudf::table_view({col1}), cudf::table_view({col2})}, {0}, column_order, null_precedence);
+      auto sorted_all =
+        cudf::sort(cudf::table_view({all_data->view()}), column_order, null_precedence);
+      CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_all->view().column(0), result->view().column(0));
+    }
 }
 
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
The `cudf::merge` API expects the key columns to be sorted. This means that if null rows are included, these null entries should all appear either at beginning or at the end of the column depending on the null_order for the sort. The `MergeDictionaryTest.WithNull` gtest placed null rows in the middle of the column. The expected results should also have included null entries at the beginning or the end.

This PR also includes an extra test for checking merge results are consistent with the sort parameters `cudf::order` and `cudf::null_order`. This test also includes a larger number of rows to ensure `thrust::merge` requires more than one tile/block in its runtime logic.