### PR TITLE
Reduce number of hostdevice_vector allocations in parquet reader

### DIFF
--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -1209,7 +1209,7 @@ void reader::impl::decode_page_data(hostdevice_vector<gpu::ColumnChunkDesc> &chu
   // offset into `chunk_nested_data`/`chunk_nested_valids` for the array of pointers for chunk `i`
   auto chunk_nested_valids = hostdevice_vector<uint32_t *>(sum_max_depths);
   auto chunk_nested_data   = hostdevice_vector<void *>(sum_max_depths);
-  auto chunk_offsets       = std::vector<size_t>(chunks.size());
+  auto chunk_offsets       = std::vector<size_t>();
 
   // Update chunks with pointers to column data.
   for (size_t c = 0, page_count = 0, str_ofs = 0, chunk_off = 0; c < chunks.size(); c++) {

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -1195,11 +1195,24 @@ void reader::impl::decode_page_data(hostdevice_vector<gpu::ColumnChunkDesc> &chu
   rmm::device_vector<gpu::nvstrdesc_s> str_dict_index;
   if (total_str_dict_indexes > 0) { str_dict_index.resize(total_str_dict_indexes); }
 
-  std::vector<hostdevice_vector<uint32_t *>> chunk_nested_valids;
-  std::vector<hostdevice_vector<void *>> chunk_nested_data;
+  // TODO (dm): hd_vec should have begin and end iterator members
+  size_t sum_max_depths =
+    std::accumulate(chunks.host_ptr(),
+                    chunks.host_ptr(chunks.size()),
+                    0,
+                    [&](size_t cursum, gpu::ColumnChunkDesc const &chunk) {
+                      return cursum + _metadata->get_output_nesting_depth(chunk.src_col_schema);
+                    });
+
+  // In order to reduce the number of allocations of hostdevice_vector, we allocate a single vector
+  // to store all per-chunk pointers to nested data/nullmask. `chunk_offsets[i]` will store the
+  // offset into `chunk_nested_data`/`chunk_nested_valids` for the array of pointers for chunk `i`
+  auto chunk_nested_valids = hostdevice_vector<uint32_t *>(sum_max_depths);
+  auto chunk_nested_data   = hostdevice_vector<void *>(sum_max_depths);
+  auto chunk_offsets       = std::vector<size_t>(chunks.size());
 
   // Update chunks with pointers to column data.
-  for (size_t c = 0, page_count = 0, str_ofs = 0; c < chunks.size(); c++) {
+  for (size_t c = 0, page_count = 0, str_ofs = 0, chunk_off = 0; c < chunks.size(); c++) {
     input_column_info const &input_col = _input_columns[chunks[c].src_col_index];
     CUDF_EXPECTS(input_col.schema_idx == chunks[c].src_col_schema,
                  "Column/page schema index mismatch");
@@ -1210,16 +1223,19 @@ void reader::impl::decode_page_data(hostdevice_vector<gpu::ColumnChunkDesc> &chu
     }
 
     size_t max_depth = _metadata->get_output_nesting_depth(chunks[c].src_col_schema);
+    chunk_offsets.push_back(chunk_off);
 
-    // allocate (gpu) an array of pointers to validity data of size : nesting depth
-    chunk_nested_valids.emplace_back(hostdevice_vector<uint32_t *>{max_depth});
-    hostdevice_vector<uint32_t *> &valids = chunk_nested_valids.back();
-    chunks[c].valid_map_base              = valids.device_ptr();
+    // get a slice of size `nesting depth` from `chunk_nested_valids` to store an array of pointers
+    // to validity data
+    auto valids              = chunk_nested_valids.host_ptr(chunk_off);
+    chunks[c].valid_map_base = chunk_nested_valids.device_ptr(chunk_off);
 
-    // allocate (gpu) an array of pointers to out data of size : nesting depth
-    chunk_nested_data.emplace_back(hostdevice_vector<void *>{max_depth});
-    hostdevice_vector<void *> &data = chunk_nested_data.back();
-    chunks[c].column_data_base      = data.device_ptr();
+    // get a slice of size `nesting depth` from `chunk_nested_data` to store an array of pointers to
+    // out data
+    auto data                  = chunk_nested_data.host_ptr(chunk_off);
+    chunks[c].column_data_base = chunk_nested_data.device_ptr(chunk_off);
+
+    chunk_off += max_depth;
 
     // fill in the arrays on the host.  there are some important considerations to
     // take into account here for nested columns.  specifically, with structs
@@ -1269,15 +1285,13 @@ void reader::impl::decode_page_data(hostdevice_vector<gpu::ColumnChunkDesc> &chu
       }
     }
 
-    // copy to the gpu
-    valids.host_to_device(stream);
-    data.host_to_device(stream);
-
     // column_data_base will always point to leaf data, even for nested types.
     page_count += chunks[c].max_num_pages;
   }
 
   chunks.host_to_device(stream);
+  chunk_nested_valids.host_to_device(stream);
+  chunk_nested_data.host_to_device(stream);
 
   if (total_str_dict_indexes > 0) {
     gpu::BuildStringDictionaryIndex(chunks.device_ptr(), chunks.size(), stream);
@@ -1337,7 +1351,9 @@ void reader::impl::decode_page_data(hostdevice_vector<gpu::ColumnChunkDesc> &chu
       cols          = &out_buf.children;
 
       // if I wasn't the one who wrote out the validity bits, skip it
-      if (chunk_nested_valids[pi->chunk_idx][l_idx] == nullptr) { continue; }
+      if (chunk_nested_valids.host_ptr(chunk_offsets[pi->chunk_idx])[l_idx] == nullptr) {
+        continue;
+      }
       out_buf.null_count() += pni[l_idx].value_count - pni[l_idx].valid_count;
     }
   }


### PR DESCRIPTION
Improves performance of parquet reader on certain multi-GPU systems, which take a long time to allocate pinned memory, by reducing the number of `hostdevice_vector` allocations.

Closes #7049

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
