### PR TITLE
Check output size overflow on strings gather

### DIFF
--- a/cpp/include/cudf/strings/detail/gather.cuh
+++ b/cpp/include/cudf/strings/detail/gather.cuh
@@ -17,9 +17,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_device_view.cuh>
-#include <cudf/detail/copy.hpp>
-#include <cudf/detail/valid_if.cuh>
-#include <cudf/strings/detail/utilities.cuh>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 
@@ -75,22 +73,38 @@ std::unique_ptr<cudf::column> gather(
   auto d_strings      = *strings_column;
 
   // build offsets column
-  auto offsets_transformer = [d_strings, strings_count] __device__(size_type idx) {
-    if (NullifyOutOfBounds && ((idx < 0) || (idx >= strings_count))) return 0;
-    if (d_strings.is_null(idx)) return 0;
-    return d_strings.element<string_view>(idx).size_bytes();
-  };
-  auto offsets_transformer_itr = thrust::make_transform_iterator(begin, offsets_transformer);
-  auto offsets_column          = make_offsets_child_column(
-    offsets_transformer_itr, offsets_transformer_itr + output_count, stream, mr);
-  auto offsets_view = offsets_column->view();
-  auto d_offsets    = offsets_view.template data<int32_t>();
+  auto offsets_column = make_numeric_column(
+    data_type{type_id::INT32}, output_count + 1, mask_state::UNALLOCATED, stream, mr);
+  auto d_offsets = offsets_column->mutable_view().template data<int32_t>();
+  thrust::transform(rmm::exec_policy(stream),
+                    begin,
+                    end,
+                    d_offsets,
+                    [d_strings, strings_count] __device__(size_type idx) {
+                      if (NullifyOutOfBounds && ((idx < 0) || (idx >= strings_count))) return 0;
+                      if (d_strings.is_null(idx)) return 0;
+                      return d_strings.element<string_view>(idx).size_bytes();
+                    });
+
+  // check total size is not too large
+  size_t total_bytes = thrust::transform_reduce(
+    rmm::exec_policy(stream),
+    d_offsets,
+    d_offsets + output_count,
+    [] __device__(auto size) { return static_cast<size_t>(size); },
+    size_t{0},
+    thrust::plus<size_t>{});
+  CUDF_EXPECTS(total_bytes < std::numeric_limits<size_type>::max(),
+               "total size of output strings is too large for a cudf column");
+
+  // create offsets from sizes
+  thrust::exclusive_scan(
+    rmm::exec_policy(stream), d_offsets, d_offsets + output_count + 1, d_offsets);
 
   // build chars column
-  size_type bytes   = thrust::device_pointer_cast(d_offsets)[output_count];
+  size_type bytes   = static_cast<size_type>(total_bytes);
   auto chars_column = create_chars_child_column(output_count, 0, bytes, stream, mr);
-  auto chars_view   = chars_column->mutable_view();
-  auto d_chars      = chars_view.template data<char>();
+  auto d_chars      = chars_column->mutable_view().template data<char>();
   // fill in chars
   auto gather_chars =
     [d_strings, begin, strings_count, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/tests/strings/array_tests.cu
+++ b/cpp/tests/strings/array_tests.cu
@@ -182,6 +182,15 @@ struct column_to_string_view_vector {
   }
 };
 
+TEST_F(StringsColumnTest, GatherTooBig)
+{
+  cudf::test::strings_column_wrapper strings({"0123456789012345678901234567890123456789"});
+  auto map = thrust::constant_iterator<int8_t>(0);
+  cudf::test::fixed_width_column_wrapper<int8_t> gather_map(
+    map, map + std::numeric_limits<cudf::size_type>::max() / 20);
+  EXPECT_THROW(cudf::gather(cudf::table_view{{strings}}, gather_map), cudf::logic_error);
+}
+
 TEST_F(StringsColumnTest, Scatter)
 {
   std::vector<const char*> h_strings1{"eee", "bb", nullptr, "", "aa", "bbb", "ééé"};


### PR DESCRIPTION
Closes #6801 

This PR adds an extra reduce call in the libcudf gather specialization logic for strings column. This will check to make sure the output size of the gather does not exceed the size limit for the child characters column. The offsets column is first created with the individual output string sizes. Then the reduce call will add these sizes to check for overflow.

Also added a gtest to check for the overflow condition.