### PR TITLE
Add `method` field to `fillna` for fixed width columns

### DIFF
--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -1060,9 +1060,12 @@ class CategoricalColumn(column.ColumnBase):
                         raise ValueError(err_msg) from err
             else:
                 fill_value = column.as_column(fill_value, nan_as_null=False)
-                # TODO: only required if fill_value has a subset of the categories:
+                # TODO: only required if fill_value has a subset of the
+                # categories:
                 fill_value = fill_value.cat()._set_categories(
-                    fill_value.cat().categories, self.categories, is_unique=True
+                    fill_value.cat().categories,
+                    self.categories,
+                    is_unique=True,
                 )
                 fill_value = column.as_column(fill_value.codes).astype(
                     self.codes.dtype

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -750,12 +750,12 @@ class ColumnBase(Column, Serializable):
 
         self._mimic_inplace(out, inplace=True)
 
-    def fillna(self, value):
+    def fillna(self, value=None, method=None):
         """Fill null values with ``value``.
 
         Returns a copy with null filled.
         """
-        raise NotImplementedError
+        return libcudf.replace.replace_nulls(input_col=self, replacement=value, method=method)
 
     def isnull(self):
         """Identify missing values in a Column.

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -755,7 +755,9 @@ class ColumnBase(Column, Serializable):
 
         Returns a copy with null filled.
         """
-        return libcudf.replace.replace_nulls(input_col=self, replacement=value, method=method)
+        return libcudf.replace.replace_nulls(
+            input_col=self, replacement=value, method=method
+        )
 
     def isnull(self):
         """Identify missing values in a Column.

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -750,13 +750,13 @@ class ColumnBase(Column, Serializable):
 
         self._mimic_inplace(out, inplace=True)
 
-    def fillna(self, value=None, method=None):
+    def fillna(self, value=None, method=None, dtype=None):
         """Fill null values with ``value``.
 
         Returns a copy with null filled.
         """
         return libcudf.replace.replace_nulls(
-            input_col=self, replacement=value, method=method
+            input_col=self, replacement=value, method=method, dtype=dtype
         )
 
     def isnull(self):

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -246,17 +246,17 @@ class DatetimeColumn(column.ColumnBase):
 
         return binop(lhs, rhs, op=op, out_dtype=out_dtype)
 
-    def fillna(self, fill_value):
-        if cudf.utils.utils.isnat(fill_value):
-            return _fillna_natwise(self)
-        if is_scalar(fill_value):
-            if not isinstance(fill_value, cudf.Scalar):
-                fill_value = cudf.Scalar(fill_value, dtype=self.dtype)
-        else:
-            fill_value = column.as_column(fill_value, nan_as_null=False)
+    def fillna(self, fill_value=None, method=None):
+        if fill_value is not None:
+            if cudf.utils.utils.isnat(fill_value):
+                return _fillna_natwise(self)
+            if is_scalar(fill_value):
+                if not isinstance(fill_value, cudf.Scalar):
+                    fill_value = cudf.Scalar(fill_value, dtype=self.dtype)
+            else:
+                fill_value = column.as_column(fill_value, nan_as_null=False)
 
-        result = libcudf.replace.replace_nulls(self, fill_value)
-        return result
+        return super().fillna(fill_value, method)
 
     def find_first_value(self, value, closest=False):
         """

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -413,15 +413,18 @@ class NumericalColumn(column.ColumnBase):
             replaced, to_replace_col, replacement_col
         )
 
-    def fillna(self, fill_value):
+    def fillna(self, fill_value=None, method=None):
         """
         Fill null values with *fill_value*
         """
+        if method is not None:
+            return super().fillna(fill_value, method)
+
         if (
             isinstance(fill_value, cudf.Scalar)
             and fill_value.dtype == self.dtype
         ):
-            return libcudf.replace.replace_nulls(self, fill_value)
+            return super().fillna(fill_value, method)
         if np.isscalar(fill_value):
             # castsafely to the same dtype as self
             fill_value_casted = self.dtype.type(fill_value)
