### PR TITLE
Implement drop_list_duplicates

### DIFF
--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -132,6 +132,7 @@ test:
     - test -f $PREFIX/include/cudf/lists/detail/concatenate.hpp
     - test -f $PREFIX/include/cudf/lists/detail/copying.hpp
     - test -f $PREFIX/include/cudf/lists/count_elements.hpp
+    - test -f $PREFIX/include/cudf/lists/drop_list_duplicates.hpp
     - test -f $PREFIX/include/cudf/lists/extract.hpp
     - test -f $PREFIX/include/cudf/lists/contains.hpp
     - test -f $PREFIX/include/cudf/lists/gather.hpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -253,6 +253,7 @@ add_library(cudf
     src/lists/copying/segmented_gather.cu
     src/lists/count_elements.cu
     src/lists/extract.cu
+    src/lists/drop_list_duplicates.cu
     src/lists/lists_column_factories.cu
     src/lists/lists_column_view.cu
     src/lists/segmented_sort.cu

--- a/cpp/include/cudf/lists/drop_list_duplicates.hpp
+++ b/cpp/include/cudf/lists/drop_list_duplicates.hpp
@@ -28,27 +28,32 @@ namespace lists {
  */
 
 /**
- * @brief Create a new column by removing duplicated entries from each list in the given
- * lists_column
+ * @brief Create a new lists column by removing duplicated entries from each list element in the
+ * given lists column
  *
- * Given an `input` list_column_view, the list rows in the column are copied to an output column
- * such that their duplicated entries are dropped out to keep only unique entries. The order of
- * those entries are not guaranteed to be preserved as in the input column.
+ * Given an `input` lists_column_view, the list elements in the column are copied to an output lists
+ * column such that their duplicated entries are dropped out to keep only the unique ones. The
+ * order of those entries within each list are not guaranteed to be preserved as in the input.
  *
- * If any row in the input column contains nested types, cudf::logic_error will be thrown.
+ * Notes:
+ *  - If any row (list element) in the input column contains nested types, cudf::logic_error will be
+ * thrown.
+ *  - By current implementation, entries in the output lists are sorted by ascending order (nulls
+ * last), but this is not guaranteed in future implementation.
  *
- * @param[in] lists_column    the input lists_column_view
- * @param[in] nulls_equal     flag to denote nulls are considered equal
- * @param[in] mr              Device memory resource used to allocate the returned column
+ * @param lists_column The input lists_column_view
+ * @param nulls_equal  Flag to specify whether null entries should be considered equal
+ * @param mr           Device resource used to allocate memory
  *
  * @code{.pseudo}
- * If the input is { {1, 1, 2, 1, 3}, {4}, {5, 6, 6, 6, 5} }
- * Then a valid output can be { {1, 2, 3}, {4}, {5, 6} }
- * Note that permuting the entries of each sublist in this output also produces another valid
+ * lists_column = { {1, 1, 2, 1, 3}, {4}, NULL, {}, {NULL, NULL, NULL, 5, 6, 6, 6, 5} }
+ * output = { {1, 2, 3}, {4}, NULL, {}, {5, 6, NULL} }
+ *
+ * Note that permuting the entries of each list in this output also produces another valid
  * output.
  * @endcode
  *
- * @return A list column with list elements having unique entries.
+ * @return A list column with list elements having unique entries
  */
 std::unique_ptr<column> drop_list_duplicates(
   lists_column_view const& lists_column,

--- a/cpp/include/cudf/lists/drop_list_duplicates.hpp
+++ b/cpp/include/cudf/lists/drop_list_duplicates.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/stream_compaction.hpp>
+
+namespace cudf {
+namespace lists {
+/**
+ * @addtogroup lists_drop_duplicates
+ * @{
+ * @file
+ */
+
+/**
+ * @brief Create a new column by removing duplicated elements from each list in the given
+ * lists_column
+ *
+ * Given an `input` list_column_view, the list elements in the column are copied to an output column
+ * such that their duplicated entries are dropped. Adopted from stream compaction, the definition of
+ * uniqueness depends on the value of @p keep:
+ * - KEEP_FIRST: only the first of a sequence of duplicate entries is copied
+ * - KEEP_LAST: only the last of a sequence of duplicate entries is copied
+ * - KEEP_NONE: all duplicate entries are dropped out
+ *
+ * @param[in] lists_column    the input lists_column_view
+ * @param[in] keep            keep first entry, last entry, or no entries if duplicates found
+ * @param[in] nulls_equal     flag to denote nulls are considered equal
+ * @param[in] mr              Device memory resource used to allocate the returned column
+ *
+ *  * @code{.pseudo}
+ * input = { {1, 1, 2, 1, 3}, {4}, {5, 6, 6, 6, 5} }
+ * if keep is KEEP_FIRST, the output will be { {1, 2, 3}, {4}, {5, 6} }
+ * if keep is KEEP_LAST, the output will be  { {2, 1, 3}, {4}, {6, 5} }
+ * if keep is KEEP_NONE, the output will be  { {2, 3}, {4}, {} }
+ * @endcode
+ *
+ * @return A list column with lists having unique entries as specified by the `keep` policy.
+ */
+std::unique_ptr<column> drop_list_duplicates(
+  lists_column_view const& lists_column,
+  duplicate_keep_option keep,
+  null_equality nulls_equal           = null_equality::EQUAL,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/** @} */  // end of group
+}  // namespace lists
+}  // namespace cudf

--- a/cpp/include/cudf/lists/drop_list_duplicates.hpp
+++ b/cpp/include/cudf/lists/drop_list_duplicates.hpp
@@ -31,14 +31,12 @@ namespace lists {
  * @brief Create a new lists column by removing duplicated entries from each list element in the
  * given lists column
  *
+ * @throw cudf::logic_error if any row (list element) in the input column is a nested type.
+ *
  * Given an `input` lists_column_view, the list elements in the column are copied to an output lists
  * column such that their duplicated entries are dropped out to keep only the unique ones. The
- * order of those entries within each list are not guaranteed to be preserved as in the input.
- *
- * Notes:
- *  - If any row (list element) in the input column contains nested types, cudf::logic_error will be
- * thrown.
- *  - By current implementation, entries in the output lists are sorted by ascending order (nulls
+ * order of those entries within each list are not guaranteed to be preserved as in the input. In
+ * the current implementation, entries in the output lists are sorted by ascending order (nulls
  * last), but this is not guaranteed in future implementation.
  *
  * @param lists_column The input lists_column_view

--- a/cpp/include/doxygen_groups.h
+++ b/cpp/include/doxygen_groups.h
@@ -146,7 +146,7 @@
  *   @defgroup lists_contains Searching
  *   @defgroup lists_gather Gathering
  *   @defgroup lists_elements Counting
- *   @defgroup lists_drop_duplicates Dropping duplicated elements
+ *   @defgroup lists_drop_duplicates Filtering
  * @}
  * @defgroup nvtext_apis NVText
  * @{

--- a/cpp/include/doxygen_groups.h
+++ b/cpp/include/doxygen_groups.h
@@ -146,6 +146,7 @@
  *   @defgroup lists_contains Searching
  *   @defgroup lists_gather Gathering
  *   @defgroup lists_elements Counting
+ *   @defgroup lists_drop_duplicates Dropping duplicated elements
  * @}
  * @defgroup nvtext_apis NVText
  * @{

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -16,16 +16,305 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/detail/copy.hpp>
 #include <cudf/detail/gather.cuh>
+#include <cudf/detail/gather.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/sorting.hpp>
 #include <cudf/lists/drop_list_duplicates.hpp>
+#include <cudf/table/row_operators.cuh>
+#include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
+#include <thrust/binary_search.h>
+#include <thrust/sequence.h>
 #include <thrust/transform.h>
 
 namespace cudf {
 namespace lists {
 namespace detail {
+struct SortPairs {
+  template <typename KeyT, typename ValueT, typename OffsetIteratorT>
+  void SortPairsAscending(KeyT const* keys_in,
+                          KeyT* keys_out,
+                          ValueT const* values_in,
+                          ValueT* values_out,
+                          int num_items,
+                          int num_segments,
+                          OffsetIteratorT begin_offsets,
+                          OffsetIteratorT end_offsets,
+                          rmm::cuda_stream_view stream)
+  {
+    rmm::device_buffer d_temp_storage;
+    size_t temp_storage_bytes = 0;
+    cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage.data(),
+                                             temp_storage_bytes,
+                                             keys_in,
+                                             keys_out,
+                                             values_in,
+                                             values_out,
+                                             num_items,
+                                             num_segments,
+                                             begin_offsets,
+                                             end_offsets,
+                                             0,
+                                             sizeof(KeyT) * 8,
+                                             stream.value());
+    d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+
+    cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage.data(),
+                                             temp_storage_bytes,
+                                             keys_in,
+                                             keys_out,
+                                             values_in,
+                                             values_out,
+                                             num_items,
+                                             num_segments,
+                                             begin_offsets,
+                                             end_offsets,
+                                             0,
+                                             sizeof(KeyT) * 8,
+                                             stream.value());
+  }
+
+  template <typename T>
+  std::enable_if_t<not is_numeric<T>(), std::unique_ptr<column>> operator()(
+    column_view const& child,
+    column_view const& segment_offsets,
+    null_order null_precedence,
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource* mr)
+  {
+    auto child_table = segmented_sort_by_key(table_view{{child}},
+                                             table_view{{child}},
+                                             segment_offsets,
+                                             {order::ASCENDING},
+                                             {null_precedence},
+                                             stream,
+                                             mr);
+    return std::move(child_table->release().front());
+  }
+
+  template <typename T>
+  std::enable_if_t<is_numeric<T>(), std::unique_ptr<column>> operator()(
+    column_view const& child,
+    column_view const& offsets,
+    null_order null_precedence,
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource* mr)
+  {
+    auto output =
+      cudf::detail::allocate_like(child, child.size(), mask_allocation_policy::NEVER, stream, mr);
+    mutable_column_view mutable_output_view = output->mutable_view();
+
+    auto keys = [&]() {
+      if (child.nullable()) {
+        rmm::device_uvector<T> keys(child.size(), stream);
+        auto const null_replace_T = null_precedence == null_order::AFTER
+                                      ? std::numeric_limits<T>::max()
+                                      : std::numeric_limits<T>::min();
+        auto device_child         = column_device_view::create(child, stream);
+        auto keys_in =
+          cudf::detail::make_null_replacement_iterator<T>(*device_child, null_replace_T);
+        thrust::copy_n(rmm::exec_policy(stream), keys_in, child.size(), keys.begin());
+        return keys;
+      }
+      return rmm::device_uvector<T>{0, stream};
+    }();
+
+    std::unique_ptr<column> sorted_indices = cudf::make_numeric_column(
+      data_type(type_to_id<size_type>()), child.size(), mask_state::UNALLOCATED, stream, mr);
+    mutable_column_view mutable_indices_view = sorted_indices->mutable_view();
+    thrust::sequence(rmm::exec_policy(stream),
+                     mutable_indices_view.begin<size_type>(),
+                     mutable_indices_view.end<size_type>(),
+                     0);
+
+    SortPairsAscending(child.nullable() ? keys.data() : child.begin<T>(),
+                       mutable_output_view.begin<T>(),
+                       mutable_indices_view.begin<size_type>(),
+                       mutable_indices_view.begin<size_type>(),
+                       child.size(),
+                       offsets.size() - 1,
+                       offsets.begin<size_type>(),
+                       offsets.begin<size_type>() + 1,
+                       stream);
+
+    std::vector<std::unique_ptr<column>> output_cols;
+    output_cols.push_back(std::move(output));
+    // rearrange the null_mask.
+    cudf::detail::gather_bitmask(cudf::table_view{{child}},
+                                 mutable_indices_view.begin<size_type>(),
+                                 output_cols,
+                                 cudf::detail::gather_bitmask_op::DONT_CHECK,
+                                 stream,
+                                 mr);
+    return std::move(output_cols.front());
+  }
+};
+#if 1
+namespace {
+template <typename InputIterator, typename BinaryPredicate>
+struct unique_copy_fn {
+  /**
+   * @brief Functor for unique_copy()
+   *
+   * The logic here is equivalent to:
+   * @code
+   *   ((keep == duplicate_keep_option::KEEP_LAST) ||
+   *    (i == 0 || !comp(iter[i], iter[i - 1]))) &&
+   *   ((keep == duplicate_keep_option::KEEP_FIRST) ||
+   *    (i == last_index || !comp(iter[i], iter[i + 1])))
+   * @endcode
+   *
+   * It is written this way so that the `comp` comparator
+   * function appears only once minimizing the inlining
+   * required and reducing the compile time.
+   */
+  __device__ bool operator()(size_type i)
+  {
+    size_type boundary = 0;
+    size_type offset   = 1;
+    auto keep_option   = duplicate_keep_option::KEEP_LAST;
+    do {
+      if ((keep_option != duplicate_keep_option::KEEP_FIRST) && (i != boundary) &&
+          comp(iter[i], iter[i - offset])) {
+        return false;
+      }
+      keep_option = duplicate_keep_option::KEEP_FIRST;
+      boundary    = last_index;
+      offset      = -offset;
+    } while (offset < 0);
+    return true;
+  }
+
+  InputIterator iter;
+  BinaryPredicate comp;
+  size_type const last_index;
+};
+}  // anonymous namespace
+
+/**
+ * @brief Copies unique elements from the range [first, last) to output iterator `output`.
+ *
+ * In a consecutive group of duplicate elements, depending on parameter `keep`,
+ * only the first element is copied, or the last element is copied or neither is copied.
+ *
+ * @return End of the range to which the elements are copied.
+ */
+template <typename InputIterator, typename OutputIterator, typename BinaryPredicate>
+OutputIterator unique_copy(InputIterator first,
+                           InputIterator last,
+                           OutputIterator output,
+                           BinaryPredicate comp,
+                           rmm::cuda_stream_view stream)
+{
+  size_type const last_index = thrust::distance(first, last) - 1;
+  return thrust::copy_if(rmm::exec_policy(stream),
+                         first,
+                         last,
+                         thrust::counting_iterator<size_type>(0),
+                         output,
+                         unique_copy_fn<InputIterator, BinaryPredicate>{first, comp, last_index});
+}
+
+/**
+ * @brief Create a column_view of index values which represents the row values of a given column
+ * without duplicated elements
+ *
+ * Given an `input` column_view, the output column `unique_indices` is generated such that it
+ * copies row indices of the input column at rows without duplicate elements
+ *
+ * @param[in] input              The input column_view
+ * @param[out] unique_indices    Column to store the indices of rows with unique elements
+ * @param[in] nulls_equal        flag to denote nulls are equal if null_equality::EQUAL,
+ *                               nulls are not equal if null_equality::UNEQUAL
+ * @param[in] stream             CUDA stream used for device memory operations and kernel launches
+ *
+ * @return column_view of unique row indices
+ */
+std::unique_ptr<table> get_unique_entries(column_view const& input,
+                                          column_view const& entry_offsets,
+
+                                          null_equality nulls_equal,
+                                          rmm::cuda_stream_view stream,
+                                          rmm::mr::device_memory_resource* mr)
+{
+  // sort only indices
+
+  // extract unique indices
+  auto device_input_table = cudf::table_device_view::create(table_view{{input}}, stream);
+
+  auto unique_indices = cudf::make_numeric_column(
+    data_type{type_id::INT32}, input.size(), mask_state::UNALLOCATED, stream);
+  auto mutable_unique_indices_view = unique_indices->mutable_view();
+
+  auto comp = row_equality_comparator<false>(
+    *device_input_table, *device_input_table, nulls_equal == null_equality::EQUAL);
+
+  auto begin = thrust::make_counting_iterator(0);
+  auto end   = begin + input.size();
+  auto result_end =
+    unique_copy(begin, end, mutable_unique_indices_view.begin<cudf::size_type>(), comp, stream);
+
+  auto indices = cudf::detail::slice(
+    unique_indices->view(),
+    0,
+    thrust::distance(mutable_unique_indices_view.begin<cudf::size_type>(), result_end));
+
+  return cudf::detail::gather(table_view{{input, entry_offsets}},
+                              indices,
+                              cudf::out_of_bounds_policy::DONT_CHECK,
+                              cudf::detail::negative_index_policy::NOT_ALLOWED,
+                              stream,
+                              mr);
+  // return std::move(tbl->release().front());
+}
+
+#endif
+
+/**
+ * @brief Populate offsets for all corresponding indices of the entries
+ *
+ * Given an `offsets` column_view and a number of entries, generate an array of corresponding
+ * offsets for all the entry indices
+ *
+ * @code{.pseudo}
+ * size = 9, offsets = { 0, 4, 6, 10 }
+ * output = { 0, 0, 0, 0, 1, 1, 2, 2, 2, 2 }
+ * @endcode
+ *
+ * @param[in] size        The number of entries to populate offsets
+ * @param[out] offsets    Column view to the offsets
+ * @param[in] stream      CUDA stream used for device memory operations and kernel launches
+ *
+ * @return a device vector of entry offsets
+ */
+std::unique_ptr<column> get_entry_offsets(size_type size,
+                                          column_view const& offsets,
+                                          rmm::cuda_stream_view stream,
+                                          rmm::mr::device_memory_resource* mr)
+{
+  auto entry_offsets = make_numeric_column(
+    data_type(type_to_id<size_type>()), size, mask_state::UNALLOCATED, stream, mr);
+  auto entry_offsets_view = entry_offsets->mutable_view();
+
+  auto offset_begin = offsets.begin<size_type>();
+  auto offsets_minus_one =
+    thrust::make_transform_iterator(offset_begin, [] __device__(auto i) { return i - 1; });
+  auto counting_iter = thrust::make_counting_iterator<size_type>(0);
+  thrust::lower_bound(rmm::exec_policy(stream),
+                      offsets_minus_one,
+                      offsets_minus_one + offsets.size(),
+                      counting_iter,
+                      counting_iter + size,
+                      entry_offsets_view.begin<size_type>());
+  return entry_offsets;
+}
 
 /**
  * @copydoc cudf::lists::drop_list_duplicates
@@ -33,95 +322,158 @@ namespace detail {
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_column,
-                                             duplicate_keep_option keep,
                                              null_equality nulls_equal,
                                              rmm::cuda_stream_view stream,
                                              rmm::mr::device_memory_resource* mr)
 {
+  /*
+   * Given input = { {1, 1, 2, 1, 3}, {4}, {5, 6, 6, 6, 5} }
+   * The output can be { {1, 2, 3}, {4}, {5, 6} }
+   *
+   * 1. Call segmented sort on the lists, obtaining
+   *   sorted_lists = { {1, 1, 1, 2, 3}, {4}, {5, 5, 6, 6, 6} }, and
+   *
+   * 2. Generate ordered indices for the list entries
+   *   indices = { {0, 1, 2, 3, 4}, {5}, {6, 7, 8, 9, 10} }
+   *
+   * 3. Remove list indices if the list entries are duplicated, obtaining
+   *   unique_indices = { {0, 3, 4}, {5}, {6, 8} }
+   *
+   * 4. Gather list entries using the unique_indices as gather map
+   *   (remember to deal with null elements)
+   *
+   * 5. Regenerate list offsets and null mask
+   *
+   *  Corner cases:
+   *   - null entries in a list: depending on the nulls_equal policy, if it is set to EQUAL then
+   * only one null entry is kept.
+   *   - null rows: just return null rows, nothing changes.
+   *   - NaN entries in a list: NaNs should be treated as equal, thus only one NaN value is kept.
+   *   - Nested types are not supported---the function should throw logic_error.
+   */
+
   if (lists_column.is_empty()) return cudf::empty_like(lists_column.parent());
+  if (cudf::is_nested(lists_column.child().type()))
+    CUDF_FAIL("Nested types are not supported in drop_list_duplicates.");
 
-    /*
-     * Given input = { {1, 1, 2, 1, 3}, {4}, {5, 6, 6, 6, 5} }
-     *  - if keep is KEEP_FIRST, the output will be { {1, 2, 3}, {4}, {5, 6} }
-     *  - if keep is KEEP_LAST, the output will be  { {2, 1, 3}, {4}, {6, 5} }
-     *  - if keep is KEEP_NONE, the output will be  { {2, 3}, {4}, {} }
-     *
-     * 1. Generate ordered indices for each list element
-     *   ordered_indices = { {0, 1, 2, 3, 4}, {5}, {6, 7, 8, 9, 10} }
-     *
-     * 2. Call sort_list on the lists and indices using the list entries as keys
-     *   sorted_lists = { {1, 1, 1, 2, 3}, {4}, {5, 5, 6, 6, 6} }, and
-     *   sorted_indices = { {0, 1, 3, 2, 4}, {5}, {6, 10, 7, 8, 9} }
-     *
-     * 3. Remove list indices if the list entries are duplicated
-     *  - with keep is KEEP_FIRST: sorted_unique_indices = { {0, 2, 4}, {5}, {6, 7} }
-     *  - with keep is KEEP_LAST:  sorted_unique_indices = { {3, 2, 4}, {5}, {10, 9} }
-     *  - with keep is KEEP_NONE:  sorted_unique_indices = { {2, 4}, {5}, {} }
-     *
-     * 4. Call sort_lists on the sorted_unique_indices to obtain the final list indices
-     *  - with keep is KEEP_FIRST: sorted_unique_indices = { {0, 2, 4}, {5}, {6, 7} }
-     *  - with keep is KEEP_LAST:  sorted_unique_indices = { {2, 3, 4}, {5}, {9, 10} }
-     *  - with keep is KEEP_NONE:  sorted_unique_indices = { {2, 4}, {5}, {} }
-     *
-     * 5. Gather list entries using the sorted_unique_indices as gather map
-     *   (remember to deal with null elements)
-     *
-     *  Corner cases:
-     *   - null entries in a list: depending on the nulls_equal policy, if it is set to EQUAL then
-     * only one null entry is kept. Which null entry to keep---it is specified by the keep policy.
-     *   - null rows: just return null rows, nothing changes.
-     *   - NaN entries in a list: NaNs should be treated as equal, thus only one NaN value is kept.
-     *  Again, which value to keep depends on the keep policy.
-     *   - Nested types are not supported---the function should throw logic_error.
-     */
+  /*
+   * 1. Call segmented sort on the lists
+   */
+  //  std::unique_ptr<column> sorted_lists;
+  //  if (nulls_equal == null_equality::EQUAL)
+  //    sorted_lists = cudf::lists::sort_lists(lists_column, order::ASCENDING, null_order::AFTER);
+  //  else
+  //    sorted_lists = cudf::lists::sort_lists(lists_column, order::ASCENDING, null_order::BEFORE);
 
-#if 0
-  auto const offsets_column = lists_column.offsets();
+  auto print = [](const cudf::column_view& arr) {
+    thrust::host_vector<int> host_data(arr.size());
+    CUDA_TRY(cudaMemcpy(
+      host_data.data(), arr.data<int>(), arr.size() * sizeof(int), cudaMemcpyDeviceToHost));
+    for (int i = 0; i < arr.size(); ++i) { printf("%d\n", host_data[i]); }
+    printf("\n\n\n");
+  };
 
-  // create a column_view with attributes of the parent and data from the offsets
-  column_view annotated_offsets(data_type{type_id::INT32},
-                                lists_column.size() + 1,
-                                offsets_column.data<int32_t>(),
-                                lists_column.null_mask(),
-                                lists_column.null_count(),
-                                lists_column.offset());
+  // Get the original offsets, which may not start from 0
+  auto segment_offsets = cudf::detail::slice(
+    lists_column.offsets(), {lists_column.offset(), lists_column.offsets().size()}, stream)[0];
+  // Make 0-based offsets so we can create a new column using those offsets
+  auto output_offset = allocate_like(segment_offsets, mask_allocation_policy::RETAIN, mr);
+  thrust::transform(rmm::exec_policy(stream),
+                    segment_offsets.begin<size_type>(),
+                    segment_offsets.end<size_type>(),
+                    output_offset->mutable_view().begin<size_type>(),
+                    [first = segment_offsets.begin<size_type>()] __device__(auto offset_index) {
+                      return offset_index - *first;
+                    });
 
-  // create a gather map for extracting elements from the child column
-  auto gather_map = make_fixed_width_column(
-    data_type{type_id::INT32}, annotated_offsets.size() - 1, mask_state::UNALLOCATED, stream);
-  auto d_gather_map       = gather_map->mutable_view().data<int32_t>();
-  auto const child_column = lists_column.child();
+  // return sorted_lists;
 
-  // build the gather map using the offsets and the provided index
-  auto const d_column = column_device_view::create(annotated_offsets, stream);
-  if (index < 0)
-    thrust::transform(rmm::exec_policy(stream),
-                      thrust::make_counting_iterator<size_type>(0),
-                      thrust::make_counting_iterator<size_type>(gather_map->size()),
-                      d_gather_map,
-                      map_index_fn<false>{*d_column, index, child_column.size()});
-  else
-    thrust::transform(rmm::exec_policy(stream),
-                      thrust::make_counting_iterator<size_type>(0),
-                      thrust::make_counting_iterator<size_type>(gather_map->size()),
-                      d_gather_map,
-                      map_index_fn<true>{*d_column, index, child_column.size()});
+  /*
+   * 2,3. Generate ordered indices for the list entries and remove list indices if the list entries
+   * are duplicated
+   */
+  auto const child         = lists_column.get_sliced_child(stream);
+  auto const entry_offsets = get_entry_offsets(child.size(), output_offset->view(), stream, mr);
 
-  // Gather only the unique entries
-  auto result = cudf::detail::gather(table_view({child_column}),
-                                     d_gather_map,
-                                     d_gather_map + gather_map->size(),
-                                     out_of_bounds_policy::NULLIFY,  // nullify-out-of-bounds
-                                     stream,
-                                     mr)
-                  ->release();
+  //  if (nulls_equal == null_equality::EQUAL)
+  //    sorted_lists = cudf::lists::sort_lists(lists_column, order::ASCENDING, null_order::AFTER);
+  //  else
+  //    sorted_lists = cudf::lists::sort_lists(lists_column, order::ASCENDING, null_order::BEFORE);
 
-  // Set zero size for the null_mask if there is no null element
-  if (result.front()->null_count() == 0)
-    result.front()->set_null_mask(rmm::device_buffer{0, stream, mr}, 0);
+  auto output_child = type_dispatcher(
+    child.type(), SortPairs{}, child, output_offset->view(), null_order::AFTER, stream, mr);
+  //  output_child = type_dispatcher(
+  //    child.type(), MakeUniquePairs{}, child, entry_offsets, null_precedence, stream, mr);
 
-  return std::unique_ptr<column>(std::move(result.front()));
-#endif
+  printf("line %d\n", __LINE__);
+
+  printf("line %d\n", __LINE__);
+
+  auto output_child_and_entry_offsets = get_unique_entries(output_child->view(),
+                                                           entry_offsets->view(),
+
+                                                           nulls_equal,
+                                                           stream,
+                                                           mr)
+                                          ->release();
+
+  printf("line %d\n", __LINE__);
+
+  auto null_mask = cudf::detail::copy_bitmask(lists_column.parent(), stream, mr);
+
+  printf("line %d\n", __LINE__);
+
+  print(output_child->view());
+
+  print(output_offset->view());
+
+  print(output_child_and_entry_offsets.back()->view());
+  /*
+   * 0 4 5 8 10
+   */
+
+  auto unique_entry_offsets = output_child_and_entry_offsets.back()->view().data<size_type>();
+
+  auto counting_iter = thrust::make_counting_iterator<size_type>(0);
+  //  auto result_end    =
+  thrust::copy_if(rmm::exec_policy(stream),
+                  counting_iter,
+                  counting_iter + child.size(),
+                  output_offset->mutable_view().begin<size_type>(),
+                  [size = child.size(), unique_entry_offsets] __device__(size_type i) -> bool {
+                    return i == 0 || i == size ||
+                           unique_entry_offsets[i] != unique_entry_offsets[i - 1];
+                  });
+
+  print(output_offset->view());
+
+  // Assemble list column & return
+  return make_lists_column(lists_column.size(),
+                           std::move(output_offset),
+                           std::move(output_child_and_entry_offsets.front()),
+                           lists_column.null_count(),
+                           std::move(null_mask));
+
+  /*
+   * 4. Gather list entries using the unique_indices as gather map
+   */
+  //  return cudf::detail::gather(lists_data,
+  //                              unique_indices,
+  //                              cudf::out_of_bounds_policy::DONT_CHECK,
+  //                              cudf::detail::negative_index_policy::NOT_ALLOWED,
+  //                              stream,
+  //                              mr);
+
+  /*
+   * 5. Regenerate list offsets and null mask
+   */
+
+  //  cudf::detail::gather_bitmask(cudf::table_view{{child}},
+  //                               mutable_indices_view.begin<size_type>(),
+  //                               output_cols,
+  //                               cudf::detail::gather_bitmask_op::DONT_CHECK,
+  //                               stream,
+  //                               mr);
 
   return empty_like(lists_column.parent());
 }
@@ -132,12 +484,10 @@ std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_colu
  * @copydoc cudf::lists::drop_list_duplicates
  */
 std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_column,
-                                             duplicate_keep_option keep,
                                              null_equality nulls_equal,
                                              rmm::mr::device_memory_resource* mr)
 {
-  return detail::drop_list_duplicates(
-    lists_column, keep, nulls_equal, rmm::cuda_stream_default, mr);
+  return detail::drop_list_duplicates(lists_column, nulls_equal, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -20,7 +20,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
-#include <cudf/lists/detail/sorting.cuh>
+#include <cudf/lists/detail/sorting.hpp>
 #include <cudf/lists/drop_list_duplicates.hpp>
 #include <cudf/table/row_operators.cuh>
 
@@ -241,11 +241,8 @@ std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_colu
   }
 
   // Call segmented sort on the list elements and store them in a temporary column sorted_list
-  auto const sorted_lists = detail::sort_lists(lists_column,
-                                               order::ASCENDING,
-                                               null_order::AFTER,
-                                               stream,
-                                               rmm::mr::get_current_device_resource());
+  auto const sorted_lists =
+    detail::sort_lists(lists_column, order::ASCENDING, null_order::AFTER, stream);
 
   // Flatten all entries (depth = 1) of the lists column
   auto const all_lists_entries = lists_column_view(sorted_lists->view()).get_sliced_child(stream);

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -13,469 +13,268 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cudf/column/column_device_view.cuh>
+
 #include <cudf/column/column_factories.hpp>
-#include <cudf/copying.hpp>
 #include <cudf/detail/copy.hpp>
-#include <cudf/detail/gather.cuh>
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
-#include <cudf/detail/sorting.hpp>
 #include <cudf/lists/drop_list_duplicates.hpp>
+#include <cudf/lists/sorting.hpp>
 #include <cudf/table/row_operators.cuh>
-#include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
-#include <thrust/sequence.h>
 #include <thrust/transform.h>
 
 namespace cudf {
 namespace lists {
 namespace detail {
-struct SortPairs {
-  template <typename KeyT, typename ValueT, typename OffsetIteratorT>
-  void SortPairsAscending(KeyT const* keys_in,
-                          KeyT* keys_out,
-                          ValueT const* values_in,
-                          ValueT* values_out,
-                          int num_items,
-                          int num_segments,
-                          OffsetIteratorT begin_offsets,
-                          OffsetIteratorT end_offsets,
-                          rmm::cuda_stream_view stream)
-  {
-    rmm::device_buffer d_temp_storage;
-    size_t temp_storage_bytes = 0;
-    cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage.data(),
-                                             temp_storage_bytes,
-                                             keys_in,
-                                             keys_out,
-                                             values_in,
-                                             values_out,
-                                             num_items,
-                                             num_segments,
-                                             begin_offsets,
-                                             end_offsets,
-                                             0,
-                                             sizeof(KeyT) * 8,
-                                             stream.value());
-    d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
-
-    cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage.data(),
-                                             temp_storage_bytes,
-                                             keys_in,
-                                             keys_out,
-                                             values_in,
-                                             values_out,
-                                             num_items,
-                                             num_segments,
-                                             begin_offsets,
-                                             end_offsets,
-                                             0,
-                                             sizeof(KeyT) * 8,
-                                             stream.value());
-  }
-
-  template <typename T>
-  std::enable_if_t<not is_numeric<T>(), std::unique_ptr<column>> operator()(
-    column_view const& child,
-    column_view const& segment_offsets,
-    null_order null_precedence,
-    rmm::cuda_stream_view stream,
-    rmm::mr::device_memory_resource* mr)
-  {
-    auto child_table = segmented_sort_by_key(table_view{{child}},
-                                             table_view{{child}},
-                                             segment_offsets,
-                                             {order::ASCENDING},
-                                             {null_precedence},
-                                             stream,
-                                             mr);
-    return std::move(child_table->release().front());
-  }
-
-  template <typename T>
-  std::enable_if_t<is_numeric<T>(), std::unique_ptr<column>> operator()(
-    column_view const& child,
-    column_view const& offsets,
-    null_order null_precedence,
-    rmm::cuda_stream_view stream,
-    rmm::mr::device_memory_resource* mr)
-  {
-    auto output =
-      cudf::detail::allocate_like(child, child.size(), mask_allocation_policy::NEVER, stream, mr);
-    mutable_column_view mutable_output_view = output->mutable_view();
-
-    auto keys = [&]() {
-      if (child.nullable()) {
-        rmm::device_uvector<T> keys(child.size(), stream);
-        auto const null_replace_T = null_precedence == null_order::AFTER
-                                      ? std::numeric_limits<T>::max()
-                                      : std::numeric_limits<T>::min();
-        auto device_child         = column_device_view::create(child, stream);
-        auto keys_in =
-          cudf::detail::make_null_replacement_iterator<T>(*device_child, null_replace_T);
-        thrust::copy_n(rmm::exec_policy(stream), keys_in, child.size(), keys.begin());
-        return keys;
-      }
-      return rmm::device_uvector<T>{0, stream};
-    }();
-
-    std::unique_ptr<column> sorted_indices = cudf::make_numeric_column(
-      data_type(type_to_id<size_type>()), child.size(), mask_state::UNALLOCATED, stream, mr);
-    mutable_column_view mutable_indices_view = sorted_indices->mutable_view();
-    thrust::sequence(rmm::exec_policy(stream),
-                     mutable_indices_view.begin<size_type>(),
-                     mutable_indices_view.end<size_type>(),
-                     0);
-
-    SortPairsAscending(child.nullable() ? keys.data() : child.begin<T>(),
-                       mutable_output_view.begin<T>(),
-                       mutable_indices_view.begin<size_type>(),
-                       mutable_indices_view.begin<size_type>(),
-                       child.size(),
-                       offsets.size() - 1,
-                       offsets.begin<size_type>(),
-                       offsets.begin<size_type>() + 1,
-                       stream);
-
-    std::vector<std::unique_ptr<column>> output_cols;
-    output_cols.push_back(std::move(output));
-    // rearrange the null_mask.
-    cudf::detail::gather_bitmask(cudf::table_view{{child}},
-                                 mutable_indices_view.begin<size_type>(),
-                                 output_cols,
-                                 cudf::detail::gather_bitmask_op::DONT_CHECK,
-                                 stream,
-                                 mr);
-    return std::move(output_cols.front());
-  }
-};
-#if 1
-namespace {
-template <typename InputIterator, typename BinaryPredicate>
-struct unique_copy_fn {
-  /**
-   * @brief Functor for unique_copy()
-   *
-   * The logic here is equivalent to:
-   * @code
-   *   ((keep == duplicate_keep_option::KEEP_LAST) ||
-   *    (i == 0 || !comp(iter[i], iter[i - 1]))) &&
-   *   ((keep == duplicate_keep_option::KEEP_FIRST) ||
-   *    (i == last_index || !comp(iter[i], iter[i + 1])))
-   * @endcode
-   *
-   * It is written this way so that the `comp` comparator
-   * function appears only once minimizing the inlining
-   * required and reducing the compile time.
-   */
-  __device__ bool operator()(size_type i)
-  {
-    size_type boundary = 0;
-    size_type offset   = 1;
-    auto keep_option   = duplicate_keep_option::KEEP_LAST;
-    do {
-      if ((keep_option != duplicate_keep_option::KEEP_FIRST) && (i != boundary) &&
-          comp(iter[i], iter[i - offset])) {
-        return false;
-      }
-      keep_option = duplicate_keep_option::KEEP_FIRST;
-      boundary    = last_index;
-      offset      = -offset;
-    } while (offset < 0);
-    return true;
-  }
-
-  InputIterator iter;
-  BinaryPredicate comp;
-  size_type const last_index;
-};
-}  // anonymous namespace
-
 /**
- * @brief Copies unique elements from the range [first, last) to output iterator `output`.
+ * @brief Copy list entries and entry list offsets ignoring duplicates
  *
- * In a consecutive group of duplicate elements, depending on parameter `keep`,
- * only the first element is copied, or the last element is copied or neither is copied.
+ * Given an array of all entries flattened from a list column and an array that maps each entry to
+ * the offset of the list containing that entry, those entries and list offsets are copied into new
+ * arrays such that the duplicated entries within each list will be ignored.
  *
- * @return End of the range to which the elements are copied.
+ * @param all_lists_entries    The input array containing all list entries
+ * @param entries_list_offsets A map from list entries to their corresponding list offsets
+ * @param nulls_equal          Flag to specify whether null entries should be considered equal
+ * @param stream               CUDA stream used for device memory operations and kernel launches
+ * @param mr                   Device resource used to allocate memory
+ *
+ * @return A pair of columns, the first one contains unique list entries and the second one contains
+ * their corresponding list offsets
  */
-template <typename InputIterator, typename OutputIterator, typename BinaryPredicate>
-OutputIterator unique_copy(InputIterator first,
-                           InputIterator last,
-                           OutputIterator output,
-                           BinaryPredicate comp,
-                           rmm::cuda_stream_view stream)
+template <bool has_nulls>
+std::vector<std::unique_ptr<column>> get_unique_entries_and_list_offsets(
+  column_view const& all_lists_entries,
+  column_view const& entries_list_offsets,
+  null_equality nulls_equal,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr)
 {
-  size_type const last_index = thrust::distance(first, last) - 1;
-  return thrust::copy_if(rmm::exec_policy(stream),
-                         first,
-                         last,
-                         thrust::counting_iterator<size_type>(0),
-                         output,
-                         unique_copy_fn<InputIterator, BinaryPredicate>{first, comp, last_index});
-}
-
-/**
- * @brief Create a column_view of index values which represents the row values of a given column
- * without duplicated elements
- *
- * Given an `input` column_view, the output column `unique_indices` is generated such that it
- * copies row indices of the input column at rows without duplicate elements
- *
- * @param[in] input              The input column_view
- * @param[out] unique_indices    Column to store the indices of rows with unique elements
- * @param[in] nulls_equal        flag to denote nulls are equal if null_equality::EQUAL,
- *                               nulls are not equal if null_equality::UNEQUAL
- * @param[in] stream             CUDA stream used for device memory operations and kernel launches
- *
- * @return column_view of unique row indices
- */
-std::unique_ptr<table> get_unique_entries(column_view const& input,
-                                          column_view const& entry_offsets,
-
-                                          null_equality nulls_equal,
-                                          rmm::cuda_stream_view stream,
-                                          rmm::mr::device_memory_resource* mr)
-{
-  // sort only indices
-
-  // extract unique indices
-  auto device_input_table = cudf::table_device_view::create(table_view{{input}}, stream);
-
-  auto unique_indices = cudf::make_numeric_column(
-    data_type{type_id::INT32}, input.size(), mask_state::UNALLOCATED, stream);
-  auto mutable_unique_indices_view = unique_indices->mutable_view();
-
-  auto comp = row_equality_comparator<false>(
+  /* Create an intermediate table, since the comparator only work on tables */
+  auto const device_input_table =
+    cudf::table_device_view::create(table_view{{all_lists_entries}}, stream);
+  auto const comp = row_equality_comparator<has_nulls>(
     *device_input_table, *device_input_table, nulls_equal == null_equality::EQUAL);
 
-  auto begin = thrust::make_counting_iterator(0);
-  auto end   = begin + input.size();
-  auto result_end =
-    unique_copy(begin, end, mutable_unique_indices_view.begin<cudf::size_type>(), comp, stream);
+  auto const num_entries = all_lists_entries.size();
+  /* Allocate memory to store the indices of the unique entries */
+  auto const unique_indices = cudf::make_numeric_column(
+    entries_list_offsets.type(), num_entries, mask_state::UNALLOCATED, stream);
+  auto const unique_indices_begin = unique_indices->mutable_view().begin<size_type>();
 
-  auto indices = cudf::detail::slice(
-    unique_indices->view(),
-    0,
-    thrust::distance(mutable_unique_indices_view.begin<cudf::size_type>(), result_end));
+  auto const copy_end =
+    thrust::copy_if(rmm::exec_policy(stream),
+                    thrust::make_counting_iterator(0),
+                    thrust::make_counting_iterator(num_entries),
+                    thrust::counting_iterator<size_type>(0),
+                    unique_indices_begin,
+                    [last_index = num_entries - 1, comp] __device__(size_type i) {
+                      return i == last_index || !comp(i, i + 1);
+                    });
+  auto const indices = cudf::detail::slice(
+    unique_indices->view(), 0, thrust::distance(unique_indices_begin, copy_end));
 
-  return cudf::detail::gather(table_view{{input, entry_offsets}},
+  /* Collect unique entries and entry list offsets */
+  return cudf::detail::gather(table_view{{all_lists_entries, entries_list_offsets}},
                               indices,
                               cudf::out_of_bounds_policy::DONT_CHECK,
                               cudf::detail::negative_index_policy::NOT_ALLOWED,
                               stream,
-                              mr);
-  // return std::move(tbl->release().front());
+                              mr)
+    ->release();
 }
-
-#endif
 
 /**
- * @brief Populate offsets for all corresponding indices of the entries
+ * @brief Generate a 0-based offset column for a lists column
  *
- * Given an `offsets` column_view and a number of entries, generate an array of corresponding
- * offsets for all the entry indices
+ * Given a lists_column_view, which may have a non-zero offset, generate a new column containing
+ * 0-based list offsets. This is done by subtracting each of the input list offset by the first
+ * offset.
  *
  * @code{.pseudo}
- * size = 9, offsets = { 0, 4, 6, 10 }
- * output = { 0, 0, 0, 0, 1, 1, 2, 2, 2, 2 }
+ * Given a list column having offsets = { 3, 7, 9, 13 },
+ * then output_offsets = { 0, 4, 6, 10 }
  * @endcode
  *
- * @param[in] size        The number of entries to populate offsets
- * @param[out] offsets    Column view to the offsets
- * @param[in] stream      CUDA stream used for device memory operations and kernel launches
+ * @param lists_column The input lists column
+ * @param stream       CUDA stream used for device memory operations and kernel launches
+ * @param mr           Device resource used to allocate memory
  *
- * @return a device vector of entry offsets
+ * @return A column containing 0-based list offsets
  */
-std::unique_ptr<column> get_entry_offsets(size_type size,
-                                          column_view const& offsets,
-                                          rmm::cuda_stream_view stream,
-                                          rmm::mr::device_memory_resource* mr)
+std::unique_ptr<column> generate_clean_offsets(lists_column_view const& lists_column,
+                                               rmm::cuda_stream_view stream,
+                                               rmm::mr::device_memory_resource* mr)
 {
-  auto entry_offsets = make_numeric_column(
-    data_type(type_to_id<size_type>()), size, mask_state::UNALLOCATED, stream, mr);
-  auto entry_offsets_view = entry_offsets->mutable_view();
-
-  auto offset_begin = offsets.begin<size_type>();
-  auto offsets_minus_one =
-    thrust::make_transform_iterator(offset_begin, [] __device__(auto i) { return i - 1; });
-  auto counting_iter = thrust::make_counting_iterator<size_type>(0);
-  thrust::lower_bound(rmm::exec_policy(stream),
-                      offsets_minus_one,
-                      offsets_minus_one + offsets.size(),
-                      counting_iter,
-                      counting_iter + size,
-                      entry_offsets_view.begin<size_type>());
-  return entry_offsets;
+  auto const list_offsets =
+    cudf::detail::slice(
+      lists_column.offsets(), {lists_column.offset(), lists_column.offsets().size()}, stream)
+      .front();
+  auto output_offsets = allocate_like(list_offsets, mask_allocation_policy::NEVER, mr);
+  thrust::transform(
+    rmm::exec_policy(stream),
+    list_offsets.begin<size_type>(),
+    list_offsets.end<size_type>(),
+    output_offsets->mutable_view().begin<size_type>(),
+    [first = list_offsets.begin<size_type>()] __device__(auto offset) { return offset - *first; });
+  return output_offsets;
 }
 
+/**
+ * @brief Populate list offsets for all list entries
+ *
+ * Given an `offsets` column_view containing offsets of a lists column and a number of all list
+ * entries in the column, generate an array that maps from each list entry to the offset of the list
+ * containing that entry.
+ *
+ * @code{.pseudo}
+ * num_entries = 10, offsets = { 0, 4, 6, 10 }
+ * output = { 1, 1, 1, 1, 2, 2, 3, 3, 3, 3 }
+ * @endcode
+ *
+ * @param num_entries The number of list entries
+ * @param offsets     Column view to the list offsets
+ * @param stream      CUDA stream used for device memory operations and kernel launches
+ * @param mr          Device resource used to allocate memory
+ *
+ * @return A column containing entry list offsets
+ */
+std::unique_ptr<column> generate_entry_list_offsets(size_type num_entries,
+                                                    column_view const& offsets,
+                                                    rmm::cuda_stream_view stream,
+                                                    rmm::mr::device_memory_resource* mr)
+{
+  auto entry_list_offsets =
+    make_numeric_column(offsets.type(), num_entries, mask_state::UNALLOCATED, stream, mr);
+  thrust::upper_bound(rmm::exec_policy(stream),
+                      offsets.begin<size_type>(),
+                      offsets.begin<size_type>() + offsets.size(),
+                      thrust::make_counting_iterator<size_type>(0),
+                      thrust::make_counting_iterator<size_type>(num_entries),
+                      entry_list_offsets->mutable_view().begin<size_type>());
+  return entry_list_offsets;
+}
+
+/**
+ * @brief Generate list offsets from entry offsets
+ *
+ * Generate an array of list offsets for the final result lists column. The list
+ * offsets of the original lists column are also taken into account to make sure the result lists
+ * column will have the same empty list rows (if any) as in the original lists column.
+ *
+ * @param[in] num_entries          The number of unique entries after removing duplicates
+ * @param[in] entries_list_offsets The mapping from list entries to their list offsets
+ * @param[out] original_offsets    The list offsets of the original lists column, which
+ * will also be used to store the new list offsets
+ * @param[in] stream               CUDA stream used for device memory operations and kernel launches
+ * @param[in] mr                   Device resource used to allocate memory
+ */
+void generate_offsets(size_type num_entries,
+                      column_view const& entries_list_offsets,
+                      mutable_column_view const& original_offsets,
+                      rmm::cuda_stream_view stream,
+                      rmm::mr::device_memory_resource* mr)
+{
+  auto const new_offsets = allocate_like(original_offsets, mask_allocation_policy::NEVER, mr);
+  /*
+   * Firstly, generate list offsets for the unique entries, ignoring empty lists (if any)
+   * If entries_list_offsets = {1, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3 }, num_entries = 11,
+   * then output = { 0, 4, 5, 8, 10 }
+   */
+  auto const end_copy = thrust::copy_if(
+    rmm::exec_policy(stream),
+    thrust::make_counting_iterator<size_type>(0),
+    thrust::make_counting_iterator<size_type>(num_entries + 1),
+    new_offsets->mutable_view().begin<size_type>(),
+    [num_entries, offsets_ptr = entries_list_offsets.begin<size_type>()] __device__(size_type i)
+      -> bool { return i == 0 || i == num_entries || offsets_ptr[i] != offsets_ptr[i - 1]; });
+
+  /*
+   * Generate a prefix sum of number of empty lists, storing inplace to the original lists
+   * offsets
+   * If the original list offsets is { 0, 0, 5, 5, 6, 6 } (there are 2 empty lists),
+   * and new_offsets = { 0, 4, 6 },
+   * then output = { 0, 1, 1, 2, 2, 3}
+   */
+  auto const iter_trans_begin = cudf::detail::make_counting_transform_iterator(
+    0, [offsets = original_offsets.begin<size_type>()] __device__(size_type i) -> size_type {
+      return (i > 0 && offsets[i] == offsets[i - 1]) ? 1 : 0;
+    });
+  thrust::inclusive_scan(rmm::exec_policy(stream),
+                         iter_trans_begin,
+                         iter_trans_begin + original_offsets.size(),
+                         original_offsets.begin<size_type>());
+
+  /*
+   * Generate the final list offsets
+   * If the original list offsets are { 0, 0, 5, 5, 6, 6 }, the new offsets are { 0, 4, 6 },
+   *  and the prefix sums of empty lists are { 0, 1, 1, 2, 2, 3 },
+   *  then output = { 0, 0, 4, 4, 5, 5 }
+   */
+  thrust::transform(
+    rmm::exec_policy(stream),
+    thrust::make_counting_iterator<size_type>(0),
+    thrust::make_counting_iterator<size_type>(original_offsets.size()),
+    original_offsets.begin<size_type>(),
+    [prefix_sum_empty_lists = original_offsets.begin<size_type>(),
+     offsets = new_offsets->view().begin<size_type>()] __device__(size_type i) -> size_type {
+      return offsets[i - prefix_sum_empty_lists[i]];
+    });
+}
 /**
  * @copydoc cudf::lists::drop_list_duplicates
  *
- * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param stream CUDA stream used for device memory operations and kernel launches
  */
 std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_column,
                                              null_equality nulls_equal,
                                              rmm::cuda_stream_view stream,
                                              rmm::mr::device_memory_resource* mr)
 {
-  /*
-   * Given input = { {1, 1, 2, 1, 3}, {4}, {5, 6, 6, 6, 5} }
-   * The output can be { {1, 2, 3}, {4}, {5, 6} }
-   *
-   * 1. Call segmented sort on the lists, obtaining
-   *   sorted_lists = { {1, 1, 1, 2, 3}, {4}, {5, 5, 6, 6, 6} }, and
-   *
-   * 2. Generate ordered indices for the list entries
-   *   indices = { {0, 1, 2, 3, 4}, {5}, {6, 7, 8, 9, 10} }
-   *
-   * 3. Remove list indices if the list entries are duplicated, obtaining
-   *   unique_indices = { {0, 3, 4}, {5}, {6, 8} }
-   *
-   * 4. Gather list entries using the unique_indices as gather map
-   *   (remember to deal with null elements)
-   *
-   * 5. Regenerate list offsets and null mask
-   *
-   *  Corner cases:
-   *   - null entries in a list: depending on the nulls_equal policy, if it is set to EQUAL then
-   * only one null entry is kept.
-   *   - null rows: just return null rows, nothing changes.
-   *   - NaN entries in a list: NaNs should be treated as equal, thus only one NaN value is kept.
-   *   - Nested types are not supported---the function should throw logic_error.
-   */
-
   if (lists_column.is_empty()) return cudf::empty_like(lists_column.parent());
   if (cudf::is_nested(lists_column.child().type()))
     CUDF_FAIL("Nested types are not supported in drop_list_duplicates.");
 
-  /*
-   * 1. Call segmented sort on the lists
-   */
-  //  std::unique_ptr<column> sorted_lists;
-  //  if (nulls_equal == null_equality::EQUAL)
-  //    sorted_lists = cudf::lists::sort_lists(lists_column, order::ASCENDING, null_order::AFTER);
-  //  else
-  //    sorted_lists = cudf::lists::sort_lists(lists_column, order::ASCENDING, null_order::BEFORE);
+  /* Call segmented sort on the list elements */
+  auto const sorted_lists = lists::sort_lists(lists_column, order::ASCENDING, null_order::AFTER);
 
-  auto print = [](const cudf::column_view& arr) {
-    thrust::host_vector<int> host_data(arr.size());
-    CUDA_TRY(cudaMemcpy(
-      host_data.data(), arr.data<int>(), arr.size() * sizeof(int), cudaMemcpyDeviceToHost));
-    for (int i = 0; i < arr.size(); ++i) { printf("%d\n", host_data[i]); }
-    printf("\n\n\n");
-  };
+  /* Flatten all entries (depth = 1) of the lists column */
+  auto const all_lists_entries = lists_column_view(sorted_lists->view()).get_sliced_child(stream);
 
-  // Get the original offsets, which may not start from 0
-  auto segment_offsets = cudf::detail::slice(
-    lists_column.offsets(), {lists_column.offset(), lists_column.offsets().size()}, stream)[0];
-  // Make 0-based offsets so we can create a new column using those offsets
-  auto output_offset = allocate_like(segment_offsets, mask_allocation_policy::RETAIN, mr);
-  thrust::transform(rmm::exec_policy(stream),
-                    segment_offsets.begin<size_type>(),
-                    segment_offsets.end<size_type>(),
-                    output_offset->mutable_view().begin<size_type>(),
-                    [first = segment_offsets.begin<size_type>()] __device__(auto offset_index) {
-                      return offset_index - *first;
-                    });
+  /* Generate a 0-based offset column */
+  auto lists_offsets = detail::generate_clean_offsets(lists_column, stream, mr);
 
-  // return sorted_lists;
+  /* Generate a mapping from list entries to offsets of the lists containing those entries */
+  auto const entries_list_offsets = detail::generate_entry_list_offsets(
+    all_lists_entries.size(), lists_offsets->view(), stream, mr);
 
-  /*
-   * 2,3. Generate ordered indices for the list entries and remove list indices if the list entries
-   * are duplicated
-   */
-  auto const child         = lists_column.get_sliced_child(stream);
-  auto const entry_offsets = get_entry_offsets(child.size(), output_offset->view(), stream, mr);
+  /* Copy non-duplicated entries (along with their list offsets) to new arrays */
+  auto unique_entries_and_list_offsets =
+    all_lists_entries.has_nulls()
+      ? detail::get_unique_entries_and_list_offsets<true>(
+          all_lists_entries, entries_list_offsets->view(), nulls_equal, stream, mr)
+      : detail::get_unique_entries_and_list_offsets<false>(
+          all_lists_entries, entries_list_offsets->view(), nulls_equal, stream, mr);
 
-  //  if (nulls_equal == null_equality::EQUAL)
-  //    sorted_lists = cudf::lists::sort_lists(lists_column, order::ASCENDING, null_order::AFTER);
-  //  else
-  //    sorted_lists = cudf::lists::sort_lists(lists_column, order::ASCENDING, null_order::BEFORE);
+  /* Generate offsets for the new lists column */
+  detail::generate_offsets(unique_entries_and_list_offsets.front()->size(),
+                           unique_entries_and_list_offsets.back()->view(),
+                           lists_offsets->mutable_view(),
+                           stream,
+                           mr);
 
-  auto output_child = type_dispatcher(
-    child.type(), SortPairs{}, child, output_offset->view(), null_order::AFTER, stream, mr);
-  //  output_child = type_dispatcher(
-  //    child.type(), MakeUniquePairs{}, child, entry_offsets, null_precedence, stream, mr);
-
-  printf("line %d\n", __LINE__);
-
-  printf("line %d\n", __LINE__);
-
-  auto output_child_and_entry_offsets = get_unique_entries(output_child->view(),
-                                                           entry_offsets->view(),
-
-                                                           nulls_equal,
-                                                           stream,
-                                                           mr)
-                                          ->release();
-
-  printf("line %d\n", __LINE__);
-
-  auto null_mask = cudf::detail::copy_bitmask(lists_column.parent(), stream, mr);
-
-  printf("line %d\n", __LINE__);
-
-  print(output_child->view());
-
-  print(output_offset->view());
-
-  print(output_child_and_entry_offsets.back()->view());
-  /*
-   * 0 4 5 8 10
-   */
-
-  auto unique_entry_offsets = output_child_and_entry_offsets.back()->view().data<size_type>();
-
-  auto counting_iter = thrust::make_counting_iterator<size_type>(0);
-  //  auto result_end    =
-  thrust::copy_if(rmm::exec_policy(stream),
-                  counting_iter,
-                  counting_iter + child.size(),
-                  output_offset->mutable_view().begin<size_type>(),
-                  [size = child.size(), unique_entry_offsets] __device__(size_type i) -> bool {
-                    return i == 0 || i == size ||
-                           unique_entry_offsets[i] != unique_entry_offsets[i - 1];
-                  });
-
-  print(output_offset->view());
-
-  // Assemble list column & return
+  /* Construct a new list column without duplicated entries */
   return make_lists_column(lists_column.size(),
-                           std::move(output_offset),
-                           std::move(output_child_and_entry_offsets.front()),
+                           std::move(lists_offsets),
+                           std::move(unique_entries_and_list_offsets.front()),
                            lists_column.null_count(),
-                           std::move(null_mask));
-
-  /*
-   * 4. Gather list entries using the unique_indices as gather map
-   */
-  //  return cudf::detail::gather(lists_data,
-  //                              unique_indices,
-  //                              cudf::out_of_bounds_policy::DONT_CHECK,
-  //                              cudf::detail::negative_index_policy::NOT_ALLOWED,
-  //                              stream,
-  //                              mr);
-
-  /*
-   * 5. Regenerate list offsets and null mask
-   */
-
-  //  cudf::detail::gather_bitmask(cudf::table_view{{child}},
-  //                               mutable_indices_view.begin<size_type>(),
-  //                               output_cols,
-  //                               cudf::detail::gather_bitmask_op::DONT_CHECK,
-  //                               stream,
-  //                               mr);
-
-  return empty_like(lists_column.parent());
+                           cudf::detail::copy_bitmask(lists_column.parent(), stream, mr));
 }
 
 }  // namespace detail

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -20,8 +20,8 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/lists/detail/sorting.cuh>
 #include <cudf/lists/drop_list_duplicates.hpp>
-#include <cudf/lists/sorting.hpp>
 #include <cudf/table/row_operators.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -240,8 +240,12 @@ std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_colu
     CUDF_FAIL("Nested types are not supported in drop_list_duplicates.");
   }
 
-  // Call segmented sort on the list elements
-  auto const sorted_lists = lists::sort_lists(lists_column, order::ASCENDING, null_order::AFTER);
+  // Call segmented sort on the list elements and store them in a temporary column sorted_list
+  auto const sorted_lists = detail::sort_lists(lists_column,
+                                               order::ASCENDING,
+                                               null_order::AFTER,
+                                               stream,
+                                               rmm::mr::get_current_device_resource());
 
   // Flatten all entries (depth = 1) of the lists column
   auto const all_lists_entries = lists_column_view(sorted_lists->view()).get_sliced_child(stream);

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -267,7 +267,7 @@ std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_colu
                            stream,
                            mr);
 
-  // Construct a new list column without duplicated entries
+  // Construct a new lists column without duplicated entries
   return make_lists_column(lists_column.size(),
                            std::move(lists_offsets),
                            std::move(unique_entries_and_list_offsets.front()),

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/gather.cuh>
+#include <cudf/lists/drop_list_duplicates.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <thrust/transform.h>
+
+namespace cudf {
+namespace lists {
+namespace detail {
+
+/**
+ * @copydoc cudf::lists::drop_list_duplicates
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_column,
+                                             duplicate_keep_option keep,
+                                             null_equality nulls_equal,
+                                             rmm::cuda_stream_view stream,
+                                             rmm::mr::device_memory_resource* mr)
+{
+  if (lists_column.is_empty()) return cudf::empty_like(lists_column.parent());
+
+    /*
+     * Given input = { {1, 1, 2, 1, 3}, {4}, {5, 6, 6, 6, 5} }
+     *  - if keep is KEEP_FIRST, the output will be { {1, 2, 3}, {4}, {5, 6} }
+     *  - if keep is KEEP_LAST, the output will be  { {2, 1, 3}, {4}, {6, 5} }
+     *  - if keep is KEEP_NONE, the output will be  { {2, 3}, {4}, {} }
+     *
+     * 1. Generate ordered indices for each list element
+     *   ordered_indices = { {0, 1, 2, 3, 4}, {5}, {6, 7, 8, 9, 10} }
+     *
+     * 2. Call sort_list on the lists and indices using the list entries as keys
+     *   sorted_lists = { {1, 1, 1, 2, 3}, {4}, {5, 5, 6, 6, 6} }, and
+     *   sorted_indices = { {0, 1, 3, 2, 4}, {5}, {6, 10, 7, 8, 9} }
+     *
+     * 3. Remove list indices if the list entries are duplicated
+     *  - with keep is KEEP_FIRST: sorted_unique_indices = { {0, 2, 4}, {5}, {6, 7} }
+     *  - with keep is KEEP_LAST:  sorted_unique_indices = { {3, 2, 4}, {5}, {10, 9} }
+     *  - with keep is KEEP_NONE:  sorted_unique_indices = { {2, 4}, {5}, {} }
+     *
+     * 4. Call sort_lists on the sorted_unique_indices to obtain the final list indices
+     *  - with keep is KEEP_FIRST: sorted_unique_indices = { {0, 2, 4}, {5}, {6, 7} }
+     *  - with keep is KEEP_LAST:  sorted_unique_indices = { {2, 3, 4}, {5}, {9, 10} }
+     *  - with keep is KEEP_NONE:  sorted_unique_indices = { {2, 4}, {5}, {} }
+     *
+     * 5. Gather list entries using the sorted_unique_indices as gather map
+     *   (remember to deal with null elements)
+     *
+     *  Corner cases:
+     *   - null entries in a list: depending on the nulls_equal policy, if it is set to EQUAL then
+     * only one null entry is kept. Which null entry to keep---it is specified by the keep policy.
+     *   - null rows: just return null rows, nothing changes.
+     *   - NaN entries in a list: NaNs should be treated as equal, thus only one NaN value is kept.
+     *  Again, which value to keep depends on the keep policy.
+     *   - Nested types are not supported---the function should throw logic_error.
+     */
+
+#if 0
+  auto const offsets_column = lists_column.offsets();
+
+  // create a column_view with attributes of the parent and data from the offsets
+  column_view annotated_offsets(data_type{type_id::INT32},
+                                lists_column.size() + 1,
+                                offsets_column.data<int32_t>(),
+                                lists_column.null_mask(),
+                                lists_column.null_count(),
+                                lists_column.offset());
+
+  // create a gather map for extracting elements from the child column
+  auto gather_map = make_fixed_width_column(
+    data_type{type_id::INT32}, annotated_offsets.size() - 1, mask_state::UNALLOCATED, stream);
+  auto d_gather_map       = gather_map->mutable_view().data<int32_t>();
+  auto const child_column = lists_column.child();
+
+  // build the gather map using the offsets and the provided index
+  auto const d_column = column_device_view::create(annotated_offsets, stream);
+  if (index < 0)
+    thrust::transform(rmm::exec_policy(stream),
+                      thrust::make_counting_iterator<size_type>(0),
+                      thrust::make_counting_iterator<size_type>(gather_map->size()),
+                      d_gather_map,
+                      map_index_fn<false>{*d_column, index, child_column.size()});
+  else
+    thrust::transform(rmm::exec_policy(stream),
+                      thrust::make_counting_iterator<size_type>(0),
+                      thrust::make_counting_iterator<size_type>(gather_map->size()),
+                      d_gather_map,
+                      map_index_fn<true>{*d_column, index, child_column.size()});
+
+  // Gather only the unique entries
+  auto result = cudf::detail::gather(table_view({child_column}),
+                                     d_gather_map,
+                                     d_gather_map + gather_map->size(),
+                                     out_of_bounds_policy::NULLIFY,  // nullify-out-of-bounds
+                                     stream,
+                                     mr)
+                  ->release();
+
+  // Set zero size for the null_mask if there is no null element
+  if (result.front()->null_count() == 0)
+    result.front()->set_null_mask(rmm::device_buffer{0, stream, mr}, 0);
+
+  return std::unique_ptr<column>(std::move(result.front()));
+#endif
+
+  return empty_like(lists_column.parent());
+}
+
+}  // namespace detail
+
+/**
+ * @copydoc cudf::lists::drop_list_duplicates
+ */
+std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_column,
+                                             duplicate_keep_option keep,
+                                             null_equality nulls_equal,
+                                             rmm::mr::device_memory_resource* mr)
+{
+  return detail::drop_list_duplicates(
+    lists_column, keep, nulls_equal, rmm::cuda_stream_default, mr);
+}
+
+}  // namespace lists
+}  // namespace cudf

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -19,6 +19,7 @@
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/lists/drop_list_duplicates.hpp>
 #include <cudf/lists/sorting.hpp>
 #include <cudf/table/row_operators.cuh>
@@ -284,6 +285,7 @@ std::unique_ptr<column> drop_list_duplicates(lists_column_view const& lists_colu
                                              null_equality nulls_equal,
                                              rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::drop_list_duplicates(lists_column, nulls_equal, rmm::cuda_stream_default, mr);
 }
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -432,6 +432,7 @@ ConfigureTest(AST_TEST ast/transform_tests.cpp)
 ConfigureTest(LISTS_TEST
     lists/contains_tests.cpp
     lists/count_elements_tests.cpp
+    lists/drop_list_duplicates_tests.cpp
     lists/extract_tests.cpp
     lists/sort_lists_tests.cpp)
 

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -14,190 +14,133 @@
  * limitations under the License.
  */
 
-//#include <tests/strings/utilities.h>
 #include <cudf/lists/drop_list_duplicates.hpp>
 
 #include <cudf_test/base_fixture.hpp>
-#include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
-#include <cudf_test/table_utilities.hpp>
 
-//#include <thrust/iterator/constant_iterator.h>
-//#include <vector>
+template <bool equal_test, class LCW>
+void test_once(cudf::column_view const& input,
+               LCW const& expected,
+               cudf::null_equality nulls_equal = cudf::null_equality::EQUAL)
+{
+  auto const results =
+    cudf::lists::drop_list_duplicates(cudf::lists_column_view{input}, nulls_equal);
+  if (equal_test)
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
+  else
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected, true);
+}
 
 struct DropListDuplicatesTest : public cudf::test::BaseFixture {
 };
 
-TEST_F(DropListDuplicatesTest, NonNullTable)
+TEST_F(DropListDuplicatesTest, InvalidCasesTests)
 {
-  using LCW = cudf::test::lists_column_wrapper<int32_t, int32_t>;
+  using ILCW = cudf::test::lists_column_wrapper<int32_t>;
+  using FLCW = cudf::test::lists_column_wrapper<float>;
+  using SLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
 
-  LCW l1{{1, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
-
-  auto sliced_list = cudf::slice(l1, {1, 5})[0];
-
-  // Ascending
-
-  LCW expected{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}};
-  auto results = cudf::lists::drop_list_duplicates(cudf::lists_column_view{sliced_list},
-                                                   cudf::null_equality::EQUAL);
-  printf("line %d\n", __LINE__);
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
+  /* Lists of nested types are not supported */
+  EXPECT_THROW(cudf::lists::drop_list_duplicates(cudf::lists_column_view{ILCW{ILCW{{1, 2}, {3}}}}),
+               cudf::logic_error);
+  EXPECT_THROW(cudf::lists::drop_list_duplicates(cudf::lists_column_view{FLCW{FLCW{{1, 2}, {3}}}}),
+               cudf::logic_error);
+  EXPECT_THROW(
+    cudf::lists::drop_list_duplicates(cudf::lists_column_view{SLCW{SLCW{SLCW{"dummy string"}}}}),
+    cudf::logic_error);
 }
 
-TEST_F(DropListDuplicatesTest, NonNullStringTable)
+TEST_F(DropListDuplicatesTest, FloatingPointTestsNonNull)
 {
-  //  using LCW = cudf::test::lists_column_wrapper<std::string, std::string>;
+  using float_type = double;
+  using LCW        = cudf::test::lists_column_wrapper<float_type>;
 
-  using LCW = cudf::test::lists_column_wrapper<int32_t, int32_t>;
-  //  LCW l1{{"hello", "apple"}, "world", "world", "my"};
+  /* Trivial cases */
+  test_once<false>(LCW{{}}, LCW{{}});
+  test_once<false>(LCW{{0, 1, 2, 3, 4, 5}, {}}, LCW{{0, 1, 2, 3, 4, 5}, {}});
 
-  LCW l1{{1, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
+  /* Multiple empty lists */
+  test_once<false>(LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
+                   LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
 
-  auto sliced_list = cudf::slice(l1, {1, 5})[0];
-
-  // Ascending
-
-  LCW expected{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}};
-  auto results = cudf::lists::drop_list_duplicates(cudf::lists_column_view{sliced_list},
-                                                   cudf::null_equality::EQUAL);
-  printf("line %d\n", __LINE__);
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
+  /* Lists contain inf/nan */
+  auto const inf = std::numeric_limits<float_type>::infinity();
+  auto const nan = std::numeric_limits<float_type>::quiet_NaN();
+  test_once<false>(LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, inf, inf, inf}, LCW{0, 1, 2, inf});
+  test_once<false>(LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, nan, nan, nan}, LCW{0, 1, 2, nan});
+  test_once<false>(LCW{nan, nan, nan, 0, 1, 2, 0, 1, 2, 0, 1, 2, inf, inf, inf},
+                   LCW{0, 1, 2, nan, inf});
+  test_once<false>(LCW{nan, inf, nan, inf, nan, inf}, LCW{nan, inf});
 }
 
-#if 0
-TEST_F(DropListDuplicatesTest, NonNullTable)
+TEST_F(DropListDuplicatesTest, IntegerTestsNonNull)
 {
-  cudf::test::fixed_width_column_wrapper<int32_t> col1{{5, 4, 3, 5, 8, 5}};
-  cudf::test::fixed_width_column_wrapper<float> col2{{4, 5, 3, 4, 9, 4}};
-  cudf::test::fixed_width_column_wrapper<int32_t> col1_key{{20, 20, 20, 19, 21, 9}};
-  cudf::test::fixed_width_column_wrapper<int32_t> col2_key{{19, 19, 20, 20, 9, 21}};
+  using LCW = cudf::test::lists_column_wrapper<int32_t>;
 
-  cudf::table_view input{{col1, col2, col1_key, col2_key}};
-  std::vector<cudf::size_type> keys{2, 3};
+  /* Trivial cases */
+  test_once<true>(LCW{{}}, LCW{{}});
+  test_once<true>(LCW{{0, 1, 2, 3, 4, 5}, {}}, LCW{{0, 1, 2, 3, 4, 5}, {}});
 
-  // Keep first of duplicate
-  // The expected table would be sorted in ascending order with respect to keys
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_first{{5, 5, 5, 3, 8}};
-  cudf::test::fixed_width_column_wrapper<float> exp_col2_first{{4, 4, 4, 3, 9}};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_key_first{{9, 19, 20, 20, 21}};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col2_key_first{{21, 20, 19, 20, 9}};
-  cudf::table_view expected_first{
-    {exp_col1_first, exp_col2_first, exp_col1_key_first, exp_col2_key_first}};
+  /* Multiple empty lists */
+  test_once<true>(LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
+                  LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
 
-  auto got_first = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST);
-
-  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_first, got_first->view());
-
-  // keep last of duplicate
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_last{{5, 5, 4, 3, 8}};
-  cudf::test::fixed_width_column_wrapper<float> exp_col2_last{{4, 4, 5, 3, 9}};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_key_last{{9, 19, 20, 20, 21}};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col2_key_last{{21, 20, 19, 20, 9}};
-  cudf::table_view expected_last{
-    {exp_col1_last, exp_col2_last, exp_col1_key_last, exp_col2_key_last}};
-
-  auto got_last = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_LAST);
-
-  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_last, got_last->view());
-
-  // Keep unique
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_unique{{5, 5, 3, 8}};
-  cudf::test::fixed_width_column_wrapper<float> exp_col2_unique{{4, 4, 3, 9}};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_key_unique{{9, 19, 20, 21}};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col2_key_unique{{21, 20, 20, 9}};
-  cudf::table_view expected_unique{
-    {exp_col1_unique, exp_col2_unique, exp_col1_key_unique, exp_col2_key_unique}};
-
-  auto got_unique = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_NONE);
-
-  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_unique, got_unique->view());
+  /* Sliced list column */
+  auto const list0 = LCW{{1, 2, 3, 2, 3, 2, 3, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
+  auto const list1 = cudf::slice(list0, {1, 5})[0];
+  test_once<true>(list0, LCW{{1, 2, 3}, {1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
+  test_once<true>(list1, LCW{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
 }
 
-TEST_F(DropListDuplicatesTest, WithNull)
+TEST_F(DropListDuplicatesTest, IntegerTestsWithNulls)
 {
-  cudf::test::fixed_width_column_wrapper<int32_t> col{{5, 4, 3, 5, 8, 1}, {1, 0, 1, 1, 1, 1}};
-  cudf::test::fixed_width_column_wrapper<int32_t> key{{20, 20, 20, 19, 21, 19}, {1, 0, 0, 1, 1, 1}};
-  cudf::table_view input{{col, key}};
-  std::vector<cudf::size_type> keys{1};
+  using LCW       = cudf::test::lists_column_wrapper<int32_t>;
+  auto const null = std::numeric_limits<int32_t>::max();
 
-  // Keep first of duplicate
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col_first{{4, 5, 5, 8}, {0, 1, 1, 1}};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_key_col_first{{20, 19, 20, 21}, {0, 1, 1, 1}};
-  cudf::table_view expected_first{{exp_col_first, exp_key_col_first}};
-  auto got_first = drop_duplicates(
-    input, keys, cudf::duplicate_keep_option::KEEP_FIRST, cudf::null_equality::EQUAL);
+  /* null lists */
+  test_once<true>(
+    LCW{{{3, 2, 1, 4, 1}, {5}, {}, {}, {10, 8, 9}, {6, 7}},
+        cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2 && i != 3; })},
+    LCW{
+      {{1, 2, 3, 4}, {5}, {}, {}, {8, 9, 10}, {6, 7}},
+      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2 && i != 3; })});
 
-  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_first, got_first->view());
+  /* null entries are equal */
+  test_once<true>(
+    LCW{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+        cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })},
+    LCW{{1, 3, 5, 7, 9, null}, std::initializer_list<bool>{true, true, true, true, true, false}});
 
