### PR TITLE
Fix default parameter values of `write_csv` and `write_parquet`

### DIFF
--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -1138,8 +1138,8 @@ class csv_writer_options {
   std::string _na_rep = "";
   // Indicates whether to write headers to csv
   bool _include_header = true;
-  // maximum number of rows to process for each file write
-  int _rows_per_chunk = 8;
+  // maximum number of rows to write in each chunk (limits memory use)
+  size_type _rows_per_chunk = std::numeric_limits<size_type>::max();
   // character to use for separating lines (default "\n")
   std::string _line_terminator = "\n";
   // character to use for separating lines (default "\n")
@@ -1158,7 +1158,7 @@ class csv_writer_options {
    * @param table Table to be written to output.
    */
   explicit csv_writer_options(sink_info const& sink, table_view const& table)
-    : _sink(sink), _table(table)
+    : _sink(sink), _table(table), _rows_per_chunk(table.num_rows())
   {
   }
 
@@ -1210,7 +1210,7 @@ class csv_writer_options {
   /**
    * @brief Returns maximum number of rows to process for each file write.
    */
-  int get_rows_per_chunk(void) const { return _rows_per_chunk; }
+  size_type get_rows_per_chunk(void) const { return _rows_per_chunk; }
 
   /**
    * @brief Returns character used for separating lines.
@@ -1259,7 +1259,7 @@ class csv_writer_options {
    *
    * @param val Number of rows per chunk.
    */
-  void set_rows_per_chunk(int val) { _rows_per_chunk = val; }
+  void set_rows_per_chunk(size_type val) { _rows_per_chunk = val; }
 
   /**
    * @brief Sets character used for separating lines.

--- a/cpp/include/cudf/io/parquet.hpp
+++ b/cpp/include/cudf/io/parquet.hpp
@@ -388,7 +388,7 @@ class parquet_writer_options {
   // Specify the sink to use for writer output
   sink_info _sink;
   // Specify the compression format to use
-  compression_type _compression = compression_type::AUTO;
+  compression_type _compression = compression_type::SNAPPY;
   // Specify the level of statistics in the output file
   statistics_freq _stats_level = statistics_freq::STATISTICS_ROWGROUP;
   // Sets of columns to output

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -1760,4 +1760,18 @@ TEST_F(CsvReaderTest, ReadMaxNumericValue)
   expect_column_data_equal(std::vector<uint64_t>(sequence, sequence + num_rows), view.column(0));
 }
 
+TEST_F(CsvReaderTest, DefaultWriteChunkSize)
+{
+  for (auto num_rows : {1, 20, 100, 1000}) {
+    auto sequence = cudf::test::make_counting_transform_iterator(
+      0, [](auto i) { return static_cast<int32_t>(i + 1000.50f); });
+    auto input_column = column_wrapper<int32_t>(sequence, sequence + num_rows);
+    auto input_table  = cudf::table_view{std::vector<cudf::column_view>{input_column}};
+
+    cudf_io::csv_writer_options opts =
+      cudf_io::csv_writer_options::builder(cudf_io::sink_info{"unused.path"}, input_table);
+    ASSERT_EQ(num_rows, opts.get_rows_per_chunk());
+  }
+}
+
 CUDF_TEST_PROGRAM_MAIN()

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -335,7 +335,7 @@ cpdef write_parquet(
         Table table,
         object path,
         object index=None,
-        object compression=None,
+        object compression="snappy",
         object statistics="ROWGROUP",
         object metadata_file_path=None,
         object int96_timestamps=False):

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -188,7 +188,7 @@ Parameters
 path : str
     File path or Root Directory path. Will be used as Root Directory path
     while writing a partitioned dataset.
-compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
+compression : {'snappy', None}, default 'snappy'
     Name of the compression to use. Use ``None`` for no compression.
 index : bool, default None
     If ``True``, include the dataframe's index(es) in the file output. If

--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -112,7 +112,7 @@ class CudfEngine(ArrowEngine):
         partition_on,
         return_metadata,
         fmd=None,
-        compression=None,
+        compression="snappy",
         index_cols=None,
         **kwargs,
     ):


### PR DESCRIPTION
Fixes #6671, #6851

- Set the `rows_per_chunk` in `csv_writer_options` to the size of the input table.
- Change `rows_per_chunk` type to `size_type` (used for number of rows).
- Set the default compression in `to_parquet`/`write_parquet` to "snappy".
