### PR TITLE
[REVIEW] Fixing parquet precision writing failing if scale is equal to precision

### DIFF
--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -304,8 +304,8 @@ class parquet_column_view {
         _decimal_scale  = -_leaf_col.type().scale();  // parquet and cudf disagree about scale signs
         CUDF_EXPECTS(decimal_precision.size() > decimal_precision_idx,
                      "Not enough decimal precision values passed for data!");
-        CUDF_EXPECTS(decimal_precision[decimal_precision_idx] > _decimal_scale,
-                     "Precision must be greater than scale!");
+        CUDF_EXPECTS(decimal_precision[decimal_precision_idx] >= _decimal_scale,
+                     "Precision must be equal to or greater than scale!");
         _decimal_precision = decimal_precision[decimal_precision_idx++];
         break;
       case cudf::type_id::DECIMAL64:
@@ -315,8 +315,8 @@ class parquet_column_view {
         _decimal_scale  = -_leaf_col.type().scale();  // parquet and cudf disagree about scale signs
         CUDF_EXPECTS(decimal_precision.size() > decimal_precision_idx,
                      "Not enough decimal precision values passed for data!");
-        CUDF_EXPECTS(decimal_precision[decimal_precision_idx] > _decimal_scale,
-                     "Precision must be greater than scale!");
+        CUDF_EXPECTS(decimal_precision[decimal_precision_idx] >= _decimal_scale,
+                     "Precision must be equal to or greater than scale!");
         _decimal_precision = decimal_precision[decimal_precision_idx++];
         break;
       default:

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -1354,6 +1354,13 @@ TEST_F(ParquetChunkedWriterTest, DecimalWrite)
   state = cudf_io::write_parquet_chunked_begin(args);
   EXPECT_THROW(cudf_io::write_parquet_chunked(table, state), cudf::logic_error);
 
+  // verify sucess if equal precision is given
+  precisions = {7, 9};
+  args.set_decimal_precision_data(precisions);
+  state = cudf_io::write_parquet_chunked_begin(args);
+  cudf_io::write_parquet_chunked(table, state);
+  cudf_io::write_parquet_chunked_end(state);
+
   // verify failure if too many precisions given
   precisions = {7, 14, 11};
   args.set_decimal_precision_data(precisions);


### PR DESCRIPTION
@razajafri noticed that precision could not be equal to scale when writing decimals. This should be allowed and this fixes that and adds a test to verify it.

closes #7145 