### PR TITLE
Fix typo in cudf.core.column.string.extract docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,9 +39,9 @@ Here are some guidelines to help the review process go smoothly.
    features or make changes out of the scope of those requested by the reviewer
    (doing this just add delays as already reviewed code ends up having to be
    re-reviewed/it is hard to tell what is new etc!). Further, please do not
-   rebase your branch on master/force push/rewrite history, doing any of these
+   rebase your branch on main/force push/rewrite history, doing any of these
    causes the context of any comments made by reviewers to be lost. If
-   conflicts occur against master they should be resolved by merging master
+   conflicts occur against main they should be resolved by merging main
    into the branch used for making the pull request.
 
 Many thanks in advance for your cooperation!

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -485,7 +485,7 @@ class StringMethods(ColumnMethodsMixin):
         pat : str
             Regular expression pattern with capturing groups.
         expand : bool, default True
-            If True, return DataFrame with on column per capture group.
+            If True, return DataFrame with one column per capture group.
             If False, return a Series/Index if there is one capture group or
             DataFrame if there are multiple capture groups.
 


### PR DESCRIPTION
change: on -> one

I read the contributing guidelines, but since this is just a documentation fix, I'm not sure which apply.

Great library, I just got started using it. A little rough around the edges, but great so far, and well worth some of the added steps.