### PR TITLE
Fix ORC reader for empty DataFrame/Table

### DIFF
--- a/cpp/src/io/orc/orc.cpp
+++ b/cpp/src/io/orc/orc.cpp
@@ -538,17 +538,19 @@ std::vector<int> metadata::select_columns(std::vector<std::string> use_names,
   if (not use_names.empty()) {
     int index = 0;
     for (const auto &use_name : use_names) {
+      bool name_found = false;
       for (int i = 0; i < get_num_columns(); ++i, ++index) {
         if (index >= get_num_columns()) { index = 0; }
         if (get_column_name(index) == use_name) {
+          name_found = true;
           selection.emplace_back(index);
           if (ff.types[index].kind == orc::TIMESTAMP) { has_timestamp_column = true; }
           index++;
           break;
         }
       }
+      CUDF_EXPECTS(name_found, "Unknown column name : " + std::string(use_name));
     }
-    CUDF_EXPECTS(selection.size() > 0, "Filtered out all columns");
   } else {
     // For now, only select all leaf nodes
     for (int i = 1; i < get_num_columns(); ++i) {

--- a/cpp/src/io/orc/orc.cpp
+++ b/cpp/src/io/orc/orc.cpp
@@ -550,14 +550,14 @@ std::vector<int> metadata::select_columns(std::vector<std::string> use_names,
     }
   } else {
     // For now, only select all leaf nodes
-    for (int i = 0; i < get_num_columns(); ++i) {
+    for (int i = 1; i < get_num_columns(); ++i) {
       if (ff.types[i].subtypes.empty()) {
         selection.emplace_back(i);
         if (ff.types[i].kind == orc::TIMESTAMP) { has_timestamp_column = true; }
       }
     }
   }
-  CUDF_EXPECTS(selection.size() > 0, "Filtered out all columns");
+  CUDF_EXPECTS(use_names.empty() or selection.size() > 0, "Filtered out all columns");
 
   return selection;
 }

--- a/cpp/src/io/orc/orc.cpp
+++ b/cpp/src/io/orc/orc.cpp
@@ -548,6 +548,7 @@ std::vector<int> metadata::select_columns(std::vector<std::string> use_names,
         }
       }
     }
+    CUDF_EXPECTS(selection.size() > 0, "Filtered out all columns");
   } else {
     // For now, only select all leaf nodes
     for (int i = 1; i < get_num_columns(); ++i) {
@@ -557,7 +558,6 @@ std::vector<int> metadata::select_columns(std::vector<std::string> use_names,
       }
     }
   }
-  CUDF_EXPECTS(use_names.empty() or selection.size() > 0, "Filtered out all columns");
 
   return selection;
 }

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -425,6 +425,9 @@ table_with_metadata reader::impl::read(size_type skip_rows,
   std::vector<std::unique_ptr<column>> out_columns;
   table_metadata out_metadata;
 
+  // There are no columns in table
+  if (_selected_columns.size() == 0) return {std::make_unique<table>(), std::move(out_metadata)};
+
   // Select only stripes required (aka row groups)
   const auto selected_stripes = _metadata->select_stripes(stripes, skip_rows, num_rows);
 

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -738,3 +738,19 @@ def test_nanoseconds_overflow():
 
     pyarrow_got = pa.orc.ORCFile(buffer).read()
     assert_eq(expected.to_pandas(), pyarrow_got.to_pandas())
+
+
+def test_empty_dataframe():
+    buffer = BytesIO()
+    expected = cudf.DataFrame()
+    expected.to_orc(buffer)
+
+    # Raise error if column name is mentioned, but it doesn't exist.
+    with pytest.raises(RuntimeError):
+        cudf.read_orc(buffer, columns=["a"])
+
+    got_df = cudf.read_orc(buffer)
+    expected_pdf = pd.read_orc(buffer)
+
+    assert_eq(expected, got_df)
+    assert_eq(expected_pdf, got_df)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
`ff.types` by default will have a [main type as struct](https://github.com/rapidsai/cudf/blob/0146f743987a6f2a51aab08f34771eb4d3531afc/cpp/src/io/orc/writer_impl.cu#L1278) under which all other columns will originate. So, we need to skip first which is not a column and start with 1st index.
(Look for `Type Information` in [ORC Specification](https://orc.apache.org/specification/ORCv1/))
 Along with that, we should also take care of the scenario where user would specify specific column name to retrieve, but it doesn't exist in case of empty data frame/table.

Added test case to validate both scenario. 

closes #7356 