### PR TITLE
[REVIEW] Adding support for explode to cuDF

### DIFF
--- a/cpp/include/cudf/reshape.hpp
+++ b/cpp/include/cudf/reshape.hpp
@@ -97,6 +97,35 @@ std::unique_ptr<column> byte_cast(
   flip_endianness endian_configuration,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+/**
+ * @brief Explodes a list column's elements.
+ *
+ * Any list is exploded into individual rows and
+ * the other rows are duplicated.
+ * ```
+ * [[5,10,15], 100],
+ * [[20,25],   200],
+ * [[30],      300],
+ * returns
+ * [5,         100],
+ * [10,        100],
+ * [15,        100],
+ * [20,        200],
+ * [25,        200],
+ * [30,        300],
+ * ```
+ *
+ * @param input_table Table to explode.
+ * @param explode_column_idx Column index to explode inside the table.
+ * @param mr Device memory resource used to allocate the returned column's device memory.
+ *
+ * @return A new table with explode_col exploded.
+ */
+std::unique_ptr<table> explode(
+  table_view const& input_table,
+  int const explode_column_idx,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 /** @} */  // end of group
 
 }  // namespace cudf

--- a/cpp/include/cudf/reshape.hpp
+++ b/cpp/include/cudf/reshape.hpp
@@ -115,6 +115,18 @@ std::unique_ptr<column> byte_cast(
  * [30,        300],
  * ```
  *
+ * Nulls propagate in different ways depending on what is null.
+ *```
+ * [[5,null,15], 100],
+ * [null,        200]
+ * returns
+ * [5,           100],
+ * [null,        100],
+ * [15,          100],
+ * ```
+ * Note that null lists are completely removed from the output
+ * and nulls inside lists are pulled out and remain.
+ *
  * @param input_table Table to explode.
  * @param explode_column_idx Column index to explode inside the table.
  * @param mr Device memory resource used to allocate the returned column's device memory.

--- a/cpp/include/cudf/reshape.hpp
+++ b/cpp/include/cudf/reshape.hpp
@@ -100,8 +100,8 @@ std::unique_ptr<column> byte_cast(
 /**
  * @brief Explodes a list column's elements.
  *
- * Any list is exploded into individual rows and
- * the other rows are duplicated.
+ * Any list is exploded, which means the elements of the list in each row are expanded into new rows
+ * in the output. The corresponding rows for other columns in the input are duplicated. Example:
  * ```
  * [[5,10,15], 100],
  * [[20,25],   200],
@@ -123,7 +123,7 @@ std::unique_ptr<column> byte_cast(
  */
 std::unique_ptr<table> explode(
   table_view const& input_table,
-  int const explode_column_idx,
+  size_type explode_column_idx,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/reshape.hpp
+++ b/cpp/include/cudf/reshape.hpp
@@ -115,17 +115,18 @@ std::unique_ptr<column> byte_cast(
  * [30,        300],
  * ```
  *
- * Nulls propagate in different ways depending on what is null.
+ * Nulls and empty lists propagate in different ways depending on what is null or empty.
  *```
  * [[5,null,15], 100],
- * [null,        200]
+ * [null,        200],
+ * [[],          300],
  * returns
  * [5,           100],
  * [null,        100],
  * [15,          100],
  * ```
  * Note that null lists are completely removed from the output
- * and nulls inside lists are pulled out and remain.
+ * and nulls and empty lists inside lists are pulled out and remain.
  *
  * @param input_table Table to explode.
  * @param explode_column_idx Column index to explode inside the table.

--- a/cpp/src/reshape/explode.cu
+++ b/cpp/src/reshape/explode.cu
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/detail/gather.cuh>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/reshape.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/binary_search.h>
+
+#include <memory>
+#include <type_traits>
+#include "thrust/iterator/counting_iterator.h"
+#include "thrust/iterator/transform_iterator.h"
+
+namespace cudf {
+namespace detail {
+namespace {
+struct explode_functor {
+  /**
+   * @brief Function object for exploding a column.
+   */
+  template <typename T>
+  std::enable_if_t<!std::is_same<T, cudf::list_view>::value, std::unique_ptr<table>> operator()(
+    table_view const& input_table,
+    int const explode_column_idx,
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource* mr) const
+  {
+    CUDF_FAIL("Unsupported non-list column");
+  }
+
+  /**
+   * @brief Function object for exploding a column.
+   */
+   template <typename T>
+  std::enable_if_t<std::is_same<T, cudf::list_view>::value, std::unique_ptr<table>> operator()(
+    table_view const& input_table,
+    int const explode_column_idx,
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource* mr) const
+  {
+    /* we explode by building a gather map that includes the number of entries in each list inside the column for each index. Interestingly, this
+     can be done with lower_bound across the offsets as values between the offsets will all map down to the index below. We have some off-by-one
+     manipulations we need to do with the output, but it's almost our gather map by itself. Once we build the gather map we need to remove
+     the explode column from the table and run gather on it. Next we build the explode column, which turns out is simply lifting
+     the child column out of the explode column. This unrolls the top level of lists. Then we need to insert the explode column back
+     into the table and return it. */
+    lists_column_view lc{input_table.column(explode_column_idx)};
+    thrust::device_vector<unsigned int> gather_map_indices(lc.child().size());
+    auto offsets = lc.offsets();
+
+    auto offsets_minus_one = thrust::make_transform_iterator(
+      offsets.begin<size_type>(), [] __device__(auto i) { return i - 1; });
+    auto counting_iter = thrust::make_counting_iterator(0);
+
+    thrust::lower_bound(rmm::exec_policy(stream),
+                        offsets_minus_one,
+                        offsets_minus_one + offsets.size(),
+                        counting_iter,
+                        counting_iter + gather_map_indices.size(),
+                        gather_map_indices.begin());
+
+    auto select_iter = thrust::make_transform_iterator(
+      thrust::make_counting_iterator(0),
+      [explode_column_idx](int i) { return i >= explode_column_idx ? i + 1 : i; });
+    std::vector<int> selected_columns(select_iter, select_iter + input_table.num_columns() - 1);
+
+    auto gather_map_iter = thrust::make_transform_iterator(gather_map_indices.begin(),
+                                                           [] __device__(int i) { return i - 1; });
+
+    auto gathered_table = cudf::detail::gather(input_table.select(selected_columns),
+                                               gather_map_iter,
+                                               gather_map_iter + gather_map_indices.size(),
+                                               cudf::out_of_bounds_policy::DONT_CHECK,
+                                               stream,
+                                               mr);
+
+    std::vector<std::unique_ptr<column>> columns = gathered_table.release()->release();
+
+    columns.insert(columns.begin() + explode_column_idx,
+                   std::make_unique<column>(column(lc.child())));
+
+    return std::make_unique<table>(std::move(columns));
+  }
+};
+}  // namespace
+
+/**
+ * @copydoc
+ * cudf::explode(input_table,explode_column,column,flip_endianess,rmm::mr::device_memory_resource)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::unique_ptr<table> explode(table_view const& input_table,
+                               int const explode_column_idx,
+                               rmm::cuda_stream_view stream,
+                               rmm::mr::device_memory_resource* mr)
+{
+  return type_dispatcher(input_table.column(explode_column_idx).type(),
+                         explode_functor{},
+                         input_table,
+                         explode_column_idx,
+                         stream,
+                         mr);
+}
+
+}  // namespace detail
+
+/**
+ * @copydoc cudf::explode(input_table,explode_column,flip_endianess,rmm::mr::device_memory_resource)
+ */
+std::unique_ptr<table> explode(table_view const& input_table,
+                               int const explode_column_idx,
+                               rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::explode(input_table, explode_column_idx, rmm::cuda_stream_default, mr);
+}
+
+}  // namespace cudf

--- a/cpp/src/reshape/explode.cu
+++ b/cpp/src/reshape/explode.cu
@@ -67,7 +67,7 @@ std::unique_ptr<table> explode_functor::operator()<list_view>(
    explode column. This unrolls the top level of lists. Then we need to insert the explode column
    back into the table and return it. */
   lists_column_view lc{input_table.column(explode_column_idx)};
-  rmm::device_uvector<unsigned int> gather_map_indices(lc.child().size(), stream, mr);
+  rmm::device_uvector<size_type> gather_map_indices(lc.child().size(), stream, mr);
   auto offsets = lc.offsets();
 
   auto offsets_minus_one = thrust::make_transform_iterator(offsets.begin<size_type>(),

--- a/cpp/src/reshape/explode.cu
+++ b/cpp/src/reshape/explode.cu
@@ -76,12 +76,12 @@ std::unique_ptr<table> explode_functor::operator()<list_view>(
   // as we go.
   auto offsets           = lc.offsets().begin<size_type>() + lc.offset();
   auto offsets_minus_one = thrust::make_transform_iterator(
-    offsets, [offsets] __device__(auto i) { return i - offsets[0] - 1; });
+    offsets, [offsets] __device__(auto i) { return (i - offsets[0]) - 1; });
   auto counting_iter = thrust::make_counting_iterator(0);
 
   thrust::lower_bound(rmm::exec_policy(stream),
                       offsets_minus_one + 1,
-                      offsets_minus_one + lc.offsets().size(),
+                      offsets_minus_one + lc.size() + 1,
                       counting_iter,
                       counting_iter + gather_map_indices.size(),
                       gather_map_indices.begin());

--- a/cpp/src/reshape/explode.cu
+++ b/cpp/src/reshape/explode.cu
@@ -79,6 +79,10 @@ std::unique_ptr<table> explode_functor::operator()<list_view>(
     offsets, [offsets] __device__(auto i) { return (i - offsets[0]) - 1; });
   auto counting_iter = thrust::make_counting_iterator(0);
 
+  // This looks like an off-by-one bug, but what is going on here is that we need to reduce each
+  // result from `lower_bound` by 1 to build the correct gather map. It was pointed out that
+  // this can be accomplished by simply skipping the first entry and using the result of
+  // `lower_bound` directly.
   thrust::lower_bound(rmm::exec_policy(stream),
                       offsets_minus_one + 1,
                       offsets_minus_one + lc.size() + 1,

--- a/cpp/src/reshape/explode.cu
+++ b/cpp/src/reshape/explode.cu
@@ -67,8 +67,7 @@ std::unique_ptr<table> explode_functor::operator()<list_view>(
    explode column. This unrolls the top level of lists. Then we need to insert the explode column
    back into the table and return it. */
   lists_column_view lc{input_table.column(explode_column_idx)};
-  // rmm::device_uvector<unsigned int> gather_map_indices(lc.child().size(), stream, mr);
-  rmm::device_vector<size_type> gather_map_indices(lc.child().size());
+  rmm::device_uvector<unsigned int> gather_map_indices(lc.child().size(), stream, mr);
   auto offsets = lc.offsets();
 
   auto offsets_minus_one = thrust::make_transform_iterator(offsets.begin<size_type>(),

--- a/cpp/src/reshape/explode.cu
+++ b/cpp/src/reshape/explode.cu
@@ -26,93 +26,94 @@
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
 
 #include <memory>
 #include <type_traits>
-#include "thrust/iterator/counting_iterator.h"
-#include "thrust/iterator/transform_iterator.h"
 
 namespace cudf {
 namespace detail {
 namespace {
+/**
+ * @brief Function object for exploding a column.
+ */
 struct explode_functor {
-  /**
-   * @brief Function object for exploding a column.
-   */
   template <typename T>
-  std::enable_if_t<!std::is_same<T, cudf::list_view>::value, std::unique_ptr<table>> operator()(
-    table_view const& input_table,
-    int const explode_column_idx,
-    rmm::cuda_stream_view stream,
-    rmm::mr::device_memory_resource* mr) const
+  std::unique_ptr<table> operator()(table_view const& input_table,
+                                    size_type explode_column_idx,
+                                    rmm::cuda_stream_view stream,
+                                    rmm::mr::device_memory_resource* mr) const
   {
     CUDF_FAIL("Unsupported non-list column");
-  }
 
-  /**
-   * @brief Function object for exploding a column.
-   */
-   template <typename T>
-  std::enable_if_t<std::is_same<T, cudf::list_view>::value, std::unique_ptr<table>> operator()(
-    table_view const& input_table,
-    int const explode_column_idx,
-    rmm::cuda_stream_view stream,
-    rmm::mr::device_memory_resource* mr) const
-  {
-    /* we explode by building a gather map that includes the number of entries in each list inside the column for each index. Interestingly, this
-     can be done with lower_bound across the offsets as values between the offsets will all map down to the index below. We have some off-by-one
-     manipulations we need to do with the output, but it's almost our gather map by itself. Once we build the gather map we need to remove
-     the explode column from the table and run gather on it. Next we build the explode column, which turns out is simply lifting
-     the child column out of the explode column. This unrolls the top level of lists. Then we need to insert the explode column back
-     into the table and return it. */
-    lists_column_view lc{input_table.column(explode_column_idx)};
-    thrust::device_vector<unsigned int> gather_map_indices(lc.child().size());
-    auto offsets = lc.offsets();
-
-    auto offsets_minus_one = thrust::make_transform_iterator(
-      offsets.begin<size_type>(), [] __device__(auto i) { return i - 1; });
-    auto counting_iter = thrust::make_counting_iterator(0);
-
-    thrust::lower_bound(rmm::exec_policy(stream),
-                        offsets_minus_one,
-                        offsets_minus_one + offsets.size(),
-                        counting_iter,
-                        counting_iter + gather_map_indices.size(),
-                        gather_map_indices.begin());
-
-    auto select_iter = thrust::make_transform_iterator(
-      thrust::make_counting_iterator(0),
-      [explode_column_idx](int i) { return i >= explode_column_idx ? i + 1 : i; });
-    std::vector<int> selected_columns(select_iter, select_iter + input_table.num_columns() - 1);
-
-    auto gather_map_iter = thrust::make_transform_iterator(gather_map_indices.begin(),
-                                                           [] __device__(int i) { return i - 1; });
-
-    auto gathered_table = cudf::detail::gather(input_table.select(selected_columns),
-                                               gather_map_iter,
-                                               gather_map_iter + gather_map_indices.size(),
-                                               cudf::out_of_bounds_policy::DONT_CHECK,
-                                               stream,
-                                               mr);
-
-    std::vector<std::unique_ptr<column>> columns = gathered_table.release()->release();
-
-    columns.insert(columns.begin() + explode_column_idx,
-                   std::make_unique<column>(column(lc.child())));
-
-    return std::make_unique<table>(std::move(columns));
+    return std::make_unique<table>();
   }
 };
+
+template <>
+std::unique_ptr<table> explode_functor::operator()<list_view>(
+  table_view const& input_table,
+  size_type explode_column_idx,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr) const
+{
+  /* we explode by building a gather map that includes the number of entries in each list inside
+   the column for each index. Interestingly, this can be done with lower_bound across the offsets
+   as values between the offsets will all map down to the index below. We have some off-by-one
+   manipulations we need to do with the output, but it's almost our gather map by itself. Once we
+   build the gather map we need to remove the explode column from the table and run gather on it.
+   Next we build the explode column, which turns out is simply lifting the child column out of the
+   explode column. This unrolls the top level of lists. Then we need to insert the explode column
+   back into the table and return it. */
+  lists_column_view lc{input_table.column(explode_column_idx)};
+  // rmm::device_uvector<unsigned int> gather_map_indices(lc.child().size(), stream, mr);
+  rmm::device_vector<size_type> gather_map_indices(lc.child().size());
+  auto offsets = lc.offsets();
+
+  auto offsets_minus_one = thrust::make_transform_iterator(offsets.begin<size_type>(),
+                                                           [] __device__(auto i) { return i - 1; });
+  auto counting_iter     = thrust::make_counting_iterator(0);
+
+  thrust::lower_bound(rmm::exec_policy(stream),
+                      offsets_minus_one,
+                      offsets_minus_one + offsets.size(),
+                      counting_iter,
+                      counting_iter + gather_map_indices.size(),
+                      gather_map_indices.begin());
+
+  auto select_iter = thrust::make_transform_iterator(
+    thrust::make_counting_iterator(0),
+    [explode_column_idx](int i) { return i >= explode_column_idx ? i + 1 : i; });
+  std::vector<int> selected_columns(select_iter, select_iter + input_table.num_columns() - 1);
+
+  auto gather_map_iter = thrust::make_transform_iterator(gather_map_indices.begin(),
+                                                         [] __device__(int i) { return i - 1; });
+
+  auto gathered_table = cudf::detail::gather(input_table.select(selected_columns),
+                                             gather_map_iter,
+                                             gather_map_iter + gather_map_indices.size(),
+                                             cudf::out_of_bounds_policy::DONT_CHECK,
+                                             stream,
+                                             mr);
+
+  std::vector<std::unique_ptr<column>> columns = gathered_table.release()->release();
+
+  columns.insert(columns.begin() + explode_column_idx,
+                 std::make_unique<column>(column(lc.child(), stream, mr)));
+
+  return std::make_unique<table>(std::move(columns));
+}
 }  // namespace
 
 /**
  * @copydoc
- * cudf::explode(input_table,explode_column,column,flip_endianess,rmm::mr::device_memory_resource)
+ * cudf::explode(input_table,explode_column_idx,rmm::mr::device_memory_resource)
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<table> explode(table_view const& input_table,
-                               int const explode_column_idx,
+                               size_type explode_column_idx,
                                rmm::cuda_stream_view stream,
                                rmm::mr::device_memory_resource* mr)
 {
@@ -127,10 +128,10 @@ std::unique_ptr<table> explode(table_view const& input_table,
 }  // namespace detail
 
 /**
- * @copydoc cudf::explode(input_table,explode_column,flip_endianess,rmm::mr::device_memory_resource)
+ * @copydoc cudf::explode(input_table,explode_column_idx,rmm::mr::device_memory_resource)
  */
 std::unique_ptr<table> explode(table_view const& input_table,
-                               int const explode_column_idx,
+                               size_type explode_column_idx,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -515,6 +515,7 @@ ConfigureTest(SEARCH_TEST "${SEARCH_TEST_SRC}")
 
 set(RESHAPE_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/reshape/byte_cast_tests.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/reshape/explode_tests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/reshape/interleave_columns_tests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/reshape/tile_tests.cpp")
 

--- a/cpp/tests/reshape/explode_tests.cpp
+++ b/cpp/tests/reshape/explode_tests.cpp
@@ -61,13 +61,105 @@ TEST_F(ExplodeTest, Basics)
       [0, 3]              300
   */
 
-  lists_column_wrapper<int32_t> a{lists_column_wrapper<int32_t>{1, 2, 7},
+  fixed_width_column_wrapper<int32_t> a{100, 200, 300};
+  lists_column_wrapper<int32_t> b{lists_column_wrapper<int32_t>{1, 2, 7},
                                   lists_column_wrapper<int32_t>{5, 6},
                                   lists_column_wrapper<int32_t>{0, 3}};
+  strings_column_wrapper c{"string0", "string1", "string2"};
+
+  fixed_width_column_wrapper<int32_t> expected_a{100, 100, 100, 200, 200, 300, 300};
+  fixed_width_column_wrapper<int32_t> expected_b{1, 2, 7, 5, 6, 0, 3};
+  strings_column_wrapper expected_c{
+    "string0", "string0", "string0", "string1", "string1", "string2", "string2"};
+
+  cudf::table_view t({a, b, c});
+  cudf::table_view expected({expected_a, expected_b, expected_c});
+
+  auto ret = cudf::explode(t, 1);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
+}
+
+TEST_F(ExplodeTest, SingleNull)
+{
+  /*
+      a                   b
+      [1, 2, 7]           100
+      [5, 6]              200
+      [0, 3]              300
+  */
+
+  auto first_invalid =
+    cudf::test::make_counting_transform_iterator(0, [](auto i) { return i == 0 ? false : true; });
+
+  lists_column_wrapper<int32_t> a({lists_column_wrapper<int32_t>{1, 2, 7},
+                                   lists_column_wrapper<int32_t>{5, 6},
+                                   lists_column_wrapper<int32_t>{0, 3}},
+                                  first_invalid);
+  fixed_width_column_wrapper<int32_t> b({100, 200, 300});
+
+  fixed_width_column_wrapper<int32_t> expected_a{5, 6, 0, 3};
+  fixed_width_column_wrapper<int32_t> expected_b{200, 200, 300, 300};
+
+  cudf::table_view t({a, b});
+  cudf::table_view expected({expected_a, expected_b});
+
+  auto ret = cudf::explode(t, 0);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
+}
+
+TEST_F(ExplodeTest, Nulls)
+{
+  /*
+      a                   b
+      [1, 2, 7]           100
+      [5, 6]              200
+      [0, 3]              300
+  */
+
+  auto valids = cudf::test::make_counting_transform_iterator(
+    0, [](auto i) { return i % 2 == 0 ? true : false; });
+  auto always_valid = cudf::test::make_counting_transform_iterator(0, [](auto i) { return true; });
+
+  lists_column_wrapper<int32_t> a({lists_column_wrapper<int32_t>{1, 2, 7},
+                                   lists_column_wrapper<int32_t>{5, 6},
+                                   lists_column_wrapper<int32_t>{0, 3}},
+                                  valids);
+  fixed_width_column_wrapper<int32_t> b({100, 200, 300}, valids);
+
+  fixed_width_column_wrapper<int32_t> expected_a({1, 2, 7, 0, 3});
+  fixed_width_column_wrapper<int32_t> expected_b({100, 100, 100, 300, 300}, always_valid);
+
+  cudf::table_view t({a, b});
+  cudf::table_view expected({expected_a, expected_b});
+
+  auto ret = cudf::explode(t, 0);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
+}
+
+TEST_F(ExplodeTest, NullsInList)
+{
+  /*
+      a                   b
+      [1, 2, 7]           100
+      [5, 6, 0, 9]        200
+      [0, 3, 8]           300
+  */
+
+  auto valids = cudf::test::make_counting_transform_iterator(
+    0, [](auto i) { return i % 2 == 0 ? true : false; });
+  auto always_valid = cudf::test::make_counting_transform_iterator(0, [](auto i) { return true; });
+
+  lists_column_wrapper<int32_t> a{lists_column_wrapper<int32_t>({1, 2, 7}, valids),
+                                  lists_column_wrapper<int32_t>({5, 6, 0, 9}, valids),
+                                  lists_column_wrapper<int32_t>({0, 3, 8}, valids)};
   fixed_width_column_wrapper<int32_t> b{100, 200, 300};
 
-  fixed_width_column_wrapper<int32_t> expected_a{1, 2, 7, 5, 6, 0, 3};
-  fixed_width_column_wrapper<int32_t> expected_b{100, 100, 100, 200, 200, 300, 300};
+  fixed_width_column_wrapper<int32_t> expected_a({1, 2, 7, 5, 6, 0, 9, 0, 3, 8},
+                                                 {1, 0, 1, 1, 0, 1, 0, 1, 0, 1});
+  fixed_width_column_wrapper<int32_t> expected_b{100, 100, 100, 200, 200, 200, 200, 300, 300, 300};
 
   cudf::table_view t({a, b});
   cudf::table_view expected({expected_a, expected_b});
@@ -107,6 +199,116 @@ TEST_F(ExplodeTest, Nested)
   cudf::table_view expected({expected_a, expected_b});
 
   auto ret = cudf::explode(t, 0);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
+}
+
+TEST_F(ExplodeTest, NestedNulls)
+{
+  /*
+      a                   b
+      [[1, 2], [7, 6, 5]] 100
+      [[5, 6]]            200
+      [[0, 3],[5],[2, 1]] 300
+  */
+
+  auto valids = cudf::test::make_counting_transform_iterator(
+    0, [](auto i) { return i % 2 == 0 ? true : false; });
+  auto always_valid = cudf::test::make_counting_transform_iterator(0, [](auto i) { return true; });
+
+  lists_column_wrapper<int32_t> a(
+    {lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{1, 2},
+                                   lists_column_wrapper<int32_t>{7, 6, 5}},
+     lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{5, 6}},
+     lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{0, 3},
+                                   lists_column_wrapper<int32_t>{5},
+                                   lists_column_wrapper<int32_t>{2, 1}}},
+    valids);
+  fixed_width_column_wrapper<int32_t> b({100, 200, 300}, valids);
+
+  lists_column_wrapper<int32_t> expected_a{lists_column_wrapper<int32_t>{1, 2},
+                                           lists_column_wrapper<int32_t>{7, 6, 5},
+                                           lists_column_wrapper<int32_t>{0, 3},
+                                           lists_column_wrapper<int32_t>{5},
+                                           lists_column_wrapper<int32_t>{2, 1}};
+  fixed_width_column_wrapper<int32_t> expected_b({100, 100, 300, 300, 300}, always_valid);
+
+  cudf::table_view t({a, b});
+  cudf::table_view expected({expected_a, expected_b});
+
+  auto ret = cudf::explode(t, 0);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
+}
+
+TEST_F(ExplodeTest, NullsInNested)
+{
+  /*
+      a                   b
+      [[1, 2], [7, 6, 5]] 100
+      [[5, 6]]            200
+      [[0, 3],[5],[2, 1]] 300
+  */
+
+  auto valids = cudf::test::make_counting_transform_iterator(
+    0, [](auto i) { return i % 2 == 0 ? true : false; });
+
+  lists_column_wrapper<int32_t> a(
+    {lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>({1, 2}, valids),
+                                   lists_column_wrapper<int32_t>{7, 6, 5}},
+     lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{5, 6}},
+     lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{0, 3},
+                                   lists_column_wrapper<int32_t>{5},
+                                   lists_column_wrapper<int32_t>({2, 1}, valids)}});
+  fixed_width_column_wrapper<int32_t> b({100, 200, 300});
+
+  lists_column_wrapper<int32_t> expected_a{lists_column_wrapper<int32_t>({1, 2}, valids),
+                                           lists_column_wrapper<int32_t>{7, 6, 5},
+                                           lists_column_wrapper<int32_t>{5, 6},
+                                           lists_column_wrapper<int32_t>{0, 3},
+                                           lists_column_wrapper<int32_t>{5},
+                                           lists_column_wrapper<int32_t>({2, 1}, valids)};
+  fixed_width_column_wrapper<int32_t> expected_b{100, 100, 200, 300, 300, 300};
+
+  cudf::table_view t({a, b});
+  cudf::table_view expected({expected_a, expected_b});
+
+  auto ret = cudf::explode(t, 0);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
+}
+
+TEST_F(ExplodeTest, NullsInNestedDoubleExplode)
+{
+  /*
+      a                   b
+      [[1, 2], [7, 6, 5]] 100
+      [[5, 6]]            200
+      [[0, 3],[5],[2, 1]] 300
+  */
+
+  auto valids = cudf::test::make_counting_transform_iterator(
+    0, [](auto i) { return i % 2 == 0 ? true : false; });
+
+  lists_column_wrapper<int32_t> a{
+    lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>({1, 2}, valids),
+                                  lists_column_wrapper<int32_t>{7, 6, 5}},
+    lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{5, 6}},
+    lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{0, 3},
+                                  lists_column_wrapper<int32_t>{5},
+                                  lists_column_wrapper<int32_t>({2, 1}, valids)}};
+  fixed_width_column_wrapper<int32_t> b{100, 200, 300};
+
+  fixed_width_column_wrapper<int32_t> expected_a({1, 2, 7, 6, 5, 5, 6, 0, 3, 5, 2, 1},
+                                                 {1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<int32_t> expected_b{
+    100, 100, 100, 100, 100, 200, 200, 300, 300, 300, 300, 300};
+
+  cudf::table_view t({a, b});
+  cudf::table_view expected({expected_a, expected_b});
+
+  auto ret = cudf::explode(t, 0);
+  ret      = cudf::explode(ret->view(), 0);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
 }

--- a/cpp/tests/reshape/explode_tests.cpp
+++ b/cpp/tests/reshape/explode_tests.cpp
@@ -156,7 +156,6 @@ TEST_F(ExplodeTest, NullsInList)
 
   auto valids = cudf::test::make_counting_transform_iterator(
     0, [](auto i) { return i % 2 == 0 ? true : false; });
-  auto always_valid = cudf::test::make_counting_transform_iterator(0, [](auto i) { return true; });
 
   lists_column_wrapper<int32_t> a{lists_column_wrapper<int32_t>({1, 2, 7}, valids),
                                   lists_column_wrapper<int32_t>({5, 6, 0, 9}, valids),

--- a/cpp/tests/reshape/explode_tests.cpp
+++ b/cpp/tests/reshape/explode_tests.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/reshape.hpp>
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <cudf_test/table_utilities.hpp>
+
+using namespace cudf::test;
+
+class ExplodeTest : public cudf::test::BaseFixture {
+};
+
+TEST_F(ExplodeTest, Empty)
+{
+  lists_column_wrapper<int32_t> a{};
+  fixed_width_column_wrapper<int32_t> b{};
+
+  cudf::table_view t({a, b});
+
+  auto ret = cudf::explode(t, 0);
+
+  fixed_width_column_wrapper<int32_t> expected_a{};
+  fixed_width_column_wrapper<int32_t> expected_b{};
+  cudf::table_view expected({expected_a, expected_b});
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
+}
+
+TEST_F(ExplodeTest, NonList)
+{
+  fixed_width_column_wrapper<int32_t> a{100, 200, 300};
+  fixed_width_column_wrapper<int32_t> b{100, 200, 300};
+
+  cudf::table_view t({a, b});
+
+  EXPECT_THROW(cudf::explode(t, 1), cudf::logic_error);
+}
+
+TEST_F(ExplodeTest, Basics)
+{
+  /*
+      a                   b
+      [1, 2, 7]           100
+      [5, 6]              200
+      [0, 3]              300
+  */
+
+  lists_column_wrapper<int32_t> a{lists_column_wrapper<int32_t>{1, 2, 7},
+                                  lists_column_wrapper<int32_t>{5, 6},
+                                  lists_column_wrapper<int32_t>{0, 3}};
+  fixed_width_column_wrapper<int32_t> b{100, 200, 300};
+
+  fixed_width_column_wrapper<int32_t> expected_a{1, 2, 7, 5, 6, 0, 3};
+  fixed_width_column_wrapper<int32_t> expected_b{100, 100, 100, 200, 200, 300, 300};
+
+  cudf::table_view t({a, b});
+  cudf::table_view expected({expected_a, expected_b});
+
+  auto ret = cudf::explode(t, 0);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
+}
+
+TEST_F(ExplodeTest, Nested)
+{
+  /*
+      a                   b
+      [[1, 2], [7, 6, 5]] 100
+      [[5, 6]]            200
+      [[0, 3],[5],[2, 1]] 300
+  */
+
+  lists_column_wrapper<int32_t> a{
+    lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{1, 2},
+                                  lists_column_wrapper<int32_t>{7, 6, 5}},
+    lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{5, 6}},
+    lists_column_wrapper<int32_t>{lists_column_wrapper<int32_t>{0, 3},
+                                  lists_column_wrapper<int32_t>{5},
+                                  lists_column_wrapper<int32_t>{2, 1}}};
+  fixed_width_column_wrapper<int32_t> b{100, 200, 300};
+
+  lists_column_wrapper<int32_t> expected_a{lists_column_wrapper<int32_t>{1, 2},
+                                           lists_column_wrapper<int32_t>{7, 6, 5},
+                                           lists_column_wrapper<int32_t>{5, 6},
+                                           lists_column_wrapper<int32_t>{0, 3},
+                                           lists_column_wrapper<int32_t>{5},
+                                           lists_column_wrapper<int32_t>{2, 1}};
+  fixed_width_column_wrapper<int32_t> expected_b{100, 100, 200, 300, 300, 300};
+
+  cudf::table_view t({a, b});
+  cudf::table_view expected({expected_a, expected_b});
+
+  auto ret = cudf::explode(t, 0);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(ret->view(), expected);
+}


### PR DESCRIPTION
This is an operation that expands lists into rows and duplicates the existing rows from other columns. Explanation can be found in the issue #6151 

partially fixes #6151 

Missing pos_explode support required to completely close out #6151