### PR TITLE
Fix JNI deprecation of all, put it on the wrong version before [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -1106,9 +1106,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Returns a boolean scalar that is true if all of the elements in
    * the column are true or non-zero otherwise false.
    * Null values are skipped.
-   * @deprecated the only output type supported is BOOL8.
    */
-  @Deprecated
   public Scalar all() {
     return all(DType.BOOL8);
   }
@@ -1118,7 +1116,9 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * if all of the elements in the column are true or non-zero
    * otherwise false or 0.
    * Null values are skipped.
+   * @deprecated the only output type supported is BOOL8.
    */
+  @Deprecated
   public Scalar all(DType outType) {
     return reduce(Aggregation.all(), outType);
   }


### PR DESCRIPTION
A while ago I deprecated the API that I wanted to keep and didn't do the one that should go away. This fixes that.