-  // Keep last of duplicate
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col_last{{3, 1, 5, 8}, {1, 1, 1, 1}};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_key_col_last{{20, 19, 20, 21}, {0, 1, 1, 1}};
-  cudf::table_view expected_last{{exp_col_last, exp_key_col_last}};
-  auto got_last = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_LAST);
-
-  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_last, got_last->view());
-
-  // Keep unique of duplicate
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col_unique{{5, 8}, {1, 1}};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_key_col_unique{{20, 21}, {1, 1}};
-  cudf::table_view expected_unique{{exp_col_unique, exp_key_col_unique}};
-  auto got_unique = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_NONE);
-
-  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_unique, got_unique->view());
+  /* nulls entries are not equal */
+  test_once<true>(
+    LCW{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+        cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })},
+    LCW{
+      {1, 3, 5, 7, 9, null, null, null, null, null},
+      std::initializer_list<bool>{true, true, true, true, true, false, false, false, false, false}},
+    cudf::null_equality::UNEQUAL);
 }
 
-TEST_F(DropListDuplicatesTest, StringKeyColumn)
+TEST_F(DropListDuplicatesTest, StringTestsNonNull)
 {
-  cudf::test::fixed_width_column_wrapper<int32_t> col{{5, 4, 3, 5, 8, 1}, {1, 0, 1, 1, 1, 1}};
-  cudf::test::strings_column_wrapper key_col{{"all", "new", "all", "new", "the", "strings"},
-                                             {1, 1, 1, 0, 1, 1}};
-  cudf::table_view input{{col, key_col}};
-  std::vector<cudf::size_type> keys{1};
-  cudf::test::fixed_width_column_wrapper<int32_t> exp_col_last{{5, 3, 4, 1, 8}, {1, 1, 0, 1, 1}};
-  cudf::test::strings_column_wrapper exp_key_col_last{{"new", "all", "new", "strings", "the"},
-                                                      {0, 1, 1, 1, 1}};
-  cudf::table_view expected_last{{exp_col_last, exp_key_col_last}};
+  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
 
-  auto got_last = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_LAST);
+  /* Trivial cases */
+  test_once<true>(LCW{{}}, LCW{{}});
+  test_once<true>(LCW{"this", "is", "a", "string"}, LCW{"a", "is", "string", "this"});
 
