### PR TITLE
Add Ufunc alias look up for appropriate numpy ufunc dispatching

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1588,6 +1588,9 @@ class Series(Frame, Serializable):
     def __eq__(self, other):
         return self._binaryop(other, "eq")
 
+    def equal(self, other, fill_value=None, axis=0):
+        return self.eq(other, fill_value, axis)
+
     def ne(self, other, fill_value=None, axis=0):
         """Not equal to of series and other, element-wise
         (binary operator ne).
@@ -1605,6 +1608,9 @@ class Series(Frame, Serializable):
 
     def __ne__(self, other):
         return self._binaryop(other, "ne")
+
+    def not_equal(self, other, fill_value=None, axis=0):
+        return self.ne(other, fill_value, axis)
 
     def lt(self, other, fill_value=None, axis=0):
         """Less than of series and other, element-wise
@@ -1624,6 +1630,9 @@ class Series(Frame, Serializable):
     def __lt__(self, other):
         return self._binaryop(other, "lt")
 
+    def less(self, other, fill_value=None, axis=0):
+        return self.lt(other, fill_value, axis)
+
     def le(self, other, fill_value=None, axis=0):
         """Less than or equal to of series and other, element-wise
         (binary operator le).
@@ -1641,6 +1650,9 @@ class Series(Frame, Serializable):
 
     def __le__(self, other):
         return self._binaryop(other, "le")
+
+    def less_equal(self, other, fill_value=None, axis=0):
+        return self.le(other, fill_value, axis)
 
     def gt(self, other, fill_value=None, axis=0):
         """Greater than of series and other, element-wise
@@ -1660,6 +1672,9 @@ class Series(Frame, Serializable):
     def __gt__(self, other):
         return self._binaryop(other, "gt")
 
+    def greater(self, other, fill_value=None, axis=0):
+        return self.gt(other, fill_value, axis)
+
     def ge(self, other, fill_value=None, axis=0):
         """Greater than or equal to of series and other, element-wise
         (binary operator ge).
@@ -1677,6 +1692,9 @@ class Series(Frame, Serializable):
 
     def __ge__(self, other):
         return self._binaryop(other, "ge")
+
+    def greater_equal(self, other, fill_value=None, axis=0):
+        return self.ge(other, fill_value, axis)
 
     def __invert__(self):
         """Bitwise invert (~) for each element.
@@ -3838,6 +3856,9 @@ class Series(Frame, Serializable):
         return self._unaryop("abs")
 
     def __abs__(self):
+        return self.abs()
+
+    def absolute(self):
         return self.abs()
 
     # Rounding

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1588,9 +1588,6 @@ class Series(Frame, Serializable):
     def __eq__(self, other):
         return self._binaryop(other, "eq")
 
-    def equal(self, other, fill_value=None, axis=0):
-        return self.eq(other, fill_value, axis)
-
     def ne(self, other, fill_value=None, axis=0):
         """Not equal to of series and other, element-wise
         (binary operator ne).
@@ -1608,9 +1605,6 @@ class Series(Frame, Serializable):
 
     def __ne__(self, other):
         return self._binaryop(other, "ne")
-
-    def not_equal(self, other, fill_value=None, axis=0):
-        return self.ne(other, fill_value, axis)
 
     def lt(self, other, fill_value=None, axis=0):
         """Less than of series and other, element-wise
@@ -1630,9 +1624,6 @@ class Series(Frame, Serializable):
     def __lt__(self, other):
         return self._binaryop(other, "lt")
 
-    def less(self, other, fill_value=None, axis=0):
-        return self.lt(other, fill_value, axis)
-
     def le(self, other, fill_value=None, axis=0):
         """Less than or equal to of series and other, element-wise
         (binary operator le).
@@ -1650,9 +1641,6 @@ class Series(Frame, Serializable):
 
     def __le__(self, other):
         return self._binaryop(other, "le")
-
-    def less_equal(self, other, fill_value=None, axis=0):
-        return self.le(other, fill_value, axis)
 
     def gt(self, other, fill_value=None, axis=0):
         """Greater than of series and other, element-wise
