### PR TITLE
Fix Debug build break with device_uvectors in grouped_rolling.cu

### DIFF
--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -128,8 +128,7 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
   //   3. [0, 500, 1000] indicates two equal-sized groups: [0,500), and [500,1000).
 
   assert(group_offsets.size() >= 2 && group_offsets.element(0, stream) == 0 &&
-         group_offsets.element(group_offsets.size() - 1, stream) ==
-           input.size() &&
+         group_offsets.element(group_offsets.size() - 1, stream) == input.size() &&
          "Must have at least one group.");
 
   auto preceding_calculator = [d_group_offsets = group_offsets.data(),

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -127,8 +127,8 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
   //   groups.)
   //   3. [0, 500, 1000] indicates two equal-sized groups: [0,500), and [500,1000).
 
-  assert(group_offsets.size() >= 2 && group_offsets[0] == 0 &&
-         group_offsets[group_offsets.size() - 1] == input.size() &&
+  assert(group_offsets.size() >= 2 && group_offsets.element(0, rmm::cuda_stream_default) == 0 &&
+         group_offsets.element(group_offsets.size() - 1, rmm::cuda_stream_default) == input.size() &&
          "Must have at least one group.");
 
   auto preceding_calculator = [d_group_offsets = group_offsets.data(),

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -128,7 +128,8 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
   //   3. [0, 500, 1000] indicates two equal-sized groups: [0,500), and [500,1000).
 
   assert(group_offsets.size() >= 2 && group_offsets.element(0, rmm::cuda_stream_default) == 0 &&
-         group_offsets.element(group_offsets.size() - 1, rmm::cuda_stream_default) == input.size() &&
+         group_offsets.element(group_offsets.size() - 1, rmm::cuda_stream_default) ==
+           input.size() &&
          "Must have at least one group.");
 
   auto preceding_calculator = [d_group_offsets = group_offsets.data(),

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -110,8 +110,8 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
   using sort_groupby_helper = cudf::groupby::detail::sort::sort_groupby_helper;
 
   sort_groupby_helper helper{group_keys, cudf::null_policy::INCLUDE, cudf::sorted::YES};
-  auto const& group_offsets{helper.group_offsets()};
-  auto const& group_labels{helper.group_labels()};
+  auto const& group_offsets{helper.group_offsets(stream)};
+  auto const& group_labels{helper.group_labels(stream)};
 
   // `group_offsets` are interpreted in adjacent pairs, each pair representing the offsets
   // of the first, and one past the last elements in a group.
@@ -127,8 +127,8 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
   //   groups.)
   //   3. [0, 500, 1000] indicates two equal-sized groups: [0,500), and [500,1000).
 
-  assert(group_offsets.size() >= 2 && group_offsets.element(0, rmm::cuda_stream_default) == 0 &&
-         group_offsets.element(group_offsets.size() - 1, rmm::cuda_stream_default) ==
+  assert(group_offsets.size() >= 2 && group_offsets.element(0, stream) == 0 &&
+         group_offsets.element(group_offsets.size() - 1, stream) ==
            input.size() &&
          "Must have at least one group.");
 


### PR DESCRIPTION
After #7523, on `Debug` builds, one seems to see the following build error:
```
cudf/cpp/src/rolling/grouped_rolling.cu(130): error: no operator "[]" matches these operands
            operand types are: const cudf::groupby::detail::sort::sort_groupby_helper::index_vector [ int ]
...
cudf/cpp/src/rolling/grouped_rolling.cu(130): error: no operator "[]" matches these operands
            operand types are: const cudf::groupby::detail::sort::sort_groupby_helper::index_vector [ unsigned long ] 
```

The offending line has an `assert()` that is only compiled during `Debug` builds. This commit corrects the indexing into `device_uvector`.