### PR TITLE
Add is_integer API that can check for the validity of a string-to-integer conversion

### DIFF
--- a/cpp/include/cudf/strings/convert/convert_integers.hpp
+++ b/cpp/include/cudf/strings/convert/convert_integers.hpp
@@ -78,7 +78,33 @@ std::unique_ptr<column> from_integers(
  * characters are valid for conversion to integers.
  *
  * The output row entry will be set to `true` if the corresponding string element
- * has at least one character in [-+0-9]. The optional sign character must only be in the first
+ * have all characters in [-+0-9]. The optional sign character must only be in the first
+ * position. Notice that the the integer value is not checked to be within its storage limits.
+ * For strict integer type check, use the other `is_integer()` API which accepts `data_type`
+ * argument.
+ *
+ * @code{.pseudo}
+ * Example:
+ * s = ['123456', '-456', '', 'A', '+7']
+ * output1 is [true, true, false, false, true]
+ * @endcode
+ *
+ * Any null row results in a null entry for that row in the output column.
+ *
+ * @param strings  Strings instance for this operation.
+ * @param mr       Device memory resource used to allocate the returned column's device memory.
+ * @return         New column of boolean results for each string.
+ */
+std::unique_ptr<column> is_integer(
+  strings_column_view const& strings,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/**
+ * @brief Returns a boolean column identifying strings in which all
+ * characters are valid for conversion to integers.
+ *
+ * The output row entry will be set to `true` if the corresponding string element
+ * has all characters in [-+0-9]. The optional sign character must only be in the first
  * position. Also, the integer component must fit within the size limits of the underlying
  * storage type, which is provided by the int_type parameter.
  *

--- a/cpp/include/cudf/strings/convert/convert_integers.hpp
+++ b/cpp/include/cudf/strings/convert/convert_integers.hpp
@@ -78,23 +78,31 @@ std::unique_ptr<column> from_integers(
  * characters are valid for conversion to integers.
  *
  * The output row entry will be set to `true` if the corresponding string element
- * has at least one character in [-+0-9].
+ * has at least one character in [-+0-9]. The optional sign character must only be in the first
+ * position. Also, the integer component must fit within the size limits of the underlying
+ * storage type, which is provided by the int_type parameter.
  *
  * @code{.pseudo}
  * Example:
- * s = ['123', '-456', '', 'A', '+7']
- * b = s.is_integer(s)
- * b is [true, true, false, false, true]
+ * s = ['123456', '-456', '', 'A', '+7']
+ *
+ * output1 = s.is_integer(s, data_type{type_id::INT32})
+ * output1 is [true, true, false, false, true]
+ *
+ * output2 = s.is_integer(s, data_type{type_id::INT8})
+ * output2 is [false, false, false, false, true]
  * @endcode
  *
  * Any null row results in a null entry for that row in the output column.
  *
- * @param strings Strings instance for this operation.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return New column of boolean results for each string.
+ * @param strings  Strings instance for this operation.
+ * @param int_type Integer type used for checking overflow.
+ * @param mr       Device memory resource used to allocate the returned column's device memory.
+ * @return         New column of boolean results for each string.
  */
 std::unique_ptr<column> is_integer(
   strings_column_view const& strings,
+  data_type int_type,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/include/cudf/strings/convert/convert_integers.hpp
+++ b/cpp/include/cudf/strings/convert/convert_integers.hpp
@@ -85,8 +85,9 @@ std::unique_ptr<column> from_integers(
  *
  * @code{.pseudo}
  * Example:
- * s = ['123456', '-456', '', 'A', '+7']
- * output1 is [true, true, false, false, true]
+ * s = ['123', '-456', '', 'A', '+7']
+ * b = s.is_integer(s)
+ * b is [true, true, false, false, true]
  * @endcode
  *
  * Any null row results in a null entry for that row in the output column.

--- a/cpp/include/cudf/strings/convert/convert_integers.hpp
+++ b/cpp/include/cudf/strings/convert/convert_integers.hpp
@@ -96,7 +96,7 @@ std::unique_ptr<column> from_integers(
  * Any null row results in a null entry for that row in the output column.
  *
  * @param strings  Strings instance for this operation.
- * @param int_type Integer type used for checking overflow.
+ * @param int_type Integer type used for checking underflow and overflow.
  * @param mr       Device memory resource used to allocate the returned column's device memory.
  * @return         New column of boolean results for each string.
  */

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -103,7 +103,10 @@ struct dispatch_is_integer_fn {
                       thrust::make_counting_iterator<size_type>(input.size()),
                       results->mutable_view().data<bool>(),
                       string_to_integer_check_fn<T>{*d_column});
+
+    // Calling mutable_view() on a column invalidates it's null count so we need to set it back
     results->set_null_count(input.null_count());
+
     return results;
   }
 
@@ -139,7 +142,10 @@ std::unique_ptr<column> is_integer(
                       if (d_column.is_null(idx)) return false;
                       return string::is_integer(d_column.element<string_view>(idx));
                     });
+
+  // Calling mutable_view() on a column invalidates it's null count so we need to set it back
   results->set_null_count(strings.null_count());
+
   return results;
 }
 
@@ -247,7 +253,10 @@ std::unique_ptr<column> to_integers(strings_column_view const& strings,
   auto const strings_dev_view = column_device_view::create(strings.parent(), stream);
   auto results_view           = results->mutable_view();
   type_dispatcher(output_type, dispatch_to_integers_fn{}, *strings_dev_view, results_view, stream);
+
+  // Calling mutable_view() on a column invalidates it's null count so we need to set it back
   results->set_null_count(strings.null_count());
+
   return results;
 }
 

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -158,8 +158,8 @@ std::unique_ptr<column> is_integer(
   return type_dispatcher(int_type, dispatch_is_integer_fn{}, strings, stream, mr);
 }
 
-}  // namespace
 }  // namespace detail
