### PR TITLE
Update Java bindings version to 0.18-SNAPSHOT [skip ci]

### DIFF
--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -36,7 +36,7 @@ nvidia-docker run -it cudf-build:10.1-devel-centos7 bash
 You can download the cuDF repo in the docker container or you can mount it into the container.
 Here I choose to download again in the container.
 ```bash
-git clone --recursive https://github.com/rapidsai/cudf.git -b branch-0.17
+git clone --recursive https://github.com/rapidsai/cudf.git -b branch-0.18
 ```
 
 ### Build cuDF jar
@@ -49,5 +49,5 @@ scl enable devtoolset-7 "java/ci/build-in-docker.sh"
 
 ### The output
 
-You can find the cuDF jar in java/target/ like cudf-0.17-SNAPSHOT-cuda10-1.jar.
+You can find the cuDF jar in java/target/ like cudf-0.18-SNAPSHOT-cuda10-1.jar.
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ai.rapids</groupId>
     <artifactId>cudf</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.18-SNAPSHOT</version>
 
     <name>cudfjni</name>
     <description>


### PR DESCRIPTION
Updating the Java bindings package version to match the libcudf version.