### PR TITLE
upgrade maven-antrun-plugin to support maven parallel builds [skip ci]

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -365,6 +365,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>cmake</id>


### PR DESCRIPTION
When running `maven` in parallel build mode (`mvn -T 1C`), getting this warning:
```console
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in cudfjni:
[WARNING] org.apache.maven.plugins:maven-antrun-plugin:1.3
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
```
Upgrading the `org.apache.maven.plugins:maven-antrun-plugin` got rid of the warning.

@jlowe @revans2 
