### PR TITLE
Make `cudf::round` for `fixed_point` when `scale = -decimal_places` a no-op

### DIFF
--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -237,6 +237,9 @@ std::unique_ptr<column> round_with(column_view const& input,
   using Type                   = device_storage_type_t<T>;
   using FixedPointRoundFunctor = RoundFunctor<Type>;
 
+  if (input.type().scale() == -decimal_places)
+    return std::make_unique<cudf::column>(input, stream, mr);
+
   // if rounding to more precision than fixed_point is capable of, just need to rescale
   // note: decimal_places has the opposite sign of numeric::scale_type (therefore have to negate)
   if (input.type().scale() > -decimal_places) {

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -56,6 +56,19 @@ TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUpZero)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfUpZeroNoOp)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+
+  auto const input  = fp_wrapper{{1125, 1150, 1160, 1240, 1250, 1260}, scale_type{0}};
+  auto const result = cudf::round(input);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(input, result->view());
+}
+
 TYPED_TEST(RoundTestsFixedPointTypes, SimpleFixedPointTestHalfEvenZero)
 {
   using namespace numeric;


### PR DESCRIPTION
@nartal1 found a small bug while working on: https://github.com/NVIDIA/spark-rapids/pull/1244

Problem is that for `fixed_point`, when the column `scale = -decimal_places`, it should be a no-op. Fix is to make it a no-op.