### PR TITLE
Extend `replace_nulls_policy` to `string` and `dictionary` type

### DIFF
--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -374,55 +374,41 @@ struct replace_policy_functor {
 };
 
 /**
- * @brief Functor called by the `type_dispatcher` in order to invoke and instantiate
- *        `replace_nulls` with the appropriate data types.
+ * @brief Function used by replace_nulls policy
  */
-struct replace_nulls_policy_kernel_forwarder {
-  template <typename col_type,
-            typename std::enable_if_t<cudf::is_fixed_width<col_type>()>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           cudf::replace_policy const& replace_policy,
-                                           rmm::cuda_stream_view stream,
-                                           rmm::mr::device_memory_resource* mr)
-  {
-    using Type     = cudf::device_storage_type_t<col_type>;
-    auto device_in = cudf::column_device_view::create(input);
-    auto index     = thrust::make_counting_iterator<cudf::size_type>(0);
-    auto valid_it  = cudf::detail::make_validity_iterator(*device_in);
-    auto in_begin  = thrust::make_zip_iterator(thrust::make_tuple(index, valid_it));
 
-    rmm::device_vector<cudf::size_type> gather_map(input.size());
-    auto gm_begin = thrust::make_zip_iterator(
-      thrust::make_tuple(gather_map.begin(), thrust::make_discard_iterator()));
+std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const& input,
+                                                        cudf::replace_policy const& replace_policy,
+                                                        rmm::cuda_stream_view stream,
+                                                        rmm::mr::device_memory_resource* mr)
+{
+  auto device_in = cudf::column_device_view::create(input);
+  auto index     = thrust::make_counting_iterator<cudf::size_type>(0);
+  auto valid_it  = cudf::detail::make_validity_iterator(*device_in);
+  auto in_begin  = thrust::make_zip_iterator(thrust::make_tuple(index, valid_it));
 
-    auto func = replace_policy_functor();
-    if (replace_policy == cudf::replace_policy::PRECEDING) {
-      thrust::inclusive_scan(
-        rmm::exec_policy(stream), in_begin, in_begin + input.size(), gm_begin, func);
-    } else {
-      auto in_rbegin = thrust::make_reverse_iterator(in_begin + input.size());
-      auto gm_rbegin = thrust::make_reverse_iterator(gm_begin + gather_map.size());
-      thrust::inclusive_scan(
-        rmm::exec_policy(stream), in_rbegin, in_rbegin + input.size(), gm_rbegin, func);
-    }
+  rmm::device_vector<cudf::size_type> gather_map(input.size());
+  auto gm_begin = thrust::make_zip_iterator(
+    thrust::make_tuple(gather_map.begin(), thrust::make_discard_iterator()));
 
-    auto output = cudf::detail::gather(cudf::table_view({input}),
-                                       gather_map.begin(),
-                                       gather_map.end(),
-                                       cudf::out_of_bounds_policy::DONT_CHECK);
-
-    return std::move(output->release()[0]);
+  auto func = replace_policy_functor();
+  if (replace_policy == cudf::replace_policy::PRECEDING) {
+    thrust::inclusive_scan(
+      rmm::exec_policy(stream), in_begin, in_begin + input.size(), gm_begin, func);
+  } else {
+    auto in_rbegin = thrust::make_reverse_iterator(in_begin + input.size());
+    auto gm_rbegin = thrust::make_reverse_iterator(gm_begin + gather_map.size());
+    thrust::inclusive_scan(
+      rmm::exec_policy(stream), in_rbegin, in_rbegin + input.size(), gm_rbegin, func);
   }
 
-  template <typename col_type, std::enable_if_t<not cudf::is_fixed_width<col_type>()>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           cudf::replace_policy const& fillna_policy,
-                                           rmm::cuda_stream_view stream,
-                                           rmm::mr::device_memory_resource* mr)
-  {
-    CUDF_FAIL("No specialization exists for the given type.");
-  }
-};
+  auto output = cudf::detail::gather(cudf::table_view({input}),
+                                     gather_map.begin(),
+                                     gather_map.end(),
+                                     cudf::out_of_bounds_policy::DONT_CHECK);
+
+  return std::move(output->release()[0]);
+}
 
 }  // end anonymous namespace
 
@@ -468,8 +454,7 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
 
   if (!input.has_nulls()) { return std::make_unique<cudf::column>(input, stream, mr); }
 
-  return cudf::type_dispatcher(
-    input.type(), replace_nulls_policy_kernel_forwarder{}, input, replace_policy, stream, mr);
+  return replace_nulls_policy_impl(input, replace_policy, stream, mr);
 }
 
 }  // namespace detail


### PR DESCRIPTION
Follow up for PR #6907 

- `replace_null` policy function now supports `string` and `dictionary` dtype column.

Since original implementation depends only on column validity and index, this extension trivially removes SFINAE on `replace_null` functor and removes `type_dispatcher`.