### PR TITLE
retry EEXIST errors during cuFile writes [skip ci]

### DIFF
--- a/java/src/main/native/src/CuFileJni.cpp
+++ b/java/src/main/native/src/CuFileJni.cpp
@@ -17,6 +17,7 @@
 #include <limits>
 
 #include <cufile.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/java/src/main/native/src/CuFileJni.cpp
+++ b/java/src/main/native/src/CuFileJni.cpp
@@ -258,22 +258,21 @@ private:
       auto const status =
           cuFileWrite(file.cufile_handle_, buffer.device_pointer(), buffer.size(), file_offset, 0);
 
-      if (status == EEXIST) {
-        file_descriptor = open(path, O_WRONLY | O_DIRECT);
-        if (file_descriptor < 0) {
-          CUDF_FAIL("Failed to open file " + std::string(path) + ": " +
-                    cuFileGetErrorString(errno));
-        }
-        file_offset = std::numeric_limits<std::size_t>::max();
-        continue;
-      }
-
       if (status < 0) {
+        if (errno == EEXIST) {
+          file_descriptor = open(path, O_WRONLY | O_DIRECT);
+          if (file_descriptor < 0) {
+            CUDF_FAIL("Failed to open file " + std::string(path) + ": " +
+                      cuFileGetErrorString(errno));
+          }
+          file_offset = std::numeric_limits<std::size_t>::max();
+          continue;
+        }
         if (IS_CUFILE_ERR(status)) {
-          CUDF_FAIL("Failed to append buffer to file " + std::string(path) + ": " +
+          CUDF_FAIL("Failed to write buffer to file " + std::string(path) + ": " +
                     cuFileGetErrorString(status));
         } else {
-          CUDF_FAIL("Failed to append buffer to file " + std::string(path) + ": " +
+          CUDF_FAIL("Failed to write buffer to file " + std::string(path) + ": " +
                     cuFileGetErrorString(errno));
         }
       }


### PR DESCRIPTION
Add retry logic when getting an `EEXIST` for writing through cuFile. This does seem to help to get through the initial spilling step.

@jlowe @revans2 @abellina 