### PR TITLE
Add support for `unique` groupby aggregation

### DIFF
--- a/docs/cudf/source/groupby.md
+++ b/docs/cudf/source/groupby.md
@@ -137,6 +137,7 @@ The following table summarizes the available aggregations and the types that sup
 | nunique             | ✅       | ✅       | ✅       | ✅          |      |        |
 | nth                 | ✅       | ✅       | ✅       |             |      |        |
 | collect             | ✅       | ✅       | ✅       |             | ✅   |        |
+| unique              | ✅       | ✅       | ✅       | ✅          |      |        |
 
 ## GroupBy apply
 

--- a/python/cudf/cudf/_lib/aggregation.pyx
+++ b/python/cudf/cudf/_lib/aggregation.pyx
@@ -41,7 +41,7 @@ class AggregationKind(Enum):
     ALL = libcudf_aggregation.aggregation.Kind.ALL
     SUM_OF_SQUARES = libcudf_aggregation.aggregation.Kind.SUM_OF_SQUARES
     MEAN = libcudf_aggregation.aggregation.Kind.MEAN
-    VARIANCE = libcudf_aggregation.aggregation.Kind.VARIANCE
+    VAR = libcudf_aggregation.aggregation.Kind.VARIANCE
     STD = libcudf_aggregation.aggregation.Kind.STD
     MEDIAN = libcudf_aggregation.aggregation.Kind.MEDIAN
     QUANTILE = libcudf_aggregation.aggregation.Kind.QUANTILE
@@ -50,13 +50,12 @@ class AggregationKind(Enum):
     NUNIQUE = libcudf_aggregation.aggregation.Kind.NUNIQUE
     NTH = libcudf_aggregation.aggregation.Kind.NTH_ELEMENT
     COLLECT = libcudf_aggregation.aggregation.Kind.COLLECT
-    COLLECT_SET = libcudf_aggregation.aggregation.Kind.COLLECT_SET
+    UNIQUE = libcudf_aggregation.aggregation.Kind.COLLECT_SET
     PTX = libcudf_aggregation.aggregation.Kind.PTX
     CUDA = libcudf_aggregation.aggregation.Kind.CUDA
 
 
 cdef class Aggregation:
-
     def __init__(self, op, **kwargs):
         self.c_obj = move(make_aggregation(op, kwargs))
 
@@ -246,7 +245,7 @@ cdef class _AggregationFactory:
         return agg
 
     @classmethod
-    def collect_set(cls):
+    def unique(cls):
         cdef Aggregation agg = Aggregation.__new__(Aggregation)
         agg.c_obj = move(libcudf_aggregation.make_collect_set_aggregation())
         return agg

--- a/python/cudf/cudf/_lib/groupby.pyx
+++ b/python/cudf/cudf/_lib/groupby.pyx
@@ -35,13 +35,15 @@ _GROUPBY_AGGS = {
     "median",
     "nunique",
     "nth",
-    "collect"
+    "collect",
+    "unique",
 }
 
 _CATEGORICAL_AGGS = {
     "count",
     "size",
     "nunique",
+    "unique",
 }
 
 _STRING_AGGS = {
@@ -51,12 +53,14 @@ _STRING_AGGS = {
     "min",
     "nunique",
     "nth",
-    "collect"
+    "collect",
+    "unique",
 }
 
 _LIST_AGGS = {
-    "collect"
+    "collect",
 }
+
 
 cdef class GroupBy:
     cdef unique_ptr[libcudf_groupby.groupby] c_obj


### PR DESCRIPTION
Adds support for `SeriesGroupBy.unique()`. Also adds support for `DataFrameGroupBy.unique()` but that's not tested, as Pandas doesn't support it (yet?).

Resolves https://github.com/rapidsai/cudf/issues/2973