+}  // namespace anonymous
 
 // external APIs
 std::unique_ptr<column> is_integer(strings_column_view const& strings,

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -118,6 +118,8 @@ struct dispatch_is_integer_fn {
   }
 };
 
+}  // namespace
+
 std::unique_ptr<column> is_integer(
   strings_column_view const& strings,
   rmm::cuda_stream_view stream,
@@ -159,7 +161,6 @@ std::unique_ptr<column> is_integer(
 }
 
 }  // namespace detail
-}  // namespace anonymous
 
 // external APIs
 std::unique_ptr<column> is_integer(strings_column_view const& strings,

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -19,7 +19,6 @@
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/integer_utils.hpp>
-#include <cudf/detail/valid_if.cuh>
 #include <cudf/strings/convert/convert_integers.hpp>
 #include <cudf/strings/detail/converters.hpp>
 #include <cudf/strings/detail/utilities.hpp>

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -165,7 +165,7 @@ struct string_to_integer_fn {
 struct dispatch_to_integers_fn {
   template <typename IntegerType, std::enable_if_t<std::is_integral<IntegerType>::value>* = nullptr>
   void operator()(column_device_view const& strings_column,
-                  mutable_column_view const& output_column,
+                  mutable_column_view& output_column,
                   rmm::cuda_stream_view stream) const
   {
     thrust::transform(rmm::exec_policy(stream),
@@ -176,9 +176,7 @@ struct dispatch_to_integers_fn {
   }
   // non-integral types throw an exception
   template <typename T, std::enable_if_t<not std::is_integral<T>::value>* = nullptr>
-  void operator()(column_device_view const&,
-                  mutable_column_view const&,
-                  rmm::cuda_stream_view) const
+  void operator()(column_device_view const&, mutable_column_view&, rmm::cuda_stream_view) const
   {
     CUDF_FAIL("Output for to_integers must be an integral type.");
   }
@@ -186,7 +184,7 @@ struct dispatch_to_integers_fn {
 
 template <>
 void dispatch_to_integers_fn::operator()<bool>(column_device_view const&,
-                                               mutable_column_view const&,
+                                               mutable_column_view&,
                                                rmm::cuda_stream_view) const
 {
   CUDF_FAIL("Output for to_integers must not be a boolean type.");

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -103,7 +103,6 @@ struct dispatch_is_integer_fn {
                       thrust::make_counting_iterator<size_type>(input.size()),
                       results->mutable_view().data<bool>(),
                       string_to_integer_check_fn<T>{*d_column});
-    results->set_null_count(input.null_count());
     return results;
   }
 
@@ -122,7 +121,7 @@ std::unique_ptr<column> is_integer(
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
-  if (strings.is_empty()) return cudf::make_empty_column(data_type{type_id::BOOL8});
+  if (strings.is_empty()) { return cudf::make_empty_column(data_type{type_id::BOOL8}); }
   return type_dispatcher(int_type, dispatch_is_integer_fn{}, strings, stream, mr);
 }
 

--- a/cpp/tests/strings/integers_tests.cu
+++ b/cpp/tests/strings/integers_tests.cu
@@ -202,7 +202,7 @@ TEST_F(StringsConvertTest, ToInteger)
   auto const expected_i16 = cudf::test::fixed_width_column_wrapper<int16_t>(
     std::initializer_list<int16_t>{0, 1234, NULL_VAL, 0, -9832, 93, 765, NULL_VAL, -1, -1, 0, 0},
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_i16, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_i16);
 
   results                 = cudf::strings::to_integers(cudf::strings_column_view(strings),
                                        cudf::data_type{cudf::type_id::INT32});
@@ -210,7 +210,7 @@ TEST_F(StringsConvertTest, ToInteger)
     std::initializer_list<int32_t>{
       0, 1234, NULL_VAL, 0, -9832, 93, 765, NULL_VAL, -1, 2147483647, -2147483648, -2147483648},
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_i32, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_i32);
 
   results                 = cudf::strings::to_integers(cudf::strings_column_view(strings),
                                        cudf::data_type{cudf::type_id::UINT32});
@@ -228,7 +228,7 @@ TEST_F(StringsConvertTest, ToInteger)
                                     2147483648,
                                     2147483648},
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_u32, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_u32);
 }
 
 TEST_F(StringsConvertTest, FromInteger)
@@ -277,7 +277,7 @@ TEST_F(StringsConvertTest, EmptyStringsColumn)
   auto results = cudf::strings::to_integers(cudf::strings_column_view(strings),
                                             cudf::data_type{cudf::type_id::INT64});
   cudf::test::fixed_width_column_wrapper<int64_t> expected{0, 0, 0};
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
 }
 
 template <typename T>

--- a/cpp/tests/strings/integers_tests.cu
+++ b/cpp/tests/strings/integers_tests.cu
@@ -30,29 +30,24 @@
 // This will make the code looks cleaner
 constexpr auto NULL_VAL = 0;
 
-using COLW_BOOL   = cudf::test::fixed_width_column_wrapper<bool>;
-using COLW_Int16  = cudf::test::fixed_width_column_wrapper<int16_t>;
-using COLW_Int32  = cudf::test::fixed_width_column_wrapper<int32_t>;
-using COLW_Int64  = cudf::test::fixed_width_column_wrapper<int64_t>;
-using COLW_UInt32 = cudf::test::fixed_width_column_wrapper<uint32_t>;
-using COLW_STR    = cudf::test::strings_column_wrapper;
-using COLV_STR    = cudf::strings_column_view;
-
 struct StringsConvertTest : public cudf::test::BaseFixture {
 };
 
 TEST_F(StringsConvertTest, IsIntegerNoNull)
 {
-  auto strings = COLW_STR(
+  auto strings = cudf::test::strings_column_wrapper(
     {"+175", "-34", "9.8", "17+2", "+-14", "1234567890", "67de", "", "1e10", "-", "++", ""});
-  auto results =
-    cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::INT32});
-  auto expected = COLW_BOOL({1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0});
+  auto results = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                           cudf::data_type{cudf::type_id::INT32});
+  auto expected =
+    cudf::test::fixed_width_column_wrapper<bool>({1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
-  strings  = COLW_STR({"0", "+0", "-0", "1234567890", "-27341132", "+012", "023", "-045"});
-  results  = cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::INT32});
-  expected = COLW_BOOL({1, 1, 1, 1, 1, 1, 1, 1});
+  strings = cudf::test::strings_column_wrapper(
+    {"0", "+0", "-0", "1234567890", "-27341132", "+012", "023", "-045"});
+  results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                      cudf::data_type{cudf::type_id::INT32});
+  expected = cudf::test::fixed_width_column_wrapper<bool>({1, 1, 1, 1, 1, 1, 1, 1});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 }
 