-  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_last, got_last->view());
+  /* One list column */
+  test_once<true>(LCW{"this", "is", "is", "is", "a", "string", "string"},
+                  LCW{"a", "is", "string", "this"});
+
+  /* Multiple lists column */
+  test_once<true>(LCW{LCW{"this", "is", "a", "no duplicate", "string"},
+                      LCW{"this", "is", "is", "a", "one duplicate", "string"},
+                      LCW{"this", "is", "is", "is", "a", "two duplicates", "string"},
+                      LCW{"this", "is", "is", "is", "is", "a", "three duplicates", "string"}},
+                  LCW{LCW{"a", "is", "no duplicate", "string", "this"},
+                      LCW{"a", "is", "one duplicate", "string", "this"},
+                      LCW{"a", "is", "string", "this", "two duplicates"},
+                      LCW{"a", "is", "string", "this", "three duplicates"}});
 }
-
-TEST_F(DropListDuplicatesTest, EmptyInputTable)
-{
-  cudf::test::fixed_width_column_wrapper<int32_t> col(std::initializer_list<int32_t>{});
-  cudf::table_view input{{col}};
-  std::vector<cudf::size_type> keys{1, 2};
-
-  auto got = drop_duplicates(
-    input, keys, cudf::duplicate_keep_option::KEEP_FIRST, cudf::null_equality::EQUAL);
-
-  CUDF_TEST_EXPECT_TABLES_EQUAL(input, got->view());
-}
-
-TEST_F(DropListDuplicatesTest, NoColumnInputTable)
-{
-  cudf::table_view input{std::vector<cudf::column_view>()};
-  std::vector<cudf::size_type> keys{1, 2};
-
-  auto got = drop_duplicates(
-    input, keys, cudf::duplicate_keep_option::KEEP_FIRST, cudf::null_equality::EQUAL);
-
-  CUDF_TEST_EXPECT_TABLES_EQUAL(input, got->view());
-}
-
-TEST_F(DropListDuplicatesTest, EmptyKeys)
-{
-  cudf::test::fixed_width_column_wrapper<int32_t> col{{5, 4, 3, 5, 8, 1}, {1, 0, 1, 1, 1, 1}};
-  cudf::test::fixed_width_column_wrapper<int32_t> empty_col{};
-  cudf::table_view input{{col}};
-  std::vector<cudf::size_type> keys{};
-
-  auto got = drop_duplicates(
-    input, keys, cudf::duplicate_keep_option::KEEP_FIRST, cudf::null_equality::EQUAL);
-
-  CUDF_TEST_EXPECT_TABLES_EQUAL(cudf::table_view{{empty_col}}, got->view());
-}
-
-#endif

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -20,6 +20,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/table_utilities.hpp>
 
 //#include <thrust/iterator/constant_iterator.h>
 //#include <vector>
