### PR TITLE
Adding unit tests for `fixed_point` with extremely large `scale`s

### DIFF
--- a/cpp/tests/fixed_point/fixed_point_tests.cu
+++ b/cpp/tests/fixed_point/fixed_point_tests.cu
@@ -583,6 +583,10 @@ TYPED_TEST(FixedPointTestBothReps, SimpleFixedPointColumnWrapper)
 
 TEST_F(FixedPointTest, PositiveScaleWithValuesOutsideUnderlyingType32)
 {
+  // This is testing fixed_point values outside the range of its underlying type.
+  // For example, 100,000,000 with scale of 6 is 100,000,000,000,000 (100 trillion) and this is
+  // outside the range of a int32_t
+
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<int32_t>;
 
   auto const a = fp_wrapper{{100000000}, scale_type{6}};
@@ -601,6 +605,10 @@ TEST_F(FixedPointTest, PositiveScaleWithValuesOutsideUnderlyingType32)
 
 TEST_F(FixedPointTest, PositiveScaleWithValuesOutsideUnderlyingType64)
 {
+  // This is testing fixed_point values outside the range of its underlying type.
+  // For example, 100,000,000 with scale of 100 is 10 ^ 108 and this is far outside the
+  // range of a int64_t
+
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<int64_t>;
 
   auto const a = fp_wrapper{{100000000}, scale_type{100}};
@@ -619,6 +627,9 @@ TEST_F(FixedPointTest, PositiveScaleWithValuesOutsideUnderlyingType64)
 
 TYPED_TEST(FixedPointTestBothReps, ExtremelyLargeNegativeScale)
 {
+  // This is testing fixed_point values with an extremely large negative scale. The fixed_point
+  // implementation should be able to handle any scale representable by an int32_t
+
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<TypeParam>;
 
   auto const a = fp_wrapper{{10}, scale_type{-201}};

--- a/cpp/tests/fixed_point/fixed_point_tests.cu
+++ b/cpp/tests/fixed_point/fixed_point_tests.cu
@@ -585,15 +585,15 @@ TEST_F(FixedPointTest, PositiveScaleWithValuesOutsideUnderlyingType32)
 {
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<int32_t>;
 
-  auto a = fp_wrapper{{100000000}, scale_type{6}};
-  auto b = fp_wrapper{{5000000}, scale_type{7}};
-  auto c = fp_wrapper{{2}, scale_type{0}};
+  auto const a = fp_wrapper{{100000000}, scale_type{6}};
+  auto const b = fp_wrapper{{5000000}, scale_type{7}};
+  auto const c = fp_wrapper{{2}, scale_type{0}};
 
-  auto expected1 = fp_wrapper{{150000000}, scale_type{6}};
-  auto expected2 = fp_wrapper{{50000000}, scale_type{6}};
+  auto const expected1 = fp_wrapper{{150000000}, scale_type{6}};
+  auto const expected2 = fp_wrapper{{50000000}, scale_type{6}};
 
-  auto result1 = cudf::binary_operation(a, b, cudf::binary_operator::ADD, {});
-  auto result2 = cudf::binary_operation(a, c, cudf::binary_operator::DIV, {});
+  auto const result1 = cudf::binary_operation(a, b, cudf::binary_operator::ADD, {});
+  auto const result2 = cudf::binary_operation(a, c, cudf::binary_operator::DIV, {});
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, result1->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, result2->view());
@@ -603,15 +603,33 @@ TEST_F(FixedPointTest, PositiveScaleWithValuesOutsideUnderlyingType64)
 {
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<int64_t>;
 
-  auto a = fp_wrapper{{100000000}, scale_type{100}};
-  auto b = fp_wrapper{{5000000}, scale_type{101}};
-  auto c = fp_wrapper{{2}, scale_type{0}};
+  auto const a = fp_wrapper{{100000000}, scale_type{100}};
+  auto const b = fp_wrapper{{5000000}, scale_type{101}};
+  auto const c = fp_wrapper{{2}, scale_type{0}};
 
-  auto expected1 = fp_wrapper{{150000000}, scale_type{100}};
-  auto expected2 = fp_wrapper{{50000000}, scale_type{100}};
+  auto const expected1 = fp_wrapper{{150000000}, scale_type{100}};
+  auto const expected2 = fp_wrapper{{50000000}, scale_type{100}};
 
-  auto result1 = cudf::binary_operation(a, b, cudf::binary_operator::ADD, {});
-  auto result2 = cudf::binary_operation(a, c, cudf::binary_operator::DIV, {});
+  auto const result1 = cudf::binary_operation(a, b, cudf::binary_operator::ADD, {});
+  auto const result2 = cudf::binary_operation(a, c, cudf::binary_operator::DIV, {});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, result1->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, result2->view());
+}
+
+TYPED_TEST(FixedPointTestBothReps, ExtremelyLargeNegativeScale)
+{
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<TypeParam>;
+
+  auto const a = fp_wrapper{{10}, scale_type{-201}};
+  auto const b = fp_wrapper{{50}, scale_type{-202}};
+  auto const c = fp_wrapper{{2}, scale_type{0}};
+
+  auto const expected1 = fp_wrapper{{150}, scale_type{-202}};
+  auto const expected2 = fp_wrapper{{5}, scale_type{-201}};
+
+  auto const result1 = cudf::binary_operation(a, b, cudf::binary_operator::ADD, {});
+  auto const result2 = cudf::binary_operation(a, c, cudf::binary_operator::DIV, {});
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, result1->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, result2->view());

--- a/cpp/tests/fixed_point/fixed_point_tests.cu
+++ b/cpp/tests/fixed_point/fixed_point_tests.cu
@@ -19,6 +19,7 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/fixed_point/fixed_point.hpp>
@@ -34,7 +35,6 @@
 #include <numeric>
 #include <type_traits>
 #include <vector>
-#include "cudf/binaryop.hpp"
 
 using namespace numeric;
 


### PR DESCRIPTION
After a discussion with Keith and Ashwin today, I realized `libcudf` was missing a couple corner cases for `fixed_point` and decided to open a small PR to add them.