### PR TITLE
Remove incorrect std::move call on return variable

### DIFF
--- a/cpp/src/sort/segmented_sort.cu
+++ b/cpp/src/sort/segmented_sort.cu
@@ -62,7 +62,7 @@ rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
                       counting_iter,
                       counting_iter + segment_ids.size(),
                       segment_ids.begin());
-  return std::move(segment_ids);
+  return segment_ids;
 }
 
 std::unique_ptr<column> segmented_sorted_order(table_view const& keys,


### PR DESCRIPTION
Returning a unique pointer using `std::move` causes a compile error for gcc 9 and above.
Simple fix to remove the incorrect move semantic in `segmented_sort.cu` `get_segment_indices`.