### PR TITLE
Java cleaner synchronization [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -858,7 +858,7 @@ public final class ColumnVector extends ColumnView {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
       long address = 0;
 

--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -114,7 +114,7 @@ public class Cuda {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
       if (cleaner != null) {
         cleaner.delRef();
       }
@@ -233,7 +233,7 @@ public class Cuda {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
       cleaner.delRef();
       if (closed) {
         cleaner.logRefCountDebug("double free " + this);

--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -41,7 +41,7 @@ public class Cuda {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
       long origAddress = stream;
       if (stream != CUDA_STREAM_DEFAULT &&
@@ -139,7 +139,7 @@ public class Cuda {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
       long origAddress = event;
       if (event != 0) {

--- a/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
@@ -41,7 +41,7 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
       long origAddress = address;
       if (address != 0) {
@@ -79,7 +79,7 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
       if (rmmBufferAddress != 0) {
         Rmm.freeDeviceBuffer(rmmBufferAddress);

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
@@ -514,7 +514,7 @@ public class HostColumnVectorCore implements AutoCloseable {
    * Close method for the column
    */
   @Override
-  public void close() {
+  public synchronized void close() {
     for (HostColumnVectorCore child : children) {
       if (child != null) {
         child.close();

--- a/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
@@ -553,7 +553,7 @@ public class HostColumnVectorCore implements AutoCloseable {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
       if (data != null || valid != null || offsets != null) {
         try {

--- a/java/src/main/java/ai/rapids/cudf/HostMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/HostMemoryBuffer.java
@@ -63,7 +63,7 @@ public class HostMemoryBuffer extends MemoryBuffer {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
       long origAddress = address;
       if (address != 0) {

--- a/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryBuffer.java
@@ -46,7 +46,7 @@ abstract public class MemoryBuffer implements AutoCloseable {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       if (parent != null) {
         if (logErrorIfNotClean) {
           log.error("A SLICED BUFFER WAS LEAKED(ID: " + id + " parent: " + parent + ")");

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -79,7 +79,7 @@ public final class MemoryCleaner {
 
     public final void addRef() {
       if (REF_COUNT_DEBUG && refCountDebug != null) {
-        synchronized (refCountDebug)  {
+        synchronized(this)  {
           refCountDebug.add(new MemoryCleaner.RefCountDebugItem("INC"));
         }
       }
@@ -87,7 +87,7 @@ public final class MemoryCleaner {
 
     public final void delRef() {
       if (REF_COUNT_DEBUG && refCountDebug != null) {
-        synchronized (refCountDebug) {
+        synchronized(this) {
           refCountDebug.add(new MemoryCleaner.RefCountDebugItem("DEC"));
         }
       }
@@ -95,7 +95,7 @@ public final class MemoryCleaner {
 
     public final void logRefCountDebug(String message) {
       if (REF_COUNT_DEBUG && refCountDebug != null) {
-        synchronized (refCountDebug) {
+        synchronized(this) {
           log.error("{} (ID: {}): {}", message, id, MemoryCleaner.stringJoin("\n", refCountDebug));
         }
       }

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -79,19 +79,25 @@ public final class MemoryCleaner {
 
     public final void addRef() {
       if (REF_COUNT_DEBUG && refCountDebug != null) {
-        refCountDebug.add(new MemoryCleaner.RefCountDebugItem("INC"));
+        synchronized (refCountDebug)  {
+          refCountDebug.add(new MemoryCleaner.RefCountDebugItem("INC"));
+        }
       }
     }
 
     public final void delRef() {
       if (REF_COUNT_DEBUG && refCountDebug != null) {
-        refCountDebug.add(new MemoryCleaner.RefCountDebugItem("DEC"));
+        synchronized (refCountDebug) {
+          refCountDebug.add(new MemoryCleaner.RefCountDebugItem("DEC"));
+        }
       }
     }
 
     public final void logRefCountDebug(String message) {
       if (REF_COUNT_DEBUG && refCountDebug != null) {
-        log.error("{} (ID: {}): {}", message, id, MemoryCleaner.stringJoin("\n", refCountDebug));
+        synchronized (refCountDebug) {
+          log.error("{} (ID: {}): {}", message, id, MemoryCleaner.stringJoin("\n", refCountDebug));
+        }
       }
     }
 

--- a/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
+++ b/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
@@ -108,7 +108,7 @@ public final class PinnedMemoryPool implements AutoCloseable {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       boolean neededCleanup = false;
       long origAddress = 0;
       if (section != null) {

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -675,7 +675,7 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
     }
 
     @Override
-    protected boolean cleanImpl(boolean logErrorIfNotClean) {
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
       if (scalarHandle != 0) {
         if (logErrorIfNotClean) {
           LOG.error("A SCALAR WAS LEAKED(ID: " + id + " " + Long.toHexString(scalarHandle) + ")");

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Decompressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Decompressor.java
@@ -175,7 +175,7 @@ public class BatchedLZ4Decompressor {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
       if (!closed) {
         cleaner.delRef();
         cleaner.clean(false);

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Decompressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/BatchedLZ4Decompressor.java
@@ -200,7 +200,7 @@ public class BatchedLZ4Decompressor {
       }
 
       @Override
-      protected boolean cleanImpl(boolean logErrorIfNotClean) {
+      protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
         boolean neededCleanup = false;
         long address = metadata;
         if (metadata != 0) {

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
@@ -135,7 +135,7 @@ public class Decompressor {
       }
 
       @Override
-      protected boolean cleanImpl(boolean logErrorIfNotClean) {
+      protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
         boolean neededCleanup = false;
         long address = metadata;
         if (metadata != 0) {

--- a/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
+++ b/java/src/main/java/ai/rapids/cudf/nvcomp/Decompressor.java
@@ -110,7 +110,7 @@ public class Decompressor {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
       if (!closed) {
         cleaner.delRef();
         cleaner.clean(false);


### PR DESCRIPTION
Add synchronization in `cleanImpl` and `close` in various places where race conditions could exist, and also within the `MemoryCleaner` to address some concurrent modification issues we've seen in tests while shutting down (i.e. invoking the cleaner) (i.e. https://github.com/NVIDIA/spark-rapids/issues/1797)