### PR TITLE
Add `cudf::binary_operation` `NULL_MIN`, `NULL_MAX` & `NULL_EQUALS` for `decimal32` and `decimal64`

### DIFF
--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -349,10 +349,12 @@ std::unique_ptr<column> make_fixed_width_column_for_output(column_view const& lh
  */
 bool is_basic_arithmetic_binop(binary_operator op)
 {
-  return op == binary_operator::ADD or  ///< operator +
-         op == binary_operator::SUB or  ///< operator -
-         op == binary_operator::MUL or  ///< operator *
-         op == binary_operator::DIV;    ///< operator / using common type of lhs and rhs
+  return op == binary_operator::ADD or       ///< operator +
+         op == binary_operator::SUB or       ///< operator -
+         op == binary_operator::MUL or       ///< operator *
+         op == binary_operator::DIV or       ///< operator / using common type of lhs and rhs
+         op == binary_operator::NULL_MIN or  ///< 2 null = null, 1 null = value, else min
+         op == binary_operator::NULL_MAX;    ///< 2 null = null, 1 null = value, else max
 }
 
 /**
@@ -360,12 +362,13 @@ bool is_basic_arithmetic_binop(binary_operator op)
  */
 bool is_comparison_binop(binary_operator op)
 {
-  return op == binary_operator::EQUAL or        ///< operator ==
-         op == binary_operator::NOT_EQUAL or    ///< operator !=
-         op == binary_operator::LESS or         ///< operator <
-         op == binary_operator::GREATER or      ///< operator >
-         op == binary_operator::LESS_EQUAL or   ///< operator <=
-         op == binary_operator::GREATER_EQUAL;  ///< operator >=
+  return op == binary_operator::EQUAL or          ///< operator ==
+         op == binary_operator::NOT_EQUAL or      ///< operator !=
+         op == binary_operator::LESS or           ///< operator <
+         op == binary_operator::GREATER or        ///< operator >
+         op == binary_operator::LESS_EQUAL or     ///< operator <=
+         op == binary_operator::GREATER_EQUAL or  ///< operator >=
+         op == binary_operator::NULL_EQUALS;      ///< 2 null = true; 1 null = false; else ==
 }
 
 /**

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -349,10 +349,12 @@ std::unique_ptr<column> make_fixed_width_column_for_output(column_view const& lh
  */
 bool is_basic_arithmetic_binop(binary_operator op)
 {
-  return op == binary_operator::ADD or  // operator +
-         op == binary_operator::SUB or  // operator -
-         op == binary_operator::MUL or  // operator *
-         op == binary_operator::DIV;    // operator / using common type of lhs and rhs
+  return op == binary_operator::ADD or       // operator +
+         op == binary_operator::SUB or       // operator -
+         op == binary_operator::MUL or       // operator *
+         op == binary_operator::DIV or       // operator / using common type of lhs and rhs
+         op == binary_operator::NULL_MIN or  // 2 null = null, 1 null = value, else min
+         op == binary_operator::NULL_MAX;    // 2 null = null, 1 null = value, else max
 }
 
 /**
@@ -374,10 +376,7 @@ bool is_comparison_binop(binary_operator op)
  */
 bool is_supported_fixed_point_binop(binary_operator op)
 {
-  return is_basic_arithmetic_binop(op) or is_comparison_binop(op) or
-         op == binary_operator::NULL_MIN or  // 2 null = null, 1 null = value, else min
-         op == binary_operator::NULL_MAX;    // 2 null = null, 1 null = value, else max
-  ;
+  return is_basic_arithmetic_binop(op) or is_comparison_binop(op);
 }
 
 /**

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -349,12 +349,10 @@ std::unique_ptr<column> make_fixed_width_column_for_output(column_view const& lh
  */
 bool is_basic_arithmetic_binop(binary_operator op)
 {
-  return op == binary_operator::ADD or       ///< operator +
-         op == binary_operator::SUB or       ///< operator -
-         op == binary_operator::MUL or       ///< operator *
-         op == binary_operator::DIV or       ///< operator / using common type of lhs and rhs
-         op == binary_operator::NULL_MIN or  ///< 2 null = null, 1 null = value, else min
-         op == binary_operator::NULL_MAX;    ///< 2 null = null, 1 null = value, else max
+  return op == binary_operator::ADD or  // operator +
+         op == binary_operator::SUB or  // operator -
+         op == binary_operator::MUL or  // operator *
+         op == binary_operator::DIV;    // operator / using common type of lhs and rhs
 }
 
 /**
@@ -362,13 +360,13 @@ bool is_basic_arithmetic_binop(binary_operator op)
  */
 bool is_comparison_binop(binary_operator op)
 {
-  return op == binary_operator::EQUAL or          ///< operator ==
-         op == binary_operator::NOT_EQUAL or      ///< operator !=
-         op == binary_operator::LESS or           ///< operator <
-         op == binary_operator::GREATER or        ///< operator >
-         op == binary_operator::LESS_EQUAL or     ///< operator <=
-         op == binary_operator::GREATER_EQUAL or  ///< operator >=
-         op == binary_operator::NULL_EQUALS;      ///< 2 null = true; 1 null = false; else ==
+  return op == binary_operator::EQUAL or          // operator ==
+         op == binary_operator::NOT_EQUAL or      // operator !=
+         op == binary_operator::LESS or           // operator <
+         op == binary_operator::GREATER or        // operator >
+         op == binary_operator::LESS_EQUAL or     // operator <=
+         op == binary_operator::GREATER_EQUAL or  // operator >=
+         op == binary_operator::NULL_EQUALS;      // 2 null = true; 1 null = false; else ==
 }
 
 /**
@@ -376,7 +374,10 @@ bool is_comparison_binop(binary_operator op)
  */
 bool is_supported_fixed_point_binop(binary_operator op)
 {
-  return is_basic_arithmetic_binop(op) or is_comparison_binop(op);
+  return is_basic_arithmetic_binop(op) or is_comparison_binop(op) or
+         op == binary_operator::NULL_MIN or  // 2 null = null, 1 null = value, else min
+         op == binary_operator::NULL_MAX;    // 2 null = null, 1 null = value, else max
+  ;
 }
 
 /**

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2296,6 +2296,54 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpEqualLessGreater)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(true_col, greater_result->view());
 }
 
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpNullMaxSimple)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const trues    = std::vector<bool>(4, true);
+  auto const col1     = fp_wrapper<RepType>{{400, 300, 200, 100}, {1, 0, 1, 1}, scale_type{-2}};
+  auto const col2     = fp_wrapper<RepType>{{100, 200, 300, 400}, {1, 1, 1, 0}, scale_type{-2}};
+  auto const expected = fp_wrapper<RepType>{{400, 200, 300, 100}, {1, 1, 1, 1}, scale_type{-2}};
+
+  auto const result = cudf::binary_operation(col1, col2, binary_operator::NULL_MAX, {});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpNullMinSimple)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const trues    = std::vector<bool>(4, true);
+  auto const col1     = fp_wrapper<RepType>{{400, 300, 200, 100}, {1, 1, 1, 0}, scale_type{-2}};
+  auto const col2     = fp_wrapper<RepType>{{100, 200, 300, 400}, {1, 0, 1, 1}, scale_type{-2}};
+  auto const expected = fp_wrapper<RepType>{{100, 300, 200, 400}, {1, 1, 1, 1}, scale_type{-2}};
+
+  auto const result = cudf::binary_operation(col1, col2, binary_operator::NULL_MIN, {});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpNullEqualsSimple)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const trues    = std::vector<bool>(4, true);
+  auto const col1     = fp_wrapper<RepType>{{400, 300, 300, 100}, {1, 1, 1, 0}, scale_type{-2}};
+  auto const col2     = fp_wrapper<RepType>{{40, 200, 20, 400}, {1, 0, 1, 0}, scale_type{-1}};
+  auto const expected = wrapper<bool>{{1, 0, 0, 1}, {1, 1, 1, 1}};
+
+  auto const result = cudf::binary_operation(col1, col2, binary_operator::NULL_EQUALS, {});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 }  // namespace binop
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2303,9 +2303,9 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpNullMaxSimple)
   using RepType   = device_storage_type_t<decimalXX>;
 
   auto const trues    = std::vector<bool>(4, true);
-  auto const col1     = fp_wrapper<RepType>{{400, 300, 200, 100}, {1, 0, 1, 1}, scale_type{-2}};
-  auto const col2     = fp_wrapper<RepType>{{100, 200, 300, 400}, {1, 1, 1, 0}, scale_type{-2}};
-  auto const expected = fp_wrapper<RepType>{{400, 200, 300, 100}, {1, 1, 1, 1}, scale_type{-2}};
+  auto const col1     = fp_wrapper<RepType>{{40, 30, 20, 10, 0}, {1, 0, 1, 1, 0}, scale_type{-2}};
+  auto const col2     = fp_wrapper<RepType>{{10, 20, 30, 40, 0}, {1, 1, 1, 0, 0}, scale_type{-2}};
+  auto const expected = fp_wrapper<RepType>{{40, 20, 30, 10, 0}, {1, 1, 1, 1, 0}, scale_type{-2}};
 
   auto const result = cudf::binary_operation(col1, col2, binary_operator::NULL_MAX, {});
 
@@ -2319,9 +2319,9 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpNullMinSimple)
   using RepType   = device_storage_type_t<decimalXX>;
 
   auto const trues    = std::vector<bool>(4, true);
-  auto const col1     = fp_wrapper<RepType>{{400, 300, 200, 100}, {1, 1, 1, 0}, scale_type{-2}};
-  auto const col2     = fp_wrapper<RepType>{{100, 200, 300, 400}, {1, 0, 1, 1}, scale_type{-2}};
-  auto const expected = fp_wrapper<RepType>{{100, 300, 200, 400}, {1, 1, 1, 1}, scale_type{-2}};
+  auto const col1     = fp_wrapper<RepType>{{40, 30, 20, 10, 0}, {1, 1, 1, 0, 0}, scale_type{-1}};
+  auto const col2     = fp_wrapper<RepType>{{10, 20, 30, 40, 0}, {1, 0, 1, 1, 0}, scale_type{-1}};
+  auto const expected = fp_wrapper<RepType>{{10, 30, 20, 40, 0}, {1, 1, 1, 1, 0}, scale_type{-1}};
 
   auto const result = cudf::binary_operation(col1, col2, binary_operator::NULL_MIN, {});
 


### PR DESCRIPTION
This PR resolves https://github.com/rapidsai/cudf/issues/7115.

Add `cudf::binary_operation` support for `NULL_MAX`, `NULL_MIN` and `NULL_EQUALS` for `decimal32` and `decimal64`.