### PR TITLE
Fix `find_package(cudf)`

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -425,7 +425,8 @@ target_include_directories(cudf
                        "$<BUILD_INTERFACE:${CUDF_GENERATED_INCLUDE_DIR}/include>"
            PRIVATE     "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/src>"
            INTERFACE   "$<INSTALL_INTERFACE:include>"
-                       "$<INSTALL_INTERFACE:include/libcudf/libcudaxx>")
+                       "$<INSTALL_INTERFACE:include/libcudf/libcudacxx>"
+                       "$<INSTALL_INTERFACE:include/libcudf/Thrust>")
 
 # Add Conda library paths if specified
 if(CONDA_LINK_DIRS)
@@ -577,6 +578,9 @@ install(DIRECTORY
             ${CUDF_GENERATED_INCLUDE_DIR}/include/libcxx
             ${CUDF_GENERATED_INCLUDE_DIR}/include/libcudacxx
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libcudf)
+
+install(DIRECTORY ${Thrust_SOURCE_DIR}/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust)
 
 include(CMakePackageConfigHelpers)
 

--- a/cpp/cmake/cudf-config.cmake.in
+++ b/cpp/cmake/cudf-config.cmake.in
@@ -22,6 +22,10 @@ find_dependency(Boost @CUDF_MIN_VERSION_Boost@)
 find_dependency(rmm @CUDF_MIN_VERSION_rmm@)
 find_dependency(gtest @CUDF_MIN_VERSION_gtest@)
 
