### PR TITLE
Remove warning in from_dlpack and to_dlpack methods

### DIFF
--- a/python/cudf/cudf/_lib/interop.pyx
+++ b/python/cudf/cudf/_lib/interop.pyx
@@ -1,7 +1,6 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
 import cudf
-import warnings
 
 from cudf._lib.table cimport Table
 from libcpp.vector cimport vector
@@ -32,10 +31,6 @@ def from_dlpack(dlpack_capsule):
 
     DLPack Tensor PyCapsule is expected to have the name "dltensor".
     """
-    warnings.warn("WARNING: cuDF from_dlpack() assumes column-major (Fortran"
-                  " order) input. If the input tensor is row-major, transpose"
-                  " it before passing it to this function.")
-
     cdef DLManagedTensor* dlpack_tensor = <DLManagedTensor*>pycapsule.\
         PyCapsule_GetPointer(dlpack_capsule, 'dltensor')
     pycapsule.PyCapsule_SetName(dlpack_capsule, 'used_dltensor')
@@ -61,11 +56,6 @@ def to_dlpack(Table source_table):
 
     DLPack Tensor PyCapsule will have the name "dltensor".
     """
-
-    warnings.warn("WARNING: cuDF to_dlpack() produces column-major (Fortran "
-                  "order) output. If the output tensor needs to be row major, "
-                  "transpose the output of this function.")
-
     for column in source_table._columns:
         if column.null_count:
             raise ValueError(

--- a/python/cudf/cudf/io/dlpack.py
+++ b/python/cudf/cudf/io/dlpack.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
 
 from cudf._lib import interop as libdlpack
 from cudf.core.column import ColumnBase

--- a/python/cudf/cudf/io/dlpack.py
+++ b/python/cudf/cudf/io/dlpack.py
@@ -33,7 +33,7 @@ def from_dlpack(pycapsule_obj):
     -----
     cuDF from_dlpack() assumes column-major (Fortran order) input. If the input
     tensor is row-major, transpose it before passing it to this function.
-"""
+    """
 
     res = libdlpack.from_dlpack(pycapsule_obj)
 

--- a/python/cudf/cudf/io/dlpack.py
+++ b/python/cudf/cudf/io/dlpack.py
@@ -16,9 +16,7 @@ def from_dlpack(pycapsule_obj):
 
     This function takes a PyCapsule object which contains a pointer to
     a DLPack tensor as input, and returns a cuDF object. This function deep
-    copies the data in the DLPack tensor into a cuDF object. This function
-    assumes column-major (Fortran order) input. If the input tensor is
-    row-major, transpose it before passing it to this function.
+    copies the data in the DLPack tensor into a cuDF object.
 
     Parameters
     ----------
@@ -30,7 +28,12 @@ def from_dlpack(pycapsule_obj):
     -------
     A cuDF DataFrame or Series depending on if the input DLPack tensor is 1D
     or 2D.
-    """
+
+    Notes
+    -----
+    cuDF from_dlpack() assumes column-major (Fortran order) input. If the input
+    tensor is row-major, transpose it before passing it to this function.
+"""
 
     res = libdlpack.from_dlpack(pycapsule_obj)
 
@@ -49,9 +52,7 @@ def to_dlpack(cudf_obj):
 
     This function takes a cuDF object as input, and returns a PyCapsule object
     which contains a pointer to DLPack tensor. This function deep copies
-    the data in the cuDF object into the DLPack tensor. This function produces
-    column-major (Fortran order) output. If the output tensor needs to be
-    row major, transpose the output of this function.
+    the data in the cuDF object into the DLPack tensor.
 
     Parameters
     ----------
@@ -61,6 +62,11 @@ def to_dlpack(cudf_obj):
     Returns
     -------
     A  DLPack tensor pointer which is encapsulated in a PyCapsule object.
+
+    Notes
+    -----
+    cuDF to_dlpack() produces column-major (Fortran order) output. If the
+    output tensor needs to be row major, transpose the output of this function.
     """
     if len(cudf_obj) == 0:
         raise ValueError("Cannot create DLPack tensor of 0 size")

--- a/python/cudf/cudf/io/dlpack.py
+++ b/python/cudf/cudf/io/dlpack.py
@@ -17,8 +17,8 @@ def from_dlpack(pycapsule_obj):
     This function takes a PyCapsule object which contains a pointer to
     a DLPack tensor as input, and returns a cuDF object. This function deep
     copies the data in the DLPack tensor into a cuDF object. This function
-    assumes column-major (Fortran order) input. If the input tensor is row-major,
-    transpose it before passing it to this function.
+    assumes column-major (Fortran order) input. If the input tensor is
+    row-major, transpose it before passing it to this function.
 
     Parameters
     ----------
@@ -50,7 +50,7 @@ def to_dlpack(cudf_obj):
     This function takes a cuDF object as input, and returns a PyCapsule object
     which contains a pointer to DLPack tensor. This function deep copies
     the data in the cuDF object into the DLPack tensor. This function produces
-    column-major (Fortran order) output. If the output tensor needs to be 
+    column-major (Fortran order) output. If the output tensor needs to be
     row major, transpose the output of this function.
 
     Parameters

--- a/python/cudf/cudf/io/dlpack.py
+++ b/python/cudf/cudf/io/dlpack.py
@@ -16,7 +16,9 @@ def from_dlpack(pycapsule_obj):
 
     This function takes a PyCapsule object which contains a pointer to
     a DLPack tensor as input, and returns a cuDF object. This function deep
-    copies the data in the DLPack tensor into a cuDF object.
+    copies the data in the DLPack tensor into a cuDF object. This function
+    assumes column-major (Fortran order) input. If the input tensor is row-major,
+    transpose it before passing it to this function.
 
     Parameters
     ----------
@@ -46,8 +48,10 @@ def to_dlpack(cudf_obj):
     `dmlc/dlpack <https://github.com/dmlc/dlpack>`_.
 
     This function takes a cuDF object as input, and returns a PyCapsule object
-    which contains a pointer to DLPack tensor. This function deep
-    copies the data in the cuDF object into the DLPack tensor.
+    which contains a pointer to DLPack tensor. This function deep copies
+    the data in the cuDF object into the DLPack tensor. This function produces
+    column-major (Fortran order) output. If the output tensor needs to be 
+    row major, transpose the output of this function.
 
     Parameters
     ----------


### PR DESCRIPTION
Fix https://github.com/rapidsai/cudf/issues/6926 .

Hi!

When invoking from_dlpack() and to_dlpack, the following warnings are displayed:

from_dlpack()
```
/opt/conda/envs/rapids/lib/python3.7/site-packages/cudf/io/dlpack.py:33: UserWarning: WARNING: cuDF from_dlpack() assumes column-major (Fortran order) input. If the input tensor is row-major, transpose it before passing it to this function.
res = libdlpack.from_dlpack(pycapsule_obj)
```

to_dlpack()
```
/opt/conda/envs/rapids/lib/python3.7/site-packages/cudf/io/dlpack.py:74: UserWarning: WARNING: cuDF to_dlpack() produces column-major (Fortran order) output. If the output tensor needs to be row major, transpose the output of this function.
return libdlpack.to_dlpack(gdf_cols)
```

I think those warnings should be removed, because it contains information that should be available in the API documentation, and not necessarily displayed each time the methods are invoked.

Some users, like me, love to have their notebooks/code without warnings. Even if it is possible to disable those warnings, I think the user should not go that way, because the warning is just repeating what the API documentation should cover.

Hope it helps!
Miguel

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
