### PR TITLE
Support `numeric_only` field for `rank()`

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1317,6 +1317,26 @@ class DataFrame(Frame, Serializable):
     def _repr_latex_(self):
         return self._get_renderable_dataframe().to_pandas()._repr_latex_()
 
+    def _get_columns_by_label(self, labels, downcast=False):
+        """
+        Return columns of dataframe by `labels`
+
+        If downcast is True, try and downcast from a DataFrame to a Series
+        """
+        new_data = super()._get_columns_by_label(labels)
+        if downcast:
+            if is_scalar(labels):
+                nlevels = 1
+            elif isinstance(labels, tuple):
+                nlevels = len(labels)
+            if self._data.multiindex is False or nlevels == self._data.nlevels:
+                return self._constructor_sliced(
+                    new_data, name=labels, index=self.index
+                )
+        return self._constructor(
+            new_data, columns=new_data.to_pandas_index(), index=self.index
+        )
+
     # unary, binary, rbinary, orderedcompare, unorderedcompare
     def _apply_op(self, fn, other=None, fill_value=None):
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1323,7 +1323,7 @@ class DataFrame(Frame, Serializable):
 
         If downcast is True, try and downcast from a DataFrame to a Series
         """
-        new_data = super()._get_columns_by_label(labels)
+        new_data = super()._get_columns_by_label(labels, downcast)
         if downcast:
             if is_scalar(labels):
                 nlevels = 1

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1622,7 +1622,6 @@ class Frame(libcudf.table.Table):
             )
             source = self._get_columns_by_label(numeric_cols)
             if source.empty:
-                print(source)
                 return source.astype("float64")
 
         out_rank_table = libcudf.sort.rank_columns(

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1614,10 +1614,16 @@ class Frame(libcudf.table.Table):
                 "na_option must be one of 'keep', 'top', or 'bottom'"
             )
 
-        # TODO code for selecting numeric columns
         source = self
         if numeric_only:
-            warnings.warn("numeric_only=True is not implemented yet")
+            numeric_cols = filter(
+                lambda name: is_numerical_dtype(self._data[name]),
+                self._data.names,
+            )
+            source = self._get_columns_by_label(numeric_cols)
+            if source.empty:
+                print(source)
+                return source.astype("float64")
 
         out_rank_table = libcudf.sort.rank_columns(
             source, method_enum, na_option, ascending, pct

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1616,9 +1616,8 @@ class Frame(libcudf.table.Table):
 
         source = self
         if numeric_only:
-            numeric_cols = filter(
-                lambda name: is_numerical_dtype(self._data[name]),
-                self._data.names,
+            numeric_cols = (
+                name for name in self._data.names if is_numerical_dtype(self._data[name])
             )
             source = self._get_columns_by_label(numeric_cols)
             if source.empty:

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -467,25 +467,12 @@ class Frame(libcudf.table.Table):
         else:
             return self._index.equals(other._index)
 
-    def _get_columns_by_label(self, labels, downcast=False):
+    def _get_columns_by_label(self, labels):
         """
         Returns columns of the Frame specified by `labels`
 
-        If downcast is True, try and downcast from a DataFrame to a Series
         """
-        new_data = self._data.select_by_label(labels)
-        if downcast:
-            if is_scalar(labels):
-                nlevels = 1
-            elif isinstance(labels, tuple):
-                nlevels = len(labels)
-            if self._data.multiindex is False or nlevels == self._data.nlevels:
-                return self._constructor_sliced(
-                    new_data, name=labels, index=self.index
-                )
-        return self._constructor(
-            new_data, columns=new_data.to_pandas_index(), index=self.index
-        )
+        return self._data.select_by_label(labels)
 
     def _get_columns_by_index(self, indices):
         """

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -467,7 +467,7 @@ class Frame(libcudf.table.Table):
         else:
             return self._index.equals(other._index)
 
