### PR TITLE
Python API for `LIstMethods.len()`

### DIFF
--- a/python/cudf/cudf/_lib/cpp/lists/count_elements.pxd
+++ b/python/cudf/cudf/_lib/cpp/lists/count_elements.pxd
@@ -1,0 +1,9 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+
+from libcpp.memory cimport unique_ptr
+
+from cudf._lib.cpp.column.column cimport column
+from cudf._lib.cpp.lists.lists_column_view cimport lists_column_view
+
+cdef extern from "cudf/lists/count_elements.hpp" namespace "cudf::lists" nogil:
+    cdef unique_ptr[column] count_elements(const lists_column_view) except +

--- a/python/cudf/cudf/_lib/cpp/lists/lists_column_view.pxd
+++ b/python/cudf/cudf/_lib/cpp/lists/lists_column_view.pxd
@@ -7,7 +7,6 @@ from cudf._lib.cpp.column.column_view cimport (
 
 cdef extern from "cudf/lists/lists_column_view.hpp" namespace "cudf" nogil:
     cdef cppclass lists_column_view(column_view):
-        lists_column_view() except +
         lists_column_view(const column_view& lists_column) except +
         column_view parent() except +
         column_view offsets() except +

--- a/python/cudf/cudf/_lib/lists.pyx
+++ b/python/cudf/cudf/_lib/lists.pyx
@@ -1,4 +1,9 @@
-from cudf._lib.cpp.lists.count_elements cimport count_elements as cpp_count_elements
+from libcpp.memory cimport unique_ptr, shared_ptr, make_shared
+from libcpp.utility cimport move
+
+from cudf._lib.cpp.lists.count_elements cimport (
+    count_elements as cpp_count_elements
+)
 from cudf._lib.cpp.lists.lists_column_view cimport lists_column_view
 from cudf._lib.cpp.column.column_view cimport column_view
 from cudf._lib.cpp.column.column cimport column
@@ -11,12 +16,14 @@ from cudf.core.dtypes import ListDtype
 def count_elements(Column col):
     if not isinstance(col.dtype, ListDtype):
         raise TypeError("col is not a list column.")
-    
-    cdef lists_column_view list_view = lists_column_view(col.view())
+
+    cdef shared_ptr[lists_column_view] list_view = make_shared[lists_column_view](
+        col.view()
+    )
     cdef unique_ptr[column] c_result
 
     with nogil:
-        c_result = cpp_count_elements(list_view)
-    
-    result = Column.from_unique_ptr(c_result)
+        c_result = move(cpp_count_elements(list_view.get()[0]))
+
+    result = Column.from_unique_ptr(move(c_result))
     return result

--- a/python/cudf/cudf/_lib/lists.pyx
+++ b/python/cudf/cudf/_lib/lists.pyx
@@ -17,6 +17,8 @@ def count_elements(Column col):
     if not isinstance(col.dtype, ListDtype):
         raise TypeError("col is not a list column.")
 
+    # shared_ptr required because lists_column_view has no default
+    # ctor
     cdef shared_ptr[lists_column_view] list_view = make_shared[lists_column_view](
         col.view()
     )

--- a/python/cudf/cudf/_lib/lists.pyx
+++ b/python/cudf/cudf/_lib/lists.pyx
@@ -1,0 +1,22 @@
+from cudf._lib.cpp.lists.count_elements cimport count_elements as cpp_count_elements
+from cudf._lib.cpp.lists.lists_column_view cimport lists_column_view
+from cudf._lib.cpp.column.column_view cimport column_view
+from cudf._lib.cpp.column.column cimport column
+
+from cudf._lib.column cimport Column
+
+
+from cudf.core.dtypes import ListDtype
+
+def count_elements(Column col):
+    if not isinstance(col.dtype, ListDtype):
+        raise TypeError("col is not a list column.")
+    
+    cdef lists_column_view list_view = lists_column_view(col.view())
+    cdef unique_ptr[column] c_result
+
+    with nogil:
+        c_result = cpp_count_elements(list_view)
+    
+    result = Column.from_unique_ptr(c_result)
+    return result

--- a/python/cudf/cudf/_lib/lists.pyx
+++ b/python/cudf/cudf/_lib/lists.pyx
@@ -13,14 +13,15 @@ from cudf._lib.column cimport Column
 
 from cudf.core.dtypes import ListDtype
 
+
 def count_elements(Column col):
     if not isinstance(col.dtype, ListDtype):
         raise TypeError("col is not a list column.")
 
     # shared_ptr required because lists_column_view has no default
     # ctor
-    cdef shared_ptr[lists_column_view] list_view = make_shared[lists_column_view](
-        col.view()
+    cdef shared_ptr[lists_column_view] list_view = (
+        make_shared[lists_column_view](col.view())
     )
     cdef unique_ptr[column] c_result
 

--- a/python/cudf/cudf/_lib/lists.pyx
+++ b/python/cudf/cudf/_lib/lists.pyx
@@ -1,3 +1,5 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+
 from libcpp.memory cimport unique_ptr, shared_ptr, make_shared
 from libcpp.utility cimport move
 

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -215,6 +215,16 @@ class ListMethods(ColumnMethodsMixin):
 
         Examples
         --------
-        # TODO
+        >>> s = cudf.Series([[1, 2, 3], None, [4, 5]])
+        >>> s
+        0    [1, 2, 3]
+        1         None
+        2       [4, 5]
+        dtype: list
+        >>> s.list.len()
+        0       3
+        1    <NA>
+        2       2
+        dtype: int32
         """
         return self._return_or_inplace(count_elements(self._column))

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -5,6 +5,7 @@ import pickle
 import pyarrow as pa
 
 import cudf
+from cudf._lib.lists import count_elements
 from cudf.core.buffer import Buffer
 from cudf.core.column import ColumnBase, column
 from cudf.core.column.methods import ColumnMethodsMixin
@@ -203,3 +204,17 @@ class ListMethods(ColumnMethodsMixin):
             return self._return_or_inplace(
                 self._column.elements, retain_index=False
             )
+
+    def len(self):
+        """
+        Computes the length of each element in the Series/Index.
+
+        Returns
+        -------
+        Series or Index
+
+        Examples
+        --------
+        # TODO
+        """
+        return self._return_or_inplace(count_elements(self._column))

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -91,11 +91,22 @@ def test_listdtype_hash():
     assert hash(a) != hash(c)
 
 
-def test_len():
-    gsr = cudf.Series([[1, 2, 3], [4, 5]])
+@pytest.mark.parametrize(
+    "data",
+    [
+        [[]],
+        [[1, 2, 3], [4, 5]],
+        [[1, 2, 3], [], [4, 5]],
+        [[1, 2, 3], None, [4, 5]],
+        [[None, None], [None]],
+        [[[[[[1, 2, 3]]]]]],
+    ],
+)
+def test_len(data):
+    gsr = cudf.Series(data)
     psr = gsr.to_pandas()
 
-    expect = psr.map(len)
+    expect = psr.map(lambda x: len(x) if x is not None else None)
     got = gsr.list.len()
 
     assert_eq(expect, got, check_dtype=False)

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -100,6 +100,8 @@ def test_listdtype_hash():
         [[1, 2, 3], None, [4, 5]],
         [[None, None], [None]],
         [[[[[[1, 2, 3]]]]]],
+        cudf.Series([[1, 2]]).iloc[0:0],
+        cudf.Series([None, [1, 2]]).iloc[0:1],
     ],
 )
 def test_len(data):

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -89,3 +89,13 @@ def test_listdtype_hash():
     c = cudf.core.dtypes.ListDtype("int32")
 
     assert hash(a) != hash(c)
+
+
+def test_len():
+    gsr = cudf.Series([[1, 2, 3], [4, 5]])
+    psr = gsr.to_pandas()
+
+    expect = psr.map(len)
+    got = gsr.list.len()
+
+    assert_eq(expect, got, check_dtype=False)


### PR DESCRIPTION
Closes #7157 

This PR adds `ListMethods.len()` API that returns an integer column that contains the length for each element in a `ListColumn`.
Example:
```python
>>> s = cudf.Series([[1,2], None, [3]])
>>> s
0    [1, 2]
1      None
2       [3]
dtype: list
>>> s.list.len()
0       2
1    <NA>
2       1
dtype: int32
```
