### PR TITLE
Work-around for gcc7 compile error on Centos7

### DIFF
--- a/cpp/include/cudf/strings/detail/strings_column_factories.cuh
+++ b/cpp/include/cudf/strings/detail/strings_column_factories.cuh
@@ -94,9 +94,9 @@ std::unique_ptr<column> make_strings_column(IndexPairIterator begin,
     (null_count > 0) ? std::move(new_nulls.first) : rmm::device_buffer{0, stream, mr};
 
   // build chars column
+  auto const avg_bytes_per_row = bytes / std::max(strings_count - null_count, 1);
   std::unique_ptr<column> chars_column = [&] {
     // use a character-parallel kernel for long string lengths
-    auto const avg_bytes_per_row = bytes / std::max(strings_count - null_count, 1);
     if (avg_bytes_per_row > FACTORY_BYTES_PER_ROW_THRESHOLD) {
       auto const d_offsets =
         device_span<size_type const>{offsets_column->view().template data<int32_t>(),

--- a/cpp/include/cudf/strings/detail/strings_column_factories.cuh
+++ b/cpp/include/cudf/strings/detail/strings_column_factories.cuh
@@ -93,8 +93,8 @@ std::unique_ptr<column> make_strings_column(IndexPairIterator begin,
   auto null_mask =
     (null_count > 0) ? std::move(new_nulls.first) : rmm::device_buffer{0, stream, mr};
 
-  // build chars column
   auto const avg_bytes_per_row = bytes / std::max(strings_count - null_count, 1);
+  // build chars column
   std::unique_ptr<column> chars_column = [&] {
     // use a character-parallel kernel for long string lengths
     if (avg_bytes_per_row > FACTORY_BYTES_PER_ROW_THRESHOLD) {


### PR DESCRIPTION
Closes #7650 

I was able to reproduce this with `nvidia/cuda:10.2-devel-centos7` docker image using gcc 7.5.0
After doing some googling and trial and error, I found just moving the offending line up one line outside the lambda in the source file gets past the error.