### PR TITLE
JNI support for creating struct column from existing columns and fixed bug in struct with no children

### DIFF
--- a/cpp/src/column/column.cu
+++ b/cpp/src/column/column.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/column/column.cu
+++ b/cpp/src/column/column.cu
@@ -266,7 +266,7 @@ struct create_column_from_view {
                        cudf::detail::slice(child, begin, end), stream, mr);
                    });
 
-    auto num_rows = children.empty() ? 0 : children.front()->size();
+    auto num_rows = view.size();
 
     return make_structs_column(num_rows,
                                std::move(children),

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -324,6 +324,33 @@ public final class ColumnVector extends ColumnView {
   }
 
   /**
+   * Create a new struct vector made up of existing columns. Note that this will copy
+   * the contents of the input columns to make a new vector. If you only want to
+   * do a quick temporary computation you can use ColumnView.makeStructView.
+   * @param columns the columns to make the struct from.
+   * @return the new ColumnVector
+   */
+  public static ColumnVector makeStruct(ColumnView... columns) {
+    try (ColumnView cv = ColumnView.makeStructView(columns)) {
+      return cv.copyToColumnVector();
+    }
+  }
+
+  /**
+   * Create a new struct vector made up of existing columns. Note that this will copy
+   * the contents of the input columns to make a new vector. If you only want to
+   * do a quick temporary computation you can use ColumnView.makeStructView.
+   * @param rows the number of rows in the struct. Used for structs with no children.
+   * @param columns the columns to make the struct from.
+   * @return the new ColumnVector
+   */
+  public static ColumnVector makeStruct(long rows, ColumnView... columns) {
+    try (ColumnView cv = ColumnView.makeStructView(rows, columns)) {
+      return cv.copyToColumnVector();
+    }
+  }
+
+  /**
    * Create a new vector of length rows, starting at the initialValue and going by step each time.
    * Only numeric types are supported.
    * @param initialValue the initial value to start at.
@@ -863,6 +890,15 @@ public final class ColumnVector extends ColumnView {
   public static ColumnVector fromStructs(HostColumnVector.DataType dataType,
                                          HostColumnVector.StructData... lists) {
     try (HostColumnVector host = HostColumnVector.fromStructs(dataType, lists)) {
+      return host.copyToDevice();
+    }
+  }
+  /**
+   * This method is evolving, unstable and currently test only.
+   * Please use with caution and expect it to change in the future.
+   */
+  public static ColumnVector emptyStructs(HostColumnVector.DataType dataType, long numRows) {
+    try (HostColumnVector host = HostColumnVector.emptyStructs(dataType, numRows)) {
       return host.copyToDevice();
     }
   }

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2289,7 +2289,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
 
 
   /**
-   * Create a new struct column made pointing to existing columns. Note that this will NOT copy
+   * Create a new struct column view of existing column views. Note that this will NOT copy
    * the contents of the input columns to make a new vector, but makes a view that must not
    * outlive the child views that it references. The resulting column cannot be null.
    * @param rows the number of rows in the struct column. This is needed if no columns
@@ -2298,7 +2298,6 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return the new column view. It is the responsibility of the caller to close this.
    */
   public static ColumnView makeStructView(long rows, ColumnView... columns) {
-
     long[] handles = new long[columns.length];
     for (int i = 0; i < columns.length; i++) {
       ColumnView cv = columns[i];
@@ -2311,7 +2310,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /**
-   * Create a new struct column made pointing to existing columns. Note that this will NOT copy
+   * Create a new struct column view of existing column views. Note that this will NOT copy
    * the contents of the input columns to make a new vector, but makes a view that must not
    * outlive the child views that it references. The resulting column cannot be null.
    * @param columns the columns to add to the struct in the order they should be added

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2020, NVIDIA CORPORATION.
+ *  Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2287,6 +2287,43 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     return new ColumnVector(mapLookup(getNativeView(), key.getScalarHandle()));
   }
 
+
+  /**
+   * Create a new struct column made pointing to existing columns. Note that this will NOT copy
+   * the contents of the input columns to make a new vector, but makes a view that must not
+   * outlive the child views that it references. The resulting column cannot be null.
+   * @param rows the number of rows in the struct column. This is needed if no columns
+   *             are provided.
+   * @param columns the columns to add to the struct in the order they should be added
+   * @return the new column view. It is the responsibility of the caller to close this.
+   */
+  public static ColumnView makeStructView(long rows, ColumnView... columns) {
+
+    long[] handles = new long[columns.length];
+    for (int i = 0; i < columns.length; i++) {
+      ColumnView cv = columns[i];
+      if (rows != cv.getRowCount()) {
+        throw new IllegalArgumentException("All columns must have the same number of rows");
+      }
+      handles[i] = cv.getNativeView();
+    }
+    return new ColumnView(makeStructView(handles, rows));
+  }
+
+  /**
+   * Create a new struct column made pointing to existing columns. Note that this will NOT copy
+   * the contents of the input columns to make a new vector, but makes a view that must not
+   * outlive the child views that it references. The resulting column cannot be null.
+   * @param columns the columns to add to the struct in the order they should be added
+   * @return the new column view. It is the responsibility of the caller to close this.
+   */
+  public static ColumnView makeStructView(ColumnView... columns) {
+    if (columns.length <= 0) {
+      throw new IllegalArgumentException("At least one column is needed to get the row count");
+    }
+    return makeStructView(columns[0].rows, columns);
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // INTERNAL/NATIVE ACCESS
   /////////////////////////////////////////////////////////////////////////////
@@ -2620,7 +2657,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   private static native long clamper(long nativeView, long loScalarHandle, long loScalarReplaceHandle,
                                      long hiScalarHandle, long hiScalarReplaceHandle);
 
-  protected native long title(long handle);
+  protected static native long title(long handle);
+
+  private static native long makeStructView(long[] handles, long rowCount);
 
   private static native long isTimestamp(long nativeView, String format);
   /**
@@ -2755,7 +2794,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
         mainOffsetsDevBuff.copyFromHostBuffer(mainColOffsets, 0, offsetsLen);
       }
       List<DeviceMemoryBuffer> toClose = new ArrayList<>();
-      long[] childHandles = (devChildren.isEmpty()) ? null : new long[devChildren.size()];
+      long[] childHandles = new long[devChildren.size()];
       for (ColumnView.NestedColumnVector ncv : devChildren) {
         toClose.addAll(ncv.getBuffersToClose());
       }

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -303,6 +303,16 @@ public final class HostColumnVector extends HostColumnVectorCore {
     }
   }
 
+  public static HostColumnVector emptyStructs(DataType dataType, long rows) {
+    StructData sd = new StructData();
+    try (ColumnBuilder cb = new ColumnBuilder(dataType, rows)) {
+      for (long i = 0; i < rows; i++) {
+        cb.append(sd);
+      }
+      return cb.build();
+    }
+  }
+
   /**
    * Create a new vector from the given values.
    */

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2020, NVIDIA CORPORATION.
+ *  Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1252,6 +1252,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
   JNI_NULL_CHECK(env, base_column, "base column native handle is null", 0);
   JNI_NULL_CHECK(env, column_handles, "array of column handles is null", 0);
   try {
+    cudf::jni::auto_set_device(env);
     cudf::column_view *original_column = reinterpret_cast<cudf::column_view *>(base_column);
     std::unique_ptr<cudf::column> copy(new cudf::column(*original_column));
     cudf::jni::native_jpointerArray<cudf::column_view> n_cudf_columns(env, column_handles);
@@ -1333,7 +1334,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_makeCudfColumnView(JNIEnv
       ret.reset(new cudf::column_view(cudf::data_type{cudf::type_id::LIST}, size, nullptr, valid,
         j_null_count, 0, {offsets_column, *children[0]}));
    } else if (n_type == cudf::type_id::STRUCT) {
-     JNI_NULL_CHECK(env, j_children, "children of a list are null", 0);
+     JNI_NULL_CHECK(env, j_children, "children of a struct are null", 0);
      cudf::jni::native_jpointerArray<cudf::column_view> children(env, j_children);
      std::vector<column_view> children_vector(children.size());
      for (int i = 0; i < children.size(); i++) {
@@ -1633,6 +1634,27 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_title(JNIEnv *env, jobjec
     cudf::column_view *view = reinterpret_cast<cudf::column_view *>(handle);
     std::unique_ptr<cudf::column> result = cudf::strings::title(*view);
     return reinterpret_cast<jlong>(result.release());
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_makeStructView(JNIEnv *env, jobject j_object,
+                                                                      jlongArray handles,
+                                                                      jlong row_count) {
+
+  JNI_NULL_CHECK(env, handles, "native view handles are null", 0)
+  try {
+    cudf::jni::auto_set_device(env);
+    std::unique_ptr<cudf::column_view> ret;
+    cudf::jni::native_jpointerArray<cudf::column_view> children(env, handles);
+    std::vector<cudf::column_view> children_vector(children.size());
+    for (int i = 0; i < children.size(); i++) {
+      children_vector[i] = *children[i];
+    }
+    ret.reset(new cudf::column_view(cudf::data_type{cudf::type_id::STRUCT}, row_count, nullptr,
+                nullptr, 0, 0, children_vector));
+
+    return reinterpret_cast<jlong>(ret.release());
   }
   CATCH_STD(env, 0);
 }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -3673,4 +3673,30 @@ public class ColumnVectorTest extends CudfTestBase {
       assertColumnsAreEqual(expected, copiedChildCv);
     }
   }
+
+  @Test
+  void testMakeStructEmpty() {
+    final int numRows = 10;
+    try (ColumnVector expected = ColumnVector.emptyStructs(new StructType(false, new ArrayList<>()), numRows);
+         ColumnVector created = ColumnVector.makeStruct(numRows)) {
+      assertColumnsAreEqual(expected, created);
+    }
+  }
+
+  @Test
+  void testMakeStruct() {
+    try (ColumnVector expected = ColumnVector.fromStructs(new StructType(false,
+            Arrays.asList(
+                new BasicType(false, DType.INT32),
+                new BasicType(false, DType.INT32),
+                new BasicType(false, DType.INT32))),
+        new HostColumnVector.StructData(1, 2, 3),
+        new HostColumnVector.StructData(4, 5, 6));
+         ColumnVector child1 = ColumnVector.fromInts(1, 4);
+         ColumnVector child2 = ColumnVector.fromInts(2, 5);
+         ColumnVector child3 = ColumnVector.fromInts(3, 6);
+         ColumnVector created = ColumnVector.makeStruct(child1, child2, child3)) {
+      assertColumnsAreEqual(expected, created);
+    }
+  }
 }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
The primary goal of this is to add in java APIs to create a struct column from other existing columns.  As a part of this work I found a very small bug in the column_vector constructor that copies data from  a column view for a struct column with no children in it.  Spark supports this use case so I thought it would be good to test/fix the issue.