### PR TITLE
Added in JNI support for out of core sort algorithm [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -1251,7 +1251,8 @@ public final class Table implements AutoCloseable {
   }
 
   /**
-   * Given a sorted table return the lower bound.
+   * Find smallest indices in a sorted table where values should be inserted to maintain order.
+   * <pre>
    * Example:
    *
    *  Single column:
@@ -1269,14 +1270,11 @@ public final class Table implements AutoCloseable {
    *                      { .7 },
    *                      { 61 }}
    *   result          = {  3 }
-   * NaNs in column values produce incorrect results.
+   * </pre>
    * The input table and the values table need to be non-empty (row count > 0)
-   * The column data types of the tables' have to match in order.
-   * Strings and String categories do not work for this method. If the input table is
-   * unsorted the results are wrong. Types of columns can be of mixed data types.
-   * @param areNullsSmallest true if nulls are assumed smallest
-   * @param valueTable the table of values that need to be inserted
-   * @param descFlags indicates the ordering of the column(s), true if descending
+   * @param areNullsSmallest per column, true if nulls are assumed smallest
+   * @param valueTable the table of values to find insertion locations for
+   * @param descFlags per column indicates the ordering, true if descending.
    * @return ColumnVector with lower bound indices for all rows in valueTable
    */
   public ColumnVector lowerBound(boolean[] areNullsSmallest,
@@ -1287,9 +1285,11 @@ public final class Table implements AutoCloseable {
   }
 
   /**
-   * Given a sorted table return the lower bound.
-   * @param valueTable the table of values that would be inserted.
-   * @param args the sort order used to sort the table.
+   * Find smallest indices in a sorted table where values should be inserted to maintain order.
+   * This is a convenience method. It pulls out the columns indicated by the args and sets up the
+   * ordering properly to call `lowerBound`.
+   * @param valueTable the table of values to find insertion locations for
+   * @param args the sort order used to sort this table.
    * @return ColumnVector with lower bound indices for all rows in valueTable
    */
   public ColumnVector lowerBound(Table valueTable, OrderByArg... args) {
@@ -1310,7 +1310,9 @@ public final class Table implements AutoCloseable {
   }
 
   /**
+   * Find largest indices in a sorted table where values should be inserted to maintain order.
    * Given a sorted table return the upper bound.
+   * <pre>
    * Example:
    *
    *  Single column:
@@ -1328,14 +1330,11 @@ public final class Table implements AutoCloseable {
    *                      { .7 },
    *                      { 61 }}
    *   result          = {  5 }
-   * NaNs in column values produce incorrect results.
+   * </pre>
    * The input table and the values table need to be non-empty (row count > 0)
-   * The column data types of the tables' have to match in order.
-   * Strings and String categories do not work for this method. If the input table is
-   * unsorted the results are wrong. Types of columns can be of mixed data types.
-   * @param areNullsSmallest true if nulls are assumed smallest
-   * @param valueTable the table of values that need to be inserted
-   * @param descFlags indicates the ordering of the column(s), true if descending
+   * @param areNullsSmallest per column, true if nulls are assumed smallest
+   * @param valueTable the table of values to find insertion locations for
+   * @param descFlags per column indicates the ordering, true if descending.
    * @return ColumnVector with upper bound indices for all rows in valueTable
    */
   public ColumnVector upperBound(boolean[] areNullsSmallest,
@@ -1346,9 +1345,11 @@ public final class Table implements AutoCloseable {
   }
 
   /**
-   * Given a sorted table return the upper bound.
-   * @param valueTable the table of values that would be inserted.
-   * @param args the sort order used to sort the table.
+   * Find largest indices in a sorted table where values should be inserted to maintain order.
+   * This is a convenience method. It pulls out the columns indicated by the args and sets up the
+   * ordering properly to call `upperBound`.
+   * @param valueTable the table of values to find insertion locations for
+   * @param args the sort order used to sort this table.
    * @return ColumnVector with upper bound indices for all rows in valueTable
    */
   public ColumnVector upperBound(Table valueTable, OrderByArg... args) {

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -578,7 +578,7 @@ bool valid_window_parameters(native_jintArray const &values, native_jintArray co
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_createCudfTableView(JNIEnv *env,
-                                                                      jclass class_object,
+                                                                      jclass,
                                                                       jlongArray j_cudf_columns) {
   JNI_NULL_CHECK(env, j_cudf_columns, "columns are null", 0);
 
@@ -596,7 +596,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_createCudfTableView(JNIEnv *en
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_deleteCudfTable(JNIEnv *env, jclass class_object,
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_deleteCudfTable(JNIEnv *env, jclass,
                                                                  jlong j_cudf_table_view) {
   JNI_NULL_CHECK(env, j_cudf_table_view, "table view handle is null", );
   try {
@@ -638,7 +638,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_columnViewsFromPacked(JNI
   CATCH_STD(env, nullptr);
 }
 
-JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_sortOrder(JNIEnv *env, jclass j_class_object,
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_sortOrder(JNIEnv *env, jclass,
                                                             jlong j_input_table,
                                                             jlongArray j_sort_keys_columns,
                                                             jbooleanArray j_is_descending,
@@ -658,18 +658,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_sortOrder(JNIEnv *env, jclass 
     const cudf::jni::native_jbooleanArray n_is_descending(env, j_is_descending);
     jsize num_columns_is_desc = n_is_descending.size();
 
-    if (num_columns_is_desc != num_columns) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                    "columns and is_descending lengths don't match", 0);
-    }
+    JNI_ARG_CHECK(env, num_columns_is_desc == num_columns,
+            "columns and is_descending lengths don't match", 0);
 
     const cudf::jni::native_jbooleanArray n_are_nulls_smallest(env, j_are_nulls_smallest);
     jsize num_columns_null_smallest = n_are_nulls_smallest.size();
 
-    if (num_columns_null_smallest != num_columns) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                    "columns and areNullsSmallest lengths don't match", 0);
-    }
+    JNI_ARG_CHECK(env, num_columns_null_smallest == num_columns,
+            "columns and is_descending lengths don't match", 0);
 
     std::vector<cudf::order> order(n_is_descending.size());
     for (int i = 0; i < n_is_descending.size(); i++) {
@@ -680,10 +676,9 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_sortOrder(JNIEnv *env, jclass 
       null_order[i] = n_are_nulls_smallest[i] ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
     }
 
-    std::vector<cudf::column_view> columns;
-    columns.reserve(num_columns);
+    std::vector<cudf::column_view> columns(num_columns);
     for (int i = 0; i < num_columns; i++) {
-      columns.push_back(*n_sort_keys_columns[i]);
+      columns[i] = *n_sort_keys_columns[i];
     }
     cudf::table_view keys(columns);
 
@@ -694,7 +689,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_sortOrder(JNIEnv *env, jclass 
 }
 
 
-JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(JNIEnv *env, jclass j_class_object,
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(JNIEnv *env, jclass,
                                                                jlong j_input_table,
                                                                jlongArray j_sort_keys_columns,
                                                                jbooleanArray j_is_descending,
@@ -714,18 +709,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(JNIEnv *env, jcla
     const cudf::jni::native_jbooleanArray n_is_descending(env, j_is_descending);
     jsize num_columns_is_desc = n_is_descending.size();
 
-    if (num_columns_is_desc != num_columns) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                    "columns and is_descending lengths don't match", NULL);
-    }
+    JNI_ARG_CHECK(env, num_columns_is_desc == num_columns,
+            "columns and is_descending lengths don't match", 0);
 
     const cudf::jni::native_jbooleanArray n_are_nulls_smallest(env, j_are_nulls_smallest);
     jsize num_columns_null_smallest = n_are_nulls_smallest.size();
 
-    if (num_columns_null_smallest != num_columns) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                    "columns and areNullsSmallest lengths don't match", NULL);
-    }
+    JNI_ARG_CHECK(env, num_columns_null_smallest == num_columns,
+            "columns and areNullsSmallest lengths don't match", 0);
 
     std::vector<cudf::order> order(n_is_descending.size());
     for (int i = 0; i < n_is_descending.size(); i++) {
@@ -736,10 +727,9 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(JNIEnv *env, jcla
       null_order[i] = n_are_nulls_smallest[i] ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
     }
 
-    std::vector<cudf::column_view> columns;
-    columns.reserve(num_columns);
+    std::vector<cudf::column_view> columns(num_columns);
     for (int i = 0; i < num_columns; i++) {
-      columns.push_back(*n_sort_keys_columns[i]);
+      columns[i] = *n_sort_keys_columns[i];
     }
     cudf::table_view keys(columns);
 
@@ -752,7 +742,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(JNIEnv *env, jcla
   CATCH_STD(env, NULL);
 }
 
-JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_merge(JNIEnv *env, jclass j_class_object,
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_merge(JNIEnv *env, jclass,
                                                              jlongArray j_table_handles,
                                                              jintArray j_sort_key_indexes,
                                                              jbooleanArray j_is_descending,
@@ -773,18 +763,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_merge(JNIEnv *env, jclass
     const cudf::jni::native_jbooleanArray n_is_descending(env, j_is_descending);
     jsize num_columns_is_desc = n_is_descending.size();
 
-    if (num_columns_is_desc != num_columns) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                    "columns and is_descending lengths don't match", NULL);
-    }
+    JNI_ARG_CHECK(env, num_columns_is_desc == num_columns,
+            "columns and is_descending lengths don't match", NULL);
 
     const cudf::jni::native_jbooleanArray n_are_nulls_smallest(env, j_are_nulls_smallest);
     jsize num_columns_null_smallest = n_are_nulls_smallest.size();
 
-    if (num_columns_null_smallest != num_columns) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                    "columns and areNullsSmallest lengths don't match", NULL);
-    }
+    JNI_ARG_CHECK(env, num_columns_null_smallest == num_columns,
+            "columns and areNullsSmallest lengths don't match", NULL);
 
     std::vector<int> indexes(n_sort_key_indexes.size());
     for (int i = 0; i < n_sort_key_indexes.size(); i++) {
@@ -813,7 +799,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_merge(JNIEnv *env, jclass
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
-    JNIEnv *env, jclass j_class_object, jobjectArray col_names, jobjectArray data_types,
+    JNIEnv *env, jclass, jobjectArray col_names, jobjectArray data_types,
     jobjectArray filter_col_names, jstring inputfilepath, jlong buffer, jlong buffer_length,
     jint header_row, jbyte delim, jbyte quote, jbyte comment, jobjectArray null_values,
     jobjectArray true_values, jobjectArray false_values) {
@@ -875,7 +861,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readParquet(
-    JNIEnv *env, jclass j_class_object, jobjectArray filter_col_names, jstring inputfilepath,
+    JNIEnv *env, jclass, jobjectArray filter_col_names, jstring inputfilepath,
     jlong buffer, jlong buffer_length, jint unit, jboolean strict_decimal_types) {
   bool read_buffer = true;
   if (buffer == 0) {
@@ -1054,7 +1040,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeParquetEnd(JNIEnv *env, jc
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readORC(
-    JNIEnv *env, jclass j_class_object, jobjectArray filter_col_names, jstring inputfilepath,
+    JNIEnv *env, jclass, jobjectArray filter_col_names, jstring inputfilepath,
     jlong buffer, jlong buffer_length, jboolean usingNumPyTypes, jint unit) {
   bool read_buffer = true;
   if (buffer == 0) {
@@ -1408,7 +1394,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_readArrowIPCEnd(JNIEnv *env, jc
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftJoin(
-    JNIEnv *env, jclass clazz, jlong left_table, jintArray left_col_join_indices, jlong right_table,
+    JNIEnv *env, jclass, jlong left_table, jintArray left_col_join_indices, jlong right_table,
     jintArray right_col_join_indices, jboolean compare_nulls_equal) {
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
   JNI_NULL_CHECK(env, left_col_join_indices, "left_col_join_indices is null", NULL);
@@ -1444,7 +1430,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftJoin(
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerJoin(
-    JNIEnv *env, jclass clazz, jlong left_table, jintArray left_col_join_indices, jlong right_table,
+    JNIEnv *env, jclass, jlong left_table, jintArray left_col_join_indices, jlong right_table,
     jintArray right_col_join_indices, jboolean compare_nulls_equal) {
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
   JNI_NULL_CHECK(env, left_col_join_indices, "left_col_join_indices is null", NULL);
@@ -1480,7 +1466,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerJoin(
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_fullJoin(
-    JNIEnv *env, jclass clazz, jlong left_table, jintArray left_col_join_indices, jlong right_table,
+    JNIEnv *env, jclass, jlong left_table, jintArray left_col_join_indices, jlong right_table,
     jintArray right_col_join_indices, jboolean compare_nulls_equal) {
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
   JNI_NULL_CHECK(env, left_col_join_indices, "left_col_join_indices is null", NULL);
@@ -1581,7 +1567,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftAntiJoin(
   CATCH_STD(env, NULL);
 }
 
-JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_crossJoin(JNIEnv *env, jclass clazz,
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_crossJoin(JNIEnv *env, jclass,
                                                                  jlong left_table,
                                                                  jlong right_table) {
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
@@ -1612,7 +1598,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_interleaveColumns(JNIEnv *env,
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_concatenate(JNIEnv *env, jclass clazz,
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_concatenate(JNIEnv *env, jclass,
                                                                    jlongArray table_handles) {
   JNI_NULL_CHECK(env, table_handles, "input tables are null", NULL);
   try {
@@ -1634,7 +1620,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_concatenate(JNIEnv *env, 
   CATCH_STD(env, NULL);
 }
 
-JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_hashPartition(JNIEnv *env, jclass clazz,
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_hashPartition(JNIEnv *env, jclass,
                                                                      jlong input_table,
                                                                      jintArray columns_to_hash,
                                                                      jint number_of_partitions,
@@ -1697,7 +1683,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_roundRobinPartition(
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_groupByAggregate(
-    JNIEnv *env, jclass clazz, jlong input_table, jintArray keys,
+    JNIEnv *env, jclass, jlong input_table, jintArray keys,
     jintArray aggregate_column_indices, jlongArray agg_instances, jboolean ignore_null_keys) {
   JNI_NULL_CHECK(env, input_table, "input table is null", NULL);
   JNI_NULL_CHECK(env, keys, "input keys are null", NULL);
@@ -1782,7 +1768,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_gather(JNIEnv *env, jclas
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_convertToRows(JNIEnv *env, jclass clazz,
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_convertToRows(JNIEnv *env, jclass,
                                                                      jlong input_table) {
   JNI_NULL_CHECK(env, input_table, "input table is null", 0);
 
@@ -1800,7 +1786,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_convertToRows(JNIEnv *env
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_convertFromRows(JNIEnv *env, jclass clazz,
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_convertFromRows(JNIEnv *env, jclass,
                                                                        jlong input_column,
                                                                        jintArray types,
                                                                        jintArray scale) {
@@ -1891,7 +1877,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_bound(JNIEnv *env, jclass, jlo
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplit(JNIEnv *env, jclass clazz,
+JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplit(JNIEnv *env, jclass,
                                                                          jlong input_table,
                                                                          jintArray split_indices) {
   JNI_NULL_CHECK(env, input_table, "native handle is null", 0);
@@ -1918,7 +1904,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplit(JNIEnv 
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_rollingWindowAggregate(
-    JNIEnv *env, jclass clazz, jlong j_input_table, jintArray j_keys, jlongArray j_default_output,
+    JNIEnv *env, jclass, jlong j_input_table, jintArray j_keys, jlongArray j_default_output,
     jintArray j_aggregate_column_indices, jlongArray j_agg_instances, jintArray j_min_periods,
     jintArray j_preceding, jintArray j_following, jboolean ignore_null_keys) {
 
@@ -1974,7 +1960,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_rollingWindowAggregate(
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_timeRangeRollingWindowAggregate(
-    JNIEnv *env, jclass clazz, jlong j_input_table, jintArray j_keys,
+    JNIEnv *env, jclass, jlong j_input_table, jintArray j_keys,
     jintArray j_timestamp_column_indices, jbooleanArray j_is_timestamp_ascending,
     jintArray j_aggregate_column_indices, jlongArray j_agg_instances, jintArray j_min_periods,
     jintArray j_preceding, jintArray j_following, 

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -394,6 +394,24 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
+  void testSortOrderSimple() {
+    try (Table table = new Table.TestBuilder()
+        .column(5, 3, 3, 1, 1)
+        .column(5, 3, 4, 1, 2)
+        .column(1, 3, 5, 7, 9)
+        .build();
+         Table expected = new Table.TestBuilder()
+             .column(1, 1, 3, 3, 5)
+             .column(2, 1, 4, 3, 5)
+             .column(9, 7, 5, 3, 1)
+             .build();
+         ColumnVector gatherMap = table.sortOrder(Table.asc(0), Table.desc(1));
+         Table sortedTable = table.gather(gatherMap)) {
+      assertTablesAreEqual(expected, sortedTable);
+    }
+  }
+
+  @Test
   void testOrderByDD() {
     try (Table table = new Table.TestBuilder()
         .column(5, 3, 3, 1, 1)


### PR DESCRIPTION
This makes changes to be able to support out of core sort on the Spark plugin. It adds sort order as an API so sorting that is not out of core does not need to gather columns that are only used for sort ordering.

It adds in versions of lower bound and upper bound that match more closely the APIs for sort so the sort order can be reused between them.

It updates the merge API to take an array of tables not just a list for simpler integration with Scala.

And makes a few minor changes to the sort order class so it can work better with Spark and debugging.