@@ -61,90 +56,101 @@ TEST_F(StringsConvertTest, IsIntegerWithNulls)
   // Input with null elements: the output should have the same null mask
   std::vector<const char*> const h_strings{
     "eee", "1234", nullptr, "", "-9832", "93.24", "765é", nullptr};
-  auto const strings = COLW_STR(
+  auto const strings = cudf::test::strings_column_wrapper(
     h_strings.begin(),
     h_strings.end(),
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
-  auto const results =
-    cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::INT32});
-  auto const expected =
-    COLW_BOOL(std::initializer_list<int8_t>{0, 1, NULL_VAL, 0, 1, 0, 0, NULL_VAL},
-              std::initializer_list<bool>{true, true, false, true, true, true, true, false});
+  auto const results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                                 cudf::data_type{cudf::type_id::INT32});
+  auto const expected = cudf::test::fixed_width_column_wrapper<bool>(
+    std::initializer_list<int8_t>{0, 1, NULL_VAL, 0, 1, 0, 0, NULL_VAL},
+    std::initializer_list<bool>{true, true, false, true, true, true, true, false});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 }
 
 TEST_F(StringsConvertTest, ZeroSizeIsInteger)
 {
   // Empty input
-  auto strings = COLW_STR{};
-  auto results =
-    cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::INT32});
+  auto strings = cudf::test::strings_column_wrapper{};
+  auto results = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                           cudf::data_type{cudf::type_id::INT32});
   EXPECT_EQ(cudf::type_id::BOOL8, results->view().type().id());
   EXPECT_EQ(0, results->view().size());
 }
 
 TEST_F(StringsConvertTest, IsIntegerBoundCheckSmallNumbers)
 {
-  auto strings = COLW_STR(
+  auto strings = cudf::test::strings_column_wrapper(
     {"-200", "-129", "-128", "-120", "0", "120", "127", "130", "150", "255", "300", "500"});
-  auto results = cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::INT8});
-  auto expected = COLW_BOOL({0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0});
+  auto results = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                           cudf::data_type{cudf::type_id::INT8});
+  auto expected =
+    cudf::test::fixed_width_column_wrapper<bool>({0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
-  results  = cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::UINT8});
-  expected = COLW_BOOL({0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0});
+  results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                      cudf::data_type{cudf::type_id::UINT8});
+  expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
-  strings = COLW_STR(
+  strings = cudf::test::strings_column_wrapper(
     {"-40000", "-32769", "-32768", "-32767", "-32766", "32765", "32766", "32767", "32768"});
-  results  = cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::INT16});
-  expected = COLW_BOOL({0, 0, 1, 1, 1, 1, 1, 1, 0});
+  results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                      cudf::data_type{cudf::type_id::INT16});
+  expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 1, 1, 1, 1, 1, 1, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
-  results  = cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::UINT16});
-  expected = COLW_BOOL({0, 0, 0, 0, 0, 1, 1, 1, 1});
+  results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                      cudf::data_type{cudf::type_id::UINT16});
+  expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 0, 0, 1, 1, 1, 1});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
-  results  = cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::INT32});
-  expected = COLW_BOOL({1, 1, 1, 1, 1, 1, 1, 1, 1});
+  results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                      cudf::data_type{cudf::type_id::INT32});
+  expected = cudf::test::fixed_width_column_wrapper<bool>({1, 1, 1, 1, 1, 1, 1, 1, 1});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 }
 
 TEST_F(StringsConvertTest, IsIntegerBoundCheckLargeNumbers)
 {
-  auto strings = COLW_STR({"-2147483649",   // std::numeric_limits<int32_t>::min() - 1
-                           "-2147483648",   // std::numeric_limits<int32_t>::min()
-                           "-2147483647",   // std::numeric_limits<int32_t>::min() + 1
-                           "2147483646",    // std::numeric_limits<int32_t>::max() - 1
-                           "2147483647",    // std::numeric_limits<int32_t>::max()
-                           "2147483648",    // std::numeric_limits<int32_t>::max() + 1
-                           "4294967294",    // std::numeric_limits<uint32_t>::max() - 1
-                           "4294967295",    // std::numeric_limits<uint32_t>::max()
-                           "4294967296"});  // std::numeric_limits<uint32_t>::max() + 1
-  auto results =
-    cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::INT32});
-  auto expected = COLW_BOOL({0, 1, 1, 1, 1, 0, 0, 0, 0});
+  auto strings =
+    cudf::test::strings_column_wrapper({"-2147483649",   // std::numeric_limits<int32_t>::min() - 1
+                                        "-2147483648",   // std::numeric_limits<int32_t>::min()
+                                        "-2147483647",   // std::numeric_limits<int32_t>::min() + 1
+                                        "2147483646",    // std::numeric_limits<int32_t>::max() - 1
+                                        "2147483647",    // std::numeric_limits<int32_t>::max()
+                                        "2147483648",    // std::numeric_limits<int32_t>::max() + 1
+                                        "4294967294",    // std::numeric_limits<uint32_t>::max() - 1
+                                        "4294967295",    // std::numeric_limits<uint32_t>::max()
+                                        "4294967296"});  // std::numeric_limits<uint32_t>::max() + 1
+  auto results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                           cudf::data_type{cudf::type_id::INT32});
+  auto expected = cudf::test::fixed_width_column_wrapper<bool>({0, 1, 1, 1, 1, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
-  results  = cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::UINT32});
-  expected = COLW_BOOL({0, 0, 0, 1, 1, 1, 1, 1, 0});
+  results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                      cudf::data_type{cudf::type_id::UINT32});
+  expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 1, 1, 1, 1, 1, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
-  strings  = COLW_STR({"-9223372036854775809",    // std::numeric_limits<int64_t>::min() - 1
-                      "-9223372036854775808",    // std::numeric_limits<int64_t>::min()
-                      "-9223372036854775807",    // std::numeric_limits<int64_t>::min() + 1
-                      "9223372036854775806",     // std::numeric_limits<int64_t>::max() - 1
-                      "9223372036854775807",     // std::numeric_limits<int64_t>::max()
-                      "9223372036854775808",     // std::numeric_limits<int64_t>::max() + 1
-                      "18446744073709551614",    // std::numeric_limits<uint64_t>::max() - 1
-                      "18446744073709551615",    // std::numeric_limits<uint64_t>::max()
-                      "18446744073709551616"});  // std::numeric_limits<uint64_t>::max() + 1
-  results  = cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::INT64});
-  expected = COLW_BOOL({0, 1, 1, 1, 1, 0, 0, 0, 0});
+  strings = cudf::test::strings_column_wrapper(
+    {"-9223372036854775809",    // std::numeric_limits<int64_t>::min() - 1
+     "-9223372036854775808",    // std::numeric_limits<int64_t>::min()
+     "-9223372036854775807",    // std::numeric_limits<int64_t>::min() + 1
+     "9223372036854775806",     // std::numeric_limits<int64_t>::max() - 1
+     "9223372036854775807",     // std::numeric_limits<int64_t>::max()
+     "9223372036854775808",     // std::numeric_limits<int64_t>::max() + 1
+     "18446744073709551614",    // std::numeric_limits<uint64_t>::max() - 1
+     "18446744073709551615",    // std::numeric_limits<uint64_t>::max()
+     "18446744073709551616"});  // std::numeric_limits<uint64_t>::max() + 1
+  results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                      cudf::data_type{cudf::type_id::INT64});
+  expected = cudf::test::fixed_width_column_wrapper<bool>({0, 1, 1, 1, 1, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
-  results  = cudf::strings::is_integer(COLV_STR(strings), cudf::data_type{cudf::type_id::UINT64});
-  expected = COLW_BOOL({0, 0, 0, 1, 1, 1, 1, 1, 0});
+  results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
+                                      cudf::data_type{cudf::type_id::UINT64});
+  expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 1, 1, 1, 1, 1, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 }
 
