### PR TITLE
`cudf::rolling` `ROW_NUMBER` support for `decimal32` and `decimal64`

### DIFF
--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -73,7 +73,7 @@ class aggregation {
     ARGMIN,          ///< Index of min element
     NUNIQUE,         ///< count number of unique elements
     NTH_ELEMENT,     ///< get the nth element
-    ROW_NUMBER,      ///< get row-number of element
+    ROW_NUMBER,      ///< get row-number of current index (relative to rolling window)
     COLLECT,         ///< collect values into a list
     LEAD,            ///< window function, accesses row at specified offset following current row
     LAG,             ///< window function, accesses row at specified offset preceding current row

--- a/cpp/src/rolling/rolling_detail.cuh
+++ b/cpp/src/rolling/rolling_detail.cuh
@@ -131,9 +131,8 @@ bool __device__ process_rolling_window(column_device_view input,
 }
 
 /**
- * @brief Calculates row-number within [start_index, end_index).
- *        Count is updated depending on `min_periods`
- *        Returns true if it was valid, else false.
+ * @brief Calculates row-number of current index within [start_index, end_index). Count is updated
+ *        depending on `min_periods`. Returns `true` if it was valid, else `false`.
  */
 template <typename InputType,
           typename OutputType,

--- a/cpp/src/rolling/rolling_detail.cuh
+++ b/cpp/src/rolling/rolling_detail.cuh
@@ -124,7 +124,7 @@ bool __device__ process_rolling_window(column_device_view input,
 {
   cudf::size_type count = end_index - start_index;
 
-  bool output_is_valid                      = (count >= min_periods);
+  bool output_is_valid                      = count >= min_periods;
   output.element<OutputType>(current_index) = count;
 
   return output_is_valid;
@@ -149,8 +149,8 @@ bool __device__ process_rolling_window(column_device_view input,
                                        size_type current_index,
                                        size_type min_periods)
 {
-  bool output_is_valid                      = ((end_index - start_index) >= min_periods);
-  output.element<OutputType>(current_index) = ((current_index - start_index) + 1);
+  bool output_is_valid                      = end_index - start_index >= min_periods;
+  output.element<OutputType>(current_index) = current_index - start_index + 1;
 
   return output_is_valid;
 }

--- a/cpp/src/rolling/rolling_detail.hpp
+++ b/cpp/src/rolling/rolling_detail.hpp
@@ -50,14 +50,10 @@ static constexpr bool is_rolling_supported()
 
     return is_valid_numeric_agg;
 
-  } else if (cudf::is_timestamp<ColumnType>()) {
+  } else if (cudf::is_timestamp<ColumnType>() || cudf::is_fixed_point<ColumnType>()) {
     return (op == aggregation::MIN) or (op == aggregation::MAX) or
            (op == aggregation::COUNT_VALID) or (op == aggregation::COUNT_ALL) or
            (op == aggregation::ROW_NUMBER) or (op == aggregation::LEAD) or (op == aggregation::LAG);
-  } else if (cudf::is_fixed_point<ColumnType>()) {
-    return (op == aggregation::MIN) or (op == aggregation::MAX) or
-           (op == aggregation::COUNT_VALID) or (op == aggregation::COUNT_ALL) or
-           (op == aggregation::LEAD) or (op == aggregation::LAG);
   } else if (std::is_same<ColumnType, cudf::string_view>()) {
     return (op == aggregation::MIN) or (op == aggregation::MAX) or
            (op == aggregation::COUNT_VALID) or (op == aggregation::COUNT_ALL) or

--- a/cpp/tests/rolling/rolling_test.cpp
+++ b/cpp/tests/rolling/rolling_test.cpp
@@ -975,7 +975,8 @@ TYPED_TEST(FixedPointTests, MinMaxCountLagLead)
   auto const expected_lead = fp_wrapper{{1729, 55, 3, 1, 2, 0}, {1, 1, 1, 1, 1, 0}, scale};
   auto const expected_count_val = fw_wrapper{{2, 3, 3, 3, 3, 2}, {1, 1, 1, 1, 1, 1}};
   auto const expected_count_all = fw_wrapper{{2, 3, 3, 3, 3, 2}, {1, 1, 1, 1, 1, 1}};
-  // auto const expected_rowno     = fw_wrapper{{1, 2, 2, 2, 2, 2}, {1, 1, 1, 1, 1, 1}};
+  auto const expected_rowno     = fw_wrapper{{1, 2, 2, 2, 2, 2}, {1, 1, 1, 1, 1, 1}};
+  auto const expected_rowno1    = fw_wrapper{{1, 1, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1}};
 
   auto const min   = rolling_window(input, 2, 1, 1, make_min_aggregation());
   auto const max   = rolling_window(input, 2, 1, 1, make_max_aggregation());
@@ -983,7 +984,7 @@ TYPED_TEST(FixedPointTests, MinMaxCountLagLead)
   auto const lead  = rolling_window(input, 2, 1, 1, make_lead_aggregation(1));
   auto const valid = rolling_window(input, 2, 1, 1, make_count_aggregation());
   auto const all   = rolling_window(input, 2, 1, 1, make_count_aggregation(null_policy::INCLUDE));
-  EXPECT_THROW(rolling_window(input, 2, 1, 1, make_row_number_aggregation()), cudf::logic_error);
+  auto const rowno = rolling_window(input, 2, 1, 1, make_row_number_aggregation());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_min, min->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_max, max->view());
@@ -991,7 +992,13 @@ TYPED_TEST(FixedPointTests, MinMaxCountLagLead)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_lead, lead->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_count_val, valid->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_count_all, all->view());
-  // CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_rowno, rowno->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_rowno, rowno->view());
+
+  // ROW_NUMBER will always return row 1 if the preceding window is set to a constant 1
+  for (int following = 1; following < 5; ++following) {
+    auto const rowno1 = rolling_window(input, 1, following, 1, make_row_number_aggregation());
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_rowno1, rowno1->view());
+  }
 }
 
 TYPED_TEST(FixedPointTests, MinMaxCountLagLeadNulls)
