### PR TITLE
Fix build failures for Java [skip ci]

### DIFF
--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -78,10 +78,10 @@ static void release_contiguous_table_jni(JNIEnv *env) {
   }
 }
 
-jobject contiguous_table_from(JNIEnv *env, cudf::contiguous_split_result &split) {
-  jlong address = reinterpret_cast<jlong>(split.all_data->data());
-  jlong size = static_cast<jlong>(split.all_data->size());
-  jlong buff_address = reinterpret_cast<jlong>(split.all_data.get());
+jobject contiguous_table_from(JNIEnv *env, cudf::packed_table &split) {
+  jlong address = reinterpret_cast<jlong>(split.data.gpu_data->data());
+  jlong size = static_cast<jlong>(split.data.gpu_data->size());
+  jlong buff_address = reinterpret_cast<jlong>(split.data.gpu_data.get());
   int num_columns = split.table.num_columns();
   cudf::jni::native_jlongArray views(env, num_columns);
   for (int i = 0; i < num_columns; i++) {
@@ -103,7 +103,7 @@ jobject contiguous_table_from(JNIEnv *env, cudf::contiguous_split_result &split)
                                             views.get_jArray(), address, size, buff_address);
 
   if (ret != nullptr) {
-    split.all_data.release();
+    split.data.gpu_data.release();
   }
   return ret;
 }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1817,7 +1817,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplit(JNIEnv 
     std::vector<cudf::size_type> indices(n_split_indices.data(),
                                          n_split_indices.data() + n_split_indices.size());
 
-    std::vector<cudf::contiguous_split_result> result = cudf::contiguous_split(*n_table, indices);
+    std::vector<cudf::packed_table> result = cudf::contiguous_split(*n_table, indices);
     cudf::jni::native_jobjectArray<jobject> n_result =
         cudf::jni::contiguous_table_array(env, result.size());
     for (int i = 0; i < result.size(); i++) {

--- a/java/src/main/native/src/cudf_jni_apis.hpp
+++ b/java/src/main/native/src/cudf_jni_apis.hpp
@@ -24,7 +24,7 @@ namespace cudf {
 namespace jni {
 
 
-jobject contiguous_table_from(JNIEnv *env, cudf::contiguous_split_result &split);
+jobject contiguous_table_from(JNIEnv *env, cudf::packed_table &split);
 
 native_jobjectArray<jobject> contiguous_table_array(JNIEnv *env, jsize length);
 


### PR DESCRIPTION
This PR is to fix build failures for Java by updating 'contiguous_split_result' to 'packed_table', involved by the PR https://github.com/rapidsai/cudf/pull/7096 .

Error log snip:
```
[2021-02-04T08:09:05.604Z]      [exec] [ 92%] Building CUDA object CMakeFiles/cudfjni.dir/src/map_lookup.cu.o
[2021-02-04T08:09:05.764Z]      [exec] make[2]: *** [CMakeFiles/cudfjni.dir/build.make:225: CMakeFiles/cudfjni.dir/src/TableJni.cpp.o] Error 1
[2021-02-04T08:09:05.860Z]      [exec] In file included from /ansible-managed/jenkins-slave/slave4/workspace/spark/cudf18_nightly/java/src/main/native/src/NvcompJni.cpp:21:0:
[2021-02-04T08:09:05.861Z]      [exec] /ansible-managed/jenkins-slave/slave4/workspace/spark/cudf18_nightly/java/src/main/native/src/cudf_jni_apis.hpp:27:50: error: 'cudf::contiguous_split_result' has not been declared
[2021-02-04T08:09:05.861Z]      [exec]  jobject contiguous_table_from(JNIEnv *env, cudf::contiguous_split_result &split);
[2021-02-04T08:09:05.861Z]      [exec]                                                   ^~~~~~~~~~~~~~~~~~~~~~~
[2021-02-04T08:09:05.861Z]      [exec] In file included from /ansible-managed/jenkins-slave/slave4/workspace/spark/cudf18_nightly/java/src/main/native/src/ScalarJni.cpp:21:0:
[2021-02-04T08:09:05.861Z]      [exec] /ansible-managed/jenkins-slave/slave4/workspace/spark/cudf18_nightly/java/src/main/native/src/cudf_jni_apis.hpp:27:50: error: 'cudf::contiguous_split_result' has not been declared
[2021-02-04T08:09:05.861Z]      [exec]  jobject contiguous_table_from(JNIEnv *env, cudf::contiguous_split_result &split);
```
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
