### PR TITLE
Fix round operator's HALF_EVEN computation for negative integers

### DIFF
--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -181,7 +181,7 @@ struct half_even_negative {
     auto const down_over_n = e / n;            // use this to determine HALF_EVEN case
     auto const down        = down_over_n * n;  // result from rounding down
     auto const diff        = generic_abs(e - down);
-    auto const adjustment  = (diff > n / 2) or (diff == n / 2 && down_over_n % 2 == 1) ? n : 0;
+    auto const adjustment  = (diff > n / 2) or (diff == n / 2 && generic_abs(down_over_n) % 2 == 1) ? n : 0;
     return down + generic_sign(e) * adjustment;
   }
 };

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -181,7 +181,8 @@ struct half_even_negative {
     auto const down_over_n = e / n;            // use this to determine HALF_EVEN case
     auto const down        = down_over_n * n;  // result from rounding down
     auto const diff        = generic_abs(e - down);
-    auto const adjustment  = (diff > n / 2) or (diff == n / 2 && generic_abs(down_over_n) % 2 == 1) ? n : 0;
+    auto const adjustment  =
+      (diff > n / 2) or (diff == n / 2 && generic_abs(down_over_n) % 2 == 1) ? n : 0;
     return down + generic_sign(e) * adjustment;
   }
 };

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -181,7 +181,7 @@ struct half_even_negative {
     auto const down_over_n = e / n;            // use this to determine HALF_EVEN case
     auto const down        = down_over_n * n;  // result from rounding down
     auto const diff        = generic_abs(e - down);
-    auto const adjustment  =
+    auto const adjustment =
       (diff > n / 2) or (diff == n / 2 && generic_abs(down_over_n) % 2 == 1) ? n : 0;
     return down + generic_sign(e) * adjustment;
   }

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -503,6 +503,17 @@ TYPED_TEST(RoundTestsIntegerTypes, SimpleNegativeIntegerHalfUp)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(RoundTestsIntegerTypes, SimpleNegativeIntegerHalfEven)
+{
+  using fw_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
+
+  auto const input    = fw_wrapper{-12, -135, -145, -146, -1454, -1455, -1500};
+  auto const expected = fw_wrapper{-10, -140, -140, -150, -1450, -1460, -1500};
+  auto const result   = cudf::round(input, -1, cudf::rounding_method::HALF_EVEN);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 TEST_F(RoundTests, SimpleNegativeIntegerWithUnsignedNumbersHalfUp)
 {
   using fw_wrapper = cudf::test::fixed_width_column_wrapper<uint32_t>;


### PR DESCRIPTION
Found a small bug while working on https://github.com/NVIDIA/spark-rapids/pull/1244/. 
For negative integers, it was not rounding to nearest even number.