-    def _get_columns_by_label(self, labels):
+    def _get_columns_by_label(self, labels, downcast):
         """
         Returns columns of the Frame specified by `labels`
 
@@ -1617,7 +1617,9 @@ class Frame(libcudf.table.Table):
         source = self
         if numeric_only:
             numeric_cols = (
-                name for name in self._data.names if is_numerical_dtype(self._data[name])
+                name
+                for name in self._data.names
+                if is_numerical_dtype(self._data[name])
             )
             source = self._get_columns_by_label(numeric_cols)
             if source.empty:

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -415,7 +415,7 @@ class Series(Frame, Serializable):
         return (
             self._constructor(data=new_data, index=self.index)
             if len(new_data) > 0
-            else Series(dtype=self.dtype, name=self.name)
+            else self._constructor(dtype=self.dtype, name=self.name)
         )
 
     @classmethod

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -404,6 +404,18 @@ class Series(Frame, Serializable):
         params.update(kwargs)
         return cls(**params)
 
+    def _get_columns_by_label(self, labels):
+        """
+        Return the column
+        """
+        new_data = super()._get_columns_by_label(labels)
+
+        return (
+            self._constructor(data=new_data, index=self.index)
+            if len(new_data) > 0
+            else Series(dtype=self.dtype, name=self.name)
+        )
+
     @classmethod
     def from_arrow(cls, array):
         """

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -404,11 +404,13 @@ class Series(Frame, Serializable):
         params.update(kwargs)
         return cls(**params)
 
-    def _get_columns_by_label(self, labels):
+    def _get_columns_by_label(self, labels, downcast=False):
+        """Return the column specified by `labels`
+
+        For cudf.Series, either the column, or an empty series is returned.
+        Parameter `downcast` does not have effects.
         """
