### PR TITLE
Build libcudf with -Wall

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -54,7 +54,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
     # Suppress parentheses warning which causes gmock to fail
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-parentheses")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-Wno-parentheses")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
 if(CMAKE_CUDA_COMPILER_VERSION)
@@ -123,11 +123,11 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-
 
 # set warnings as errors
 # TODO: remove `no-maybe-unitialized` used to suppress warnings in rmm::exec_policy
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wall -Werror=cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-error=deprecated-declarations")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror=cross-execution-space-call -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations")
 
 option(DISABLE_DEPRECATION_WARNING "Disable warnings generated from deprecated declarations." OFF)
 if(DISABLE_DEPRECATION_WARNING)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-deprecated-declarations")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-Wno-deprecated-declarations")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 endif(DISABLE_DEPRECATION_WARNING)
 
@@ -140,7 +140,7 @@ endif(CMAKE_CUDA_LINEINFO)
 # Debug options
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     message(STATUS "Building with debugging flags")
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G -Xcompiler -rdynamic")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G -Xcompiler=-rdynamic")
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 # To apply RUNPATH to transitive dependencies (this is a temporary solution)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -50,7 +50,9 @@ set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=deprecated-declarations")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
     # Suppress parentheses warning which causes gmock to fail
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-parentheses")
 endif(CMAKE_COMPILER_IS_GNUCXX)
@@ -121,7 +123,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-
 
 # set warnings as errors
 # TODO: remove `no-maybe-unitialized` used to suppress warnings in rmm::exec_policy
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror=cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-error=deprecated-declarations")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wall -Werror=cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-error=deprecated-declarations")
 
 option(DISABLE_DEPRECATION_WARNING "Disable warnings generated from deprecated declarations." OFF)
 if(DISABLE_DEPRECATION_WARNING)