@@ -162,43 +168,45 @@ TEST_F(StringsConvertTest, ToInteger)
                                      "2147483647",
                                      "-2147483648",
                                      "2147483648"};
-  COLW_STR strings(
+  cudf::test::strings_column_wrapper strings(
     h_strings.begin(),
     h_strings.end(),
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
 
-  auto results =
-    cudf::strings::to_integers(COLV_STR(strings), cudf::data_type{cudf::type_id::INT16});
-  auto const expected_i16 = COLW_Int16(
+  auto results            = cudf::strings::to_integers(cudf::strings_column_view(strings),
+                                            cudf::data_type{cudf::type_id::INT16});
+  auto const expected_i16 = cudf::test::fixed_width_column_wrapper<int16_t>(
     std::initializer_list<int16_t>{0, 1234, NULL_VAL, 0, -9832, 93, 765, NULL_VAL, -1, -1, 0, 0},
     std::initializer_list<bool>{
       true, true, false, true, true, true, true, false, true, true, true, true});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_i16, true);
 
-  results = cudf::strings::to_integers(COLV_STR(strings), cudf::data_type{cudf::type_id::INT32});
-  auto const expected_i32 = COLW_Int32(
+  results                 = cudf::strings::to_integers(cudf::strings_column_view(strings),
+                                       cudf::data_type{cudf::type_id::INT32});
+  auto const expected_i32 = cudf::test::fixed_width_column_wrapper<int32_t>(
     std::initializer_list<int32_t>{
       0, 1234, NULL_VAL, 0, -9832, 93, 765, NULL_VAL, -1, 2147483647, -2147483648, -2147483648},
     std::initializer_list<bool>{
       true, true, false, true, true, true, true, false, true, true, true, true});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_i32, true);
 
-  results = cudf::strings::to_integers(COLV_STR(strings), cudf::data_type{cudf::type_id::UINT32});
-  auto const expected_u32 =
-    COLW_UInt32(std::initializer_list<uint32_t>{0,
-                                                1234,
-                                                NULL_VAL,
-                                                0,
-                                                4294957464,
-                                                93,
-                                                765,
-                                                NULL_VAL,
-                                                4294967295,
-                                                2147483647,
-                                                2147483648,
-                                                2147483648},
-                std::initializer_list<bool>{
-                  true, true, false, true, true, true, true, false, true, true, true, true});
+  results                 = cudf::strings::to_integers(cudf::strings_column_view(strings),
+                                       cudf::data_type{cudf::type_id::UINT32});
+  auto const expected_u32 = cudf::test::fixed_width_column_wrapper<uint32_t>(
+    std::initializer_list<uint32_t>{0,
+                                    1234,
+                                    NULL_VAL,
+                                    0,
+                                    4294957464,
+                                    93,
+                                    765,
+                                    NULL_VAL,
+                                    4294967295,
+                                    2147483647,
+                                    2147483648,
+                                    2147483648},
+    std::initializer_list<bool>{
+      true, true, false, true, true, true, true, false, true, true, true, true});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_u32, true);
 }
 