@@ -1672,9 +1660,6 @@ class Series(Frame, Serializable):
     def __gt__(self, other):
         return self._binaryop(other, "gt")
 
-    def greater(self, other, fill_value=None, axis=0):
-        return self.gt(other, fill_value, axis)
-
     def ge(self, other, fill_value=None, axis=0):
         """Greater than or equal to of series and other, element-wise
         (binary operator ge).
@@ -1692,9 +1677,6 @@ class Series(Frame, Serializable):
 
     def __ge__(self, other):
         return self._binaryop(other, "ge")
-
-    def greater_equal(self, other, fill_value=None, axis=0):
-        return self.ge(other, fill_value, axis)
 
     def __invert__(self):
         """Bitwise invert (~) for each element.
@@ -3856,9 +3838,6 @@ class Series(Frame, Serializable):
         return self._unaryop("abs")
 
     def __abs__(self):
-        return self.abs()
-
-    def absolute(self):
         return self.abs()
 
     # Rounding

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -10,7 +10,17 @@ from cudf.tests.utils import assert_eq
     "np_ar_tup", [(np.random.random(100), np.random.random(100))]
 )
 @pytest.mark.parametrize(
-    "func", [np.greater, np.less, np.less_equal, np.subtract],
+    "func",
+    [
+        np.greater,
+        np.greater_equal,
+        np.less,
+        np.less_equal,
+        np.subtract,
+        np.equal,
+        np.not_equal,
+        np.fmod,
+    ],
 )
 def test_ufunc_cudf_series(np_ar_tup, func):
     x, y = np_ar_tup[0], np_ar_tup[1]
@@ -27,7 +37,34 @@ def test_ufunc_cudf_series(np_ar_tup, func):
     "np_ar_tup", [(np.random.random(100), np.random.random(100))]
 )
 @pytest.mark.parametrize(
-    "func", [np.greater, np.less, np.less_equal],
+    "func",
+    [
+        np.greater,
+        np.greater_equal,
+        np.less,
+        np.less_equal,
+        np.equal,
+        np.not_equal,
+    ],
+)
+def test_ufunc_cudf_series_cudf_dispatch(np_ar_tup, func):
+    x, y = np_ar_tup[0].astype(np.float32), np_ar_tup[1].astype(np.float32)
+    x[0] = np.nan
+    y[1] = np.nan
+    s_1, s_2 = cudf.Series(x), cudf.Series(y)
+    expect = func(x, y)
+    got = func(s_1, s_2)
+    if np.isscalar(expect):
+        assert_eq(expect, got)
+    else:
+        assert_eq(expect, got.to_array())
+
+
+@pytest.mark.parametrize(
+    "np_ar_tup", [(np.random.random(100), np.random.random(100))]
+)
+@pytest.mark.parametrize(
+    "func", [np.logaddexp, np.fmax, np.fmod],
 )
 def test_ufunc_cudf_series_cupy_array(np_ar_tup, func):
     x, y = np_ar_tup[0], np_ar_tup[1]
@@ -43,7 +80,7 @@ def test_ufunc_cudf_series_cupy_array(np_ar_tup, func):
 
 
 @pytest.mark.parametrize(
-    "func", [np.greater, np.less, np.less_equal],
+    "func", [np.fmod, np.logaddexp],
 )
 def test_error_with_null_cudf_series(func):
     s_1 = cudf.Series([1, 2])
@@ -66,7 +103,7 @@ def test_error_with_null_cudf_series(func):
 
 
 @pytest.mark.parametrize(
-    "func", [np.absolute, np.sign],
+    "func", [np.absolute, np.sign, np.exp2, np.tanh],
 )
 def test_ufunc_cudf_series_with_index(func):
     data = [-1, 2, 3, 0]
