### PR TITLE
Always build and export the cudf::cudftestutil target

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -514,6 +514,8 @@ install(TARGETS cudftestutil
         DESTINATION lib
         EXPORT cudf-targets)
 
+add_library(cudf::cudftestutil ALIAS cudftestutil)
+
 ###################################################################################################
 # - add tests -------------------------------------------------------------------------------------
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -118,6 +118,8 @@ include(cmake/Modules/ConfigureCUDA.cmake)
 
 # find zlib
 find_package(ZLIB REQUIRED)
+# find Threads (needed by cudftestutil)
+find_package(Threads REQUIRED)
 # add third party dependencies using CPM
 include(cmake/thirdparty/CUDF_GetCPM.cmake)
 # find boost
@@ -134,6 +136,8 @@ include(cmake/thirdparty/CUDF_GetArrow.cmake)
 include(cmake/thirdparty/CUDF_GetDLPack.cmake)
 # find libcu++
 include(cmake/thirdparty/CUDF_GetLibcudacxx.cmake)
+# find or install GoogleTest
+include(cmake/thirdparty/CUDF_GetGTest.cmake)
 # Stringify libcudf and libcudacxx headers used in JIT operations
 include(cmake/Modules/StringifyJITHeaders.cmake)
 
@@ -480,34 +484,35 @@ add_library(cudf::cudf ALIAS cudf)
 # - tests and benchmarks --------------------------------------------------------------------------
 ###################################################################################################
 
-if (CUDF_BUILD_TESTS OR CUDF_BUILD_BENCHMARKS)
-    # Find or install GoogleTest
-    CPMFindPackage(NAME GTest
-        VERSION         1.10.0
-        GIT_REPOSITORY  https://github.com/google/googletest.git
-        GIT_TAG         release-1.10.0
-        GIT_SHALLOW     TRUE
-        OPTIONS         "INSTALL_GTEST OFF"
-        # googletest >= 1.10.0 provides a cmake config file -- use it if it exists
-        FIND_PACKAGE_ARGUMENTS "CONFIG")
-    # Add GTest aliases if they don't already exist.
-    # Assumes if GTest::gtest doesn't exist, the others don't either.
-    # TODO: Is this always a valid assumption?
-    if(NOT TARGET GTest::gtest)
-        add_library(GTest::gtest ALIAS gtest)
-        add_library(GTest::gmock ALIAS gmock)
-        add_library(GTest::gtest_main ALIAS gtest_main)
-        add_library(GTest::gmock_main ALIAS gmock_main)
-    endif()
-    if(GTest_ADDED)
-        install(TARGETS gmock
-                        gtest
-                        gmock_main
-                        gtest_main
-            DESTINATION lib
-            EXPORT cudf-targets)
-    endif()
-endif()
+###################################################################################################
+# - build cudftestutil ----------------------------------------------------------------------------
+
+add_library(cudftestutil STATIC
+            tests/utilities/base_fixture.cpp
+            tests/utilities/column_utilities.cu
+            tests/utilities/table_utilities.cu
+            tests/strings/utilities.cu)
+
+target_compile_options(cudftestutil
+            PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_FLAGS}>"
+                   "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>"
+)
+
+target_compile_features(cudftestutil PUBLIC cxx_std_14 cuda_std_14)
+
+target_link_libraries(cudftestutil
+               PUBLIC GTest::gmock
+                      GTest::gtest
+                      Threads::Threads
+                      cudf)
+
+target_include_directories(cudftestutil
+    PUBLIC "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}>"
+           "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/src>")
+
+install(TARGETS cudftestutil
+        DESTINATION lib
+        EXPORT cudf-targets)
 
 ###################################################################################################
 # - add tests -------------------------------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -421,7 +421,8 @@ target_include_directories(cudf
                        "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/include>"
                        "$<BUILD_INTERFACE:${CUDF_GENERATED_INCLUDE_DIR}/include>"
            PRIVATE     "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/src>"
-           INTERFACE   "$<INSTALL_INTERFACE:include>")
+           INTERFACE   "$<INSTALL_INTERFACE:include>"
+                       "$<INSTALL_INTERFACE:include/libcudf/libcudaxx>")
 
 # Add Conda library paths if specified
 if(CONDA_LINK_DIRS)

--- a/cpp/cmake/cudf-build-config.cmake.in
+++ b/cpp/cmake/cudf-build-config.cmake.in
@@ -36,6 +36,8 @@ include(@CUDF_SOURCE_DIR@/cmake/thirdparty/CUDF_GetThrust.cmake)
 # find rmm
 set(CUDF_MIN_VERSION_rmm "${CUDF_VERSION_MAJOR}.${CUDF_VERSION_MINOR}")
 include(@CUDF_SOURCE_DIR@/cmake/thirdparty/CUDF_GetRMM.cmake)
