### PR TITLE
Improve `assert_eq` handling of scalar

### DIFF
--- a/python/cudf/cudf/tests/test_testing.py
+++ b/python/cudf/cudf/tests/test_testing.py
@@ -10,7 +10,7 @@ from cudf.testing import (
     assert_index_equal,
     assert_series_equal,
 )
-from cudf.tests.utils import NUMERIC_TYPES, OTHER_TYPES
+from cudf.tests.utils import NUMERIC_TYPES, OTHER_TYPES, assert_eq
 
 
 @pytest.mark.parametrize("rdata", [[1, 2, 5], [1, 2, 6], [1, 2, 5, 6]])
@@ -299,3 +299,40 @@ def test_range_index_and_int_index_eqaulity(index, exact):
             assert_index_equal(idx1, idx2, exact=exact)
     else:
         assert_index_equal(idx1, idx2, exact=exact)
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        (1493282, 1493282),
+        (1493282.0, 1493282.0 + 1e-8),
+        ("abc", "abc"),
+        (0, np.array(0)),
+        (
+            np.datetime64(123456, "ns"),
+            pd.Timestamp(np.datetime64(123456, "ns")),
+        ),
+        ("int64", np.dtype("int64")),
+    ],
+)
+def test_basic_scalar_eqaulity(left, right):
+    assert_eq(left, right)
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        (1493282, 1493274),
+        (1493282.0, 1493282.0 + 1e-6),
+        ("abc", "abd"),
+        (0, np.array(1)),
+        (
+            np.datetime64(123456, "ns"),
+            pd.Timestamp(np.datetime64(123457, "ns")),
+        ),
+        ("int64", np.dtype("int32")),
+    ],
+)
+def test_basic_scalar_ineqaulity(left, right):
+    with pytest.raises(AssertionError, match=r".*not (almost )?equal.*"):
+        assert_eq(left, right)

--- a/python/cudf/cudf/tests/test_testing.py
+++ b/python/cudf/cudf/tests/test_testing.py
@@ -316,7 +316,7 @@ def test_range_index_and_int_index_eqaulity(index, exact):
         (np.nan, np.nan),
     ],
 )
-def test_basic_scalar_eqaulity(left, right):
+def test_basic_scalar_equality(left, right):
     assert_eq(left, right)
 
 
@@ -334,6 +334,6 @@ def test_basic_scalar_eqaulity(left, right):
         ("int64", np.dtype("int32")),
     ],
 )
-def test_basic_scalar_ineqaulity(left, right):
+def test_basic_scalar_inequality(left, right):
     with pytest.raises(AssertionError, match=r".*not (almost )?equal.*"):
         assert_eq(left, right)

--- a/python/cudf/cudf/tests/test_testing.py
+++ b/python/cudf/cudf/tests/test_testing.py
@@ -313,6 +313,7 @@ def test_range_index_and_int_index_eqaulity(index, exact):
             pd.Timestamp(np.datetime64(123456, "ns")),
         ),
         ("int64", np.dtype("int64")),
+        (np.nan, np.nan),
     ],
 )
 def test_basic_scalar_eqaulity(left, right):

--- a/python/cudf/cudf/tests/utils.py
+++ b/python/cudf/cudf/tests/utils.py
@@ -97,13 +97,13 @@ def assert_eq(left, right, **kwargs):
         else:
             assert np.array_equal(left, right)
     else:
+        # Use the overloaded __eq__ of the operands
         if left == right:
             return True
+        elif any([np.issubdtype(type(x), np.floating) for x in (left, right)]):
+            np.testing.assert_almost_equal(left, right)
         else:
-            if np.isnan(left):
-                assert np.isnan(right)
-            else:
-                assert np.allclose(left, right, equal_nan=True)
+            np.testing.assert_equal(left, right)
     return True
 
 


### PR DESCRIPTION
Closes #7199

Refactors scalar handling inside `assert_eq`. On higher level, this PR proposes a "whitelist" style testing: all compares should go to the "strict equal" code path unless explicitly allowed. This allows the test system to capture all unintended inequality except the ones that's discussed upon. For example, this PR creates two whitelist items:
- If the operands overrides `__eq__`, use it to determine equality.
- If the operands are floating type, assert approximate equality.
For all other cases, the operands should be strictly equal. Note that for testing purposes, `np.nan` are considered equal to itself.