-        Return the column
-        """
-        new_data = super()._get_columns_by_label(labels)
+        new_data = super()._get_columns_by_label(labels, downcast)
 
         return (
             self._constructor(data=new_data, index=self.index)

--- a/python/cudf/cudf/tests/test_rank.py
+++ b/python/cudf/cudf/tests/test_rank.py
@@ -35,8 +35,8 @@ def test_rank_all_arguments(
     if method == "first" and dtype == "O":
         # not supported by pandas
         return
-    
-    pdf = pdf.copy(deep=True) # for parallel pytest
+
+    pdf = pdf.copy(deep=True)  # for parallel pytest
     if numeric_only:
         pdf["str"] = np.array(
             ["a", "b", "c", "d", "e", "1", "2", "3", "4", "5"]

--- a/python/cudf/cudf/tests/test_rank.py
+++ b/python/cudf/cudf/tests/test_rank.py
@@ -10,152 +10,145 @@ from cudf.core import DataFrame
 from cudf.tests.utils import assert_eq, assert_exceptions_equal
 
 
-class TestRank:
-    index = np.array([5, 4, 3, 2, 1, 6, 7, 8, 9, 10])
-    col1 = np.array([5, 4, 3, 5, 8, 5, 2, 1, 6, 6])
-    col2 = np.array([5, 4, np.nan, 5, 8, 5, np.inf, np.nan, 6, -np.inf])
-
-    @pytest.mark.parametrize("dtype", ["O", "f8", "i4"])
-    @pytest.mark.parametrize("ascending", [True, False])
-    @pytest.mark.parametrize(
-        "method", ["average", "min", "max", "first", "dense"]
+@pytest.fixture
+def pdf():
+    return pd.DataFrame(
+        {
+            "col1": np.array([5, 4, 3, 5, 8, 5, 2, 1, 6, 6]),
+            "col2": np.array(
+                [5, 4, np.nan, 5, 8, 5, np.inf, np.nan, 6, -np.inf]
+            ),
+        },
+        index=np.array([5, 4, 3, 2, 1, 6, 7, 8, 9, 10]),
     )
-    @pytest.mark.parametrize("na_option", ["keep", "top", "bottom"])
-    @pytest.mark.parametrize("pct", [True, False])
-    def test_rank_all_arguments(
-        self, dtype, ascending, method, na_option, pct
+
+
+@pytest.mark.parametrize("dtype", ["O", "f8", "i4"])
+@pytest.mark.parametrize("ascending", [True, False])
+@pytest.mark.parametrize("method", ["average", "min", "max", "first", "dense"])
+@pytest.mark.parametrize("na_option", ["keep", "top", "bottom"])
+@pytest.mark.parametrize("pct", [True, False])
+@pytest.mark.parametrize("numeric_only", [True, False])
+def test_rank_all_arguments(
+    pdf, dtype, ascending, method, na_option, pct, numeric_only
+):
+    if method == "first" and dtype == "O":
+        # not supported by pandas
+        return
+    if numeric_only:
+        pdf["str"] = np.array(
+            ["a", "b", "c", "d", "e", "1", "2", "3", "4", "5"]
+        )
+    gdf = DataFrame.from_pandas(pdf)
+
+    kwargs = {
+        "method": method,
+        "na_option": na_option,
+        "ascending": ascending,
+        "pct": pct,
+        "numeric_only": numeric_only,
+    }
+
+    # Series
+    assert_eq(gdf["col1"].rank(**kwargs), pdf["col1"].rank(**kwargs))
+    assert_eq(gdf["col2"].rank(**kwargs), pdf["col2"].rank(**kwargs))
+    if numeric_only:
+        expect = pdf["str"].rank(**kwargs)
+        got = gdf["str"].rank(**kwargs)
+        assert expect.empty == got.empty
+
+    # TODO: https://github.com/pandas-dev/pandas/issues/32593
+    # Dataframe (bug in pandas)
+    if (
+        na_option == "top"
+        and method == "first"
+        and not dtype == "O"
+        and ascending
     ):
-        if method == "first" and dtype == "O":
-            # not supported by pandas
-            return
-        pdf = pd.DataFrame(index=self.index)
-        pdf["col1"] = self.col1.astype(dtype)
-        pdf["col2"] = self.col2.astype(dtype)
-        gdf = DataFrame.from_pandas(pdf)
+        assert_eq(gdf.rank(**kwargs), pdf.rank(**kwargs))
+    else:
+        with pytest.raises(AssertionError, match="values are different"):
+            assert_eq(gdf.rank(**kwargs), pdf.rank(**kwargs))
 
-        def _check(gs, ps, method, na_option, ascending, pct):
-            ranked_gs = gs.rank(
-                method=method,
-                na_option=na_option,
-                ascending=ascending,
-                pct=pct,
-            )
-            ranked_ps = ps.rank(
-                method=method,
-                na_option=na_option,
-                ascending=ascending,
-                pct=pct,
-            )
-            assert_eq(ranked_ps, ranked_gs.to_pandas())
 
-        # # Series
-        _check(
-            gdf["col1"],
-            pdf["col1"],
-            method=method,
-            na_option=na_option,
-            ascending=ascending,
-            pct=pct,
-        )
-        _check(
-            gdf["col2"],
-            pdf["col2"],
-            method=method,
-            na_option=na_option,
-            ascending=ascending,
-            pct=pct,
-        )
-        # TODO: https://github.com/pandas-dev/pandas/issues/32593
-        # Dataframe (bug in pandas)
-        # _check(
-        #     gdf,
-        #     pdf,
-        #     method=method,
-        #     na_option=na_option,
-        #     ascending=ascending,
-        #     pct=pct,
-        # )
+def test_rank_error_arguments(pdf):
+    gdf = DataFrame.from_pandas(pdf)
 
-    def test_rank_error_arguments(self):
-        pdf = pd.DataFrame(index=self.index)
-        pdf["col1"] = self.col1
-        pdf["col2"] = self.col2
-        gdf = DataFrame.from_pandas(pdf)
-
-        assert_exceptions_equal(
-            lfunc=pdf["col1"].rank,
-            rfunc=gdf["col1"].rank,
-            lfunc_args_and_kwargs=(
-                [],
-                {
-                    "method": "randomname",
-                    "na_option": "keep",
-                    "ascending": True,
-                    "pct": True,
-                },
-            ),
-            rfunc_args_and_kwargs=(
-                [],
-                {
-                    "method": "randomname",
-                    "na_option": "keep",
-                    "ascending": True,
-                    "pct": True,
-                },
-            ),
-        )
-
-        assert_exceptions_equal(
-            lfunc=pdf["col1"].rank,
-            rfunc=gdf["col1"].rank,
-            lfunc_args_and_kwargs=(
-                [],
-                {
-                    "method": "first",
-                    "na_option": "randomname",
-                    "ascending": True,
-                    "pct": True,
-                },
-            ),
-            rfunc_args_and_kwargs=(
-                [],
-                {
-                    "method": "first",
-                    "na_option": "randomname",
-                    "ascending": True,
-                    "pct": True,
-                },
-            ),
-        )
-
-    sort_group_args = [
-        np.full((3,), np.nan),
-        100 * np.random.random(10),
-        np.full((3,), np.inf),
-        np.full((3,), -np.inf),
-    ]
-    sort_dtype_args = [np.int32, np.float32, np.float64]
-    # TODO: np.int64, disabled because of bug
-    # https://github.com/pandas-dev/pandas/issues/32859
-
-    @pytest.mark.parametrize(
-        "elem,dtype",
-        list(
-            product(
-                combinations_with_replacement(sort_group_args, 4),
-                sort_dtype_args,
-            )
+    assert_exceptions_equal(
+        lfunc=pdf["col1"].rank,
+        rfunc=gdf["col1"].rank,
+        lfunc_args_and_kwargs=(
+            [],
+            {
+                "method": "randomname",
+                "na_option": "keep",
+                "ascending": True,
+                "pct": True,
+            },
+        ),
+        rfunc_args_and_kwargs=(
+            [],
+            {
+                "method": "randomname",
+                "na_option": "keep",
+                "ascending": True,
+                "pct": True,
+            },
         ),
     )
-    def test_series_rank_combinations(self, elem, dtype):
-        np.random.seed(0)
-        gdf = DataFrame()
-        gdf["a"] = aa = np.fromiter(
-            chain.from_iterable(elem), np.float64
-        ).astype(dtype)
-        ranked_gs = gdf["a"].rank(method="first")
-        df = pd.DataFrame()
-        df["a"] = aa
-        ranked_ps = df["a"].rank(method="first")
-        # Check
-        assert_eq(ranked_ps, ranked_gs.to_pandas())
+
+    assert_exceptions_equal(
+        lfunc=pdf["col1"].rank,
+        rfunc=gdf["col1"].rank,
+        lfunc_args_and_kwargs=(
+            [],
+            {
+                "method": "first",
+                "na_option": "randomname",
+                "ascending": True,
+                "pct": True,
+            },
+        ),
+        rfunc_args_and_kwargs=(
+            [],
+            {
+                "method": "first",
+                "na_option": "randomname",
+                "ascending": True,
+                "pct": True,
+            },
+        ),
+    )
+
+
+sort_group_args = [
+    np.full((3,), np.nan),
+    100 * np.random.random(10),
+    np.full((3,), np.inf),
+    np.full((3,), -np.inf),
+]
+sort_dtype_args = [np.int32, np.float32, np.float64]
+# TODO: np.int64, disabled because of bug
+# https://github.com/pandas-dev/pandas/issues/32859
+
+
+@pytest.mark.parametrize(
+    "elem,dtype",
+    list(
+        product(
+            combinations_with_replacement(sort_group_args, 4), sort_dtype_args,
+        )
+    ),
+)
+def test_series_rank_combinations(elem, dtype):
+    np.random.seed(0)
+    gdf = DataFrame()
+    gdf["a"] = aa = np.fromiter(chain.from_iterable(elem), np.float64).astype(
+        dtype
+    )
+    ranked_gs = gdf["a"].rank(method="first")
+    df = pd.DataFrame()
+    df["a"] = aa
+    ranked_ps = df["a"].rank(method="first")
+    # Check
+    assert_eq(ranked_ps, ranked_gs.to_pandas())

--- a/python/cudf/cudf/tests/test_rank.py
+++ b/python/cudf/cudf/tests/test_rank.py
@@ -35,6 +35,8 @@ def test_rank_all_arguments(
     if method == "first" and dtype == "O":
         # not supported by pandas
         return
+    
+    pdf = pdf.copy(deep=True) # for parallel pytest
     if numeric_only:
         pdf["str"] = np.array(
             ["a", "b", "c", "d", "e", "1", "2", "3", "4", "5"]


### PR DESCRIPTION
Closes #7174 

This PR adds support for `numeric_only` field for `Dataframe.rank()`  and `Series.rank()`. When user specifies `numeric_only=True`, only the numerical data type columns are selected to construct a cudf object and passed to lower level for processing.

Two minor refactors are also included in this PR:

- This PR refactors internal API of `Frame._get_columns_by_label`, which now supports dispatching to this method from both `Dataframe` and `Series`. 
- This PR refactors `test_rank.py`, moving test functions inside class `TestRank` out as top level functions. All test variables shared among test cases are moved to a `pytests.fixture` method. A `Dataframe.rank` test case that expects to raise due to a [pandas bug](https://github.com/pandas-dev/pandas/issues/32593) is now captured under `pytest.raises`.