### PR TITLE
Add support for `cudf::binary_operation` `TRUE_DIV` for `decimal32` and `decimal64`

### DIFF
--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cudf/detail/utilities/release_assert.cuh>
 #include <cudf/types.hpp>
 
 // Note: The <cuda/std/*> versions are used in order for Jitify to work with our fixed_point type.
@@ -24,7 +25,6 @@
 #include <cuda/std/type_traits>  // add cuda namespace
 
 #include <algorithm>
-#include <cassert>
 #include <cmath>
 #include <string>
 
@@ -90,7 +90,7 @@ template <typename Rep,
                                            is_supported_representation_type<Rep>())>* = nullptr>
 CUDA_HOST_DEVICE_CALLABLE Rep ipow(T exponent)
 {
-  assert(("integer exponentiation with negative exponent is not possible.", exponent >= 0));
+  release_assert(exponent >= 0 && "integer exponentiation with negative exponent is not possible.");
   if (exponent == 0) return static_cast<Rep>(1);
   auto extra  = static_cast<Rep>(1);
   auto square = static_cast<Rep>(Base);
@@ -641,8 +641,8 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator+(fixed_point<Rep1, Ra
 
 #if defined(__CUDACC_DEBUG__)
 
-  assert(("fixed_point overflow of underlying representation type " + print_rep<Rep1>(),
-          !addition_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value)));
+  release_assert(!addition_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
+                 "fixed_point overflow of underlying representation type " + print_rep<Rep1>());
 
 #endif
 
@@ -659,8 +659,9 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator-(fixed_point<Rep1, Ra
 
 #if defined(__CUDACC_DEBUG__)
 
-  assert(("fixed_point overflow of underlying representation type " + print_rep<Rep1>(),
-          !subtraction_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value)));
+  release_assert(
+    !subtraction_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
+    "fixed_point overflow of underlying representation type " + print_rep<Rep1>());
 
 #endif
 
@@ -674,8 +675,8 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator*(fixed_point<Rep1, Ra
 {
 #if defined(__CUDACC_DEBUG__)
 
-  assert(("fixed_point overflow of underlying representation type " + print_rep<Rep1>(),
-          !multiplication_overflow<Rep1>(lhs._value, rhs._value)));
+  release_assert(!multiplication_overflow<Rep1>(lhs._value, rhs._value) &&
+                 "fixed_point overflow of underlying representation type " + print_rep<Rep1>());
 
 #endif
 
@@ -690,8 +691,8 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator/(fixed_point<Rep1, Ra
 {
 #if defined(__CUDACC_DEBUG__)
 
-  assert(("fixed_point overflow of underlying representation type " + print_rep<Rep1>(),
-          !division_overflow<Rep1>(lhs._value, rhs._value)));
+  release_assert(!division_overflow<Rep1>(lhs._value, rhs._value) &&
+                 "fixed_point overflow of underlying representation type " + print_rep<Rep1>());
 
 #endif
 

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -91,7 +91,7 @@ template <typename Rep,
                                            is_supported_representation_type<Rep>())>* = nullptr>
 CUDA_HOST_DEVICE_CALLABLE Rep ipow(T exponent)
 {
-  assert(("integer power on negative exponent is not possible.", exponent >= 0));
+  assert(("integer power with negative exponent is not possible.", exponent >= 0));
   if (exponent == 0) return static_cast<Rep>(1);
   auto extra  = static_cast<Rep>(1);
   auto square = static_cast<Rep>(Base);

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <cmath>
 #include <string>
+#include "cudf/utilities/error.hpp"
 
 //! `fixed_point` and supporting types
 namespace numeric {
@@ -90,6 +91,7 @@ template <typename Rep,
                                            is_supported_representation_type<Rep>())>* = nullptr>
 CUDA_HOST_DEVICE_CALLABLE Rep ipow(T exponent)
 {
+  assert(("integer power on negative exponent is not possible.", exponent >= 0));
   if (exponent == 0) return static_cast<Rep>(1);
   auto extra  = static_cast<Rep>(1);
   auto square = static_cast<Rep>(Base);

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -27,7 +27,6 @@
 #include <cassert>
 #include <cmath>
 #include <string>
-#include "cudf/utilities/error.hpp"
 
 //! `fixed_point` and supporting types
 namespace numeric {
@@ -91,7 +90,7 @@ template <typename Rep,
                                            is_supported_representation_type<Rep>())>* = nullptr>
 CUDA_HOST_DEVICE_CALLABLE Rep ipow(T exponent)
 {
-  assert(("integer power with negative exponent is not possible.", exponent >= 0));
+  assert(("integer exponentiation with negative exponent is not possible.", exponent >= 0));
   if (exponent == 0) return static_cast<Rep>(1);
   auto extra  = static_cast<Rep>(1);
   auto square = static_cast<Rep>(Base);

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -430,6 +430,8 @@ std::unique_ptr<column> fixed_point_binary_operation(scalar const& lhs,
 {
   using namespace numeric;
 
+  CUDF_EXPECTS(is_fixed_point(lhs.type()), "Input must have fixed_point data_type.");
+  CUDF_EXPECTS(is_fixed_point(rhs.type()), "Input must have fixed_point data_type.");
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
   CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Data type mismatch");
   if (op == binary_operator::TRUE_DIV)
@@ -531,6 +533,8 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 {
   using namespace numeric;
 
+  CUDF_EXPECTS(is_fixed_point(lhs.type()), "Input must have fixed_point data_type.");
+  CUDF_EXPECTS(is_fixed_point(rhs.type()), "Input must have fixed_point data_type.");
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
   CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Data type mismatch");
   if (op == binary_operator::TRUE_DIV)
@@ -632,6 +636,8 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 {
   using namespace numeric;
 
+  CUDF_EXPECTS(is_fixed_point(lhs.type()), "Input must have fixed_point data_type.");
+  CUDF_EXPECTS(is_fixed_point(rhs.type()), "Input must have fixed_point data_type.");
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
   CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Data type mismatch");
   if (op == binary_operator::TRUE_DIV)

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -20,6 +20,7 @@
 #include "compiled/binary_ops.hpp"
 #include "jit/code/code.h"
 #include "jit/util.hpp"
+#include "thrust/optional.h"
 
 #include <jit/launcher.h>
 #include <jit/parser.h>
@@ -376,7 +377,8 @@ bool is_comparison_binop(binary_operator op)
  */
 bool is_supported_fixed_point_binop(binary_operator op)
 {
-  return is_basic_arithmetic_binop(op) or is_comparison_binop(op);
+  return is_basic_arithmetic_binop(op) or is_comparison_binop(op) or
+         op == binary_operator::TRUE_DIV;
 }
 
 /**
@@ -389,6 +391,8 @@ bool is_supported_fixed_point_binop(binary_operator op)
  */
 int32_t compute_scale_for_binop(binary_operator op, int32_t left_scale, int32_t right_scale)
 {
+  CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation.");
+  if (op == binary_operator::TRUE_DIV) CUDF_FAIL("TRUE_DIV scale cannot be computed.");
   if (op == binary_operator::MUL) return left_scale + right_scale;
   if (op == binary_operator::DIV) return left_scale - right_scale;
   return std::min(left_scale, right_scale);
@@ -571,26 +575,51 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
                                                      column_view const& rhs,
                                                      binary_operator op,
+                                                     thrust::optional<cudf::data_type> output_type,
                                                      rmm::cuda_stream_view stream,
                                                      rmm::mr::device_memory_resource* mr)
 {
   using namespace numeric;
 
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
-  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(),
-               "Both columns must be of the same fixed_point type");
+  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Both columns must be of the same type");
+  CUDF_EXPECTS(op != binary_operator::TRUE_DIV || output_type.has_value(),
+               "TRUE_DIV requires result_type.");
 
-  auto const scale       = compute_scale_for_binop(op, lhs.type().scale(), rhs.type().scale());
-  auto const output_type = is_comparison_binop(op) ? data_type{type_id::BOOL8}  //
-                                                   : data_type{lhs.type().id(), scale};
-  auto out = make_fixed_width_column_for_output(lhs, rhs, op, output_type, stream, mr);
+  // TODO cleanup
+  auto const scale = op == binary_operator::TRUE_DIV
+                       ? output_type.value().scale()
+                       : compute_scale_for_binop(op, lhs.type().scale(), rhs.type().scale());
+
+  auto const out_type = output_type.value_or([&] {
+    return is_comparison_binop(op) ? data_type{type_id::BOOL8}  //
+                                   : data_type{lhs.type().id(), scale};
+  }());
+
+  auto out = make_fixed_width_column_for_output(lhs, rhs, op, out_type, stream, mr);
 
   if (lhs.is_empty() or rhs.is_empty()) return out;
 
   auto out_view = out->mutable_view();
 
-  if (lhs.type().scale() != rhs.type().scale() && is_same_scale_necessary(op)) {
-    // Adjust columns so they have they same scale
+  if (op == binary_operator::TRUE_DIV) {
+    auto const diff   = lhs.type().scale() - output_type.value().scale();
+    auto const result = [&] {
+      if (lhs.type().id() == type_id::DECIMAL32) {
+        auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(diff);
+        auto const scalar = make_fixed_point_scalar<decimal32>(factor, scale_type{scale});
+        return binary_operation(*scalar, lhs, binary_operator::MUL, lhs.type(), stream, mr);
+      } else {
+        CUDF_EXPECTS(lhs.type().id() == type_id::DECIMAL64, "Unexpected DTYPE");
+        auto const factor = numeric::detail::ipow<int64_t, Radix::BASE_10>(diff);
+        auto const scalar = make_fixed_point_scalar<decimal64>(factor, scale_type{scale});
+        return binary_operation(*scalar, lhs, binary_operator::MUL, lhs.type(), stream, mr);
+      }
+    }();
+    binops::jit::binary_operation(out_view, result->view(), rhs, binary_operator::DIV, stream);
+    return out;
+  } else if (lhs.type().scale() != rhs.type().scale() && is_same_scale_necessary(op)) {
+    // Adjust columns so they have they same scale TODO modify comment
     if (rhs.type().scale() < lhs.type().scale()) {
       auto const diff   = lhs.type().scale() - rhs.type().scale();
       auto const result = [&] {
@@ -700,8 +729,11 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
   if (lhs.type().id() == type_id::STRING and rhs.type().id() == type_id::STRING)
     return binops::compiled::binary_operation(lhs, rhs, op, output_type, stream, mr);
 
-  if (is_fixed_point(lhs.type()) or is_fixed_point(rhs.type()))
-    return fixed_point_binary_operation(lhs, rhs, op, stream, mr);
+  if (is_fixed_point(lhs.type()) or is_fixed_point(rhs.type())) {
+    auto const optional_type =
+      op == binary_operator::TRUE_DIV ? output_type : thrust::optional<data_type>{thrust::nullopt};
+    return fixed_point_binary_operation(lhs, rhs, op, optional_type, stream, mr);
+  }
 
   // Check for datatype
   CUDF_EXPECTS(is_fixed_width(output_type), "Invalid/Unsupported output datatype");

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -20,7 +20,6 @@
 #include "compiled/binary_ops.hpp"
 #include "jit/code/code.h"
 #include "jit/util.hpp"
-#include "thrust/optional.h"
 
 #include <jit/launcher.h>
 #include <jit/parser.h>
@@ -49,6 +48,8 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <string>
+
+#include <thrust/optional.h>
 
 namespace cudf {
 

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -423,25 +423,53 @@ bool is_same_scale_necessary(binary_operator op)
 std::unique_ptr<column> fixed_point_binary_operation(scalar const& lhs,
                                                      column_view const& rhs,
                                                      binary_operator op,
+                                                     thrust::optional<cudf::data_type> output_type,
                                                      rmm::cuda_stream_view stream,
                                                      rmm::mr::device_memory_resource* mr)
 {
   using namespace numeric;
 
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
-  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(),
-               "Both columns must be of the same fixed_point type");
+  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Both columns must be of the same type");
+  CUDF_EXPECTS(op != binary_operator::TRUE_DIV || output_type.has_value(),
+               "TRUE_DIV requires result_type.");
 
-  auto const scale       = compute_scale_for_binop(op, lhs.type().scale(), rhs.type().scale());
-  auto const output_type = is_comparison_binop(op) ? data_type{type_id::BOOL8}  //
-                                                   : data_type{lhs.type().id(), scale};
-  auto out = make_fixed_width_column_for_output(lhs, rhs, op, output_type, stream, mr);
+  auto const scale = op == binary_operator::TRUE_DIV
+                       ? output_type.value().scale()
+                       : compute_scale_for_binop(op, lhs.type().scale(), rhs.type().scale());
+
+  auto const out_type = output_type.value_or(
+    is_comparison_binop(op) ? data_type{type_id::BOOL8} : data_type{lhs.type().id(), scale});
+
+  auto out = make_fixed_width_column_for_output(lhs, rhs, op, out_type, stream, mr);
 
   if (rhs.is_empty()) return out;
 
   auto out_view = out->mutable_view();
 
-  if (lhs.type().scale() != rhs.type().scale() && is_same_scale_necessary(op)) {
+  if (op == binary_operator::TRUE_DIV) {
+    // Adjust scalar so lhs has the scale needed to get desired output data_type (scale)
+    auto const diff = lhs.type().scale() - rhs.type().scale() - scale;
+    if (lhs.type().id() == type_id::DECIMAL32) {
+      auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(diff);
+      auto const val    = static_cast<fixed_point_scalar<decimal32> const&>(lhs).value();
+      auto const scalar = lhs.type().scale() < rhs.type().scale()
+                            ? make_fixed_point_scalar<decimal32>(val / factor, scale_type{scale})
+                            : make_fixed_point_scalar<decimal32>(val * factor, scale_type{scale});
+      printf("%i %i\n", factor, val);
+      binops::jit::binary_operation(out_view, *scalar, rhs, binary_operator::DIV, stream);
+      return out;
+
+    } else {
+      auto const factor = numeric::detail::ipow<int64_t, Radix::BASE_10>(diff);
+      auto const val    = static_cast<fixed_point_scalar<decimal64> const&>(lhs).value();
+      auto const scalar = lhs.type().scale() < rhs.type().scale()
+                            ? make_fixed_point_scalar<decimal64>(val / factor, scale_type{scale})
+                            : make_fixed_point_scalar<decimal64>(val * factor, scale_type{scale});
+      binops::jit::binary_operation(out_view, *scalar, rhs, binary_operator::DIV, stream);
+      return out;
+    }
+  } else if (lhs.type().scale() != rhs.type().scale() && is_same_scale_necessary(op)) {
     // Adjust scalar/column so they have they same scale
     if (rhs.type().scale() < lhs.type().scale()) {
       auto const diff = lhs.type().scale() - rhs.type().scale();
@@ -694,8 +722,11 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
   if (lhs.type().id() == type_id::STRING and rhs.type().id() == type_id::STRING)
     return binops::compiled::binary_operation(lhs, rhs, op, output_type, stream, mr);
 
-  if (is_fixed_point(lhs.type()) or is_fixed_point(rhs.type()))
-    return fixed_point_binary_operation(lhs, rhs, op, stream, mr);
+  if (is_fixed_point(lhs.type()) or is_fixed_point(rhs.type())) {
+    auto const type =
+      op == binary_operator::TRUE_DIV ? output_type : thrust::optional<data_type>{thrust::nullopt};
+    return fixed_point_binary_operation(lhs, rhs, op, type, stream, mr);
+  }
 
   // Check for datatype
   CUDF_EXPECTS(is_fixed_width(output_type), "Invalid/Unsupported output datatype");

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -432,8 +432,8 @@ std::unique_ptr<column> fixed_point_binary_operation(scalar const& lhs,
 
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
   CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Data type mismatch");
-  CUDF_EXPECTS(op != binary_operator::TRUE_DIV || output_type.has_value(),
-               "TRUE_DIV requires result_type.");
+  if (op == binary_operator::TRUE_DIV)
+    CUDF_EXPECTS(output_type.has_value(), "TRUE_DIV requires result_type.");
 
   auto const scale = op == binary_operator::TRUE_DIV
                        ? output_type.value().scale()
@@ -450,7 +450,7 @@ std::unique_ptr<column> fixed_point_binary_operation(scalar const& lhs,
 
   if (op == binary_operator::TRUE_DIV) {
     // Adjust scalar so lhs has the scale needed to get desired output data_type (scale)
-    auto const diff         = lhs.type().scale() - rhs.type().scale() - scale;
+    auto const diff         = (lhs.type().scale() - rhs.type().scale()) - scale;
     auto const unused_scale = scale_type{0};  // scale of out_view already set
     if (lhs.type().id() == type_id::DECIMAL32) {
       auto const factor       = numeric::detail::ipow<int32_t, Radix::BASE_10>(std::abs(diff));
@@ -533,8 +533,8 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
   CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Data type mismatch");
-  CUDF_EXPECTS(op != binary_operator::TRUE_DIV || output_type.has_value(),
-               "TRUE_DIV requires result_type.");
+  if (op == binary_operator::TRUE_DIV)
+    CUDF_EXPECTS(output_type.has_value(), "TRUE_DIV requires result_type.");
 
   auto const scale = op == binary_operator::TRUE_DIV
                        ? output_type.value().scale()
@@ -551,7 +551,7 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 
   if (op == binary_operator::TRUE_DIV) {
     // Adjust columns so lhs has the scale needed to get desired output data_type (scale)
-    auto const diff         = lhs.type().scale() - rhs.type().scale() - scale;
+    auto const diff         = (lhs.type().scale() - rhs.type().scale()) - scale;
     auto const interim_op   = diff < 0 ? binary_operator::DIV : binary_operator::MUL;
     auto const scalar_scale = scale_type{rhs.type().scale() + scale};
     auto const result       = [&] {
@@ -634,8 +634,8 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
   CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Data type mismatch");
-  CUDF_EXPECTS(op != binary_operator::TRUE_DIV || output_type.has_value(),
-               "TRUE_DIV requires result_type.");
+  if (op == binary_operator::TRUE_DIV)
+    CUDF_EXPECTS(output_type.has_value(), "TRUE_DIV requires result_type.");
 
   auto const scale = op == binary_operator::TRUE_DIV
                        ? output_type.value().scale()
@@ -652,7 +652,7 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 
   if (op == binary_operator::TRUE_DIV) {
     // Adjust columns so lhs has the scale needed to get desired output data_type (scale)
-    auto const diff         = lhs.type().scale() - rhs.type().scale() - scale;
+    auto const diff         = (lhs.type().scale() - rhs.type().scale()) - scale;
     auto const interim_op   = diff < 0 ? binary_operator::DIV : binary_operator::MUL;
     auto const scalar_scale = scale_type{rhs.type().scale() + scale};
     auto const result       = [&] {

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -550,17 +550,19 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 
   if (op == binary_operator::TRUE_DIV) {
     // Adjust columns so lhs has the scale needed to get desired output data_type (scale)
-    auto const diff   = lhs.type().scale() - rhs.type().scale() - scale;
-    auto const result = [&] {
+    auto const diff         = lhs.type().scale() - rhs.type().scale() - scale;
+    auto const interim_op   = diff < 0 ? binary_operator::DIV : binary_operator::MUL;
+    auto const scalar_scale = scale_type{rhs.type().scale() + scale};
+    auto const result       = [&] {
       if (lhs.type().id() == type_id::DECIMAL32) {
-        auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(diff);
-        auto const scalar = make_fixed_point_scalar<decimal32>(factor, scale_type{scale});
-        return binary_operation(*scalar, lhs, binary_operator::MUL, {}, stream, mr);
+        auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(std::abs(diff));
+        auto const scalar = make_fixed_point_scalar<decimal32>(factor, scalar_scale);
+        return binary_operation(lhs, *scalar, interim_op, {}, stream, mr);
       } else {
         CUDF_EXPECTS(lhs.type().id() == type_id::DECIMAL64, "Unexpected DTYPE");
-        auto const factor = numeric::detail::ipow<int64_t, Radix::BASE_10>(diff);
-        auto const scalar = make_fixed_point_scalar<decimal64>(factor, scale_type{scale});
-        return binary_operation(*scalar, lhs, binary_operator::MUL, {}, stream, mr);
+        auto const factor = numeric::detail::ipow<int64_t, Radix::BASE_10>(std::abs(diff));
+        auto const scalar = make_fixed_point_scalar<decimal64>(factor, scalar_scale);
+        return binary_operation(lhs, *scalar, interim_op, {}, stream, mr);
       }
     }();
     binops::jit::binary_operation(out_view, result->view(), rhs, binary_operator::DIV, stream);
@@ -649,17 +651,19 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 
   if (op == binary_operator::TRUE_DIV) {
     // Adjust columns so lhs has the scale needed to get desired output data_type (scale)
-    auto const diff   = lhs.type().scale() - rhs.type().scale() - scale;
-    auto const result = [&] {
+    auto const diff         = lhs.type().scale() - rhs.type().scale() - scale;
+    auto const interim_op   = diff < 0 ? binary_operator::DIV : binary_operator::MUL;
+    auto const scalar_scale = scale_type{rhs.type().scale() + scale};
+    auto const result       = [&] {
       if (lhs.type().id() == type_id::DECIMAL32) {
-        auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(diff);
-        auto const scalar = make_fixed_point_scalar<decimal32>(factor, scale_type{scale});
-        return binary_operation(*scalar, lhs, binary_operator::MUL, {}, stream, mr);
+        auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(std::abs(diff));
+        auto const scalar = make_fixed_point_scalar<decimal32>(factor, scalar_scale);
+        return binary_operation(lhs, *scalar, interim_op, {}, stream, mr);
       } else {
         CUDF_EXPECTS(lhs.type().id() == type_id::DECIMAL64, "Unexpected DTYPE");
-        auto const factor = numeric::detail::ipow<int64_t, Radix::BASE_10>(diff);
-        auto const scalar = make_fixed_point_scalar<decimal64>(factor, scale_type{scale});
-        return binary_operation(*scalar, lhs, binary_operator::MUL, {}, stream, mr);
+        auto const factor = numeric::detail::ipow<int64_t, Radix::BASE_10>(std::abs(diff));
+        auto const scalar = make_fixed_point_scalar<decimal64>(factor, scalar_scale);
+        return binary_operation(lhs, *scalar, interim_op, {}, stream, mr);
       }
     }();
     binops::jit::binary_operation(out_view, result->view(), rhs, binary_operator::DIV, stream);

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -452,7 +452,7 @@ std::unique_ptr<column> fixed_point_binary_operation(scalar const& lhs,
     auto const diff         = lhs.type().scale() - rhs.type().scale() - scale;
     auto const scalar_scale = scale_type{rhs.type().scale() + scale};
     if (lhs.type().id() == type_id::DECIMAL32) {
-      auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(diff);
+      auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(std::abs(diff));
       auto const val    = static_cast<fixed_point_scalar<decimal32> const&>(lhs).value();
       auto const scalar = diff < 0 ? make_fixed_point_scalar<decimal32>(val / factor, scalar_scale)
                                    : make_fixed_point_scalar<decimal32>(val * factor, scalar_scale);
@@ -460,7 +460,7 @@ std::unique_ptr<column> fixed_point_binary_operation(scalar const& lhs,
       return out;
 
     } else {
-      auto const factor = numeric::detail::ipow<int64_t, Radix::BASE_10>(diff);
+      auto const factor = numeric::detail::ipow<int64_t, Radix::BASE_10>(std::abs(diff));
       auto const val    = static_cast<fixed_point_scalar<decimal64> const&>(lhs).value();
       auto const scalar = diff < 0 ? make_fixed_point_scalar<decimal64>(val / factor, scalar_scale)
                                    : make_fixed_point_scalar<decimal64>(val * factor, scalar_scale);

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -632,7 +632,7 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
   using namespace numeric;
 
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
-  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Both columns must be of the same type");
+  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Data type mismatch");
   CUDF_EXPECTS(op != binary_operator::TRUE_DIV || output_type.has_value(),
                "TRUE_DIV requires result_type.");
 

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -458,7 +458,6 @@ std::unique_ptr<column> fixed_point_binary_operation(scalar const& lhs,
       auto const scalar       = make_fixed_point_scalar<decimal32>(scaled_value, unused_scale);
       binops::jit::binary_operation(out_view, *scalar, rhs, binary_operator::DIV, stream);
       return out;
-
     } else {
       auto const factor       = numeric::detail::ipow<int64_t, Radix::BASE_10>(std::abs(diff));
       auto const val          = static_cast<fixed_point_scalar<decimal64> const&>(lhs).value();

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -450,20 +450,20 @@ std::unique_ptr<column> fixed_point_binary_operation(scalar const& lhs,
   if (op == binary_operator::TRUE_DIV) {
     // Adjust scalar so lhs has the scale needed to get desired output data_type (scale)
     auto const diff         = lhs.type().scale() - rhs.type().scale() - scale;
-    auto const scalar_scale = scale_type{rhs.type().scale() + scale};
+    auto const unused_scale = scale_type{0};  // scale of out_view already set
     if (lhs.type().id() == type_id::DECIMAL32) {
-      auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(std::abs(diff));
-      auto const val    = static_cast<fixed_point_scalar<decimal32> const&>(lhs).value();
-      auto const scalar = diff < 0 ? make_fixed_point_scalar<decimal32>(val / factor, scalar_scale)
-                                   : make_fixed_point_scalar<decimal32>(val * factor, scalar_scale);
+      auto const factor       = numeric::detail::ipow<int32_t, Radix::BASE_10>(std::abs(diff));
+      auto const val          = static_cast<fixed_point_scalar<decimal32> const&>(lhs).value();
+      auto const scaled_value = diff < 0 ? val / factor : val * factor;
+      auto const scalar       = make_fixed_point_scalar<decimal32>(scaled_value, unused_scale);
       binops::jit::binary_operation(out_view, *scalar, rhs, binary_operator::DIV, stream);
       return out;
 
     } else {
-      auto const factor = numeric::detail::ipow<int64_t, Radix::BASE_10>(std::abs(diff));
-      auto const val    = static_cast<fixed_point_scalar<decimal64> const&>(lhs).value();
-      auto const scalar = diff < 0 ? make_fixed_point_scalar<decimal64>(val / factor, scalar_scale)
-                                   : make_fixed_point_scalar<decimal64>(val * factor, scalar_scale);
+      auto const factor       = numeric::detail::ipow<int64_t, Radix::BASE_10>(std::abs(diff));
+      auto const val          = static_cast<fixed_point_scalar<decimal64> const&>(lhs).value();
+      auto const scaled_value = diff < 0 ? val / factor : val * factor;
+      auto const scalar       = make_fixed_point_scalar<decimal64>(scaled_value, unused_scale);
       binops::jit::binary_operation(out_view, *scalar, rhs, binary_operator::DIV, stream);
       return out;
     }

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -531,7 +531,7 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
   using namespace numeric;
 
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
-  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Both columns must be of the same type");
+  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Data type mismatch");
   CUDF_EXPECTS(op != binary_operator::TRUE_DIV || output_type.has_value(),
                "TRUE_DIV requires result_type.");
 

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -430,7 +430,7 @@ std::unique_ptr<column> fixed_point_binary_operation(scalar const& lhs,
   using namespace numeric;
 
   CUDF_EXPECTS(is_supported_fixed_point_binop(op), "Unsupported fixed_point binary operation");
-  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Both columns must be of the same type");
+  CUDF_EXPECTS(lhs.type().id() == rhs.type().id(), "Data type mismatch");
   CUDF_EXPECTS(op != binary_operator::TRUE_DIV || output_type.has_value(),
                "TRUE_DIV requires result_type.");
 

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -525,7 +525,7 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 
   if (op == binary_operator::TRUE_DIV) {
     // Adjust columns so lhs has the scale needed to get desired output data_type (scale)
-    auto const diff   = lhs.type().scale() - scale;
+    auto const diff   = lhs.type().scale() - rhs.type().scale() - scale;
     auto const result = [&] {
       if (lhs.type().id() == type_id::DECIMAL32) {
         auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(diff);
@@ -624,7 +624,7 @@ std::unique_ptr<column> fixed_point_binary_operation(column_view const& lhs,
 
   if (op == binary_operator::TRUE_DIV) {
     // Adjust columns so lhs has the scale needed to get desired output data_type (scale)
-    auto const diff   = lhs.type().scale() - scale;
+    auto const diff   = lhs.type().scale() - rhs.type().scale() - scale;
     auto const result = [&] {
       if (lhs.type().id() == type_id::DECIMAL32) {
         auto const factor = numeric::detail::ipow<int32_t, Radix::BASE_10>(diff);

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2303,6 +2303,22 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpNullEqualsSimple)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs      = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
+  auto const rhs      = fp_wrapper<RepType>{{4, 4, 4, 4}, scale_type{0}};
+  auto const expected = fp_wrapper<RepType>{{25, 75, 125, 175}, scale_type{-2}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), -2};
+  auto const result = cudf::binary_operation(lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 }  // namespace binop
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2420,21 +2420,69 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv7)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
-// TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv8)
-// {
-//   using namespace numeric;
-//   using decimalXX = TypeParam;
-//   using RepType   = device_storage_type_t<decimalXX>;
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv8)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
 
-//   auto const lhs      = fp_wrapper<RepType>{{4000, 6000, 80000}, scale_type{-1}};
-//   auto const rhs      = make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
-//   auto const expected = fp_wrapper<RepType>{{0, 1, 40}, scale_type{2}};
+  auto const lhs      = fp_wrapper<RepType>{{4000, 6000, 80000}, scale_type{-1}};
+  auto const rhs      = make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
+  auto const expected = fp_wrapper<RepType>{{0, 1, 16}, scale_type{2}};
 
-//   auto const type   = data_type{type_to_id<decimalXX>(), 2};
-//   auto const result = cudf::binary_operation(lhs, *rhs, cudf::binary_operator::TRUE_DIV, type);
+  auto const type   = data_type{type_to_id<decimalXX>(), 2};
+  auto const result = cudf::binary_operation(lhs, *rhs, cudf::binary_operator::TRUE_DIV, type);
 
-//   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
-// }
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv9)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs      = fp_wrapper<RepType>{{100000, 200000, 300000}, scale_type{-2}};
+  auto const rhs      = make_fixed_point_scalar<decimalXX>(7, scale_type{1});
+  auto const expected = fp_wrapper<RepType>{{1, 2, 4}, scale_type{1}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), 1};
+  auto const result = cudf::binary_operation(lhs, *rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv10)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs      = fp_wrapper<RepType>{{100000, 200000, 300000}, scale_type{-2}};
+  auto const rhs      = make_fixed_point_scalar<decimalXX>(7, scale_type{0});
+  auto const expected = fp_wrapper<RepType>{{14, 28, 42}, scale_type{1}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), 1};
+  auto const result = cudf::binary_operation(lhs, *rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv11)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs      = fp_wrapper<RepType>{{1000000, 2000000, 3000000}, scale_type{-2}};
+  auto const rhs      = fp_wrapper<RepType>{{7, 7, 7}, scale_type{0}};
+  auto const expected = fp_wrapper<RepType>{{142, 285, 428}, scale_type{1}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), 1};
+  auto const result = cudf::binary_operation(lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
 
 }  // namespace binop
 }  // namespace test

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2351,6 +2351,22 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv3)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv4)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs      = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{1}};
+  auto const rhs      = make_fixed_point_scalar<decimalXX>(3, scale_type{0});
+  auto const expected = fp_wrapper<RepType>{{3333, 10000, 16666, 23333}, scale_type{-2}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), -2};
+  auto const result = cudf::binary_operation(lhs, *rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 }  // namespace binop
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2326,7 +2326,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv2)
   using RepType   = device_storage_type_t<decimalXX>;
 
   auto const lhs      = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{1}};
-  auto const rhs      = fp_wrapper<RepType>{{2, 2, 2, 2}, scale_type{0}};
+  auto const rhs      = fp_wrapper<RepType>{{20, 20, 20, 20}, scale_type{-1}};
   auto const expected = fp_wrapper<RepType>{{5000, 15000, 25000, 35000}, scale_type{-2}};
 
   auto const type   = data_type{type_to_id<decimalXX>(), -2};
@@ -2342,7 +2342,7 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv3)
   using RepType   = device_storage_type_t<decimalXX>;
 
   auto const lhs      = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{1}};
-  auto const rhs      = fp_wrapper<RepType>{{3, 9, 3, 3}, scale_type{0}};
+  auto const rhs      = fp_wrapper<RepType>{{300, 900, 300, 300}, scale_type{-2}};
   auto const expected = fp_wrapper<RepType>{{3333, 3333, 16666, 23333}, scale_type{-2}};
 
   auto const type   = data_type{type_to_id<decimalXX>(), -2};
@@ -2359,6 +2359,22 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv4)
 
   auto const lhs      = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{1}};
   auto const rhs      = make_fixed_point_scalar<decimalXX>(3, scale_type{0});
+  auto const expected = fp_wrapper<RepType>{{3333, 10000, 16666, 23333}, scale_type{-2}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), -2};
+  auto const result = cudf::binary_operation(lhs, *rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv5)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs      = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{1}};
+  auto const rhs      = make_fixed_point_scalar<decimalXX>(30000, scale_type{-4});
   auto const expected = fp_wrapper<RepType>{{3333, 10000, 16666, 23333}, scale_type{-2}};
 
   auto const type   = data_type{type_to_id<decimalXX>(), -2};

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2400,22 +2400,22 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv6)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
-// TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv7)
-// {
-//   using namespace numeric;
-//   using decimalXX = TypeParam;
-//   using RepType   = device_storage_type_t<decimalXX>;
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv7)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
 
-//   auto const lhs = make_fixed_point_scalar<decimalXX>(300, scale_type{-2});
-//   auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
+  auto const lhs = make_fixed_point_scalar<decimalXX>(300, scale_type{-2});
+  auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
 
-//   auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
+  auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
 
-//   auto const type   = data_type{type_to_id<decimalXX>(), -2};
-//   auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+  auto const type   = data_type{type_to_id<decimalXX>(), -2};
+  auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
 
-//   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
-// }
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
 
 TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv8)
 {

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2319,6 +2319,38 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv2)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs      = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{1}};
+  auto const rhs      = fp_wrapper<RepType>{{2, 2, 2, 2}, scale_type{0}};
+  auto const expected = fp_wrapper<RepType>{{5000, 15000, 25000, 35000}, scale_type{-2}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), -2};
+  auto const result = cudf::binary_operation(lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv3)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs      = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{1}};
+  auto const rhs      = fp_wrapper<RepType>{{3, 9, 3, 3}, scale_type{0}};
+  auto const expected = fp_wrapper<RepType>{{3333, 3333, 16666, 23333}, scale_type{-2}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), -2};
+  auto const result = cudf::binary_operation(lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 }  // namespace binop
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2383,6 +2383,74 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv5)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv6)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs = make_fixed_point_scalar<decimalXX>(30000, scale_type{-4});
+  auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
+
+  auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), -2};
+  auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+// TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv7)
+// {
+//   using namespace numeric;
+//   using decimalXX = TypeParam;
+//   using RepType   = device_storage_type_t<decimalXX>;
+
+//   auto const lhs = make_fixed_point_scalar<decimalXX>(300, scale_type{-2});
+//   auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
+
+//   auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
+
+//   auto const type   = data_type{type_to_id<decimalXX>(), -2};
+//   auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+
+//   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+// }
+
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv8)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs = make_fixed_point_scalar<decimalXX>(30, scale_type{-1});
+  auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
+
+  auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), -2};
+  auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv9)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs = make_fixed_point_scalar<decimalXX>(3, scale_type{0});
+  auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
+
+  auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), -2};
+  auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 }  // namespace binop
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2403,6 +2403,39 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv6)
   }
 }
 
+TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv7)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = device_storage_type_t<decimalXX>;
+
+  auto const lhs = make_fixed_point_scalar<decimalXX>(12000, scale_type{-1});
+  auto const rhs = fp_wrapper<RepType>{{100, 200, 300, 500, 600, 800, 1200, 1300}, scale_type{-2}};
+
+  auto const expected = fp_wrapper<RepType>{{12, 6, 4, 2, 2, 1, 1, 0}, scale_type{2}};
+
+  auto const type   = data_type{type_to_id<decimalXX>(), 2};
+  auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+// TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv8)
+// {
+//   using namespace numeric;
+//   using decimalXX = TypeParam;
+//   using RepType   = device_storage_type_t<decimalXX>;
+
+//   auto const lhs      = fp_wrapper<RepType>{{4000, 6000, 80000}, scale_type{-1}};
+//   auto const rhs      = make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
+//   auto const expected = fp_wrapper<RepType>{{0, 1, 40}, scale_type{2}};
+
+//   auto const type   = data_type{type_to_id<decimalXX>(), 2};
+//   auto const result = cudf::binary_operation(lhs, *rhs, cudf::binary_operator::TRUE_DIV, type);
+
+//   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+// }
+
 }  // namespace binop
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/binaryop/binop-integration-test.cpp
+++ b/cpp/tests/binaryop/binop-integration-test.cpp
@@ -2389,66 +2389,18 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv6)
   using decimalXX = TypeParam;
   using RepType   = device_storage_type_t<decimalXX>;
 