@@ -81,7 +118,7 @@ def test_ufunc_cudf_series_with_index(func):
 
 
 @pytest.mark.parametrize(
-    "func", [np.greater, np.logaddexp],
+    "func", [np.logaddexp2, np.power],
 )
 def test_ufunc_cudf_series_with_nonaligned_index(func):
     cudf_s1 = cudf.Series(data=[-1, 2, 3, 0], index=[2, 3, 1, 0])

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -68,6 +68,21 @@ def test_ufunc_cudf_series_cudf_dispatch(np_ar_tup, func):
     else:
         assert_eq(expect, got.fillna(np.nan).to_array())
 
+    scalar = 0.5
+    expect = func(x, scalar)
+    got = func(s_1, scalar)
+    if np.isscalar(expect):
+        assert_eq(expect, got)
+    else:
+        assert_eq(expect, got.fillna(np.nan).to_array())
+
+    expect = func(scalar, x)
+    got = func(scalar, s_1)
+    if np.isscalar(expect):
+        assert_eq(expect, got)
+    else:
+        assert_eq(expect, got.fillna(np.nan).to_array())
+
 
 @pytest.mark.parametrize(
     "np_ar_tup", [(np.random.random(100), np.random.random(100))]

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -154,3 +154,15 @@ def test_ufunc_cudf_series_with_nonaligned_index(func):
         ValueError, match="Can only compare identically-labeled Series objects"
     ):
         func(cudf_s1, cudf_s2)
+
+
+@pytest.mark.parametrize(
+    "func", [np.add],
+)
+def test_ufunc_cudf_series_error_with_out_kwarg(func):
+    cudf_s1 = cudf.Series(data=[-1, 2, 3, 0])
+    cudf_s2 = cudf.Series(data=[-1, 2, 3, 0])
+    cudf_s3 = cudf.Series(data=[0, 0, 0, 0])
+    # this throws a value-error because of presence of out kwarg
+    with pytest.raises(TypeError):
+        func(x1=cudf_s1, x2=cudf_s2, out=cudf_s3)

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -20,6 +20,7 @@ from cudf.tests.utils import assert_eq
         np.equal,
         np.not_equal,
         np.fmod,
+        np.power,
     ],
 )
 def test_ufunc_cudf_series(np_ar_tup, func):
@@ -39,12 +40,19 @@ def test_ufunc_cudf_series(np_ar_tup, func):
 @pytest.mark.parametrize(
     "func",
     [
-        np.greater,
-        np.greater_equal,
-        np.less,
-        np.less_equal,
+        np.subtract,
+        np.multiply,
+        np.floor_divide,
+        np.true_divide,
+        np.power,
+        np.remainder,
+        np.divide,
         np.equal,
         np.not_equal,
+        np.less,
+        np.less_equal,
+        np.greater,
+        np.greater_equal,
     ],
 )
 def test_ufunc_cudf_series_cudf_dispatch(np_ar_tup, func):
@@ -54,10 +62,11 @@ def test_ufunc_cudf_series_cudf_dispatch(np_ar_tup, func):
     s_1, s_2 = cudf.Series(x), cudf.Series(y)
     expect = func(x, y)
     got = func(s_1, s_2)
+    got = got.fillna(np.nan)
     if np.isscalar(expect):
         assert_eq(expect, got)
     else:
