### PR TITLE
Correct ORC docstring; other minor cuIO improvements

### DIFF
--- a/cpp/include/cudf/detail/utilities/trie.cuh
+++ b/cpp/include/cudf/detail/utilities/trie.cuh
@@ -89,8 +89,12 @@ inline thrust::host_vector<SerialTrieNode> createSerializedTrie(
   // Serialize the tree trie
   std::deque<IndexedTrieNode> to_visit;
   thrust::host_vector<SerialTrieNode> nodes;
-  // suport for matching empty input
+
+  // If the Tree trie matches empty strings, the root node is marked as 'end of word'.
+  // The first node in the serialized trie is also used to match empty strings, so we're
+  // initializing it using the `is_end_of_word` value from the root node.
   nodes.push_back(SerialTrieNode(trie_terminating_character, tree_trie.is_end_of_word));
+
   // Add root node to queue. this node is not included to the serialized trie
   to_visit.emplace_back(&tree_trie, -1);
   while (!to_visit.empty()) {

--- a/cpp/src/io/csv/csv_gpu.cu
+++ b/cpp/src/io/csv/csv_gpu.cu
@@ -225,7 +225,7 @@ __global__ void __launch_bounds__(csvparse_block_dim)
       long tempPos   = pos - 1;
       long field_len = pos - start;
 
-      if (field_len < 0 || serialized_trie_contains(opts.trie_na, raw_csv + start, field_len)) {
+      if (serialized_trie_contains(opts.trie_na, raw_csv + start, field_len)) {
         atomicAdd(&d_columnData[actual_col].null_count, 1);
       } else if (serialized_trie_contains(opts.trie_true, raw_csv + start, field_len) ||
                  serialized_trie_contains(opts.trie_false, raw_csv + start, field_len)) {

--- a/cpp/src/io/json/json_gpu.cu
+++ b/cpp/src/io/json/json_gpu.cu
@@ -545,7 +545,7 @@ __global__ void convert_data_to_columns_kernel(parse_options_view opts,
        input_field_index++) {
     auto const desc =
       next_field_descriptor(current, row_data_range.second, opts, input_field_index, col_map);
-    auto const value_len = static_cast<size_t>(std::max(desc.value_end - desc.value_begin, 0l));
+    auto const value_len = static_cast<size_t>(std::max(desc.value_end - desc.value_begin, 0L));
 
     current = desc.value_end + 1;
 
@@ -616,7 +616,7 @@ __global__ void detect_data_types_kernel(
        input_field_index++) {
     auto const desc =
       next_field_descriptor(current, row_data_range.second, opts, input_field_index, col_map);
-    auto const value_len = static_cast<size_t>(std::max(desc.value_end - desc.value_begin, 0l));
+    auto const value_len = static_cast<size_t>(std::max(desc.value_end - desc.value_begin, 0L));
 
     // Advance to the next field; +1 to skip the delimiter
     current = desc.value_end + 1;

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -635,7 +635,7 @@ reader::impl::impl(std::unique_ptr<datasource> source,
 
   opts_.trie_true  = createSerializedTrie({"true"});
   opts_.trie_false = createSerializedTrie({"false"});
-  opts_.trie_na    = createSerializedTrie({"null"});
+  opts_.trie_na    = createSerializedTrie({"", "null"});
 
   opts_.dayfirst = options.is_enabled_dayfirst();
 }

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -256,7 +256,7 @@ Examples
 --------
 >>> import cudf
 >>> num_rows, stripes, names = cudf.io.read_orc_metadata(filename)
->>> df = [cudf.read_orc(fname, stripe=i) for i in range(stripes)]
+>>> df = [cudf.read_orc(fname, stripes=i) for i in range(stripes)]
 >>> df = cudf.concat(df)
 >>> df
   num1                datetime text


### PR DESCRIPTION
Fixes #6923

Included other minor cuIO improvements that are too small for individual PRs:
- Remove unnecessary NaN-related conditions in JSON, CSV.
- Expand a comment in `createSerializedTrie` to make initialization clearer.