### PR TITLE
Minor `cudf::round` internal refactoring

### DIFF
--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -16,7 +16,6 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/binaryop.hpp>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/round.hpp>


### PR DESCRIPTION
This is a small cleanup that replaces a `cudf::binary_operation` with a much cleaner `cudf::cast`.