-        assert_eq(expect, got.to_array())
+        assert_eq(expect, got.fillna(np.nan).to_array())
 
 
 @pytest.mark.parametrize(
@@ -118,7 +127,7 @@ def test_ufunc_cudf_series_with_index(func):
 
 
 @pytest.mark.parametrize(
-    "func", [np.logaddexp2, np.power],
+    "func", [np.logaddexp2],
 )
 def test_ufunc_cudf_series_with_nonaligned_index(func):
     cudf_s1 = cudf.Series(data=[-1, 2, 3, 0], index=[2, 3, 1, 0])

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -35,6 +35,22 @@ def test_ufunc_cudf_series(np_ar_tup, func):
 
 
 @pytest.mark.parametrize(
+    "func", [np.bitwise_and, np.bitwise_or, np.bitwise_xor],
+)
+def test_ufunc_cudf_series_bitwise(func):
+    x = np.random.randint(size=100, low=0, high=100)
+    y = np.random.randint(size=100, low=0, high=100)
+
+    s_1, s_2 = cudf.Series(x), cudf.Series(y)
+    expect = func(x, y)
+    got = func(s_1, s_2)
+    if np.isscalar(expect):
+        assert_eq(expect, got)
+    else:
+        assert_eq(expect, got.to_array())
+
+
+@pytest.mark.parametrize(
     "np_ar_tup", [(np.random.random(100), np.random.random(100))]
 )
 @pytest.mark.parametrize(
@@ -104,7 +120,8 @@ def test_ufunc_cudf_series_cupy_array(np_ar_tup, func):
 
 
 @pytest.mark.parametrize(
-    "func", [np.fmod, np.logaddexp],
+    "func",
+    [np.fmod, np.logaddexp, np.bitwise_and, np.bitwise_or, np.bitwise_xor],
 )
 def test_error_with_null_cudf_series(func):
     s_1 = cudf.Series([1, 2])

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -481,9 +481,6 @@ _UFUNC_ALIASES = {
     "less_equal": "le",
     "greater": "gt",
     "greater_equal": "ge",
-    "bitwise_or": "or",
-    "bitwise_and": "and",
-    "bitwise_xor": "xor",
     "absolute": "abs",
 }
 # For op(., cudf.Series) -> cudf.Series.__r{op}__

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -473,14 +473,8 @@ def search_range(start, stop, x, step=1, side="left"):
     return max(min(length, i), 0)
 
 
-UFUNC_ALIASES = {
-    "subtract": "sub",
-    "multiply": "mul",
-    "floor_divide": "floordiv",
-    "true_divide": "truediv",
+_UFUNC_ALIASES = {
     "power": "pow",
-    "remainder": "mod",
-    "divide": "div",
     "equal": "eq",
     "not_equal": "ne",
     "less": "lt",
@@ -492,35 +486,62 @@ UFUNC_ALIASES = {
     "bitwise_xor": "xor",
     "absolute": "abs",
 }
+# For op(., cudf.Series) -> cudf.Series.__r{op}__
+_REVERSED_NAMES = {
+    "lt": "__gt__",
+    "le": "__ge__",
+    "gt": "__lt__",
+    "ge": "__le__",
+    "eq": "__eq__",
+    "ne": "__ne__",
+}
+
+# can probably be used to remove cudf/core/ops.py
+def _get_cudf_series_ufunc(fname, args, kwargs, cudf_ser_submodule):
+    if isinstance(args[0], cudf.Series):
+        cudf_ser_func = getattr(cudf_ser_submodule, fname)
+        return cudf_ser_func(*args, **kwargs)
+    elif len(args) == 2 and isinstance(args[1], cudf.Series):
+        rev_name = _REVERSED_NAMES.get(fname, f"__r{fname}__")
+        cudf_ser_func = getattr(cudf_ser_submodule, rev_name)
+        return cudf_ser_func(args[1], args[0], **kwargs)
+    return NotImplemented
 
 
 # Utils for using appropriate dispatch for array functions
 def get_appropriate_dispatched_func(
     cudf_submodule, cudf_ser_submodule, cupy_submodule, func, args, kwargs
 ):
-    fname = func.__name__
-    # Dispatch these functions to appropiate alias from the UFUNC_ALIASES
-    fname = UFUNC_ALIASES.get(fname, fname)
+    if kwargs.get("out") is None:
+        fname = func.__name__
+        # Dispatch these functions to appropiate alias from the _UFUNC_ALIASES
+        is_ufunc = fname in _UFUNC_ALIASES
+        fname = _UFUNC_ALIASES.get(fname, fname)
 
-    if hasattr(cudf_submodule, fname):
-        cudf_func = getattr(cudf_submodule, fname)
-        return cudf_func(*args, **kwargs)
+        if hasattr(cudf_submodule, fname):
+            cudf_func = getattr(cudf_submodule, fname)
+            return cudf_func(*args, **kwargs)
 
-    elif hasattr(cudf_ser_submodule, fname):
-        cudf_ser_func = getattr(cudf_ser_submodule, fname)
-        return cudf_ser_func(*args, **kwargs)
+        elif hasattr(cudf_ser_submodule, fname):
+            if is_ufunc:
+                return _get_cudf_series_ufunc(
+                    fname, args, kwargs, cudf_ser_submodule
+                )
+            else:
+                cudf_ser_func = getattr(cudf_ser_submodule, fname)
+                return cudf_ser_func(*args, **kwargs)
 
-    elif hasattr(cupy_submodule, fname):
-        cupy_func = getattr(cupy_submodule, fname)
-        # Handle case if cupy impliments it as a numpy function
-        # Unsure if needed
-        if cupy_func is func:
-            return NotImplemented
+        elif hasattr(cupy_submodule, fname):
+            cupy_func = getattr(cupy_submodule, fname)
+            # Handle case if cupy impliments it as a numpy function
+            # Unsure if needed
+            if cupy_func is func:
+                return NotImplemented
 
-        cupy_compatible_args, index = _get_cupy_compatible_args_index(args)
-        if cupy_compatible_args:
-            cupy_output = cupy_func(*cupy_compatible_args, **kwargs)
-            return _cast_to_appropriate_cudf_type(cupy_output, index)
+            cupy_compatible_args, index = _get_cupy_compatible_args_index(args)
+            if cupy_compatible_args:
+                cupy_output = cupy_func(*cupy_compatible_args, **kwargs)
+                return _cast_to_appropriate_cudf_type(cupy_output, index)
 
     return NotImplemented
 

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -496,7 +496,7 @@ _REVERSED_NAMES = {
     "ne": "__ne__",
 }
 
-# can probably be used to remove cudf/core/ops.py
+# todo: can probably be used to remove cudf/core/ops.py
 def _get_cudf_series_ufunc(fname, args, kwargs, cudf_ser_submodule):
     if isinstance(args[0], cudf.Series):
         cudf_ser_func = getattr(cudf_ser_submodule, fname)

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -496,6 +496,7 @@ _REVERSED_NAMES = {
     "ne": "__ne__",
 }
 
+
 # todo: can probably be used to remove cudf/core/ops.py
 def _get_cudf_series_ufunc(fname, args, kwargs, cudf_ser_submodule):
     if isinstance(args[0], cudf.Series):

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -473,11 +473,34 @@ def search_range(start, stop, x, step=1, side="left"):
     return max(min(length, i), 0)
 
 
+UFUNC_ALIASES = {
+    "subtract": "sub",
+    "multiply": "mul",
+    "floor_divide": "floordiv",
+    "true_divide": "truediv",
+    "power": "pow",
+    "remainder": "mod",
+    "divide": "div",
+    "equal": "eq",
+    "not_equal": "ne",
+    "less": "lt",
+    "less_equal": "le",
+    "greater": "gt",
+    "greater_equal": "ge",
+    "bitwise_or": "or",
+    "bitwise_and": "and",
+    "bitwise_xor": "xor",
+    "absolute": "abs",
+}
+
+
 # Utils for using appropriate dispatch for array functions
 def get_appropriate_dispatched_func(
     cudf_submodule, cudf_ser_submodule, cupy_submodule, func, args, kwargs
 ):
     fname = func.__name__
+    # Dispatch these functions to appropiate alias from the UFUNC_ALIASES
+    fname = UFUNC_ALIASES.get(fname, fname)
 
     if hasattr(cudf_submodule, fname):
         cudf_func = getattr(cudf_submodule, fname)


### PR DESCRIPTION
This PR closes https://github.com/rapidsai/cudf/issues/6921 by dispatching to appropriate cudf alias for numpy functions from the UFUNC_ALIASES dictionary :  
```python
 _UFUNC_ALIASES = {
    "power": "pow",
    "equal": "eq",
    "not_equal": "ne",
    "less": "lt",
    "less_equal": "le",
    "greater": "gt",
    "greater_equal": "ge",
    "absolute": "abs",
}
```


