### PR TITLE
Fix Thrust unroll patch command

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -13,7 +13,7 @@ FetchContent_Declare(
     GIT_TAG        1.10.0
     GIT_SHALLOW    true
     # NOTE: If you change the GIT_TAG you will likely need to change this patch file too
-    PATCH_COMMAND  (git apply -R ${CMAKE_CURRENT_SOURCE_DIR}/thrust.patch || true) && git apply ${CMAKE_CURRENT_SOURCE_DIR}/thrust.patch
+    PATCH_COMMAND  git apply ${CMAKE_CURRENT_SOURCE_DIR}/thrust.patch
 )
 
 FetchContent_GetProperties(thrust)


### PR DESCRIPTION
PR #6982 added a `PATCH_COMMAND` when fetching Thrust to remove unrolling in `thrust::sort`, thereby improving compile time and performance in some cases. But the command failed on local builds from source (At least on my machine under rapids-compose). 

This PR simplifies the command.