### PR TITLE
Clean up included headers in `device_operators.cuh`

### DIFF
--- a/cpp/include/cudf/detail/utilities/device_operators.cuh
+++ b/cpp/include/cudf/detail/utilities/device_operators.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/detail/utilities/device_operators.cuh
+++ b/cpp/include/cudf/detail/utilities/device_operators.cuh
@@ -22,13 +22,11 @@
  * @file device_operators.cuh
  */
 
+#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
-
-// will fail to compile if grouped with the includes above
-#include <cudf/fixed_point/fixed_point.hpp>
 
 #include <type_traits>
 


### PR DESCRIPTION
This resolves https://github.com/rapidsai/cudf/issues/5746 (seems like the issue self resolved, just removing now unnecessary comment and clang-formatting).