### PR TITLE
Fix type comparison for java [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/BinaryOperable.java
+++ b/java/src/main/java/ai/rapids/cudf/BinaryOperable.java
@@ -41,42 +41,42 @@ public interface BinaryOperable {
   static DType implicitConversion(BinaryOperable lhs, BinaryOperable rhs) {
     DType a = lhs.getType();
     DType b = rhs.getType();
-    if (a == DType.FLOAT64 || b == DType.FLOAT64) {
+    if (a.equals(DType.FLOAT64) || b.equals(DType.FLOAT64)) {
       return DType.FLOAT64;
     }
-    if (a == DType.FLOAT32 || b == DType.FLOAT32) {
+    if (a.equals(DType.FLOAT32) || b.equals(DType.FLOAT32)) {
       return DType.FLOAT32;
     }
-    if (a == DType.UINT64 || b == DType.UINT64) {
+    if (a.equals(DType.UINT64) || b.equals(DType.UINT64)) {
       return DType.UINT64;
     }
-    if (a == DType.INT64 || b == DType.INT64 ||
-        a == DType.TIMESTAMP_MILLISECONDS || b == DType.TIMESTAMP_MILLISECONDS ||
-        a == DType.TIMESTAMP_MICROSECONDS || b == DType.TIMESTAMP_MICROSECONDS ||
-        a == DType.TIMESTAMP_SECONDS || b == DType.TIMESTAMP_SECONDS ||
-        a == DType.TIMESTAMP_NANOSECONDS || b == DType.TIMESTAMP_NANOSECONDS) {
+    if (a.equals(DType.INT64) || b.equals(DType.INT64) ||
+        a.equals(DType.TIMESTAMP_MILLISECONDS) || b.equals(DType.TIMESTAMP_MILLISECONDS) ||
+        a.equals(DType.TIMESTAMP_MICROSECONDS) || b.equals(DType.TIMESTAMP_MICROSECONDS) ||
+        a.equals(DType.TIMESTAMP_SECONDS) || b.equals(DType.TIMESTAMP_SECONDS) ||
+        a.equals(DType.TIMESTAMP_NANOSECONDS) || b.equals(DType.TIMESTAMP_NANOSECONDS)) {
       return DType.INT64;
     }
-    if (a == DType.UINT32 || b == DType.UINT32) {
+    if (a.equals(DType.UINT32) || b.equals(DType.UINT32)) {
       return DType.UINT32;
     }
-    if (a == DType.INT32 || b == DType.INT32 ||
-        a == DType.TIMESTAMP_DAYS || b == DType.TIMESTAMP_DAYS) {
+    if (a.equals(DType.INT32) || b.equals(DType.INT32) ||
+        a.equals(DType.TIMESTAMP_DAYS) || b.equals(DType.TIMESTAMP_DAYS)) {
       return DType.INT32;
     }
-    if (a == DType.UINT16 || b == DType.UINT16) {
+    if (a.equals(DType.UINT16) || b.equals(DType.UINT16)) {
       return DType.UINT16;
     }
-    if (a == DType.INT16 || b == DType.INT16) {
+    if (a.equals(DType.INT16) || b.equals(DType.INT16)) {
       return DType.INT16;
     }
-    if (a == DType.UINT8 || b == DType.UINT8) {
+    if (a.equals(DType.UINT8) || b.equals(DType.UINT8)) {
       return DType.UINT8;
     }
-    if (a == DType.INT8 || b == DType.INT8) {
+    if (a.equals(DType.INT8) || b.equals(DType.INT8)) {
       return DType.INT8;
     }
-    if (a == DType.BOOL8 || b == DType.BOOL8) {
+    if (a.equals(DType.BOOL8) || b.equals(DType.BOOL8)) {
       return DType.BOOL8;
     }
     if (a.isDecimalType() && b.isDecimalType()) {

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -83,8 +83,8 @@ public final class ColumnVector extends ColumnView {
     super(ColumnVector.initViewHandle(
         type, (int)rows, nullCount.orElse(UNKNOWN_NULL_COUNT).intValue(),
         dataBuffer, validityBuffer, offsetBuffer, null));
-    assert type != DType.LIST : "This constructor should not be used for list type";
-    if (type != DType.STRING) {
+    assert !type.equals(DType.LIST) : "This constructor should not be used for list type";
+    if (!type.equals(DType.STRING)) {
       assert offsetBuffer == null : "offsets are only supported for STRING";
     }
     assert (nullCount.isPresent() && nullCount.get() <= Integer.MAX_VALUE)
@@ -120,7 +120,7 @@ public final class ColumnVector extends ColumnView {
     super(initViewHandle(type, (int)rows, nullCount.orElse(UNKNOWN_NULL_COUNT).intValue(),
         dataBuffer, validityBuffer,
         offsetBuffer, childHandles));
-    if (type != DType.STRING && type != DType.LIST) {
+    if (!type.equals(DType.STRING) && !type.equals(DType.LIST)) {
       assert offsetBuffer == null : "offsets are only supported for STRING, LISTS";
     }
     assert (nullCount.isPresent() && nullCount.get() <= Integer.MAX_VALUE)
@@ -393,15 +393,15 @@ public final class ColumnVector extends ColumnView {
   public static ColumnVector stringConcatenate(Scalar separator, Scalar narep, ColumnView[] columns) {
     assert columns.length >= 2 : ".stringConcatenate() operation requires at least 2 columns";
     assert separator != null : "separator scalar provided may not be null";
-    assert separator.getType() == DType.STRING : "separator scalar must be a string scalar";
+    assert separator.getType().equals(DType.STRING) : "separator scalar must be a string scalar";
     assert narep != null : "narep scalar provided may not be null";
-    assert narep.getType() == DType.STRING : "narep scalar must be a string scalar";
+    assert narep.getType().equals(DType.STRING) : "narep scalar must be a string scalar";
     long size = columns[0].getRowCount();
     long[] column_views = new long[columns.length];
 
     for(int i = 0; i < columns.length; i++) {
       assert columns[i] != null : "Column vectors passed may not be null";
-      assert columns[i].getType() == DType.STRING : "All columns must be of type string for .cat() operation";
+      assert columns[i].getType().equals(DType.STRING) : "All columns must be of type string for .cat() operation";
       assert columns[i].getRowCount() == size : "Row count mismatch, all columns must have the same number of rows";
       column_views[i] = columns[i].getNativeView();
     }
@@ -426,8 +426,8 @@ public final class ColumnVector extends ColumnView {
       assert columns[i] != null : "Column vectors passed may not be null";
       assert columns[i].getRowCount() == size : "Row count mismatch, all columns must be the same size";
       assert !columns[i].getType().isDurationType() : "Unsupported column type Duration";
-      assert !columns[i].getType().isTimestamp() : "Unsupported column type Timestamp";
-      assert !columns[i].getType().isNestedType() || columns[i].getType() == DType.LIST :
+      assert !columns[i].getType().isTimestampType() : "Unsupported column type Timestamp";
+      assert !columns[i].getType().isNestedType() || columns[i].getType().equals(DType.LIST) :
           "Unsupported nested type column";
       columnViews[i] = columns[i].getNativeView();
     }
@@ -452,7 +452,7 @@ public final class ColumnVector extends ColumnView {
       assert columns[i] != null : "Column vectors passed may not be null";
       assert columns[i].getRowCount() == size : "Row count mismatch, all columns must be the same size";
       assert !columns[i].getType().isDurationType() : "Unsupported column type Duration";
-      assert !columns[i].getType().isTimestamp() : "Unsupported column type Timestamp";
+      assert !columns[i].getType().isTimestampType() : "Unsupported column type Timestamp";
       assert !columns[i].getType().isNestedType() : "Unsupported column of nested type";
       columnViews[i] = columns[i].getNativeView();
     }
@@ -492,7 +492,7 @@ public final class ColumnVector extends ColumnView {
    */
   @Override
   public ColumnVector castTo(DType type) {
-    if (this.type == type) {
+    if (this.type.equals(type)) {
       // Optimization
       return incRefCount();
     }

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -163,7 +163,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Returns a new ColumnVector with NaNs converted to nulls, preserving the existing null values.
    */
   public final ColumnVector nansToNulls() {
-    assert type == DType.FLOAT32 || type == DType.FLOAT64;
+    assert type.equals(DType.FLOAT32) || type.equals(DType.FLOAT64);
     return new ColumnVector(nansToNulls(this.getNativeView()));
   }
 
@@ -177,7 +177,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return ColumnVector holding length of string at index 'i' in the original vector
    */
   public final ColumnVector getCharLengths() {
-    assert DType.STRING == type : "char length only available for String type";
+    assert DType.STRING.equals(type) : "char length only available for String type";
     return new ColumnVector(charLengths(getNativeView()));
   }
 
@@ -187,7 +187,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return ColumnVector, where each element at i = byte count of string at index 'i' in the original vector
    */
   public final ColumnVector getByteCount() {
-    assert type == DType.STRING : "type has to be a String";
+    assert type.equals(DType.STRING) : "type has to be a String";
     return new ColumnVector(byteCount(getNativeView()));
   }
 
@@ -223,7 +223,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return - Boolean vector
    */
   public final ColumnVector isInteger() {
-    assert type == DType.STRING;
+    assert type.equals(DType.STRING);
     return new ColumnVector(isInteger(getNativeView()));
   }
 
@@ -240,7 +240,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return - Boolean vector
    */
   public final ColumnVector isFloat() {
-    assert type == DType.STRING;
+    assert type.equals(DType.STRING);
     return new ColumnVector(isFloat(getNativeView()));
   }
 
@@ -314,7 +314,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return the computed vector
    */
   public final ColumnVector ifElse(ColumnView trueValues, ColumnView falseValues) {
-    if (type != DType.BOOL8) {
+    if (!type.equals(DType.BOOL8)) {
       throw new IllegalArgumentException("Cannot select with a predicate vector of type " + type);
     }
     long result = ifElseVV(getNativeView(), trueValues.getNativeView(), falseValues.getNativeView());
@@ -334,7 +334,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return the computed vector
    */
   public final ColumnVector ifElse(ColumnView trueValues, Scalar falseValue) {
-    if (type != DType.BOOL8) {
+    if (!type.equals(DType.BOOL8)) {
       throw new IllegalArgumentException("Cannot select with a predicate vector of type " + type);
     }
     long result = ifElseVS(getNativeView(), trueValues.getNativeView(), falseValue.getScalarHandle());
@@ -354,7 +354,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return the computed vector
    */
   public final ColumnVector ifElse(Scalar trueValue, ColumnView falseValues) {
-    if (type != DType.BOOL8) {
+    if (!type.equals(DType.BOOL8)) {
       throw new IllegalArgumentException("Cannot select with a predicate vector of type " + type);
     }
     long result = ifElseSV(getNativeView(), trueValue.getScalarHandle(), falseValues.getNativeView());
@@ -372,7 +372,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return the computed vector
    */
   public final ColumnVector ifElse(Scalar trueValue, Scalar falseValue) {
-    if (type != DType.BOOL8) {
+    if (!type.equals(DType.BOOL8)) {
       throw new IllegalArgumentException("Cannot select with a predicate vector of type " + type);
     }
     long result = ifElseSS(getNativeView(), trueValue.getScalarHandle(), falseValue.getScalarHandle());
@@ -545,7 +545,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return - A new INT16 vector allocated on the GPU.
    */
   public final ColumnVector year() {
-    assert type.isTimestamp();
+    assert type.isTimestampType();
     return new ColumnVector(year(getNativeView()));
   }
 
@@ -557,7 +557,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return - A new INT16 vector allocated on the GPU.
    */
   public final ColumnVector month() {
-    assert type.isTimestamp();
+    assert type.isTimestampType();
     return new ColumnVector(month(getNativeView()));
   }
 
@@ -569,7 +569,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return - A new INT16 vector allocated on the GPU.
    */
   public final ColumnVector day() {
-    assert type.isTimestamp();
+    assert type.isTimestampType();
     return new ColumnVector(day(getNativeView()));
   }
 
@@ -617,7 +617,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new INT16 vector allocated on the GPU. Monday=1, ..., Sunday=7
    */
   public final ColumnVector weekDay() {
-    assert type.isTimestamp();
+    assert type.isTimestampType();
     return new ColumnVector(weekDay(getNativeView()));
   }
 
@@ -629,7 +629,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new TIMESTAMP_DAYS vector allocated on the GPU.
    */
   public final ColumnVector lastDayOfMonth() {
-    assert type.isTimestamp();
+    assert type.isTimestampType();
     return new ColumnVector(lastDayOfMonth(getNativeView()));
   }
 
@@ -641,7 +641,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new INT16 vector allocated on the GPU. The value is between [1, {365-366}]
    */
   public final ColumnVector dayOfYear() {
-    assert type.isTimestamp();
+    assert type.isTimestampType();
     return new ColumnVector(dayOfYear(getNativeView()));
   }
 
@@ -1264,7 +1264,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Any null string entries return corresponding null output column entries
    */
   public final ColumnVector toTitle() {
-    assert type == DType.STRING;
+    assert type.equals(DType.STRING);
     return new ColumnVector(title(getNativeView()));
   }
   /////////////////////////////////////////////////////////////////////////////
@@ -1465,7 +1465,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampDays() {
-    if (type == DType.STRING) {
+    if (type.equals(DType.STRING)) {
       return asTimestamp(DType.TIMESTAMP_DAYS, "%Y-%m-%dT%H:%M:%SZ%f");
     }
     return castTo(DType.TIMESTAMP_DAYS);
@@ -1478,7 +1478,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampDays(String format) {
-    assert type == DType.STRING : "A column of type string is required when using a format string";
+    assert type.equals(DType.STRING) : "A column of type string is required when using a format string";
     return asTimestamp(DType.TIMESTAMP_DAYS, format);
   }
 
@@ -1488,7 +1488,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampSeconds() {
-    if (type == DType.STRING) {
+    if (type.equals(DType.STRING)) {
       return asTimestamp(DType.TIMESTAMP_SECONDS, "%Y-%m-%dT%H:%M:%SZ%f");
     }
     return castTo(DType.TIMESTAMP_SECONDS);
@@ -1501,7 +1501,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampSeconds(String format) {
-    assert type == DType.STRING : "A column of type string is required when using a format string";
+    assert type.equals(DType.STRING) : "A column of type string is required when using a format string";
     return asTimestamp(DType.TIMESTAMP_SECONDS, format);
   }
 
@@ -1511,7 +1511,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampMicroseconds() {
-    if (type == DType.STRING) {
+    if (type.equals(DType.STRING)) {
       return asTimestamp(DType.TIMESTAMP_MICROSECONDS, "%Y-%m-%dT%H:%M:%SZ%f");
     }
     return castTo(DType.TIMESTAMP_MICROSECONDS);
@@ -1524,7 +1524,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampMicroseconds(String format) {
-    assert type == DType.STRING : "A column of type string is required when using a format string";
+    assert type.equals(DType.STRING) : "A column of type string is required when using a format string";
     return asTimestamp(DType.TIMESTAMP_MICROSECONDS, format);
   }
 
@@ -1534,7 +1534,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampMilliseconds() {
-    if (type == DType.STRING) {
+    if (type.equals(DType.STRING)) {
       return asTimestamp(DType.TIMESTAMP_MILLISECONDS, "%Y-%m-%dT%H:%M:%SZ%f");
     }
     return castTo(DType.TIMESTAMP_MILLISECONDS);
@@ -1547,7 +1547,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampMilliseconds(String format) {
-    assert type == DType.STRING : "A column of type string is required when using a format string";
+    assert type.equals(DType.STRING) : "A column of type string is required when using a format string";
     return asTimestamp(DType.TIMESTAMP_MILLISECONDS, format);
   }
 
@@ -1557,7 +1557,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampNanoseconds() {
-    if (type == DType.STRING) {
+    if (type.equals(DType.STRING)) {
       return asTimestamp(DType.TIMESTAMP_NANOSECONDS, "%Y-%m-%dT%H:%M:%SZ%9f");
     }
     return castTo(DType.TIMESTAMP_NANOSECONDS);
@@ -1570,7 +1570,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asTimestampNanoseconds(String format) {
-    assert type == DType.STRING : "A column of type string is required when using a format string";
+    assert type.equals(DType.STRING) : "A column of type string is required when using a format string";
     return asTimestamp(DType.TIMESTAMP_NANOSECONDS, format);
   }
 
@@ -1586,10 +1586,10 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    *         original column vector.
    */
   public final ColumnVector asTimestamp(DType timestampType, String format) {
-    assert type == DType.STRING : "A column of type string " +
+    assert type.equals(DType.STRING) : "A column of type string " +
         "is required for .to_timestamp() operation";
     assert format != null : "Format string may not be NULL";
-    assert timestampType.isTimestamp() : "unsupported conversion to non-timestamp DType";
+    assert timestampType.isTimestampType() : "unsupported conversion to non-timestamp DType";
     // Only nativeID is passed in the below function as timestamp type does not have `scale`.
     return new ColumnVector(stringTimestampToTimestamp(getNativeView(),
         timestampType.typeId.getNativeId(), format));
@@ -1654,7 +1654,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new vector allocated on the GPU
    */
   public final ColumnVector asStrings(String format) {
-    assert type.isTimestamp() : "unsupported conversion from non-timestamp DType";
+    assert type.isTimestampType() : "unsupported conversion from non-timestamp DType";
     assert format != null || format.isEmpty(): "Format string may not be NULL or empty";
 
     return new ColumnVector(timestampToStringTimestamp(this.getNativeView(), format));
@@ -1710,7 +1710,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return a new column of the values at those indexes.
    */
   public final ColumnVector extractListElement(int index) {
-    assert type == DType.LIST : "A column of type LIST is required for .extractListElement()";
+    assert type.equals(DType.LIST) : "A column of type LIST is required for .extractListElement()";
     return new ColumnVector(extractListElement(getNativeView(), index));
   }
 
@@ -1722,7 +1722,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Convert a string to upper case.
    */
   public final ColumnVector upper() {
-    assert type == DType.STRING : "A column of type string is required for .upper() operation";
+    assert type.equals(DType.STRING) : "A column of type string is required for .upper() operation";
     return new ColumnVector(upperStrings(getNativeView()));
   }
 
@@ -1730,7 +1730,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Convert a string to lower case.
    */
   public final ColumnVector lower() {
-    assert type == DType.STRING : "A column of type string is required for .lower() operation";
+    assert type.equals(DType.STRING) : "A column of type string is required for .lower() operation";
     return new ColumnVector(lowerStrings(getNativeView()));
   }
 
@@ -1764,9 +1764,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @param end character index to end the search on (exclusive).
    */
   public final ColumnVector stringLocate(Scalar substring, int start, int end) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert substring != null : "target string may not be null";
-    assert substring.getType() == DType.STRING : "substring scalar must be a string scalar";
+    assert substring.getType().equals(DType.STRING) : "substring scalar must be a string scalar";
     assert start >= 0 : "start index must be a positive value";
     assert end >= start || end == -1 : "end index must be -1 or >= the start index";
 
@@ -1784,9 +1784,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return New table of strings columns.
    */
   public final Table stringSplit(Scalar delimiter) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert delimiter != null : "delimiter may not be null";
-    assert delimiter.getType() == DType.STRING : "delimiter must be a string scalar";
+    assert delimiter.getType().equals(DType.STRING) : "delimiter must be a string scalar";
     return new Table(stringSplit(this.getNativeView(), delimiter.getScalarHandle()));
   }
 
@@ -1838,9 +1838,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return New table of strings columns.
    */
   public final ColumnVector stringSplitRecord(Scalar delimiter, int maxSplit) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert delimiter != null : "delimiter may not be null";
-    assert delimiter.getType() == DType.STRING : "delimiter must be a string scalar";
+    assert delimiter.getType().equals(DType.STRING) : "delimiter must be a string scalar";
     return new ColumnVector(
         stringSplitRecord(this.getNativeView(), delimiter.getScalarHandle(), maxSplit));
   }
@@ -1864,7 +1864,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the substrings.
    */
   public final ColumnVector substring(int start, int end) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     return new ColumnVector(substring(getNativeView(), start, end));
   }
 
@@ -1876,9 +1876,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the substrings/
    */
   public final ColumnVector substring(ColumnView start, ColumnView end) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert (rows == start.getRowCount() && rows == end.getRowCount()) : "Number of rows must be equal";
-    assert (start.getType() == DType.INT32 && end.getType() == DType.INT32) : "start and end " +
+    assert (start.getType().equals(DType.INT32) && end.getType().equals(DType.INT32)) : "start and end " +
         "vectors must be of integer type";
     return new ColumnVector(substringColumn(getNativeView(), start.getNativeView(), end.getNativeView()));
   }
@@ -1898,9 +1898,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    */
   public final ColumnVector stringReplace(Scalar target, Scalar replace) {
 
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert target != null : "target string may not be null";
-    assert target.getType() == DType.STRING : "target string must be a string scalar";
+    assert target.getType().equals(DType.STRING) : "target string must be a string scalar";
     assert target.getJavaString().isEmpty() == false : "target scalar may not be empty";
 
     return new ColumnVector(stringReplace(getNativeView(), target.getScalarHandle(),
@@ -1994,9 +1994,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the boolean results.
    */
   public final ColumnVector startsWith(Scalar pattern) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert pattern != null : "pattern scalar may not be null";
-    assert pattern.getType() == DType.STRING : "pattern scalar must be a string scalar";
+    assert pattern.getType().equals(DType.STRING) : "pattern scalar must be a string scalar";
     return new ColumnVector(stringStartWith(getNativeView(), pattern.getScalarHandle()));
   }
 
@@ -2007,9 +2007,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the boolean results.
    */
   public final ColumnVector endsWith(Scalar pattern) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert pattern != null : "pattern scalar may not be null";
-    assert pattern.getType() == DType.STRING : "pattern scalar must be a string scalar";
+    assert pattern.getType().equals(DType.STRING) : "pattern scalar must be a string scalar";
     return new ColumnVector(stringEndWith(getNativeView(), pattern.getScalarHandle()));
   }
 
@@ -2018,7 +2018,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the stripped strings.
    */
   public final ColumnVector strip() {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     try (Scalar emptyString = Scalar.fromString("")) {
       return new ColumnVector(stringStrip(getNativeView(), StripType.BOTH.nativeId,
           emptyString.getScalarHandle()));
@@ -2031,9 +2031,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the stripped strings.
    */
   public final ColumnVector strip(Scalar toStrip) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert toStrip != null : "toStrip scalar may not be null";
-    assert toStrip.getType() == DType.STRING : "toStrip must be a string scalar";
+    assert toStrip.getType().equals(DType.STRING) : "toStrip must be a string scalar";
     return new ColumnVector(stringStrip(getNativeView(), StripType.BOTH.nativeId, toStrip.getScalarHandle()));
   }
 
@@ -2042,7 +2042,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the stripped strings.
    */
   public final ColumnVector lstrip() {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     try (Scalar emptyString = Scalar.fromString("")) {
       return new ColumnVector(stringStrip(getNativeView(), StripType.LEFT.nativeId,
           emptyString.getScalarHandle()));
@@ -2055,9 +2055,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the stripped strings.
    */
   public final ColumnVector lstrip(Scalar toStrip) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert toStrip != null : "toStrip  Scalar may not be null";
-    assert toStrip.getType() == DType.STRING : "toStrip must be a string scalar";
+    assert toStrip.getType().equals(DType.STRING) : "toStrip must be a string scalar";
     return new ColumnVector(stringStrip(getNativeView(), StripType.LEFT.nativeId, toStrip.getScalarHandle()));
   }
 
@@ -2066,7 +2066,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the stripped strings.
    */
   public final ColumnVector rstrip() {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     try (Scalar emptyString = Scalar.fromString("")) {
       return new ColumnVector(stringStrip(getNativeView(), StripType.RIGHT.nativeId,
           emptyString.getScalarHandle()));
@@ -2079,9 +2079,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return A new java column vector containing the stripped strings.
    */
   public final ColumnVector rstrip(Scalar toStrip) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert toStrip != null : "toStrip  Scalar may not be null";
-    assert toStrip.getType() == DType.STRING : "toStrip must be a string scalar";
+    assert toStrip.getType().equals(DType.STRING) : "toStrip must be a string scalar";
     return new ColumnVector(stringStrip(getNativeView(), StripType.RIGHT.nativeId, toStrip.getScalarHandle()));
   }
 
@@ -2093,9 +2093,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    */
 
   public final ColumnVector stringContains(Scalar compString) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert compString != null : "compString scalar may not be null";
-    assert compString.getType() == DType.STRING : "compString scalar must be a string scalar";
+    assert compString.getType().equals(DType.STRING) : "compString scalar must be a string scalar";
     return new ColumnVector(stringContains(getNativeView(), compString.getScalarHandle()));
   }
 
@@ -2192,7 +2192,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return New ColumnVector of boolean results for each string.
    */
   public final ColumnVector matchesRe(String pattern) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert pattern != null : "pattern may not be null";
     assert !pattern.isEmpty() : "pattern string may not be empty";
     return new ColumnVector(matchesRe(getNativeView(), pattern));
@@ -2215,7 +2215,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return New ColumnVector of boolean results for each string.
    */
   public final ColumnVector containsRe(String pattern) {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert pattern != null : "pattern may not be null";
     assert !pattern.isEmpty() : "pattern string may not be empty";
     return new ColumnVector(containsRe(getNativeView(), pattern));
@@ -2234,7 +2234,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * not contain any capture groups.
    */
   public final Table extractRe(String pattern) throws CudfException {
-    assert type == DType.STRING : "column type must be a String";
+    assert type.equals(DType.STRING) : "column type must be a String";
     assert pattern != null : "pattern may not be null";
     return new Table(extractRe(this.getNativeView(), pattern));
   }
@@ -2246,9 +2246,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    */
   public final ColumnVector getMapValue(Scalar key) {
 
-    assert type == DType.LIST : "column type must be a LIST";
+    assert type.equals(DType.LIST) : "column type must be a LIST";
     assert key != null : "target string may not be null";
-    assert key.getType() == DType.STRING : "target string must be a string scalar";
+    assert key.getType().equals(DType.STRING) : "target string must be a string scalar";
 
     return new ColumnVector(mapLookup(getNativeView(), key.getScalarHandle()));
   }
@@ -2797,7 +2797,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
       DeviceMemoryBuffer offsets = null;
       if (dataBuffer != null) {
         long dataLen = rows * type.getSizeInBytes();
-        if (type == DType.STRING) {
+        if (type.equals(DType.STRING)) {
           // This needs a different type
           dataLen = getEndStringOffset(rows, rows - 1, offsetBuffer);
           if (dataLen == 0 && nullCount.get() == 0) {

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
@@ -124,9 +124,9 @@ public class HostColumnVectorCore implements AutoCloseable {
    * @return an object that would need to be casted to appropriate type based on this vector's data type
    */
   Object getElement(int rowIndex) {
-    if (type == DType.LIST) {
+    if (type.equals(DType.LIST)) {
       return getList(rowIndex);
-    } else if (type == DType.STRUCT) {
+    } else if (type.equals(DType.STRUCT)) {
       return getStruct(rowIndex);
     } else {
       if (isNull(rowIndex)) {
@@ -399,7 +399,7 @@ public class HostColumnVectorCore implements AutoCloseable {
    */
   public List getList(long rowIndex) {
     assert rowIndex < rows;
-    assert type == DType.LIST;
+    assert type.equals(DType.LIST);
     List retList = new ArrayList();
     int start = (int)getStartListOffset(rowIndex);
     int end = (int)getEndListOffset(rowIndex);
@@ -421,7 +421,7 @@ public class HostColumnVectorCore implements AutoCloseable {
    */
   public HostColumnVector.StructData getStruct(int rowIndex) {
     assert rowIndex < rows;
-    assert type == DType.STRUCT;
+    assert type.equals(DType.STRUCT);
     List<Object> retList = new ArrayList<>();
     // check if null or empty
     if (isNull(rowIndex)) {

--- a/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
+++ b/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
@@ -244,7 +244,7 @@ public class JCudfSerialization {
         children = new SerializedColumnHeader[childProviders.length];
         long childRowOffset = rowOffset;
         long childNumRows = numRows;
-        if (dtype == DType.LIST) {
+        if (dtype.equals(DType.LIST)) {
           if (numRows > 0) {
             childRowOffset = column.getOffset(rowOffset);
             childNumRows = column.getOffset(rowOffset + numRows) - childRowOffset;
@@ -293,9 +293,9 @@ public class JCudfSerialization {
 
       if (dtype.isNestedType()) {
         assert children != null;
-        if (dtype == DType.LIST) {
+        if (dtype.equals(DType.LIST)) {
           total += 4;  // 4-byte child row count
-        } else if (dtype == DType.STRUCT) {
+        } else if (dtype.equals(DType.STRUCT)) {
           total += 4;  // 4-byte child count
         } else {
           throw new IllegalStateException("Unexpected nested type: " + dtype);
@@ -315,9 +315,9 @@ public class JCudfSerialization {
       dout.writeInt((int) nullCount);
       if (dtype.isNestedType()) {
         assert children != null;
-        if (dtype == DType.LIST) {
+        if (dtype.equals(DType.LIST)) {
           dout.writeInt((int) children[0].getRowCount());
-        } else if (dtype == DType.STRUCT) {
+        } else if (dtype.equals(DType.STRUCT)) {
           dout.writeInt(getNumChildren());
         } else {
           throw new IllegalStateException("Unexpected nested type: " + dtype);
@@ -335,10 +335,10 @@ public class JCudfSerialization {
       if (dtype.isNestedType()) {
         int numChildren;
         long childRowCount;
-        if (dtype == DType.LIST) {
+        if (dtype.equals(DType.LIST)) {
           numChildren = 1;
           childRowCount = din.readInt();
-        } else if (dtype == DType.STRUCT) {
+        } else if (dtype.equals(DType.STRUCT)) {
           numChildren = din.readInt();
           childRowCount = rowCount;
         } else {
@@ -718,7 +718,7 @@ public class JCudfSerialization {
       if (numRows > 0) {
         // Add in size of offsets vector
         totalDataSize += padFor64byteAlignment((numRows + 1) * Integer.BYTES);
-        if (type == DType.STRING) {
+        if (type.equals(DType.STRING)) {
           totalDataSize += padFor64byteAlignment(getRawStringDataLength(column, rowOffset, numRows));
         }
       }
@@ -727,12 +727,12 @@ public class JCudfSerialization {
     }
 
     if (numRows > 0 && type.isNestedType()) {
-      if (type == DType.LIST) {
+      if (type.equals(DType.LIST)) {
         ColumnBufferProvider child = column.getChildProviders()[0];
         long childStartRow = column.getOffset(rowOffset);
         long childNumRows = column.getOffset(rowOffset + numRows) - childStartRow;
         totalDataSize += getSlicedSerializedDataSizeInBytes(child, childStartRow, childNumRows);
-      } else if (type == DType.STRUCT) {
+      } else if (type.equals(DType.STRUCT)) {
         for (ColumnBufferProvider childProvider : column.getChildProviders()) {
           totalDataSize += getSlicedSerializedDataSizeInBytes(childProvider, rowOffset, numRows);
         }
@@ -813,7 +813,7 @@ public class JCudfSerialization {
         int startOffset = buffer.getInt(bufferOffset);
         int endOffset = buffer.getInt(bufferOffset + (rowCount * Integer.BYTES));
         bufferOffset += padFor64byteAlignment(offsetsLen);
-        if (dtype == DType.STRING) {
+        if (dtype.equals(DType.STRING)) {
           dataLen = endOffset - startOffset;
           data = bufferOffset;
           bufferOffset += padFor64byteAlignment(dataLen);
@@ -1046,7 +1046,7 @@ public class JCudfSerialization {
     if (dtype.hasOffsets()) {
       if (rowCount > 0) {
         totalSize += padFor64byteAlignment((rowCount + 1) * Integer.BYTES);
-        if (dtype == DType.STRING) {
+        if (dtype.equals(DType.STRING)) {
           long stringDataLen = 0;
           for (ColumnBufferProvider provider : providers) {
             stringDataLen += getRawStringDataLength(provider, 0, provider.getRowCount());
@@ -1425,7 +1425,7 @@ public class JCudfSerialization {
     if (dtype.hasOffsets()) {
       if (header.getRowCount() > 0) {
         copyConcatOffsets(out, providers);
-        if (dtype == DType.STRING) {
+        if (dtype.equals(DType.STRING)) {
           copyConcatStringData(out, providers);
         }
       }
@@ -1462,7 +1462,7 @@ public class JCudfSerialization {
       if (numRows > 0) {
         try (NvtxRange offsetRange = new NvtxRange("Write Offset Data", NvtxColor.ORANGE)) {
           copySlicedOffsets(out, column, rowOffset, numRows);
-          if (type == DType.STRING) {
+          if (type.equals(DType.STRING)) {
             try (NvtxRange dataRange = new NvtxRange("Write String Data", NvtxColor.RED)) {
               copySlicedStringData(out, column, rowOffset, numRows);
             }
@@ -1476,14 +1476,14 @@ public class JCudfSerialization {
     }
 
     if (numRows > 0 && type.isNestedType()) {
-      if (type == DType.LIST) {
+      if (type.equals(DType.LIST)) {
         try (NvtxRange range = new NvtxRange("Write List Child", NvtxColor.PURPLE)) {
           ColumnBufferProvider child = column.getChildProviders()[0];
           long childStartRow = column.getOffset(rowOffset);
           long childNumRows = column.getOffset(rowOffset + numRows) - childStartRow;
           writeSliced(out, child, childStartRow, childNumRows);
         }
-      } else if (type == DType.STRUCT) {
+      } else if (type.equals(DType.STRUCT)) {
         try (NvtxRange range = new NvtxRange("Write Struct Children", NvtxColor.PURPLE)) {
           for (ColumnBufferProvider child : column.getChildProviders()) {
             writeSliced(out, child, rowOffset, numRows);

--- a/java/src/main/java/ai/rapids/cudf/ORCOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ORCOptions.java
@@ -68,7 +68,7 @@ public class ORCOptions extends ColumnFilterOptions {
      * @return builder for chaining
      */
     public ORCOptions.Builder withTimeUnit(DType unit) {
-      assert unit.isTimestamp();
+      assert unit.isTimestampType();
       this.unit = unit;
       return this;
     }

--- a/java/src/main/java/ai/rapids/cudf/ParquetOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ParquetOptions.java
@@ -58,7 +58,7 @@ public class ParquetOptions extends ColumnFilterOptions {
      * @return builder for chaining
      */
     public Builder withTimeUnit(DType unit) {
-      assert unit.isTimestamp();
+      assert unit.isTimestampType();
       this.unit = unit;
       return this;
     }

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -276,7 +276,7 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
    */
   public static Scalar durationFromLong(DType type, long value) {
     if (type.isDurationType()) {
-      if (type == DType.DURATION_DAYS) {
+      if (type.equals(DType.DURATION_DAYS)) {
         int intValue = (int)value;
         if (value != intValue) {
           throw new IllegalArgumentException("value too large for type " + type + ": " + value);
@@ -304,8 +304,8 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
   }
 
   public static Scalar timestampFromLong(DType type, long value) {
-    if (type.isTimestamp()) {
-      if (type == DType.TIMESTAMP_DAYS) {
+    if (type.isTimestampType()) {
+      if (type.equals(DType.TIMESTAMP_DAYS)) {
         int intValue = (int)value;
         if (value != intValue) {
           throw new IllegalArgumentException("value too large for type " + type + ": " + value);
@@ -507,7 +507,7 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     Scalar other = (Scalar) o;
-    if (type != other.type) return false;
+    if (!type.equals(other.type)) return false;
     boolean valid = isValid();
     if (valid != other.isValid()) return false;
     if (!valid) return true;

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -1301,7 +1301,7 @@ public final class Table implements AutoCloseable {
     assert this.getRowCount() != 0 : "Input table cannot be empty";
     assert valueTable.getRowCount() != 0 : "Value table cannot be empty";
     for (int i = 0; i < Math.min(columns.length, valueTable.columns.length); i++) {
-      assert valueTable.columns[i].getType() == this.getColumn(i).getType() :
+      assert valueTable.columns[i].getType().equals(this.getColumn(i).getType()) :
           "Input and values tables' data types do not match";
     }
   }
@@ -1577,7 +1577,7 @@ public final class Table implements AutoCloseable {
    * the filter defined by the boolean mask
    */
   public Table filter(ColumnVector mask) {
-    assert mask.getType() == DType.BOOL8 : "Mask column must be of type BOOL8";
+    assert mask.getType().equals(DType.BOOL8) : "Mask column must be of type BOOL8";
     assert getRowCount() == 0 || getRowCount() == mask.getRowCount() : "Mask column has incorrect size";
     return new Table(filter(nativeHandle, mask.getNativeView()));
   }
@@ -2668,9 +2668,9 @@ public final class Table implements AutoCloseable {
           DType dtype = dataType.getType();
           Object dataArray = typeErasedData.get(i);
           if (dtype.isNestedType()) {
-            if (dtype == DType.LIST) {
+            if (dtype.equals(DType.LIST)) {
               columns.add(fromLists(dataType, (Object[][]) dataArray));
-            } else if (dtype == DType.STRUCT) {
+            } else if (dtype.equals(DType.STRUCT)) {
               columns.add(fromStructs(dataType, (StructData[]) dataArray));
             } else {
               throw new IllegalStateException("Unexpected nested type: " + dtype);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -1188,21 +1188,21 @@ public class ColumnVectorTest extends CudfTestBase {
   @Test
   void testFromScalarNull() {
     final int rowCount = 4;
-    for (DType.DTypeEnum type : DType.DTypeEnum.values()) {
-      if (type == DType.DTypeEnum.EMPTY || type == DType.DTypeEnum.LIST || type == DType.DTypeEnum.STRUCT) {
+    for (DType.DTypeEnum typeEnum : DType.DTypeEnum.values()) {
+      if (typeEnum == DType.DTypeEnum.EMPTY || typeEnum == DType.DTypeEnum.LIST || typeEnum == DType.DTypeEnum.STRUCT) {
         continue;
       }
       DType dType;
-      if (type.isDecimalType()) {
+      if (typeEnum.isDecimalType()) {
         // magic number to invoke factory method specialized for decimal types
-        dType = DType.create(type, -8);
+        dType = DType.create(typeEnum, -8);
       } else {
-        dType = DType.create(type);
+        dType = DType.create(typeEnum);
       }
       try (Scalar s = Scalar.fromNull(dType);
            ColumnVector c = ColumnVector.fromScalar(s, rowCount);
            HostColumnVector hc = c.copyToHost()) {
-        assertEquals(type, c.getType().typeId);
+        assertEquals(typeEnum, c.getType().typeId);
         assertEquals(rowCount, c.getRowCount());
         assertEquals(rowCount, c.getNullCount());
         for (int i = 0; i < rowCount; ++i) {

--- a/java/src/test/java/ai/rapids/cudf/ReductionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ReductionTest.java
@@ -48,7 +48,7 @@ class ReductionTest extends CudfTestBase {
       return Scalar.fromNull(baseType);
     }
     if (FLOAT_REDUCTIONS.contains(op.kind)) {
-      if (baseType == DType.FLOAT32) {
+      if (baseType.equals(DType.FLOAT32)) {
         return Scalar.fromFloat((Float) expectedObject);
       }
       return Scalar.fromDouble((Double) expectedObject);

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -321,7 +321,7 @@ public class TableTest extends CudfTestBase {
       for (long row = 0; row < numRows; row++) {
         try (HostColumnVector cv = table.getColumn(col).copyToHost()) {
           Object key = 0;
-          if (cv.getType() == DType.INT32) {
+          if (cv.getType().equals(DType.INT32)) {
             key = cv.getInt(row);
           } else {
             key = cv.getDouble(row);
@@ -804,7 +804,7 @@ public class TableTest extends CudfTestBase {
     try (Table table = Table.readORC(TEST_ORC_TIMESTAMP_DATE_FILE)) {
       assertEquals(2, table.getNumberOfColumns());
       found = table.getColumn(0).getType();
-      assertTrue(found.isTimestamp());
+      assertTrue(found.isTimestampType());
       assertEquals(DType.TIMESTAMP_MILLISECONDS, table.getColumn(1).getType());
     }
 

--- a/java/src/test/java/ai/rapids/cudf/TimestampColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TimestampColumnVectorTest.java
@@ -118,7 +118,7 @@ public class TimestampColumnVectorTest extends CudfTestBase {
     try (ColumnVector timestampColumnVector = ColumnVector.timestampMilliSecondsFromLongs(TIMES_MS);
          ColumnVector tmp = timestampColumnVector.year();
          HostColumnVector result = tmp.copyToHost()) {
-      assert timestampColumnVector.getType() == DType.TIMESTAMP_MILLISECONDS;
+      assert timestampColumnVector.getType().equals(DType.TIMESTAMP_MILLISECONDS);
       assertEquals(1965, result.getShort(0));
       assertEquals(2018, result.getShort(1));
       assertEquals(2023, result.getShort(2));
@@ -138,7 +138,7 @@ public class TimestampColumnVectorTest extends CudfTestBase {
     try (ColumnVector timestampColumnVector = ColumnVector.timestampMilliSecondsFromLongs(TIMES_MS);
          ColumnVector tmp = timestampColumnVector.month();
          HostColumnVector result = tmp.copyToHost()) {
-      assert timestampColumnVector.getType() == DType.TIMESTAMP_MILLISECONDS;
+      assert timestampColumnVector.getType().equals(DType.TIMESTAMP_MILLISECONDS);
       assertEquals(10, result.getShort(0));
       assertEquals(7, result.getShort(1));
       assertEquals(1, result.getShort(2));
@@ -156,7 +156,7 @@ public class TimestampColumnVectorTest extends CudfTestBase {
   @Test
   public void getDay() {
     try (ColumnVector timestampColumnVector = ColumnVector.timestampMilliSecondsFromLongs(TIMES_MS)) {
-      assert timestampColumnVector.getType() == DType.TIMESTAMP_MILLISECONDS;
+      assert timestampColumnVector.getType().equals(DType.TIMESTAMP_MILLISECONDS);
       try (ColumnVector tmp = timestampColumnVector.day();
            HostColumnVector result = tmp.copyToHost()) {
         assertEquals(26, result.getShort(0));
@@ -177,7 +177,7 @@ public class TimestampColumnVectorTest extends CudfTestBase {
   @Test
   public void getHour() {
     try (ColumnVector timestampColumnVector = ColumnVector.timestampMilliSecondsFromLongs(TIMES_MS)) {
-      assert timestampColumnVector.getType() == DType.TIMESTAMP_MILLISECONDS;
+      assert timestampColumnVector.getType().equals(DType.TIMESTAMP_MILLISECONDS);
       try (ColumnVector tmp = timestampColumnVector.hour();
            HostColumnVector result = tmp.copyToHost()) {
         assertEquals(14, result.getShort(0));
@@ -198,7 +198,7 @@ public class TimestampColumnVectorTest extends CudfTestBase {
   @Test
   public void getMinute() {
     try (ColumnVector timestampColumnVector = ColumnVector.timestampMilliSecondsFromLongs(TIMES_MS)) {
-      assert timestampColumnVector.getType() == DType.TIMESTAMP_MILLISECONDS;
+      assert timestampColumnVector.getType().equals(DType.TIMESTAMP_MILLISECONDS);
       try (ColumnVector tmp = timestampColumnVector.minute();
            HostColumnVector result = tmp.copyToHost()) {
         assertEquals(1, result.getShort(0));
@@ -219,7 +219,7 @@ public class TimestampColumnVectorTest extends CudfTestBase {
   @Test
   public void getSecond() {
     try (ColumnVector timestampColumnVector = ColumnVector.timestampMilliSecondsFromLongs(TIMES_MS)) {
-      assert timestampColumnVector.getType() == DType.TIMESTAMP_MILLISECONDS;
+      assert timestampColumnVector.getType().equals(DType.TIMESTAMP_MILLISECONDS);
       try (ColumnVector tmp = timestampColumnVector.second();
            HostColumnVector result = tmp.copyToHost()) {
         assertEquals(12, result.getShort(0));


### PR DESCRIPTION
As a part of trying to support upper and lower bounds for decimal I found that type checking for this function was broken because it used `==` for equality instead of `.equals`.  Looking further I found a few other places where this was a bug (one in ColumnVector that is mostly a performance issue and one in Scalar)  I decided to update all of the code to use .equals for comparison of types to make it consistent so it is less likely to have bugs like this crop up in the future.

I also took the opportunity to internally move away from using `isTimestamp` (which is deprecated) to `isTimestampType`