### PR TITLE
Pass stream and user resource to make_default_constructed_scalar

### DIFF
--- a/cpp/include/cudf/scalar/scalar_factories.hpp
+++ b/cpp/include/cudf/scalar/scalar_factories.hpp
@@ -113,8 +113,13 @@ std::unique_ptr<scalar> make_string_scalar(
  * @throws std::bad_alloc if device memory allocation fails
  *
  * @param type The desired element type
+ * @param stream CUDA stream used for device memory operations.
+ * @param mr Device memory resource used to allocate the scalar's `data` and `is_valid` bool.
  */
-std::unique_ptr<scalar> make_default_constructed_scalar(data_type type);
+std::unique_ptr<scalar> make_default_constructed_scalar(
+  data_type type,
+  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Construct scalar using the given value of fixed width type

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -101,7 +101,7 @@ struct get_element_functor {
       stream);
 
     if (!key_index_scalar.is_valid(stream)) {
-      auto null_result = make_default_constructed_scalar(dict_view.keys().type());
+      auto null_result = make_default_constructed_scalar(dict_view.keys().type(), stream, mr);
       null_result->set_valid(false, stream);
       return null_result;
     }

--- a/cpp/src/reductions/minmax.cu
+++ b/cpp/src/reductions/minmax.cu
@@ -252,8 +252,8 @@ std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
   if (col.null_count() == col.size()) {
     // this handles empty and all-null columns
     // return scalars with valid==false
-    return {make_default_constructed_scalar(col.type()),
-            make_default_constructed_scalar(col.type())};
+    return {make_default_constructed_scalar(col.type(), stream, mr),
+            make_default_constructed_scalar(col.type(), stream, mr)};
   }
 
   return type_dispatcher(col.type(), minmax_functor{}, col, stream, mr);

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -112,7 +112,7 @@ std::unique_ptr<scalar> reduce(
   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource())
 {
-  std::unique_ptr<scalar> result = make_default_constructed_scalar(output_dtype);
+  std::unique_ptr<scalar> result = make_default_constructed_scalar(output_dtype, stream, mr);
   result->set_valid(false, stream);
 
   // check if input column is empty

--- a/cpp/tests/scalar/factories_test.cpp
+++ b/cpp/tests/scalar/factories_test.cpp
@@ -89,7 +89,7 @@ TYPED_TEST(TimestampScalarFactory, TypeCast)
 }
 
 template <typename T>
-struct DefaultScalarFactory : public cudf::test::BaseFixture {
+struct DefaultScalarFactory : public ScalarFactoryTest {
   static constexpr auto factory = cudf::make_default_constructed_scalar;
 };
 
@@ -98,7 +98,8 @@ TYPED_TEST_CASE(DefaultScalarFactory, MixedTypes);
 
 TYPED_TEST(DefaultScalarFactory, FactoryDefault)
 {
-  std::unique_ptr<cudf::scalar> s = this->factory(cudf::data_type{cudf::type_to_id<TypeParam>()});
+  std::unique_ptr<cudf::scalar> s =
+    this->factory(cudf::data_type{cudf::type_to_id<TypeParam>()}, this->stream(), this->mr());
 
   EXPECT_EQ(s->type(), cudf::data_type{cudf::type_to_id<TypeParam>()});
   EXPECT_FALSE(s->is_valid());
@@ -106,7 +107,8 @@ TYPED_TEST(DefaultScalarFactory, FactoryDefault)
 
 TYPED_TEST(DefaultScalarFactory, TypeCast)
 {
-  std::unique_ptr<cudf::scalar> s = this->factory(cudf::data_type{cudf::type_to_id<TypeParam>()});
+  std::unique_ptr<cudf::scalar> s =
+    this->factory(cudf::data_type{cudf::type_to_id<TypeParam>()}, this->stream(), this->mr());
 
   auto numeric_s = static_cast<cudf::scalar_type_t<TypeParam>*>(s.get());
 


### PR DESCRIPTION
The `make_default_constructed_scalar` factory currently [doesn't take streams or user resources](https://github.com/rapidsai/cudf/blob/c929ba1fe85c152d6e8b4c868cd36f0802dafa51/cpp/src/scalar/scalar_factories.cpp#L100-L133), which could lead to inconsistent results if the constructed scalar is used with a non-default non-blocking stream later on. This PR is to fix the issue. 