### PR TITLE
Fix skiprows issue with ORC Reader

### DIFF
--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -1211,8 +1211,9 @@ __global__ void __launch_bounds__(block_size)
         uint32_t skippedrows = min(static_cast<uint32_t>(first_row - row_in), nrows);
         uint32_t skip_count  = 0;
         for (uint32_t i = t * 32; i < skippedrows; i += 32 * 32) {
-          uint32_t bits = s->vals.u32[i >> 5];
-          if (i + 32 > skippedrows) { bits &= (1 << (skippedrows - i)) - 1; }
+          uint32_t bits = (i + 32 <= skippedrows)
+                            ? s->vals.u32[i >> 5]
+                            : (rle8_read_bool32(s->vals.u32, i) & ((1 << (skippedrows - i)) - 1));
           skip_count += __popc(bits);
         }
         skip_count = warp_reduce(temp_storage[t / 32]).Sum(skip_count);

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -1211,11 +1211,13 @@ __global__ void __launch_bounds__(block_size)
         uint32_t skippedrows = min(static_cast<uint32_t>(first_row - row_in), nrows);
         uint32_t skip_count  = 0;
         for (uint32_t i = t * 32; i < skippedrows; i += 32 * 32) {
-          uint32_t bits = (i + 32 <= skippedrows)
-                            ? s->vals.u32[i >> 5]
-                            : (__brev(__byte_perm(s->vals.u32[i >> 5], 0, 0x0123)) &
-                               ((1 << (skippedrows - i)) -
-                                1));  // Need to arrange the bits to apply mask properly.
+          uint32_t bits =
+            (i + 32 <= skippedrows)
+              ? s->vals.u32[i >> 5]
+              : (__byte_perm(s->vals.u32[i >> 5],
+                             0,
+                             0x0123) &  // Need to arrange the bytes to apply mask properly.
+                 (0xffffffffu << (0x20 - skippedrows + i)));
           skip_count += __popc(bits);
         }
         skip_count = warp_reduce(temp_storage[t / 32]).Sum(skip_count);

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -1213,7 +1213,9 @@ __global__ void __launch_bounds__(block_size)
         for (uint32_t i = t * 32; i < skippedrows; i += 32 * 32) {
           uint32_t bits = (i + 32 <= skippedrows)
                             ? s->vals.u32[i >> 5]
-                            : (rle8_read_bool32(s->vals.u32, i) & ((1 << (skippedrows - i)) - 1));
+                            : (__brev(__byte_perm(s->vals.u32[i >> 5], 0, 0x0123)) &
+                               ((1 << (skippedrows - i)) -
+                                1));  // Need to arrange the bits to apply mask properly.
           skip_count += __popc(bits);
         }
         skip_count = warp_reduce(temp_storage[t / 32]).Sum(skip_count);

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -1211,13 +1211,10 @@ __global__ void __launch_bounds__(block_size)
         uint32_t skippedrows = min(static_cast<uint32_t>(first_row - row_in), nrows);
         uint32_t skip_count  = 0;
         for (uint32_t i = t * 32; i < skippedrows; i += 32 * 32) {
-          uint32_t bits =
-            (i + 32 <= skippedrows)
-              ? s->vals.u32[i >> 5]
-              : (__byte_perm(s->vals.u32[i >> 5],
-                             0,
-                             0x0123) &  // Need to arrange the bytes to apply mask properly.
-                 (0xffffffffu << (0x20 - skippedrows + i)));
+          // Need to arrange the bytes to apply mask properly.
+          uint32_t bits = (i + 32 <= skippedrows) ? s->vals.u32[i >> 5]
+                                                  : (__byte_perm(s->vals.u32[i >> 5], 0, 0x0123) &
+                                                     (0xffffffffu << (0x20 - skippedrows + i)));
           skip_count += __popc(bits);
         }
         skip_count = warp_reduce(temp_storage[t / 32]).Sum(skip_count);

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -320,13 +320,12 @@ def test_orc_read_rows(datadir, skiprows, num_rows):
 
 
 def test_orc_read_skiprows(tmpdir):
-    fname = tmpdir.join("TestOrcFile.skiprows.orc")
+    buff = BytesIO()
     df = pd.DataFrame(
         {"a": [1, 0, 1, 0, None, 1, 1, 1, 0, None, 0, 0, 1, 1, 1, 1]},
         dtype=pd.BooleanDtype(),
     )
-    output = open(fname, "wb")
-    writer = pyorc.Writer(output, pyorc.Struct(a=pyorc.Boolean()))
+    writer = pyorc.Writer(buff, pyorc.Struct(a=pyorc.Boolean()))
     tuples = list(
         map(
             lambda x: (None,) if x[0] is pd.NA else x,
@@ -338,8 +337,8 @@ def test_orc_read_skiprows(tmpdir):
 
     skiprows = 10
 
-    expected = cudf.read_orc(fname)[skiprows::].reset_index(drop=True)
-    got = cudf.read_orc(fname, skiprows=skiprows)
+    expected = cudf.read_orc(buff)[skiprows::].reset_index(drop=True)
+    got = cudf.read_orc(buff, skiprows=skiprows)
 
     assert_eq(expected, got)
 

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.orc
+import pyorc
 import pytest
 
 import cudf
@@ -316,6 +317,31 @@ def test_orc_read_rows(datadir, skiprows, num_rows):
     pdf = pdf[skiprows : skiprows + num_rows]
 
     np.testing.assert_allclose(pdf, gdf)
+
+
+def test_orc_read_skiprows(tmpdir):
+    fname = tmpdir.join("TestOrcFile.skiprows.orc")
+    df = pd.DataFrame(
+        {"a": [1, 0, 1, 0, None, 1, 1, 1, 0, None, 0, 0, 1, 1, 1, 1]},
+        dtype=pd.BooleanDtype(),
+    )
+    output = open(fname, "wb")
+    writer = pyorc.Writer(output, pyorc.Struct(a=pyorc.Boolean()))
+    tuples = list(
+        map(
+            lambda x: (None,) if x[0] is pd.NA else x,
+            list(df.itertuples(index=False, name=None)),
+        )
+    )
+    writer.writerows(tuples)
+    writer.close()
+
+    skiprows = 10
+
+    expected = cudf.read_orc(fname)[skiprows::].reset_index(drop=True)
+    got = cudf.read_orc(fname, skiprows=skiprows)
+
+    assert_eq(expected, got)
 
 
 def test_orc_reader_uncompressed_block(datadir):


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
closes #7343

The validity bits in streams are placed msb to lsb in a byte, [True, False, True. False. True, True, True, False] -> 10101110.
So, when it is being analyzed as 32 bit chunk, we can't apply mask directly, which caused this issue. `__brev(__byte_perm(bits, 0, 0x0123)) ` takes care of that issue and rearranges the bits as per the expectation.