-  auto const lhs = make_fixed_point_scalar<decimalXX>(30000, scale_type{-4});
-  auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
+  for (auto const i : {0, 1, 2, 3, 4, 5, 6, 7}) {
+    auto const val = 3 * numeric::detail::ipow<int32_t, Radix::BASE_10>(i);
+    auto const lhs = make_fixed_point_scalar<decimalXX>(val, scale_type{-i});
+    auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
 
-  auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
+    auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
 
-  auto const type   = data_type{type_to_id<decimalXX>(), -2};
-  auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
+    auto const type   = data_type{type_to_id<decimalXX>(), -2};
+    auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
-}
-
-TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv7)
-{
-  using namespace numeric;
-  using decimalXX = TypeParam;
-  using RepType   = device_storage_type_t<decimalXX>;
-
-  auto const lhs = make_fixed_point_scalar<decimalXX>(300, scale_type{-2});
-  auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
-
-  auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
-
-  auto const type   = data_type{type_to_id<decimalXX>(), -2};
-  auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
-
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
-}
-
-TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv8)
-{
-  using namespace numeric;
-  using decimalXX = TypeParam;
-  using RepType   = device_storage_type_t<decimalXX>;
-
-  auto const lhs = make_fixed_point_scalar<decimalXX>(30, scale_type{-1});
-  auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
-
-  auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
-
-  auto const type   = data_type{type_to_id<decimalXX>(), -2};
-  auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
-
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
-}
-
-TYPED_TEST(FixedPointTestBothReps, FixedPointBinaryOpTrueDiv9)
-{
-  using namespace numeric;
-  using decimalXX = TypeParam;
-  using RepType   = device_storage_type_t<decimalXX>;
-
-  auto const lhs = make_fixed_point_scalar<decimalXX>(3, scale_type{0});
-  auto const rhs = fp_wrapper<RepType>{{10, 30, 50, 70}, scale_type{-1}};
-
-  auto const expected = fp_wrapper<RepType>{{300, 100, 60, 42}, scale_type{-2}};
-
-  auto const type   = data_type{type_to_id<decimalXX>(), -2};
-  auto const result = cudf::binary_operation(*lhs, rhs, cudf::binary_operator::TRUE_DIV, type);
-
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
 }
 
 }  // namespace binop


### PR DESCRIPTION
This resolves a part of https://github.com/rapidsai/cudf/issues/7132

**ToDo:**
* [x] Simple unit test
* [x] Comprehensive unit tests
* [x] Initial Column + Column
* [x] Full Column + Column
* [x] Column + Scalar
* [x] Scalar + Column
* [x] Cleanup