### PR TITLE
Fix -Werror=sign-compare errors in device code

### DIFF
--- a/cpp/include/cudf/strings/detail/gather.cuh
+++ b/cpp/include/cudf/strings/detail/gather.cuh
@@ -94,7 +94,7 @@ std::unique_ptr<cudf::column> gather(
     [] __device__(auto size) { return static_cast<size_t>(size); },
     size_t{0},
     thrust::plus<size_t>{});
-  CUDF_EXPECTS(total_bytes < std::numeric_limits<size_type>::max(),
+  CUDF_EXPECTS(total_bytes < static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "total size of output strings is too large for a cudf column");
 
   // create offsets from sizes

--- a/cpp/include/cudf/strings/detail/strings_column_factories.cuh
+++ b/cpp/include/cudf/strings/detail/strings_column_factories.cuh
@@ -52,7 +52,7 @@ std::unique_ptr<column> make_strings_column(IndexPairIterator begin,
   };
   size_t bytes = thrust::transform_reduce(
     rmm::exec_policy(stream), begin, end, size_checker, 0, thrust::plus<size_t>());
-  CUDF_EXPECTS(bytes < std::numeric_limits<size_type>::max(),
+  CUDF_EXPECTS(bytes < static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "total size of strings is too large for cudf column");
 
   // build offsets column from the strings sizes

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -227,7 +227,7 @@ std::unique_ptr<column> fused_concatenate(std::vector<column_view> const& views,
   auto const& d_offsets   = std::get<2>(device_views);
   auto const output_size  = std::get<3>(device_views);
 
-  CUDF_EXPECTS(output_size < std::numeric_limits<size_type>::max(),
+  CUDF_EXPECTS(output_size < static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "Total number of concatenated rows exceeds size_type range");
 
   // Allocate output
@@ -364,7 +364,7 @@ void bounds_and_type_check(ColIter begin, ColIter end)
     std::accumulate(begin, end, std::size_t{}, [](size_t a, auto const& b) {
       return a + static_cast<size_t>(b.size());
     });
-  CUDF_EXPECTS(total_row_count <= std::numeric_limits<size_type>::max(),
+  CUDF_EXPECTS(total_row_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "Total number of concatenated rows exceeds size_type range");
 
   // march each child

--- a/cpp/src/io/csv/datetime.cuh
+++ b/cpp/src/io/csv/datetime.cuh
@@ -130,7 +130,7 @@ __inline__ __device__ constexpr int32_t daysSinceBaseline(int year, int month, i
 __inline__ __device__ constexpr int32_t daysSinceEpoch(int year, int month, int day)
 {
   // Shift the start date to epoch to match unix time
-  static_assert(daysSinceBaseline(1970, 1, 1) == 719468_days,
+  static_assert(static_cast<uint32_t>(daysSinceBaseline(1970, 1, 1)) == 719468_days,
                 "Baseline to epoch returns incorrect number of days");
 
   return daysSinceBaseline(year, month, day) - daysSinceBaseline(1970, 1, 1);

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -221,9 +221,9 @@ std::unique_ptr<column> concatenate(std::vector<column_view> const& columns,
 
   if (strings_count == 0) { return make_empty_strings_column(stream, mr); }
 
-  CUDF_EXPECTS(offsets_count <= std::numeric_limits<size_type>::max(),
+  CUDF_EXPECTS(offsets_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "total number of strings is too large for cudf column");
-  CUDF_EXPECTS(total_bytes <= std::numeric_limits<size_type>::max(),
+  CUDF_EXPECTS(total_bytes <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "total size of strings is too large for cudf column");
 
   bool const has_nulls =

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -54,7 +54,7 @@ std::unique_ptr<column> make_strings_column(
                                           size_checker,
                                           0,
                                           thrust::plus<size_t>());
-  CUDF_EXPECTS(bytes < std::numeric_limits<size_type>::max(),
+  CUDF_EXPECTS(bytes < static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "total size of strings is too large for cudf column");
 
   // build offsets column from the strings sizes

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -213,7 +213,7 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
   if (strings_count == 0) return cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32});
   CUDF_EXPECTS(strings_count > 1, "the input strings must include at least 2 strings");
   CUDF_EXPECTS(static_cast<size_t>(strings_count) * static_cast<size_t>(strings_count) <
-                 std::numeric_limits<int32_t>().max(),
+                 static_cast<std::size_t>(std::numeric_limits<cudf::size_type>().max()),
                "too many strings to create the output column");
 
   // create device column of the input strings column

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -220,8 +220,9 @@ std::unique_ptr<cudf::column> normalize_characters(cudf::strings_column_view con
     return normalizer.normalize(d_chars, d_offsets, strings.size(), stream);
   }();
 
-  CUDF_EXPECTS(result.first->size() <= std::numeric_limits<cudf::size_type>::max(),
-               "output too large for strings column");
+  CUDF_EXPECTS(
+    result.first->size() <= static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max()),
+    "output too large for strings column");
 
   // convert the result into a strings column
   // - the cp_chars are the new 4-byte code-point values for all the characters in the output

--- a/cpp/src/text/subword/subword_tokenize.cu
+++ b/cpp/src/text/subword/subword_tokenize.cu
@@ -135,7 +135,8 @@ tokenizer_result subword_tokenize(cudf::strings_column_view const& strings,
 {
   CUDF_EXPECTS(stride <= max_sequence_length,
                "stride must be less than or equal to max_sequence_length");
-  CUDF_EXPECTS(max_sequence_length * max_rows_tensor < std::numeric_limits<cudf::size_type>::max(),
+  CUDF_EXPECTS(max_sequence_length * max_rows_tensor <
+                 static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max()),
                "max_sequence_length x max_rows_tensor is too large for cudf output column size");
   auto const strings_count = strings.size();
   if (strings_count == 0 || strings.chars_size() == 0)


### PR DESCRIPTION
Not sure why these aren't being caught in local 10.2 envs or CI builds, but I can't build a local CUDA 11.0 env due to a mamba bug.