### PR TITLE
Fix groupby agg/apply behaviour when no key columns are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Bug Fixes
 
 - PR #6912 Fix rmm_mode=managed parameter for gtests
+- PR #6945 Fix groupby agg/apply behaviour when no key columns are provided 
 
 
 # cuDF 0.17.0 (Date TBD)

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -164,6 +164,9 @@ class GroupBy(Serializable):
         """
         normalized_aggs = self._normalize_aggs(func)
 
+        # Note: When there are no key columns, the below produces
+        # a Float64Index, while Pandas returns an Int64Index
+        # (GH: 6945)
         result = self._groupby.aggregate(self.obj, normalized_aggs)
 
         result = cudf.DataFrame._from_table(result)

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -1350,7 +1350,7 @@ def test_groupby_apply_return_series_dataframe(cust_func):
 @pytest.mark.parametrize(
     "pdf", [pd.DataFrame(), pd.DataFrame({"a": []}), pd.Series([])]
 )
-def test_groupby_no_columns(pdf):
+def test_groupby_no_keys(pdf):
     gdf = cudf.from_pandas(pdf)
     assert_eq(
         pdf.groupby([]).max(),
@@ -1363,9 +1363,22 @@ def test_groupby_no_columns(pdf):
 @pytest.mark.parametrize(
     "pdf", [pd.DataFrame(), pd.DataFrame({"a": []}), pd.Series([])]
 )
-def test_groupby_apply_empty(pdf):
+def test_groupby_apply_no_keys(pdf):
     gdf = cudf.from_pandas(pdf)
     assert_eq(
         pdf.groupby([]).apply(lambda x: x.max()),
         gdf.groupby([]).apply(lambda x: x.max()),
+    )
+
+
+@pytest.mark.parametrize(
+    "pdf",
+    [pd.DataFrame({"a": [1, 2]}), pd.DataFrame({"a": [1, 2], "b": [2, 3]})],
+)
+def test_groupby_nonempty_no_keys(pdf):
+    gdf = cudf.from_pandas(pdf)
+    assert_exceptions_equal(
+        lambda: pdf.groupby([]),
+        lambda: gdf.groupby([]),
+        compare_error_message=False,
     )

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -1345,3 +1345,16 @@ def test_groupby_apply_return_series_dataframe(cust_func):
     actual = gdf.groupby(["key"]).apply(cust_func)
 
     assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize(
+    "pdf", [pd.DataFrame(), pd.DataFrame({"a": []}), pd.Series([])]
+)
+def test_groupby_no_columns(pdf):
+    gdf = cudf.from_pandas(pdf)
+    assert_eq(
+        pdf.groupby([]).max(),
+        gdf.groupby([]).max(),
+        check_dtype=False,
+        check_index_type=False,
+    )

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -1358,3 +1358,14 @@ def test_groupby_no_columns(pdf):
         check_dtype=False,
         check_index_type=False,
     )
+
+
+@pytest.mark.parametrize(
+    "pdf", [pd.DataFrame(), pd.DataFrame({"a": []}), pd.Series([])]
+)
+def test_groupby_apply_empty(pdf):
+    gdf = cudf.from_pandas(pdf)
+    assert_eq(
+        pdf.groupby([]).apply(lambda x: x.max()),
+        gdf.groupby([]).apply(lambda x: x.max()),
+    )

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -1356,7 +1356,7 @@ def test_groupby_no_keys(pdf):
         pdf.groupby([]).max(),
         gdf.groupby([]).max(),
         check_dtype=False,
-        check_index_type=False,
+        check_index_type=False,  # Int64Index v/s Float64Index
     )
 
 

--- a/python/cudf/cudf/tests/utils.py
+++ b/python/cudf/cudf/tests/utils.py
@@ -11,8 +11,8 @@ import pytest
 from pandas import testing as tm
 
 import cudf
-from cudf.core.column.datetime import _numpy_to_pandas_conversion
 from cudf._lib.null_mask import bitmask_allocation_size_bytes
+from cudf.core.column.datetime import _numpy_to_pandas_conversion
 from cudf.utils import dtypes as dtypeutils
 
 supported_numpy_dtypes = [
@@ -74,8 +74,6 @@ def assert_eq(left, right, **kwargs):
     without switching between assert_frame_equal/assert_series_equal/...
     functions.
     """
-    __tracebackhide__ = True
-
     if hasattr(left, "to_pandas"):
         left = left.to_pandas()
     if hasattr(right, "to_pandas"):


### PR DESCRIPTION
More Pandas-like behaviour for groupby when no keys are passed.

Possibly fixes #6927.
