### PR TITLE
Add `scale` and `value` methods to `fixed_point`

### DIFF
--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -276,9 +276,9 @@ class fixed_point {
   }
 
   /**
-   * @brief Method that returns the underlying value stored of the `fixed_point` number
+   * @brief Method that returns the underlying value of the `fixed_point` number
    *
-   * @return rep The underlying value stored of the `fixed_point` number
+   * @return The underlying value of the `fixed_point` number
    */
   CUDA_HOST_DEVICE_CALLABLE rep value() const { return _value; }
 

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -276,6 +276,20 @@ class fixed_point {
   }
 
   /**
+   * @brief Method that returns the underlying value stored of the `fixed_point` number
+   *
+   * @return rep The underlying value stored of the `fixed_point` number
+   */
+  CUDA_HOST_DEVICE_CALLABLE rep value() const { return _value; }
+
+  /**
+   * @brief Method that returns the scale of the `fixed_point` number
+   *
+   * @return scale_type The scale of the `fixed_point` number
+   */
+  CUDA_HOST_DEVICE_CALLABLE scale_type scale() const { return _scale; }
+
+  /**
    * @brief Explicit conversion operator to `bool`
    *
    * @return The `fixed_point` value as a boolean (zero is `false`, nonzero is `true`)

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -285,7 +285,7 @@ class fixed_point {
   /**
    * @brief Method that returns the scale of the `fixed_point` number
    *
-   * @return scale_type The scale of the `fixed_point` number
+   * @return The scale of the `fixed_point` number
    */
   CUDA_HOST_DEVICE_CALLABLE scale_type scale() const { return _scale; }
 

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -330,8 +330,7 @@ class fixed_point_scalar : public scalar {
                      bool is_valid                       = true,
                      rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
-    : scalar{data_type{type_to_id<T>(), _type.scale()}, is_valid, stream, mr},
-      _data{numeric::scaled_integer<rep_type>{value}.value}
+    : scalar{data_type{type_to_id<T>(), value.scale()}, is_valid, stream, mr}, _data{value.value()}
   {
   }
 

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -216,7 +216,8 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
 {
   using namespace numeric;
   using RepType = typename ElementTo::rep;
-  auto to_rep   = [](ElementTo fp) { return static_cast<scaled_integer<RepType>>(fp).value; };
+
+  auto to_rep            = [](ElementTo fp) { return fp.value(); };
   auto transformer_begin = thrust::make_transform_iterator(begin, to_rep);
   auto const size        = cudf::distance(begin, end);
   auto const elements = thrust::host_vector<RepType>(transformer_begin, transformer_begin + size);

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -122,8 +122,7 @@ struct fixed_point_unary_cast {
                                        cudf::is_fixed_point<TargetT>())>* = nullptr>
   CUDA_DEVICE_CALLABLE DeviceT operator()(SourceT const element)
   {
-    auto const fp = TargetT{element, scale};
-    return numeric::scaled_integer<DeviceT>{fp}.value;
+    return TargetT{element, scale}.value();
   }
 };
 


### PR DESCRIPTION
This PR adds `fixed_point::scale()` and `fixed_point::value()`. It enables developers to avoid the following piece of code (which is how you can currently access scale and value).
```cpp
auto si = numeric::scaled_integer<rep_type>{value};
// use si.value or si.scale
```
Note that this PR should merged after https://github.com/rapidsai/cudf/pull/7105 (or I can resolve conflict if it gets merged first)