### PR TITLE
Another fix for offsets_end() iterator in lists_column_view

### DIFF
--- a/cpp/include/cudf/lists/lists_column_view.hpp
+++ b/cpp/include/cudf/lists/lists_column_view.hpp
@@ -103,11 +103,16 @@ class lists_column_view : private column_view {
   }
 
   /**
-   * @brief Return one past the last offset
+   * @brief Return pointer to the position that is one past the last offset
+   *
+   * This function return the position that is one past the last offset of the lists column.
+   * Since the current lists column may be a sliced column, this offsets_end() iterator should not
+   * be computed using the size of the offsets() child column, which is also the offsets of the
+   * entire original (non-sliced) lists column.
    *
    * @return int32_t const* Pointer to one past the last offset
    */
-  offset_iterator offsets_end() const noexcept { return offsets_begin() + offsets().size(); }
+  offset_iterator offsets_end() const noexcept { return offsets_begin() + size() + 1; }
 };
 /** @} */  // end of group
 }  // namespace cudf


### PR DESCRIPTION
This is another fix for `offsets_end()` iterator in lists_column_view. The last fix (https://github.com/rapidsai/cudf/pull/7551) was still not correct---that iterator should not be computed using the size of the `offsets()` child column, which is also the offsets of the original (non-sliced) column. Instead, it should be computed using the `size()` of the current column.

Interestingly, my previous fix passed all the unit tests, since thrust does not throw anything (like access violation) when the input range is larger than the output range.