### PR TITLE
Update CI scripts to use cupy=8.5.0

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -83,8 +83,8 @@ gpuci_conda_retry install -y \
                   "ucx-py=${MINOR_VERSION}"
 
 # https://docs.rapids.ai/maintainers/depmgmt/
-# gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
-# gpuci_conda_retry install -y "your-pkg=1.0.0"
+gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
+gpuci_conda_retry install -y "cupy=8.5.0"
 
 
 gpuci_logger "Check compiler versions"


### PR DESCRIPTION
This PR attempts to resolve [percentile test failures](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/prb/job/cudf-gpu-test/CUDA=10.1,GPU_LABEL=gpu,OS=ubuntu16.04,PYTHON=3.7/1362/testReport/junit/dask_cudf.tests/test_core/test_dataframe_describe/) by updating CuPy dependency on CI build scripts to version 8.5.0, which includes https://github.com/cupy/cupy/pull/4742 .