### PR TITLE
Fix typo in list_device_view::pair_rep_end()

### DIFF
--- a/cpp/include/cudf/lists/list_device_view.cuh
+++ b/cpp/include/cudf/lists/list_device_view.cuh
@@ -187,7 +187,7 @@ class list_device_view {
   CUDA_DEVICE_CALLABLE const_pair_rep_iterator<T> pair_rep_end() const
   {
     return const_pair_rep_iterator<T>{thrust::counting_iterator<size_type>(size()),
-                                      pair_accessor<T>{*this}};
+                                      pair_rep_accessor<T>{*this}};
   }
 
  private:

--- a/cpp/src/lists/contains.cu
+++ b/cpp/src/lists/contains.cu
@@ -114,18 +114,15 @@ struct lookup_functor {
           return;
         }
 
-        auto list_pair_begin = list.pair_rep_begin<ElementType>();
-        auto list_pair_end   = list_pair_begin + list.size();
-
         auto search_key = search_key_and_validity.first;
         d_bools[row_index] =
           thrust::find_if(thrust::seq,
-                          list_pair_begin,
-                          list_pair_end,
+                          list.pair_rep_begin<ElementType>(),
+                          list.pair_rep_end<ElementType>(),
                           [search_key] __device__(auto element_and_validity) {
                             return element_and_validity.second &&
                                    cudf::equality_compare(element_and_validity.first, search_key);
-                          }) != list_pair_end;
+                          }) != list.pair_rep_end<ElementType>();
         d_validity[row_index] =
           d_bools[row_index] ||
           thrust::none_of(thrust::seq,


### PR DESCRIPTION
#7349 introduced rep-iterators for `list_device_view`. In implementation for `list_device_view::pair_rep_end()` has a typo, and is incorrect. 

The change in this PR should fix the problem, and exercise the corrected implementation from `lists::contains()`.