### PR TITLE
Remove floating point types from cudf::sort fast-path

### DIFF
--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -88,8 +88,10 @@ std::unique_ptr<table> sort(table_view input,
                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
+  // fast-path sort conditions: single, non-floating-point, fixed-width column with no nulls
   if (input.num_columns() == 1 && !input.column(0).has_nulls() &&
-      cudf::is_fixed_width(input.column(0).type())) {
+      cudf::is_fixed_width(input.column(0).type()) &&
+      !cudf::is_floating_point(input.column(0).type())) {
     auto output    = std::make_unique<column>(input.column(0), stream, mr);
     auto view      = output->mutable_view();
     bool ascending = (column_order.empty() ? true : column_order.front() == order::ASCENDING);

--- a/cpp/tests/table/row_operators_tests.cpp
+++ b/cpp/tests/table/row_operators_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 #include <cudf/column/column_view.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf_test/base_fixture.hpp>
@@ -82,8 +83,16 @@ TEST_F(RowOperatorTestForNAN, NANSortingNonNull)
   auto result = cudf::sorted_order(input_table, {cudf::order::ASCENDING});
   cudf::test::fixed_width_column_wrapper<int32_t> expected_asc{{6, 2, 0, 5, 3, 4, 1}};
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_asc, result->view());
+  auto sorted_result = cudf::sort(input_table, {cudf::order::ASCENDING});
+  auto gather_result = cudf::gather(input_table, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_result->view().column(0),
+                                      gather_result->view().column(0));
 
   result = cudf::sorted_order(input_table, {cudf::order::DESCENDING});
   cudf::test::fixed_width_column_wrapper<int32_t> expected_desc{{1, 4, 3, 5, 0, 2, 6}};
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_desc, result->view());
+  sorted_result = cudf::sort(input_table, {cudf::order::DESCENDING});
+  gather_result = cudf::gather(input_table, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_result->view().column(0),
+                                      gather_result->view().column(0));
 }


### PR DESCRIPTION
PR #7215 removed single floating point columns from radix sort fast-path but missed disabling the fast-path sort for floating-point in `cudf::sort()`. 

This PR fixes `cudf::sort` and adds a new test to the existing `RowOperatorTestForNAN.NANSortingNonNull` gtest.