### PR TITLE
bitmask_or implementation with bitmask refactor

### DIFF
--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -805,7 +805,7 @@ namespace detail {
  * @brief Convenience function to get offset word from a bitmask
  *
  * @see copy_offset_bitmask
- * @see offset_bitmask_and
+ * @see offset_bitmask_binop
  */
 __device__ inline bitmask_type get_mask_offset_word(bitmask_type const* __restrict__ source,
                                                     size_type destination_word_index,

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -138,7 +138,6 @@ void inplace_bitmask_binop(
                            stream.value()));
 
   cudf::detail::grid_1d config(dest_mask.size(), 256);
-  stream.synchronize();
   offset_bitmask_binop<<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
     op, dest_mask, d_masks, d_begin_bits, mask_size_bits);
   CHECK_CUDA(stream.value());

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -92,7 +92,6 @@ rmm::device_buffer bitmask_binop(
                         stream,
                         mr);
 
-  stream.synchronize();
   return dest_mask;
 }
 
@@ -141,6 +140,7 @@ void inplace_bitmask_binop(
   offset_bitmask_binop<<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
     op, dest_mask, d_masks, d_begin_bits, mask_size_bits);
   CHECK_CUDA(stream.value());
+  stream.synchronize();
 }
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/detail/utilities/cuda.cuh>
+#include <cudf/null_mask.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+using cudf::detail::device_span;
+
+namespace cudf {
+namespace {
+/**
+ * @brief Computes the merger of an array of bitmasks using a binary operator
+ *
+ * @param op The binary operator used to combine the bitmasks
+ * @param destination The bitmask to write result into
+ * @param source Array of source mask pointers. All masks must be of same size
+ * @param begin_bit Array of offsets into corresponding @p source masks.
+ *                  Must be same size as source array
+ * @param num_sources Number of masks in @p source array
+ * @param source_size Number of bits in each mask in @p source
+ * @param number_of_mask_words The number of words of type bitmask_type to copy
+ */
+template <typename Binop>
+__global__ void offset_bitmask_binop(Binop op,
+                                     device_span<bitmask_type> destination,
+                                     device_span<bitmask_type const *> source,
+                                     device_span<size_type> begin_bit,
+                                     size_type source_size)
+{
+  for (size_type destination_word_index = threadIdx.x + blockIdx.x * blockDim.x;
+       destination_word_index < destination.size();
+       destination_word_index += blockDim.x * gridDim.x) {
+    bitmask_type destination_word = detail::get_mask_offset_word(
+      source[0], destination_word_index, begin_bit[0], begin_bit[0] + source_size);
+    for (size_type i = 1; i < source.size(); i++) {
+      destination_word =
+        op(destination_word,
+           detail::get_mask_offset_word(
+             source[i], destination_word_index, begin_bit[i], begin_bit[i] + source_size));
+    }
+
+    destination[destination_word_index] = destination_word;
+  }
+}
+}  // namespace
+namespace detail {
+/**
+ * @copydoc bitmask_binop(Binop op, std::vector<bitmask_type const*>, std::vector<size_type> const&,
+ * size_type, rmm::mr::device_memory_resource *)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ */
+template <typename Binop>
+rmm::device_buffer bitmask_binop(
+  Binop op,
+  std::vector<bitmask_type const *> const &masks,
+  std::vector<size_type> const &begin_bits,
+  size_type mask_size,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource())
+{
+  CUDF_EXPECTS(std::all_of(begin_bits.begin(), begin_bits.end(), [](auto b) { return b >= 0; }),
+               "Invalid range.");
+  CUDF_EXPECTS(std::all_of(masks.begin(), masks.end(), [](auto p) { return p != nullptr; }),
+               "Mask pointer cannot be null");
+  rmm::device_buffer dest_mask{};
+  auto num_bytes = bitmask_allocation_size_bytes(mask_size);
+
+  rmm::device_vector<bitmask_type const *> d_masks(masks);
+  rmm::device_vector<size_type> d_begin_bits(begin_bits);
+
+  dest_mask = rmm::device_buffer{num_bytes, stream, mr};
+
+  inplace_bitmask_binop(op,
+                        device_span<bitmask_type>(static_cast<bitmask_type *>(dest_mask.data()),
+                                                  num_bitmask_words(mask_size)),
+                        device_span<bitmask_type const *>(d_masks.data().get(), d_masks.size()),
+                        device_span<size_type>(d_begin_bits.data().get(), d_begin_bits.size()),
+                        mask_size,
+                        stream,
+                        mr);
+
+  return dest_mask;
+}
+
+/**
+ * @brief Performs a merger of the specified bitmasks using the binary operator
+ *        provided, and writes in place to destination
+ *
+ * @param op The binary operator used to combine the bitmasks
+ * @param dest_mask Destination to which the AND result is written
+ * @param masks The list of data pointers of the bitmasks to be ANDed
+ * @param begin_bits The bit offsets from which each mask is to be ANDed
+ * @param mask_size The number of bits to be ANDed in each mask
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned device_buffer
+ * @return rmm::device_buffer Output bitmask
+ */
+template <typename Binop>
+void inplace_bitmask_binop(
+  Binop op,
+  device_span<bitmask_type> dest_mask,
+  device_span<bitmask_type const *> masks,
+  device_span<size_type> begin_bits,
+  size_type mask_size,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource())
+{
+  CUDF_EXPECTS(mask_size > 0, "Invalid bit range.");
+
+  cudf::detail::grid_1d config(dest_mask.size(), 256);
+  offset_bitmask_binop<<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
+    op, dest_mask, masks, begin_bits, mask_size);
+  CHECK_CUDA(stream.value());
+}
+
+}  // namespace detail
+
+}  // namespace cudf

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -26,91 +26,85 @@
 using cudf::detail::device_span;
 
 namespace cudf {
-namespace {
+namespace detail {
 /**
  * @brief Computes the merger of an array of bitmasks using a binary operator
  *
  * @param op The binary operator used to combine the bitmasks
  * @param destination The bitmask to write result into
  * @param source Array of source mask pointers. All masks must be of same size
- * @param begin_bit Array of offsets into corresponding @p source masks.
- *                  Must be same size as source array
- * @param num_sources Number of masks in @p source array
- * @param source_size Number of bits in each mask in @p source
- * @param number_of_mask_words The number of words of type bitmask_type to copy
+ * @param source_begin_bits Array of offsets into corresponding @p source masks.
+ *                          Must be same size as source array
+ * @param source_size_bits Number of bits in each mask in @p source
  */
 template <typename Binop>
 __global__ void offset_bitmask_binop(Binop op,
                                      device_span<bitmask_type> destination,
-                                     device_span<bitmask_type const *> source,
-                                     device_span<size_type> begin_bit,
-                                     size_type source_size)
+                                     device_span<bitmask_type const *> const source,
+                                     device_span<size_type> const source_begin_bits,
+                                     size_type source_size_bits)
 {
   for (size_type destination_word_index = threadIdx.x + blockIdx.x * blockDim.x;
        destination_word_index < destination.size();
        destination_word_index += blockDim.x * gridDim.x) {
-    bitmask_type destination_word = detail::get_mask_offset_word(
-      source[0], destination_word_index, begin_bit[0], begin_bit[0] + source_size);
+    bitmask_type destination_word =
+      detail::get_mask_offset_word(source[0],
+                                   destination_word_index,
+                                   source_begin_bits[0],
+                                   source_begin_bits[0] + source_size_bits);
     for (size_type i = 1; i < source.size(); i++) {
       destination_word =
+
         op(destination_word,
-           detail::get_mask_offset_word(
-             source[i], destination_word_index, begin_bit[i], begin_bit[i] + source_size));
+           detail::get_mask_offset_word(source[i],
+                                        destination_word_index,
+                                        source_begin_bits[i],
+                                        source_begin_bits[i] + source_size_bits));
     }
 
     destination[destination_word_index] = destination_word;
   }
 }
-}  // namespace
-namespace detail {
+
 /**
- * @copydoc bitmask_binop(Binop op, std::vector<bitmask_type const*>, std::vector<size_type> const&,
- * size_type, rmm::mr::device_memory_resource *)
+ * @copydoc bitmask_binop(Binop op, host_span<bitmask_type const *> const, host_span<size_type>
+ * const, size_type, rmm::mr::device_memory_resource *)
  *
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
 template <typename Binop>
 rmm::device_buffer bitmask_binop(
   Binop op,
-  std::vector<bitmask_type const *> const &masks,
-  std::vector<size_type> const &begin_bits,
-  size_type mask_size,
+  host_span<bitmask_type const *> const masks,
+  host_span<size_type> const masks_begin_bits,
+  size_type mask_size_bits,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource())
 {
-  CUDF_EXPECTS(std::all_of(begin_bits.begin(), begin_bits.end(), [](auto b) { return b >= 0; }),
-               "Invalid range.");
-  CUDF_EXPECTS(std::all_of(masks.begin(), masks.end(), [](auto p) { return p != nullptr; }),
-               "Mask pointer cannot be null");
-  rmm::device_buffer dest_mask{};
-  auto num_bytes = bitmask_allocation_size_bytes(mask_size);
-
-  rmm::device_vector<bitmask_type const *> d_masks(masks);
-  rmm::device_vector<size_type> d_begin_bits(begin_bits);
-
-  dest_mask = rmm::device_buffer{num_bytes, stream, mr};
+  auto dest_mask = rmm::device_buffer{bitmask_allocation_size_bytes(mask_size_bits), stream, mr};
 
   inplace_bitmask_binop(op,
                         device_span<bitmask_type>(static_cast<bitmask_type *>(dest_mask.data()),
-                                                  num_bitmask_words(mask_size)),
-                        device_span<bitmask_type const *>(d_masks.data().get(), d_masks.size()),
-                        device_span<size_type>(d_begin_bits.data().get(), d_begin_bits.size()),
-                        mask_size,
+                                                  num_bitmask_words(mask_size_bits)),
+                        masks,
+                        masks_begin_bits,
+                        mask_size_bits,
                         stream,
                         mr);
 
+  stream.synchronize();
   return dest_mask;
 }
 
 /**
- * @brief Performs a merger of the specified bitmasks using the binary operator
+ * @brief Performs a merge of the specified bitmasks using the binary operator
  *        provided, and writes in place to destination
  *
  * @param op The binary operator used to combine the bitmasks
- * @param dest_mask Destination to which the AND result is written
- * @param masks The list of data pointers of the bitmasks to be ANDed
- * @param begin_bits The bit offsets from which each mask is to be ANDed
- * @param mask_size The number of bits to be ANDed in each mask
+ * @param dest_mask Destination to which the merged result is written
+ * @param masks The list of data pointers of the bitmasks to be merged
+ * @param masks_begin_bits The bit offsets from which each mask is to be merged
+ * @param mask_size_bits The number of bits to be ANDed in each mask
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned device_buffer
  * @return rmm::device_buffer Output bitmask
@@ -119,17 +113,31 @@ template <typename Binop>
 void inplace_bitmask_binop(
   Binop op,
   device_span<bitmask_type> dest_mask,
-  device_span<bitmask_type const *> masks,
-  device_span<size_type> begin_bits,
-  size_type mask_size,
+  host_span<bitmask_type const *> const masks,
+  host_span<size_type> const masks_begin_bits,
+  size_type mask_size_bits,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource())
 {
-  CUDF_EXPECTS(mask_size > 0, "Invalid bit range.");
+  CUDF_EXPECTS(
+    std::all_of(masks_begin_bits.begin(), masks_begin_bits.end(), [](auto b) { return b >= 0; }),
+    "Invalid range.");
+  CUDF_EXPECTS(mask_size_bits > 0, "Invalid bit range.");
+  CUDF_EXPECTS(std::all_of(masks.begin(), masks.end(), [](auto p) { return p != nullptr; }),
+               "Mask pointer cannot be null");
+
+  rmm::device_uvector<bitmask_type const *> d_masks(masks.size(), stream, mr);
+  rmm::device_uvector<size_type> d_begin_bits(masks_begin_bits.size(), stream, mr);
+
+  CUDA_TRY(cudaMemcpy(d_masks.data(), masks.data(), masks.size_bytes(), cudaMemcpyHostToDevice));
+  CUDA_TRY(cudaMemcpy(d_begin_bits.data(),
+                      masks_begin_bits.data(),
+                      masks_begin_bits.size_bytes(),
+                      cudaMemcpyHostToDevice));
 
   cudf::detail::grid_1d config(dest_mask.size(), 256);
   offset_bitmask_binop<<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
-    op, dest_mask, masks, begin_bits, mask_size);
+    op, dest_mask, d_masks, d_begin_bits, mask_size_bits);
   CHECK_CUDA(stream.value());
 }
 

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -88,6 +88,21 @@ rmm::device_buffer copy_bitmask(
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 /**
+ * @copydoc bitmask_binop(Binop op, std::vector<bitmask_type const*>, std::vector<size_type> const&,
+ * size_type, rmm::mr::device_memory_resource *)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ */
+template <typename Binop>
+rmm::device_buffer bitmask_binop(
+  Binop op,
+  std::vector<bitmask_type const *> const &masks,
+  std::vector<size_type> const &begin_bits,
+  size_type mask_size,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+
+/**
  * @copydoc bitmask_and(std::vector<bitmask_type const*>, std::vector<size_type> const&, size_type,
  * rmm::mr::device_memory_resource *)
  *
@@ -101,12 +116,47 @@ rmm::device_buffer bitmask_and(
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 /**
+ * @copydoc cudf::bitmask_binop
+ *
+ * @param[in] stream CUDA stream used for device memory operations and kernel launches.
+ */
+template <typename Binop>
+rmm::device_buffer bitmask_binop(
+  Binop op,
+  table_view const &view,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+
+/**
  * @copydoc cudf::bitmask_and
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
 rmm::device_buffer bitmask_and(
   table_view const &view,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+
+/**
+ * @brief Performs a merger of the specified bitmasks using the binary operator
+ *        provided, and writes in place to destination
+ *
+ * @param op The binary operator used to combine the bitmasks
+ * @param dest_mask Destination to which the AND result is written
+ * @param masks The list of data pointers of the bitmasks to be ANDed
+ * @param begin_bits The bit offsets from which each mask is to be ANDed
+ * @param mask_size The number of bits to be ANDed in each mask
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned device_buffer
+ * @return rmm::device_buffer Output bitmask
+ */
+template <typename Binop>
+void inplace_bitmask_binop(
+  Binop op,
+  bitmask_type *dest_mask,
+  std::vector<bitmask_type const *> const &masks,
+  std::vector<size_type> const &begin_bits,
+  size_type mask_size,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -89,21 +89,6 @@ rmm::device_buffer copy_bitmask(
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 /**
- * @copydoc bitmask_binop(Binop op, std::vector<bitmask_type const*>, std::vector<size_type> const&,
- * size_type, rmm::mr::device_memory_resource *)
- *
- * @param stream CUDA stream used for device memory operations and kernel launches
- */
-template <typename Binop>
-rmm::device_buffer bitmask_binop(
-  Binop op,
-  std::vector<bitmask_type const *> const &masks,
-  std::vector<size_type> const &begin_bits,
-  size_type mask_size,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
-
-/**
  * @copydoc bitmask_and(std::vector<bitmask_type const*>, std::vector<size_type> const&, size_type,
  * rmm::mr::device_memory_resource *)
  *
@@ -123,29 +108,6 @@ rmm::device_buffer bitmask_and(
  */
 rmm::device_buffer bitmask_and(
   table_view const &view,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
-
-/**
- * @brief Performs a merger of the specified bitmasks using the binary operator
- *        provided, and writes in place to destination
- *
- * @param op The binary operator used to combine the bitmasks
- * @param dest_mask Destination to which the AND result is written
- * @param masks The list of data pointers of the bitmasks to be ANDed
- * @param begin_bits The bit offsets from which each mask is to be ANDed
- * @param mask_size The number of bits to be ANDed in each mask
- * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned device_buffer
- * @return rmm::device_buffer Output bitmask
- */
-template <typename Binop>
-void inplace_bitmask_binop(
-  Binop op,
-  device_span<bitmask_type> destination,
-  device_span<bitmask_type const *> source,
-  device_span<size_type> begin_bit,
-  size_type mask_size,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -116,18 +117,6 @@ rmm::device_buffer bitmask_and(
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 /**
- * @copydoc cudf::bitmask_binop
- *
- * @param[in] stream CUDA stream used for device memory operations and kernel launches.
- */
-template <typename Binop>
-rmm::device_buffer bitmask_binop(
-  Binop op,
-  table_view const &view,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
-
-/**
  * @copydoc cudf::bitmask_and
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
@@ -153,9 +142,9 @@ rmm::device_buffer bitmask_and(
 template <typename Binop>
 void inplace_bitmask_binop(
   Binop op,
-  bitmask_type *dest_mask,
-  std::vector<bitmask_type const *> const &masks,
-  std::vector<size_type> const &begin_bits,
+  device_span<bitmask_type> destination,
+  device_span<bitmask_type const *> source,
+  device_span<size_type> begin_bit,
   size_type mask_size,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -95,8 +95,8 @@ rmm::device_buffer copy_bitmask(
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
 rmm::device_buffer bitmask_and(
-  host_span<bitmask_type const *> const masks,
-  host_span<size_type> const masks_begin_bits,
+  host_span<bitmask_type const *> masks,
+  host_span<size_type const> masks_begin_bits,
   size_type mask_size_bits,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
@@ -135,8 +135,8 @@ rmm::device_buffer bitmask_or(
  */
 void inplace_bitmask_and(
   device_span<bitmask_type> dest_mask,
-  host_span<bitmask_type const *> const masks,
-  host_span<size_type> const masks_begin_bits,
+  host_span<bitmask_type const *> masks,
+  host_span<size_type const> masks_begin_bits,
   size_type mask_size_bits,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,15 +89,15 @@ rmm::device_buffer copy_bitmask(
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 /**
- * @copydoc bitmask_and(std::vector<bitmask_type const*>, std::vector<size_type> const&, size_type,
- * rmm::mr::device_memory_resource *)
+ * @copydoc bitmask_and(host_span<bitmask_type const *> const, host_span<size_type> const,
+ * size_type, rmm::mr::device_memory_resource *)
  *
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
 rmm::device_buffer bitmask_and(
-  std::vector<bitmask_type const *> const &masks,
-  std::vector<size_type> const &begin_bits,
-  size_type mask_size,
+  host_span<bitmask_type const *> const masks,
+  host_span<size_type> const masks_begin_bits,
+  size_type mask_size_bits,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
@@ -112,22 +112,32 @@ rmm::device_buffer bitmask_and(
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 /**
+ * @copydoc cudf::bitmask_or
+ *
+ * @param[in] stream CUDA stream used for device memory operations and kernel launches.
+ */
+rmm::device_buffer bitmask_or(
+  table_view const &view,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+
+/**
  * @brief Performs a bitwise AND of the specified bitmasks,
  *        and writes in place to destination
  *
  * @param dest_mask Destination to which the AND result is written
  * @param masks The list of data pointers of the bitmasks to be ANDed
- * @param begin_bits The bit offsets from which each mask is to be ANDed
- * @param mask_size The number of bits to be ANDed in each mask
+ * @param masks_begin_bits The bit offsets from which each mask is to be ANDed
+ * @param mask_size_bits The number of bits to be ANDed in each mask
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned device_buffer
  * @return rmm::device_buffer Output bitmask
  */
 void inplace_bitmask_and(
-  bitmask_type *dest_mask,
-  std::vector<bitmask_type const *> const &masks,
-  std::vector<size_type> const &begin_bits,
-  size_type mask_size,
+  device_span<bitmask_type> dest_mask,
+  host_span<bitmask_type const *> const masks,
+  host_span<size_type> const masks_begin_bits,
+  size_type mask_size_bits,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -220,5 +220,19 @@ rmm::device_buffer bitmask_and(
   table_view const& view,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+/**
+ * @brief Returns a bitwise OR of the bitmasks of columns of a table
+ *
+ * If any of the columns isn't nullable, it is considered all valid.
+ * If no column in the table is nullable, an empty bitmask is returned.
+ *
+ * @param view The table of columns
+ * @param mr Device memory resource used to allocate the returned device_buffer
+ * @return rmm::device_buffer Output bitmask
+ */
+rmm::device_buffer bitmask_or(
+  table_view const& view,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 /** @} */  // end of group
 }  // namespace cudf

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -410,7 +410,6 @@ void inplace_bitmask_and(device_span<bitmask_type> dest_mask,
     mask_size,
     stream,
     mr);
-  stream.synchronize();
 }
 
 // Bitwise AND of the masks

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -396,8 +396,8 @@ rmm::device_buffer copy_bitmask(column_view const &view,
 
 // Inplace Bitwise AND of the masks
 void inplace_bitmask_and(device_span<bitmask_type> dest_mask,
-                         host_span<bitmask_type const *> const masks,
-                         host_span<size_type> const begin_bits,
+                         host_span<bitmask_type const *> masks,
+                         host_span<size_type const> begin_bits,
                          size_type mask_size,
                          rmm::cuda_stream_view stream,
                          rmm::mr::device_memory_resource *mr)
@@ -414,8 +414,8 @@ void inplace_bitmask_and(device_span<bitmask_type> dest_mask,
 }
 
 // Bitwise AND of the masks
-rmm::device_buffer bitmask_and(host_span<bitmask_type const *> const masks,
-                               host_span<size_type> const begin_bits,
+rmm::device_buffer bitmask_and(host_span<bitmask_type const *> masks,
+                               host_span<size_type const> begin_bits,
                                size_type mask_size,
                                rmm::cuda_stream_view stream,
                                rmm::mr::device_memory_resource *mr)

--- a/cpp/src/structs/structs_column_factories.cu
+++ b/cpp/src/structs/structs_column_factories.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@
 
 #include <algorithm>
 #include <memory>
-
 namespace cudf {
 namespace {
 // Helper function to superimpose validity of parent struct
@@ -44,18 +43,19 @@ void superimpose_parent_nullmask(bitmask_type const* parent_null_mask,
     // Child should have a null mask.
     // `AND` the child's null mask with the parent's.
 
-    auto data_type{child.type()};
-    auto num_rows{child.size()};
-
     auto current_child_mask = child.mutable_view().null_mask();
 
-    cudf::detail::inplace_bitmask_and(current_child_mask,
-                                      {reinterpret_cast<bitmask_type const*>(parent_null_mask),
-                                       reinterpret_cast<bitmask_type const*>(current_child_mask)},
-                                      {0, 0},
-                                      child.size(),
-                                      stream,
-                                      mr);
+    std::vector<bitmask_type const*> masks{
+      reinterpret_cast<bitmask_type const*>(parent_null_mask),
+      reinterpret_cast<bitmask_type const*>(current_child_mask)};
+    std::vector<size_type> begin_bits{0, 0};
+    cudf::detail::inplace_bitmask_and(
+      detail::device_span<bitmask_type>(current_child_mask, num_bitmask_words(child.size())),
+      masks,
+      begin_bits,
+      child.size(),
+      stream,
+      mr);
     child.set_null_count(UNKNOWN_NULL_COUNT);
   }
 

--- a/cpp/tests/bitmask/bitmask_tests.cu
+++ b/cpp/tests/bitmask/bitmask_tests.cu
@@ -498,7 +498,8 @@ TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorDiscontiguous)
     concatenated_bitmask.data(), gold_mask.data(), cudf::num_bitmask_words(num_elements));
 }
 
-struct MergeBitmaskTest : public cudf::test::BaseFixture {};
+struct MergeBitmaskTest : public cudf::test::BaseFixture {
+};
 
 TEST_F(MergeBitmaskTest, TestBitmaskAnd)
 {
@@ -515,12 +516,14 @@ TEST_F(MergeBitmaskTest, TestBitmaskAnd)
   rmm::device_buffer result3 = cudf::bitmask_and(input3);
 
   auto odd_indices =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i%2; });
+    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
   auto odd = cudf::test::detail::make_null_mask(odd_indices, odd_indices + input2.num_rows());
 
   EXPECT_EQ(nullptr, result1.data());
-  CUDF_TEST_EXPECT_EQUAL_BUFFERS(result2.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
-  CUDF_TEST_EXPECT_EQUAL_BUFFERS(result3.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
+  CUDF_TEST_EXPECT_EQUAL_BUFFERS(
+    result2.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
+  CUDF_TEST_EXPECT_EQUAL_BUFFERS(
+    result3.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
 }
 
 TEST_F(MergeBitmaskTest, TestBitmaskOr)
@@ -538,11 +541,13 @@ TEST_F(MergeBitmaskTest, TestBitmaskOr)
   rmm::device_buffer result3 = cudf::bitmask_or(input3);
 
   auto all_but_index3 =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i!=3; });
-  auto null3 = cudf::test::detail::make_null_mask(all_but_index3, all_but_index3 + input2.num_rows());
+    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
+  auto null3 =
+    cudf::test::detail::make_null_mask(all_but_index3, all_but_index3 + input2.num_rows());
 
   EXPECT_EQ(nullptr, result1.data());
-  CUDF_TEST_EXPECT_EQUAL_BUFFERS(result2.data(), null3.data(), cudf::num_bitmask_words(input2.num_rows()));
+  CUDF_TEST_EXPECT_EQUAL_BUFFERS(
+    result2.data(), null3.data(), cudf::num_bitmask_words(input2.num_rows()));
   EXPECT_EQ(nullptr, result3.data());
 }
 

--- a/cpp/tests/bitmask/bitmask_tests.cu
+++ b/cpp/tests/bitmask/bitmask_tests.cu
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <climits>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/null_mask.hpp>
@@ -22,6 +23,7 @@
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
+#include "rmm/device_buffer.hpp"
 
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
@@ -413,7 +415,7 @@ TEST_F(CopyBitmaskTest, TestZeroOffset)
   cleanEndWord(splice_mask, begin_bit, end_bit);
   auto number_of_bits = end_bit - begin_bit;
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    gold_splice_mask.data(), splice_mask.data(), number_of_bits / CHAR_BIT);
+    gold_splice_mask.data(), splice_mask.data(), cudf::num_bitmask_words(number_of_bits));
 }
 
 TEST_F(CopyBitmaskTest, TestNonZeroOffset)
@@ -433,7 +435,7 @@ TEST_F(CopyBitmaskTest, TestNonZeroOffset)
   cleanEndWord(splice_mask, begin_bit, end_bit);
   auto number_of_bits = end_bit - begin_bit;
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    gold_splice_mask.data(), splice_mask.data(), number_of_bits / CHAR_BIT);
+    gold_splice_mask.data(), splice_mask.data(), cudf::num_bitmask_words(number_of_bits));
 }
 
 TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorContiguous)
@@ -468,7 +470,7 @@ TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorContiguous)
   rmm::device_buffer concatenated_bitmask = cudf::concatenate_masks(views);
   cleanEndWord(concatenated_bitmask, 0, num_elements);
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    concatenated_bitmask.data(), gold_mask.data(), num_elements / CHAR_BIT);
+    concatenated_bitmask.data(), gold_mask.data(), cudf::num_bitmask_words(num_elements));
 }
 
 TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorDiscontiguous)
@@ -493,7 +495,55 @@ TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorDiscontiguous)
   rmm::device_buffer concatenated_bitmask = cudf::concatenate_masks(views);
   cleanEndWord(concatenated_bitmask, 0, num_elements);
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    concatenated_bitmask.data(), gold_mask.data(), num_elements / CHAR_BIT);
+    concatenated_bitmask.data(), gold_mask.data(), cudf::num_bitmask_words(num_elements));
+}
+
+struct MergeBitmaskTest : public cudf::test::BaseFixture {};
+
+TEST_F(MergeBitmaskTest, TestBitmaskAnd)
+{
+  cudf::test::fixed_width_column_wrapper<bool> const bools_col1({0, 1, 0, 1, 1}, {0, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<bool> const bools_col2({0, 2, 1, 0, 255}, {1, 1, 0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<bool> const bools_col3({0, 2, 1, 0, 255});
+
+  auto const input1 = cudf::table_view({bools_col3});
+  auto const input2 = cudf::table_view({bools_col1, bools_col2});
+  auto const input3 = cudf::table_view({bools_col1, bools_col2, bools_col3});
+
+  rmm::device_buffer result1 = cudf::bitmask_and(input1);
+  rmm::device_buffer result2 = cudf::bitmask_and(input2);
+  rmm::device_buffer result3 = cudf::bitmask_and(input3);
+
+  auto odd_indices =
+    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i%2; });
+  auto odd = cudf::test::detail::make_null_mask(odd_indices, odd_indices + input2.num_rows());
+
+  EXPECT_EQ(nullptr, result1.data());
+  CUDF_TEST_EXPECT_EQUAL_BUFFERS(result2.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
+  CUDF_TEST_EXPECT_EQUAL_BUFFERS(result3.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
+}
+
+TEST_F(MergeBitmaskTest, TestBitmaskOr)
+{
+  cudf::test::fixed_width_column_wrapper<bool> const bools_col1({0, 1, 0, 1, 1}, {1, 1, 0, 0, 1});
+  cudf::test::fixed_width_column_wrapper<bool> const bools_col2({0, 2, 1, 0, 255}, {0, 0, 1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<bool> const bools_col3({0, 2, 1, 0, 255});
+
+  auto const input1 = cudf::table_view({bools_col3});
+  auto const input2 = cudf::table_view({bools_col1, bools_col2});
+  auto const input3 = cudf::table_view({bools_col1, bools_col2, bools_col3});
+
+  rmm::device_buffer result1 = cudf::bitmask_or(input1);
+  rmm::device_buffer result2 = cudf::bitmask_or(input2);
+  rmm::device_buffer result3 = cudf::bitmask_or(input3);
+
+  auto all_but_index3 =
+    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i!=3; });
+  auto null3 = cudf::test::detail::make_null_mask(all_but_index3, all_but_index3 + input2.num_rows());
+
+  EXPECT_EQ(nullptr, result1.data());
+  CUDF_TEST_EXPECT_EQUAL_BUFFERS(result2.data(), null3.data(), cudf::num_bitmask_words(input2.num_rows()));
+  EXPECT_EQ(nullptr, result3.data());
 }
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/bitmask/bitmask_tests.cu
+++ b/cpp/tests/bitmask/bitmask_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <climits>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/null_mask.hpp>
@@ -23,10 +22,10 @@
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
-#include "rmm/device_buffer.hpp"
 
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
+#include <rmm/device_buffer.hpp>
 
 struct BitmaskUtilitiesTest : public cudf::test::BaseFixture {
 };

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -520,7 +520,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return the new ColumnVector with merged null mask.
    */
   public final ColumnVector mergeAndSetValidity(BinaryOp mergeOp, ColumnView... columns) {
-    assert mergeOp == BinaryOp.BITWISE_AND : "Only BITWISE_AND supported right now";
+    assert mergeOp == BinaryOp.BITWISE_AND || mergeOp == BinaryOp.BITWISE_OR : "Only BITWISE_AND and BITWISE_OR supported right now";
     long[] columnViews = new long[columns.length];
     long size = getRowCount();
 

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1305,10 +1305,16 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
     cudf::table_view *input_table = new cudf::table_view(column_views);
 
     cudf::binary_operator op = static_cast<cudf::binary_operator>(bin_op);
-    if(op == cudf::binary_operator::BITWISE_AND) {
-      copy->set_null_mask(cudf::bitmask_and(*input_table));
+    switch(op) {
+      case cudf::binary_operator::BITWISE_AND:
+        copy->set_null_mask(cudf::bitmask_and(*input_table));
+        break;
+      case cudf::binary_operator::BITWISE_OR:
+        copy->set_null_mask(cudf::bitmask_or(*input_table));
+        break;
+      default:
+        JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Unsupported merge operation", 0);
     }
-
     return reinterpret_cast<jlong>(copy.release());
   }
   CATCH_STD(env, 0);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1313,7 +1313,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
         copy->set_null_mask(cudf::bitmask_or(*input_table));
         break;
       default:
-        JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Unsupported merge operation", 0);
+        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Unsupported merge operation", 0);
     }
 
     return reinterpret_cast<jlong>(copy.release());

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1315,6 +1315,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
       default:
         JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Unsupported merge operation", 0);
     }
+
     return reinterpret_cast<jlong>(copy.release());
   }
   CATCH_STD(env, 0);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -571,7 +571,7 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
-  void testNullReconfigureNulls() {
+  void testAndNullReconfigureNulls() {
     try (ColumnVector v0 = ColumnVector.fromBoxedInts(0, 100, null, null, Integer.MIN_VALUE, null);
          ColumnVector v1 = ColumnVector.fromBoxedInts(0, 100, 1, 2, Integer.MIN_VALUE, null);
          ColumnVector intResult = v1.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0);
@@ -580,6 +580,25 @@ public class ColumnVectorTest extends CudfTestBase {
          ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", null, null, "MIN_VALUE", null);
          ColumnVector noMaskResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND)) {
       assertColumnsAreEqual(v0, intResult);
+      assertColumnsAreEqual(stringExpected, stringResult);
+      assertColumnsAreEqual(v2, noMaskResult);
+    }
+  }
+
+  @Test
+  void testOrNullReconfigureNulls() {
+    try (ColumnVector v0 = ColumnVector.fromBoxedInts(0, 100, null, null, Integer.MIN_VALUE, null);
+         ColumnVector v1 = ColumnVector.fromBoxedInts(0, 100, 1, 2, Integer.MIN_VALUE, null);
+         ColumnVector intResultV0 = v1.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0);
+         ColumnVector intResultV0V1 = v1.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1);
+         ColumnVector intResultMulti = v1.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v0, v1, v1, v0, v1, v0);
+         ColumnVector v2 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
+         ColumnVector stringResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1);
+         ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", null);
+         ColumnVector noMaskResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_OR)) {
+      assertColumnsAreEqual(v0, intResultV0);
+      assertColumnsAreEqual(v1, intResultV0V1);
+      assertColumnsAreEqual(v1, intResultMulti);
       assertColumnsAreEqual(stringExpected, stringResult);
       assertColumnsAreEqual(v2, noMaskResult);
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -589,9 +589,11 @@ public class ColumnVectorTest extends CudfTestBase {
   void testOrNullReconfigureNulls() {
     try (ColumnVector v0 = ColumnVector.fromBoxedInts(0, 100, null, null, Integer.MIN_VALUE, null);
          ColumnVector v1 = ColumnVector.fromBoxedInts(0, 100, 1, 2, Integer.MIN_VALUE, null);
+         ColumnVector v2 = ColumnVector.fromBoxedInts(0, 100, 1, 2, Integer.MIN_VALUE, Integer.MAX_VALUE);
          ColumnVector intResultV0 = v1.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0);
          ColumnVector intResultV0V1 = v1.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1);
          ColumnVector intResultMulti = v1.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v0, v1, v1, v0, v1, v0);
+         ColumnVector intResultv0v1v2 = v2.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1, v2);
          ColumnVector v2 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
          ColumnVector stringResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1);
          ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", null);
