### PR TITLE
Add JNI support for converting Arrow buffers to CUDF ColumnVectors [skip ci]

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -132,6 +132,12 @@
             <version>2.25.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <version>${arrow.version}</version>
+           <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>
@@ -151,6 +157,7 @@
         <GPU_ARCHS>ALL</GPU_ARCHS>
         <native.build.path>${project.build.directory}/cmake-build</native.build.path>
         <slf4j.version>1.7.30</slf4j.version>
+        <arrow.version>0.15.1</arrow.version>
     </properties>
 
     <profiles>

--- a/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
@@ -22,8 +22,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 
 /**
- * Column builder from Arrow data. This builder takes in pointers to the Arrow off heap
- * memory and allows efficient building of CUDF ColumnVectors from that Arrow data.
+ * Column builder from Arrow data. This builder takes in byte buffers referencing
+ * Arrow data and allows efficient building of CUDF ColumnVectors from that Arrow data.
  * The caller can add multiple batches where each batch corresponds to Arrow data
  * and those batches get concatenated together after being converted to CUDF
  * ColumnVectors.
@@ -102,12 +102,12 @@ public final class ArrowColumnBuilder implements AutoCloseable {
     @Override
     public String toString() {
       return "ArrowColumnBuilder{" +
-          "type=" + type +
-          ", data=" + data +
-          ", validity=" + validity +
-          ", offsets=" + offsets +
-          ", nullCount=" + nullCount +
-          ", rows=" + rows +
-          '}';
+        "type=" + type +
+        ", data=" + data +
+        ", validity=" + validity +
+        ", offsets=" + offsets +
+        ", nullCount=" + nullCount +
+        ", rows=" + rows +
+        '}';
     }
 }

--- a/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
@@ -74,13 +74,13 @@ public final class ArrowColumnBuilder implements AutoCloseable {
       if (this.numBatches == 1) {
         vecRet = allVecs.get(0);
       } else if (this.numBatches > 1) {
-	try {
-          vecRet = ColumnVector.concatenate(allVecs.toArray(new ColumnVector[0]));
-	} finally {
+        try {
+         vecRet = ColumnVector.concatenate(allVecs.toArray(new ColumnVector[0]));
+        } finally {
           for (ColumnVector cv : allVecs) {
             cv.close();
           }
-	}
+        }
       } else {
         throw new IllegalStateException("Can't build a ColumnVector when no Arrow batches specified");
       }

--- a/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
@@ -43,7 +43,7 @@ public final class ArrowColumnBuilder implements AutoCloseable {
     }
 
     /**
-     * Add an Arrow buffer. This api allows you to add multiple if you want them
+     * Add an Arrow buffer. This API allows you to add multiple if you want them
      * combined into a single ColumnVector.
      * Note, this takes all data, validity, and offsets buffers, but they may not all
      * be needed based on the data type. The buffer should be null if its not used

--- a/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
@@ -97,9 +97,7 @@ public final class ArrowColumnBuilder implements AutoCloseable {
       } finally {
         // close the vectors that were concatenated
         if (numBatches > 1) {
-          for (ColumnVector cv : allVecs) {
-            cv.close();
-          }
+          allVecs.forEach(cv -> cv.close());
         }
       }
       return vecRet;

--- a/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
@@ -19,8 +19,6 @@
 package ai.rapids.cudf;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.StringJoiner;
 
 /**
  * Column builder from Arrow data. This builder takes in pointers to the Arrow off heap
@@ -28,17 +26,19 @@ import java.util.StringJoiner;
  * The caller can add multiple batches where each batch corresponds to Arrow data
  * and those batches get concatenated together after being converted to CUDF
  * ColumnVectors.
+ * This currently only supports primitive types and Strings, Decimals and nested types
+ * such as list and struct are not supported.
  */
 public final class ArrowColumnBuilder implements AutoCloseable {
     private DType type;
-    private ArrayList<Long> data = new ArrayList<>();
-    private ArrayList<Long> dataLength = new ArrayList<>();
-    private ArrayList<Long> validity = new ArrayList<>();
-    private ArrayList<Long> validityLength = new ArrayList<>();
-    private ArrayList<Long> offsets = new ArrayList<>();
-    private ArrayList<Long> offsetsLength = new ArrayList<>();
-    private ArrayList<Long> nullCount = new ArrayList<>();
-    private ArrayList<Long> rows = new ArrayList<>();
+    private final ArrayList<Long> data = new ArrayList<>();
+    private final ArrayList<Long> dataLength = new ArrayList<>();
+    private final ArrayList<Long> validity = new ArrayList<>();
+    private final ArrayList<Long> validityLength = new ArrayList<>();
+    private final ArrayList<Long> offsets = new ArrayList<>();
+    private final ArrayList<Long> offsetsLength = new ArrayList<>();
+    private final ArrayList<Long> nullCount = new ArrayList<>();
+    private final ArrayList<Long> rows = new ArrayList<>();
 
     public ArrowColumnBuilder(HostColumnVector.DataType type) {
       this.type = type.getType();
@@ -50,6 +50,8 @@ public final class ArrowColumnBuilder implements AutoCloseable {
      * Note, this takes all data, validity, and offsets buffers, but they may not all
      * be needed based on the data type. The buffer and length should be set to 0
      * if they aren't used for that type.
+     * This api only supports primitive types and Strings, Decimals and nested types
+     * such as list and struct are not supported.
      * @param rows - number of rows in this Arrow buffer
      * @param nullCount - number of null values in this Arrow buffer
      * @param data - memory address of the Arrow data buffer
@@ -110,7 +112,6 @@ public final class ArrowColumnBuilder implements AutoCloseable {
 
     @Override
     public String toString() {
-      StringJoiner sj = new StringJoiner(",");
       return "ArrowColumnBuilder{" +
           "type=" + type +
           ", data=" + data +

--- a/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
@@ -48,7 +48,7 @@ public final class ArrowColumnBuilder implements AutoCloseable {
      * Add an Arrow buffer. This api allows you to add multiple if you want them
      * combined into a single ColumnVector.
      * Note, this takes all data, validity, and offsets buffers, but they may not all
-     * be used based on the data type. The buffer and length should just be set to 0
+     * be needed based on the data type. The buffer and length should be set to 0
      * if they aren't used for that type.
      * @param rows - number of rows in this Arrow buffer
      * @param nullCount - number of null values in this Arrow buffer

--- a/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
@@ -48,7 +48,7 @@ public final class ArrowColumnBuilder implements AutoCloseable {
      * Note, this takes all data, validity, and offsets buffers, but they may not all
      * be needed based on the data type. The buffer should be null if its not used
      * for that type.
-     * This api only supports primitive types and Strings, Decimals and nested types
+     * This API only supports primitive types and Strings, Decimals and nested types
      * such as list and struct are not supported.
      * @param rows - number of rows in this Arrow buffer
      * @param nullCount - number of null values in this Arrow buffer

--- a/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
@@ -47,7 +47,7 @@ public final class ArrowColumnBuilder implements AutoCloseable {
      * combined into a single ColumnVector.
      * Note, this takes all data, validity, and offsets buffers, but they may not all
      * be needed based on the data type. The buffer should be null if its not used
-     * used for that type.
+     * for that type.
      * This api only supports primitive types and Strings, Decimals and nested types
      * such as list and struct are not supported.
      * @param rows - number of rows in this Arrow buffer

--- a/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
+++ b/java/src/main/java/ai/rapids/cudf/ArrowColumnBuilder.java
@@ -1,0 +1,111 @@
+/*
+ *
+ *  Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package ai.rapids.cudf;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+/**
+ * Column builder from Arrow data. This builder takes in pointers to the Arrow off heap
+ * memory and allows efficient building of CUDF ColumnVectors from that arrow data.
+ * The caller can add multiple batches where each batch corresponds to Arrow data
+ * and those batches get concatenated together after being converted to CUDF
+ * ColumnVectors.
+ */
+public final class ArrowColumnBuilder implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(ArrowColumnBuilder.class);
+
+    private DType type;
+    private ArrayList<Long> data = new ArrayList<>();
+    private ArrayList<Long> dataLength = new ArrayList<>();
+    private ArrayList<Long> validity = new ArrayList<>();
+    private ArrayList<Long> validityLength = new ArrayList<>();
+    private ArrayList<Long> offsets = new ArrayList<>();
+    private ArrayList<Long> offsetsLength = new ArrayList<>();
+    private ArrayList<Long> nullCount = new ArrayList<>();
+    private ArrayList<Long> rows = new ArrayList<>();
+    private int numBatches = 0;
+    private String colName;
+
+    public ArrowColumnBuilder(HostColumnVector.DataType type, String name) {
+      this.type = type.getType();
+      this.colName = name;
+    }
+
+    public void addBatch(long rows, long nullCount, long data, long dataLength, long valid,
+                         long validLength, long offsets, long offsetsLength) {
+      this.numBatches += 1;
+      this.rows.add(rows);
+      this.nullCount.add(nullCount);
+      this.data.add(data);
+      this.dataLength.add(dataLength);
+      this.validity.add(valid);
+      this.validityLength.add(validLength);
+      this.offsets.add(offsets);
+      this.offsetsLength.add(offsetsLength);
+    }
+
+    /**
+     * Create the immutable ColumnVector, copied to the device based on the Arrow data.
+     */
+    public final ColumnVector buildAndPutOnDevice() {
+      log.warn("buildAndPutOnDevice type before is: " + type + " name is: " + colName + " num batches is: " + this.numBatches);
+      ArrayList<ColumnVector> allVecs = new ArrayList<>();
+      for (int i = 0; i < this.numBatches; i++) {
+        allVecs.add(ColumnVector.fromArrow(type, colName, rows.get(i), nullCount.get(i),
+          data.get(i), dataLength.get(i), validity.get(i), validityLength.get(i),
+          offsets.get(i), offsetsLength.get(i)));
+      }
+      ColumnVector vecRet;
+      if (this.numBatches == 1) {
+        vecRet = allVecs.get(0);
+      } else if (this.numBatches > 1) {
+        vecRet = ColumnVector.concatenate(allVecs.toArray(new ColumnVector[0]));
+      } else {
+        throw new IllegalStateException("Can't build a ColumnVector when no Arrow batches specified");
+      }
+      return vecRet;
+    }
+
+    @Override
+    public void close() {
+      // memory buffers owned outside of this
+    }
+
+    @Override
+    public String toString() {
+      StringJoiner sj = new StringJoiner(",");
+      return "ArrowColumnBuilder{" +
+          "type=" + type +
+          ", data=" + data +
+          ", dataLength=" + dataLength +
+          ", validity=" + validity +
+          ", validityLength=" + validityLength +
+          ", offsets=" + offsets +
+          ", offsetsLength=" + offsetsLength+
+          ", nullCount=" + nullCount +
+          ", rows=" + rows +
+          ", populatedRows=" + rows +
+          '}';
+    }
+}

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -316,7 +316,7 @@ public final class ColumnVector extends ColumnView {
    * Any of the buffers not used for that datatype should be set to null.
    * The buffers are expected to be off heap buffers, but if they are not,
    * it will handle copying them to direct byte buffers.
-   * This only supports primitive types and Strings, Decimals and nested types
+   * This only supports primitive types. Strings, Decimals and nested types
    * such as list and struct are not supported.
    * @param type - type of the column
    * @param numRows - Number of rows in the arrow column

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -313,7 +313,6 @@ public final class ColumnVector extends ColumnView {
   /**
    * Create a ColumnVector from the off heap Apache Arrow buffers passed in.
    * @param type - type of the column
-   * @param colName - Name of the column
    * @param numRows - Number of rows in the arrow column
    * @param nullCount - Null count
    * @param data - address of the Arrow data buffer
@@ -326,7 +325,6 @@ public final class ColumnVector extends ColumnView {
    */
   public static ColumnVector fromArrow(
       DType type,
-      String colName,
       long numRows,
       long nullCount,
       long data,
@@ -335,7 +333,7 @@ public final class ColumnVector extends ColumnView {
       long validityLength,
       long offsets,
       long offsetsLength) {
-    long columnHandle = fromArrow(type.typeId.getNativeId(), colName, numRows, nullCount, data,
+    long columnHandle = fromArrow(type.typeId.getNativeId(), numRows, nullCount, data,
          dataLength, validity, validityLength, offsets, offsetsLength);
     ColumnVector vec = new ColumnVector(columnHandle);
     return vec;
@@ -646,7 +644,7 @@ public final class ColumnVector extends ColumnView {
 
   private static native long sequence(long initialValue, long step, int rows);
 
-  private static native long fromArrow(int type, String col_name, long col_length,
+  private static native long fromArrow(int type, long col_length,
       long null_count, long data, long data_size, long validity, long validity_size,
       long offsets, long offsets_size) throws CudfException;
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -312,6 +312,8 @@ public final class ColumnVector extends ColumnView {
 
   /**
    * Create a ColumnVector from the off heap Apache Arrow buffers passed in.
+   * Any of the buffers not used for that datatype should be set to 0 for the
+   * address and size.
    * @param type - type of the column
    * @param numRows - Number of rows in the arrow column
    * @param nullCount - Null count

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -311,6 +311,37 @@ public final class ColumnVector extends ColumnView {
   }
 
   /**
+   * Create a ColumnVector from the off heap Apache Arrow buffers passed in.
+   * @param type - type of the column
+   * @param colName - Name of the column
+   * @param numRows - Number of rows in the arrow column
+   * @param nullCount - Null count
+   * @param data - address of the Arrow data buffer
+   * @param dataLength - size of the Arrow data buffer
+   * @param validity - address of the Arrow validity buffer
+   * @param validityLength - size of the Arrow validity buffer
+   * @param offsets - address of the Arrow offsets buffer
+   * @param offsetsLength - size of the Arrow offsets buffer
+   * @return - new ColumnVector
+   */
+  public static ColumnVector fromArrow(
+      DType type,
+      String colName,
+      long numRows,
+      long nullCount,
+      long data,
+      long dataLength,
+      long validity,
+      long validityLength,
+      long offsets,
+      long offsetsLength) {
+    long columnHandle = fromArrow(type.typeId.getNativeId(), colName, numRows, nullCount, data,
+         dataLength, validity, validityLength, offsets, offsetsLength);
+    ColumnVector vec = new ColumnVector(columnHandle);
+    return vec;
+  }
+
+  /**
    * Create a new vector of length rows, where each row is filled with the Scalar's
    * value
    * @param scalar - Scalar to use to fill rows
@@ -614,6 +645,10 @@ public final class ColumnVector extends ColumnView {
   /////////////////////////////////////////////////////////////////////////////
 
   private static native long sequence(long initialValue, long step, int rows);
+
+  private static native long fromArrow(int type, String col_name, long col_length,
+      long null_count, long data, long data_size, long validity, long validity_size,
+      long offsets, long offsets_size) throws CudfException;
 
   private static native long fromScalar(long scalarHandle, int rowCount) throws CudfException;
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -314,6 +314,8 @@ public final class ColumnVector extends ColumnView {
    * Create a ColumnVector from the off heap Apache Arrow buffers passed in.
    * Any of the buffers not used for that datatype should be set to 0 for the
    * address and size.
+   * This only supports primitive types and Strings, Decimals and nested types
+   * such as list and struct are not supported.
    * @param type - type of the column
    * @param numRows - Number of rows in the arrow column
    * @param nullCount - Null count

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -312,33 +313,26 @@ public final class ColumnVector extends ColumnView {
 
   /**
    * Create a ColumnVector from the off heap Apache Arrow buffers passed in.
-   * Any of the buffers not used for that datatype should be set to 0 for the
-   * address and size.
+   * Any of the buffers not used for that datatype should be set to null.
    * This only supports primitive types and Strings, Decimals and nested types
    * such as list and struct are not supported.
    * @param type - type of the column
    * @param numRows - Number of rows in the arrow column
    * @param nullCount - Null count
-   * @param data - address of the Arrow data buffer
-   * @param dataLength - size of the Arrow data buffer
-   * @param validity - address of the Arrow validity buffer
-   * @param validityLength - size of the Arrow validity buffer
-   * @param offsets - address of the Arrow offsets buffer
-   * @param offsetsLength - size of the Arrow offsets buffer
+   * @param data - ByteBuffer of the Arrow data buffer
+   * @param validity - ByteBuffer of the Arrow validity buffer
+   * @param offsets - ByteBuffer of the Arrow offsets buffer
    * @return - new ColumnVector
    */
   public static ColumnVector fromArrow(
       DType type,
       long numRows,
       long nullCount,
-      long data,
-      long dataLength,
-      long validity,
-      long validityLength,
-      long offsets,
-      long offsetsLength) {
+      ByteBuffer data,
+      ByteBuffer validity,
+      ByteBuffer offsets) {
     long columnHandle = fromArrow(type.typeId.getNativeId(), numRows, nullCount, data,
-         dataLength, validity, validityLength, offsets, offsetsLength);
+      validity, offsets);
     ColumnVector vec = new ColumnVector(columnHandle);
     return vec;
   }
@@ -649,8 +643,8 @@ public final class ColumnVector extends ColumnView {
   private static native long sequence(long initialValue, long step, int rows);
 
   private static native long fromArrow(int type, long col_length,
-      long null_count, long data, long data_size, long validity, long validity_size,
-      long offsets, long offsets_size) throws CudfException;
+      long null_count, ByteBuffer data, ByteBuffer validity,
+      ByteBuffer offsets) throws CudfException;
 
   private static native long fromScalar(long scalarHandle, int rowCount) throws CudfException;
 

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -90,19 +90,19 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv *env, 
     std::shared_ptr<arrow::Array> arrow_array;
     switch (n_type) {
       case cudf::type_id::DECIMAL32:
-        JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Don't support converting DECIMAL32 yet", 0);
+        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting DECIMAL32 yet", 0);
         break;
       case cudf::type_id::DECIMAL64:
-        JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Don't support converting DECIMAL64 yet", 0);
+        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting DECIMAL64 yet", 0);
         break;
       case cudf::type_id::STRUCT:
-        JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Don't support converting STRUCT yet", 0);
+        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting STRUCT yet", 0);
         break;
       case cudf::type_id::LIST:
-        JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Don't support converting LIST yet", 0);
+        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting LIST yet", 0);
         break;
       case cudf::type_id::DICTIONARY32:
-        JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Don't support converting DICTIONARY32 yet", 0);
+        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting DICTIONARY32 yet", 0);
         break;
       case cudf::type_id::STRING:
         arrow_array = std::make_shared<arrow::StringArray>(j_col_length, offsets_buffer, data_buffer, null_buffer, j_null_count);

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -54,16 +54,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_sequence(JNIEnv *env, j
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv *env, jclass,
-                                                                        jint j_type,
-                                                                        jstring j_col_name,
-                                                                        jlong j_col_length,
-                                                                        jlong j_null_count,
-                                                                        jlong j_data,
-                                                                        jlong j_data_size,
-                                                                        jlong j_validity,
-                                                                        jlong j_validity_size,
-                                                                        jlong j_offsets,
-                                                                        jlong j_offsets_size) {
+                                                                   jint j_type,
+                                                                   jlong j_col_length,
+                                                                   jlong j_null_count,
+                                                                   jlong j_data,
+                                                                   jlong j_data_size,
+                                                                   jlong j_validity,
+                                                                   jlong j_validity_size,
+                                                                   jlong j_offsets,
+                                                                   jlong j_offsets_size) {
   try {
     cudf::jni::auto_set_device(env);
     cudf::type_id n_type = static_cast<cudf::type_id>(j_type);
@@ -98,9 +97,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv *env, 
         // this handles the primitive types
         arrow_array = cudf::detail::to_arrow_array(n_type, j_col_length, data_buffer, null_buffer, j_null_count);
     }
-    cudf::jni::native_jstring col_name(env, j_col_name);
-    auto struct_meta = cudf::column_metadata{col_name.get()};
-    auto name_and_type = arrow::field(struct_meta.name, arrow_array->type());
+    auto name_and_type = arrow::field("col", arrow_array->type());
     std::vector<std::shared_ptr<arrow::Field>> fields = {name_and_type};
     std::shared_ptr<arrow::Schema> schema = std::make_shared<arrow::Schema>(fields);
     auto arrow_table = arrow::Table::Make(schema, std::vector<std::shared_ptr<arrow::Array>>{arrow_array});

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -57,7 +57,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv *env, 
                                                                    jint j_type,
                                                                    jlong j_col_length,
                                                                    jlong j_null_count,
-								   jobject j_data_obj,
+                                                                   jobject j_data_obj,
                                                                    jobject j_validity_obj,
                                                                    jobject j_offsets_obj) {
   try {

--- a/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
@@ -47,7 +47,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
 
   @Test
   void testArrowIntMultiBatches() {
-    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.INT32) , "col1");
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.INT32));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     int numVecs = 4;
     IntVector[] vectors = new IntVector[numVecs];
@@ -67,9 +67,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
         vector.setValueCount(count);
         vectors[j] = vector;
         long data = vector.getDataBuffer().memoryAddress();
-        long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+        long dataLen = vector.getDataBuffer().capacity();
         long valid = vector.getValidityBuffer().memoryAddress();
-        long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+        long validLen = vector.getValidityBuffer().capacity();
         builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
       }
       ColumnVector cv = builder.buildAndPutOnDevice();
@@ -85,7 +85,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
 
   @Test
   void testArrowLong() {
-    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.INT64) , "col1");
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.INT64));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     BigIntVector vector = new BigIntVector("vec", allocator);
     try {
@@ -97,9 +97,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       }
       vector.setValueCount(count);
       long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long dataLen = vector.getDataBuffer().capacity();
       long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long validLen = vector.getValidityBuffer().capacity();
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.INT64);
@@ -112,7 +112,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
 
   @Test
   void testArrowDouble() {
-    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.FLOAT64) , "col1");
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.FLOAT64));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     Float8Vector vector = new Float8Vector("vec", allocator);
     try {
@@ -124,9 +124,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       }
       vector.setValueCount(count);
       long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long dataLen = vector.getDataBuffer().capacity();
       long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long validLen = vector.getValidityBuffer().capacity();
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.FLOAT64);
@@ -140,7 +140,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
 
   @Test
   void testArrowFloat() {
-    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.FLOAT32) , "col1");
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.FLOAT32));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     Float4Vector vector = new Float4Vector("vec", allocator);
     try {
@@ -152,9 +152,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       }
       vector.setValueCount(count);
       long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long dataLen = vector.getDataBuffer().capacity();
       long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long validLen = vector.getValidityBuffer().capacity();
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.FLOAT32);
@@ -172,7 +172,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
 
   @Test
   void testArrowString() {
-    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.STRING) , "col1");
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.STRING));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     VarCharVector vector = new VarCharVector("vec", allocator);
     try {
@@ -185,11 +185,11 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       }
       vector.setValueCount(count);
       long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long dataLen = vector.getDataBuffer().capacity();
       long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long validLen = vector.getValidityBuffer().capacity();
       long offsets = vector.getOffsetBuffer().memoryAddress();
