### PR TITLE
Support `Series.__setitem__` with key to a new row

### DIFF
--- a/python/cudf/cudf/core/indexing.py
+++ b/python/cudf/cudf/core/indexing.py
@@ -498,7 +498,7 @@ def _normalize_dtypes(df):
 
 def _append_new_row_inplace(col: ColumnLike, value: ScalarLike):
     """Append a scalar `value` to the end of `col` inplace.
-       Cast to common type if possible, otherwise raises `ValueError`
+       Cast to common type if possible
     """
     to_type = find_common_type([type(value), col.dtype])
     val_col = as_column(value, dtype=to_type)

--- a/python/cudf/cudf/core/indexing.py
+++ b/python/cudf/cudf/core/indexing.py
@@ -4,7 +4,6 @@ from typing import Any, Union
 
 import numpy as np
 import pandas as pd
-from cupy import isscalar
 from nvtx import annotate
 
 import cudf
@@ -148,9 +147,9 @@ class _SeriesLocIndexer(object):
             key = self._loc_to_iloc(key)
         except KeyError as e:
             if (
-                isscalar(key)
+                is_scalar(key)
                 and not isinstance(self._sr.index, cudf.MultiIndex)
-                and isscalar(value)
+                and is_scalar(value)
             ):
                 _append_new_row_inplace(self._sr.index._values, key)
                 _append_new_row_inplace(self._sr._column, value)

--- a/python/cudf/cudf/core/indexing.py
+++ b/python/cudf/cudf/core/indexing.py
@@ -4,12 +4,16 @@ from typing import Any, Union
 
 import numpy as np
 import pandas as pd
+from cupy import isscalar
 from nvtx import annotate
 
 import cudf
+from cudf._lib.concat import concat_columns
 from cudf._lib.scalar import _is_null_host_scalar
-from cudf._typing import DataFrameOrSeries, ScalarLike
+from cudf._typing import ColumnLike, DataFrameOrSeries, ScalarLike
+from cudf.core.column.column import as_column
 from cudf.utils.dtypes import (
+    find_common_type,
     is_categorical_dtype,
     is_column_like,
     is_list_like,
@@ -140,7 +144,19 @@ class _SeriesLocIndexer(object):
         return self._sr.iloc[arg]
 
     def __setitem__(self, key, value):
-        key = self._loc_to_iloc(key)
+        try:
+            key = self._loc_to_iloc(key)
+        except KeyError as e:
+            if (
+                isscalar(key)
+                and not isinstance(self._sr.index, cudf.MultiIndex)
+                and isscalar(value)
+            ):
+                _append_new_row_inplace(self._sr.index._values, key)
+                _append_new_row_inplace(self._sr._column, value)
+                return
+            else:
+                raise e
         if isinstance(value, (pd.Series, cudf.Series)):
             value = cudf.Series(value)
             value = value._align_to_index(self._sr.index, how="right")
@@ -479,3 +495,14 @@ def _normalize_dtypes(df):
         for name, col in df._data.items():
             df[name] = col.astype(normalized_dtype)
     return df
+
+
+def _append_new_row_inplace(col: ColumnLike, value: ScalarLike):
+    """Append a scalar `value` to the end of `col` inplace.
+       Cast to common type if possible, otherwise raises `ValueError`
+    """
+    to_type = find_common_type([type(value), col.dtype])
+    val_col = as_column(value, dtype=to_type)
+    old_col = col.astype(to_type)
+
+    col._mimic_inplace(concat_columns([old_col, val_col]), inplace=True)

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -1037,6 +1037,7 @@ def test_series_setitem_string(key, value):
     [
         ("a", 4),
         ("b", 4),
+        ("d", 4),
         (["a", "b"], 4),
         (["a", "b"], [4, 5]),
         ([True, False, True], 4),

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -1037,7 +1037,10 @@ def test_series_setitem_string(key, value):
     [
         ("a", 4),
         ("b", 4),
+        ("b", np.int8(8)),
         ("d", 4),
+        ("d", np.int8(16)),
+        ("d", np.float32(16)),
         (["a", "b"], 4),
         (["a", "b"], [4, 5]),
         ([True, False, True], 4),
@@ -1047,6 +1050,27 @@ def test_series_setitem_string(key, value):
 )
 def test_series_setitem_loc(key, value):
     psr = pd.Series([1, 2, 3], ["a", "b", "c"])
+    gsr = cudf.from_pandas(psr)
+    psr.loc[key] = value
+    gsr.loc[key] = value
+    assert_eq(psr, gsr)
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        (1, "d"),
+        (2, "e"),
+        (4, "f"),
+        ([1, 3], "g"),
+        ([1, 3], ["g", "h"]),
+        ([True, False, True], "i"),
+        ([False, False, False], "j"),
+        ([True, False, True], ["k", "l"]),
+    ],
+)
+def test_series_setitem_loc_numeric_index(key, value):
+    psr = pd.Series(["a", "b", "c"], [1, 2, 3])
     gsr = cudf.from_pandas(psr)
     psr.loc[key] = value
     gsr.loc[key] = value


### PR DESCRIPTION
Closes #7290 

Supports assigning to a new row (specified by a new label) in a series.