### PR TITLE
Add `ffill` and `bfill` to string columns

### DIFF
--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -4925,15 +4925,13 @@ class StringColumn(column.ColumnBase):
         replacement = column.as_column(replacement, dtype=self.dtype)
         return libcudf.replace.replace(self, to_replace, replacement)
 
-    def fillna(self, fill_value, method=None):
-        if method is not None:
-            raise NotImplementedError(
-                "fillna for string column with `method` parameter is not"
-                "supported."
-            )
-        if not is_scalar(fill_value):
-            fill_value = column.as_column(fill_value, dtype=self.dtype)
-        return super().fillna(value=fill_value, dtype="object")
+    def fillna(self, fill_value=None, method=None):
+        if fill_value is not None:
+            if not is_scalar(fill_value):
+                fill_value = column.as_column(fill_value, dtype=self.dtype)
+            return super().fillna(value=fill_value, dtype="object")
+        else:
+            return super().fillna(method=method)
 
     def _find_first_and_last(self, value):
         found_indices = self.str().contains(f"^{value}$")

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -453,13 +453,24 @@ def test_fillna_datetime(psr, fill_value, inplace):
         ),
         # Timedelta
         np.array(
-            [10, 100, 1000, None, None, 1000, 100, 10], dtype="datetime64[ns]"
+            [10, 100, 1000, None, None, 10, 100, 1000], dtype="datetime64[ns]"
         ),
         np.array(
-            [None, None, 1000, None, 1000, 100, 10], dtype="datetime64[ns]"
+            [None, None, 10, None, 1000, 100, 10], dtype="datetime64[ns]"
         ),
         np.array(
             [10, 100, None, None, 1000, None, None], dtype="datetime64[ns]"
+        ),
+        # String
+        np.array(
+            ["10", "100", "1000", None, None, "10", "100", "1000"],
+            dtype="object",
+        ),
+        np.array(
+            [None, None, "1000", None, "10", "100", "10"], dtype="object"
+        ),
+        np.array(
+            ["10", "100", None, None, "1000", None, None], dtype="object"
         ),
     ],
 )


### PR DESCRIPTION
Follow up of PR #7004 

Adds `method` field to `fillna` method in string type column to support `ffill` and `bfill`.
Also involves a small change to a `datetime64` `ffill`, `bfill` test case to improve test robustness.