### PR TITLE
ENH Pass ccache variables to conda recipe & use Ninja in CI

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 ##############################################
 # cuDF CPU conda build script for CI         #
 ##############################################
@@ -18,6 +18,9 @@ export CUDA_REL=${CUDA_VERSION%.*}
 # Setup 'gpuci_conda_retry' for build retries (results in 2 total attempts)
 export GPUCI_CONDA_RETRY_MAX=1
 export GPUCI_CONDA_RETRY_SLEEP=30
+
+# Use Ninja to build
+export CMAKE_GENERATOR="Ninja"
 
 # Switch to project root; also root of repo checkout
 cd $WORKSPACE

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -21,6 +21,13 @@ build:
     - PARALLEL_LEVEL
     - VERSION_SUFFIX
     - PROJECT_FLASH
+    - CCACHE_DIR
+    - CCACHE_NOHASHDIR
+    - CCACHE_COMPILERCHECK
+    - CMAKE_GENERATOR
+    - CMAKE_C_COMPILER_LAUNCHER
+    - CMAKE_CXX_COMPILER_LAUNCHER
+    - CMAKE_CUDA_COMPILER_LAUNCHER
   run_exports:
     - {{ pin_subpackage("libcudf", max_pin="x.x") }}
 


### PR DESCRIPTION
- Add ccache env variables to conda recipe
- Use Ninja in CI