-      long offsetsLen = vector.getOffsetBuffer().getActualMemoryConsumed();
+      long offsetsLen = vector.getOffsetBuffer().capacity();
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, offsets, offsetsLen);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.STRING);
@@ -202,7 +202,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
 
   @Test
   void testArrowDays() {
-    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.TIMESTAMP_DAYS) , "col1");
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.TIMESTAMP_DAYS));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     DateDayVector vector = new DateDayVector("vec", allocator);
     try {
@@ -214,9 +214,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       }
       vector.setValueCount(count);
       long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long dataLen = vector.getDataBuffer().capacity();
       long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long validLen = vector.getValidityBuffer().capacity();
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.TIMESTAMP_DAYS);
@@ -233,7 +233,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     DecimalVector vector = new DecimalVector("vec", allocator, 7, 3);
     try {
-      ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL32, 3)) , "col1");
+      ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL32, 3)));
       ((DecimalVector) vector).setSafe(0, -3);
       ((DecimalVector) vector).setSafe(1, 1);
       ((DecimalVector) vector).setSafe(2, 2);
@@ -242,9 +242,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       ((DecimalVector) vector).setSafe(5, 5);
       vector.setValueCount(6);
       long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long dataLen = vector.getDataBuffer().capacity();
       long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long validLen = vector.getValidityBuffer().capacity();
 
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
       assertThrows(IllegalArgumentException.class, () -> {
@@ -260,15 +260,15 @@ public class ArrowColumnVectorTest extends CudfTestBase {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     DecimalVector vector = new DecimalVector("vec", allocator, 18, 0);
     try {
-      ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL64, -11)) , "col1");
+      ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL64, -11)));
       ((DecimalVector) vector).setSafe(0, -3);
       ((DecimalVector) vector).setSafe(1, 1);
       ((DecimalVector) vector).setSafe(2, 2);
       vector.setValueCount(3);
       long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long dataLen = vector.getDataBuffer().capacity();
       long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long validLen = vector.getValidityBuffer().capacity();
 
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
       assertThrows(IllegalArgumentException.class, () -> {
@@ -284,13 +284,13 @@ public class ArrowColumnVectorTest extends CudfTestBase {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     ListVector vector = ListVector.empty("list", allocator);
     try {
-      ArrowColumnBuilder builder = new ArrowColumnBuilder(new ListType(true, new HostColumnVector.BasicType(true, DType.STRING)) , "col1");
+      ArrowColumnBuilder builder = new ArrowColumnBuilder(new ListType(true, new HostColumnVector.BasicType(true, DType.STRING)));
       long data = 0;
       long dataLen = 0;
       long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long validLen = vector.getValidityBuffer().capacity();
       long offsets = vector.getOffsetBuffer().memoryAddress();
-      long offsetsLen = vector.getOffsetBuffer().getActualMemoryConsumed();
+      long offsetsLen = vector.getOffsetBuffer().capacity();
 
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, offsets, offsetsLen);
       assertThrows(IllegalArgumentException.class, () -> {
@@ -306,11 +306,11 @@ public class ArrowColumnVectorTest extends CudfTestBase {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     StructVector vector = StructVector.empty("struct", allocator);
     try {
-      ArrowColumnBuilder builder = new ArrowColumnBuilder(new StructType(true, new HostColumnVector.BasicType(true, DType.STRING)) , "col1");
+      ArrowColumnBuilder builder = new ArrowColumnBuilder(new StructType(true, new HostColumnVector.BasicType(true, DType.STRING)));
       long data = 0;
       long dataLen = 0;
       long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long validLen = vector.getValidityBuffer().capacity();
 
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
       assertThrows(IllegalArgumentException.class, () -> {

--- a/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
@@ -54,18 +54,18 @@ public class ArrowColumnVectorTest extends CudfTestBase {
     try {
       ArrayList<Integer> expectedArr = new ArrayList<Integer>();
       for (int j = 0; j < numVecs; j++) {
-	int pos = 0;
-	int count = 10000;
+        int pos = 0;
+        int count = 10000;
         IntVector vector = new IntVector("intVec", allocator);
         int start = count * j;
         int end = count * (j + 1);
         for (int i = start; i < end; i++) {
           expectedArr.add(i);
           ((IntVector) vector).setSafe(pos, i);
-	  pos++;
+          pos++;
         }
         vector.setValueCount(count);
-	vectors[j] = vector;
+        vectors[j] = vector;
         long data = vector.getDataBuffer().memoryAddress();
         long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
         long valid = vector.getValidityBuffer().memoryAddress();

--- a/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
@@ -86,8 +86,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
   void testArrowLong() {
     ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.INT64));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    BigIntVector vector = new BigIntVector("vec", allocator);
-    try {
+    try (BigIntVector vector = new BigIntVector("vec", allocator)) {
       ArrayList<Long> expectedArr = new ArrayList<Long>();
       int count = 10000;
       for (int i = 0; i < count; i++) {
@@ -102,8 +101,6 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       assertEquals(cv.getType(), DType.INT64);
       ColumnVector expected = ColumnVector.fromBoxedLongs(expectedArr.toArray(new Long[0]));
       assertColumnsAreEqual(expected, cv, "Longs");
-    } finally {
-      vector.close();
     }
   }
 
@@ -111,8 +108,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
   void testArrowLongOnHeap() {
     ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.INT64));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    BigIntVector vector = new BigIntVector("vec", allocator);
-    try {
+    try (BigIntVector vector = new BigIntVector("vec", allocator)) {
       ArrayList<Long> expectedArr = new ArrayList<Long>();
       int count = 10000;
       for (int i = 0; i < count; i++) {
@@ -134,8 +130,6 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       assertEquals(cv.getType(), DType.INT64);
       ColumnVector expected = ColumnVector.fromBoxedLongs(expectedArr.toArray(new Long[0]));
       assertColumnsAreEqual(expected, cv, "Longs");
-    } finally {
-      vector.close();
     }
   }
 
@@ -143,8 +137,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
   void testArrowDouble() {
     ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.FLOAT64));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    Float8Vector vector = new Float8Vector("vec", allocator);
-    try {
+    try (Float8Vector vector = new Float8Vector("vec", allocator)) {
       ArrayList<Double> expectedArr = new ArrayList<Double>();
       int count = 10000;
       for (int i = 0; i < count; i++) {
@@ -160,8 +153,6 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       double[] array = expectedArr.stream().mapToDouble(i->i).toArray();
       ColumnVector expected = ColumnVector.fromDoubles(array);
       assertColumnsAreEqual(expected, cv, "doubles");
-    } finally {
-      vector.close();
     }
   }
 
@@ -169,8 +160,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
   void testArrowFloat() {
     ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.FLOAT32));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    Float4Vector vector = new Float4Vector("vec", allocator);
-    try {
+    try (Float4Vector vector = new Float4Vector("vec", allocator)) {
       ArrayList<Float> expectedArr = new ArrayList<Float>();
       int count = 10000;
       for (int i = 0; i < count; i++) {
@@ -190,8 +180,6 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       }
       ColumnVector expected = ColumnVector.fromFloats(floatArray);
       assertColumnsAreEqual(expected, cv, "floats");
-    } finally {
-      vector.close();
     }
   }
 
@@ -199,8 +187,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
   void testArrowString() {
     ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.STRING));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    VarCharVector vector = new VarCharVector("vec", allocator);
-    try {
+    try (VarCharVector vector = new VarCharVector("vec", allocator)) {
       ArrayList<String> expectedArr = new ArrayList<String>();
       int count = 10000;
       for (int i = 0; i < count; i++) {
@@ -217,8 +204,6 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       assertEquals(cv.getType(), DType.STRING);
       ColumnVector expected = ColumnVector.fromStrings(expectedArr.toArray(new String[0]));
       assertColumnsAreEqual(expected, cv, "Strings");
-    } finally {
-      vector.close();
     }
   }
 
@@ -226,8 +211,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
   void testArrowStringOnHeap() {
     ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.STRING));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    VarCharVector vector = new VarCharVector("vec", allocator);
-    try {
+    try (VarCharVector vector = new VarCharVector("vec", allocator)) {
       ArrayList<String> expectedArr = new ArrayList<String>();
       int count = 10000;
       for (int i = 0; i < count; i++) {
@@ -253,8 +237,6 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       assertEquals(cv.getType(), DType.STRING);
       ColumnVector expected = ColumnVector.fromStrings(expectedArr.toArray(new String[0]));
       assertColumnsAreEqual(expected, cv, "Strings");
-    } finally {
-      vector.close();
     }
   }
 
@@ -262,8 +244,7 @@ public class ArrowColumnVectorTest extends CudfTestBase {
   void testArrowDays() {
     ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.TIMESTAMP_DAYS));
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    DateDayVector vector = new DateDayVector("vec", allocator);
-    try {
+    try (DateDayVector vector = new DateDayVector("vec", allocator)) {
       ArrayList<Integer> expectedArr = new ArrayList<Integer>();
       int count = 10000;
       for (int i = 0; i < count; i++) {
@@ -279,16 +260,13 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       int[] array = expectedArr.stream().mapToInt(i->i).toArray();
       ColumnVector expected = ColumnVector.daysFromInts(array);
       assertColumnsAreEqual(expected, cv, "timestamp days");
-    } finally {
-      vector.close();
     }
   }
 
   @Test
   void testArrowDecimalThrows() {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    DecimalVector vector = new DecimalVector("vec", allocator, 7, 3);
-    try {
+    try (DecimalVector vector = new DecimalVector("vec", allocator, 7, 3)) {
       ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL32, 3)));
       ((DecimalVector) vector).setSafe(0, -3);
       ((DecimalVector) vector).setSafe(1, 1);
@@ -303,16 +281,13 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       assertThrows(IllegalArgumentException.class, () -> {
         builder.buildAndPutOnDevice();
       });
-    } finally {
-      vector.close();
     }
   }
 
   @Test
   void testArrowDecimal64Throws() {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    DecimalVector vector = new DecimalVector("vec", allocator, 18, 0);
-    try {
+    try (DecimalVector vector = new DecimalVector("vec", allocator, 18, 0)) {
       ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL64, -11)));
       ((DecimalVector) vector).setSafe(0, -3);
       ((DecimalVector) vector).setSafe(1, 1);
@@ -324,40 +299,32 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       assertThrows(IllegalArgumentException.class, () -> {
         builder.buildAndPutOnDevice();
       });
-    } finally {
-      vector.close();
     }
   }
 
   @Test
   void testArrowListThrows() {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    ListVector vector = ListVector.empty("list", allocator);
-    try {
+    try (ListVector vector = ListVector.empty("list", allocator)) {
       ArrowColumnBuilder builder = new ArrowColumnBuilder(new ListType(true, new HostColumnVector.BasicType(true, DType.STRING)));
       // buffer don't matter as we expect it to throw anyway
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), null, null, null);
       assertThrows(IllegalArgumentException.class, () -> {
         builder.buildAndPutOnDevice();
       });
-    } finally {
-      vector.close();
     }
   }
 
   @Test
   void testArrowStructThrows() {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    StructVector vector = StructVector.empty("struct", allocator);
-    try {
+    try (StructVector vector = StructVector.empty("struct", allocator)) {
       ArrowColumnBuilder builder = new ArrowColumnBuilder(new StructType(true, new HostColumnVector.BasicType(true, DType.STRING)));
       // buffer don't matter as we expect it to throw anyway
       builder.addBatch(vector.getValueCount(), vector.getNullCount(), null, null, null);
       assertThrows(IllegalArgumentException.class, () -> {
         builder.buildAndPutOnDevice();
       });
-    } finally {
-      vector.close();
     }
   }
 }

--- a/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
@@ -18,6 +18,7 @@
 
 package ai.rapids.cudf;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 
 import ai.rapids.cudf.HostColumnVector.BasicType;
@@ -66,11 +67,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
         }
         vector.setValueCount(count);
         vectors[j] = vector;
-        long data = vector.getDataBuffer().memoryAddress();
-        long dataLen = vector.getDataBuffer().capacity();
-        long valid = vector.getValidityBuffer().memoryAddress();
-        long validLen = vector.getValidityBuffer().capacity();
-        builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+        ByteBuffer data = vector.getDataBuffer().nioBuffer();
+        ByteBuffer valid = vector.getValidityBuffer().nioBuffer();
+        builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, valid, null);
       }
       ColumnVector cv = builder.buildAndPutOnDevice();
       ColumnVector expected = ColumnVector.fromBoxedInts(expectedArr.toArray(new Integer[0]));
@@ -96,11 +95,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
         ((BigIntVector) vector).setSafe(i, i);
       }
       vector.setValueCount(count);
-      long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().capacity();
-      long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().capacity();
-      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ByteBuffer data = vector.getDataBuffer().nioBuffer();
+      ByteBuffer valid = vector.getValidityBuffer().nioBuffer();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, valid, null);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.INT64);
       ColumnVector expected = ColumnVector.fromBoxedLongs(expectedArr.toArray(new Long[0]));
@@ -123,11 +120,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
         ((Float8Vector) vector).setSafe(i, i);
       }
       vector.setValueCount(count);
