### PR TITLE
Add Resources to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 **NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cudf/blob/main/README.md) ensure you are on the `main` branch.
 
+## Resources
+
+- [cuDF Reference Documentation](https://docs.rapids.ai/api/cudf/stable/): Python API reference, tutorials, and topic guides.
+- [libcudf Reference Documentation](https://docs.rapids.ai/api/libcudf/stable/): C/C++ CUDA library API reference.
+- [Getting Started](https://rapids.ai/start.html): Instructions for installing cuDF.
+- [RAPIDS Community](https://rapids.ai/community.html): Get help, contribute, and collaborate.
+- [GitHub repository](https://github.com/rapidsai/cudf): Download the cuDF source code.
+- [Issue tracker](https://github.com/rapidsai/cudf/issues): Report issues or request features.
+
+## Overview
+
 Built based on the [Apache Arrow](http://arrow.apache.org/) columnar memory format, cuDF is a GPU DataFrame library for loading, joining, aggregating, filtering, and otherwise manipulating data.
 
 cuDF provides a pandas-like API that will be familiar to data engineers & data scientists, so they can use it to easily accelerate their workflows without going into the details of CUDA programming.


### PR DESCRIPTION
Resolves #7217 by adding a section of commonly needed resource links at the top of the README.

In #7217, I also proposed adding relevant badges (e.g. for build status, download links, citation information, etc.). I would be happy to add that to this PR if that is of interest. I'm opening the PR without badges for now, because I think the "Resources" section is valuable by itself, for readers who want quick access to common destinations.
