### PR TITLE
Fix libcudf strings logic where size_type is used to access INT32 column data

### DIFF
--- a/cpp/benchmarks/common/generate_benchmark_input.cpp
+++ b/cpp/benchmarks/common/generate_benchmark_input.cpp
@@ -307,7 +307,7 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
  */
 struct string_column_data {
   std::vector<char> chars;
-  std::vector<int32_t> offsets;
+  std::vector<cudf::size_type> offsets;
   std::vector<cudf::bitmask_type> null_mask;
   explicit string_column_data(cudf::size_type rows, cudf::size_type size)
   {

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -288,7 +288,7 @@ template <typename StringsIterator, typename ValidityIterator>
 auto make_chars_and_offsets(StringsIterator begin, StringsIterator end, ValidityIterator v)
 {
   std::vector<char> chars{};
-  std::vector<int32_t> offsets(1, 0);
+  std::vector<cudf::size_type> offsets(1, 0);
   for (auto str = begin; str < end; ++str) {
     std::string tmp = (*v++) ? std::string(*str) : std::string{};
     chars.insert(chars.end(), std::cbegin(tmp), std::cend(tmp));
@@ -721,7 +721,7 @@ class strings_column_wrapper : public detail::column_wrapper {
   strings_column_wrapper(StringsIterator begin, StringsIterator end) : column_wrapper{}
   {
     std::vector<char> chars;
-    std::vector<int32_t> offsets;
+    std::vector<cudf::size_type> offsets;
     auto all_valid           = make_counting_transform_iterator(0, [](auto i) { return true; });
     std::tie(chars, offsets) = detail::make_chars_and_offsets(begin, end, all_valid);
     wrapped                  = cudf::make_strings_column(chars, offsets);
@@ -761,7 +761,7 @@ class strings_column_wrapper : public detail::column_wrapper {
   {
     size_type num_strings = std::distance(begin, end);
     std::vector<char> chars;
-    std::vector<int32_t> offsets;
+    std::vector<size_type> offsets;
     std::tie(chars, offsets) = detail::make_chars_and_offsets(begin, end, v);
     wrapped =
       cudf::make_strings_column(chars, offsets, detail::make_null_mask_vector(v, v + num_strings));

--- a/cpp/src/strings/contains.cu
+++ b/cpp/src/strings/contains.cu
@@ -172,11 +172,11 @@ struct count_fn {
     prog.set_stack_mem(data1, data2);
     if (d_strings.is_null(idx)) return 0;
     string_view d_str  = d_strings.element<string_view>(idx);
+    auto const nchars  = d_str.length();
     int32_t find_count = 0;
-    size_type nchars   = d_str.length();
-    size_type begin    = 0;
-    while (begin <= nchars) {
-      auto end = nchars;
+    int32_t begin      = 0;
+    while (begin < nchars) {
+      auto end = static_cast<int32_t>(nchars);
       if (prog.find(idx, d_str, begin, end) <= 0) break;
       ++find_count;
       begin = end > begin ? end : begin + 1;

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -238,7 +238,8 @@ struct parse_datetime {
         case 'M': timeparts[TP_MINUTE] = str2int(ptr, item.length); break;
         case 'S': timeparts[TP_SECOND] = str2int(ptr, item.length); break;
         case 'f': {
-          int32_t const read_size = std::min(static_cast<int32_t>(item.length), length);
+          int32_t const read_size =
+            std::min(static_cast<int32_t>(item.length), static_cast<int32_t>(length));
           int64_t const fraction  = str2int(ptr, read_size) * power_of_ten(item.length - read_size);
           timeparts[TP_SUBSECOND] = static_cast<int32_t>(fraction);
           break;

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -119,7 +119,7 @@ __global__ void fused_concatenate_string_offset_kernel(column_device_view const*
                                                        size_t const* partition_offsets,
                                                        size_type const num_input_views,
                                                        size_type const output_size,
-                                                       size_type* output_data,
+                                                       int32_t* output_data,
                                                        bitmask_type* output_mask,
                                                        size_type* out_valid_count)
 {

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -53,7 +53,7 @@ std::unique_ptr<cudf::column> copy_slice(strings_column_view const& strings,
     auto offsets_column = std::make_unique<cudf::column>(
       cudf::slice(strings.offsets(), {0, strings_count + 1}).front(), stream, mr);
     auto data_size =
-      cudf::detail::get_value<size_type>(offsets_column->view(), strings_count, stream);
+      cudf::detail::get_value<int32_t>(offsets_column->view(), strings_count, stream);
     auto chars_column = std::make_unique<cudf::column>(
       cudf::slice(strings.chars(), {0, data_size}).front(), stream, mr);
     auto null_mask = cudf::detail::copy_bitmask(strings.null_mask(), 0, strings_count, stream, mr);

--- a/cpp/src/strings/findall.cu
+++ b/cpp/src/strings/findall.cu
@@ -68,15 +68,15 @@ struct findall_fn {
     u_char data2[stack_size];
     prog.set_stack_mem(data1, data2);
     string_view d_str      = d_strings.element<string_view>(idx);
-    auto nchars            = d_str.length();
-    size_type spos         = 0;
-    size_type epos         = nchars;
+    auto const nchars      = d_str.length();
+    int32_t spos           = 0;
+    int32_t epos           = static_cast<int32_t>(nchars);
     size_type column_count = 0;
     while (spos <= nchars) {
       if (prog.find(idx, d_str, spos, epos) <= 0) break;  // no more matches found
       if (column_count == column_index) break;            // found our column
       spos = epos > spos ? epos : spos + 1;
-      epos = nchars;
+      epos = static_cast<int32_t>(nchars);
       ++column_count;
     }
     if (spos <= epos) {

--- a/cpp/src/strings/regex/regexec.cu
+++ b/cpp/src/strings/regex/regexec.cu
@@ -73,8 +73,8 @@ reprog_device::reprog_device(reprog& prog)
 // Create instance of the reprog that can be passed into a device kernel
 std::unique_ptr<reprog_device, std::function<void(reprog_device*)>> reprog_device::create(
   std::string const& pattern,
-  const uint8_t* codepoint_flags,
-  size_type strings_count,
+  uint8_t const* codepoint_flags,
+  int32_t strings_count,
   rmm::cuda_stream_view stream)
 {
   std::vector<char32_t> pattern32 = string_to_char32_vector(pattern);

--- a/cpp/src/strings/replace/backref_re.cuh
+++ b/cpp/src/strings/replace/backref_re.cuh
@@ -87,8 +87,8 @@ struct backrefs_fn {
             lpos_template += copy_length;
           }
           // extract the specific group's string for this backref's index
-          size_type spos_extract = begin;  // these are modified
-          size_type epos_extract = end;    // by extract()
+          int32_t spos_extract = begin;  // these are modified
+          int32_t epos_extract = end;    // by extract()
           if ((prog.extract(idx, d_str, spos_extract, epos_extract, backref.first - 1) <= 0) ||
               (epos_extract <= spos_extract))
             return;  // no value for this backref number; that is ok
@@ -109,7 +109,7 @@ struct backrefs_fn {
     if (out_ptr && (lpos < d_str.size_bytes()))  // copy remainder of input string
       memcpy(out_ptr, in_ptr + lpos, d_str.size_bytes() - lpos);
     else if (!out_ptr)
-      d_offsets[idx] = nbytes;
+      d_offsets[idx] = static_cast<int32_t>(nbytes);
   }
 };
 

--- a/cpp/src/strings/replace/multi_re.cu
+++ b/cpp/src/strings/replace/multi_re.cu
@@ -89,7 +89,8 @@ struct replace_multi_regex_fn {
           continue;                             // or later in the string
         reprog_device prog = progs[ptn_idx];
         prog.set_stack_mem(data1, data2);
-        size_type begin = ch_pos, end = nchars;
+        auto begin = static_cast<int32_t>(ch_pos);
+        auto end   = static_cast<int32_t>(nchars);
         if (!prog.is_empty() && prog.find(idx, d_str, begin, end) > 0)
           d_ranges[ptn_idx] = found_range{begin, end};  // found a match
         else
@@ -124,7 +125,7 @@ struct replace_multi_regex_fn {
     if (out_ptr)  // copy the remainder
       memcpy(out_ptr, in_ptr + lpos, d_str.size_bytes() - lpos);
     else
-      d_offsets[idx] = nbytes;
+      d_offsets[idx] = static_cast<int32_t>(nbytes);
   }
 };
 

--- a/cpp/src/strings/replace/replace_re.cu
+++ b/cpp/src/strings/replace/replace_re.cu
@@ -74,8 +74,8 @@ struct replace_regex_fn {
     auto in_ptr       = d_str.data();                    // input pointer (i)
     auto out_ptr      = d_chars ? d_chars + d_offsets[idx] : nullptr;  // output pointer (o)
     size_type lpos    = 0;
-    size_type begin   = 0;
-    size_type end     = nchars;  // working vars
+    int32_t begin     = 0;
+    int32_t end       = static_cast<int32_t>(nchars);
     // copy input to output replacing strings as we go
     while (mxn-- > 0)  // maximum number of replaces
     {
@@ -91,12 +91,12 @@ struct replace_regex_fn {
         lpos = epos;                                                        // i:bbbbsssseeee
       }                                                                     //  in_ptr --^
       begin = end;
-      end   = nchars;
+      end   = static_cast<int32_t>(nchars);
     }
     if (out_ptr)                                                  // copy the remainder
       memcpy(out_ptr, in_ptr + lpos, d_str.size_bytes() - lpos);  // o:bbbbrrrrrreeee
     else
-      d_offsets[idx] = nbytes;
+      d_offsets[idx] = static_cast<int32_t>(nbytes);
   }
 };
 

--- a/cpp/src/strings/split/split_record.cu
+++ b/cpp/src/strings/split/split_record.cu
@@ -233,8 +233,8 @@ std::unique_ptr<column> split_record_fn(strings_column_view const& strings,
     data_type{type_id::INT32}, strings_count + 1, mask_state::UNALLOCATED, stream, mr);
   auto d_offsets = offsets->mutable_view().data<int32_t>();
   thrust::transform(rmm::exec_policy(stream),
-                    thrust::make_counting_iterator(0),
-                    thrust::make_counting_iterator(strings_count),
+                    thrust::make_counting_iterator<size_type>(0),
+                    thrust::make_counting_iterator<size_type>(strings_count),
                     d_offsets,
                     counter);
   thrust::exclusive_scan(

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -152,11 +152,11 @@ std::unique_ptr<column> make_strings_column(const rmm::device_vector<char>& stri
   auto offsets_column = make_numeric_column(
     data_type{type_id::INT32}, num_strings + 1, mask_state::UNALLOCATED, stream, mr);
   auto offsets_view = offsets_column->mutable_view();
-  CUDA_TRY(cudaMemcpyAsync(offsets_view.data<int32_t>(),
-                           offsets.data().get(),
-                           (num_strings + 1) * sizeof(int32_t),
-                           cudaMemcpyDeviceToDevice,
-                           stream.value()));
+  thrust::transform(rmm::exec_policy(stream),
+                    offsets.begin(),
+                    offsets.end(),
+                    offsets_view.data<int32_t>(),
+                    [] __device__(auto offset) { return static_cast<int32_t>(offset); });
   // build null bitmask
   rmm::device_buffer null_mask{
     valid_mask.data().get(),

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -224,7 +224,7 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
   // We only need memory for half the size of the output matrix since the edit distance calculation
   // is commutative -- `distance(strings[i],strings[j]) == distance(strings[j],strings[i])`
   cudf::size_type n_upper = (strings_count * (strings_count - 1)) / 2;
-  rmm::device_uvector<cudf::size_type> offsets(n_upper, stream);
+  rmm::device_uvector<int32_t> offsets(n_upper, stream);
   auto d_offsets = offsets.data();
   CUDA_TRY(cudaMemsetAsync(d_offsets, 0, n_upper * sizeof(cudf::size_type), stream.value()));
   thrust::for_each_n(

--- a/cpp/src/text/generate_ngrams.cu
+++ b/cpp/src/text/generate_ngrams.cu
@@ -221,7 +221,7 @@ std::unique_ptr<cudf::column> generate_character_ngrams(cudf::strings_column_vie
   auto const d_strings      = *strings_column;
 
   // create a vector of ngram offsets for each string
-  rmm::device_vector<cudf::size_type> ngram_offsets(strings_count + 1);
+  rmm::device_vector<int32_t> ngram_offsets(strings_count + 1);
   thrust::transform_exclusive_scan(
     rmm::exec_policy(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
@@ -230,7 +230,7 @@ std::unique_ptr<cudf::column> generate_character_ngrams(cudf::strings_column_vie
     [d_strings, strings_count, ngrams] __device__(auto idx) {
       if (d_strings.is_null(idx) || (idx == strings_count)) return 0;
       auto const length = d_strings.element<cudf::string_view>(idx).length();
-      return std::max(0, (length + 1 - ngrams));
+      return std::max(0, static_cast<int32_t>(length + 1 - ngrams));
     },
     cudf::size_type{0},
     thrust::plus<cudf::size_type>());

--- a/cpp/src/text/utilities/tokenize_ops.cuh
+++ b/cpp/src/text/utilities/tokenize_ops.cuh
@@ -139,7 +139,7 @@ struct characters_tokenizer {
 struct strings_tokenizer {
   cudf::column_device_view const d_strings;  ///< strings to tokenize
   cudf::string_view const d_delimiter;       ///< delimiter characters to tokenize around
-  cudf::size_type* d_offsets{};              ///< offsets into the d_tokens vector for each string
+  int32_t* d_offsets{};                      ///< offsets into the d_tokens vector for each string
   string_index_pair* d_tokens{};             ///< token positions in device memory
 
   /**
@@ -184,7 +184,7 @@ struct multi_delimiter_strings_tokenizer {
   cudf::column_device_view const d_strings;  ///< strings column to tokenize
   delimiterator delimiters_begin;            ///< first delimiter
   delimiterator delimiters_end;              ///< last delimiter
-  cudf::size_type* d_offsets{};              ///< offsets into the d_tokens output vector
+  int32_t* d_offsets{};                      ///< offsets into the d_tokens output vector
   string_index_pair* d_tokens{};             ///< token positions found for each string
 
   /**

--- a/cpp/tests/strings/find_tests.cpp
+++ b/cpp/tests/strings/find_tests.cpp
@@ -281,7 +281,7 @@ TEST_F(StringsFindTest, ErrorCheck)
                cudf::logic_error);
 }
 
-class FindParmsTest : public StringsFindTest, public testing::WithParamInterface<int32_t> {
+class FindParmsTest : public StringsFindTest, public testing::WithParamInterface<cudf::size_type> {
 };
 
 TEST_P(FindParmsTest, Find)
@@ -308,12 +308,12 @@ TEST_P(FindParmsTest, Find)
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
   }
   {
-    auto begin   = position;
+    auto begin   = static_cast<int32_t>(position);
     auto results = cudf::strings::find(strings_view, cudf::string_scalar(""), begin);
     cudf::test::fixed_width_column_wrapper<int32_t> expected(
       {begin, (begin > 0 ? -1 : 0), begin, begin, begin});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
-    auto end = position + 1;
+    auto end = static_cast<int32_t>(position + 1);
     results  = cudf::strings::rfind(strings_view, cudf::string_scalar(""), 0, end);
     cudf::test::fixed_width_column_wrapper<int32_t> rexpected({end, 0, end, end, end});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, rexpected);
@@ -322,4 +322,4 @@ TEST_P(FindParmsTest, Find)
 
 INSTANTIATE_TEST_CASE_P(StringsFindTest,
                         FindParmsTest,
-                        testing::ValuesIn(std::array<int32_t, 4>{0, 1, 2, 3}));
+                        testing::ValuesIn(std::array<cudf::size_type, 4>{0, 1, 2, 3}));

--- a/cpp/tests/strings/substring_tests.cpp
+++ b/cpp/tests/strings/substring_tests.cpp
@@ -50,7 +50,7 @@ TEST_F(StringsSubstringsTest, Substring)
 }
 
 class SubstringParmsTest : public StringsSubstringsTest,
-                           public testing::WithParamInterface<int32_t> {
+                           public testing::WithParamInterface<cudf::size_type> {
 };
 
 TEST_P(SubstringParmsTest, Substring)


### PR DESCRIPTION
I tried experimenting with changing the `cudf::size_type` to `int64_t` and found many, many places that assume `size_type` and `int32_t` (and `int`) are interchangeable. This PR attempts to fix some of the places where offsets column is created as INT32 but the column data is incorrectly referenced as `data<size_type>()` for example.
Also, this PR fixes some places that accepts/returns only int32_t (regex internal functions) or size_type (factories) which should be casted or accounted for.
This is not a full set of possible violations found but may help minimize future errors. No function has changed/added.