### PR TITLE
Add in basic support to JNI for logical_cast [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -1297,6 +1297,20 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /**
+   * Zero-copy cast between types with the same underlying representation.
+   *
+   * Similar to reinterpret_cast or bit_cast in C++. This will essentially take the underlying data
+   * and update the metadata to reflect a new type. Not all types are supported the width of the
+   * types must match.
+   * @param type the type you want to go to.
+   * @return a ColumnView that cannot outlive the Column that owns the actual data it points to.
+   */
+  public ColumnView logicalCastTo(DType type) {
+    return new ColumnView(logicalCastTo(getNativeView(),
+        type.typeId.getNativeId(), type.getScale()));
+  }
+
+  /**
    * Cast to Byte - ColumnVector
    * This method takes the value provided by the ColumnVector and casts to byte
    * When casting from a Date, Timestamp, or Boolean to a byte type the underlying numerical
@@ -2471,6 +2485,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   private static native long extractListElement(long nativeView, int index);
 
   private static native long castTo(long nativeHandle, int type, int scale);
+
+  private static native long logicalCastTo(long nativeHandle, int type, int scale);
 
   private static native long byteListCast(long nativeHandle, boolean config);
 

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -732,7 +732,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_logicalCastTo(JNIEnv *env
     cudf::jni::auto_set_device(env);
     cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
     cudf::data_type n_data_type = cudf::jni::make_data_type(type, scale);
-    std::unique_ptr<cudf::column_view> result(new cudf::column_view);
+    std::unique_ptr<cudf::column_view> result = std::make_unique<cudf::column_view>();
     *result = cudf::logical_cast(*column, n_data_type);
     return reinterpret_cast<jlong>(result.release());
   }

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -724,6 +724,21 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_castTo(JNIEnv *env, jclas
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_logicalCastTo(JNIEnv *env, jclass,
+                                                                     jlong handle, jint type,
+                                                                     jint scale) {
+  JNI_NULL_CHECK(env, handle, "native handle is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::column_view *column = reinterpret_cast<cudf::column_view *>(handle);
+    cudf::data_type n_data_type = cudf::jni::make_data_type(type, scale);
+    std::unique_ptr<cudf::column_view> result(new cudf::column_view);
+    *result = cudf::logical_cast(*column, n_data_type);
+    return reinterpret_cast<jlong>(result.release());
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_byteListCast(JNIEnv *env, jobject j_object,
                                                                     jlong handle,
                                                                     jboolean endianness_config) {

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -1982,6 +1982,15 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testLogicalCast() {
+    try (ColumnVector cv = ColumnVector.decimalFromLongs(-2, 1L, 2L, 100L, 552L);
+         ColumnVector expected = ColumnVector.fromLongs(1L, 2L, 100L, 552L);
+         ColumnView casted = cv.logicalCastTo(DType.INT64)) {
+      assertColumnsAreEqual(expected, casted);
+    }
+  }
+
+  @Test
   void testFixedWidthCast() {
     int[] values = new int[]{1,3,4,5,2};
     long[] longValues = Arrays.stream(values).asLongStream().toArray();

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -92,7 +92,7 @@ public class TableTest extends CudfTestBase {
    * @param expect The expected result column
    * @param cv The input column
    */
-  public static void assertColumnsAreEqual(ColumnVector expect, ColumnVector cv) {
+  public static void assertColumnsAreEqual(ColumnView expect, ColumnView cv) {
     assertColumnsAreEqual(expect, cv, "unnamed");
   }
 
@@ -102,7 +102,7 @@ public class TableTest extends CudfTestBase {
    * @param cv The input column
    * @param colName The name of the column
    */
-  public static void assertColumnsAreEqual(ColumnVector expected, ColumnVector cv, String colName) {
+  public static void assertColumnsAreEqual(ColumnView expected, ColumnView cv, String colName) {
     assertPartialColumnsAreEqual(expected, 0, expected.getRowCount(), cv, colName, true);
   }
 
@@ -121,7 +121,7 @@ public class TableTest extends CudfTestBase {
    * @param expected The expected result Struct column
    * @param cv The input Struct column
    */
-  public static void assertStructColumnsAreEqual(ColumnVector expected, ColumnVector cv) {
+  public static void assertStructColumnsAreEqual(ColumnView expected, ColumnView cv) {
     assertPartialStructColumnsAreEqual(expected, 0, expected.getRowCount(), cv, "unnamed", true);
   }
 
@@ -134,8 +134,8 @@ public class TableTest extends CudfTestBase {
    * @param colName The name of the column
    * @param enableNullCheck Whether to check for nulls in the Struct column
    */
-  public static void assertPartialStructColumnsAreEqual(ColumnVector expected, long rowOffset, long length,
-                                                        ColumnVector cv, String colName, boolean enableNullCheck) {
+  public static void assertPartialStructColumnsAreEqual(ColumnView expected, long rowOffset, long length,
+      ColumnView cv, String colName, boolean enableNullCheck) {
     try (HostColumnVector hostExpected = expected.copyToHost();
          HostColumnVector hostcv = cv.copyToHost()) {
       assertPartialColumnsAreEqual(hostExpected, rowOffset, length, hostcv, colName, enableNullCheck);
@@ -149,8 +149,8 @@ public class TableTest extends CudfTestBase {
    * @param colName The name of the column
    * @param enableNullCheck Whether to check for nulls in the column
    */
-  public static void assertPartialColumnsAreEqual(ColumnVector expected, long rowOffset, long length,
-                                                  ColumnVector cv, String colName, boolean enableNullCheck) {
+  public static void assertPartialColumnsAreEqual(ColumnView expected, long rowOffset, long length,
+      ColumnView cv, String colName, boolean enableNullCheck) {
     try (HostColumnVector hostExpected = expected.copyToHost();
          HostColumnVector hostcv = cv.copyToHost()) {
       assertPartialColumnsAreEqual(hostExpected, rowOffset, length, hostcv, colName, enableNullCheck);


### PR DESCRIPTION
This exposes `logical_cast` through a JNI API. I also updated some of the test code to take a ColumnView instead of a ColumnVector so I could test it more easily.