### PR TITLE
Fix failing CI ORC test

### DIFF
--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -675,7 +675,7 @@ def test_orc_reader_gmt_timestamps(datadir):
     assert_eq(pdf, gdf)
 
 
-def test_orc_bool_encode_fail():
+def test_orc_bool_encode_fail(tmpdir):
     np.random.seed(0)
 
     # Generate a boolean column longer than a single stripe
@@ -686,12 +686,12 @@ def test_orc_bool_encode_fail():
     # Should throw instead of generating a file that is incompatible
     # with other readers (see issue #6763)
     with pytest.raises(RuntimeError):
-        fail_df.to_orc("should_throw.orc")
+        fail_df.to_orc(tmpdir.join("should_throw.orc"))
 
     # Generate a boolean column that fits into a single stripe
     okay_df = cudf.DataFrame({"col": gen_rand_series("bool", 500000)})
     okay_df["col"][500000 - 1] = None
-    fname = "single_stripe.orc"
+    fname = tmpdir.join("single_stripe.orc")
     # Invalid row is in the last row group of the stripe;
     # encoding is assumed to be correct
     okay_df.to_orc(fname)

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -675,8 +675,9 @@ def test_orc_reader_gmt_timestamps(datadir):
     assert_eq(pdf, gdf)
 
 
-def test_orc_bool_encode_fail(tmpdir):
+def test_orc_bool_encode_fail():
     np.random.seed(0)
+    buffer = BytesIO()
 
     # Generate a boolean column longer than a single stripe
     fail_df = cudf.DataFrame({"col": gen_rand_series("bool", 600000)})
@@ -686,16 +687,15 @@ def test_orc_bool_encode_fail(tmpdir):
     # Should throw instead of generating a file that is incompatible
     # with other readers (see issue #6763)
     with pytest.raises(RuntimeError):
-        fail_df.to_orc(tmpdir.join("should_throw.orc"))
+        fail_df.to_orc(buffer)
 
     # Generate a boolean column that fits into a single stripe
     okay_df = cudf.DataFrame({"col": gen_rand_series("bool", 500000)})
     okay_df["col"][500000 - 1] = None
-    fname = tmpdir.join("single_stripe.orc")
     # Invalid row is in the last row group of the stripe;
     # encoding is assumed to be correct
-    okay_df.to_orc(fname)
+    okay_df.to_orc(buffer)
 
     # Also validate data
-    pdf = pa.orc.ORCFile(fname).read().to_pandas()
+    pdf = pa.orc.ORCFile(buffer).read().to_pandas()
     assert_eq(okay_df, pdf)


### PR DESCRIPTION
Use a buffer for output in the newly added ORC test.