+# find gtest
+include(@CUDF_SOURCE_DIR@/cmake/thirdparty/CUDF_GetGTest.cmake)
 
 # find arrow
 if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/cudf-arrow-targets.cmake")

--- a/cpp/cmake/cudf-config.cmake.in
+++ b/cpp/cmake/cudf-config.cmake.in
@@ -24,6 +24,7 @@ find_dependency(rmm @CUDF_MIN_VERSION_rmm@)
 find_dependency(Thrust @CUDF_MIN_VERSION_Thrust@)
 find_dependency(dlpack @CUDF_MIN_VERSION_dlpack@)
 find_dependency(libcudacxx @CUDF_MIN_VERSION_libcudacxx@)
+find_dependency(gtest @CUDF_MIN_VERSION_gtest@)
 
 thrust_create_target(cudf::Thrust FROM_OPTIONS)
 

--- a/cpp/cmake/cudf-config.cmake.in
+++ b/cpp/cmake/cudf-config.cmake.in
@@ -19,14 +19,14 @@ find_dependency(Arrow @CUDF_VERSION_Arrow@)
 find_dependency(ArrowCUDA @CUDF_VERSION_Arrow@)
 find_dependency(Boost @CUDF_MIN_VERSION_Boost@)
 
-find_dependency(jitify)
+# find_dependency(jitify)
 find_dependency(rmm @CUDF_MIN_VERSION_rmm@)
-find_dependency(Thrust @CUDF_MIN_VERSION_Thrust@)
-find_dependency(dlpack @CUDF_MIN_VERSION_dlpack@)
-find_dependency(libcudacxx @CUDF_MIN_VERSION_libcudacxx@)
+# find_dependency(Thrust @CUDF_MIN_VERSION_Thrust@)
+# find_dependency(dlpack @CUDF_MIN_VERSION_dlpack@)
+# find_dependency(libcudacxx @CUDF_MIN_VERSION_libcudacxx@)
 find_dependency(gtest @CUDF_MIN_VERSION_gtest@)
 
-thrust_create_target(cudf::Thrust FROM_OPTIONS)
+# thrust_create_target(cudf::Thrust FROM_OPTIONS)
 
 list(POP_FRONT CMAKE_MODULE_PATH)
 

--- a/cpp/cmake/cudf-config.cmake.in
+++ b/cpp/cmake/cudf-config.cmake.in
@@ -19,14 +19,8 @@ find_dependency(Arrow @CUDF_VERSION_Arrow@)
 find_dependency(ArrowCUDA @CUDF_VERSION_Arrow@)
 find_dependency(Boost @CUDF_MIN_VERSION_Boost@)
 
-# find_dependency(jitify)
 find_dependency(rmm @CUDF_MIN_VERSION_rmm@)
-# find_dependency(Thrust @CUDF_MIN_VERSION_Thrust@)
-# find_dependency(dlpack @CUDF_MIN_VERSION_dlpack@)
-# find_dependency(libcudacxx @CUDF_MIN_VERSION_libcudacxx@)
 find_dependency(gtest @CUDF_MIN_VERSION_gtest@)
-
-# thrust_create_target(cudf::Thrust FROM_OPTIONS)
 
 list(POP_FRONT CMAKE_MODULE_PATH)
 

--- a/cpp/cmake/thirdparty/CUDF_GetCPM.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetCPM.cmake
@@ -17,3 +17,12 @@ if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
 endif()
 
 include(${CPM_DOWNLOAD_LOCATION})
+
+function(fix_cmake_global_defaults target)
+    if(TARGET ${target})
+        get_target_property(_is_imported ${target} IMPORTED)
+        if(_is_imported)
+            set_target_properties(${target} PROPERTIES IMPORTED_GLOBAL TRUE)
+        endif()
+    endif()
+endfunction()

--- a/cpp/cmake/thirdparty/CUDF_GetCPM.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetCPM.cmake
@@ -18,6 +18,8 @@ endif()
 
 include(${CPM_DOWNLOAD_LOCATION})
 
+# If a target is installed, found by the `find_package` step of CPMFindPackage,
+# and marked as IMPORTED, make it globally accessible to consumers of our libs.
 function(fix_cmake_global_defaults target)
     if(TARGET ${target})
         get_target_property(_is_imported ${target} IMPORTED)