@@ -210,14 +218,14 @@ TEST_F(StringsConvertTest, FromInteger)
   std::vector<const char*> h_expected{
     "100", "987654321", nullptr, "0", "-12761", "0", "5", "-4", "2147483647", "-2147483648"};
 
-  COLW_Int32 integers(
+  cudf::test::fixed_width_column_wrapper<int32_t> integers(
     h_integers.begin(),
     h_integers.end(),
     thrust::make_transform_iterator(h_expected.begin(), [](auto str) { return str != nullptr; }));
 
   auto results = cudf::strings::from_integers(integers);
 
-  COLW_STR expected(
+  cudf::test::strings_column_wrapper expected(
     h_expected.begin(),
     h_expected.end(),
     thrust::make_transform_iterator(h_expected.begin(), [](auto str) { return str != nullptr; }));
@@ -244,10 +252,10 @@ TEST_F(StringsConvertTest, ZeroSizeIntegersColumn)
 TEST_F(StringsConvertTest, EmptyStringsColumn)
 {
   // Empty strings will all result in null elements
-  COLW_STR strings({"", "", ""});
-  auto results =
-    cudf::strings::to_integers(COLV_STR(strings), cudf::data_type{cudf::type_id::INT64});
-  COLW_Int64 expected{0, 0, 0};
+  cudf::test::strings_column_wrapper strings({"", "", ""});
+  auto results = cudf::strings::to_integers(cudf::strings_column_view(strings),
+                                            cudf::data_type{cudf::type_id::INT64});
+  cudf::test::fixed_width_column_wrapper<int64_t> expected{0, 0, 0};
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
 }
 
@@ -281,11 +289,11 @@ TYPED_TEST(StringsIntegerConvertTest, FromToInteger)
   for (auto itr = h_integers.begin(); itr != h_integers.end(); ++itr)
     h_strings.push_back(std::to_string(*itr));
 
-  COLW_STR expected(h_strings.begin(), h_strings.end());
+  cudf::test::strings_column_wrapper expected(h_strings.begin(), h_strings.end());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results_strings, expected);
 
   // convert back to integers
-  auto strings_view = COLV_STR(results_strings->view());
+  auto strings_view = cudf::strings_column_view(results_strings->view());
   auto results_integers =
     cudf::strings::to_integers(strings_view, cudf::data_type(cudf::type_to_id<TypeParam>()));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results_integers, integers->view());
@@ -305,7 +313,7 @@ TYPED_TEST(StringsFloatConvertTest, FromToIntegerError)
   auto column = cudf::make_numeric_column(dtype, 100);
   EXPECT_THROW(cudf::strings::from_integers(column->view()), cudf::logic_error);
 
-  COLW_STR strings{"this string intentionally left blank"};
+  cudf::test::strings_column_wrapper strings{"this string intentionally left blank"};
   EXPECT_THROW(cudf::strings::to_integers(column->view(), dtype), cudf::logic_error);
 }
 
