### PR TITLE
fix Arrow CMake file

### DIFF
--- a/cpp/cmake/Templates/Arrow.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/Arrow.CMakeLists.txt.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/cmake/Templates/Arrow.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/Arrow.CMakeLists.txt.cmake
@@ -14,6 +14,8 @@
 # limitations under the License.
 #=============================================================================
 
+cmake_minimum_required(VERSION 3.14...3.17 FATAL_ERROR)
+
 project(cudf-Arrow)
 
 include(ExternalProject)


### PR DESCRIPTION
With the latest cmake (built from head), it crashes with `-DARROW_STATIC_LIB=ON`. Adding `cmake_minimum_required` to match what's in the top-level file.
