### PR TITLE
Add `MultiIndex.rename` API

### DIFF
--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -220,7 +220,7 @@ class MultiIndex(Index):
                     ('B', 2020),
                     ('B', 2021)],
                 names=['lv1', 'lv2'])
-        
+
         ``names`` argument must be a list, and must have same length as
         ``MultiIndex.levels``:
 

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -187,21 +187,47 @@ class MultiIndex(Index):
 
     def rename(self, names, inplace=False):
         """
-        Alter Multiindex level names
-
-        Defaults to returning new index.
+        Alter MultiIndex level names
 
         Parameters
         ----------
         names : list of label
             Names to set, length must be the same as number of levels
         inplace : bool, default False
-            If True, modifies objects directly, instead of creating a new
-            ``MultiIndex``
+            If True, modifies objects directly, otherwise returns a new
+            ``MultiIndex`` instance
 
         Returns
-        -------
-        None or Index
+        --------
+        None or MultiIndex
+
+        Examples
+        --------
+        Renaming each levels of a MultiIndex to specified name:
+
+        >>> midx = cudf.MultiIndex.from_product(
+                [('A', 'B'), (2020, 2021)], names=['c1', 'c2'])
+        >>> midx.rename(['lv1', 'lv2'])
+        MultiIndex([('A', 2020),
+                    ('A', 2021),
+                    ('B', 2020),
+                    ('B', 2021)],
+                names=['lv1', 'lv2'])
+        >>> midx.rename(['lv1', 'lv2'], inplace=True)
+        >>> midx
+        MultiIndex([('A', 2020),
+                    ('A', 2021),
+                    ('B', 2020),
+                    ('B', 2021)],
+                names=['lv1', 'lv2'])
+        
+        ``names`` argument must be a list, and must have same length as
+        ``MultiIndex.levels``:
+
+        >>> midx.rename(['lv0'])
+        Traceback (most recent call last):
+        ValueError: Length of names must match number of levels in MultiIndex.
+
         """
 
         return self.set_names(names, level=None, inplace=inplace)

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -185,6 +185,27 @@ class MultiIndex(Index):
         assert len(value) == self.nlevels
         self._names = pd.core.indexes.frozen.FrozenList(value)
 
+    def rename(self, names, inplace=False):
+        """
+        Alter Multiindex level names
+
+        Defaults to returning new index.
+
+        Parameters
+        ----------
+        names : list of label
+            Names to set, length must be the same as number of levels
+        inplace : bool, default False
+            If True, modifies objects directly, instead of creating a new
+            ``MultiIndex``
+
+        Returns
+        -------
+        None or Index
+        """
+
+        return self.set_names(names, level=None, inplace=inplace)
+
     def set_names(self, names, level=None, inplace=False):
         if (
             level is not None

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -1452,3 +1452,52 @@ def test_multiindex_set_names_error(level, names):
         lfunc_args_and_kwargs=([], {"names": names, "level": level}),
         rfunc_args_and_kwargs=([], {"names": names, "level": level}),
     )
+
+
+@pytest.mark.parametrize(
+    "idx",
+    [
+        pd.MultiIndex.from_product([["python", "cobra"], [2018, 2019]]),
+        pd.MultiIndex.from_product(
+            [["python", "cobra"], [2018, 2019]], names=["old name", None]
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "names",
+    [
+        [None, None],
+        ["a", None],
+        ["new name", "another name"],
+        [1, None],
+        [2, 3],
+        [42, "name"],
+    ],
+)
+@pytest.mark.parametrize("inplace", [True, False])
+def test_multiindex_rename(idx, names, inplace):
+    pi = idx.copy()
+    gi = cudf.from_pandas(idx)
+
+    expected = pi.rename(names=names, inplace=inplace)
+    actual = gi.rename(names=names, inplace=inplace)
+
+    if inplace:
+        expected, actual = pi, gi
+
+    assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize(
+    "names", ["plain string", 123, ["str"], ["l1", "l2", "l3"]]
+)
+def test_multiindex_rename_error(names):
+    pi = pd.MultiIndex.from_product([["python", "cobra"], [2018, 2019]])
+    gi = cudf.from_pandas(pi)
+
+    assert_exceptions_equal(
+        lfunc=pi.rename,
+        rfunc=gi.rename,
+        lfunc_args_and_kwargs=([], {"names": names}),
+        rfunc_args_and_kwargs=([], {"names": names}),
+    )


### PR DESCRIPTION
Closes #7057 

Properly overrides `MultiIndex.rename` from `Index.rename`, reusing API from `MultiIndex.set_names`.