### PR TITLE
fix missing renames of dask git branches from master to main [skip ci]

### DIFF
--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -75,10 +75,10 @@ conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
 # conda install "your-pkg=1.0.0"
 
 # Install the master version of dask, distributed, and streamz
-logger "pip install git+https://github.com/dask/distributed.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
-logger "pip install git+https://github.com/dask/dask.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/distributed.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/dask.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
 logger "pip install git+https://github.com/python-streamz/streamz.git --upgrade --no-deps"
 pip install "git+https://github.com/python-streamz/streamz.git" --upgrade --no-deps
 

--- a/conda/recipes/dask-cudf/run_test.sh
+++ b/conda/recipes/dask-cudf/run_test.sh
@@ -9,11 +9,11 @@ function logger() {
 }
 
 # Install the latest version of dask and distributed
-logger "pip install git+https://github.com/dask/distributed.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/distributed.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
 
-logger "pip install git+https://github.com/dask/dask.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/dask.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
 
 logger "python -c 'import dask_cudf'"
 python -c "import dask_cudf"


### PR DESCRIPTION
There were a few renames of master --> main that were missed for the recent dask branch rename, fixed them.