### PR TITLE
[REVIEW] FIX Remove random build directory generation for ccache

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -19,8 +19,9 @@ export CUDA_REL=${CUDA_VERSION%.*}
 export GPUCI_CONDA_RETRY_MAX=1
 export GPUCI_CONDA_RETRY_SLEEP=30
 
-# Use Ninja to build
+# Use Ninja to build, setup Conda Build Dir
 export CMAKE_GENERATOR="Ninja"
+export CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
 
 # Switch to project root; also root of repo checkout
 cd $WORKSPACE
@@ -68,29 +69,29 @@ fi
 
 if [ "$BUILD_LIBCUDF" == '1' ]; then
   gpuci_logger "Build conda pkg for libcudf"
-  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf $CONDA_BUILD_ARGS
-  mkdir -p ${WORKSPACE}/.conda-bld/libcudf/work
-  cp -r ${WORKSPACE}/.conda-bld/work/* ${WORKSPACE}/.conda-bld/libcudf/work
+  gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/libcudf $CONDA_BUILD_ARGS
+  mkdir -p ${CONDA_BLD_DIR}/libcudf/work
+  cp -r ${CONDA_BLD_DIR}/work/* ${CONDA_BLD_DIR}/libcudf/work
 
 
   gpuci_logger "Build conda pkg for libcudf_kafka"
-  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf_kafka $CONDA_BUILD_ARGS
-  mkdir -p ${WORKSPACE}/.conda-bld/libcudf_kafka/work
-  cp -r ${WORKSPACE}/.conda-bld/work/* ${WORKSPACE}/.conda-bld/libcudf_kafka/work
+  gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/libcudf_kafka $CONDA_BUILD_ARGS
+  mkdir -p ${CONDA_BLD_DIR}/libcudf_kafka/work
+  cp -r ${CONDA_BLD_DIR}/work/* ${CONDA_BLD_DIR}/libcudf_kafka/work
 fi
 
 if [ "$BUILD_CUDF" == '1' ]; then
   gpuci_logger "Build conda pkg for cudf"
-  gpuci_conda_retry build conda/recipes/cudf --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
+  gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/cudf --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
 
   gpuci_logger "Build conda pkg for dask-cudf"
-  gpuci_conda_retry build conda/recipes/dask-cudf --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
+  gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/dask-cudf --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
 
   gpuci_logger "Build conda pkg for cudf_kafka"
-  gpuci_conda_retry build conda/recipes/cudf_kafka --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
+  gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/cudf_kafka --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
 
   gpuci_logger "Build conda pkg for custreamz"
-  gpuci_conda_retry build conda/recipes/custreamz --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
+  gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/custreamz --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
 fi
 ################################################################################
 # UPLOAD - Conda packages

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -68,10 +68,13 @@ fi
 
 if [ "$BUILD_LIBCUDF" == '1' ]; then
   gpuci_logger "Build conda pkg for libcudf"
-  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld/libcudf conda/recipes/libcudf $CONDA_BUILD_ARGS
+  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf $CONDA_BUILD_ARGS
+  cp ${WORKSPACE}/.conda-bld/work ${WORKSPACE}/.conda-bld/libcudf/work
+
 
   gpuci_logger "Build conda pkg for libcudf_kafka"
-  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld/libcudf_kafka conda/recipes/libcudf_kafka $CONDA_BUILD_ARGS
+  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf_kafka $CONDA_BUILD_ARGS
+  cp ${WORKSPACE}/.conda-bld/work ${WORKSPACE}/.conda-bld/libcudf_kafka/work
 fi
 
 if [ "$BUILD_CUDF" == '1' ]; then

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -68,10 +68,10 @@ fi
 
 if [ "$BUILD_LIBCUDF" == '1' ]; then
   gpuci_logger "Build conda pkg for libcudf"
-  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf $CONDA_BUILD_ARGS
+  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld/libcudf conda/recipes/libcudf $CONDA_BUILD_ARGS
 
   gpuci_logger "Build conda pkg for libcudf_kafka"
-  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf_kafka $CONDA_BUILD_ARGS
+  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld/libcudf_kafka conda/recipes/libcudf_kafka $CONDA_BUILD_ARGS
 fi
 
 if [ "$BUILD_CUDF" == '1' ]; then

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -64,11 +64,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
   CONDA_CHANNEL=""
 else
   CONDA_BUILD_ARGS="--dirty --no-remove-work-dir"
-  if [[ ${CONDA_BLD_DIR} == "${WORKSPACE}/.conda-bld" ]]; then
-    CONDA_CHANNEL="-c $WORKSPACE/ci/artifacts/cudf/cpu/.conda-bld/"
-  else
-    CONDA_CHANNEL="-c $WORKSPACE/ci/artifacts/cudf/cpu/conda-bld/"
-  fi
+  CONDA_CHANNEL="-c $WORKSPACE/ci/artifacts/cudf/cpu/.conda-bld/"
 fi
 
 if [ "$BUILD_LIBCUDF" == '1' ]; then

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -69,12 +69,14 @@ fi
 if [ "$BUILD_LIBCUDF" == '1' ]; then
   gpuci_logger "Build conda pkg for libcudf"
   gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf $CONDA_BUILD_ARGS
-  cp ${WORKSPACE}/.conda-bld/work ${WORKSPACE}/.conda-bld/libcudf/work
+  mkdir -p ${WORKSPACE}/.conda-bld/libcudf/work
+  cp -r ${WORKSPACE}/.conda-bld/work/* ${WORKSPACE}/.conda-bld/libcudf/work
 
 
   gpuci_logger "Build conda pkg for libcudf_kafka"
   gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf_kafka $CONDA_BUILD_ARGS
-  cp ${WORKSPACE}/.conda-bld/work ${WORKSPACE}/.conda-bld/libcudf_kafka/work
+  mkdir -p ${WORKSPACE}/.conda-bld/libcudf_kafka/work
+  cp -r ${WORKSPACE}/.conda-bld/work/* ${WORKSPACE}/.conda-bld/libcudf_kafka/work
 fi
 
 if [ "$BUILD_CUDF" == '1' ]; then

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -68,10 +68,10 @@ fi
 
 if [ "$BUILD_LIBCUDF" == '1' ]; then
   gpuci_logger "Build conda pkg for libcudf"
-  gpuci_conda_retry build conda/recipes/libcudf $CONDA_BUILD_ARGS
+  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf $CONDA_BUILD_ARGS
 
   gpuci_logger "Build conda pkg for libcudf_kafka"
-  gpuci_conda_retry build conda/recipes/libcudf_kafka $CONDA_BUILD_ARGS
+  gpuci_conda_retry build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf_kafka $CONDA_BUILD_ARGS
 fi
 
 if [ "$BUILD_CUDF" == '1' ]; then

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -64,7 +64,11 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
   CONDA_CHANNEL=""
 else
   CONDA_BUILD_ARGS="--dirty --no-remove-work-dir"
-  CONDA_CHANNEL="-c $WORKSPACE/ci/artifacts/cudf/cpu/conda-bld/"
+  if [[ ${CONDA_BLD_DIR} == "${WORKSPACE}/.conda-bld" ]]; then
+    CONDA_CHANNEL="-c $WORKSPACE/ci/artifacts/cudf/cpu/.conda-bld/"
+  else
+    CONDA_CHANNEL="-c $WORKSPACE/ci/artifacts/cudf/cpu/conda-bld/"
+  fi
 fi
 
 if [ "$BUILD_LIBCUDF" == '1' ]; then

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -30,10 +30,10 @@ fi
 gpuci_logger "Get conda file output locations"
 export LIBCUDF_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf --output`
 export LIBCUDF_KAFKA_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf_kafka --output`
-export CUDF_FILE=`conda build conda/recipes/cudf --python=$PYTHON --output`
-export DASK_CUDF_FILE=`conda build conda/recipes/dask-cudf --python=$PYTHON --output`
-export CUDF_KAFKA_FILE=`conda build conda/recipes/cudf_kafka --python=$PYTHON --output`
-export CUSTREAMZ_FILE=`conda build conda/recipes/custreamz --python=$PYTHON --output`
+export CUDF_FILE=`conda build --croot ${CONDA_BLD_DIR} conda/recipes/cudf --python=$PYTHON --output`
+export DASK_CUDF_FILE=`conda build --croot ${CONDA_BLD_DIR} conda/recipes/dask-cudf --python=$PYTHON --output`
+export CUDF_KAFKA_FILE=`conda build --croot ${CONDA_BLD_DIR} conda/recipes/cudf_kafka --python=$PYTHON --output`
+export CUSTREAMZ_FILE=`conda build --croot ${CONDA_BLD_DIR} conda/recipes/custreamz --python=$PYTHON --output`
 
 ################################################################################
 # UPLOAD - Conda packages

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -28,8 +28,8 @@ fi
 ################################################################################
 
 gpuci_logger "Get conda file output locations"
-export LIBCUDF_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf --output`
-export LIBCUDF_KAFKA_FILE=`conda --no-build-id --croot ${WORKSPACE}/.conda-bld build conda/recipes/libcudf_kafka --output`
+export LIBCUDF_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld/libcudf conda/recipes/libcudf --output`
+export LIBCUDF_KAFKA_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld/libcudf_kafka conda/recipes/libcudf_kafka --output`
 export CUDF_FILE=`conda build conda/recipes/cudf --python=$PYTHON --output`
 export DASK_CUDF_FILE=`conda build conda/recipes/dask-cudf --python=$PYTHON --output`
 export CUDF_KAFKA_FILE=`conda build conda/recipes/cudf_kafka --python=$PYTHON --output`

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -28,8 +28,8 @@ fi
 ################################################################################
 
 gpuci_logger "Get conda file output locations"
-export LIBCUDF_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld/libcudf conda/recipes/libcudf --output`
-export LIBCUDF_KAFKA_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld/libcudf_kafka conda/recipes/libcudf_kafka --output`
+export LIBCUDF_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf --output`
+export LIBCUDF_KAFKA_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf_kafka --output`
 export CUDF_FILE=`conda build conda/recipes/cudf --python=$PYTHON --output`
 export DASK_CUDF_FILE=`conda build conda/recipes/dask-cudf --python=$PYTHON --output`
 export CUDF_KAFKA_FILE=`conda build conda/recipes/cudf_kafka --python=$PYTHON --output`

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -28,8 +28,8 @@ fi
 ################################################################################
 
 gpuci_logger "Get conda file output locations"
-export LIBCUDF_FILE=`conda build conda/recipes/libcudf --output`
-export LIBCUDF_KAFKA_FILE=`conda build conda/recipes/libcudf_kafka --output`
+export LIBCUDF_FILE=`conda build --no-build-id --croot ${WORKSPACE}/.conda-bld conda/recipes/libcudf --output`
+export LIBCUDF_KAFKA_FILE=`conda --no-build-id --croot ${WORKSPACE}/.conda-bld build conda/recipes/libcudf_kafka --output`
 export CUDF_FILE=`conda build conda/recipes/cudf --python=$PYTHON --output`
 export DASK_CUDF_FILE=`conda build conda/recipes/dask-cudf --python=$PYTHON --output`
 export CUDF_KAFKA_FILE=`conda build conda/recipes/cudf_kafka --python=$PYTHON --output`

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -24,6 +24,7 @@ cd $WORKSPACE
 
 # Determine CUDA release version
 export CUDA_REL=${CUDA_VERSION%.*}
+export CONDA_ARTIFACT_PATH=${WORKSPACE}/ci/artifacts/cudf/cpu/.conda-bld/
 
 # Parse git describe
 export GIT_DESCRIBE_TAG=`git describe --tags`
@@ -170,15 +171,15 @@ else
         ${gt} --gtest_output=xml:${WORKSPACE}/test-results/
     done
 
-    CUDF_CONDA_FILE=`find $WORKSPACE/ci/artifacts/cudf/cpu/conda-bld/ -name "libcudf-*.tar.bz2"`
+    CUDF_CONDA_FILE=`find ${CONDA_ARTIFACT_PATH} -name "libcudf-*.tar.bz2"`
     CUDF_CONDA_FILE=`basename "$CUDF_CONDA_FILE" .tar.bz2` #get filename without extension
     CUDF_CONDA_FILE=${CUDF_CONDA_FILE//-/=} #convert to conda install
-    KAFKA_CONDA_FILE=`find $WORKSPACE/ci/artifacts/cudf/cpu/conda-bld/ -name "libcudf_kafka-*.tar.bz2"`
+    KAFKA_CONDA_FILE=`find ${CONDA_ARTIFACT_PATH} -name "libcudf_kafka-*.tar.bz2"`
     KAFKA_CONDA_FILE=`basename "$KAFKA_CONDA_FILE" .tar.bz2` #get filename without extension
     KAFKA_CONDA_FILE=${KAFKA_CONDA_FILE//-/=} #convert to conda install
 
     gpuci_logger "Installing $CUDF_CONDA_FILE & $KAFKA_CONDA_FILE"
-    conda install -c $WORKSPACE/ci/artifacts/cudf/cpu/conda-bld/ "$CUDF_CONDA_FILE" "$KAFKA_CONDA_FILE"
+    conda install -c ${CONDA_ARTIFACT_PATH} "$CUDF_CONDA_FILE" "$KAFKA_CONDA_FILE"
 
     install_dask
 


### PR DESCRIPTION
This changes the root directory of the build folder for conda. Instead of generating a random build folder name, it will create a consistent build folder name at the `croot` location. This folder name is unique in CI, as every build has a unique `${WORKSPACE}` that is used.

Lots of workarounds added to properly work with Project Flash. Several `mv` commands are added to put build artifacts in a folder Project Flash expects them to be in.