### PR TITLE
Auto-label PRs based on their content [skip-ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,23 +3,23 @@
 # Labels culled from https://github.com/rapidsai/cudf/labels
 
 cuDF (Python):
-  - python/
-  - notebooks/
+  - python/**
+  - notebooks/**
   
 libcudf:
-  - cpp/
+  - cpp/**
 
 CMake:
   - **/CMakeLists.txt
-  - **/cmake/
+  - **/cmake/**
   
 cuDF (Java):
-  - java/
+  - java/**
   
 Ops:
-  - .github/
-  - /ci/
-  - conda/
+  - .github/**
+  - /ci/**
+  - conda/**
   - **/Dockerfile
   - **/.dockerignore
-  - docker/
+  - docker/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+# https://github.com/actions/labeler#common-examples
+# Generated from https://github.com/rapidsai/cudf/blob/main/.github/CODEOWNERS
+# Labels culled from https://github.com/rapidsai/cudf/labels
+
+cuDF (Python):
+  - python/
+  - notebooks/
+  
+libcudf:
+  - cpp/
+
+CMake:
+  - **/CMakeLists.txt
+  - **/cmake/
+  
+cuDF (Java):
+  - java/
+  
+Ops:
+  - .github/
+  - /ci/
+  - conda/
+  - **/Dockerfile
+  - **/.dockerignore
+  - docker/

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,23 +3,23 @@
 # Labels culled from https://github.com/rapidsai/cudf/labels
 
 cuDF (Python):
-  - python/**
-  - notebooks/**
+  - 'python/**'
+  - 'notebooks/**'
   
 libcudf:
-  - cpp/**
+  - 'cpp/**'
 
 CMake:
-  - **/CMakeLists.txt
-  - **/cmake/**
+  - '**/CMakeLists.txt'
+  - '**/cmake/**'
   
 cuDF (Java):
-  - java/**
+  - 'java/**'
   
 Ops:
-  - .github/**
-  - /ci/**
-  - conda/**
-  - **/Dockerfile
-  - **/.dockerignore
-  - docker/**
+  - '.github/**'
+  - 'ci/**'
+  - 'conda/**'
+  - '**/Dockerfile'
+  - '**/.dockerignore'
+  - 'docker/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ cuDF (Python):
   - 'python/**'
   - 'notebooks/**'
   
-cpp:
+libcudf:
   - 'cpp/**'
 
 CMake:
@@ -16,7 +16,7 @@ CMake:
 cuDF (Java):
   - 'java/**'
 
-ci:
+gpuCI:
   - 'ci/**'
 
 conda:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,4 @@
-# https://github.com/actions/labeler#common-examples
-# Generated from https://github.com/rapidsai/cudf/blob/main/.github/CODEOWNERS
-# Labels culled from https://github.com/rapidsai/cudf/labels
+# Documentation for conifg - https://github.com/actions/labeler#common-examples
 
 cuDF (Python):
   - 'python/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ cuDF (Python):
   - 'python/**'
   - 'notebooks/**'
   
-libcudf:
+cpp:
   - 'cpp/**'
 
 CMake:
@@ -15,11 +15,9 @@ CMake:
   
 cuDF (Java):
   - 'java/**'
-  
-Ops:
-  - '.github/**'
+
+ci:
   - 'ci/**'
+
+conda:
   - 'conda/**'
-  - '**/Dockerfile'
-  - '**/.dockerignore'
-  - 'docker/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-# Documentation for conifg - https://github.com/actions/labeler#common-examples
+# Documentation for config - https://github.com/actions/labeler#common-examples
 
 cuDF (Python):
   - 'python/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds the GitHub action [PR Labeler](https://github.com/actions/labeler) to auto-label PRs based on their content. 

Labeling is managed with a configuration file `.github/labeler.yml` using the following [options](https://github.com/actions/labeler#usage).