@@ -313,7 +321,7 @@ TEST_F(StringsConvertTest, HexToInteger)
 {
   std::vector<const char*> h_strings{
     "1234", nullptr, "98BEEF", "1a5", "CAFE", "2face", "0xAABBCCDD", "112233445566"};
-  COLW_STR strings(
+  cudf::test::strings_column_wrapper strings(
     h_strings.begin(),
     h_strings.end(),
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
@@ -327,9 +335,9 @@ TEST_F(StringsConvertTest, HexToInteger)
         h_expected.push_back(static_cast<int>(std::stol(std::string(*itr), 0, 16)));
     }
 
-    auto results =
-      cudf::strings::hex_to_integers(COLV_STR(strings), cudf::data_type{cudf::type_id::INT32});
-    COLW_Int32 expected(
+    auto results = cudf::strings::hex_to_integers(cudf::strings_column_view(strings),
+                                                  cudf::data_type{cudf::type_id::INT32});
+    cudf::test::fixed_width_column_wrapper<int32_t> expected(
       h_expected.begin(),
       h_expected.end(),
       thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
@@ -344,9 +352,9 @@ TEST_F(StringsConvertTest, HexToInteger)
         h_expected.push_back(std::stol(std::string(*itr), 0, 16));
     }
 
-    auto results =
-      cudf::strings::hex_to_integers(COLV_STR(strings), cudf::data_type{cudf::type_id::INT64});
-    COLW_Int64 expected(
+    auto results = cudf::strings::hex_to_integers(cudf::strings_column_view(strings),
+                                                  cudf::data_type{cudf::type_id::INT64});
+    cudf::test::fixed_width_column_wrapper<int64_t> expected(
       h_expected.begin(),
       h_expected.end(),
       thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
@@ -368,11 +376,12 @@ TEST_F(StringsConvertTest, IsHex)
                                      "0",
                                      "0x",
                                      "x"};
-  COLW_STR strings(
+  cudf::test::strings_column_wrapper strings(
     h_strings.begin(),
     h_strings.end(),
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
-  COLW_BOOL expected({0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0}, {1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1});
-  auto results = cudf::strings::is_hex(COLV_STR(strings));
+  cudf::test::fixed_width_column_wrapper<bool> expected({0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0},
+                                                        {1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+  auto results = cudf::strings::is_hex(cudf::strings_column_view(strings));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 }

--- a/cpp/tests/strings/integers_tests.cu
+++ b/cpp/tests/strings/integers_tests.cu
@@ -30,11 +30,11 @@
 // This will make the code looks cleaner
 constexpr auto NULL_VAL = 0;
 
-using FCW_B   = cudf::test::fixed_width_column_wrapper<bool>;
-using FCW_I16 = cudf::test::fixed_width_column_wrapper<int16_t>;
-using FCW_I32 = cudf::test::fixed_width_column_wrapper<int32_t>;
-using FCW_I64 = cudf::test::fixed_width_column_wrapper<int64_t>;
-using FCW_U32 = cudf::test::fixed_width_column_wrapper<uint32_t>;
+using FWC_B   = cudf::test::fixed_width_column_wrapper<bool>;
+using FWC_I16 = cudf::test::fixed_width_column_wrapper<int16_t>;
+using FWC_I32 = cudf::test::fixed_width_column_wrapper<int32_t>;
+using FWC_I64 = cudf::test::fixed_width_column_wrapper<int64_t>;
+using FWC_U32 = cudf::test::fixed_width_column_wrapper<uint32_t>;
 using STR_CW  = cudf::test::strings_column_wrapper;
 using STR_CV  = cudf::strings_column_view;
 using INZ_B   = std::initializer_list<bool>;
@@ -57,12 +57,12 @@ TEST_F(StringsConvertTest, IsInteger)
   strings =
     STR_CW({"+175", "-34", "9.8", "17+2", "+-14", "1234567890", "67de", "", "1e10", "-", "++", ""});
   results       = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::INT32});
-  auto expected = FCW_B({1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0});
+  auto expected = FWC_B({1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   strings  = STR_CW({"0", "+0", "-0", "1234567890", "-27341132", "+012", "023", "-045"});
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::INT32});
-  expected = FCW_B({1, 1, 1, 1, 1, 1, 1, 1});
+  expected = FWC_B({1, 1, 1, 1, 1, 1, 1, 1});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   // Input with null elements: the output should have the same null mask
@@ -73,7 +73,7 @@ TEST_F(StringsConvertTest, IsInteger)
     h_strings.end(),
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::INT32});
-  expected = FCW_B(INZ_I8{0, 1, NULL_VAL, 0, 1, 0, 0, NULL_VAL},
+  expected = FWC_B(INZ_I8{0, 1, NULL_VAL, 0, 1, 0, 0, NULL_VAL},
                    INZ_B{true, true, false, true, true, true, true, false});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 }
@@ -83,25 +83,25 @@ TEST_F(StringsConvertTest, IsIntegerBoundCheck)
   auto strings =
     STR_CW({"-200", "-129", "-128", "-120", "0", "120", "127", "130", "150", "255", "300", "500"});
   auto results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::INT8});
-  auto expected = FCW_B({0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0});
+  auto expected = FWC_B({0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::UINT8});
-  expected = FCW_B({0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0});
+  expected = FWC_B({0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   strings =
     STR_CW({"-40000", "-32769", "-32768", "-32767", "-32766", "32765", "32766", "32767", "32768"});
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::INT16});
-  expected = FCW_B({0, 0, 1, 1, 1, 1, 1, 1, 0});
+  expected = FWC_B({0, 0, 1, 1, 1, 1, 1, 1, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::UINT16});
-  expected = FCW_B({0, 0, 0, 0, 0, 1, 1, 1, 1});
+  expected = FWC_B({0, 0, 0, 0, 0, 1, 1, 1, 1});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::INT32});
-  expected = FCW_B({1, 1, 1, 1, 1, 1, 1, 1, 1});
+  expected = FWC_B({1, 1, 1, 1, 1, 1, 1, 1, 1});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   strings  = STR_CW({"-2147483649",   // std::numeric_limits<int32_t>::min() - 1
@@ -114,11 +114,11 @@ TEST_F(StringsConvertTest, IsIntegerBoundCheck)
                     "4294967295",    // std::numeric_limits<uint32_t>::max()
                     "4294967296"});  // std::numeric_limits<uint32_t>::max() + 1
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::INT32});
-  expected = FCW_B({0, 1, 1, 1, 1, 0, 0, 0, 0});
+  expected = FWC_B({0, 1, 1, 1, 1, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::UINT32});
-  expected = FCW_B({0, 0, 0, 1, 1, 1, 1, 1, 0});
+  expected = FWC_B({0, 0, 0, 1, 1, 1, 1, 1, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   strings  = STR_CW({"-9223372036854775809",    // std::numeric_limits<int64_t>::min() - 1
@@ -131,11 +131,11 @@ TEST_F(StringsConvertTest, IsIntegerBoundCheck)
                     "18446744073709551615",    // std::numeric_limits<uint64_t>::max()
                     "18446744073709551616"});  // std::numeric_limits<uint64_t>::max() + 1
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::INT64});
-  expected = FCW_B({0, 1, 1, 1, 1, 0, 0, 0, 0});
+  expected = FWC_B({0, 1, 1, 1, 1, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 
   results  = cudf::strings::is_integer(STR_CV(strings), cudf::data_type{cudf::type_id::UINT64});
-  expected = FCW_B({0, 0, 0, 1, 1, 1, 1, 1, 0});
+  expected = FWC_B({0, 0, 0, 1, 1, 1, 1, 1, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 }
 
@@ -160,12 +160,12 @@ TEST_F(StringsConvertTest, ToInteger)
 
   auto results = cudf::strings::to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::INT16});
   auto const expected_i16 =
-    FCW_I16(INZ_I16{0, 1234, NULL_VAL, 0, -9832, 93, 765, NULL_VAL, -1, -1, 0, 0},
+    FWC_I16(INZ_I16{0, 1234, NULL_VAL, 0, -9832, 93, 765, NULL_VAL, -1, -1, 0, 0},
             INZ_B{true, true, false, true, true, true, true, false, true, true, true, true});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_i16, true);
 
   results = cudf::strings::to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::INT32});
