### PR TITLE
Add gbenchmarks for reduction aggregations any() and all()

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -181,6 +181,7 @@ ConfigureBench(TYPE_DISPATCHER_BENCH "${TD_BENCH_SRC}")
 # - reduction benchmark ---------------------------------------------------------------------------
 
 set(REDUCTION_BENCH_SRC
+  "${CMAKE_CURRENT_SOURCE_DIR}/reduction/anyall_benchmark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/reduction/reduce_benchmark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/reduction/minmax_benchmark.cpp")
 

--- a/cpp/benchmarks/reduction/anyall_benchmark.cpp
+++ b/cpp/benchmarks/reduction/anyall_benchmark.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+#include <benchmarks/fixture/benchmark_fixture.hpp>
+#include <benchmarks/synchronization/synchronization.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/reduction.hpp>
 #include <cudf/types.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
-#include <fixture/benchmark_fixture.hpp>
-#include <synchronization/synchronization.hpp>
 
 #include <memory>
 #include <random>
@@ -31,7 +31,7 @@ class Reduction : public cudf::benchmark {
 template <typename type>
 void BM_reduction_anyall(benchmark::State& state, std::unique_ptr<cudf::aggregation> const& agg)
 {
-  const cudf::size_type column_size{(cudf::size_type)state.range(0)};
+  const cudf::size_type column_size{static_cast<cudf::size_type>(state.range(0))};
 
   cudf::test::UniformRandomGenerator<long> rand_gen(0, 100);
   auto data_it = cudf::test::make_counting_transform_iterator(

--- a/cpp/benchmarks/reduction/anyall_benchmark.cpp
+++ b/cpp/benchmarks/reduction/anyall_benchmark.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/reduction.hpp>
+#include <cudf/types.hpp>
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <fixture/benchmark_fixture.hpp>
+#include <synchronization/synchronization.hpp>
+
+#include <memory>
+#include <random>
+
+class Reduction : public cudf::benchmark {
+};
+
+template <typename type>
+void BM_reduction_anyall(benchmark::State& state, std::unique_ptr<cudf::aggregation> const& agg)
+{
+  const cudf::size_type column_size{(cudf::size_type)state.range(0)};
+
+  cudf::test::UniformRandomGenerator<long> rand_gen(0, 100);
+  auto data_it = cudf::test::make_counting_transform_iterator(
+    0, [&rand_gen](cudf::size_type row) { return rand_gen.generate(); });
+  cudf::test::fixed_width_column_wrapper<type, typename decltype(data_it)::value_type> values(
+    data_it, data_it + column_size);
+
+  auto input_column = cudf::column_view(values);
+  cudf::data_type output_dtype{cudf::type_id::BOOL8};
+
+  for (auto _ : state) {
+    cuda_event_timer timer(state, true);
+    auto result = cudf::reduce(input_column, agg, output_dtype);
+  }
+}
+
+#define concat(a, b, c) a##b##c
+#define get_agg(op) concat(cudf::make_, op, _aggregation())
+
+// TYPE, OP
+#define RBM_BENCHMARK_DEFINE(name, type, aggregation)             \
+  BENCHMARK_DEFINE_F(Reduction, name)(::benchmark::State & state) \
+  {                                                               \
+    BM_reduction_anyall<type>(state, get_agg(aggregation));       \
+  }                                                               \
+  BENCHMARK_REGISTER_F(Reduction, name)                           \
+    ->UseManualTime()                                             \
+    ->Arg(10000)      /* 10k */                                   \
+    ->Arg(100000)     /* 100k */                                  \
+    ->Arg(1000000)    /* 1M */                                    \
+    ->Arg(10000000)   /* 10M */                                   \
+    ->Arg(100000000); /* 100M */
+
+#define REDUCE_BENCHMARK_DEFINE(type, aggregation) \
+  RBM_BENCHMARK_DEFINE(concat(type, _, aggregation), type, aggregation)
+
+REDUCE_BENCHMARK_DEFINE(bool, all);
+REDUCE_BENCHMARK_DEFINE(int8_t, all);
+REDUCE_BENCHMARK_DEFINE(int32_t, all);
+REDUCE_BENCHMARK_DEFINE(float, all);
+REDUCE_BENCHMARK_DEFINE(bool, any);
+REDUCE_BENCHMARK_DEFINE(int8_t, any);
+REDUCE_BENCHMARK_DEFINE(int32_t, any);
+REDUCE_BENCHMARK_DEFINE(float, any);


### PR DESCRIPTION
While investing the long compile times of the reduction source files `any.cu` and `all.cu` I found it necessary to build a gbenchmark to ensure changes did not effect the performance of these functions.