-      long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().capacity();
-      long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().capacity();
-      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ByteBuffer data = vector.getDataBuffer().nioBuffer();
+      ByteBuffer valid = vector.getValidityBuffer().nioBuffer();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, valid, null);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.FLOAT64);
       double[] array = expectedArr.stream().mapToDouble(i->i).toArray();
@@ -151,11 +146,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
         ((Float4Vector) vector).setSafe(i, i);
       }
       vector.setValueCount(count);
-      long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().capacity();
-      long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().capacity();
-      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ByteBuffer data = vector.getDataBuffer().nioBuffer();
+      ByteBuffer valid = vector.getValidityBuffer().nioBuffer();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, valid, null);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.FLOAT32);
       float[] floatArray = new float[expectedArr.size()];
@@ -184,13 +177,10 @@ public class ArrowColumnVectorTest extends CudfTestBase {
         ((VarCharVector) vector).setSafe(i, new Text(toAdd));
       }
       vector.setValueCount(count);
-      long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().capacity();
-      long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().capacity();
-      long offsets = vector.getOffsetBuffer().memoryAddress();
-      long offsetsLen = vector.getOffsetBuffer().capacity();
-      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, offsets, offsetsLen);
+      ByteBuffer data = vector.getDataBuffer().nioBuffer();
+      ByteBuffer valid = vector.getValidityBuffer().nioBuffer();
+      ByteBuffer offsets = vector.getOffsetBuffer().nioBuffer();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, valid, offsets);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.STRING);
       ColumnVector expected = ColumnVector.fromStrings(expectedArr.toArray(new String[0]));
