### PR TITLE
Fix some bugs in java scalar support for decimal [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -536,9 +536,15 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
     case TIMESTAMP_MILLISECONDS:
     case TIMESTAMP_MICROSECONDS:
     case TIMESTAMP_NANOSECONDS:
-      return getLong() == getLong();
+      return getLong() == other.getLong();
     case STRING:
       return Arrays.equals(getUTF8(), other.getUTF8());
+    case DECIMAL32:
+      return getInt() == other.getInt() &&
+          getType().getScale() == other.getType().getScale();
+    case DECIMAL64:
+      return getLong() == other.getLong() &&
+          getType().getScale() == other.getType().getScale();
     default:
       throw new IllegalStateException("Unexpected type: " + type);
     }
@@ -566,6 +572,7 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
       case INT32:
       case UINT32:
       case TIMESTAMP_DAYS:
+      case DECIMAL32:
         valueHash = getInt();
         break;
       case INT64:
@@ -574,6 +581,7 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
       case TIMESTAMP_MILLISECONDS:
       case TIMESTAMP_MICROSECONDS:
       case TIMESTAMP_NANOSECONDS:
+      case DECIMAL64:
         valueHash = Long.hashCode(getLong());
         break;
       case FLOAT32:
@@ -641,6 +649,11 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
         sb.append('"');
         sb.append(getJavaString());
         sb.append('"');
+        break;
+      case DECIMAL32:
+        // FALL THROUGH
+      case DECIMAL64:
+        sb.append(getBigDecimal());
         break;
       default:
         throw new IllegalArgumentException("Unknown scalar type: " + type);

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -525,6 +525,7 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
     case INT32:
     case UINT32:
     case TIMESTAMP_DAYS:
+    case DECIMAL32:
       return getInt() == other.getInt();
     case FLOAT32:
       return getFloat() == other.getFloat();
@@ -536,15 +537,10 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
     case TIMESTAMP_MILLISECONDS:
     case TIMESTAMP_MICROSECONDS:
     case TIMESTAMP_NANOSECONDS:
+    case DECIMAL64:
       return getLong() == other.getLong();
     case STRING:
       return Arrays.equals(getUTF8(), other.getUTF8());
-    case DECIMAL32:
-      return getInt() == other.getInt() &&
-          getType().getScale() == other.getType().getScale();
-    case DECIMAL64:
-      return getLong() == other.getLong() &&
-          getType().getScale() == other.getType().getScale();
     default:
       throw new IllegalStateException("Unexpected type: " + type);
     }


### PR DESCRIPTION
This fixes some bugs in the java support for decimal scalar values.  They are fairly minor but prevented me from doing some debugging earlier, and could impact tests in the future.