### PR TITLE
Implement `cudf::group_by` (sort) for `decimal32` and `decimal64`

### DIFF
--- a/cpp/include/cudf/detail/aggregation/aggregation.cuh
+++ b/cpp/include/cudf/detail/aggregation/aggregation.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/detail/aggregation/aggregation.cuh
+++ b/cpp/include/cudf/detail/aggregation/aggregation.cuh
@@ -432,7 +432,7 @@ struct identity_initializer {
   template <typename T, aggregation::Kind k>
   static constexpr bool is_supported()
   {
-    // Note: !is_fixed_point<T>() means that aggregatations for fixed_point should happen on the
+    // Note: !is_fixed_point<T>() means that aggregations for fixed_point should happen on the
     //       underlying type (see device_storage_type_t), not that fixed_point is not supported
     return cudf::is_fixed_width<T>() && !is_fixed_point<T>() and
            (k == aggregation::SUM or k == aggregation::MIN or k == aggregation::MAX or

--- a/cpp/include/cudf/detail/aggregation/aggregation.cuh
+++ b/cpp/include/cudf/detail/aggregation/aggregation.cuh
@@ -432,6 +432,8 @@ struct identity_initializer {
   template <typename T, aggregation::Kind k>
   static constexpr bool is_supported()
   {
+    // Note: !is_fixed_point<T>() means that aggregatations for fixed_point should happen on the
+    //       underlying type (see device_storage_type_t), not that fixed_point is not supported
     return cudf::is_fixed_width<T>() && !is_fixed_point<T>() and
            (k == aggregation::SUM or k == aggregation::MIN or k == aggregation::MAX or
             k == aggregation::COUNT_VALID or k == aggregation::COUNT_ALL or

--- a/cpp/include/cudf/utilities/type_dispatcher.hpp
+++ b/cpp/include/cudf/utilities/type_dispatcher.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/utilities/type_dispatcher.hpp
+++ b/cpp/include/cudf/utilities/type_dispatcher.hpp
@@ -103,16 +103,31 @@ using device_storage_type_t =
 // clang-format on
 
 /**
+ * @brief Returns the corresponding `type_id` of type stored on device for a given `type_id`
+ *
+ * @param id   The given `type_id`
+ * @return     Corresponding `type_id` of type stored on device
+ */
+inline type_id device_storage_type_id(type_id id)
+{
+  switch (id) {
+    case type_id::DECIMAL32: return type_id::INT32;
+    case type_id::DECIMAL64: return type_id::INT64;
+    default: return id;
+  }
+}
+
+/**
  * @brief Checks if `fixed_point`-like types have template type `T` matching the column's
  * stored type id
  *
- * @tparam T The type that is stored on the device
- * @param id The `data_type::id` of the column
- * @return true If T matches the stored column type id
- * @return false If T does not match the stored column type id
+ * @tparam     T The type that is stored on the device
+ * @param id   The `data_type::id` of the column
+ * @return     `true` If T matches the stored column `type_id`
+ * @return     `false` If T does not match the stored column `type_id`
  */
 template <typename T>
-bool type_id_matches_device_storage_type(type_id const& id)
+bool type_id_matches_device_storage_type(type_id id)
 {
   return (id == type_id::DECIMAL32 && std::is_same<T, int32_t>::value) ||
          (id == type_id::DECIMAL64 && std::is_same<T, int64_t>::value) || id == type_to_id<T>();

--- a/cpp/rmm_log.txt
+++ b/cpp/rmm_log.txt
@@ -1,0 +1,1 @@
+[ 23294][23:00:25:246785][info  ] ----- RMM LOG BEGIN [PTDS DISABLED] -----

--- a/cpp/rmm_log.txt
+++ b/cpp/rmm_log.txt
@@ -1,1 +1,0 @@
-[ 23294][23:00:25:246785][info  ] ----- RMM LOG BEGIN [PTDS DISABLED] -----

--- a/cpp/src/aggregation/aggregation.cu
+++ b/cpp/src/aggregation/aggregation.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/aggregation/aggregation.cu
+++ b/cpp/src/aggregation/aggregation.cu
@@ -27,8 +27,13 @@ void initialize_with_identity(mutable_table_view& table,
   // TODO: Initialize all the columns in a single kernel instead of invoking one
   // kernel per column
   for (size_type i = 0; i < table.num_columns(); ++i) {
-    auto col = table.column(i);
-    dispatch_type_and_aggregation(col.type(), aggs[i], identity_initializer{}, col, stream);
+    auto col        = table.column(i);
+    auto const type = [&] {
+      if (not is_fixed_point(col.type())) return col.type();
+      return col.type().id() == type_id::DECIMAL32 ? data_type{type_id::INT32}
+                                                   : data_type{type_id::INT64};
+    }();
+    dispatch_type_and_aggregation(type, aggs[i], identity_initializer{}, col, stream);
   }
 }
 

--- a/cpp/src/aggregation/aggregation.cu
+++ b/cpp/src/aggregation/aggregation.cu
@@ -28,11 +28,7 @@ void initialize_with_identity(mutable_table_view& table,
   // kernel per column
   for (size_type i = 0; i < table.num_columns(); ++i) {
     auto col        = table.column(i);
-    auto const type = [&] {
-      if (not is_fixed_point(col.type())) return col.type();
-      return col.type().id() == type_id::DECIMAL32 ? data_type{type_id::INT32}
-                                                   : data_type{type_id::INT64};
-    }();
+    auto const type = data_type{device_storage_type_id(col.type().id())};
     dispatch_type_and_aggregation(type, aggs[i], identity_initializer{}, col, stream);
   }
 }

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -41,7 +41,7 @@ struct reduce_functor {
   static constexpr bool is_supported()
   {
     if (K == aggregation::SUM)
-      return cudf::is_numeric<T>() || cudf::is_duration<T>();
+      return cudf::is_numeric<T>() || cudf::is_duration<T>() || cudf::is_fixed_point<T>();
     else if (K == aggregation::MIN or K == aggregation::MAX)
       return cudf::is_fixed_width<T>() and is_relationally_comparable<T, T>();
     else if (K == aggregation::ARGMIN or K == aggregation::ARGMAX)
@@ -58,11 +58,16 @@ struct reduce_functor {
     rmm::cuda_stream_view stream,
     rmm::mr::device_memory_resource* mr)
   {
+    using DeviceType = device_storage_type_t<T>;
     using OpType     = cudf::detail::corresponding_operator_t<K>;
     using ResultType = cudf::detail::target_type_t<T, K>;
 
+    auto result_type = is_fixed_point<T>()
+                         ? data_type{type_to_id<ResultType>(), values.type().scale()}
+                         : data_type{type_to_id<ResultType>()};
+
     std::unique_ptr<column> result =
-      make_fixed_width_column(data_type(type_to_id<ResultType>()),
+      make_fixed_width_column(result_type,
                               num_groups,
                               values.has_nulls() ? mask_state::ALL_NULL : mask_state::UNALLOCATED,
                               stream,
@@ -83,7 +88,7 @@ struct reduce_functor {
                          [d_values     = *valuesview,
                           d_result     = *resultview,
                           dest_indices = group_labels.data().get()] __device__(auto i) {
-                           cudf::detail::update_target_element<T, K, true, true>{}(
+                           cudf::detail::update_target_element<DeviceType, K, true, true>{}(
                              d_result, dest_indices[i], d_values, i);
                          });
     } else {

--- a/cpp/tests/groupby/group_count_test.cpp
+++ b/cpp/tests/groupby/group_count_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/groupby/group_count_test.cpp
+++ b/cpp/tests/groupby/group_count_test.cpp
@@ -201,7 +201,7 @@ TYPED_TEST(FixedPointTestBothReps, GroupByCount)
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
-TYPED_TEST(FixedPointTestBothReps, GroupBySum)
+TYPED_TEST(FixedPointTestBothReps, GroupBySumProduct)
 {
   using namespace numeric;
   using decimalXX    = TypeParam;
@@ -222,6 +222,11 @@ TYPED_TEST(FixedPointTestBothReps, GroupBySum)
 
   auto agg1 = cudf::make_sum_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
+
+  auto agg2 = cudf::make_product_aggregation();
+  EXPECT_THROW(test_single_agg(
+                 keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES),
+               cudf::logic_error);
 }
 
 TYPED_TEST(FixedPointTestBothReps, GroupByMin)
@@ -243,6 +248,28 @@ TYPED_TEST(FixedPointTestBothReps, GroupByMin)
   // test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
   auto agg1 = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
+}
+
+TYPED_TEST(FixedPointTestBothReps, GroupByMax)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = cudf::device_storage_type_t<decimalXX>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+  using K          = int32_t;
+
+  auto const scale = scale_type{-1};
+  auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  auto const vals  = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+
+  auto const expect_keys = fixed_width_column_wrapper<K>{1, 2, 3};
+  auto const expect_vals = fp_wrapper{{6, 9, 8}, scale};
+
+  // auto agg = cudf::make_min_aggregation();
+  // test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+
+  auto agg1 = cudf::make_max_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 }
 


### PR DESCRIPTION
This PR resolves a part of https://github.com/rapidsai/cudf/issues/3556.

I decided to push the changes for sort `cudf::group_by` and hash `group_by` in different PRs.