+set(Thrust_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../include/libcudf/Thrust")
+find_dependency(Thrust @CUDF_MIN_VERSION_Thrust@)
+thrust_create_target(cudf::Thrust FROM_OPTIONS)
+
 list(POP_FRONT CMAKE_MODULE_PATH)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cudf-targets.cmake")

--- a/cpp/cmake/cudf-config.cmake.in
+++ b/cpp/cmake/cudf-config.cmake.in
@@ -16,6 +16,8 @@ find_dependency(Threads)
 find_dependency(ZLIB)
 
 find_dependency(Arrow @CUDF_VERSION_Arrow@)
+
+set(ArrowCUDA_DIR "${Arrow_DIR}")
 find_dependency(ArrowCUDA @CUDF_VERSION_Arrow@)
 find_dependency(Boost @CUDF_MIN_VERSION_Boost@)
 

--- a/cpp/cmake/cudf-config.cmake.in
+++ b/cpp/cmake/cudf-config.cmake.in
@@ -20,7 +20,7 @@ find_dependency(ArrowCUDA @CUDF_VERSION_Arrow@)
 find_dependency(Boost @CUDF_MIN_VERSION_Boost@)
 
 find_dependency(rmm @CUDF_MIN_VERSION_rmm@)
-find_dependency(gtest @CUDF_MIN_VERSION_gtest@)
+find_dependency(GTest @CUDF_MIN_VERSION_GTest@)
 
 set(Thrust_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../include/libcudf/Thrust")
 find_dependency(Thrust @CUDF_MIN_VERSION_Thrust@)

--- a/cpp/cmake/cudf-config.cmake.in
+++ b/cpp/cmake/cudf-config.cmake.in
@@ -15,11 +15,15 @@ find_dependency(CUDAToolkit)
 find_dependency(Threads)
 find_dependency(ZLIB)
 
+# Don't look for a Boost CMake configuration file because it adds the
+# `-DBOOST_ALL_NO_LIB` and `-DBOOST_FILESYSTEM_DYN_LINK` compile defs
+set(Boost_NO_BOOST_CMAKE ON)
+find_dependency(Boost @CUDF_MIN_VERSION_Boost@ COMPONENTS filesystem)
+
 find_dependency(Arrow @CUDF_VERSION_Arrow@)
 
 set(ArrowCUDA_DIR "${Arrow_DIR}")
 find_dependency(ArrowCUDA @CUDF_VERSION_Arrow@)
-find_dependency(Boost @CUDF_MIN_VERSION_Boost@)
 
 find_dependency(rmm @CUDF_MIN_VERSION_rmm@)
 find_dependency(GTest @CUDF_MIN_VERSION_GTest@)

--- a/cpp/cmake/thirdparty/CUDF_GetGTest.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetGTest.cmake
@@ -48,6 +48,6 @@ function(find_and_configure_gtest VERSION)
     endif()
 endfunction()
 
-set(CUDF_MIN_VERSION_gtest 1.10.0)
+set(CUDF_MIN_VERSION_GTest 1.10.0)
 
-find_and_configure_gtest(${CUDF_MIN_VERSION_gtest})
+find_and_configure_gtest(${CUDF_MIN_VERSION_GTest})

--- a/cpp/cmake/thirdparty/CUDF_GetThrust.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetThrust.cmake
@@ -24,6 +24,7 @@ function(find_and_configure_thrust VERSION)
 
     thrust_create_target(cudf::Thrust FROM_OPTIONS)
     set(THRUST_LIBRARY "cudf::Thrust" PARENT_SCOPE)
+    set(Thrust_SOURCE_DIR "${Thrust_SOURCE_DIR}" PARENT_SCOPE)
 endfunction()
 
 set(CUDF_MIN_VERSION_Thrust 1.10.0)


### PR DESCRIPTION
This PR makes `find_package(cudf)` work when `libcudf` is installed via conda.

This should make CPM use the conda-installed `libcudf` in https://github.com/rapidsai/cudf/pull/7484 and https://github.com/rapidsai/cuspatial/pull/365.

Tested in a `gpuci/miniconda-cuda:10.2-devel-ubuntu18.04` container.

Install dependencies:
```
mamba install -n base \
 -c conda-forge gtest gmock cmake=3.18 boost-cpp=1.72.0 \
 -c rapidsai-nightly libcudf
```

Use this `CMakeLists.txt`:
```cmake
cmake_minimum_required(VERSION 3.18)
project(test VERSION 1.0.0 LANGUAGES C CXX CUDA)
find_package(cudf)
add_library(test test.cpp)
target_link_libraries(test cudf::cudf)
```

<details><summary>See this output:</summary><pre>
(base) root@8c350dfb37f1:/tmp/findpackagecudf# mkdir build && cmake -B build -S .
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- The CUDA compiler identification is NVIDIA 10.2.89
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /usr/local/cuda/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
-- Found CUDAToolkit: /usr/local/cuda/include (found version "10.2.89") 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found ZLIB: /opt/conda/lib/libz.so (found version "1.2.11") 
-- Found Boost: /opt/conda/include (found suitable version "1.72.0", minimum required is "1.65.0") found components: filesystem 
-- Found Thrust: /usr/local/cuda/include (found suitable version "1.9.7", minimum required is "1.9.0") 
-- Found rmm: /opt/conda/lib/cmake/rmm/rmm-config.cmake (found suitable version "0.19.0", minimum required is "0.19") 
-- Found GTest: /opt/conda/lib/libgtest.so (Required is at least version "1.10.0") 
-- Found Thrust: /opt/conda/include/libcudf/Thrust/thrust/cmake/thrust-config.cmake (found suitable version "1.10.0.0", minimum required is "1.10.0") 
-- Found cudf: /opt/conda/lib/cmake/cudf/cudf-config.cmake (found version "0.19.0") 
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/findpackagecudf/build
</pre></details>

<details><summary>The generated compile command for test.cpp:</summary><pre>
/usr/bin/c++
 -DBOOST_NO_CXX14_CONSTEXPR
 -DCUDF_VERSION=0.19.0
 -DJITIFY_USE_CACHE
 -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
 -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA
 -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP
 -I/opt/conda/include/libcudf/Thrust/dependencies/cub
 -isystem /opt/conda/include
 -isystem /opt/conda/include/libcudf/libcudacxx
 -isystem /opt/conda/include/libcudf/Thrust
 -isystem /usr/local/cuda/include
 -fPIC
 -o CMakeFiles/test.dir/test.cpp.o
 -c /tmp/findpackagecudf/test.cpp
</pre></details>