@@ -438,9 +441,8 @@ class NumericalColumn(column.ColumnBase):
                 fill_value = _safe_cast_to_int(fill_value, self.dtype)
             else:
                 fill_value = fill_value.astype(self.dtype)
-        result = libcudf.replace.replace_nulls(self, fill_value)
 
-        return result
+        return super().fillna(fill_value, method)
 
     def find_first_value(self, value, closest=False):
         """

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -4925,7 +4925,12 @@ class StringColumn(column.ColumnBase):
         replacement = column.as_column(replacement, dtype=self.dtype)
         return libcudf.replace.replace(self, to_replace, replacement)
 
-    def fillna(self, fill_value):
+    def fillna(self, fill_value, method=None):
+        if method is not None:
+            raise NotImplementedError(
+                'fillna for string column with `method` parameter is not' 
+                'supported.'
+            )
         if not is_scalar(fill_value):
             fill_value = column.as_column(fill_value, dtype=self.dtype)
         return libcudf.replace.replace_nulls(self, fill_value, dtype="object")

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -4933,7 +4933,7 @@ class StringColumn(column.ColumnBase):
             )
         if not is_scalar(fill_value):
             fill_value = column.as_column(fill_value, dtype=self.dtype)
-        return libcudf.replace.replace_nulls(self, fill_value, dtype="object")
+        return super().fillna(value=fill_value, dtype="object")
 
     def _find_first_and_last(self, value):
         found_indices = self.str().contains(f"^{value}$")

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -4928,8 +4928,8 @@ class StringColumn(column.ColumnBase):
     def fillna(self, fill_value, method=None):
         if method is not None:
             raise NotImplementedError(
-                'fillna for string column with `method` parameter is not' 
-                'supported.'
+                "fillna for string column with `method` parameter is not"
+                "supported."
             )
         if not is_scalar(fill_value):
             fill_value = column.as_column(fill_value, dtype=self.dtype)

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -9,7 +9,7 @@ from nvtx import annotate
 
 import cudf
 from cudf import _lib as libcudf
-from cudf.core.column import column, string
+from cudf.core.column import ColumnBase, column, string
 from cudf.core.column.datetime import _numpy_to_pandas_conversion
 from cudf.utils.dtypes import is_scalar, np_to_pa_dtype
 from cudf.utils.utils import _fillna_natwise
@@ -281,7 +281,7 @@ class TimeDeltaColumn(column.ColumnBase):
             else:
                 fill_value = column.as_column(fill_value, nan_as_null=False)
 
-            return libcudf.replace.replace_nulls(col, fill_value)
+            return ColumnBase.fillna(col, fill_value)
         else:
             return super().fillna(method=method)
 

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1314,7 +1314,7 @@ class Frame(libcudf.table.Table):
     def fillna(
         self, value=None, method=None, axis=None, inplace=False, limit=None
     ):
-        """Fill null values with ``value``.
+        """Fill null values with ``value`` or specified ``method``.
 
         Parameters
         ----------
@@ -1322,7 +1322,13 @@ class Frame(libcudf.table.Table):
             Value to use to fill nulls. If Series-like, null values
             are filled with values in corresponding indices.
             A dict can be used to provide different values to fill nulls
-            in different columns.
+            in different columns. Cannot be used with ``method``.
+        
+        method : {'ffill', 'bfill'}, default None
+            Method to use for filling null values in the dataframe or series.
+            `ffill` propagates the last non-null values forward to the next
+            non-null value. `bfill` propagates backward with the next non-null
+            value. Cannot be used with ``value``.
 
         Returns
         -------

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1386,6 +1386,28 @@ class Frame(libcudf.table.Table):
         0  1  3
         1  2  4
         2  3  5
+
+        ``fillna`` specified with fill ``method``
+
+        >>> ser = cudf.Series([1, None, None, 2, 3, None, None])
+        >>> ser.fillna(method='ffill')
+        0    1
+        1    1
+        2    1
+        3    2
+        4    3
+        5    3
+        6    3
+        dtype: int64
+        >>> ser.fillna(method='bfill')
+        0       1
+        1       2
+        2       2
+        3       2
+        4       3
+        5    <NA>
+        6    <NA>
+        dtype: int64
         """
         if limit is not None:
             raise NotImplementedError("The limit keyword is not supported")

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1323,7 +1323,7 @@ class Frame(libcudf.table.Table):
             are filled with values in corresponding indices.
             A dict can be used to provide different values to fill nulls
             in different columns. Cannot be used with ``method``.
