### PR TITLE
Pin librdkakfa to gcc 7 compatible version

### DIFF
--- a/conda/recipes/libcudf_kafka/meta.yaml
+++ b/conda/recipes/libcudf_kafka/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - cmake >=3.17.0
   host:
     - libcudf {{ version }}
-    - librdkafka 1.5
+    - librdkafka >=1.5.0,<1.5.3
   run:
     - {{ pin_compatible('librdkafka', max_pin='x.x') }} #TODO: librdkafka should be automatically included here by run_exports but is not
 


### PR DESCRIPTION
`librdkakfa` 1.5.3 required gcc 9.3 (https://anaconda.org/conda-forge/librdkafka/files?version=1.5.3) and `libcudf_kakfa` (https://anaconda.org/rapidsai-nightly/libcudf_kafka/files?version=0.18.0a201215) is being built requiring 1.5.3 which is not compatible with the rest of RAPIDS.