@@ -213,11 +203,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
         ((DateDayVector) vector).setSafe(i, i);
       }
       vector.setValueCount(count);
-      long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().capacity();
-      long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().capacity();
-      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ByteBuffer data = vector.getDataBuffer().nioBuffer();
+      ByteBuffer valid = vector.getValidityBuffer().nioBuffer();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, valid, null);
       ColumnVector cv = builder.buildAndPutOnDevice();
       assertEquals(cv.getType(), DType.TIMESTAMP_DAYS);
       int[] array = expectedArr.stream().mapToInt(i->i).toArray();
@@ -241,12 +229,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       ((DecimalVector) vector).setSafe(4, 4);
       ((DecimalVector) vector).setSafe(5, 5);
       vector.setValueCount(6);
-      long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().capacity();
-      long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().capacity();
-
-      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ByteBuffer data = vector.getDataBuffer().nioBuffer();
+      ByteBuffer valid = vector.getValidityBuffer().nioBuffer();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, valid, null);
       assertThrows(IllegalArgumentException.class, () -> {
         builder.buildAndPutOnDevice();
       });
@@ -265,12 +250,9 @@ public class ArrowColumnVectorTest extends CudfTestBase {
       ((DecimalVector) vector).setSafe(1, 1);
       ((DecimalVector) vector).setSafe(2, 2);
       vector.setValueCount(3);
-      long data = vector.getDataBuffer().memoryAddress();
-      long dataLen = vector.getDataBuffer().capacity();
-      long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().capacity();
-
-      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ByteBuffer data = vector.getDataBuffer().nioBuffer();
+      ByteBuffer valid = vector.getValidityBuffer().nioBuffer();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, valid, null);
       assertThrows(IllegalArgumentException.class, () -> {
         builder.buildAndPutOnDevice();
       });