-  auto const expected_i32 = FCW_I32(
+  auto const expected_i32 = FWC_I32(
     INZ_I32{
       0, 1234, NULL_VAL, 0, -9832, 93, 765, NULL_VAL, -1, 2147483647, -2147483648, -2147483648},
     INZ_B{true, true, false, true, true, true, true, false, true, true, true, true});
@@ -173,7 +173,7 @@ TEST_F(StringsConvertTest, ToInteger)
 
   results = cudf::strings::to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::UINT32});
   auto const expected_u32 =
-    FCW_U32(INZ_U32{0,
+    FWC_U32(INZ_U32{0,
                     1234,
                     NULL_VAL,
                     0,
@@ -197,7 +197,7 @@ TEST_F(StringsConvertTest, FromInteger)
   std::vector<const char*> h_expected{
     "100", "987654321", nullptr, "0", "-12761", "0", "5", "-4", "2147483647", "-2147483648"};
 
-  FCW_I32 integers(
+  FWC_I32 integers(
     h_integers.begin(),
     h_integers.end(),
     thrust::make_transform_iterator(h_expected.begin(), [](auto str) { return str != nullptr; }));
@@ -233,7 +233,7 @@ TEST_F(StringsConvertTest, EmptyStringsColumn)
   // Empty strings will all result in null elements
   STR_CW strings({"", "", ""});
   auto results = cudf::strings::to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::INT64});
-  FCW_I64 expected{0, 0, 0};
+  FWC_I64 expected{0, 0, 0};
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
 }
 
@@ -315,7 +315,7 @@ TEST_F(StringsConvertTest, HexToInteger)
 
     auto results =
       cudf::strings::hex_to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::INT32});
-    FCW_I32 expected(
+    FWC_I32 expected(
       h_expected.begin(),
       h_expected.end(),
       thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
@@ -332,7 +332,7 @@ TEST_F(StringsConvertTest, HexToInteger)
 
     auto results =
       cudf::strings::hex_to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::INT64});
-    FCW_I64 expected(
+    FWC_I64 expected(
       h_expected.begin(),
       h_expected.end(),
       thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
@@ -358,7 +358,7 @@ TEST_F(StringsConvertTest, IsHex)
     h_strings.begin(),
     h_strings.end(),
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
-  FCW_B expected({0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0}, {1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+  FWC_B expected({0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0}, {1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1});
   auto results = cudf::strings::is_hex(STR_CV(strings));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
 }

--- a/cpp/tests/strings/integers_tests.cu
+++ b/cpp/tests/strings/integers_tests.cu
@@ -41,14 +41,14 @@ TEST_F(StringsConvertTest, IsIntegerNoNull)
                                            cudf::data_type{cudf::type_id::INT32});
   auto expected =
     cudf::test::fixed_width_column_wrapper<bool>({1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   strings = cudf::test::strings_column_wrapper(
     {"0", "+0", "-0", "1234567890", "-27341132", "+012", "023", "-045"});
   results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
                                       cudf::data_type{cudf::type_id::INT32});
   expected = cudf::test::fixed_width_column_wrapper<bool>({1, 1, 1, 1, 1, 1, 1, 1});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
 
 TEST_F(StringsConvertTest, IsIntegerWithNulls)
@@ -65,7 +65,7 @@ TEST_F(StringsConvertTest, IsIntegerWithNulls)
   auto const expected = cudf::test::fixed_width_column_wrapper<bool>(
     std::initializer_list<int8_t>{0, 1, NULL_VAL, 0, 1, 0, 0, NULL_VAL},
     std::initializer_list<bool>{true, true, false, true, true, true, true, false});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
 
 TEST_F(StringsConvertTest, ZeroSizeIsInteger)
@@ -86,29 +86,29 @@ TEST_F(StringsConvertTest, IsIntegerBoundCheckSmallNumbers)
                                            cudf::data_type{cudf::type_id::INT8});
   auto expected =
     cudf::test::fixed_width_column_wrapper<bool>({0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
                                       cudf::data_type{cudf::type_id::UINT8});
   expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   strings = cudf::test::strings_column_wrapper(
     {"-40000", "-32769", "-32768", "-32767", "-32766", "32765", "32766", "32767", "32768"});
   results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
                                       cudf::data_type{cudf::type_id::INT16});
   expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 1, 1, 1, 1, 1, 1, 0});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
                                       cudf::data_type{cudf::type_id::UINT16});
   expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 0, 0, 1, 1, 1, 1});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
                                       cudf::data_type{cudf::type_id::INT32});
   expected = cudf::test::fixed_width_column_wrapper<bool>({1, 1, 1, 1, 1, 1, 1, 1, 1});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
 
 TEST_F(StringsConvertTest, IsIntegerBoundCheckLargeNumbers)
@@ -126,12 +126,12 @@ TEST_F(StringsConvertTest, IsIntegerBoundCheckLargeNumbers)
   auto results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
                                            cudf::data_type{cudf::type_id::INT32});
   auto expected = cudf::test::fixed_width_column_wrapper<bool>({0, 1, 1, 1, 1, 0, 0, 0, 0});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
                                       cudf::data_type{cudf::type_id::UINT32});
   expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 1, 1, 1, 1, 1, 0});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   strings = cudf::test::strings_column_wrapper(
     {"-9223372036854775809",    // std::numeric_limits<int64_t>::min() - 1
@@ -146,12 +146,12 @@ TEST_F(StringsConvertTest, IsIntegerBoundCheckLargeNumbers)
   results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
                                       cudf::data_type{cudf::type_id::INT64});
   expected = cudf::test::fixed_width_column_wrapper<bool>({0, 1, 1, 1, 1, 0, 0, 0, 0});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   results  = cudf::strings::is_integer(cudf::strings_column_view(strings),
                                       cudf::data_type{cudf::type_id::UINT64});
   expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 1, 1, 1, 1, 1, 0});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
 
 TEST_F(StringsConvertTest, ToInteger)