@@ -27,6 +28,44 @@
 struct DropListDuplicatesTest : public cudf::test::BaseFixture {
 };
 
+TEST_F(DropListDuplicatesTest, NonNullTable)
+{
+  using LCW = cudf::test::lists_column_wrapper<int32_t, int32_t>;
+
+  LCW l1{{1, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
+
+  auto sliced_list = cudf::slice(l1, {1, 5})[0];
+
+  // Ascending
+
+  LCW expected{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}};
+  auto results = cudf::lists::drop_list_duplicates(cudf::lists_column_view{sliced_list},
+                                                   cudf::null_equality::EQUAL);
+  printf("line %d\n", __LINE__);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
+}
+
+TEST_F(DropListDuplicatesTest, NonNullStringTable)
+{
+  //  using LCW = cudf::test::lists_column_wrapper<std::string, std::string>;
+
+  using LCW = cudf::test::lists_column_wrapper<int32_t, int32_t>;
+  //  LCW l1{{"hello", "apple"}, "world", "world", "my"};
+
+  LCW l1{{1, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
+
+  auto sliced_list = cudf::slice(l1, {1, 5})[0];
+
+  // Ascending
+
+  LCW expected{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}};
+  auto results = cudf::lists::drop_list_duplicates(cudf::lists_column_view{sliced_list},
+                                                   cudf::null_equality::EQUAL);
+  printf("line %d\n", __LINE__);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
+}
+
+#if 0
 TEST_F(DropListDuplicatesTest, NonNullTable)
 {
   cudf::test::fixed_width_column_wrapper<int32_t> col1{{5, 4, 3, 5, 8, 5}};
@@ -86,8 +125,8 @@ TEST_F(DropListDuplicatesTest, WithNull)
   cudf::test::fixed_width_column_wrapper<int32_t> exp_col_first{{4, 5, 5, 8}, {0, 1, 1, 1}};
   cudf::test::fixed_width_column_wrapper<int32_t> exp_key_col_first{{20, 19, 20, 21}, {0, 1, 1, 1}};
   cudf::table_view expected_first{{exp_col_first, exp_key_col_first}};
-  auto got_first =
-    drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST, null_equality::EQUAL);
+  auto got_first = drop_duplicates(
+    input, keys, cudf::duplicate_keep_option::KEEP_FIRST, cudf::null_equality::EQUAL);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected_first, got_first->view());
 
@@ -131,8 +170,8 @@ TEST_F(DropListDuplicatesTest, EmptyInputTable)
   cudf::table_view input{{col}};
   std::vector<cudf::size_type> keys{1, 2};
 
-  auto got =
-    drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST, null_equality::EQUAL);
+  auto got = drop_duplicates(
+    input, keys, cudf::duplicate_keep_option::KEEP_FIRST, cudf::null_equality::EQUAL);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(input, got->view());
 }
