### PR TITLE
Update codeowners file [skip-ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,8 @@ java/              @rapidsai/cudf-java-codeowners
 
 #build/ops code owners
 .github/           @rapidsai/ops-codeowners
-/ci/                @rapidsai/ops-codeowners
+/ci/               @rapidsai/ops-codeowners
 conda/             @rapidsai/ops-codeowners
-/Dockerfile      @rapidsai/ops-codeowners
-/.dockerignore   @rapidsai/ops-codeowners
-/docker/            @rapidsai/ops-codeowners
+/Dockerfile        @rapidsai/ops-codeowners
+/.dockerignore     @rapidsai/ops-codeowners
+/docker/           @rapidsai/ops-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,9 +14,9 @@ python/dask_cudf/  @rapidsai/cudf-dask-codeowners
 java/              @rapidsai/cudf-java-codeowners
 
 #build/ops code owners
-.github/           @rapidsai/ops-codeowners 
+.github/           @rapidsai/ops-codeowners
 /ci/                @rapidsai/ops-codeowners
 conda/             @rapidsai/ops-codeowners
-**/Dockerfile      @rapidsai/ops-codeowners
-**/.dockerignore   @rapidsai/ops-codeowners
-docker/            @rapidsai/ops-codeowners
+/Dockerfile      @rapidsai/ops-codeowners
+/.dockerignore   @rapidsai/ops-codeowners
+/docker/            @rapidsai/ops-codeowners


### PR DESCRIPTION
This PR updates the `codeowners` file to only require `ops-codeowners` reviews on the `Dockerfile`/`.dockerignore`/`docker` files in the repo's root directory. This will prevent `ops-codeowners` from getting tagged in reviews for PRs such as #7671.