### PR TITLE
fix java cuFile tests [skip ci]

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -330,7 +330,7 @@
                         <dependency>
                             <groupId>org.junit.jupiter</groupId>
                             <artifactId>junit-jupiter-engine</artifactId>
-                            <version>5.2.0</version>
+                            <version>5.4.2</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/CuFileJni.cpp
+++ b/java/src/main/native/src/CuFileJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/CuFileJni.cpp
+++ b/java/src/main/native/src/CuFileJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/CuFileJni.cpp
+++ b/java/src/main/native/src/CuFileJni.cpp
@@ -183,8 +183,7 @@ public:
    * @return std::unique_ptr<cufile_file> for writing.
    */
   static auto make_writer(char const *path) {
-    // NOTE: 0664 is what Spark disk block manager uses.
-    auto const file_descriptor = open(path, O_CREAT | O_WRONLY | O_DIRECT, 0664);
+    auto const file_descriptor = open(path, O_CREAT | O_WRONLY | O_DIRECT, S_IRUSR | S_IWUSR);
     if (file_descriptor < 0) {
       CUDF_FAIL("Failed to open file to write: " + cuFileGetErrorString(errno));
     }

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ai.rapids.cudf;
 
 import org.junit.jupiter.api.AfterEach;

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -5,13 +5,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class CuFileTest extends CudfTestBase {
-  @TempDir File tempDir;
-
   @AfterEach
   void tearDown() {
     if (PinnedMemoryPool.isInitialized()) {
@@ -20,9 +19,38 @@ public class CuFileTest extends CudfTestBase {
   }
 
   @Test
-  public void testCopyToFile() {
+  public void testCopyToFile(@TempDir File tempDir) {
     assumeTrue(CuFile.libraryLoaded());
     File tempFile = new File(tempDir, "tempFile");
+    assertFalse(tempFile.exists());
+    verifyCopyToFile(tempFile);
+  }
+
+  @Test
+  public void testCopyToExistingFile(@TempDir File tempDir) throws IOException {
+    assumeTrue(CuFile.libraryLoaded());
+    File tempFile = new File(tempDir, "tempFile");
+    assertTrue(tempFile.createNewFile());
+    verifyCopyToFile(tempFile);
+  }
+
+  @Test
+  public void testAppendToFile(@TempDir File tempDir) {
+    assumeTrue(CuFile.libraryLoaded());
+    File tempFile = new File(tempDir, "tempFile");
+    assertFalse(tempFile.exists());
+    verifyAppendToFile(tempFile);
+  }
+
+  @Test
+  public void testAppendToExistingFile(@TempDir File tempDir) throws IOException {
+    assumeTrue(CuFile.libraryLoaded());
+    File tempFile = new File(tempDir, "tempFile");
+    assertTrue(tempFile.createNewFile());
+    verifyAppendToFile(tempFile);
+  }
+
+  private void verifyCopyToFile(File tempFile) {
     try (HostMemoryBuffer orig = HostMemoryBuffer.allocate(16);
          DeviceMemoryBuffer from = DeviceMemoryBuffer.allocate(16);
          DeviceMemoryBuffer to = DeviceMemoryBuffer.allocate(16);
@@ -36,10 +64,7 @@ public class CuFileTest extends CudfTestBase {
     }
   }
 
-  @Test
-  public void testAppendToFile() {
-    assumeTrue(CuFile.libraryLoaded());
-    File tempFile = new File(tempDir, "tempFile");
+  private void verifyAppendToFile(File tempFile) {
     try (HostMemoryBuffer orig = HostMemoryBuffer.allocate(16);
          DeviceMemoryBuffer from = DeviceMemoryBuffer.allocate(16);
          DeviceMemoryBuffer to = DeviceMemoryBuffer.allocate(16);


### PR DESCRIPTION
Turns out we need version > 5.4 of the junit jupiter engine to support `@TempDir`.
- Changed the file mode to match Spark's disk manager.
- Changed to use `fstat` to get the file length when appending.
- Add tests for when a file already exists.