@@ -142,8 +181,8 @@ TEST_F(DropListDuplicatesTest, NoColumnInputTable)
   cudf::table_view input{std::vector<cudf::column_view>()};
   std::vector<cudf::size_type> keys{1, 2};
 
-  auto got =
-    drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST, null_equality::EQUAL);
+  auto got = drop_duplicates(
+    input, keys, cudf::duplicate_keep_option::KEEP_FIRST, cudf::null_equality::EQUAL);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(input, got->view());
 }
@@ -155,8 +194,10 @@ TEST_F(DropListDuplicatesTest, EmptyKeys)
   cudf::table_view input{{col}};
   std::vector<cudf::size_type> keys{};
 
-  auto got =
-    drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST, null_equality::EQUAL);
+  auto got = drop_duplicates(
+    input, keys, cudf::duplicate_keep_option::KEEP_FIRST, cudf::null_equality::EQUAL);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(cudf::table_view{{empty_col}}, got->view());
 }
+
+#endif

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -65,14 +65,17 @@ TEST_F(DropListDuplicatesTest, FloatingPointTestsNonNull)
   test_once<false>(FLT_LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
                    FLT_LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
 
-  auto constexpr inf = std::numeric_limits<float_type>::infinity();
-  auto constexpr nan = std::numeric_limits<float_type>::quiet_NaN();
-  /* Lists contain inf/nan */
-  test_once<false>(FLT_LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, inf, inf, inf}, FLT_LCW{0, 1, 2, inf});
-  test_once<false>(FLT_LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, nan, nan, nan}, FLT_LCW{0, 1, 2, nan});
-  test_once<false>(FLT_LCW{nan, nan, nan, 0, 1, 2, 0, 1, 2, 0, 1, 2, inf, inf, inf},
-                   FLT_LCW{0, 1, 2, nan, inf});
-  test_once<false>(FLT_LCW{nan, inf, nan, inf, nan, inf}, FLT_LCW{nan, inf});
+  auto constexpr p_inf = std::numeric_limits<float_type>::infinity();
+  auto constexpr m_inf = -std::numeric_limits<float_type>::infinity();
+  /*
+   * Lists contain inf
+   * We can't test for lists containing nan because the order of nan is
+   * undefined after sorting
+   */
+  test_once<false>(FLT_LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, p_inf, p_inf, p_inf},
+                   FLT_LCW{0, 1, 2, p_inf});
+  test_once<false>(FLT_LCW{p_inf, 0, m_inf, 0, p_inf, 0, m_inf, 0, p_inf, 0, m_inf},
+                   FLT_LCW{m_inf, 0, p_inf});
 }
 
 TEST_F(DropListDuplicatesTest, IntegerTestsNonNull)

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -95,10 +95,16 @@ TEST_F(DropListDuplicatesTest, IntegerTestsNonNull)
 
   // Sliced list column
   auto const list0 = INT_LCW{{1, 2, 3, 2, 3, 2, 3, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
-  auto const list1 = cudf::slice(list0, {1, 5})[0];
-  // TODO: add a test for cudf::slice(list0, {1, 3})[0] after the issue#7530 is fixed
+  auto const list1 = cudf::slice(list0, {0, 5})[0];
+  auto const list2 = cudf::slice(list0, {1, 5})[0];
+  auto const list3 = cudf::slice(list0, {1, 3})[0];
+  auto const list4 = cudf::slice(list0, {0, 3})[0];
+
   test_once<true>(list0, INT_LCW{{1, 2, 3}, {1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
-  test_once<true>(list1, INT_LCW{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
+  test_once<true>(list1, INT_LCW{{1, 2, 3}, {1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
+  test_once<true>(list2, INT_LCW{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
+  test_once<true>(list3, INT_LCW{{1, 2, 3, 4}, {5}});
+  test_once<true>(list4, INT_LCW{{1, 2, 3}, {1, 2, 3, 4}, {5}});
 }
 
 TEST_F(DropListDuplicatesTest, IntegerTestsWithNulls)

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -51,9 +51,9 @@ TEST_F(DropListDuplicatesTest, InvalidCasesTests)
   EXPECT_THROW(
     cudf::lists::drop_list_duplicates(cudf::lists_column_view{FLT_LCW{FLT_LCW{{1, 2}, {3}}}}),
     cudf::logic_error);
-  EXPECT_THROW(cudf::lists::drop_list_duplicates(
-                 cudf::lists_column_view{STR_LCW{STR_LCW{STR_LCW{"string"}}}}),
-               cudf::logic_error);
+  EXPECT_THROW(
+    cudf::lists::drop_list_duplicates(cudf::lists_column_view{STR_LCW{STR_LCW{STR_LCW{"string"}}}}),
+    cudf::logic_error);
 }
 
 TEST_F(DropListDuplicatesTest, FloatingPointTestsNonNull)

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -52,7 +52,7 @@ TEST_F(DropListDuplicatesTest, InvalidCasesTests)
     cudf::lists::drop_list_duplicates(cudf::lists_column_view{FLT_LCW{FLT_LCW{{1, 2}, {3}}}}),
     cudf::logic_error);
   EXPECT_THROW(cudf::lists::drop_list_duplicates(
-                 cudf::lists_column_view{STR_LCW{STR_LCW{STR_LCW{"dummy string"}}}}),
+                 cudf::lists_column_view{STR_LCW{STR_LCW{STR_LCW{"string"}}}}),
                cudf::logic_error);
 }
 

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -43,7 +43,7 @@ struct DropListDuplicatesTest : public cudf::test::BaseFixture {
 
 TEST_F(DropListDuplicatesTest, InvalidCasesTests)
 {
-  /* Lists of nested types are not supported */
+  // Lists of nested types are not supported
   EXPECT_THROW(
     cudf::lists::drop_list_duplicates(cudf::lists_column_view{INT_LCW{INT_LCW{{1, 2}, {3}}}}),
     cudf::logic_error);
@@ -57,21 +57,20 @@ TEST_F(DropListDuplicatesTest, InvalidCasesTests)
 
 TEST_F(DropListDuplicatesTest, FloatingPointTestsNonNull)
 {
-  /* Trivial cases */
+  // Trivial cases
   test_once<false>(FLT_LCW{{}}, FLT_LCW{{}});
   test_once<false>(FLT_LCW{{0, 1, 2, 3, 4, 5}, {}}, FLT_LCW{{0, 1, 2, 3, 4, 5}, {}});
 
-  /* Multiple empty lists */
+  // Multiple empty lists
   test_once<false>(FLT_LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
                    FLT_LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
 
   auto constexpr p_inf = std::numeric_limits<float_type>::infinity();
   auto constexpr m_inf = -std::numeric_limits<float_type>::infinity();
-  /*
-   * Lists contain inf
-   * We can't test for lists containing nan because the order of nan is
-   * undefined after sorting
-   */
+
+  // Lists contain inf
+  // We can't test for lists containing nan because the order of nan is
+  // undefined after sorting
   test_once<false>(FLT_LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, p_inf, p_inf, p_inf},
                    FLT_LCW{0, 1, 2, p_inf});
   test_once<false>(FLT_LCW{p_inf, 0, m_inf, 0, p_inf, 0, m_inf, 0, p_inf, 0, m_inf},
@@ -80,17 +79,18 @@ TEST_F(DropListDuplicatesTest, FloatingPointTestsNonNull)
 
 TEST_F(DropListDuplicatesTest, IntegerTestsNonNull)
 {
-  /* Trivial cases */
+  // Trivial cases
   test_once<true>(INT_LCW{{}}, INT_LCW{{}});
   test_once<true>(INT_LCW{{0, 1, 2, 3, 4, 5}, {}}, INT_LCW{{0, 1, 2, 3, 4, 5}, {}});
 
-  /* Multiple empty lists */
+  // Multiple empty lists
   test_once<true>(INT_LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
                   INT_LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
 
-  /* Sliced list column */
+  // Sliced list column
   auto const list0 = INT_LCW{{1, 2, 3, 2, 3, 2, 3, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
   auto const list1 = cudf::slice(list0, {1, 5})[0];
+  // TODO: add a test for cudf::slice(list0, {1, 3})[0] after the issue#7530 is fixed
   test_once<true>(list0, INT_LCW{{1, 2, 3}, {1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
   test_once<true>(list1, INT_LCW{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
 }
@@ -99,7 +99,7 @@ TEST_F(DropListDuplicatesTest, IntegerTestsWithNulls)
 {
   auto constexpr null = std::numeric_limits<int_type>::max();
 
-  /* null lists */
+  // null lists
   test_once<true>(INT_LCW{{{3, 2, 1, 4, 1}, {5}, {}, {}, {10, 8, 9}, {6, 7}},
                           cudf::detail::make_counting_transform_iterator(
                             0, [](auto i) { return i != 2 && i != 3; })},
@@ -107,14 +107,14 @@ TEST_F(DropListDuplicatesTest, IntegerTestsWithNulls)
                           cudf::detail::make_counting_transform_iterator(
                             0, [](auto i) { return i != 2 && i != 3; })});
 
-  /* null entries are equal */
+  // null entries are equal
   test_once<true>(
     INT_LCW{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
             cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })},
     INT_LCW{{1, 3, 5, 7, 9, null},
             std::initializer_list<bool>{true, true, true, true, true, false}});
 
-  /* nulls entries are not equal */
+  // nulls entries are not equal
   test_once<true>(
     INT_LCW{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
             cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })},
@@ -126,15 +126,15 @@ TEST_F(DropListDuplicatesTest, IntegerTestsWithNulls)
 
 TEST_F(DropListDuplicatesTest, StringTestsNonNull)
 {
-  /* Trivial cases */
+  // Trivial cases
   test_once<true>(STR_LCW{{}}, STR_LCW{{}});
   test_once<true>(STR_LCW{"this", "is", "a", "string"}, STR_LCW{"a", "is", "string", "this"});
 
-  /* One list column */
+  // One list column
   test_once<true>(STR_LCW{"this", "is", "is", "is", "a", "string", "string"},
                   STR_LCW{"a", "is", "string", "this"});
 
-  /* Multiple lists column */
+  // Multiple lists column
   test_once<true>(
     STR_LCW{STR_LCW{"this", "is", "a", "no duplicate", "string"},
             STR_LCW{"this", "is", "is", "a", "one duplicate", "string"},
@@ -150,7 +150,7 @@ TEST_F(DropListDuplicatesTest, StringTestsWithNulls)
 {
   auto const null = std::string("");
 
-  /* One list column with null entries */
+  // One list column with null entries
   test_once<true>(
     STR_LCW{{"this", null, "is", "is", "is", "a", null, "string", null, "string"},
             cudf::detail::make_counting_transform_iterator(
@@ -158,7 +158,7 @@ TEST_F(DropListDuplicatesTest, StringTestsWithNulls)
     STR_LCW{{"a", "is", "string", "this", null},
             cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 4; })});
 
-  /* Multiple lists column with null lists and null entries */
+  // Multiple lists column with null lists and null entries
   test_once<true>(
     STR_LCW{{STR_LCW{{"this", null, "is", null, "a", null, "no duplicate", null, "string"},
                      cudf::detail::make_counting_transform_iterator(

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -87,7 +87,7 @@ TEST_F(DropListDuplicatesTest, IntegerTestsNonNull)
   test_once<true>(INT_LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
                   INT_LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
 
-  // List containing similar entries
+  // Adjacent lists containing the same entries
   test_once<true>(
     INT_LCW{{1, 1, 1, 1, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 2, 2, 2}, {2, 2, 2, 2, 3, 3, 3, 3}},
     INT_LCW{{1}, {1, 2}, {2, 3}});

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -32,10 +32,11 @@ void test_once(cudf::column_view const& input,
 {
   auto const results =
     cudf::lists::drop_list_duplicates(cudf::lists_column_view{input}, nulls_equal);
-  if (equal_test)
+  if (equal_test) {
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
-  else
+  } else {
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected, true);
+  }
 }
 
 struct DropListDuplicatesTest : public cudf::test::BaseFixture {

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//#include <tests/strings/utilities.h>
+#include <cudf/lists/drop_list_duplicates.hpp>
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+
+//#include <thrust/iterator/constant_iterator.h>
+//#include <vector>
+
+struct DropListDuplicatesTest : public cudf::test::BaseFixture {
+};
+
+TEST_F(DropListDuplicatesTest, NonNullTable)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> col1{{5, 4, 3, 5, 8, 5}};
+  cudf::test::fixed_width_column_wrapper<float> col2{{4, 5, 3, 4, 9, 4}};
+  cudf::test::fixed_width_column_wrapper<int32_t> col1_key{{20, 20, 20, 19, 21, 9}};
+  cudf::test::fixed_width_column_wrapper<int32_t> col2_key{{19, 19, 20, 20, 9, 21}};
+
+  cudf::table_view input{{col1, col2, col1_key, col2_key}};
+  std::vector<cudf::size_type> keys{2, 3};
+
+  // Keep first of duplicate
+  // The expected table would be sorted in ascending order with respect to keys
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_first{{5, 5, 5, 3, 8}};
+  cudf::test::fixed_width_column_wrapper<float> exp_col2_first{{4, 4, 4, 3, 9}};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_key_first{{9, 19, 20, 20, 21}};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col2_key_first{{21, 20, 19, 20, 9}};
+  cudf::table_view expected_first{
+    {exp_col1_first, exp_col2_first, exp_col1_key_first, exp_col2_key_first}};
+
+  auto got_first = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_first, got_first->view());
+
+  // keep last of duplicate
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_last{{5, 5, 4, 3, 8}};
+  cudf::test::fixed_width_column_wrapper<float> exp_col2_last{{4, 4, 5, 3, 9}};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_key_last{{9, 19, 20, 20, 21}};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col2_key_last{{21, 20, 19, 20, 9}};
+  cudf::table_view expected_last{
+    {exp_col1_last, exp_col2_last, exp_col1_key_last, exp_col2_key_last}};
+
+  auto got_last = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_LAST);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_last, got_last->view());
+
+  // Keep unique
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_unique{{5, 5, 3, 8}};
+  cudf::test::fixed_width_column_wrapper<float> exp_col2_unique{{4, 4, 3, 9}};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col1_key_unique{{9, 19, 20, 21}};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col2_key_unique{{21, 20, 20, 9}};
+  cudf::table_view expected_unique{
+    {exp_col1_unique, exp_col2_unique, exp_col1_key_unique, exp_col2_key_unique}};
+
+  auto got_unique = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_NONE);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_unique, got_unique->view());
+}
+
+TEST_F(DropListDuplicatesTest, WithNull)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> col{{5, 4, 3, 5, 8, 1}, {1, 0, 1, 1, 1, 1}};
+  cudf::test::fixed_width_column_wrapper<int32_t> key{{20, 20, 20, 19, 21, 19}, {1, 0, 0, 1, 1, 1}};
+  cudf::table_view input{{col, key}};
+  std::vector<cudf::size_type> keys{1};
+
+  // Keep first of duplicate
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col_first{{4, 5, 5, 8}, {0, 1, 1, 1}};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_key_col_first{{20, 19, 20, 21}, {0, 1, 1, 1}};
+  cudf::table_view expected_first{{exp_col_first, exp_key_col_first}};
+  auto got_first =
+    drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST, null_equality::EQUAL);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_first, got_first->view());
+
+  // Keep last of duplicate
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col_last{{3, 1, 5, 8}, {1, 1, 1, 1}};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_key_col_last{{20, 19, 20, 21}, {0, 1, 1, 1}};
+  cudf::table_view expected_last{{exp_col_last, exp_key_col_last}};
+  auto got_last = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_LAST);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_last, got_last->view());
+
+  // Keep unique of duplicate
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col_unique{{5, 8}, {1, 1}};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_key_col_unique{{20, 21}, {1, 1}};
+  cudf::table_view expected_unique{{exp_col_unique, exp_key_col_unique}};
+  auto got_unique = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_NONE);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_unique, got_unique->view());
+}
+
+TEST_F(DropListDuplicatesTest, StringKeyColumn)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> col{{5, 4, 3, 5, 8, 1}, {1, 0, 1, 1, 1, 1}};
+  cudf::test::strings_column_wrapper key_col{{"all", "new", "all", "new", "the", "strings"},
+                                             {1, 1, 1, 0, 1, 1}};
+  cudf::table_view input{{col, key_col}};
+  std::vector<cudf::size_type> keys{1};
+  cudf::test::fixed_width_column_wrapper<int32_t> exp_col_last{{5, 3, 4, 1, 8}, {1, 1, 0, 1, 1}};
+  cudf::test::strings_column_wrapper exp_key_col_last{{"new", "all", "new", "strings", "the"},
+                                                      {0, 1, 1, 1, 1}};
+  cudf::table_view expected_last{{exp_col_last, exp_key_col_last}};
+
+  auto got_last = drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_LAST);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_last, got_last->view());
+}
+
+TEST_F(DropListDuplicatesTest, EmptyInputTable)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> col(std::initializer_list<int32_t>{});
+  cudf::table_view input{{col}};
+  std::vector<cudf::size_type> keys{1, 2};
+
+  auto got =
+    drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST, null_equality::EQUAL);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(input, got->view());
+}
+
+TEST_F(DropListDuplicatesTest, NoColumnInputTable)
+{
+  cudf::table_view input{std::vector<cudf::column_view>()};
+  std::vector<cudf::size_type> keys{1, 2};
+
+  auto got =
+    drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST, null_equality::EQUAL);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(input, got->view());
+}
+
+TEST_F(DropListDuplicatesTest, EmptyKeys)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> col{{5, 4, 3, 5, 8, 1}, {1, 0, 1, 1, 1, 1}};
+  cudf::test::fixed_width_column_wrapper<int32_t> empty_col{};
+  cudf::table_view input{{col}};
+  std::vector<cudf::size_type> keys{};
+
+  auto got =
+    drop_duplicates(input, keys, cudf::duplicate_keep_option::KEEP_FIRST, null_equality::EQUAL);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(cudf::table_view{{empty_col}}, got->view());
+}

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -87,6 +87,11 @@ TEST_F(DropListDuplicatesTest, IntegerTestsNonNull)
   test_once<true>(INT_LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
                   INT_LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
 
+  // List containing similar entries
+  test_once<true>(
+    INT_LCW{{1, 1, 1, 1, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 2, 2, 2}, {2, 2, 2, 2, 3, 3, 3, 3}},
+    INT_LCW{{1}, {1, 2}, {2, 3}});
+
   // Sliced list column
   auto const list0 = INT_LCW{{1, 2, 3, 2, 3, 2, 3, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
   auto const list1 = cudf::slice(list0, {1, 5})[0];

--- a/cpp/tests/lists/drop_list_duplicates_tests.cpp
+++ b/cpp/tests/lists/drop_list_duplicates_tests.cpp
@@ -19,6 +19,12 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 
+using float_type = float;
+using int_type   = int32_t;
+using INT_LCW    = cudf::test::lists_column_wrapper<int_type>;
+using FLT_LCW    = cudf::test::lists_column_wrapper<float_type>;
+using STR_LCW    = cudf::test::lists_column_wrapper<cudf::string_view>;
+
 template <bool equal_test, class LCW>
 void test_once(cudf::column_view const& input,
                LCW const& expected,
@@ -37,86 +43,79 @@ struct DropListDuplicatesTest : public cudf::test::BaseFixture {
 
 TEST_F(DropListDuplicatesTest, InvalidCasesTests)
 {
-  using ILCW = cudf::test::lists_column_wrapper<int32_t>;
-  using FLCW = cudf::test::lists_column_wrapper<float>;
-  using SLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
-
   /* Lists of nested types are not supported */
-  EXPECT_THROW(cudf::lists::drop_list_duplicates(cudf::lists_column_view{ILCW{ILCW{{1, 2}, {3}}}}),
-               cudf::logic_error);
-  EXPECT_THROW(cudf::lists::drop_list_duplicates(cudf::lists_column_view{FLCW{FLCW{{1, 2}, {3}}}}),
-               cudf::logic_error);
   EXPECT_THROW(
-    cudf::lists::drop_list_duplicates(cudf::lists_column_view{SLCW{SLCW{SLCW{"dummy string"}}}}),
+    cudf::lists::drop_list_duplicates(cudf::lists_column_view{INT_LCW{INT_LCW{{1, 2}, {3}}}}),
     cudf::logic_error);
+  EXPECT_THROW(
+    cudf::lists::drop_list_duplicates(cudf::lists_column_view{FLT_LCW{FLT_LCW{{1, 2}, {3}}}}),
+    cudf::logic_error);
+  EXPECT_THROW(cudf::lists::drop_list_duplicates(
+                 cudf::lists_column_view{STR_LCW{STR_LCW{STR_LCW{"dummy string"}}}}),
+               cudf::logic_error);
 }
 
 TEST_F(DropListDuplicatesTest, FloatingPointTestsNonNull)
 {
-  using float_type = double;
-  using LCW        = cudf::test::lists_column_wrapper<float_type>;
-
   /* Trivial cases */
-  test_once<false>(LCW{{}}, LCW{{}});
-  test_once<false>(LCW{{0, 1, 2, 3, 4, 5}, {}}, LCW{{0, 1, 2, 3, 4, 5}, {}});
+  test_once<false>(FLT_LCW{{}}, FLT_LCW{{}});
+  test_once<false>(FLT_LCW{{0, 1, 2, 3, 4, 5}, {}}, FLT_LCW{{0, 1, 2, 3, 4, 5}, {}});
 
   /* Multiple empty lists */
-  test_once<false>(LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
-                   LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
+  test_once<false>(FLT_LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
+                   FLT_LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
 
+  auto constexpr inf = std::numeric_limits<float_type>::infinity();
+  auto constexpr nan = std::numeric_limits<float_type>::quiet_NaN();
   /* Lists contain inf/nan */
-  auto const inf = std::numeric_limits<float_type>::infinity();
-  auto const nan = std::numeric_limits<float_type>::quiet_NaN();
-  test_once<false>(LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, inf, inf, inf}, LCW{0, 1, 2, inf});
-  test_once<false>(LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, nan, nan, nan}, LCW{0, 1, 2, nan});
-  test_once<false>(LCW{nan, nan, nan, 0, 1, 2, 0, 1, 2, 0, 1, 2, inf, inf, inf},
-                   LCW{0, 1, 2, nan, inf});
-  test_once<false>(LCW{nan, inf, nan, inf, nan, inf}, LCW{nan, inf});
+  test_once<false>(FLT_LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, inf, inf, inf}, FLT_LCW{0, 1, 2, inf});
+  test_once<false>(FLT_LCW{0, 1, 2, 0, 1, 2, 0, 1, 2, nan, nan, nan}, FLT_LCW{0, 1, 2, nan});
+  test_once<false>(FLT_LCW{nan, nan, nan, 0, 1, 2, 0, 1, 2, 0, 1, 2, inf, inf, inf},
+                   FLT_LCW{0, 1, 2, nan, inf});
+  test_once<false>(FLT_LCW{nan, inf, nan, inf, nan, inf}, FLT_LCW{nan, inf});
 }
 
 TEST_F(DropListDuplicatesTest, IntegerTestsNonNull)
 {
-  using LCW = cudf::test::lists_column_wrapper<int32_t>;
-
   /* Trivial cases */
-  test_once<true>(LCW{{}}, LCW{{}});
-  test_once<true>(LCW{{0, 1, 2, 3, 4, 5}, {}}, LCW{{0, 1, 2, 3, 4, 5}, {}});
+  test_once<true>(INT_LCW{{}}, INT_LCW{{}});
+  test_once<true>(INT_LCW{{0, 1, 2, 3, 4, 5}, {}}, INT_LCW{{0, 1, 2, 3, 4, 5}, {}});
 
   /* Multiple empty lists */
-  test_once<true>(LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
-                  LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
+  test_once<true>(INT_LCW{{}, {}, {5, 4, 3, 2, 1, 0}, {}, {6}, {}},
+                  INT_LCW{{}, {}, {0, 1, 2, 3, 4, 5}, {}, {6}, {}});
 
   /* Sliced list column */
-  auto const list0 = LCW{{1, 2, 3, 2, 3, 2, 3, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
+  auto const list0 = INT_LCW{{1, 2, 3, 2, 3, 2, 3, 2, 3}, {3, 2, 1, 4, 1}, {5}, {10, 8, 9}, {6, 7}};
   auto const list1 = cudf::slice(list0, {1, 5})[0];
-  test_once<true>(list0, LCW{{1, 2, 3}, {1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
-  test_once<true>(list1, LCW{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
+  test_once<true>(list0, INT_LCW{{1, 2, 3}, {1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
+  test_once<true>(list1, INT_LCW{{1, 2, 3, 4}, {5}, {8, 9, 10}, {6, 7}});
 }
 
 TEST_F(DropListDuplicatesTest, IntegerTestsWithNulls)
 {
-  using LCW       = cudf::test::lists_column_wrapper<int32_t>;
-  auto const null = std::numeric_limits<int32_t>::max();
+  auto constexpr null = std::numeric_limits<int_type>::max();
 
   /* null lists */
-  test_once<true>(
-    LCW{{{3, 2, 1, 4, 1}, {5}, {}, {}, {10, 8, 9}, {6, 7}},
-        cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2 && i != 3; })},
-    LCW{
-      {{1, 2, 3, 4}, {5}, {}, {}, {8, 9, 10}, {6, 7}},
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2 && i != 3; })});
+  test_once<true>(INT_LCW{{{3, 2, 1, 4, 1}, {5}, {}, {}, {10, 8, 9}, {6, 7}},
+                          cudf::detail::make_counting_transform_iterator(
+                            0, [](auto i) { return i != 2 && i != 3; })},
+                  INT_LCW{{{1, 2, 3, 4}, {5}, {}, {}, {8, 9, 10}, {6, 7}},
+                          cudf::detail::make_counting_transform_iterator(
+                            0, [](auto i) { return i != 2 && i != 3; })});
 
   /* null entries are equal */
   test_once<true>(
-    LCW{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-        cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })},
-    LCW{{1, 3, 5, 7, 9, null}, std::initializer_list<bool>{true, true, true, true, true, false}});
+    INT_LCW{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+            cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })},
+    INT_LCW{{1, 3, 5, 7, 9, null},
+            std::initializer_list<bool>{true, true, true, true, true, false}});
 
   /* nulls entries are not equal */
   test_once<true>(
-    LCW{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-        cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })},
-    LCW{
+    INT_LCW{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+            cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })},
+    INT_LCW{
       {1, 3, 5, 7, 9, null, null, null, null, null},
       std::initializer_list<bool>{true, true, true, true, true, false, false, false, false, false}},
     cudf::null_equality::UNEQUAL);
@@ -124,23 +123,50 @@ TEST_F(DropListDuplicatesTest, IntegerTestsWithNulls)
 
 TEST_F(DropListDuplicatesTest, StringTestsNonNull)
 {
-  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
-
   /* Trivial cases */
-  test_once<true>(LCW{{}}, LCW{{}});
-  test_once<true>(LCW{"this", "is", "a", "string"}, LCW{"a", "is", "string", "this"});
+  test_once<true>(STR_LCW{{}}, STR_LCW{{}});
+  test_once<true>(STR_LCW{"this", "is", "a", "string"}, STR_LCW{"a", "is", "string", "this"});
 
   /* One list column */
-  test_once<true>(LCW{"this", "is", "is", "is", "a", "string", "string"},
-                  LCW{"a", "is", "string", "this"});
+  test_once<true>(STR_LCW{"this", "is", "is", "is", "a", "string", "string"},
+                  STR_LCW{"a", "is", "string", "this"});
 
   /* Multiple lists column */
-  test_once<true>(LCW{LCW{"this", "is", "a", "no duplicate", "string"},
-                      LCW{"this", "is", "is", "a", "one duplicate", "string"},
-                      LCW{"this", "is", "is", "is", "a", "two duplicates", "string"},
-                      LCW{"this", "is", "is", "is", "is", "a", "three duplicates", "string"}},
-                  LCW{LCW{"a", "is", "no duplicate", "string", "this"},
-                      LCW{"a", "is", "one duplicate", "string", "this"},
-                      LCW{"a", "is", "string", "this", "two duplicates"},
-                      LCW{"a", "is", "string", "this", "three duplicates"}});
+  test_once<true>(
+    STR_LCW{STR_LCW{"this", "is", "a", "no duplicate", "string"},
+            STR_LCW{"this", "is", "is", "a", "one duplicate", "string"},
+            STR_LCW{"this", "is", "is", "is", "a", "two duplicates", "string"},
+            STR_LCW{"this", "is", "is", "is", "is", "a", "three duplicates", "string"}},
+    STR_LCW{STR_LCW{"a", "is", "no duplicate", "string", "this"},
+            STR_LCW{"a", "is", "one duplicate", "string", "this"},
+            STR_LCW{"a", "is", "string", "this", "two duplicates"},
+            STR_LCW{"a", "is", "string", "this", "three duplicates"}});
+}
+
+TEST_F(DropListDuplicatesTest, StringTestsWithNulls)
+{
+  auto const null = std::string("");
+
+  /* One list column with null entries */
+  test_once<true>(
+    STR_LCW{{"this", null, "is", "is", "is", "a", null, "string", null, "string"},
+            cudf::detail::make_counting_transform_iterator(
+              0, [](auto i) { return i != 1 && i != 6 && i != 8; })},
+    STR_LCW{{"a", "is", "string", "this", null},
+            cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 4; })});
+
+  /* Multiple lists column with null lists and null entries */
+  test_once<true>(
+    STR_LCW{{STR_LCW{{"this", null, "is", null, "a", null, "no duplicate", null, "string"},
+                     cudf::detail::make_counting_transform_iterator(
+                       0, [](auto i) { return i % 2 == 0; })},
+             STR_LCW{},
+             STR_LCW{"this", "is", "is", "a", "one duplicate", "string"}},
+            cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })},
+    STR_LCW{
+      {STR_LCW{{"a", "is", "no duplicate", "string", "this", null},
+               cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i <= 4; })},
+       STR_LCW{},
+       STR_LCW{"a", "is", "one duplicate", "string", "this"}},
+      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })});
 }


### PR DESCRIPTION
Closes #7494 and partially addresses #7414.

This is the new implementation for `drop_list_duplicates`, which removes duplicated entries from lists column. The result is a new lists column in which each list row contains only unique entries. By current implementation, the output lists will have entries sorted by ascending order (null(s) last).

Example with null_equality=EQUAL:
```
input: { {1, 1, 2, 1, 3}, {4}, NULL, {}, {NULL, NULL, NULL, 5, 6, 6, 6, 5} }
output: { {1, 2, 3}, {4}, NULL, {}, {5, 6, NULL} }

```

Example with null_equality=UNEQUAL:
```
input: { {1, 1, 2, 1, 3}, {4}, NULL, {}, {NULL, NULL, NULL, 5, 6, 6, 6, 5} }
output: { {1, 2, 3}, {4}, NULL, {}, {5, 6, NULL, NULL, NULL} }

```