### PR TITLE
[gpuCI] Auto-merge branch-0.18 to branch-0.19 [skip ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+# Documentation for config - https://github.com/actions/labeler#common-examples
+
+cuDF (Python):
+  - 'python/**'
+  - 'notebooks/**'
+  
+libcudf:
+  - 'cpp/**'
+
+CMake:
+  - '**/CMakeLists.txt'
+  - '**/cmake/**'
+  
+cuDF (Java):
+  - 'java/**'
+
+gpuCI:
+  - 'ci/**'
+
+conda:
+  - 'conda/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.18` that creates a PR to keep `branch-0.19` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.