### PR TITLE
Enable logic for GPU auto-detection in cudfjni

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [tests] [libcudf_kafk
    --disable_nvtx       - disable inserting NVTX profiling ranges
    --show_depr_warn     - show cmake deprecation warnings
    --ptds               - enable per-thread default stream
-   -h                   - print this text
+   -h | --h[elp]        - print this text
 
    default action (no args) is to build and install 'libcudf' then 'cudf'
    then 'dask_cudf' targets
@@ -75,7 +75,7 @@ function buildAll {
     ((${NUMARGS} == 0 )) || !(echo " ${ARGS} " | grep -q " [^-]\+ ")
 }
 
-if hasArg -h; then
+if hasArg -h || hasArg --h || hasArg --help; then
     echo "${HELP}"
     exit 0
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 
 # cuDF build script
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2019-2020, NVIDIA CORPORATION.
+  Copyright (c) 2019-2021, NVIDIA CORPORATION.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -148,6 +148,7 @@
         <PER_THREAD_DEFAULT_STREAM>OFF</PER_THREAD_DEFAULT_STREAM>
         <RMM_LOGGING_LEVEL>INFO</RMM_LOGGING_LEVEL>
         <USE_GDS>OFF</USE_GDS>
+        <GPU_ARCHS>ALL</GPU_ARCHS>
         <native.build.path>${project.build.directory}/cmake-build</native.build.path>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
@@ -375,7 +376,7 @@
                                     <arg value="-DCMAKE_CXX_FLAGS=${cxx.flags}"/>
                                     <arg value="-DCMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}"/>
                                     <arg value="-DCUDF_CPP_BUILD_DIR=${CUDF_CPP_BUILD_DIR}"/>
-                                    <arg value="-DGPU_ARCHS=ALL"/>
+                                    <arg value="-DGPU_ARCHS=${GPU_ARCHS}"/>
                                 </exec>
                                 <exec dir="${native.build.path}"
                                       failonerror="true"


### PR DESCRIPTION
Allow overriding `GPU_ARCHS` with an empty string in cudfjni to enable automatic detection
```bash
mvn clean install -DARROW_STATIC_LIB=ON -DBoost_USE_STATIC_LIBS=ON -DGPU_ARCHS=
...
     [exec] -- CUDA_VERSION: 11.0
     [exec] Auto detection of gpu-archs: 75
     [exec] GPU_ARCHS = 75
```

Allow `--h[elp]`  switch to `$CUDF_HOME/build.sh` 
