### PR TITLE
Add other cudf::strings::replace functions to current strings replace gbenchmark

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -307,7 +307,7 @@ ConfigureBench(SUBWORD_TOKENIZER_BENCH "${SUBWORD_TOKENIZER_BENCH_SRC}")
 set(STRINGS_BENCH_SRC
   "${CMAKE_CURRENT_SOURCE_DIR}/string/case_benchmark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/string/convert_durations_benchmark.cpp"
-  "${CMAKE_CURRENT_SOURCE_DIR}/string/replace_scalar_benchmark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/string/replace_benchmark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/string/url_decode_benchmark.cpp")
 
 ConfigureBench(STRINGS_BENCH "${STRINGS_BENCH_SRC}")


### PR DESCRIPTION
Reference #5698

This builds off of PR #7369 to add `cudf::strings::replace_slice` and the multi-column version of `cudf::strings::replace` to the current gbenchmark that only measures scalar strings replace.

The current `replace_scalar_benchmark.cpp` is also renamed to `replace_benchmark.cpp` since it now handles more than the scalar replace.
