### PR TITLE
Fix std::exeception catch-by-reference gcc9 compile error

### DIFF
--- a/cpp/src/text/subword/load_hash_file.cu
+++ b/cpp/src/text/subword/load_hash_file.cu
@@ -133,7 +133,7 @@ uint32_t str_to_uint32(std::string const& str, uint64_t line_no)
     message += "': ";
     message += exc.what();
     std::cerr << message << std::endl;
-    throw exc;
+    throw;
   }
 }
 
@@ -155,7 +155,7 @@ uint64_t str_to_uint64(std::string const& str, uint64_t line_no)
     message += "': ";
     message += exc.what();
     std::cerr << message << std::endl;
-    throw exc;
+    throw;
   }
 }
 }  // namespace

--- a/cpp/src/text/subword/load_hash_file.cu
+++ b/cpp/src/text/subword/load_hash_file.cu
@@ -125,7 +125,7 @@ uint32_t str_to_uint32(std::string const& str, uint64_t line_no)
 {
   try {
     return std::stoi(str);  // there is no std::stoui
-  } catch (std::exception exc) {
+  } catch (std::exception const& exc) {
     std::string message("Line ");
     message += std::to_string(line_no) + ": ";
     message += "cannot convert integer from '";
@@ -147,7 +147,7 @@ uint64_t str_to_uint64(std::string const& str, uint64_t line_no)
 {
   try {
     return std::stoul(str);
-  } catch (std::exception exc) {
+  } catch (std::exception const& exc) {
     std::string message("Line ");
     message += std::to_string(line_no) + ": ";
     message += "cannot convert integer from '";


### PR DESCRIPTION
Compile error (for gcc-9) created by change in #7254 as mentioned in the following comment.
https://github.com/rapidsai/cudf/pull/7254#issuecomment-777940995

Core C++ Guidelines for catching exceptions says to always catch by reference.
Polymorphism is supported only with pointers and references.
http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Re-exception-ref