--- a/cpp/benchmarks/common/generate_benchmark_input.cpp
+++ b/cpp/benchmarks/common/generate_benchmark_input.cpp
@@ -474,7 +474,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::list_view>(data_profile
     std::vector<int32_t> offsets{0};
     offsets.reserve(num_rows + 1);
     std::vector<cudf::bitmask_type> null_mask(null_mask_size(num_rows), ~0);
-    for (uint32_t row = 1; row < num_rows + 1; ++row) {
+    for (cudf::size_type row = 1; row < num_rows + 1; ++row) {
       offsets.push_back(
         std::min<int32_t>(current_child_column->size(), offsets.back() + len_dist(engine)));
       if (!valid_dist(engine)) cudf::clear_bit_unsafe(null_mask.data(), row);
@@ -531,7 +531,7 @@ columns_vector create_random_columns(data_profile const& profile,
 std::vector<cudf::type_id> repeat_dtypes(std::vector<cudf::type_id> const& dtype_ids,
                                          cudf::size_type num_cols)
 {
-  if (dtype_ids.size() == static_cast<size_t>(num_cols)) { return dtype_ids; }
+  if (dtype_ids.size() == static_cast<std::size_t>(num_cols)) { return dtype_ids; }
   std::vector<cudf::type_id> out_dtypes;
   out_dtypes.reserve(num_cols);
   for (cudf::size_type col = 0; col < num_cols; ++col)

--- a/cpp/benchmarks/common/generate_benchmark_input.cpp
+++ b/cpp/benchmarks/common/generate_benchmark_input.cpp
@@ -474,7 +474,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::list_view>(data_profile
     std::vector<int32_t> offsets{0};
     offsets.reserve(num_rows + 1);
     std::vector<cudf::bitmask_type> null_mask(null_mask_size(num_rows), ~0);
-    for (int row = 1; row < num_rows + 1; ++row) {
+    for (uint32_t row = 1; row < num_rows + 1; ++row) {
       offsets.push_back(
         std::min<int32_t>(current_child_column->size(), offsets.back() + len_dist(engine)));
       if (!valid_dist(engine)) cudf::clear_bit_unsafe(null_mask.data(), row);
@@ -531,7 +531,7 @@ columns_vector create_random_columns(data_profile const& profile,
 std::vector<cudf::type_id> repeat_dtypes(std::vector<cudf::type_id> const& dtype_ids,
                                          cudf::size_type num_cols)
 {
-  if (dtype_ids.size() == num_cols) { return dtype_ids; }
+  if (dtype_ids.size() == static_cast<size_t>(num_cols)) { return dtype_ids; }
   std::vector<cudf::type_id> out_dtypes;
   out_dtypes.reserve(num_cols);
   for (cudf::size_type col = 0; col < num_cols; ++col)

--- a/cpp/benchmarks/null_mask/set_null_mask_benchmark.cpp
+++ b/cpp/benchmarks/null_mask/set_null_mask_benchmark.cpp
@@ -28,7 +28,7 @@ void BM_setnullmask(benchmark::State& state)
 {
   const cudf::size_type size{(cudf::size_type)state.range(0)};
   rmm::device_buffer mask = cudf::create_null_mask(size, cudf::mask_state::UNINITIALIZED);
-  auto begin = 0, middle = size / 2, end = size;
+  auto begin = 0, end = size;
 
   for (auto _ : state) {
     cuda_event_timer raii(state, true);  // flush_l2_cache = true, stream = 0

--- a/cpp/benchmarks/synchronization/synchronization.cpp
+++ b/cpp/benchmarks/synchronization/synchronization.cpp
@@ -24,7 +24,7 @@
 cuda_event_timer::cuda_event_timer(benchmark::State& state,
                                    bool flush_l2_cache,
                                    rmm::cuda_stream_view stream)
-  : p_state(&state), stream(stream)
+  : stream(stream), p_state(&state)
 {
   // flush all of L2$
   if (flush_l2_cache) {

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -330,8 +330,12 @@ class fixed_point_scalar : public scalar {
                      bool is_valid                       = true,
                      rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
-    : scalar{data_type{type_to_id<T>(), _type.scale()}, is_valid, stream, mr},
-      _data{numeric::scaled_integer<rep_type>{value}.value}
+    : scalar{data_type{type_to_id<T>(),
+                       static_cast<numeric::scaled_integer<rep_type>>(value).scale},
+             is_valid,
+             stream,
+             mr},
+      _data{static_cast<numeric::scaled_integer<rep_type>>(value).value}
   {
   }
 

--- a/cpp/src/copying/slice.cpp
+++ b/cpp/src/copying/slice.cpp
@@ -90,7 +90,7 @@ std::vector<cudf::table_view> slice(cudf::table_view const& input,
   size_t num_output_tables = indices.size() / 2;
   for (size_t i = 0; i < num_output_tables; i++) {
     std::vector<cudf::column_view> table_columns;
-    for (size_t j = 0; j < input.num_columns(); j++) {
+    for (size_type j = 0; j < input.num_columns(); j++) {
       table_columns.emplace_back(sliced_table[j][i]);
     }
     result.emplace_back(table_view{table_columns});

--- a/cpp/src/interop/to_arrow.cpp
+++ b/cpp/src/interop/to_arrow.cpp
@@ -204,7 +204,7 @@ std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::struct_view>(
   arrow::MemoryPool* ar_mr,
   rmm::cuda_stream_view stream)
 {
-  CUDF_EXPECTS(metadata.children_meta.size() == input.num_children(),
+  CUDF_EXPECTS(metadata.children_meta.size() == static_cast<size_t>(input.num_children()),
                "Number of field names and number of children doesn't match\n");
   std::unique_ptr<column> tmp_column = nullptr;
 
@@ -300,13 +300,12 @@ std::shared_ptr<arrow::Table> to_arrow(table_view input,
                                        rmm::cuda_stream_view stream,
                                        arrow::MemoryPool* ar_mr)
 {
-  CUDF_EXPECTS((metadata.size() == input.num_columns()),
+  CUDF_EXPECTS((metadata.size() == static_cast<size_t>(input.num_columns())),
                "columns' metadata should be equal to number of columns in table");
 
   std::vector<std::shared_ptr<arrow::Array>> arrays;
   std::vector<std::shared_ptr<arrow::Field>> fields;
 
-  size_type index = 0;
   std::transform(
     input.begin(),
     input.end(),

--- a/cpp/src/interop/to_arrow.cpp
+++ b/cpp/src/interop/to_arrow.cpp
@@ -204,7 +204,7 @@ std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::struct_view>(
   arrow::MemoryPool* ar_mr,
   rmm::cuda_stream_view stream)
 {
-  CUDF_EXPECTS(metadata.children_meta.size() == static_cast<size_t>(input.num_children()),
+  CUDF_EXPECTS(metadata.children_meta.size() == static_cast<std::size_t>(input.num_children()),
                "Number of field names and number of children doesn't match\n");
   std::unique_ptr<column> tmp_column = nullptr;
 
@@ -300,7 +300,7 @@ std::shared_ptr<arrow::Table> to_arrow(table_view input,
                                        rmm::cuda_stream_view stream,
                                        arrow::MemoryPool* ar_mr)
 {
-  CUDF_EXPECTS((metadata.size() == static_cast<size_t>(input.num_columns())),
+  CUDF_EXPECTS((metadata.size() == static_cast<std::size_t>(input.num_columns())),
                "columns' metadata should be equal to number of columns in table");
 
   std::vector<std::shared_ptr<arrow::Array>> arrays;

--- a/cpp/src/io/avro/avro.cpp
+++ b/cpp/src/io/avro/avro.cpp
@@ -135,7 +135,7 @@ bool container::parse(file_metadata *md, size_t max_num_rows, size_t first_row)
       if (parent_idx >= 0) {
         while (parent_idx >= 0) {
           if (md->schema[parent_idx].kind == type_union) {
-            size_t pos = parent_idx + 1;
+            std::size_t pos = parent_idx + 1;
             for (int num_children = md->schema[parent_idx].num_children; num_children > 0;
                  --num_children) {
               int skip = 1;

--- a/cpp/src/io/avro/avro.cpp
+++ b/cpp/src/io/avro/avro.cpp
@@ -135,7 +135,7 @@ bool container::parse(file_metadata *md, size_t max_num_rows, size_t first_row)
       if (parent_idx >= 0) {
         while (parent_idx >= 0) {
           if (md->schema[parent_idx].kind == type_union) {
-            int pos = parent_idx + 1;
+            size_t pos = parent_idx + 1;
             for (int num_children = md->schema[parent_idx].num_children; num_children > 0;
                  --num_children) {
               int skip = 1;

--- a/cpp/src/io/avro/avro.h
+++ b/cpp/src/io/avro/avro.h
@@ -36,7 +36,7 @@ namespace avro {
  */
 struct schema_entry {
   explicit schema_entry(type_kind_e kind_, int32_t parent_idx_ = -1, int32_t num_children_ = 0)
-    : kind(kind_), parent_idx(parent_idx_), num_children(num_children_)
+    : parent_idx(parent_idx_), num_children(num_children_), kind(kind_)
   {
   }
   int32_t parent_idx   = -1;  // index of parent entry in schema array, negative if no parent

--- a/cpp/src/io/avro/avro_common.h
+++ b/cpp/src/io/avro/avro_common.h
@@ -28,7 +28,7 @@ struct block_desc_s {
                                   uint32_t size_,
                                   uint32_t first_row_,
                                   uint32_t num_rows_)
-    : offset(offset_), first_row(first_row_), num_rows(num_rows_), size(size_)
+    : offset(offset_), size(size_), first_row(first_row_), num_rows(num_rows_)
   {
   }
 

--- a/cpp/src/io/comp/cpu_unbz2.cpp
+++ b/cpp/src/io/comp/cpu_unbz2.cpp
@@ -375,7 +375,7 @@ int32_t bz2_decompress_block(unbz_state_s *s)
       } while (--es);
     }
 
-    if (nextSym == EOB) break;
+    if (nextSym == static_cast<uint32_t>(EOB)) break;
 
     if (nblock >= nblockMAX) return BZ_DATA_ERROR;
     nn = nextSym - 1;

--- a/cpp/src/io/orc/orc.cpp
+++ b/cpp/src/io/orc/orc.cpp
@@ -278,6 +278,7 @@ OrcDecompressor::OrcDecompressor(CompressionKind kind, uint32_t blockSize)
   if (kind != NONE) {
     int stream_type = IO_UNCOMP_STREAM_TYPE_INFER;  // Will be treated as invalid
     switch (kind) {
+      case NONE: break;
       case ZLIB:
         stream_type    = IO_UNCOMP_STREAM_TYPE_INFLATE;
         m_log2MaxRatio = 11;  // < 2048:1

--- a/cpp/src/io/parquet/parquet.cpp
+++ b/cpp/src/io/parquet/parquet.cpp
@@ -284,7 +284,7 @@ bool CompactProtocolReader::read(KeyValue *k)
  */
 bool CompactProtocolReader::InitSchema(FileMetaData *md)
 {
-  if (static_cast<size_t>(WalkSchema(md)) != md->schema.size()) return false;
+  if (static_cast<std::size_t>(WalkSchema(md)) != md->schema.size()) return false;
 
   /* Inside FileMetaData, there is a std::vector of RowGroups and each RowGroup contains a
    * a std::vector of ColumnChunks. Each ColumnChunk has a member ColumnMetaData, which contains

--- a/cpp/src/io/parquet/parquet.cpp
+++ b/cpp/src/io/parquet/parquet.cpp
@@ -68,7 +68,6 @@ bool CompactProtocolReader::skip_struct_field(int t, int depth)
     case ST_FLD_STRUCT:
       for (;;) {
         int c = getb();
-        int d = c >> 4;
         t     = c & 0xf;
         if (!c) break;
         if (depth > 10) return false;
@@ -285,7 +284,7 @@ bool CompactProtocolReader::read(KeyValue *k)
  */
 bool CompactProtocolReader::InitSchema(FileMetaData *md)
 {
-  if (WalkSchema(md) != md->schema.size()) return false;
+  if (static_cast<size_t>(WalkSchema(md)) != md->schema.size()) return false;
 
   /* Inside FileMetaData, there is a std::vector of RowGroups and each RowGroup contains a
    * a std::vector of ColumnChunks. Each ColumnChunk has a member ColumnMetaData, which contains

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -45,7 +45,7 @@ class memory_mapped_source : public datasource {
     uint8_t *_data = nullptr;
 
    public:
-    memory_mapped_buffer(uint8_t *data, size_t size) : _data(data), _size(size) {}
+    memory_mapped_buffer(uint8_t *data, size_t size) : _size(size), _data(data) {}
     size_t size() const override { return _size; }
     const uint8_t *data() const override { return _data; }
   };

--- a/cpp/src/jit/launcher.cpp
+++ b/cpp/src/jit/launcher.cpp
@@ -40,8 +40,8 @@ launcher::launcher(const std::string& hash,
 }
 
 launcher::launcher(launcher&& launcher)
-  : program{std::move(launcher.program)},
-    cache_instance{cudf::jit::cudfJitCache::Instance()},
+  : cache_instance{cudf::jit::cudfJitCache::Instance()},
+    program{std::move(launcher.program)},
     kernel_inst{std::move(launcher.kernel_inst)},
     stream{launcher.stream}
 {

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -216,8 +216,8 @@ class regex_parser {
     }
 
     /* sort on span start */
-    for (size_t p = 0; p < cls.size(); p += 2)
-      for (size_t np = p + 2; np < cls.size(); np += 2)
+    for (std::size_t p = 0; p < cls.size(); p += 2)
+      for (std::size_t np = p + 2; np < cls.size(); np += 2)
         if (cls[np] < cls[p]) {
           c           = cls[np];
           cls[np]     = cls[p];
@@ -231,7 +231,7 @@ class regex_parser {
     reclass yycls{builtins};
     if (cls.size() >= 2) {
       int np   = 0;
-      size_t p = 0;
+      std::size_t p = 0;
       yycls.literals += cls[p++];
       yycls.literals += cls[p++];
       for (; p < cls.size(); p += 2) {
@@ -682,7 +682,7 @@ class regex_compiler {
     int rep_start = -1;
 
     out.clear();
-    for (size_t i = 0; i < in.size(); i++) {
+    for (std::size_t i = 0; i < in.size(); i++) {
       if (in[i].t != COUNTED && in[i].t != COUNTED_LAZY) {
         out.push_back(in[i]);
         if (in[i].t == LBRA || in[i].t == LBRA_NC) {
@@ -701,11 +701,11 @@ class regex_compiler {
         regex_parser::Item item = in[i];
         if (item.d.yycount.n <= 0) {
           // need to erase
-          for (size_t j = 0; j < i - rep_start; j++) out.pop_back();
+          for (std::size_t j = 0; j < i - rep_start; j++) out.pop_back();
         } else {
           // repeat
           for (int j = 1; j < item.d.yycount.n; j++)
-            for (size_t k = rep_start; k < i; k++) out.push_back(in[k]);
+            for (std::size_t k = rep_start; k < i; k++) out.push_back(in[k]);
         }
 
         // optional repeats
@@ -715,7 +715,7 @@ class regex_compiler {
             o_item.t    = LBRA_NC;
             o_item.d.yy = 0;
             out.push_back(o_item);
-            for (size_t k = rep_start; k < i; k++) out.push_back(in[k]);
+            for (std::size_t k = rep_start; k < i; k++) out.push_back(in[k]);
           }
           for (int j = item.d.yycount.n; j < item.d.yycount.m; j++) {
             regex_parser::Item o_item;
@@ -746,7 +746,7 @@ class regex_compiler {
             }
           } else  // copy it once then put '*'
           {
-            for (size_t k = rep_start; k < i; k++) out.push_back(in[k]);
+            for (std::size_t k = rep_start; k < i; k++) out.push_back(in[k]);
 
             if (item.t == COUNTED) {
               o_item.t = STAR;
@@ -908,7 +908,7 @@ void reprog::optimize2()
 void reprog::print()
 {
   printf("Instructions:\n");
-  for (size_t i = 0; i < _insts.size(); i++) {
+  for (std::size_t i = 0; i < _insts.size(); i++) {
     const reinst& inst = _insts[i];
     printf("%zu :", i);
     switch (inst.type) {

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -230,7 +230,7 @@ class regex_parser {
     /* merge spans */
     reclass yycls{builtins};
     if (cls.size() >= 2) {
-      int np   = 0;
+      int np        = 0;
       std::size_t p = 0;
       yycls.literals += cls[p++];
       yycls.literals += cls[p++];

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -216,8 +216,8 @@ class regex_parser {
     }
 
     /* sort on span start */
-    for (int p = 0; p < cls.size(); p += 2)
-      for (int np = p + 2; np < cls.size(); np += 2)
+    for (size_t p = 0; p < cls.size(); p += 2)
+      for (size_t np = p + 2; np < cls.size(); np += 2)
         if (cls[np] < cls[p]) {
           c           = cls[np];
           cls[np]     = cls[p];
@@ -230,8 +230,8 @@ class regex_parser {
     /* merge spans */
     reclass yycls{builtins};
     if (cls.size() >= 2) {
-      int np = 0;
-      int p  = 0;
+      int np   = 0;
+      size_t p = 0;
       yycls.literals += cls[p++];
       yycls.literals += cls[p++];
       for (; p < cls.size(); p += 2) {
@@ -682,7 +682,7 @@ class regex_compiler {
     int rep_start = -1;
 
     out.clear();
-    for (int i = 0; i < in.size(); i++) {
+    for (size_t i = 0; i < in.size(); i++) {
       if (in[i].t != COUNTED && in[i].t != COUNTED_LAZY) {
         out.push_back(in[i]);
         if (in[i].t == LBRA || in[i].t == LBRA_NC) {
@@ -701,11 +701,11 @@ class regex_compiler {
         regex_parser::Item item = in[i];
         if (item.d.yycount.n <= 0) {
           // need to erase
-          for (int j = 0; j < i - rep_start; j++) out.pop_back();
+          for (size_t j = 0; j < i - rep_start; j++) out.pop_back();
         } else {
           // repeat
           for (int j = 1; j < item.d.yycount.n; j++)
-            for (int k = rep_start; k < i; k++) out.push_back(in[k]);
+            for (size_t k = rep_start; k < i; k++) out.push_back(in[k]);
         }
 
         // optional repeats
@@ -715,7 +715,7 @@ class regex_compiler {
             o_item.t    = LBRA_NC;
             o_item.d.yy = 0;
             out.push_back(o_item);
-            for (int k = rep_start; k < i; k++) out.push_back(in[k]);
+            for (size_t k = rep_start; k < i; k++) out.push_back(in[k]);
           }
           for (int j = item.d.yycount.n; j < item.d.yycount.m; j++) {
             regex_parser::Item o_item;
@@ -746,7 +746,7 @@ class regex_compiler {
             }
           } else  // copy it once then put '*'
           {
-            for (int k = rep_start; k < i; k++) out.push_back(in[k]);
+            for (size_t k = rep_start; k < i; k++) out.push_back(in[k]);
 
             if (item.t == COUNTED) {
               o_item.t = STAR;
@@ -763,7 +763,7 @@ class regex_compiler {
 
  public:
   regex_compiler(const char32_t* pattern, int dot_type, reprog& prog)
-    : m_prog(prog), cursubid(0), pushsubid(0), lastwasand(false), nbra(0), yyclass_id(0), yy(0)
+    : m_prog(prog), cursubid(0), pushsubid(0), lastwasand(false), nbra(0), yy(0), yyclass_id(0)
   {
     // Parse
     std::vector<regex_parser::Item> items;
@@ -908,9 +908,9 @@ void reprog::optimize2()
 void reprog::print()
 {
   printf("Instructions:\n");
-  for (int i = 0; i < _insts.size(); i++) {
+  for (size_t i = 0; i < _insts.size(); i++) {
     const reinst& inst = _insts[i];
-    printf("%d :", i);
+    printf("%zu :", i);
     switch (inst.type) {
       default: printf("Unknown instruction: %d, nextid= %d", inst.type, inst.u2.next_id); break;
       case CHAR:

--- a/cpp/tests/binaryop/assert-binops.h
+++ b/cpp/tests/binaryop/assert-binops.h
@@ -120,7 +120,7 @@ void ASSERT_BINOP(column_view const& out,
     } else {
       auto out_valid = out_h.second;
       for (size_type i = 0; i < num_bitmask_words(out_data.size()); ++i) {
-        ASSERT_EQ(out_valid[i], 0);
+        ASSERT_EQ(out_valid[i], bitmask_type{0});
       }
     }
   }
@@ -167,7 +167,7 @@ void ASSERT_BINOP(column_view const& out,
     } else {
       auto out_valid = out_h.second;
       for (size_type i = 0; i < num_bitmask_words(out_data.size()); ++i) {
-        ASSERT_EQ(out_valid[i], 0);
+        ASSERT_EQ(out_valid[i], bitmask_type{0});
       }
     }
   }

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -938,9 +938,6 @@ TEST_F(BinaryOperationIntegrationTest, ShiftRightUnsigned_Vector_Vector_SI32)
   using TypeLhs = int;
   using TypeRhs = int;
 
-  using SHIFT_RIGHT_UNSIGNED =
-    cudf::library::operation::ShiftRightUnsigned<TypeOut, TypeLhs, TypeRhs>;
-
   int num_els = 4;
 
   TypeLhs lhs[] = {-8, 78, -93, 0, -INT_MAX};
@@ -1149,8 +1146,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Scalar_Vector_B8_tsD_tsD)
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Scalar_B8_string_string_EmptyString)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto str_col = cudf::test::strings_column_wrapper({"eee", "bb", "<null>", "", "aa", "bbb", "ééé"},
                                                     {true, false, true, true, true, false, true});
@@ -1171,8 +1166,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Scalar_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Scalar_Vector_B8_string_string_ValidString)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto str_col = cudf::test::strings_column_wrapper({"eee", "bb", "<null>", "", "aa", "bbb", "ééé"},
                                                     {true, false, true, true, true, false, true});
@@ -1193,8 +1186,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Scalar_Vector_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Scalar_B8_string_string_NoMatch)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   // Try with non nullable input
   auto str_col =
@@ -1216,8 +1207,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Scalar_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Scalar_Vector_B8_string_string_NullNonNull)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   // Try with all invalid input
   auto str_col = cudf::test::strings_column_wrapper({"eee", "bb", "<null>", "", "aa", "bbb", "ééé"},
@@ -1240,8 +1229,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Scalar_Vector_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Scalar_B8_string_string_NullNonNull)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   // Try with all invalid input
   auto str_col =
@@ -1264,8 +1251,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Scalar_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Scalar_Vector_B8_string_string_NullNull)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   // Try with all invalid input
   auto str_col =
@@ -1289,8 +1274,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Scalar_Vector_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Scalar_Vector_B8_string_string_MatchInvalid)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto str_col = cudf::test::strings_column_wrapper({"eee", "bb", "<null>", "", "aa", "bbb", "ééé"},
                                                     {true, false, true, true, true, false, true});
@@ -1311,8 +1294,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Scalar_Vector_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_InvalidScalar_B8_string_string)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto str_col = cudf::test::strings_column_wrapper({"eee", "bb", "<null>", "", "aa", "bbb", "ééé"},
                                                     {true, false, true, true, true, false, true});
@@ -1369,8 +1350,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_tsD_tsD_N
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_string_MixMix)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto lhs_col =
     cudf::test::strings_column_wrapper({"eee", "invalid", "<null>", "", "aa", "invalid", "ééé"},
@@ -1393,8 +1372,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_string_MixValid)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto lhs_col =
     cudf::test::strings_column_wrapper({"eee", "invalid", "<null>", "", "aa", "invalid", "ééé"},
@@ -1416,8 +1393,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_string_MixInvalid)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto lhs_col =
     cudf::test::strings_column_wrapper({"eee", "invalid", "<null>", "", "aa", "invalid", "ééé"},
@@ -1440,8 +1415,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_string_ValidValid)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto lhs_col =
     cudf::test::strings_column_wrapper({"eee", "invalid", "<null>", "", "aa", "invalid", "ééé"});
@@ -1462,8 +1435,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_string_ValidInvalid)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto lhs_col =
     cudf::test::strings_column_wrapper({"eee", "invalid", "<null>", "", "aa", "invalid", "ééé"});
@@ -1485,8 +1456,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_st
 TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_Vector_B8_string_string_InvalidInvalid)
 {
   using TypeOut = bool;
-  using TypeLhs = std::string;
-  using TypeRhs = std::string;
 
   auto lhs_col =
     cudf::test::strings_column_wrapper({"eee", "invalid", "<null>", "", "aa", "invalid", "ééé"},
@@ -1510,7 +1479,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareEqual_Vector_VectorAllInvalid_B8
 {
   using TypeOut = bool;
   using TypeLhs = int32_t;
-  using TypeRhs = int32_t;
 
   auto lhs_col = fixed_width_column_wrapper<TypeLhs>{{-INT32_MAX, -37, 0, 499, 44, INT32_MAX},
                                                      {false, false, false, false, false, false}};
@@ -1620,7 +1588,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareMin_Vector_Vector_SI64_SI32_SI8)
 {
   using TypeOut = int64_t;
   using TypeLhs = int32_t;
-  using TypeRhs = int8_t;
 
   auto int_col =
     fixed_width_column_wrapper<TypeLhs>{{999, -37, 0, INT32_MAX, -INT32_MAX, -4379, 55},
@@ -1643,7 +1610,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareMax_Vector_Vector_SI64_SI32_SI8)
 {
   using TypeOut = int64_t;
   using TypeLhs = int32_t;
-  using TypeRhs = int8_t;
 
   auto int_col = fixed_width_column_wrapper<TypeLhs>{
     {999, -37, 0, INT32_MAX, -INT32_MAX, -4379, 55}, {true, true, true, true, true, true, true}};
@@ -1697,7 +1663,6 @@ TEST_F(BinaryOperationIntegrationTest, NullAwareMax_Vector_Vector_SI32_SI64_SI8)
 {
   using TypeOut = int32_t;
   using TypeLhs = int64_t;
-  using TypeRhs = int8_t;
 
   auto int_col =
     fixed_width_column_wrapper<TypeLhs>{{999, -37, 0, INT32_MAX, -INT32_MAX, -4379, 55},
@@ -1862,8 +1827,6 @@ TEST_F(BinaryOperationIntegrationTest, PMod_Scalar_Vector_FP32)
   using TypeLhs = float;
   using TypeRhs = float;
 
-  using PMOD = cudf::library::operation::PMod<TypeOut, TypeLhs, TypeRhs>;
-
   auto lhs = cudf::scalar_type_t<TypeLhs>(-86099.68377);
   auto rhs = fixed_width_column_wrapper<TypeRhs>{{90770.74881, -15456.4335, 32213.22119}};
 
@@ -1881,8 +1844,6 @@ TEST_F(BinaryOperationIntegrationTest, PMod_Vector_Scalar_FP64)
   using TypeLhs = double;
   using TypeRhs = double;
 
-  using PMOD = cudf::library::operation::PMod<TypeOut, TypeLhs, TypeRhs>;
-
   auto lhs = fixed_width_column_wrapper<TypeLhs>{{90770.74881, -15456.4335, 32213.22119}};
   auto rhs = cudf::scalar_type_t<TypeRhs>(-86099.68377);
 
@@ -1899,8 +1860,6 @@ TEST_F(BinaryOperationIntegrationTest, PMod_Vector_Vector_FP64_FP32_FP64)
   using TypeOut = double;
   using TypeLhs = float;
   using TypeRhs = double;
-
-  using PMOD = cudf::library::operation::PMod<TypeOut, TypeLhs, TypeRhs>;
 
   auto lhs = fixed_width_column_wrapper<TypeLhs>{
     {24854.55893, 79946.87288, -86099.68377, -86099.68377, 1.0, 1.0, -1.0, -1.0}};

--- a/cpp/tests/copying/scatter_tests.cpp
+++ b/cpp/tests/copying/scatter_tests.cpp
@@ -168,8 +168,6 @@ TYPED_TEST(ScatterIndexTypeTests, ScatterScalarOutOfBounds)
 {
   using cudf::scalar_type_t;
   using cudf::test::fixed_width_column_wrapper;
-  using scalar_ptr    = std::unique_ptr<cudf::scalar>;
-  using scalar_vector = std::vector<scalar_ptr>;
 
   auto const source = scalar_type_t<TypeParam>(100, true);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
@@ -739,7 +737,7 @@ struct BooleanMaskScalarScatter : public cudf::test::BaseFixture {
     static_cast<ScalarType*>(scalar.get())->set_value(value);
     static_cast<ScalarType*>(scalar.get())->set_valid(validity);
 
-    return std::move(scalar);
+    return scalar;
   }
 };
 

--- a/cpp/tests/copying/slice_tests.cpp
+++ b/cpp/tests/copying/slice_tests.cpp
@@ -273,7 +273,7 @@ TEST_F(SliceCornerCases, EmptyColumn)
   auto type_match_count = std::count_if(result.cbegin(), result.cend(), [](auto const& col) {
     return col.type().id() == cudf::type_id::EMPTY;
   });
-  EXPECT_EQ(type_match_count, expected);
+  EXPECT_EQ(static_cast<size_t>(type_match_count), expected);
 }
 
 TEST_F(SliceCornerCases, EmptyIndices)

--- a/cpp/tests/copying/slice_tests.cpp
+++ b/cpp/tests/copying/slice_tests.cpp
@@ -273,7 +273,7 @@ TEST_F(SliceCornerCases, EmptyColumn)
   auto type_match_count = std::count_if(result.cbegin(), result.cend(), [](auto const& col) {
     return col.type().id() == cudf::type_id::EMPTY;
   });
-  EXPECT_EQ(static_cast<size_t>(type_match_count), expected);
+  EXPECT_EQ(static_cast<std::size_t>(type_match_count), expected);
 }
 
 TEST_F(SliceCornerCases, EmptyIndices)

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -114,7 +114,7 @@ std::vector<std::vector<bool>> create_expected_validity(std::vector<cudf::size_t
       std::vector<bool>(validity.begin() + indices[index], validity.begin() + indices[index + 1]));
   }
 
-  return std::move(result);
+  return result;
 }
 
 template <typename T>
@@ -147,7 +147,7 @@ std::vector<cudf::table> create_expected_string_tables_for_splits(
   auto ret_cols_1 = create_expected_string_columns(strings[1], indices, validity[1]);
 
   std::vector<cudf::table> ret_tables;
-  for (int i = 0; i < ret_cols_0.size(); ++i) {
+  for (size_t i = 0; i < ret_cols_0.size(); ++i) {
     std::vector<std::unique_ptr<cudf::column>> scols;
     scols.push_back(ret_cols_0[i].release());
     scols.push_back(ret_cols_1[i].release());
@@ -666,7 +666,7 @@ void split_null_input_strings_column_value(SplitFunc Split, CompareFunc Compare)
 
   auto expected = create_expected_string_tables_for_splits(strings, validity_masks, splits);
 
-  for (int i = 0; i < result.size(); ++i) { Compare(expected[i], result[i]); }
+  for (size_t i = 0; i < result.size(); ++i) { Compare(expected[i], result[i]); }
 }
 
 // split with strings
@@ -958,7 +958,7 @@ void split_nested_struct_of_list(SplitFunc Split, CompareFunc Compare)
   auto expected_struct_validity = create_expected_validity(splits, struct_validity);
   EXPECT_EQ(expected_names.size(), result.size());
 
-  for (int index = 0; index < result.size(); index++) {
+  for (size_t index = 0; index < result.size(); index++) {
     auto expected =
       structs_column_wrapper({expected_names[index], expected_ages[index], expected_lists[index]},
                              expected_struct_validity[index]);
@@ -1430,7 +1430,7 @@ TEST_F(ContiguousSplitNestedTypesTest, ListOfStruct)
   auto expected = cudf::split(static_cast<cudf::column_view>(*outer_list), splits);
   CUDF_EXPECTS(result.size() == expected.size(), "Split result size mismatch");
 
-  for (int index = 0; index < result.size(); index++) {
+  for (size_t index = 0; index < result.size(); index++) {
     cudf::test::expect_columns_equivalent(expected[index], result[index].table.column(0));
   }
 }

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -147,7 +147,7 @@ std::vector<cudf::table> create_expected_string_tables_for_splits(
   auto ret_cols_1 = create_expected_string_columns(strings[1], indices, validity[1]);
 
   std::vector<cudf::table> ret_tables;
-  for (size_t i = 0; i < ret_cols_0.size(); ++i) {
+  for (std::size_t i = 0; i < ret_cols_0.size(); ++i) {
     std::vector<std::unique_ptr<cudf::column>> scols;
     scols.push_back(ret_cols_0[i].release());
     scols.push_back(ret_cols_1[i].release());
@@ -666,7 +666,7 @@ void split_null_input_strings_column_value(SplitFunc Split, CompareFunc Compare)
 
   auto expected = create_expected_string_tables_for_splits(strings, validity_masks, splits);
 
-  for (size_t i = 0; i < result.size(); ++i) { Compare(expected[i], result[i]); }
+  for (std::size_t i = 0; i < result.size(); ++i) { Compare(expected[i], result[i]); }
 }
 
 // split with strings
@@ -958,7 +958,7 @@ void split_nested_struct_of_list(SplitFunc Split, CompareFunc Compare)
   auto expected_struct_validity = create_expected_validity(splits, struct_validity);
   EXPECT_EQ(expected_names.size(), result.size());
 
-  for (size_t index = 0; index < result.size(); index++) {
+  for (std::size_t index = 0; index < result.size(); index++) {
     auto expected =
       structs_column_wrapper({expected_names[index], expected_ages[index], expected_lists[index]},
                              expected_struct_validity[index]);
@@ -1430,7 +1430,7 @@ TEST_F(ContiguousSplitNestedTypesTest, ListOfStruct)
   auto expected = cudf::split(static_cast<cudf::column_view>(*outer_list), splits);
   CUDF_EXPECTS(result.size() == expected.size(), "Split result size mismatch");
 
-  for (size_t index = 0; index < result.size(); index++) {
+  for (std::size_t index = 0; index < result.size(); index++) {
     cudf::test::expect_columns_equivalent(expected[index], result[index].table.column(0));
   }
 }

--- a/cpp/tests/dictionary/search_test.cpp
+++ b/cpp/tests/dictionary/search_test.cpp
@@ -31,13 +31,13 @@ TEST_F(DictionarySearchTest, StringsColumn)
   auto result = cudf::dictionary::get_index(dictionary, cudf::string_scalar("ccc"));
   EXPECT_TRUE(result->is_valid());
   auto n_result = dynamic_cast<cudf::numeric_scalar<uint32_t>*>(result.get());
-  EXPECT_EQ(3, n_result->value());
+  EXPECT_EQ(uint32_t{3}, n_result->value());
 
   result = cudf::dictionary::get_index(dictionary, cudf::string_scalar("eee"));
   EXPECT_FALSE(result->is_valid());
   result   = cudf::dictionary::detail::get_insert_index(dictionary, cudf::string_scalar("eee"));
   n_result = dynamic_cast<cudf::numeric_scalar<uint32_t>*>(result.get());
-  EXPECT_EQ(5, n_result->value());
+  EXPECT_EQ(uint32_t{5}, n_result->value());
 }
 
 TEST_F(DictionarySearchTest, WithNulls)
@@ -47,13 +47,13 @@ TEST_F(DictionarySearchTest, WithNulls)
   auto result = cudf::dictionary::get_index(dictionary, cudf::numeric_scalar<int64_t>(4));
   EXPECT_TRUE(result->is_valid());
   auto n_result = dynamic_cast<cudf::numeric_scalar<uint32_t>*>(result.get());
-  EXPECT_EQ(0, n_result->value());
+  EXPECT_EQ(uint32_t{0}, n_result->value());
 
   result = cudf::dictionary::get_index(dictionary, cudf::numeric_scalar<int64_t>(5));
   EXPECT_FALSE(result->is_valid());
   result = cudf::dictionary::detail::get_insert_index(dictionary, cudf::numeric_scalar<int64_t>(5));
   n_result = dynamic_cast<cudf::numeric_scalar<uint32_t>*>(result.get());
-  EXPECT_EQ(1, n_result->value());
+  EXPECT_EQ(uint32_t{1}, n_result->value());
 }
 
 TEST_F(DictionarySearchTest, EmptyColumn)

--- a/cpp/tests/groupby/group_nth_element_test.cpp
+++ b/cpp/tests/groupby/group_nth_element_test.cpp
@@ -300,8 +300,6 @@ struct groupby_nth_element_string_test : public cudf::test::BaseFixture {
 TEST_F(groupby_nth_element_string_test, basic_string)
 {
   using K = int32_t;
-  using V = std::string;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
 
   fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   strings_column_wrapper vals{"ABCD", "1", "2", "3", "4", "5", "6", "7", "8", "9"};

--- a/cpp/tests/grouped_rolling/grouped_rolling_test.cpp
+++ b/cpp/tests/grouped_rolling/grouped_rolling_test.cpp
@@ -304,7 +304,6 @@ class GroupedRollingTest : public cudf::test::BaseFixture {
     // input data and mask
 
     std::vector<bitmask_type> in_valid = cudf::test::bitmask_to_host(input);
-    bitmask_type* valid_mask           = in_valid.data();
 
     for (size_type i = 0; i < num_rows; i++) {
       // load sizes
@@ -890,7 +889,6 @@ class GroupedTimeRangeRollingTest : public cudf::test::BaseFixture {
     // input data and mask
 
     std::vector<bitmask_type> in_valid = cudf::test::bitmask_to_host(input);
-    bitmask_type* valid_mask           = in_valid.data();
 
     for (size_type i = 0; i < num_rows; i++) {
       // load sizes

--- a/cpp/tests/interop/dlpack_test.cpp
+++ b/cpp/tests/interop/dlpack_test.cpp
@@ -244,7 +244,7 @@ TYPED_TEST(DLPackNumericTests, ToDlpack1D)
   validate_dtype<TypeParam>(tensor.dtype);
   EXPECT_EQ(kDLGPU, tensor.ctx.device_type);
   EXPECT_EQ(1, tensor.ndim);
-  EXPECT_EQ(0, tensor.byte_offset);
+  EXPECT_EQ(uint64_t{0}, tensor.byte_offset);
   EXPECT_EQ(nullptr, tensor.strides);
 
   EXPECT_NE(nullptr, tensor.data);
@@ -277,7 +277,7 @@ TYPED_TEST(DLPackNumericTests, ToDlpack2D)
   validate_dtype<TypeParam>(tensor.dtype);
   EXPECT_EQ(kDLGPU, tensor.ctx.device_type);
   EXPECT_EQ(2, tensor.ndim);
-  EXPECT_EQ(0, tensor.byte_offset);
+  EXPECT_EQ(uint64_t{0}, tensor.byte_offset);
 
   EXPECT_NE(nullptr, tensor.data);
   EXPECT_NE(nullptr, tensor.shape);

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -2021,7 +2021,7 @@ TEST_F(ParquetReaderTest, DecimalRead)
       -9694494, -5343299, 3558393,  -8789072, 2697890,  -4454707, 8299309,  -6223703, -3112513,
       7537487,  825776,   -495683,  328299,   -4529727, 0,        -9999999, 9999999};
 
-    EXPECT_EQ(static_cast<size_t>(result.tbl->view().column(0).size()),
+    EXPECT_EQ(static_cast<std::size_t>(result.tbl->view().column(0).size()),
               sizeof(col0_data) / sizeof(col0_data[0]));
     cudf::test::fixed_point_column_wrapper<int32_t> col0(
       std::begin(col0_data), std::end(col0_data), validity, numeric::scale_type{-4});
@@ -2046,7 +2046,7 @@ TEST_F(ParquetReaderTest, DecimalRead)
                            45844829680593,  71401416837149,  0,
                            -99999999999999, 99999999999999};
 
-    EXPECT_EQ(static_cast<size_t>(result.tbl->view().column(1).size()),
+    EXPECT_EQ(static_cast<std::size_t>(result.tbl->view().column(1).size()),
               sizeof(col1_data) / sizeof(col1_data[0]));
     cudf::test::fixed_point_column_wrapper<int64_t> col1(
       std::begin(col1_data), std::end(col1_data), validity, numeric::scale_type{-5});
@@ -2162,7 +2162,7 @@ TEST_F(ParquetReaderTest, DecimalRead)
                            9913714, 901749,  7776938, 3186566, 4955569, 5131067, 98619,
                            2282579, 7521455, 4430706, 1937859, 4532040, 0};
 
-    EXPECT_EQ(static_cast<size_t>(result.tbl->view().column(0).size()),
+    EXPECT_EQ(static_cast<std::size_t>(result.tbl->view().column(0).size()),
               sizeof(col0_data) / sizeof(col0_data[0]));
     cudf::test::fixed_point_column_wrapper<int64_t> col0(
       std::begin(col0_data), std::end(col0_data), validity_c0, numeric::scale_type{-3});
@@ -2191,7 +2191,7 @@ TEST_F(ParquetReaderTest, DecimalRead)
                            0,
                            363993164092};
 
-    EXPECT_EQ(static_cast<size_t>(result.tbl->view().column(1).size()),
+    EXPECT_EQ(static_cast<std::size_t>(result.tbl->view().column(1).size()),
               sizeof(col1_data) / sizeof(col1_data[0]));
     cudf::test::fixed_point_column_wrapper<int64_t> col1(
       std::begin(col1_data), std::end(col1_data), validity_c1, numeric::scale_type{-11});

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -1489,7 +1489,7 @@ class custom_test_memmap_sink : public cudf::io::data_sink {
 
   bool supports_device_write() const override { return supports_device_writes; }
 
-  void device_write(void const* gpu_data, size_t size, rmm::cuda_stream_view stream)
+  void device_write(void const* gpu_data, size_t size, rmm::cuda_stream_view stream) override
   {
     char* ptr = nullptr;
     CUDA_TRY(cudaMallocHost(&ptr, size));
@@ -2021,7 +2021,8 @@ TEST_F(ParquetReaderTest, DecimalRead)
       -9694494, -5343299, 3558393,  -8789072, 2697890,  -4454707, 8299309,  -6223703, -3112513,
       7537487,  825776,   -495683,  328299,   -4529727, 0,        -9999999, 9999999};
 
-    EXPECT_EQ(result.tbl->view().column(0).size(), sizeof(col0_data) / sizeof(col0_data[0]));
+    EXPECT_EQ(static_cast<size_t>(result.tbl->view().column(0).size()),
+              sizeof(col0_data) / sizeof(col0_data[0]));
     cudf::test::fixed_point_column_wrapper<int32_t> col0(
       std::begin(col0_data), std::end(col0_data), validity, numeric::scale_type{-4});
     cudf::test::expect_columns_equal(result.tbl->view().column(0), col0);
@@ -2045,7 +2046,8 @@ TEST_F(ParquetReaderTest, DecimalRead)
                            45844829680593,  71401416837149,  0,
                            -99999999999999, 99999999999999};
 
-    EXPECT_EQ(result.tbl->view().column(1).size(), sizeof(col1_data) / sizeof(col1_data[0]));
+    EXPECT_EQ(static_cast<size_t>(result.tbl->view().column(1).size()),
+              sizeof(col1_data) / sizeof(col1_data[0]));
     cudf::test::fixed_point_column_wrapper<int64_t> col1(
       std::begin(col1_data), std::end(col1_data), validity, numeric::scale_type{-5});
     cudf::test::expect_columns_equal(result.tbl->view().column(1), col1);
@@ -2160,7 +2162,8 @@ TEST_F(ParquetReaderTest, DecimalRead)
                            9913714, 901749,  7776938, 3186566, 4955569, 5131067, 98619,
                            2282579, 7521455, 4430706, 1937859, 4532040, 0};
 
-    EXPECT_EQ(result.tbl->view().column(0).size(), sizeof(col0_data) / sizeof(col0_data[0]));
+    EXPECT_EQ(static_cast<size_t>(result.tbl->view().column(0).size()),
+              sizeof(col0_data) / sizeof(col0_data[0]));
     cudf::test::fixed_point_column_wrapper<int64_t> col0(
       std::begin(col0_data), std::end(col0_data), validity_c0, numeric::scale_type{-3});
     cudf::test::expect_columns_equal(result.tbl->view().column(0), col0);
@@ -2188,7 +2191,8 @@ TEST_F(ParquetReaderTest, DecimalRead)
                            0,
                            363993164092};
 
-    EXPECT_EQ(result.tbl->view().column(1).size(), sizeof(col1_data) / sizeof(col1_data[0]));
+    EXPECT_EQ(static_cast<size_t>(result.tbl->view().column(1).size()),
+              sizeof(col1_data) / sizeof(col1_data[0]));
     cudf::test::fixed_point_column_wrapper<int64_t> col1(
       std::begin(col1_data), std::end(col1_data), validity_c1, numeric::scale_type{-11});
     cudf::test::expect_columns_equal(result.tbl->view().column(1), col1);

--- a/cpp/tests/jit/jit-cache-multiprocess-test.cpp
+++ b/cpp/tests/jit/jit-cache-multiprocess-test.cpp
@@ -82,7 +82,7 @@ TEST_F(JitCacheMultiProcessTest, MultiProcessTest)
   CUDA_TRY(cudaMallocManaged(&input, sizeof(input)));
   CUDA_TRY(cudaMallocManaged(&output, sizeof(output) * num_tests * 2));
 
-  for (size_t i = 0; i < num_tests; i++) {
+  for (int i = 0; i < num_tests; i++) {
     if (cpid > 0)
       usleep(10000);
     else

--- a/cpp/tests/lead_lag/lead_lag_test.cpp
+++ b/cpp/tests/lead_lag/lead_lag_test.cpp
@@ -59,7 +59,7 @@ TYPED_TEST(TypedLeadLagWindowTest, LeadLagBasics)
 
   auto const input_col =
     fixed_width_column_wrapper<T>{0, 1, 2, 3, 4, 5, 0, 10, 20, 30, 40, 50}.release();
-  auto const input_size   = input_col->size();
+
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 
@@ -103,7 +103,7 @@ TYPED_TEST(TypedLeadLagWindowTest, LeadLagWithNulls)
   auto const input_col = fixed_width_column_wrapper<T>{{0, 1, 2, 3, 4, 5, 0, 10, 20, 30, 40, 50},
                                                        {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}}
                            .release();
-  auto const input_size   = input_col->size();
+
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 
@@ -147,7 +147,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithDefaults)
   auto const input_col = fixed_width_column_wrapper<T>{{0, 1, 2, 3, 4, 5, 0, 10, 20, 30, 40, 50},
                                                        {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}}
                            .release();
-  auto const input_size   = input_col->size();
+
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 
@@ -196,7 +196,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithDefaultsContainingNulls)
   auto const input_col = fixed_width_column_wrapper<T>{{0, 1, 2, 3, 4, 5, 0, 10, 20, 30, 40, 50},
                                                        {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}}
                            .release();
-  auto const input_size   = input_col->size();
+
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 
@@ -246,7 +246,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithOutOfRangeOffsets)
   auto const input_col = fixed_width_column_wrapper<T>{{0, 1, 2, 3, 4, 5, 0, 10, 20, 30, 40, 50},
                                                        {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}}
                            .release();
-  auto const input_size   = input_col->size();
+
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 
@@ -295,7 +295,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithZeroOffsets)
   auto const input_col = fixed_width_column_wrapper<T>{{0, 1, 2, 3, 4, 5, 0, 10, 20, 30, 40, 50},
                                                        {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}}
                            .release();
-  auto const input_size   = input_col->size();
+
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 
@@ -330,7 +330,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithNegativeOffsets)
   auto const input_col = fixed_width_column_wrapper<T>{{0, 1, 2, 3, 4, 5, 0, 10, 20, 30, 40, 50},
                                                        {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}}
                            .release();
-  auto const input_size   = input_col->size();
+
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 
@@ -381,7 +381,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithNoGrouping)
 
   auto const input_col =
     fixed_width_column_wrapper<T>{{0, 1, 2, 3, 4, 5}, {1, 1, 0, 1, 1, 1}}.release();
-  auto const input_size    = input_col->size();
+
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{}};
 
   auto const default_value =
@@ -426,7 +426,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithAllNullInput)
     {0, 1, 2, 3, 4, 5, 0, 10, 20, 30, 40, 50}, make_counting_transform_iterator(0, [](auto i) {
       return false;
     })}.release();
-  auto const input_size   = input_col->size();
+
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 
@@ -479,7 +479,7 @@ TYPED_TEST(TypedLeadLagWindowTest, DefaultValuesWithoutLeadLag)
     {0, 1, 2, 3, 4, 5}, make_counting_transform_iterator(0, [](auto i) {
       return true;
     })}.release();
-  auto const input_size    = input_col->size();
+
   auto const grouping_key  = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 
@@ -515,7 +515,7 @@ TEST_F(LeadLagWindowTest, LeadLagWithoutFixedWidthInput)
     {"0", "1", "2", "3", "4", "5"}, make_counting_transform_iterator(0, [](auto i) {
       return false;
     })}.release();
-  auto const input_size    = input_col->size();
+
   auto const grouping_key  = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0};
   auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{grouping_key}};
 

--- a/cpp/tests/merge/merge_string_test.cpp
+++ b/cpp/tests/merge/merge_string_test.cpp
@@ -264,8 +264,6 @@ TYPED_TEST(MergeStringTest, Merge1StringKeyNullColumns)
   cudf::column_view const& a_left_tbl_cview{static_cast<cudf::column_view const&>(leftColWrap1)};
   cudf::column_view const& a_right_tbl_cview{static_cast<cudf::column_view const&>(rightColWrap1)};
   const cudf::size_type outputRows = a_left_tbl_cview.size() + a_right_tbl_cview.size();
-  const cudf::size_type column1TotalNulls =
-    a_left_tbl_cview.null_count() + a_right_tbl_cview.null_count();
 
   // data: "ab", "ac", "bc", "bd", "cd", "ce", "de", "df" | valid: 1 1 1 1 1 1 0 0
   strings_column_wrapper expectedDataWrap1({"ab",

--- a/cpp/tests/partitioning/hash_partition_test.cpp
+++ b/cpp/tests/partitioning/hash_partition_test.cpp
@@ -70,7 +70,7 @@ TEST_F(HashPartition, ZeroPartitions)
   // Expect empty table with same number of columns and zero partitions
   EXPECT_EQ(input.num_columns(), output->num_columns());
   EXPECT_EQ(0, output->num_rows());
-  EXPECT_EQ(size_t{0}, offsets.size());
+  EXPECT_EQ(std::size_t{0}, offsets.size());
 }
 
 TEST_F(HashPartition, ZeroRows)
@@ -90,7 +90,7 @@ TEST_F(HashPartition, ZeroRows)
   // Expect empty table with same number of columns and zero partitions
   EXPECT_EQ(input.num_columns(), output->num_columns());
   EXPECT_EQ(0, output->num_rows());
-  EXPECT_EQ(size_t{0}, offsets.size());
+  EXPECT_EQ(std::size_t{0}, offsets.size());
 }
 
 TEST_F(HashPartition, ZeroColumns)
@@ -107,7 +107,7 @@ TEST_F(HashPartition, ZeroColumns)
   // Expect empty table with same number of columns and zero partitions
   EXPECT_EQ(input.num_columns(), output->num_columns());
   EXPECT_EQ(0, output->num_rows());
-  EXPECT_EQ(size_t{0}, offsets.size());
+  EXPECT_EQ(std::size_t{0}, offsets.size());
 }
 
 TEST_F(HashPartition, MixedColumnTypes)

--- a/cpp/tests/partitioning/hash_partition_test.cpp
+++ b/cpp/tests/partitioning/hash_partition_test.cpp
@@ -70,7 +70,7 @@ TEST_F(HashPartition, ZeroPartitions)
   // Expect empty table with same number of columns and zero partitions
   EXPECT_EQ(input.num_columns(), output->num_columns());
   EXPECT_EQ(0, output->num_rows());
-  EXPECT_EQ(0, offsets.size());
+  EXPECT_EQ(size_t{0}, offsets.size());
 }
 
 TEST_F(HashPartition, ZeroRows)
@@ -90,7 +90,7 @@ TEST_F(HashPartition, ZeroRows)
   // Expect empty table with same number of columns and zero partitions
   EXPECT_EQ(input.num_columns(), output->num_columns());
   EXPECT_EQ(0, output->num_rows());
-  EXPECT_EQ(0, offsets.size());
+  EXPECT_EQ(size_t{0}, offsets.size());
 }
 
 TEST_F(HashPartition, ZeroColumns)
@@ -107,7 +107,7 @@ TEST_F(HashPartition, ZeroColumns)
   // Expect empty table with same number of columns and zero partitions
   EXPECT_EQ(input.num_columns(), output->num_columns());
   EXPECT_EQ(0, output->num_rows());
-  EXPECT_EQ(0, offsets.size());
+  EXPECT_EQ(size_t{0}, offsets.size());
 }
 
 TEST_F(HashPartition, MixedColumnTypes)

--- a/cpp/tests/partitioning/round_robin_test.cpp
+++ b/cpp/tests/partitioning/round_robin_test.cpp
@@ -101,7 +101,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions13_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 5, 9};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -139,7 +139,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions13_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 4, 9};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -177,7 +177,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions13_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 4, 8};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -236,7 +236,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions11_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 4, 8};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -273,7 +273,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions11_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 3, 7};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -310,7 +310,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions11_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 4, 7};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -370,7 +370,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinDegeneratePartitions11_15)
 
     std::vector<cudf::size_type> expected_partition_offsets{
       0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 11};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -408,7 +408,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinDegeneratePartitions11_15)
 
     std::vector<cudf::size_type> expected_partition_offsets{
       0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 7, 8, 9, 10};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -446,7 +446,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinDegeneratePartitions11_15)
 
     std::vector<cudf::size_type> expected_partition_offsets{
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 10};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -505,7 +505,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinDegeneratePartitions11_11)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -583,7 +583,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinNPartitionsDivideNRows)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 7, 14};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -630,7 +630,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinNPartitionsDivideNRows)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 7, 14};
-    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -687,7 +687,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinSinglePartition)
   }
 
   std::vector<cudf::size_type> expected_partition_offsets{0};
-  EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
+  EXPECT_EQ(static_cast<std::size_t>(num_partitions), expected_partition_offsets.size());
   EXPECT_EQ(expected_partition_offsets, result.second);
 }
 

--- a/cpp/tests/partitioning/round_robin_test.cpp
+++ b/cpp/tests/partitioning/round_robin_test.cpp
@@ -101,7 +101,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions13_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 5, 9};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -139,7 +139,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions13_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 4, 9};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -177,7 +177,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions13_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 4, 8};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -236,7 +236,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions11_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 4, 8};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -273,7 +273,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions11_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 3, 7};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -310,7 +310,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinPartitions11_3)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 4, 7};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -370,7 +370,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinDegeneratePartitions11_15)
 
     std::vector<cudf::size_type> expected_partition_offsets{
       0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 11};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -408,7 +408,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinDegeneratePartitions11_15)
 
     std::vector<cudf::size_type> expected_partition_offsets{
       0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 7, 8, 9, 10};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -446,7 +446,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinDegeneratePartitions11_15)
 
     std::vector<cudf::size_type> expected_partition_offsets{
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 10};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -505,7 +505,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinDegeneratePartitions11_11)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -583,7 +583,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinNPartitionsDivideNRows)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 7, 14};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -630,7 +630,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinNPartitionsDivideNRows)
     }
 
     std::vector<cudf::size_type> expected_partition_offsets{0, 7, 14};
-    EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+    EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
 
     EXPECT_EQ(expected_partition_offsets, result.second);
   }
@@ -687,7 +687,7 @@ TYPED_TEST(RoundRobinTest, RoundRobinSinglePartition)
   }
 
   std::vector<cudf::size_type> expected_partition_offsets{0};
-  EXPECT_EQ(num_partitions, expected_partition_offsets.size());
+  EXPECT_EQ(static_cast<size_t>(num_partitions), expected_partition_offsets.size());
   EXPECT_EQ(expected_partition_offsets, result.second);
 }
 

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -155,8 +155,6 @@ TYPED_TEST(MinMaxReductionTest, MinMax)
 
   // test with some nulls
   cudf::test::fixed_width_column_wrapper<T> col_nulls = construct_null_column(v, host_bools);
-  cudf::size_type valid_count =
-    cudf::column_view(col_nulls).size() - cudf::column_view(col_nulls).null_count();
 
   auto r_min = replace_nulls(v, host_bools, std::numeric_limits<T>::max());
   auto r_max = replace_nulls(v, host_bools, std::numeric_limits<T>::lowest());
@@ -177,9 +175,8 @@ TYPED_TEST(MinMaxReductionTest, MinMax)
   EXPECT_EQ(min_null_result->value(), expected_min_null_result);
   EXPECT_EQ(max_null_result->value(), expected_max_null_result);
 
-  // test with some nulls
+  // test with all null
   cudf::test::fixed_width_column_wrapper<T> col_all_nulls = construct_null_column(v, all_null);
-  cudf::size_type all_null_valid_count                    = 0;
 
   auto all_null_r_min = replace_nulls(v, all_null, std::numeric_limits<T>::max());
   auto all_null_r_max = replace_nulls(v, all_null, std::numeric_limits<T>::lowest());
@@ -231,10 +228,8 @@ TYPED_TEST(SumReductionTest, Sum)
 
   // test with nulls
   cudf::test::fixed_width_column_wrapper<T> col_nulls = construct_null_column(v, host_bools);
-  cudf::size_type valid_count =
-    cudf::column_view(col_nulls).size() - cudf::column_view(col_nulls).null_count();
-  auto r                = replace_nulls(v, host_bools, T{0});
-  T expected_null_value = std::accumulate(r.begin(), r.end(), T{0});
+  auto r                                              = replace_nulls(v, host_bools, T{0});
+  T expected_null_value                               = std::accumulate(r.begin(), r.end(), T{0});
 
   this->reduction_test(
     col_nulls, expected_null_value, this->ret_non_arithmetic, cudf::make_sum_aggregation());
@@ -264,10 +259,8 @@ TYPED_TEST(ReductionTest, Product)
 
   // test with nulls
   cudf::test::fixed_width_column_wrapper<T> col_nulls = construct_null_column(v, host_bools);
-  cudf::size_type valid_count =
-    cudf::column_view(col_nulls).size() - cudf::column_view(col_nulls).null_count();
-  auto r                        = replace_nulls(v, host_bools, T{1});
-  TypeParam expected_null_value = calc_prod(r);
+  auto r                                              = replace_nulls(v, host_bools, T{1});
+  TypeParam expected_null_value                       = calc_prod(r);
 
   this->reduction_test(
     col_nulls, expected_null_value, this->ret_non_arithmetic, cudf::make_product_aggregation());
@@ -294,10 +287,8 @@ TYPED_TEST(ReductionTest, SumOfSquare)
 
   // test with nulls
   cudf::test::fixed_width_column_wrapper<T> col_nulls = construct_null_column(v, host_bools);
-  cudf::size_type valid_count =
-    cudf::column_view(col_nulls).size() - cudf::column_view(col_nulls).null_count();
-  auto r                = replace_nulls(v, host_bools, T{0});
-  T expected_null_value = calc_reduction(r);
+  auto r                                              = replace_nulls(v, host_bools, T{0});
+  T expected_null_value                               = calc_reduction(r);
 
   this->reduction_test(col_nulls,
                        expected_null_value,
@@ -1751,7 +1742,7 @@ TYPED_TEST(DictionaryReductionTest, NthElement)
   // test with nulls
   std::vector<bool> validity({1, 1, 0, 1, 1, 1, 0, 1});
   cudf::test::dictionary_column_wrapper<T> col_nulls(v.begin(), v.end(), validity.begin());
-  cudf::size_type valid_count = std::count(validity.begin(), validity.end(), true);
+
   this->reduction_test(col_nulls,
                        v[n],  // expected_value,
                        true,

--- a/cpp/tests/reshape/tile_tests.cpp
+++ b/cpp/tests/reshape/tile_tests.cpp
@@ -34,8 +34,6 @@ TYPED_TEST_CASE(TileTest, cudf::test::AllTypes);
 
 TYPED_TEST(TileTest, NoColumns)
 {
-  using T = TypeParam;
-
   cudf::table_view in(std::vector<cudf::column_view>{});
 
   auto expected = in;

--- a/cpp/tests/sort/is_sorted_tests.cpp
+++ b/cpp/tests/sort/is_sorted_tests.cpp
@@ -176,8 +176,6 @@ TYPED_TEST_CASE(IsSortedTest, ComparableTypes);
 
 TYPED_TEST(IsSortedTest, NoColumns)
 {
-  using T = TypeParam;
-
   cudf::table_view in{std::vector<cudf::table_view>{}};
   std::vector<cudf::order> order{};
   std::vector<cudf::null_order> null_precedence{};

--- a/cpp/tests/strings/extract_tests.cpp
+++ b/cpp/tests/strings/extract_tests.cpp
@@ -140,7 +140,7 @@ TEST_F(StringsExtractTests, ExtractEventTest)
                                       "user@test.com",
                                       "Test Message Description"});
 
-  for (auto idx = 0; idx < patterns.size(); ++idx) {
+  for (size_t idx = 0; idx < patterns.size(); ++idx) {
     auto results = cudf::strings::extract(strings_view, patterns[idx]);
     cudf::test::strings_column_wrapper expected({expecteds[idx]});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view().column(0), expected);

--- a/cpp/tests/strings/extract_tests.cpp
+++ b/cpp/tests/strings/extract_tests.cpp
@@ -140,7 +140,7 @@ TEST_F(StringsExtractTests, ExtractEventTest)
                                       "user@test.com",
                                       "Test Message Description"});
 
-  for (size_t idx = 0; idx < patterns.size(); ++idx) {
+  for (std::size_t idx = 0; idx < patterns.size(); ++idx) {
     auto results = cudf::strings::extract(strings_view, patterns[idx]);
     cudf::test::strings_column_wrapper expected({expecteds[idx]});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view().column(0), expected);

--- a/cpp/tests/text/subword_tests.cpp
+++ b/cpp/tests/text/subword_tests.cpp
@@ -83,7 +83,7 @@ TEST(TextSubwordTest, Tokenize)
     std::vector<uint32_t> base_data(
       {2023, 2003, 1037, 3231, 1012, 1037, 3231, 2023, 2003, 1012, 0, 0, 0, 0, 0, 0});
     std::vector<uint32_t> h_expected;
-    for (auto idx = 0; idx < nrows; ++idx)
+    for (uint32_t idx = 0; idx < nrows; ++idx)
       h_expected.insert(h_expected.end(), base_data.begin(), base_data.end());
     cudf::test::fixed_width_column_wrapper<uint32_t> expected(h_expected.begin(), h_expected.end());
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tensor_token_ids->view(), expected);
@@ -92,7 +92,7 @@ TEST(TextSubwordTest, Tokenize)
   {
     std::vector<uint32_t> base_data({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0});
     std::vector<uint32_t> h_expected;
-    for (auto idx = 0; idx < nrows; ++idx)
+    for (uint32_t idx = 0; idx < nrows; ++idx)
       h_expected.insert(h_expected.end(), base_data.begin(), base_data.end());
     cudf::test::fixed_width_column_wrapper<uint32_t> expected(h_expected.begin(), h_expected.end());
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tensor_attention_mask->view(), expected);
@@ -100,7 +100,7 @@ TEST(TextSubwordTest, Tokenize)
 
   {
     std::vector<uint32_t> h_expected;
-    for (auto idx = 0; idx < nrows; ++idx) {
+    for (uint32_t idx = 0; idx < nrows; ++idx) {
       // 0,0,9,1,0,9,2,0,9,3,0,9,4,0,9,5,0,9,6,0,9,7,0,9,8,0,9,9,0,9,...
       h_expected.push_back(idx);
       h_expected.push_back(0);
@@ -129,7 +129,7 @@ TEST(TextSubwordTest, TokenizeMultiRow)
                                          false,  // do_truncate
                                          MAX_ROWS_TENSOR);
 
-  EXPECT_EQ(3, result.nrows_tensor);
+  EXPECT_EQ(uint32_t{3}, result.nrows_tensor);
   cudf::test::fixed_width_column_wrapper<uint32_t> expected_tokens(
     {2023, 2003, 1037, 3231, 1012, 0,    0,    0,    2023, 2003, 1037, 3231,
      1012, 2023, 2003, 1037, 2003, 1037, 3231, 1012, 0,    0,    0,    0});
@@ -158,7 +158,7 @@ TEST(TextSubwordTest, TokenizeMaxEqualsTokens)
                                          false,  // do_truncate
                                          MAX_ROWS_TENSOR);
 
-  EXPECT_EQ(1, result.nrows_tensor);
+  EXPECT_EQ(uint32_t{1}, result.nrows_tensor);
   cudf::test::fixed_width_column_wrapper<uint32_t> expected_tokens({2023, 2003, 1037, 3231, 1012});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tensor_token_ids->view(), expected_tokens);
   cudf::test::fixed_width_column_wrapper<uint32_t> expected_attn({1, 1, 1, 1, 1});
@@ -204,7 +204,7 @@ TEST(TextSubwordTest, EmptyStrings)
                                          true,   // do_lower_case
                                          false,  // do_truncate
                                          MAX_ROWS_TENSOR);
-  EXPECT_EQ(0, result.nrows_tensor);
+  EXPECT_EQ(uint32_t{0}, result.nrows_tensor);
   EXPECT_EQ(0, result.tensor_token_ids->size());
   EXPECT_EQ(0, result.tensor_attention_mask->size());
   EXPECT_EQ(0, result.tensor_metadata->size());
@@ -222,7 +222,7 @@ TEST(TextSubwordTest, AllNullStrings)
                                          true,   // do_lower_case
                                          false,  // do_truncate
                                          MAX_ROWS_TENSOR);
-  EXPECT_EQ(0, result.nrows_tensor);
+  EXPECT_EQ(uint32_t{0}, result.nrows_tensor);
   EXPECT_EQ(0, result.tensor_token_ids->size());
   EXPECT_EQ(0, result.tensor_attention_mask->size());
   EXPECT_EQ(0, result.tensor_metadata->size());
@@ -244,7 +244,7 @@ TEST(TextSubwordTest, TokenizeFromVocabStruct)
                                          true,  // do_truncate
                                          MAX_ROWS_TENSOR);
 
-  EXPECT_EQ(2, result.nrows_tensor);
+  EXPECT_EQ(uint32_t{2}, result.nrows_tensor);
   cudf::test::fixed_width_column_wrapper<uint32_t> expected_tokens(
     {2023, 2003, 1037, 3231, 1012, 0, 0, 0, 2023, 2003, 1037, 3231, 1012, 2023, 2003, 1037});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tensor_token_ids->view(), expected_tokens);

--- a/cpp/tests/unary/unary_ops_test.cpp
+++ b/cpp/tests/unary/unary_ops_test.cpp
@@ -203,8 +203,6 @@ TYPED_TEST(IsNAN, EmptyColumn)
 
 TYPED_TEST(IsNAN, NonFloatingColumn)
 {
-  using T = TypeParam;
-
   cudf::test::fixed_width_column_wrapper<int32_t> col{{1, 2, 5, 3, 5, 6, 7}, {1, 0, 1, 1, 0, 1, 1}};
 
   EXPECT_THROW(std::unique_ptr<cudf::column> got = cudf::is_nan(col), cudf::logic_error);
@@ -258,8 +256,6 @@ TYPED_TEST(IsNotNAN, EmptyColumn)
 
 TYPED_TEST(IsNotNAN, NonFloatingColumn)
 {
-  using T = TypeParam;
-
   cudf::test::fixed_width_column_wrapper<int64_t> col{{1, 2, 5, 3, 5, 6, 7}, {1, 0, 1, 1, 0, 1, 1}};
 
   EXPECT_THROW(std::unique_ptr<cudf::column> got = cudf::is_not_nan(col), cudf::logic_error);

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -167,7 +167,7 @@ TEST_F(ColumnUtilitiesStringsTest, StringsToHost)
   auto host_data  = cudf::test::to_host<std::string>(strings);
   auto result_itr = host_data.first.begin();
   for (auto itr = h_strings.begin(); itr != h_strings.end(); ++itr, ++result_itr) {
-    if (*itr) EXPECT_TRUE((*result_itr) == (*itr));
+    if (*itr) { EXPECT_TRUE((*result_itr) == (*itr)); }
   }
 }
 
@@ -180,7 +180,7 @@ TEST_F(ColumnUtilitiesStringsTest, StringsToHostAllNulls)
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
   auto host_data = cudf::test::to_host<std::string>(strings);
   auto results   = host_data.first;
-  EXPECT_EQ(3, host_data.first.size());
+  EXPECT_EQ(size_t{3}, host_data.first.size());
   EXPECT_TRUE(std::all_of(results.begin(), results.end(), [](auto s) { return s.empty(); }));
 }
 

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -180,7 +180,7 @@ TEST_F(ColumnUtilitiesStringsTest, StringsToHostAllNulls)
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
   auto host_data = cudf::test::to_host<std::string>(strings);
   auto results   = host_data.first;
-  EXPECT_EQ(size_t{3}, host_data.first.size());
+  EXPECT_EQ(std::size_t{3}, host_data.first.size());
   EXPECT_TRUE(std::all_of(results.begin(), results.end(), [](auto s) { return s.empty(); }));
 }
 

--- a/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
+++ b/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
@@ -1303,9 +1303,6 @@ TEST_F(ListColumnWrapperTest, ListOfListOfBools)
 {
   using namespace cudf;
 
-  using T = int;
-  using L = test::lists_column_wrapper<T>;
-
   // List<List<bool>> 3 rows
   //
   // List<List<bool>>:
@@ -1360,7 +1357,7 @@ TEST_F(ListColumnWrapperTest, MismatchedHierarchies)
   // trying to build a column out of a List<List<int>> column, and a List<int> column
   // is not valid if the leaf lists are not empty.
   {
-    auto expect_failure = []() { test::lists_column_wrapper<T> list{{{1, 2, 3}}, {4, 5}}; };
+    auto expect_failure = []() { LCW list{{{1, 2, 3}}, {4, 5}}; };
     EXPECT_THROW(expect_failure(), cudf::logic_error);
   }
 }


### PR DESCRIPTION
I discovered we're not building libcudf the `-Wall` GCC flag. This PR enables `-Wall` for GCC and nvcc, and fixes most of the errors.

~~The only error I haven't fixed yet is `-Werror=uninitialized` on this line [this line](https://github.com/rapidsai/cudf/blob/branch-0.18/cpp/include/cudf/scalar/scalar.hpp#L334), but @codereport is on it.~~ Fixed :heavy_check_mark: 

