### PR TITLE
Add gbenchmark for strings split/split_record functions

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -311,6 +311,7 @@ set(STRINGS_BENCH_SRC
   "${CMAKE_CURRENT_SOURCE_DIR}/string/copy_benchmark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/string/find_benchmark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/string/replace_benchmark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/string/split_benchmark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/string/url_decode_benchmark.cpp")
 
 ConfigureBench(STRINGS_BENCH "${STRINGS_BENCH_SRC}")

--- a/cpp/benchmarks/string/split_benchmark.cpp
+++ b/cpp/benchmarks/string/split_benchmark.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include <benchmarks/common/generate_benchmark_input.hpp>
+#include <benchmarks/fixture/benchmark_fixture.hpp>
+#include <benchmarks/synchronization/synchronization.hpp>
+
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/strings/split/split.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf_test/column_wrapper.hpp>
+
+#include <limits>
+
+class StringSplit : public cudf::benchmark {
+};
+
+enum split_type { split, split_ws, record, record_ws };
+
+static void BM_split(benchmark::State& state, split_type rt)
+{
+  cudf::size_type const n_rows{static_cast<cudf::size_type>(state.range(0))};
+  cudf::size_type const max_str_length{static_cast<cudf::size_type>(state.range(1))};
+  data_profile table_profile;
+  table_profile.set_distribution_params(
+    cudf::type_id::STRING, distribution_id::NORMAL, 0, max_str_length);
+  auto const table =
+    create_random_table({cudf::type_id::STRING}, 1, row_count{n_rows}, table_profile);
+  cudf::strings_column_view input(table->view().column(0));
+  cudf::string_scalar target("+");
+
+  for (auto _ : state) {
+    cuda_event_timer raii(state, true, 0);
+    switch (rt) {
+      case split: cudf::strings::split(input, target); break;
+      case split_ws: cudf::strings::split(input); break;
+      case record: cudf::strings::split_record(input, target); break;
+      case record_ws: cudf::strings::split_record(input); break;
+    }
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.chars_size());
+}
+
+static void generate_bench_args(benchmark::internal::Benchmark* b)
+{
+  int const min_rows   = 1 << 12;
+  int const max_rows   = 1 << 24;
+  int const row_mult   = 8;
+  int const min_rowlen = 1 << 5;
+  int const max_rowlen = 1 << 13;
+  int const len_mult   = 4;
+  for (int row_count = min_rows; row_count <= max_rows; row_count *= row_mult) {
+    for (int rowlen = min_rowlen; rowlen <= max_rowlen; rowlen *= len_mult) {
+      // avoid generating combinations that exceed the cudf column limit
+      size_t total_chars = static_cast<size_t>(row_count) * rowlen;
+      if (total_chars < std::numeric_limits<cudf::size_type>::max()) {
+        b->Args({row_count, rowlen});
+      }
+    }
+  }
+}
+
+#define STRINGS_BENCHMARK_DEFINE(name)                          \
+  BENCHMARK_DEFINE_F(StringSplit, name)                         \
+  (::benchmark::State & st) { BM_split(st, split_type::name); } \
+  BENCHMARK_REGISTER_F(StringSplit, name)                       \
+    ->Apply(generate_bench_args)                                \
+    ->UseManualTime()                                           \
+    ->Unit(benchmark::kMillisecond);
+
+STRINGS_BENCHMARK_DEFINE(split)
+STRINGS_BENCHMARK_DEFINE(split_ws)
+STRINGS_BENCHMARK_DEFINE(record)
+STRINGS_BENCHMARK_DEFINE(record_ws)

--- a/cpp/src/strings/split/split_record.cu
+++ b/cpp/src/strings/split/split_record.cu
@@ -243,9 +243,9 @@ std::unique_ptr<column> split_record_fn(strings_column_view const& strings,
   // last entry is the total number of tokens to be generated
   auto total_tokens = cudf::detail::get_value<int32_t>(offsets->view(), strings_count, stream);
   // split each string into an array of index-pair values
-  rmm::device_vector<string_index_pair> tokens(total_tokens);
+  rmm::device_uvector<string_index_pair> tokens(total_tokens, stream);
   reader.d_token_offsets = d_offsets;
-  reader.d_tokens        = tokens.data().get();
+  reader.d_tokens        = tokens.data();
   thrust::for_each_n(
     rmm::exec_policy(stream), thrust::make_counting_iterator<size_type>(0), strings_count, reader);
   // convert the index-pairs into one big strings column


### PR DESCRIPTION
Reference #5698
This creates a gbenchmark for the `cudf::strings::split` and `cudf::strings::split_record` functions.

This PR also includes changes to `split.cu` to use `device_uvector` for temporary buffers instead of `device_vector` and other minor code cleanup like adding more `const` decls.