### PR TITLE
Update cupy to >= 7.8

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - protobuf
     - python
     - pandas >=1.0,<1.2.0dev0
-    - cupy >7.1.0,<9.0.0a0
+    - cupy >=7.8.0,<9.0.0a0
     - numba >=0.49.0
     - numpy
     - {{ pin_compatible('pyarrow', max_pin='x.x.x') }}


### PR DESCRIPTION
PR to update CuPy to version 7.8 to keep versions in sync (cuML requires 7.8 as of https://github.com/rapidsai/cuml/pull/3378 due to usage of cupy.full order parameter) and corresponds to integration PR https://github.com/rapidsai/integration/pull/208

cc @ajschmidt8 