### PR TITLE
`fixed_point_value` double-shifts in `fixed_point` construction

### DIFF
--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -372,7 +372,8 @@ class fixed_point_scalar : public scalar {
    */
   T fixed_point_value(rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
   {
-    return T{_data.value(stream), numeric::scale_type{type().scale()}};
+    using namespace numeric;
+    return T{scaled_integer<rep_type>{_data.value(stream), scale_type{type().scale()}}};
   }
 
   /**

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -1072,7 +1072,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionProduct)
     auto const scale    = scale_type{i};
     auto const column   = fp_wrapper{{1, 2, 3, 1, 2, 3}, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
-    auto const expected = decimalXX{36, scale};
+    auto const expected = decimalXX{scaled_integer<RepType>{36, scale_type{i * 6}}};
 
     auto const result        = cudf::reduce(column, cudf::make_product_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());
@@ -1091,23 +1091,14 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionSum)
   for (int i = -3; i <= 0; ++i) {
     auto const scale = scale_type{i};
 
-    auto const ZERO  = decimalXX{0, scale};
-    auto const ONE   = decimalXX{1, scale};
-    auto const TWO   = decimalXX{2, scale};
-    auto const THREE = decimalXX{3, scale};
-    auto const FOUR  = decimalXX{4, scale};
-    auto const TEN   = decimalXX{10, scale};
-
-    auto const in       = std::vector<decimalXX>{ONE, TWO, THREE, FOUR};
     auto const column   = fp_wrapper{{1, 2, 3, 4}, scale};
-    auto const expected = std::accumulate(in.cbegin(), in.cend(), ZERO, std::plus<decimalXX>());
+    auto const expected = decimalXX{scaled_integer<RepType>{10, scale}};
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
     auto const result        = cudf::reduce(column, cudf::make_sum_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
-    EXPECT_EQ(result_scalar->fixed_point_value(), TEN);
   }
 }
 
@@ -1146,7 +1137,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionSumFractional)
     auto const scale    = scale_type{i};
     auto const column   = fp_wrapper{{111, 222, 333}, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
-    auto const expected = decimalXX{666, scale};
+    auto const expected = decimalXX{scaled_integer<RepType>{666, scale}};
 
     auto const result        = cudf::reduce(column, cudf::make_sum_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());
@@ -1169,7 +1160,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionSumLarge)
     auto const column         = fp_wrapper{values.cbegin(), values.cend(), scale};
     auto const out_type       = static_cast<cudf::column_view>(column).type();
     auto const expected_value = std::accumulate(values.cbegin(), values.cend(), RepType{0});
-    auto const expected       = decimalXX{expected_value, scale};
+    auto const expected       = decimalXX{scaled_integer<RepType>{expected_value, scale}};
 
     auto const result        = cudf::reduce(column, cudf::make_sum_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());
@@ -1187,7 +1178,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionMin)
 
   for (int i = -3; i <= 0; ++i) {
     auto const scale    = scale_type{i};
-    auto const ONE      = decimalXX{1, scale};
+    auto const ONE      = decimalXX{scaled_integer<RepType>{1, scale}};
     auto const column   = fp_wrapper{{1, 2, 3, 4}, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
@@ -1228,7 +1219,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionMax)
 
   for (int i = -3; i <= 0; ++i) {
     auto const scale    = scale_type{i};
-    auto const FOUR     = decimalXX{4, scale};
+    auto const FOUR     = decimalXX{scaled_integer<RepType>{4, scale}};
     auto const column   = fp_wrapper{{1, 2, 3, 4}, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
@@ -1251,7 +1242,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointReductionMaxLarge)
     auto f = cudf::test::make_counting_transform_iterator(0, [](auto e) { return e % 43; });
     auto const column   = fp_wrapper{f, f + 5000, scale};
     auto const out_type = static_cast<cudf::column_view>(column).type();
-    auto const expected = decimalXX{42, scale};
+    auto const expected = decimalXX{scaled_integer<RepType>{42, scale}};
 
     auto const result        = cudf::reduce(column, cudf::make_max_aggregation(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX> *>(result.get());


### PR DESCRIPTION
There was a bug that got merged in https://github.com/rapidsai/cudf/pull/6814. The `fixed_point_value` should have been using the `scaled_integer` constructor. My unit tests didn't catch it because I also used the wrong constructor in the unit tests. Both cases have been fixed (and clean up and missing docs added).