-        
+
         method : {'ffill', 'bfill'}, default None
             Method to use for filling null values in the dataframe or series.
             `ffill` propagates the last non-null values forward to the next

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1311,7 +1311,9 @@ class Frame(libcudf.table.Table):
 
         return self._mimic_inplace(result, inplace=inplace)
 
-    def fillna(self, value=None, method=None, axis=None, inplace=False, limit=None):
+    def fillna(
+        self, value=None, method=None, axis=None, inplace=False, limit=None
+    ):
         """Fill null values with ``value``.
 
         Parameters
@@ -1387,7 +1389,7 @@ class Frame(libcudf.table.Table):
         if value is not None and method is not None:
             raise ValueError("Cannot specify both 'value' and 'method'.")
 
-        if method and not method in {"ffill", "bfill"}:
+        if method and method not in {"ffill", "bfill"}:
             raise NotImplementedError(f"Fill method {method} is not supported")
 
         if isinstance(value, cudf.Series):
@@ -1411,10 +1413,9 @@ class Frame(libcudf.table.Table):
 
         for name in copy_data.keys():
             should_fill = (
-                (name in value and
-                    not libcudf.scalar._is_null_host_scalar(value[name]))
-                or method is not None
-            )
+                name in value
+                and not libcudf.scalar._is_null_host_scalar(value[name])
+            ) or method is not None
             if should_fill:
                 copy_data[name] = copy_data[name].fillna(value[name], method)
         result = self._from_table(Frame(copy_data, self._index))

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1896,7 +1896,9 @@ class Series(Frame, Serializable):
     def fill(self, fill_value, begin=0, end=-1, inplace=False):
         return self._fill([fill_value], begin, end, inplace)
 
-    def fillna(self, value=None, method=None, axis=None, inplace=False, limit=None):
+    def fillna(
+        self, value=None, method=None, axis=None, inplace=False, limit=None
+    ):
         if isinstance(value, pd.Series):
             value = Series.from_pandas(value)
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1896,7 +1896,7 @@ class Series(Frame, Serializable):
     def fill(self, fill_value, begin=0, end=-1, inplace=False):
         return self._fill([fill_value], begin, end, inplace)
 
-    def fillna(self, value, method=None, axis=None, inplace=False, limit=None):
+    def fillna(self, value=None, method=None, axis=None, inplace=False, limit=None):
         if isinstance(value, pd.Series):
             value = Series.from_pandas(value)
 

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -217,23 +217,20 @@ def test_series_fillna_numerical(psr, data_dtype, fill_value, inplace):
         [1, 2, None, 3, 4, None, None],
     ],
 )
-@pytest.mark.parametrize(
-    "container",
-    [pd.Series, pd.DataFrame]
-)
+@pytest.mark.parametrize("container", [pd.Series, pd.DataFrame])
 @pytest.mark.parametrize("data_dtype", NUMERIC_TYPES)
-@pytest.mark.parametrize("method", ['ffill', 'bfill'])
+@pytest.mark.parametrize("method", ["ffill", "bfill"])
 @pytest.mark.parametrize("inplace", [True, False])
 def test_fillna_method_numerical(data, container, data_dtype, method, inplace):
     if container == pd.DataFrame:
-        data = {'a': data, 'b': data, 'c': data}
-    
+        data = {"a": data, "b": data, "c": data}
+
     pdata = container(data)
 
     if np.dtype(data_dtype).kind not in ("f"):
         data_dtype = cudf.utils.dtypes.cudf_dtypes_to_pandas_dtypes[
-                np.dtype(data_dtype)
-            ]
+            np.dtype(data_dtype)
+        ]
     pdata = pdata.astype(data_dtype)
 
     # Explicitly using nans_as_nulls=True
@@ -415,36 +412,63 @@ def test_fillna_datetime(psr, fill_value, inplace):
     [
         # Categorical
         pd.Categorical([1, 2, None, None, 3, 4]),
-        pd.Categorical([None, None ,1, None, 3, 4]),
+        pd.Categorical([None, None, 1, None, 3, 4]),
         pd.Categorical([1, 2, None, 3, 4, None, None]),
-        pd.Categorical(['1', '20', None, None, '3', '40']),
-        pd.Categorical([None, None ,'10', None, '30', '4']),
-        pd.Categorical(['1', '20', None, '30', '4', None, None]),
+        pd.Categorical(["1", "20", None, None, "3", "40"]),
+        pd.Categorical([None, None, "10", None, "30", "4"]),
+        pd.Categorical(["1", "20", None, "30", "4", None, None]),
         # Datetime
-        np.array(['2020-01-01 08:00:00', '2020-01-01 09:00:00', None, 
-        '2020-01-01 10:00:00', None, '2020-01-01 10:00:00'], dtype='datetime64[ns]'),
-
-        np.array([None, None, '2020-01-01 09:00:00',
-        '2020-01-01 10:00:00', None, '2020-01-01 10:00:00'], dtype='datetime64[ns]'),
-
-        np.array(['2020-01-01 09:00:00', None, None,
-        '2020-01-01 10:00:00', None, None], dtype='datetime64[ns]'),
-
+        np.array(
+            [
+                "2020-01-01 08:00:00",
+                "2020-01-01 09:00:00",
+                None,
+                "2020-01-01 10:00:00",
+                None,
+                "2020-01-01 10:00:00",
+            ],
+            dtype="datetime64[ns]",
+        ),
+        np.array(
+            [
+                None,
+                None,
+                "2020-01-01 09:00:00",
+                "2020-01-01 10:00:00",
+                None,
+                "2020-01-01 10:00:00",
+            ],
+            dtype="datetime64[ns]",
+        ),
+        np.array(
+            [
+                "2020-01-01 09:00:00",
+                None,
+                None,
+                "2020-01-01 10:00:00",
+                None,
+                None,
+            ],
+            dtype="datetime64[ns]",
+        ),
         # Timedelta
-        np.array([10, 100, 1000, None, None, 1000, 100, 10], dtype='datetime64[ns]'),
-        np.array([None, None, 1000, None, 1000, 100, 10], dtype='datetime64[ns]'),
-        np.array([10, 100, None, None, 1000, None, None], dtype='datetime64[ns]'),
-    ]
+        np.array(
+            [10, 100, 1000, None, None, 1000, 100, 10], dtype="datetime64[ns]"
+        ),
+        np.array(
+            [None, None, 1000, None, 1000, 100, 10], dtype="datetime64[ns]"
+        ),
+        np.array(
+            [10, 100, None, None, 1000, None, None], dtype="datetime64[ns]"
+        ),
+    ],
 )
-@pytest.mark.parametrize(
-    "container",
-    [pd.Series, pd.DataFrame]
-)
-@pytest.mark.parametrize("method", ['ffill', 'bfill'])
+@pytest.mark.parametrize("container", [pd.Series, pd.DataFrame])
+@pytest.mark.parametrize("method", ["ffill", "bfill"])
 @pytest.mark.parametrize("inplace", [True, False])
 def test_fillna_method_fixed_width_non_num(data, container, method, inplace):
     if container == pd.DataFrame:
-        data = {'a': data, 'b': data, 'c': data}
+        data = {"a": data, "b": data, "c": data}
 
     pdata = container(data)
 
@@ -459,6 +483,7 @@ def test_fillna_method_fixed_width_non_num(data, container, method, inplace):
         actual = gdata
 
     assert_eq(expected, actual)
+
 
 @pytest.mark.parametrize(
     "df",

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -210,6 +210,46 @@ def test_series_fillna_numerical(psr, data_dtype, fill_value, inplace):
 
 
 @pytest.mark.parametrize(
+    "data",
+    [
+        [1, None, None, 2, 3, 4],
+        [None, None, 1, 2, None, 3, 4],
+        [1, 2, None, 3, 4, None, None],
+    ],
+)
+@pytest.mark.parametrize(
+    "container",
+    [pd.Series, pd.DataFrame]
+)
+@pytest.mark.parametrize("data_dtype", NUMERIC_TYPES)
+@pytest.mark.parametrize("method", ['ffill', 'bfill'])
+@pytest.mark.parametrize("inplace", [True, False])
+def test_fillna_method_numerical(data, container, data_dtype, method, inplace):
+    if container == pd.DataFrame:
+        data = {'a': data, 'b': data, 'c': data}
+    
+    pdata = container(data)
+
+    if np.dtype(data_dtype).kind not in ("f"):
+        data_dtype = cudf.utils.dtypes.cudf_dtypes_to_pandas_dtypes[
+                np.dtype(data_dtype)
+            ]
+    pdata = pdata.astype(data_dtype)
+
+    # Explicitly using nans_as_nulls=True
+    gdata = cudf.from_pandas(pdata, nan_as_null=True)
+
+    expected = pdata.fillna(method=method, inplace=inplace)
+    actual = gdata.fillna(method=method, inplace=inplace)
+
+    if inplace:
+        expected = pdata
+        actual = gdata
+
+    assert_eq(expected, actual, check_dtype=False)
+
+
+@pytest.mark.parametrize(
     "psr",
     [
         pd.Series(["a", "b", "a", None, "c", None], dtype="category"),
@@ -369,6 +409,56 @@ def test_fillna_datetime(psr, fill_value, inplace):
 
     assert_eq(expected, got)
 
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # Categorical
+        pd.Categorical([1, 2, None, None, 3, 4]),
+        pd.Categorical([None, None ,1, None, 3, 4]),
+        pd.Categorical([1, 2, None, 3, 4, None, None]),
+        pd.Categorical(['1', '20', None, None, '3', '40']),
+        pd.Categorical([None, None ,'10', None, '30', '4']),
+        pd.Categorical(['1', '20', None, '30', '4', None, None]),
+        # Datetime
+        np.array(['2020-01-01 08:00:00', '2020-01-01 09:00:00', None, 
+        '2020-01-01 10:00:00', None, '2020-01-01 10:00:00'], dtype='datetime64[ns]'),
+
+        np.array([None, None, '2020-01-01 09:00:00',
+        '2020-01-01 10:00:00', None, '2020-01-01 10:00:00'], dtype='datetime64[ns]'),
+
+        np.array(['2020-01-01 09:00:00', None, None,
+        '2020-01-01 10:00:00', None, None], dtype='datetime64[ns]'),
+
+        # Timedelta
+        np.array([10, 100, 1000, None, None, 1000, 100, 10], dtype='datetime64[ns]'),
+        np.array([None, None, 1000, None, 1000, 100, 10], dtype='datetime64[ns]'),
+        np.array([10, 100, None, None, 1000, None, None], dtype='datetime64[ns]'),
+    ]
+)
+@pytest.mark.parametrize(
+    "container",
+    [pd.Series, pd.DataFrame]
+)
+@pytest.mark.parametrize("method", ['ffill', 'bfill'])
+@pytest.mark.parametrize("inplace", [True, False])
+def test_fillna_method_fixed_width_non_num(data, container, method, inplace):
+    if container == pd.DataFrame:
+        data = {'a': data, 'b': data, 'c': data}
+
+    pdata = container(data)
+
+    # Explicitly using nans_as_nulls=True
+    gdata = cudf.from_pandas(pdata, nan_as_null=True)
+
+    expected = pdata.fillna(method=method, inplace=inplace)
+    actual = gdata.fillna(method=method, inplace=inplace)
+
+    if inplace:
+        expected = pdata
+        actual = gdata
+
+    assert_eq(expected, actual)
 
 @pytest.mark.parametrize(
     "df",


### PR DESCRIPTION
Closes #1361 

- Provides "`ffill`" and "`bfill`" `fillna` methods for `Numerical`, `Datetime`, `Timedelta` and `Categorical` type column.
- Supports `method` parameter for `Series.fillna` and `DataFrame.fillna`