### PR TITLE
Missing `device_storage_dispatch` change affecting `cudf::gather` 

### DIFF
--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -557,14 +557,14 @@ struct column_gatherer_impl<struct_view, MapItRoot> {
                    std::back_inserter(output_struct_members),
                    [&gather_map_begin, &gather_map_end, nullify_out_of_bounds, stream, mr](
                      cudf::column_view const& col) {
-                     return cudf::type_dispatcher(col.type(),
-                                                  column_gatherer{},
-                                                  col,
-                                                  gather_map_begin,
-                                                  gather_map_end,
-                                                  nullify_out_of_bounds,
-                                                  stream,
-                                                  mr);
+                     return cudf::type_dispatcher<dispatch_storage_type>(col.type(),
+                                                                         column_gatherer{},
+                                                                         col,
+                                                                         gather_map_begin,
+                                                                         gather_map_end,
+                                                                         nullify_out_of_bounds,
+                                                                         stream,
+                                                                         mr);
                    });
 
     gather_bitmask(

--- a/cpp/src/lists/copying/gather.cu
+++ b/cpp/src/lists/copying/gather.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/lists/copying/gather.cu
+++ b/cpp/src/lists/copying/gather.cu
@@ -96,17 +96,17 @@ std::unique_ptr<column> gather_list_leaf(column_view const& column,
   size_type gather_map_size = gd.gather_map_size;
 
   // call the normal gather
-  auto leaf_column =
-    cudf::type_dispatcher(column.type(),
-                          cudf::detail::column_gatherer{},
-                          column,
-                          gather_map_begin,
-                          gather_map_begin + gather_map_size,
-                          // note : we don't need to bother checking for out-of-bounds here since
-                          // our inputs at this stage aren't coming from the user.
-                          false,
-                          stream,
-                          mr);
+  auto leaf_column = cudf::type_dispatcher<dispatch_storage_type>(
+    column.type(),
+    cudf::detail::column_gatherer{},
+    column,
+    gather_map_begin,
+    gather_map_begin + gather_map_size,
+    // note : we don't need to bother checking for out-of-bounds here since
+    // our inputs at this stage aren't coming from the user.
+    false,
+    stream,
+    mr);
 
   // the column_gatherer doesn't create the null mask because it expects
   // that will be done in the gather_bitmask() step.  however, gather_bitmask()

--- a/cpp/tests/collect_list/collect_list_test.cpp
+++ b/cpp/tests/collect_list/collect_list_test.cpp
@@ -41,8 +41,10 @@ template <typename T>
 struct TypedCollectListTest : public CollectListTest {
 };
 
-using TypesForTest = cudf::test::
-  Concat<cudf::test::IntegralTypes, cudf::test::FloatingPointTypes, cudf::test::DurationTypes>;
+using TypesForTest = cudf::test::Concat<cudf::test::IntegralTypes,
+                                        cudf::test::FloatingPointTypes,
+                                        cudf::test::DurationTypes,
+                                        cudf::test::FixedPointTypes>;
 
 TYPED_TEST_CASE(TypedCollectListTest, TypesForTest);
 

--- a/cpp/tests/copying/gather_list_tests.cu
+++ b/cpp/tests/copying/gather_list_tests.cu
@@ -35,6 +35,7 @@ template <typename T>
 class GatherTestListTyped : public cudf::test::BaseFixture {
 };
 using FixedWidthTypesNotBool = cudf::test::Concat<cudf::test::IntegralTypesNotBool,
+                                                  cudf::test::FixedPointTypes,
                                                   cudf::test::FloatingPointTypes,
                                                   cudf::test::DurationTypes,
                                                   cudf::test::TimestampTypes>;


### PR DESCRIPTION
Resolves https://github.com/rapidsai/cudf/issues/7441

Missed a necessary change to `type_dispatcher` invocation in `/lists/copyting/gather.cu` in https://github.com/rapidsai/cudf/pull/7419