@@ -1011,7 +1018,7 @@ TYPED_TEST(FixedPointTests, MinMaxCountLagLeadNulls)
   auto const expected_lead      = fp_wrapper{{1729, 55, 343, 1, 2, 0}, {0, 1, 0, 1, 1, 0}, scale};
   auto const expected_count_val = fw_wrapper{{1, 2, 1, 2, 2, 2}, {1, 1, 1, 1, 1, 1}};
   auto const expected_count_all = fw_wrapper{{2, 3, 3, 3, 3, 2}, {1, 1, 1, 1, 1, 1}};
-  // auto const expected_rowno     = fw_wrapper{{1, 2, 2, 2, 2, 2}, {1, 1, 1, 1, 1, 1}};
+  auto const expected_rowno     = fw_wrapper{{1, 2, 2, 2, 2, 2}, {1, 1, 1, 1, 1, 1}};
 
   auto const min   = rolling_window(input, 2, 1, 1, make_min_aggregation());
   auto const max   = rolling_window(input, 2, 1, 1, make_max_aggregation());
@@ -1019,7 +1026,7 @@ TYPED_TEST(FixedPointTests, MinMaxCountLagLeadNulls)
   auto const lead  = rolling_window(input, 2, 1, 1, make_lead_aggregation(1));
   auto const valid = rolling_window(input, 2, 1, 1, make_count_aggregation());
   auto const all   = rolling_window(input, 2, 1, 1, make_count_aggregation(null_policy::INCLUDE));
-  EXPECT_THROW(rolling_window(input, 2, 1, 1, make_row_number_aggregation()), cudf::logic_error);
+  auto const rowno = rolling_window(input, 2, 1, 1, make_row_number_aggregation());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_min, min->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_max, max->view());
@@ -1027,7 +1034,7 @@ TYPED_TEST(FixedPointTests, MinMaxCountLagLeadNulls)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_lead, lead->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_count_val, valid->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_count_all, all->view());
-  // CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_rowno, rowno->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_rowno, rowno->view());
 }
 
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
This PR adds support for `cudf::rolling` for the `ROW_NUMBER` option for `decimal32` and `decimal64`. It also clarifies the documentation.

