### PR TITLE
Use string literals in `fixed_point` `release_assert`s

### DIFF
--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -627,7 +627,7 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator+(fixed_point<Rep1, Ra
 #if defined(__CUDACC_DEBUG__)
 
   assert(!addition_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
-                 "fixed_point overflow");
+         "fixed_point overflow");
 
 #endif
 
@@ -644,9 +644,8 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator-(fixed_point<Rep1, Ra
 
 #if defined(__CUDACC_DEBUG__)
 
-  assert(
-    !subtraction_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
-    "fixed_point overflow");
+  assert(!subtraction_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
+         "fixed_point overflow");
 
 #endif
 

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cmath>
 #include <string>
+#include <cassert>
 
 //! `fixed_point` and supporting types
 namespace numeric {
@@ -625,7 +626,7 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator+(fixed_point<Rep1, Ra
 
 #if defined(__CUDACC_DEBUG__)
 
-  release_assert(!addition_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
+  assert(!addition_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
                  "fixed_point overflow");
 
 #endif
@@ -643,7 +644,7 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator-(fixed_point<Rep1, Ra
 
 #if defined(__CUDACC_DEBUG__)
 
-  release_assert(
+  assert(
     !subtraction_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
     "fixed_point overflow");
 
@@ -659,7 +660,7 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator*(fixed_point<Rep1, Ra
 {
 #if defined(__CUDACC_DEBUG__)
 
-  release_assert(!multiplication_overflow<Rep1>(lhs._value, rhs._value) && "fixed_point overflow");
+  assert(!multiplication_overflow<Rep1>(lhs._value, rhs._value) && "fixed_point overflow");
 
 #endif
 
@@ -674,7 +675,7 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator/(fixed_point<Rep1, Ra
 {
 #if defined(__CUDACC_DEBUG__)
 
-  release_assert(!division_overflow<Rep1>(lhs._value, rhs._value) && "fixed_point overflow");
+  assert(!division_overflow<Rep1>(lhs._value, rhs._value) && "fixed_point overflow");
 
 #endif
 

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -25,9 +25,9 @@
 #include <cuda/std/type_traits>  // add cuda namespace
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <string>
-#include <cassert>
 
 //! `fixed_point` and supporting types
 namespace numeric {

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -550,22 +550,6 @@ class fixed_point {
   }
 };  // namespace numeric
 
-/** @brief Function that converts Rep to `std::string`
- *
- * @tparam Rep Representation type
- * @return String-ified Rep
- */
-template <typename Rep>
-std::string print_rep()
-{
-  if (cuda::std::is_same<Rep, int32_t>::value)
-    return "int32_t";
-  else if (cuda::std::is_same<Rep, int64_t>::value)
-    return "int64_t";
-  else
-    return "unknown type";
-}
-
 /** @brief Function for identifying integer overflow when adding
  *
  * @tparam Rep Type of integer to check for overflow on
@@ -642,7 +626,7 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator+(fixed_point<Rep1, Ra
 #if defined(__CUDACC_DEBUG__)
 
   release_assert(!addition_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
-                 "fixed_point overflow of underlying representation type " + print_rep<Rep1>());
+                 "fixed_point overflow");
 
 #endif
 
@@ -661,7 +645,7 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator-(fixed_point<Rep1, Ra
 
   release_assert(
     !subtraction_overflow<Rep1>(lhs.rescaled(scale)._value, rhs.rescaled(scale)._value) &&
-    "fixed_point overflow of underlying representation type " + print_rep<Rep1>());
+    "fixed_point overflow");
 
 #endif
 
@@ -675,8 +659,7 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator*(fixed_point<Rep1, Ra
 {
 #if defined(__CUDACC_DEBUG__)
 
-  release_assert(!multiplication_overflow<Rep1>(lhs._value, rhs._value) &&
-                 "fixed_point overflow of underlying representation type " + print_rep<Rep1>());
+  release_assert(!multiplication_overflow<Rep1>(lhs._value, rhs._value) && "fixed_point overflow");
 
 #endif
 
@@ -691,8 +674,7 @@ CUDA_HOST_DEVICE_CALLABLE fixed_point<Rep1, Rad1> operator/(fixed_point<Rep1, Ra
 {
 #if defined(__CUDACC_DEBUG__)
 
-  release_assert(!division_overflow<Rep1>(lhs._value, rhs._value) &&
-                 "fixed_point overflow of underlying representation type " + print_rep<Rep1>());
+  release_assert(!division_overflow<Rep1>(lhs._value, rhs._value) && "fixed_point overflow");
 
 #endif
 


### PR DESCRIPTION
`release_assert` is only happy with string literals, not `const car*` and not `std::string`. Solution is to remove `print_rep` and just use a string literal.