### PR TITLE
Fix offset_end iterator for lists_column_view, which was not correctl…

### DIFF
--- a/cpp/include/cudf/lists/lists_column_view.hpp
+++ b/cpp/include/cudf/lists/lists_column_view.hpp
@@ -107,7 +107,7 @@ class lists_column_view : private column_view {
    *
    * @return int32_t const* Pointer to one past the last offset
    */
-  offset_iterator offsets_end() const noexcept { return offsets_begin() + size() + 1; }
+  offset_iterator offsets_end() const noexcept { return offsets_begin() + offsets().size(); }
 };
 /** @} */  // end of group
 }  // namespace cudf

--- a/cpp/include/cudf/lists/lists_column_view.hpp
+++ b/cpp/include/cudf/lists/lists_column_view.hpp
@@ -107,7 +107,7 @@ class lists_column_view : private column_view {
    *
    * @return int32_t const* Pointer to one past the last offset
    */
-  offset_iterator offsets_end() const noexcept { return offsets_begin() + size(); }
+  offset_iterator offsets_end() const noexcept { return offsets_begin() + size() + 1; }
 };
 /** @} */  // end of group
 }  // namespace cudf


### PR DESCRIPTION
Fix the `offset_end` iterator in `lists_column_view`. Since the offset column size is one element larger than the number of column rows, the `offset_end` should be computed as `offset_begin() + size() + 1`. This can also be done by `offset_begin() + offsets().size()`.

This PR blocks https://github.com/rapidsai/cudf/pull/7528, thus it must be merged before that PR.