### PR TITLE
Fixes bug when `Series.__setitem__` value is specified with another series

### DIFF
--- a/python/cudf/cudf/core/indexing.py
+++ b/python/cudf/cudf/core/indexing.py
@@ -92,6 +92,9 @@ class _SeriesIlocIndexer(object):
         # coerce value into a scalar or column
         if is_scalar(value):
             value = to_cudf_compatible_scalar(value)
+        elif isinstance(value, (pd.Series, cudf.Series)):
+            value = cudf.Series(value)
+            value = value._align_to_index(self._sr.index, how="right")
         else:
             value = column.as_column(value)
 

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -931,6 +931,10 @@ def test_series_setitem_null():
         ([], []),
         (slice(None, None), 1),
         (slice(-1, -3), 7),
+        (
+            slice(None, None, None),
+            pd.Series([5, 4, 3, 2, 1], index=[2, 4, 1, 3, 0]),
+        ),
     ],
 )
 @pytest.mark.parametrize("nulls", ["none", "some", "all"])


### PR DESCRIPTION
Closes #7368

When calling `__setitem__` on a series with another series, the index of the other series is not being considered. This PR fixes that.