@@ -285,14 +267,8 @@ public class ArrowColumnVectorTest extends CudfTestBase {
     ListVector vector = ListVector.empty("list", allocator);
     try {
       ArrowColumnBuilder builder = new ArrowColumnBuilder(new ListType(true, new HostColumnVector.BasicType(true, DType.STRING)));
-      long data = 0;
-      long dataLen = 0;
-      long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().capacity();
-      long offsets = vector.getOffsetBuffer().memoryAddress();
-      long offsetsLen = vector.getOffsetBuffer().capacity();
-
-      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, offsets, offsetsLen);
+      // buffer don't matter as we expect it to throw anyway
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), null, null, null);
       assertThrows(IllegalArgumentException.class, () -> {
         builder.buildAndPutOnDevice();
       });
@@ -307,12 +283,8 @@ public class ArrowColumnVectorTest extends CudfTestBase {
     StructVector vector = StructVector.empty("struct", allocator);
     try {
       ArrowColumnBuilder builder = new ArrowColumnBuilder(new StructType(true, new HostColumnVector.BasicType(true, DType.STRING)));
-      long data = 0;
-      long dataLen = 0;
-      long valid = vector.getValidityBuffer().memoryAddress();
-      long validLen = vector.getValidityBuffer().capacity();
-
-      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      // buffer don't matter as we expect it to throw anyway
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), null, null, null);
       assertThrows(IllegalArgumentException.class, () -> {
         builder.buildAndPutOnDevice();
       });