@@ -599,6 +601,7 @@ public class ColumnVectorTest extends CudfTestBase {
       assertColumnsAreEqual(v0, intResultV0);
       assertColumnsAreEqual(v1, intResultV0V1);
       assertColumnsAreEqual(v1, intResultMulti);
+      assertColumnsAreEqual(v1, intResultv0v1v2);
       assertColumnsAreEqual(stringExpected, stringResult);
       assertColumnsAreEqual(v2, noMaskResult);
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -594,16 +594,16 @@ public class ColumnVectorTest extends CudfTestBase {
          ColumnVector intResultV0V1 = v1.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1);
          ColumnVector intResultMulti = v1.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v0, v1, v1, v0, v1, v0);
          ColumnVector intResultv0v1v2 = v2.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1, v2);
-         ColumnVector v2 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
-         ColumnVector stringResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1);
+         ColumnVector v3 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
+         ColumnVector stringResult = v3.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1);
          ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", null);
-         ColumnVector noMaskResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_OR)) {
+         ColumnVector noMaskResult = v3.mergeAndSetValidity(BinaryOp.BITWISE_OR)) {
       assertColumnsAreEqual(v0, intResultV0);
       assertColumnsAreEqual(v1, intResultV0V1);
       assertColumnsAreEqual(v1, intResultMulti);
-      assertColumnsAreEqual(v1, intResultv0v1v2);
+      assertColumnsAreEqual(v2, intResultv0v1v2);
       assertColumnsAreEqual(stringExpected, stringResult);
-      assertColumnsAreEqual(v2, noMaskResult);
+      assertColumnsAreEqual(v3, noMaskResult);
     }
   }
 


### PR DESCRIPTION
Refactors the bitmask merging functionality to support any binary function, allowing for `bitwise_or` support in addition the existing `bitwise_and` support. Includes changes to the Java api and JNI to access the `bitwise_or` functionality.