### PR TITLE
Replace device_vector with device_uvector in null_mask

### DIFF
--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -21,7 +21,6 @@
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_vector.hpp>
 
 namespace cudf {
 /**

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -53,7 +53,7 @@ void set_null_mask(bitmask_type *bitmask,
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
 std::vector<size_type> segmented_count_set_bits(bitmask_type const *bitmask,
-                                                std::vector<size_type> const &indices,
+                                                host_span<size_type const> indices,
                                                 rmm::cuda_stream_view stream);
 
 /**
@@ -62,7 +62,7 @@ std::vector<size_type> segmented_count_set_bits(bitmask_type const *bitmask,
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
 std::vector<size_type> segmented_count_unset_bits(bitmask_type const *bitmask,
-                                                  std::vector<size_type> const &indices,
+                                                  host_span<size_type const> indices,
                                                   rmm::cuda_stream_view stream);
 
 /**

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
 
 #include <rmm/device_buffer.hpp>
 
@@ -136,38 +137,32 @@ cudf::size_type count_unset_bits(bitmask_type const* bitmask, size_type start, s
  * `[indices[2*i], indices[(2*i)+1])` (where 0 <= i < indices.size() / 2).
  *
  * Returns an empty vector if `bitmask == nullptr`.
- * @throws cudf::logic_error if `indices.size() % 2 != 0`
- * @throws cudf::logic_error if `indices[2*i] < 0 or
- * indices[2*i] > indices[(2*i)+1]`
  *
- * @param[in] bitmask Bitmask residing in device memory whose bits will be
- * counted
- * @param[in] indices A vector of indices used to specify ranges to count the
- * number of set bits
- * @return std::vector<size_type> A vector storing the number of non-zero bits
- * in the specified ranges
+ * @throws cudf::logic_error if `indices.size() % 2 != 0`
+ * @throws cudf::logic_error if `indices[2*i] < 0 or indices[2*i] > indices[(2*i)+1]`
+ *
+ * @param[in] bitmask Bitmask residing in device memory whose bits will be counted
+ * @param[in] indices A host_span of indices specifying ranges to count the number of set bits
+ * @return A vector storing the number of non-zero bits in the specified ranges
  */
 std::vector<size_type> segmented_count_set_bits(bitmask_type const* bitmask,
-                                                std::vector<cudf::size_type> const& indices);
+                                                host_span<cudf::size_type const> indices);
 
 /**
  * @brief Given a bitmask, counts the number of unset (0) bits in every range
  * `[indices[2*i], indices[(2*i)+1])` (where 0 <= i < indices.size() / 2).
  *
  * Returns an empty vector if `bitmask == nullptr`.
- * @throws cudf::logic_error if `indices.size() % 2 != 0`
- * @throws cudf::logic_error if `indices[2*i] < 0 or
- * indices[2*i] > indices[(2*i)+1]`
  *
- * @param[in] bitmask Bitmask residing in device memory whose bits will be
- * counted
- * @param[in] indices A vector of indices used to specify ranges to count the
- * number of unset bits
- * @return std::vector<size_type> A vector storing the number of zero bits in
- * the specified ranges
+ * @throws cudf::logic_error if `indices.size() % 2 != 0`
+ * @throws cudf::logic_error if `indices[2*i] < 0 or indices[2*i] > indices[(2*i)+1]`
+ *
+ * @param[in] bitmask Bitmask residing in device memory whose bits will be counted
+ * @param[in] indices A host_span of indices specifying ranges to count the number of unset bits
+ * @return A vector storing the number of zero bits in the specified ranges
  */
 std::vector<size_type> segmented_count_unset_bits(bitmask_type const* bitmask,
-                                                  std::vector<cudf::size_type> const& indices);
+                                                  host_span<cudf::size_type const> indices);
 
 /**
  * @brief Creates a `device_buffer` from a slice of bitmask defined by a range


### PR DESCRIPTION
Replaces remaining `device_vector` instances in null_mask.cu with `device_uvector`. Change the interface of `segmented_count_[un]set_bits` to take `host_span` instead of `std::vector`.