### PR TITLE
Make inclusive scan safe for cases with leading nulls

### DIFF
--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -135,7 +135,8 @@ void set_null_mask(bitmask_type *bitmask,
 {
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(begin_bit >= 0, "Invalid range.");
-  CUDF_EXPECTS(begin_bit < end_bit, "Invalid bit range.");
+  CUDF_EXPECTS(begin_bit <= end_bit, "Invalid bit range.");
+  if (begin_bit == end_bit) return;
   if (bitmask != nullptr) {
     auto number_of_mask_words =
       num_bitmask_words(end_bit) - begin_bit / detail::size_in_bits<bitmask_type>();

--- a/cpp/src/reductions/scan.cu
+++ b/cpp/src/reductions/scan.cu
@@ -116,9 +116,8 @@ struct scan_dispatcher {
       thrust::find_if_not(
         rmm::exec_policy(stream), v, v + input_view.size(), thrust::identity<bool>{}) -
       v;
-    if (first_null_position > 0)
-      cudf::set_null_mask(
-        static_cast<cudf::bitmask_type*>(mask.data()), 0, first_null_position, true);
+    cudf::set_null_mask(
+      static_cast<cudf::bitmask_type*>(mask.data()), 0, first_null_position, true);
     cudf::set_null_mask(
       static_cast<cudf::bitmask_type*>(mask.data()), first_null_position, input_view.size(), false);
     return mask;

--- a/cpp/src/reductions/scan.cu
+++ b/cpp/src/reductions/scan.cu
@@ -116,8 +116,9 @@ struct scan_dispatcher {
       thrust::find_if_not(
         rmm::exec_policy(stream), v, v + input_view.size(), thrust::identity<bool>{}) -
       v;
-    cudf::set_null_mask(
-      static_cast<cudf::bitmask_type*>(mask.data()), 0, first_null_position, true);
+    if (first_null_position > 0)
+      cudf::set_null_mask(
+        static_cast<cudf::bitmask_type*>(mask.data()), 0, first_null_position, true);
     cudf::set_null_mask(
       static_cast<cudf::bitmask_type*>(mask.data()), first_null_position, input_view.size(), false);
     return mask;

--- a/cpp/tests/bitmask/set_nullmask_tests.cu
+++ b/cpp/tests/bitmask/set_nullmask_tests.cu
@@ -105,8 +105,7 @@ TEST_F(SetBitmaskTest, error_range)
   std::vector<size_pair> begin_end_fail{
     {-1, size},  // begin>=0
     {-2, -1},    // begin>=0
-    {8, 8},      // begin<end
-    {9, 8},      // begin<end
+    {9, 8},      // begin<=end
   };
   for (auto begin_end : begin_end_fail) {
     auto begin = begin_end.first, end = begin_end.second;
@@ -116,8 +115,8 @@ TEST_F(SetBitmaskTest, error_range)
   std::vector<size_pair> begin_end_pass{
     {0, size},         // begin>=0
     {0, 1},            // begin>=0
-    {8, 9},            // begin<end
-    {size - 1, size},  // begin<end
+    {8, 9},            // begin<=end
+    {size - 1, size},  // begin<=end
   };
   for (auto begin_end : begin_end_pass) {
     auto begin = begin_end.first, end = begin_end.second;

--- a/cpp/tests/bitmask/set_nullmask_tests.cu
+++ b/cpp/tests/bitmask/set_nullmask_tests.cu
@@ -115,6 +115,7 @@ TEST_F(SetBitmaskTest, error_range)
   std::vector<size_pair> begin_end_pass{
     {0, size},         // begin>=0
     {0, 1},            // begin>=0
+    {8, 8},            // begin==end
     {8, 9},            // begin<=end
     {size - 1, size},  // begin<=end
   };

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -472,8 +472,8 @@ TYPED_TEST(ScanTest, EmptyColumnskip_nulls)
 
 TYPED_TEST(ScanTest, LeadingNulls)
 {
-  auto const v  = cudf::test::make_type_param_vector<TypeParam>({100, 200, 300});
-  auto const b  = std::vector<bool>{0, 1, 1};
+  auto const v = cudf::test::make_type_param_vector<TypeParam>({100, 200, 300});
+  auto const b = std::vector<bool>{0, 1, 1};
   cudf::test::fixed_width_column_wrapper<TypeParam> const col_in(v.begin(), v.end(), b.begin());
   std::unique_ptr<cudf::column> col_out;
 

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -472,7 +472,6 @@ TYPED_TEST(ScanTest, EmptyColumnskip_nulls)
 
 TYPED_TEST(ScanTest, LeadingNulls)
 {
-  bool do_print = true;
   auto const v  = cudf::test::make_type_param_vector<TypeParam>({100, 200, 300});
   auto const b  = std::vector<bool>{0, 1, 1};
   cudf::test::fixed_width_column_wrapper<TypeParam> const col_in(v.begin(), v.end(), b.begin());

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -487,10 +487,6 @@ TYPED_TEST(ScanTest, LeadingNulls)
       cudf::scan(col_in, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE));
   cudf::test::fixed_width_column_wrapper<TypeParam> expected_col_out(
     out_v.begin(), out_v.end(), out_b.begin());
-  if (do_print) {
-    print_view(expected_col_out, "expect = ");
-    print_view(col_out->view(), "result = ");
-  }
   CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(expected_col_out, col_out->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_col_out, col_out->view());
 }

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -470,6 +470,32 @@ TYPED_TEST(ScanTest, EmptyColumnskip_nulls)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_col_out2, col_out->view());
 }
 
+TYPED_TEST(ScanTest, LeadingNulls)
+{
+  bool do_print = true;
+  auto const v  = cudf::test::make_type_param_vector<TypeParam>({100, 200, 300});
+  auto const b  = std::vector<bool>{0, 1, 1};
+  cudf::test::fixed_width_column_wrapper<TypeParam> const col_in(v.begin(), v.end(), b.begin());
+  std::unique_ptr<cudf::column> col_out;
+
+  // expected outputs
+  std::vector<TypeParam> out_v(v.size());
+  std::vector<bool> out_b(v.size(), 0);
+
+  // skipna=false
+  CUDF_EXPECT_NO_THROW(
+    col_out =
+      cudf::scan(col_in, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE));
+  cudf::test::fixed_width_column_wrapper<TypeParam> expected_col_out(
+    out_v.begin(), out_v.end(), out_b.begin());
+  if (do_print) {
+    print_view(expected_col_out, "expect = ");
+    print_view(col_out->view(), "result = ");
+  }
+  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(expected_col_out, col_out->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_col_out, col_out->view());
+}
+
 template <typename T>
 struct FixedPointTestBothReps : public cudf::test::BaseFixture {
 };


### PR DESCRIPTION
This PR includes a test that passes a column with leading nulls to `scan`, which is currently failing, and a fix for the failure.