### PR TITLE
fix cuFile JNI compile errors [skip ci]

### DIFF
--- a/java/src/main/native/src/CuFileJni.cpp
+++ b/java/src/main/native/src/CuFileJni.cpp
@@ -218,7 +218,8 @@ public:
       }
     }
 
-    CUDF_EXPECTS(status == buffer.size(), "Size of bytes read is different from buffer size");
+    CUDF_EXPECTS(static_cast<std::size_t>(status) == buffer.size(),
+                 "Size of bytes read is different from buffer size");
   }
 
   /**
@@ -239,7 +240,8 @@ public:
       }
     }
 
-    CUDF_EXPECTS(status == buffer.size(), "Size of bytes written is different from buffer size");
+    CUDF_EXPECTS(static_cast<std::size_t>(status) == buffer.size(),
+                 "Size of bytes written is different from buffer size");
   }
 
   /**


### PR DESCRIPTION
Some cudf change caused compile errors in `CuFileJni.cpp`:
```console
     [exec] In file included from /home/rou/src/cudf/java/src/main/native/src/CuFileJni.cpp:22:
     [exec] /home/rou/src/cudf/java/src/main/native/src/CuFileJni.cpp: In member function ‘void {anonymous}::cufile_file::read(const {anonymous}::cufile_buffer&, std::size_t) const’:
     [exec] /home/rou/src/cudf/java/src/main/native/src/CuFileJni.cpp:221:25: error: comparison of integer expressions of different signedness: ‘const long int’ and ‘std::size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
     [exec]   221 |     CUDF_EXPECTS(status == buffer.size(), "Size of bytes read is different from buffer size");
     [exec]       |                  ~~~~~~~^~~~~~~~~~~~~~~~
     [exec] /home/rou/src/cudf/java/src/main/native/../../../../cpp/include/cudf/utilities/error.hpp:63:7: note: in definition of macro ‘CUDF_EXPECTS’
     [exec]    63 |   (!!(cond)) ? static_cast<void>(0)                                 \
     [exec]       |       ^~~~
     [exec] /home/rou/src/cudf/java/src/main/native/src/CuFileJni.cpp: In member function ‘void {anonymous}::cufile_file::write(const {anonymous}::cufile_buffer&, std::size_t)’:
     [exec] /home/rou/src/cudf/java/src/main/native/src/CuFileJni.cpp:242:25: error: comparison of integer expressions of different signedness: ‘const long int’ and ‘std::size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
     [exec]   242 |     CUDF_EXPECTS(status == buffer.size(), "Size of bytes written is different from buffer size");
     [exec]       |                  ~~~~~~~^~~~~~~~~~~~~~~~
     [exec] /home/rou/src/cudf/java/src/main/native/../../../../cpp/include/cudf/utilities/error.hpp:63:7: note: in definition of macro ‘CUDF_EXPECTS’
     [exec]    63 |   (!!(cond)) ? static_cast<void>(0)                                 \
     [exec]       |       ^~~~
     [exec] cc1plus: all warnings being treated as errors
     [exec] make[2]: *** [CMakeFiles/cufilejni.dir/build.make:82: CMakeFiles/cufilejni.dir/src/CuFileJni.cpp.o] Error 1
     [exec] make[1]: *** [CMakeFiles/Makefile2:97: CMakeFiles/cufilejni.dir/all] Error 2
```