--- a/cpp/cmake/thirdparty/CUDF_GetGTest.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetGTest.cmake
@@ -1,0 +1,48 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+function(find_and_configure_gtest VERSION)
+    # Find or install GoogleTest
+    CPMFindPackage(NAME GTest
+        VERSION         ${VERSION}
+        GIT_REPOSITORY  https://github.com/google/googletest.git
+        GIT_TAG         release-${VERSION}
+        GIT_SHALLOW     TRUE
+        OPTIONS         "INSTALL_GTEST OFF"
+        # googletest >= 1.10.0 provides a cmake config file -- use it if it exists
+        FIND_PACKAGE_ARGUMENTS "CONFIG")
+    # Add GTest aliases if they don't already exist.
+    # Assumes if GTest::gtest doesn't exist, the others don't either.
+    # TODO: Is this always a valid assumption?
+    if(NOT TARGET GTest::gtest)
+        add_library(GTest::gtest ALIAS gtest)
+        add_library(GTest::gmock ALIAS gmock)
+        add_library(GTest::gtest_main ALIAS gtest_main)
+        add_library(GTest::gmock_main ALIAS gmock_main)
+    endif()
+    if(GTest_ADDED)
+        install(TARGETS gmock
+                        gtest
+                        gmock_main
+                        gtest_main
+            DESTINATION lib
+            EXPORT cudf-targets)
+    endif()
+endfunction()
+
+set(CUDF_MIN_VERSION_gtest 1.10.0)
+
+find_and_configure_gtest(${CUDF_MIN_VERSION_gtest})

--- a/cpp/cmake/thirdparty/CUDF_GetGTest.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetGTest.cmake
@@ -33,6 +33,11 @@ function(find_and_configure_gtest VERSION)
         add_library(GTest::gtest_main ALIAS gtest_main)
         add_library(GTest::gmock_main ALIAS gmock_main)
     endif()
+    # Make sure consumers of cudf can also see GTest::* targets
+    fix_cmake_global_defaults(GTest::gtest)
+    fix_cmake_global_defaults(GTest::gmock)
+    fix_cmake_global_defaults(GTest::gtest_main)
+    fix_cmake_global_defaults(GTest::gmock_main)
     if(GTest_ADDED)
         install(TARGETS gmock
                         gtest

--- a/cpp/cmake/thirdparty/CUDF_GetRMM.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetRMM.cmake
@@ -43,7 +43,6 @@ function(find_and_configure_rmm VERSION)
         OPTIONS         "BUILD_TESTS OFF"
                         "BUILD_BENCHMARKS OFF"
                         "CUDA_STATIC_RUNTIME ${CUDA_STATIC_RUNTIME}"
-                        "CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES}"
                         "DISABLE_DEPRECATION_WARNING ${DISABLE_DEPRECATION_WARNING}"
     )
     cudf_restore_if_enabled(BUILD_TESTS)

--- a/cpp/cmake/thirdparty/CUDF_GetRMM.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetRMM.cmake
@@ -49,13 +49,9 @@ function(find_and_configure_rmm VERSION)
     cudf_restore_if_enabled(BUILD_TESTS)
     cudf_restore_if_enabled(BUILD_BENCHMARKS)
 
-    #Make sure consumers of cudf can also see rmm::rmm
-    if(TARGET rmm::rmm)
-        get_target_property(rmm_is_imported rmm::rmm IMPORTED)
-        if(rmm_is_imported)
-            set_target_properties(rmm::rmm PROPERTIES IMPORTED_GLOBAL TRUE)
-        endif()
-    endif()
+    # Make sure consumers of cudf can also see rmm::rmm
+    fix_cmake_global_defaults(rmm::rmm)
+
     if(NOT rmm_BINARY_DIR IN_LIST CMAKE_PREFIX_PATH)
         list(APPEND CMAKE_PREFIX_PATH "${rmm_BINARY_DIR}")
         set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} PARENT_SCOPE)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -15,38 +15,6 @@
 #=============================================================================
 
 ###################################################################################################
-# - common test utils -----------------------------------------------------------------------------
-
-find_package(Threads REQUIRED)
-
-add_library(cudftestutil STATIC
-            utilities/base_fixture.cpp
-            utilities/column_utilities.cu
-            utilities/table_utilities.cu
-            strings/utilities.cu)
-
-target_compile_options(cudftestutil
-            PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_FLAGS}>"
-                   "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>"
-)
-
-target_compile_features(cudftestutil PUBLIC cxx_std_14 cuda_std_14)
-
-target_link_libraries(cudftestutil
-               PUBLIC GTest::gmock
-                      GTest::gtest
-                      Threads::Threads
-                      cudf)
-
-target_include_directories(cudftestutil
-    PUBLIC "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}>"
-           "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/src>")
-
-install(TARGETS cudftestutil
-        DESTINATION lib
-        EXPORT cudf-targets)
-
-###################################################################################################
 # - compiler function -----------------------------------------------------------------------------
 
 function(ConfigureTest CMAKE_TEST_NAME )


### PR DESCRIPTION
We should always build the static `cudftestutil` target regardless of whether `BUILD_TESTS=ON` was passed.

Needed by https://github.com/rapidsai/cudf/pull/7484 and https://github.com/rapidsai/cuspatial/pull/365.