### PR TITLE
Skip Thrust sort patch if already applied

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -13,7 +13,7 @@ FetchContent_Declare(
     GIT_TAG        1.10.0
     GIT_SHALLOW    true
     # NOTE: If you change the GIT_TAG you will likely need to change this patch file too
-    PATCH_COMMAND  git apply ${CMAKE_CURRENT_SOURCE_DIR}/thrust.patch
+    PATCH_COMMAND  patch -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/thrust.patch || true
 )
 
 FetchContent_GetProperties(thrust)


### PR DESCRIPTION
#7002 attempted to fix the temporary Thrust sort patch introduced in #6982 which didn't work with CMake 3.19+.  

This PR updates the thirdparty CMakeLists.txt file to continue if the Thrust sort patch has already been applied.
Today, the first time cmake is run, the Thrust sort.h is patched. But if cmake is run again without cleaning the build directory, the build will fail, because the file has already been patched.  @trxcllnt showed us the correct `patch` incantation to ignore the patch if already applied.

CC @davidwendt 