@@ -230,7 +230,7 @@ TEST_F(StringsConvertTest, FromInteger)
     h_expected.end(),
     thrust::make_transform_iterator(h_expected.begin(), [](auto str) { return str != nullptr; }));
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
 
 TEST_F(StringsConvertTest, ZeroSizeStringsColumn)
@@ -341,7 +341,7 @@ TEST_F(StringsConvertTest, HexToInteger)
       h_expected.begin(),
       h_expected.end(),
       thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
   }
   {
     std::vector<int64_t> h_expected;
@@ -358,7 +358,7 @@ TEST_F(StringsConvertTest, HexToInteger)
       h_expected.begin(),
       h_expected.end(),
       thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
   }
 }
 
@@ -383,5 +383,5 @@ TEST_F(StringsConvertTest, IsHex)
   cudf::test::fixed_width_column_wrapper<bool> expected({0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0},
                                                         {1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1});
   auto results = cudf::strings::is_hex(cudf::strings_column_view(strings));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }

--- a/cpp/tests/strings/integers_tests.cu
+++ b/cpp/tests/strings/integers_tests.cu
@@ -159,54 +159,33 @@ TEST_F(StringsConvertTest, ToInteger)
     thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
 
   auto results = cudf::strings::to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::INT16});
-  auto const expected_i16 = FCW_I16(
-    INZ_I16{NULL_VAL,
-            1234,
-            NULL_VAL,
-            NULL_VAL,
-            -9832,
-            NULL_VAL,
-            NULL_VAL,
-            NULL_VAL,
-            NULL_VAL,
-            NULL_VAL,
-            NULL_VAL,
-            NULL_VAL},
-    INZ_B{false, true, false, false, true, false, false, false, false, false, false, false});
+  auto const expected_i16 =
+    FCW_I16(INZ_I16{0, 1234, NULL_VAL, 0, -9832, 93, 765, NULL_VAL, -1, -1, 0, 0},
+            INZ_B{true, true, false, true, true, true, true, false, true, true, true, true});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_i16, true);
 
   results = cudf::strings::to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::INT32});
-  auto const expected_i32 =
-    FCW_I32(INZ_I32{NULL_VAL,
-                    1234,
-                    NULL_VAL,
-                    NULL_VAL,
-                    -9832,
-                    NULL_VAL,
-                    NULL_VAL,
-                    NULL_VAL,
-                    NULL_VAL,
-                    2147483647,
-                    -2147483648,
-                    NULL_VAL},
-            INZ_B{false, true, false, false, true, false, false, false, false, true, true, false});
+  auto const expected_i32 = FCW_I32(
+    INZ_I32{
+      0, 1234, NULL_VAL, 0, -9832, 93, 765, NULL_VAL, -1, 2147483647, -2147483648, -2147483648},
+    INZ_B{true, true, false, true, true, true, true, false, true, true, true, true});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_i32, true);
 
   results = cudf::strings::to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::UINT32});
   auto const expected_u32 =
-    FCW_U32(INZ_U32{NULL_VAL,
+    FCW_U32(INZ_U32{0,
                     1234,
                     NULL_VAL,
+                    0,
+                    4294957464,
+                    93,
+                    765,
                     NULL_VAL,
-                    NULL_VAL,
-                    NULL_VAL,
-                    NULL_VAL,
-                    NULL_VAL,
-                    NULL_VAL,
+                    4294967295,
                     2147483647,
-                    NULL_VAL,
+                    2147483648,
                     2147483648},
-            INZ_B{false, true, false, false, false, false, false, false, false, true, false, true});
+            INZ_B{true, true, false, true, true, true, true, false, true, true, true, true});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_u32, true);
 }
 
@@ -254,8 +233,7 @@ TEST_F(StringsConvertTest, EmptyStringsColumn)
   // Empty strings will all result in null elements
   STR_CW strings({"", "", ""});
   auto results = cudf::strings::to_integers(STR_CV(strings), cudf::data_type{cudf::type_id::INT64});
-  FCW_I64 expected(std::initializer_list<int32_t>{0, 0, 0},
-                   std::initializer_list<bool>{false, false, false});
+  FCW_I64 expected{0, 0, 0};
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected, true);
 }
 

--- a/cpp/tests/strings/integers_tests.cu
+++ b/cpp/tests/strings/integers_tests.cu
@@ -272,7 +272,6 @@ TEST_F(StringsConvertTest, ZeroSizeIntegersColumn)
 
 TEST_F(StringsConvertTest, EmptyStringsColumn)
 {
-  // Empty strings will all result in null elements
   cudf::test::strings_column_wrapper strings({"", "", ""});
   auto results = cudf::strings::to_integers(cudf::strings_column_view(strings),
                                             cudf::data_type{cudf::type_id::INT64});


### PR DESCRIPTION
This PR addresses #5110, #7080, and rework https://github.com/rapidsai/cudf/pull/7094. It adds the function `cudf::strings::is_integer` that can check if strings can be correctly converted into integer values. Underflow and overflow are also taken into account.

Note that this `cudf::strings::is_integer` is different from the existing `cudf::strings::string::is_integer`, which only checks for pattern and does not care about under/overflow.

Examples:
```
s = { "eee", "-200", "-100", "127", "128", "1.5", NULL}

is_integer(s, INT8) = { 0, 0, 1, 1, 0, 0, NULL}
is_integer(s, INT32) = { 0, 1, 1, 1, 1, 0, NULL}
```