--- a/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ArrowColumnVectorTest.java
@@ -1,0 +1,323 @@
+/*
+ *
+ *  Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package ai.rapids.cudf;
+
+import java.util.ArrayList;
+
+import ai.rapids.cudf.HostColumnVector.BasicType;
+import ai.rapids.cudf.HostColumnVector.ListType;
+import ai.rapids.cudf.HostColumnVector.StructType;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.util.Text;
+
+import org.junit.jupiter.api.Test;
+
+import static ai.rapids.cudf.TableTest.assertColumnsAreEqual;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ArrowColumnVectorTest extends CudfTestBase {
+
+  @Test
+  void testArrowIntMultiBatches() {
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.INT32) , "col1");
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    int numVecs = 4;
+    IntVector[] vectors = new IntVector[numVecs];
+    try {
+      ArrayList<Integer> expectedArr = new ArrayList<Integer>();
+      for (int j = 0; j < numVecs; j++) {
+	int pos = 0;
+	int count = 10000;
+        IntVector vector = new IntVector("intVec", allocator);
+        int start = count * j;
+        int end = count * (j + 1);
+        for (int i = start; i < end; i++) {
+          expectedArr.add(i);
+          ((IntVector) vector).setSafe(pos, i);
+	  pos++;
+        }
+        vector.setValueCount(count);
+	vectors[j] = vector;
+        long data = vector.getDataBuffer().memoryAddress();
+        long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+        long valid = vector.getValidityBuffer().memoryAddress();
+        long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+        builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      }
+      ColumnVector cv = builder.buildAndPutOnDevice();
+      ColumnVector expected = ColumnVector.fromBoxedInts(expectedArr.toArray(new Integer[0]));
+      assertEquals(cv.getType(), DType.INT32);
+      assertColumnsAreEqual(expected, cv, "ints");
+    } finally {
+      for (int i = 0; i < numVecs; i++) {
+        vectors[i].close();
+      }
+    }
+  }
+
+  @Test
+  void testArrowLong() {
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.INT64) , "col1");
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    BigIntVector vector = new BigIntVector("vec", allocator);
+    try {
+      ArrayList<Long> expectedArr = new ArrayList<Long>();
+      int count = 10000;
+      for (int i = 0; i < count; i++) {
+        expectedArr.add(new Long(i));
+        ((BigIntVector) vector).setSafe(i, i);
+      }
+      vector.setValueCount(count);
+      long data = vector.getDataBuffer().memoryAddress();
+      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long valid = vector.getValidityBuffer().memoryAddress();
+      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ColumnVector cv = builder.buildAndPutOnDevice();
+      assertEquals(cv.getType(), DType.INT64);
+      ColumnVector expected = ColumnVector.fromBoxedLongs(expectedArr.toArray(new Long[0]));
+      assertColumnsAreEqual(expected, cv, "Longs");
+    } finally {
+      vector.close();
+    }
+  }
+
+  @Test
+  void testArrowDouble() {
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.FLOAT64) , "col1");
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    Float8Vector vector = new Float8Vector("vec", allocator);
+    try {
+      ArrayList<Double> expectedArr = new ArrayList<Double>();
+      int count = 10000;
+      for (int i = 0; i < count; i++) {
+        expectedArr.add(new Double(i));
+        ((Float8Vector) vector).setSafe(i, i);
+      }
+      vector.setValueCount(count);
+      long data = vector.getDataBuffer().memoryAddress();
+      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long valid = vector.getValidityBuffer().memoryAddress();
+      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ColumnVector cv = builder.buildAndPutOnDevice();
+      assertEquals(cv.getType(), DType.FLOAT64);
+      double[] array = expectedArr.stream().mapToDouble(i->i).toArray();
+      ColumnVector expected = ColumnVector.fromDoubles(array);
+      assertColumnsAreEqual(expected, cv, "doubles");
+    } finally {
+      vector.close();
+    }
+  }
+
+  @Test
+  void testArrowFloat() {
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.FLOAT32) , "col1");
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    Float4Vector vector = new Float4Vector("vec", allocator);
+    try {
+      ArrayList<Float> expectedArr = new ArrayList<Float>();
+      int count = 10000;
+      for (int i = 0; i < count; i++) {
+        expectedArr.add(new Float(i));
+        ((Float4Vector) vector).setSafe(i, i);
+      }
+      vector.setValueCount(count);
+      long data = vector.getDataBuffer().memoryAddress();
+      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long valid = vector.getValidityBuffer().memoryAddress();
+      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ColumnVector cv = builder.buildAndPutOnDevice();
+      assertEquals(cv.getType(), DType.FLOAT32);
+      float[] floatArray = new float[expectedArr.size()];
+      int i = 0;
+      for (Float f : expectedArr) {
+        floatArray[i++] = (f != null ? f : Float.NaN); // Or whatever default you want.
+      }
+      ColumnVector expected = ColumnVector.fromFloats(floatArray);
+      assertColumnsAreEqual(expected, cv, "floats");
+    } finally {
+      vector.close();
+    }
+  }
+
+  @Test
+  void testArrowString() {
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.STRING) , "col1");
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    VarCharVector vector = new VarCharVector("vec", allocator);
+    try {
+      ArrayList<String> expectedArr = new ArrayList<String>();
+      int count = 10000;
+      for (int i = 0; i < count; i++) {
+        String toAdd = i + "testString";
+        expectedArr.add(toAdd);
+        ((VarCharVector) vector).setSafe(i, new Text(toAdd));
+      }
+      vector.setValueCount(count);
+      long data = vector.getDataBuffer().memoryAddress();
+      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long valid = vector.getValidityBuffer().memoryAddress();
+      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long offsets = vector.getOffsetBuffer().memoryAddress();
+      long offsetsLen = vector.getOffsetBuffer().getActualMemoryConsumed();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, offsets, offsetsLen);
+      ColumnVector cv = builder.buildAndPutOnDevice();
+      assertEquals(cv.getType(), DType.STRING);
+      ColumnVector expected = ColumnVector.fromStrings(expectedArr.toArray(new String[0]));
+      assertColumnsAreEqual(expected, cv, "Strings");
+    } finally {
+      vector.close();
+    }
+  }
+
+  @Test
+  void testArrowDays() {
+    ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.TIMESTAMP_DAYS) , "col1");
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    DateDayVector vector = new DateDayVector("vec", allocator);
+    try {
+      ArrayList<Integer> expectedArr = new ArrayList<Integer>();
+      int count = 10000;
+      for (int i = 0; i < count; i++) {
+        expectedArr.add(i);
+        ((DateDayVector) vector).setSafe(i, i);
+      }
+      vector.setValueCount(count);
+      long data = vector.getDataBuffer().memoryAddress();
+      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long valid = vector.getValidityBuffer().memoryAddress();
+      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      ColumnVector cv = builder.buildAndPutOnDevice();
+      assertEquals(cv.getType(), DType.TIMESTAMP_DAYS);
+      int[] array = expectedArr.stream().mapToInt(i->i).toArray();
+      ColumnVector expected = ColumnVector.daysFromInts(array);
+      assertColumnsAreEqual(expected, cv, "timestamp days");
+    } finally {
+      vector.close();
+    }
+  }
+
+  @Test
+  void testArrowDecimalThrows() {
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    DecimalVector vector = new DecimalVector("vec", allocator, 7, 3);
+    try {
+      ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL32, 3)) , "col1");
+      ((DecimalVector) vector).setSafe(0, -3);
+      ((DecimalVector) vector).setSafe(1, 1);
+      ((DecimalVector) vector).setSafe(2, 2);
+      ((DecimalVector) vector).setSafe(3, 3);
+      ((DecimalVector) vector).setSafe(4, 4);
+      ((DecimalVector) vector).setSafe(5, 5);
+      vector.setValueCount(6);
+      long data = vector.getDataBuffer().memoryAddress();
+      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long valid = vector.getValidityBuffer().memoryAddress();
+      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      assertThrows(IllegalArgumentException.class, () -> {
+        builder.buildAndPutOnDevice();
+      });
+    } finally {
+      vector.close();
+    }
+  }
+
+  @Test
+  void testArrowDecimal64Throws() {
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    DecimalVector vector = new DecimalVector("vec", allocator, 18, 0);
+    try {
+      ArrowColumnBuilder builder = new ArrowColumnBuilder(new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL64, -11)) , "col1");
+      ((DecimalVector) vector).setSafe(0, -3);
+      ((DecimalVector) vector).setSafe(1, 1);
+      ((DecimalVector) vector).setSafe(2, 2);
+      vector.setValueCount(3);
+      long data = vector.getDataBuffer().memoryAddress();
+      long dataLen = vector.getDataBuffer().getActualMemoryConsumed();
+      long valid = vector.getValidityBuffer().memoryAddress();
+      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      assertThrows(IllegalArgumentException.class, () -> {
+        builder.buildAndPutOnDevice();
+      });
+    } finally {
+      vector.close();
+    }
+  }
+
+  @Test
+  void testArrowListThrows() {
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    ListVector vector = ListVector.empty("list", allocator);
+    try {
+      ArrowColumnBuilder builder = new ArrowColumnBuilder(new ListType(true, new HostColumnVector.BasicType(true, DType.STRING)) , "col1");
+      long data = 0;
+      long dataLen = 0;
+      long valid = vector.getValidityBuffer().memoryAddress();
+      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+      long offsets = vector.getOffsetBuffer().memoryAddress();
+      long offsetsLen = vector.getOffsetBuffer().getActualMemoryConsumed();
+
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, offsets, offsetsLen);
+      assertThrows(IllegalArgumentException.class, () -> {
+        builder.buildAndPutOnDevice();
+      });
+    } finally {
+      vector.close();
+    }
+  }
+
+  @Test
+  void testArrowStructThrows() {
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    StructVector vector = StructVector.empty("struct", allocator);
+    try {
+      ArrowColumnBuilder builder = new ArrowColumnBuilder(new StructType(true, new HostColumnVector.BasicType(true, DType.STRING)) , "col1");
+      long data = 0;
+      long dataLen = 0;
+      long valid = vector.getValidityBuffer().memoryAddress();
+      long validLen = vector.getValidityBuffer().getActualMemoryConsumed();
+
+      builder.addBatch(vector.getValueCount(), vector.getNullCount(), data, dataLen, valid, validLen, 0, 0);
+      assertThrows(IllegalArgumentException.class, () -> {
+        builder.buildAndPutOnDevice();
+      });
+    } finally {
+      vector.close();
+    }
+  }
+}


### PR DESCRIPTION
This adds in the JNI layer to be able to take build up Arrow column vectors which are just references to off heap arrow buffers and then convert those into CUDF ColumnVectors by directly copying the arrow data to the GPU.

The way this works is you create a ArrowColumnBuilder for each column you need. You call addBatch for each separate arrow buffer you want to add into that column and then you call buildAndPutOnDevice() on the Builder. That will cause the arrow pointer to be passed into CUDF, an Arrow Table with 1 column is created, that Arrow table gets passed into the cudf::from_arrow which returns a CUDF Table and we grab the 1 column from that and return it.

Note this only supports primitive types and Strings for now. List, Struct, Dictionary, and Decimal are not supported yet.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
