### PR TITLE
CMAKE_CUDA_ARCHITECTURES doesn't change when build-system invokes cmake

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -135,7 +135,7 @@ if hasArg clean; then
 fi
 
 if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
-    CUDF_CMAKE_CUDA_ARCHITECTURES="-DCMAKE_CUDA_ARCHITECTURES="
+    CUDF_CMAKE_CUDA_ARCHITECTURES="-DCMAKE_CUDA_ARCHITECTURES=ALL"
     echo "Building for the architecture of the GPU in the system..."
 else
     CUDF_CMAKE_CUDA_ARCHITECTURES=""

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,10 +22,9 @@ cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 # This needs to be run before enabling the CUDA language due to the default initialization behavior
 # of `CMAKE_CUDA_ARCHITECTURES`, https://gitlab.kitware.com/cmake/cmake/-/issues/21302
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES OR CMAKE_CUDA_ARCHITECTURES STREQUAL "ALL")
   set(CUDF_BUILD_FOR_ALL_ARCHS TRUE)
 elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "")
-  unset(CMAKE_CUDA_ARCHITECTURES CACHE)
   set(CUDF_BUILD_FOR_DETECTED_ARCHS TRUE)
 endif()
 

--- a/cpp/cmake/thirdparty/CUDF_GetRMM.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetRMM.cmake
@@ -43,7 +43,6 @@ function(find_and_configure_rmm VERSION)
         OPTIONS         "BUILD_TESTS OFF"
                         "BUILD_BENCHMARKS OFF"
                         "CUDA_STATIC_RUNTIME ${CUDA_STATIC_RUNTIME}"
-                        "CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES}"
                         "DISABLE_DEPRECATION_WARNING ${DISABLE_DEPRECATION_WARNING}"
     )
     cudf_restore_if_enabled(BUILD_TESTS)


### PR DESCRIPTION
Consider the following:
```
cmake -DCMAKE_CUDA_ARCHITECTURES="" . #build for detected
touch <cudf_dir>/cpp/CMakeLists.txt
ninja #should be build for detected

cmake -DCMAKE_CUDA_ARCHITECTURES= . #build for all
touch <cudf_dir>/cpp/CMakeLists.txt
ninja #should be build for all

cmake -DCMAKE_CUDA_ARCHITECTURES="" . #build for detected
touch <cudf_dir>/cpp/CMakeLists.txt
ninja #should be build for detected
```

Before these changes the invocations of `ninja` would always
go back to building for all when ever `ninja` was invoked. The issue
is that once a CMake cache variable exists it can't be removed
via `-DCMAKE_CUDA_ARCHITECTURES=` and therefore becomes sticky.

To resolve the issue you can now pass `-DCMAKE_CUDA_ARCHITECTURES=ALL`
to consistently get all archs, and now the build-system should not
change what CUDA archs you are building for.