### PR TITLE
Fix null-bounds calculation for ranged window queries

### DIFF
--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -75,10 +75,10 @@ conda install "rmm=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
 # conda install "your-pkg=1.0.0"
 
 # Install the master version of dask, distributed, and streamz
-logger "pip install git+https://github.com/dask/distributed.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
-logger "pip install git+https://github.com/dask/dask.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/distributed.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/dask.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
 logger "pip install git+https://github.com/python-streamz/streamz.git --upgrade --no-deps"
 pip install "git+https://github.com/python-streamz/streamz.git" --upgrade --no-deps
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -97,11 +97,11 @@ conda config --show-sources
 conda list --show-channel-urls
 
 function install_dask {
-    # Install the master version of dask, distributed, and streamz
-    gpuci_logger "Install the master version of dask, distributed, and streamz"
+    # Install the main version of dask, distributed, and streamz
+    gpuci_logger "Install the main version of dask, distributed, and streamz"
     set -x
-    pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
-    pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
+    pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
+    pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
     pip install "git+https://github.com/python-streamz/streamz.git" --upgrade --no-deps
     set +x
 }
@@ -151,7 +151,7 @@ else
     #Project Flash
     export LIB_BUILD_DIR="$WORKSPACE/ci/artifacts/cudf/cpu/libcudf_work/cpp/build"
     export LD_LIBRARY_PATH="$LIB_BUILD_DIR:$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
-    
+
     if hasArg --skip-tests; then
         gpuci_logger "Skipping Tests"
         exit 0

--- a/conda/environments/cudf_dev_cuda10.1.yml
+++ b/conda/environments/cudf_dev_cuda10.1.yml
@@ -61,7 +61,7 @@ dependencies:
   - protobuf
   - nvtx>=0.2.1
   - pip:
-      - git+https://github.com/dask/dask.git@master
-      - git+https://github.com/dask/distributed.git@master
+      - git+https://github.com/dask/dask.git@main
+      - git+https://github.com/dask/distributed.git@main
       - git+https://github.com/python-streamz/streamz.git
       - pyorc

--- a/conda/environments/cudf_dev_cuda10.2.yml
+++ b/conda/environments/cudf_dev_cuda10.2.yml
@@ -61,7 +61,7 @@ dependencies:
   - protobuf
   - nvtx>=0.2.1
   - pip:
-      - git+https://github.com/dask/dask.git@master
-      - git+https://github.com/dask/distributed.git@master
+      - git+https://github.com/dask/dask.git@main
+      - git+https://github.com/dask/distributed.git@main
       - git+https://github.com/python-streamz/streamz.git
       - pyorc

--- a/conda/environments/cudf_dev_cuda11.0.yml
+++ b/conda/environments/cudf_dev_cuda11.0.yml
@@ -61,7 +61,7 @@ dependencies:
   - protobuf
   - nvtx>=0.2.1
   - pip:
-      - git+https://github.com/dask/dask.git@master
-      - git+https://github.com/dask/distributed.git@master
+      - git+https://github.com/dask/dask.git@main
+      - git+https://github.com/dask/distributed.git@main
       - git+https://github.com/python-streamz/streamz.git
       - pyorc

--- a/conda/recipes/dask-cudf/run_test.sh
+++ b/conda/recipes/dask-cudf/run_test.sh
@@ -9,11 +9,11 @@ function logger() {
 }
 
 # Install the latest version of dask and distributed
-logger "pip install git+https://github.com/dask/distributed.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/distributed.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
 
-logger "pip install git+https://github.com/dask/dask.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/dask.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
 
 logger "python -c 'import dask_cudf'"
 python -c "import dask_cudf"

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -385,7 +385,7 @@ get_null_bounds_for_timestamp_column(column_view const& timestamp_column,
 
   if (timestamp_column.has_nulls()) {
     auto p_timestamps_device_view = column_device_view::create(timestamp_column);
-    auto num_groups               = group_offsets.size();
+    auto num_groups               = group_offsets.size() - 1;
 
     // Null timestamps exist. Find null bounds, per group.
     thrust::for_each(

--- a/python/dask_cudf/dask_cudf/io/orc.py
+++ b/python/dask_cudf/dask_cudf/io/orc.py
@@ -2,11 +2,12 @@
 
 from io import BufferedWriter, IOBase
 
+from fsspec.core import get_fs_token_paths
+from fsspec.utils import stringify_path
 from pyarrow import orc as orc
 
 from dask import dataframe as dd
 from dask.base import tokenize
-from dask.bytes.core import get_fs_token_paths, stringify_path
 from dask.dataframe.io.utils import _get_pyarrow_dtypes
 
 import cudf


### PR DESCRIPTION
This commit fixes an off-by-one error in `grouped_time_range_rolling_window()`, for cases where the order-by column (i.e. the timestamp) contains null values.

The error was reported when running Spark with the `spark-rapids` plugin enabled, manifesting in a process crash:
```
21/03/11 04:26:51 ERROR TaskSetManager: Task 3 in stage 4.0 failed 1 times; aborting job
org.apache.spark.SparkException: Job aborted due to stage failure: Task 3 in stage 4.0 failed 1 times, most recent failure: Los
t task 3.0 in stage 4.0 (TID 5, 10.0.0.23, executor driver): ai.rapids.cudf.CudfException: for_each: failed to synchronize: cud
aErrorLaunchFailure: unspecified launch failure
        at ai.rapids.cudf.Table.timeRangeRollingWindowAggregate(Native Method)
        at ai.rapids.cudf.Table.access$3100(Table.java:45)
        at ai.rapids.cudf.Table$AggregateOperation.aggregateWindowsOverTimeRanges(Table.java:2258)
        at com.nvidia.spark.rapids.GpuWindowExpression.$anonfun$evaluateRangeBasedWindowExpression$2(GpuWindowExpression.scala:
233)
        at com.nvidia.spark.rapids.Arm.withResource(Arm.scala:28)
        at com.nvidia.spark.rapids.Arm.withResource$(Arm.scala:26)
        at com.nvidia.spark.rapids.GpuWindowExpression.withResource(GpuWindowExpression.scala:132)
        at com.nvidia.spark.rapids.GpuWindowExpression.$anonfun$evaluateRangeBasedWindowExpression$1(GpuWindowExpression.scala:
224)
```

It is interesting that a fair number of the 870+ tests from 75 test cases in `grouped_rolling_test.cpp` exercise this code path. `cuda-memcheck` still does not seem to detect the corruption in `CountMultiGroupTimestampASCNullsFirst`, for instance:
```
✗ cuda-memcheck gtests/GROUPED_ROLLING_TEST --gtest_filter=TypedNullTimestampTestForRangeQ eries/0.CountMultiGroupTimestampASCNullsFirst
========= CUDA-MEMCHECK
Note: Google Test filter = TypedNullTimestampTestForRangeQueries/0.CountMultiGroupTimestampASCNullsFirst
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TypedNullTimestampTestForRangeQueries/0, where TypeParam = signed char
[ RUN      ] TypedNullTimestampTestForRangeQueries/0.CountMultiGroupTimestampASCNullsFirst
[       OK ] TypedNullTimestampTestForRangeQueries/0.CountMultiGroupTimestampASCNullsFirst (663 ms)
[----------] 1 test from TypedNullTimestampTestForRangeQueries/0 (663 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (663 ms total)
[  PASSED  ] 1 test.
========= ERROR SUMMARY: 0 errors
```


