### PR TITLE
Disable some pragma unroll statements in thrust sort.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## New Features
 - PR #6856 Add groupby idxmin, idxmax aggregation
-
 - PR #6847 Add a cmake find module for cuFile in JNI code
 - PR #6902 Implement `DataFrame.quantile` for `datetime` and `timedelta` data types
 - PR #6814 Implement `cudf::reduce` for `decimal32` and `decimal64` (part 1)
@@ -15,6 +14,7 @@
 - PR #6838 Fix `columns` & `index` handling in dataframe constructor
 - PR #6750 Remove **kwargs from string/categorical methods
 - PR #6939 Use simplified `rmm::exec_policy`
+- PR #6982 Disable some pragma unroll statements in thrust `sort.h`
 
 ## Bug Fixes
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -12,6 +12,8 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
     GIT_TAG        1.10.0
     GIT_SHALLOW    true
+    # NOTE: If you change the GIT_TAG you will likely need to change this patch file too
+    PATCH_COMMAND  (git apply -R ${CMAKE_CURRENT_SOURCE_DIR}/thrust.patch || true) && git apply ${CMAKE_CURRENT_SOURCE_DIR}/thrust.patch
 )
 
 FetchContent_GetProperties(thrust)

--- a/thirdparty/thrust.patch
+++ b/thirdparty/thrust.patch
@@ -1,0 +1,44 @@
+diff --git a/thrust/system/cuda/detail/sort.h b/thrust/system/cuda/detail/sort.h
+index 1ffeef0..5e80800 100644
+--- a/thrust/system/cuda/detail/sort.h
++++ b/thrust/system/cuda/detail/sort.h
+@@ -108,7 +108,7 @@ namespace __merge_sort {
+     key_type key2 = keys_shared[keys2_beg];
+ 
+ 
+-#pragma unroll
++#pragma unroll 1
+     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
+     {
+       bool p = (keys2_beg < keys2_end) &&
+@@ -311,10 +311,10 @@ namespace __merge_sort {
+       void stable_odd_even_sort(key_type (&keys)[ITEMS_PER_THREAD],
+                                 item_type (&items)[ITEMS_PER_THREAD])
+       {
+-#pragma unroll
++#pragma unroll 1
+         for (int i = 0; i < ITEMS_PER_THREAD; ++i)
+         {
+-#pragma unroll
++#pragma unroll 1
+           for (int j = 1 & i; j < ITEMS_PER_THREAD - 1; j += 2)
+           {
+             if (compare_op(keys[j + 1], keys[j]))
+@@ -350,7 +350,7 @@ namespace __merge_sort {
+         // each thread has  sorted keys_loc
+         // merge sort keys_loc in shared memory
+         //
+-#pragma unroll
++#pragma unroll 1
+         for (int coop = 2; coop <= BLOCK_THREADS; coop *= 2)
+         {
+           sync_threadblock();
+@@ -479,7 +479,7 @@ namespace __merge_sort {
+           // and fill the remainig keys with it
+           //
+           key_type max_key = keys_loc[0];
+-#pragma unroll
++#pragma unroll 1
+           for (int ITEM = 1; ITEM < ITEMS_PER_THREAD; ++ITEM)
+           {
+             if (ITEMS_PER_THREAD * tid + ITEM < num_remaining)


### PR DESCRIPTION
Closes #6955 

This will improve the compile time and size for any function using `thrust::sort` and `thrust::stable_sort`. 
The PR includes a .patch file to be applied during cmake when downloading the thrust library.