### PR TITLE
Change JNI API to avoid loading native dependencies when creating sort order classes. [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/OrderByArg.java
+++ b/java/src/main/java/ai/rapids/cudf/OrderByArg.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *  Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package ai.rapids.cudf;
+
+import java.io.Serializable;
+
+/**
+ * Provides the ordering for specific columns.
+ */
+public final class OrderByArg implements Serializable {
+  final int index;
+  final boolean isDescending;
+  final boolean isNullSmallest;
+
+  OrderByArg(int index, boolean isDescending, boolean isNullSmallest) {
+    this.index = index;
+    this.isDescending = isDescending;
+    this.isNullSmallest = isNullSmallest;
+  }
+
+  public static OrderByArg asc(final int index) {
+    return new OrderByArg(index, false, false);
+  }
+
+  public static OrderByArg desc(final int index) {
+    return new OrderByArg(index, true, false);
+  }
+
+  public static OrderByArg asc(final int index, final boolean isNullSmallest) {
+    return new OrderByArg(index, false, isNullSmallest);
+  }
+
+  public static OrderByArg desc(final int index, final boolean isNullSmallest) {
+    return new OrderByArg(index, true, isNullSmallest);
+  }
+
+  @Override
+  public String toString() {
+    return "ORDER BY " + index +
+        (isDescending ? " DESC " : " ASC ") +
+        (isNullSmallest ? "NULL SMALLEST" : "NULL LARGEST");
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -25,7 +25,6 @@ import ai.rapids.cudf.HostColumnVector.StructData;
 import ai.rapids.cudf.HostColumnVector.StructType;
 
 import java.io.File;
-import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
@@ -1444,7 +1443,7 @@ public final class Table implements AutoCloseable {
    * responsible for cleaning up
    * the {@link ColumnVector} returned as part of the output {@link Table}
    * <p>
-   * Example usage: orderBy(true, Table.asc(0), Table.desc(3)...);
+   * Example usage: orderBy(true, OrderByArg.asc(0), OrderByArg.desc(3)...);
    * @param args Suppliers to initialize sortKeys.
    * @return Sorted Table
    */
@@ -1510,22 +1509,6 @@ public final class Table implements AutoCloseable {
    */
   public static Table merge(List<Table> tables, OrderByArg... args) {
     return merge(tables.toArray(new Table[tables.size()]), args);
-  }
-
-  public static OrderByArg asc(final int index) {
-    return new OrderByArg(index, false, false);
-  }
-
-  public static OrderByArg desc(final int index) {
-    return new OrderByArg(index, true, false);
-  }
-
-  public static OrderByArg asc(final int index, final boolean isNullSmallest) {
-    return new OrderByArg(index, false, isNullSmallest);
-  }
-
-  public static OrderByArg desc(final int index, final boolean isNullSmallest) {
-    return new OrderByArg(index, true, isNullSmallest);
   }
 
   /**
@@ -2092,25 +2075,6 @@ public final class Table implements AutoCloseable {
   /////////////////////////////////////////////////////////////////////////////
   // HELPER CLASSES
   /////////////////////////////////////////////////////////////////////////////
-
-  public static final class OrderByArg implements Serializable {
-    final int index;
-    final boolean isDescending;
-    final boolean isNullSmallest;
-
-    OrderByArg(int index, boolean isDescending, boolean isNullSmallest) {
-      this.index = index;
-      this.isDescending = isDescending;
-      this.isNullSmallest = isNullSmallest;
-    }
-
-    @Override
-    public String toString() {
-      return "ORDER BY " + index +
-          (isDescending ? " DESC " : " ASC ") +
-          (isNullSmallest ? "NULL SMALLEST" : "NULL LARGEST");
-    }
-  }
 
   /**
    * class to encapsulate indices and table

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -369,9 +369,9 @@ public class TableTest extends CudfTestBase {
                  .column(3, 2, 1, 2, null, 3, 5, 2)
                  .column(1, 9, 7, 3, 5, 3, 1, 10)
                  .build();
-         Table sortedTable1 = table1.orderBy(Table.asc(0), Table.desc(1));
-         Table sortedTable2 = table2.orderBy(Table.asc(0), Table.desc(1));
-         Table merged = Table.merge(Arrays.asList(sortedTable1, sortedTable2), Table.asc(0), Table.desc(1))) {
+         Table sortedTable1 = table1.orderBy(OrderByArg.asc(0), OrderByArg.desc(1));
+         Table sortedTable2 = table2.orderBy(OrderByArg.asc(0), OrderByArg.desc(1));
+         Table merged = Table.merge(Arrays.asList(sortedTable1, sortedTable2), OrderByArg.asc(0), OrderByArg.desc(1))) {
       assertTablesAreEqual(expected, merged);
     }
   }
@@ -388,7 +388,7 @@ public class TableTest extends CudfTestBase {
              .column(2, 1, 4, 3, 5)
              .column(9, 7, 5, 3, 1)
              .build();
-         Table sortedTable = table.orderBy(Table.asc(0), Table.desc(1))) {
+         Table sortedTable = table.orderBy(OrderByArg.asc(0), OrderByArg.desc(1))) {
       assertTablesAreEqual(expected, sortedTable);
     }
   }
@@ -405,7 +405,7 @@ public class TableTest extends CudfTestBase {
              .column(2, 1, 4, 3, 5)
              .column(9, 7, 5, 3, 1)
              .build();
-         ColumnVector gatherMap = table.sortOrder(Table.asc(0), Table.desc(1));
+         ColumnVector gatherMap = table.sortOrder(OrderByArg.asc(0), OrderByArg.desc(1));
          Table sortedTable = table.gather(gatherMap)) {
       assertTablesAreEqual(expected, sortedTable);
     }
@@ -423,7 +423,7 @@ public class TableTest extends CudfTestBase {
              .column(5, 4, 3, 2, 1)
              .column(1, 5, 3, 9, 7)
              .build();
-         Table sortedTable = table.orderBy(Table.desc(0), Table.desc(1))) {
+         Table sortedTable = table.orderBy(OrderByArg.desc(0), OrderByArg.desc(1))) {
       assertTablesAreEqual(expected, sortedTable);
     }
   }
@@ -442,7 +442,7 @@ public class TableTest extends CudfTestBase {
              .column("1", "0", "2", "4", "3")
              .column(7, 9, 5, 1, 3)
              .build();
-         Table sortedTable = table.orderBy(Table.asc(0), Table.desc(1))) {
+         Table sortedTable = table.orderBy(OrderByArg.asc(0), OrderByArg.desc(1))) {
       assertTablesAreEqual(expected, sortedTable);
     }
   }
@@ -461,7 +461,7 @@ public class TableTest extends CudfTestBase {
              .column(null, null, 4, 3, 5)
              .column(9, 7, 5, 3, 1)
              .build();
-         Table sortedTable = table.orderBy(Table.asc(0))) {
+         Table sortedTable = table.orderBy(OrderByArg.asc(0))) {
       assertTablesAreEqual(expected, sortedTable);
     }
   }
@@ -867,7 +867,7 @@ public class TableTest extends CudfTestBase {
              .column(null, null, 203, null, null, null, null, 201, 202, 204) // right
              .build();
          Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
   }
@@ -891,7 +891,7 @@ public class TableTest extends CudfTestBase {
            .build();
 
            Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0));
-           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+           Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
          assertTablesAreEqual(expectedResults, orderedJoinedTable);
        }
 
@@ -902,7 +902,7 @@ public class TableTest extends CudfTestBase {
            .build();
 
            Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), false);
-           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+           Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
          assertTablesAreEqual(expectedResults, orderedJoinedTable);
        }
     }
@@ -919,7 +919,7 @@ public class TableTest extends CudfTestBase {
              .column( 20,  21,  22,  23,  24,  25,  26,  27,  28,  29)
              .build();
          Table joinedTable = leftTable.onColumns(0).leftJoin(rightTable.onColumns(0), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true));
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true));
          Table expected = new Table.TestBuilder()
              .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317) // common
              .column( 10,  11,  12,  13,  14,  15,  16,  17,  18,  19) // left
@@ -945,7 +945,7 @@ public class TableTest extends CudfTestBase {
                  .column(null, null, null, null, null, 201, 200, null, 203, 202,  204,  205) // right
                  .build();
          Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(0, true))) {
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(0, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
   }
@@ -968,7 +968,7 @@ public class TableTest extends CudfTestBase {
               .column( 200,  202,  200,  202, null, null, null, null, null, 201, null, 203,  204,  205) // right
               .build();
            Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0));
-           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(0, true), Table.asc(1, true))) {
+           Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(0, true), OrderByArg.asc(1, true))) {
         assertTablesAreEqual(expectedResults, orderedJoinedTable);
       }
 
@@ -980,7 +980,7 @@ public class TableTest extends CudfTestBase {
               .build();
            Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(0), false);
            Table orderedJoinedTable = joinedTable.orderBy(
-                   Table.asc(0, true), Table.asc(1, true), Table.asc(2, true))) {
+               OrderByArg.asc(0, true), OrderByArg.asc(1, true), OrderByArg.asc(2, true))) {
         assertTablesAreEqual(expectedResults, orderedJoinedTable);
       }
     }
@@ -997,7 +997,7 @@ public class TableTest extends CudfTestBase {
                  .column(200, 201, 202, 203, 204, 205, 206, 207, 208, 209)
                  .build();
          Table joinedTable = leftTable.onColumns(0).fullJoin(rightTable.onColumns(new int[]{0}), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true));
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true));
          Table expected = new Table.TestBuilder()
                  .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317) // common
                  .column(100, 101, 102, 103, 104, 105, 106, 107, 108, 109) // left
@@ -1023,7 +1023,7 @@ public class TableTest extends CudfTestBase {
              .column(202, 200, 201, 203) // right
              .build();
          Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
   }
@@ -1046,7 +1046,7 @@ public class TableTest extends CudfTestBase {
              .column(202, 200,  201, 203) // right
              .build();
          Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0));
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
         assertTablesAreEqual(expected, orderedJoinedTable);
       }
 
@@ -1057,7 +1057,7 @@ public class TableTest extends CudfTestBase {
               .column(202, 200,  203) // right
               .build();
            Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(0), false);
-           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))){
+           Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))){
         assertTablesAreEqual(expected, orderedJoinedTable);
       }
     }
@@ -1074,7 +1074,7 @@ public class TableTest extends CudfTestBase {
              .column(200, 201, 202, 203, 204, 205, 206, 207, 208, 209)
              .build();
          Table joinedTable = leftTable.onColumns(0).innerJoin(rightTable.onColumns(new int[]{0}), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true));
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true));
          Table expected = new Table.TestBuilder()
              .column(360, 326, 254, 306, 109, 361, 251, 335, 301, 317) // common
              .column(100, 101, 102, 103, 104, 105, 106, 107, 108, 109) // left
@@ -1099,7 +1099,7 @@ public class TableTest extends CudfTestBase {
              .column(102, 107, 108, 109)
              .build();
          Table joinedTable = leftTable.onColumns(0).leftSemiJoin(rightTable.onColumns(0), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
   }
@@ -1116,7 +1116,7 @@ public class TableTest extends CudfTestBase {
              .column("20", "21", "22", "23", "24", "25", "26", "27", "28", "29")
              .build();
          Table joinedTable = leftTable.onColumns(0, 2).leftSemiJoin(rightTable.onColumns(0, 1), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(0, true));
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(0, true));
          Table expected = new Table.TestBuilder()
              .column(254,   326,   361)
              .column(null,   11,    17)
@@ -1143,7 +1143,7 @@ public class TableTest extends CudfTestBase {
                .column(102, 107,  108, 109)
                .build();
             Table joinedTable = leftTable.onColumns(0).leftSemiJoin(rightTable.onColumns(0));
-            Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+            Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
           assertTablesAreEqual(expected, orderedJoinedTable);
        }
 
@@ -1153,7 +1153,7 @@ public class TableTest extends CudfTestBase {
               .column(102, 107, 109)
               .build();
            Table joinedTable = leftTable.onColumns(0).leftSemiJoin(rightTable.onColumns(0), false);
-           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+           Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
         assertTablesAreEqual(expected, orderedJoinedTable);
       }
     }
@@ -1174,7 +1174,7 @@ public class TableTest extends CudfTestBase {
              .column(100, 101, 103, 104, 105, 106)
              .build();
          Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
   }
@@ -1196,7 +1196,7 @@ public class TableTest extends CudfTestBase {
               .column(100, 101, 103, 104, 105, 106)
               .build();
            Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0));
-           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+           Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
         assertTablesAreEqual(expected, orderedJoinedTable);
       }
 
@@ -1206,7 +1206,7 @@ public class TableTest extends CudfTestBase {
               .column(100, 101, 103, 104, 105, 106,  108)
               .build();
            Table joinedTable = leftTable.onColumns(0).leftAntiJoin(rightTable.onColumns(0), false);
-           Table orderedJoinedTable = joinedTable.orderBy(Table.asc(1, true))) {
+           Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(1, true))) {
         assertTablesAreEqual(expected, orderedJoinedTable);
       }
     }
@@ -1224,7 +1224,7 @@ public class TableTest extends CudfTestBase {
              .column("20", "21", "22", "23", "24", "25", "26", "27", "28", "29")
              .build();
          Table joinedTable = leftTable.onColumns(0, 2).leftAntiJoin(rightTable.onColumns(0, 1), true);
-         Table orderedJoinedTable = joinedTable.orderBy(Table.asc(2, true));
+         Table orderedJoinedTable = joinedTable.orderBy(OrderByArg.asc(2, true));
          Table expected = new Table.TestBuilder()
              .column( 360,  326, null,  306, null,  251,  301,  317)
              .column(  10,   11, null,   13,   14,   16,   18,   19)
@@ -1249,8 +1249,8 @@ public class TableTest extends CudfTestBase {
          Table joinedTable = leftTable.crossJoin(rightTable);
          Table orderedJoinedTable =
                  joinedTable.orderBy(
-                         Table.asc(0, true),
-                         Table.asc(1, true))) {
+                     OrderByArg.asc(0, true),
+                     OrderByArg.asc(1, true))) {
       assertTablesAreEqual(expected, orderedJoinedTable);
     }
   }
@@ -2297,7 +2297,7 @@ public class TableTest extends CudfTestBase {
       try (Table t3 = t1
               .groupBy(0, 1)
               .aggregate(Aggregation.nunique().onColumn(0));
-           Table sorted = t3.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+           Table sorted = t3.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            Table expected = new Table.TestBuilder()
                    .column( "1",  "1",  "1",  "1")
                    .column(   0,    1,    3,    5)
@@ -2318,7 +2318,7 @@ public class TableTest extends CudfTestBase {
       try (Table t3 = t1
               .groupBy(0, 1)
               .aggregate(Aggregation.nunique(true).onColumn(0));
-           Table sorted = t3.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+           Table sorted = t3.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            Table expected = new Table.TestBuilder()
                    .column( "1",  "1",  "1",  "1")
                    .column(   0,    1,    3,    5)
@@ -2370,8 +2370,8 @@ public class TableTest extends CudfTestBase {
         .decimal32Column(-1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3) // Decimal GBY Key
         .decimal64Column(1, 1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L, 5L, 6L, 6L) // Decimal OBY Key
         .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
-           Table decSorted = unsorted.orderBy(Table.asc(0), Table.asc(4), Table.asc(5));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
+           Table decSorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(4), OrderByArg.asc(5));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -2406,8 +2406,8 @@ public class TableTest extends CudfTestBase {
         .decimal64Column(1, 1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L, 5L, 6L, 6L) // Decimal OBY Key
         .decimal64Column(2, 7L, 5L, 1L, 9L, 7L, 9L, 8L, 2L, 8L, 0L, 6L, 6L) // Decimal Agg Column
         .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
-           Table decSorted = unsorted.orderBy(Table.asc(0), Table.asc(4), Table.asc(5));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
+           Table decSorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(4), OrderByArg.asc(5));
            ColumnVector expectSortedAggCol = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
            ColumnVector expectDecSortedAggCol = ColumnVector.decimalFromLongs(2, 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
@@ -2444,8 +2444,8 @@ public class TableTest extends CudfTestBase {
         .decimal64Column(1, 1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L, 5L, 6L, 6L) // Decimal OBY Key
         .decimal64Column(2, 7L, 5L, 1L, 9L, 7L, 9L, 8L, 2L, 8L, 0L, 6L, 6L) // Decimal Agg Column
         .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
-           Table decSorted = unsorted.orderBy(Table.asc(0), Table.asc(4), Table.asc(5));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
+           Table decSorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(4), OrderByArg.asc(5));
            ColumnVector expectSortedAggCol = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
            ColumnVector expectDecSortedAggCol = ColumnVector.decimalFromLongs(2, 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
@@ -2479,7 +2479,7 @@ public class TableTest extends CudfTestBase {
         .column(1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6) // OBY Key
         .column(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6) // Agg Column
         .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -2509,8 +2509,8 @@ public class TableTest extends CudfTestBase {
         .decimal64Column(1, 1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L, 5L, 6L, 6L) // Decimal OBY Key
         .decimal64Column(2, 7L, 5L, 1L, 9L, 7L, 9L, 8L, 2L, 8L, 0L, 6L, 6L) // Decimal Agg Column
         .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
-           Table decSorted = unsorted.orderBy(Table.asc(0), Table.asc(4), Table.asc(5));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
+           Table decSorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(4), OrderByArg.asc(5));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
            ColumnVector expectDecSortedAggColumn = ColumnVector.decimalFromLongs(2, 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
@@ -2590,7 +2590,7 @@ public class TableTest extends CudfTestBase {
               ).build();
          ColumnVector expectSortedAggColumn = ColumnVector
              .fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, null, 0, 6, null)) {
-      try (Table sorted = raw.orderBy(Table.asc(0), Table.asc(1), Table.asc(2))) {
+      try (Table sorted = raw.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2))) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
 
@@ -2652,8 +2652,8 @@ public class TableTest extends CudfTestBase {
         .decimal64Column(-2, 7L, 5L, 1L, 9L, 7L, 9L, 8L, 2L, 8L, 0L, 6L, 6L) // Decimal Agg Column
         .build()) {
 
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
-           Table decSorted = unsorted.orderBy(Table.asc(0), Table.asc(4), Table.asc(5));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
+           Table decSorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(4), OrderByArg.asc(5));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
            ColumnVector expectDecSortedAggColumn = ColumnVector.decimalFromLongs(-2, 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
@@ -2745,8 +2745,8 @@ public class TableTest extends CudfTestBase {
         .decimal64Column(-2, 7L, 5L, 1L, 9L, 7L, 9L, 8L, 2L, 8L, 0L, 6L, 6L) // Decimal Agg Column
         .build()) {
 
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
-           Table decSorted = unsorted.orderBy(Table.asc(0), Table.asc(4), Table.asc(5));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
+           Table decSorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(4), OrderByArg.asc(5));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
            ColumnVector decExpectSortedAggColumn = ColumnVector.decimalFromLongs(-2, 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
@@ -2833,7 +2833,7 @@ public class TableTest extends CudfTestBase {
                                                  .column( 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6) // OBY Key
                                                  .column( 7, 5, 3, 7, 7, 9, 8, 4, 8, 0, 4, 8) // Agg Column
                                                  .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            ColumnVector expectedSortedAggCol = ColumnVector.fromBoxedInts(7, 5, 3, 7, 7, 9, 8, 4, 8, 0, 4, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectedSortedAggCol, sortedAggColumn);
@@ -2859,7 +2859,7 @@ public class TableTest extends CudfTestBase {
                                                  .column( 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6) // OBY Key
                                                  .column( 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6) // Agg Column
                                                  .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            ColumnVector expectedSortedAggCol = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectedSortedAggCol, sortedAggColumn);
@@ -2909,7 +2909,7 @@ public class TableTest extends CudfTestBase {
                                                  .build();
          ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
 
-      try (Table sorted = unsorted.orderBy(Table.asc(0))) {
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0))) {
         ColumnVector sortedAggColumn = sorted.getColumn(1);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
 
@@ -2934,7 +2934,7 @@ public class TableTest extends CudfTestBase {
                                                  .timestampDayColumn( 1, 1, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7) // Timestamp Key
                                                  .column(             7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8) // Agg Column
                                                  .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -2962,7 +2962,7 @@ public class TableTest extends CudfTestBase {
         .timestampDayColumn( 1, 1, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7) // Timestamp Key
         .column(             7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8) // Agg Column
         .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -2991,7 +2991,7 @@ public class TableTest extends CudfTestBase {
                                                  .timestampDayColumn( 1, 1, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7) // Timestamp Key
                                                  .column(             7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8) // Agg Column
                                                  .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -3029,7 +3029,7 @@ public class TableTest extends CudfTestBase {
                                                  .timestampDayColumn( 1, 1, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7) // Timestamp Key
                                                  .column(             7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8) // Agg Column
                                                  .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -3056,7 +3056,7 @@ public class TableTest extends CudfTestBase {
                                                  .timestampDayColumn( 7, 6, 6, 5,  5, 4, 4, 3,  3, 3, 2, 1, 1) // Timestamp Key
                                                  .column(             7, 5, 1, 9,  7, 9, 8, 2,  8, 0, 6, 6, 8) // Agg Column
                                                  .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.desc(2));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.desc(2));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -3093,7 +3093,7 @@ public class TableTest extends CudfTestBase {
     try (Table unsorted = new Table.TestBuilder().timestampDayColumn( 1, 1, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7) // Timestamp Key
                                                  .column(             7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8) // Agg Column
                                                  .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(1);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -3137,7 +3137,7 @@ public class TableTest extends CudfTestBase {
                                                  .timestampDayColumn( 1, 1, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7) // Timestamp Key
                                                  .column(             7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8) // Agg Column
                                                  .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -3167,7 +3167,7 @@ public class TableTest extends CudfTestBase {
                                     .timestampDayColumn( X, X, X, 2, 3, 5,  X, X, 1, 2, 4, 5, 7) // Timestamp Key
                                     .column(             7, 5, 1, 9, 7, 9,  8, 2, 8, 0, 6, 6, 8) // Agg Column
                                     .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2, true));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2, true));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -3239,7 +3239,7 @@ public class TableTest extends CudfTestBase {
             .timestampDayColumn( X, X, X, 5, 3, 2,  X, X, 7, 5, 4, 2, 1) // Timestamp Key
             .column(             7, 5, 1, 9, 7, 9,  8, 2, 8, 0, 6, 6, 8) // Agg Column
             .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.desc(2, false));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.desc(2, false));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -3316,7 +3316,7 @@ public class TableTest extends CudfTestBase {
             .timestampDayColumn( 2, 3, 5, X, X, X,  1, 2, 4, 5, 7, X, X) // Timestamp Key
             .column(             7, 5, 1, 9, 7, 9,  8, 2, 8, 0, 6, 6, 8) // Agg Column
             .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.asc(2, false));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2, false));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -3387,7 +3387,7 @@ public class TableTest extends CudfTestBase {
             .timestampDayColumn( 5, 3, 2, X, X, X,  7, 5, 4, 2, 1, X, X) // Timestamp Key
             .column(             7, 5, 1, 9, 7, 9,  8, 2, 8, 0, 6, 6, 8) // Agg Column
             .build()) {
-      try (Table sorted = unsorted.orderBy(Table.asc(0), Table.asc(1), Table.desc(2, true));
+      try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.desc(2, true));
            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
@@ -3463,7 +3463,7 @@ public class TableTest extends CudfTestBase {
                                            .column(   1,    1,    1, null,    1,    1)
                                            .build()) {
       try (Table tmp = t1.groupBy(0).aggregate(count(1), count(2), count(3));
-           Table t3 = tmp.orderBy(Table.asc(0, true));
+           Table t3 = tmp.orderBy(OrderByArg.asc(0, true));
            HostColumnVector groupCol = t3.getColumn(0).copyToHost();
            HostColumnVector countCol = t3.getColumn(1).copyToHost();
            HostColumnVector nullCountCol = t3.getColumn(2).copyToHost();
@@ -3500,7 +3500,7 @@ public class TableTest extends CudfTestBase {
             .column(   1,    1,    1, null,    1,    1)
             .build()) {
       try (Table tmp = t1.groupBy(0).aggregate(count(1, true), count(2, true), count(3, true), count(3));
-           Table t3 = tmp.orderBy(Table.asc(0, true));
+           Table t3 = tmp.orderBy(OrderByArg.asc(0, true));
            HostColumnVector groupCol = t3.getColumn(0).copyToHost();
            HostColumnVector countCol = t3.getColumn(1).copyToHost();
            HostColumnVector nullCountCol = t3.getColumn(2).copyToHost();
@@ -3547,7 +3547,7 @@ public class TableTest extends CudfTestBase {
           .build();
 
       try (Table tmp = t1.groupBy(options, 0).aggregate(count(1), count(2), count(3));
-           Table t3 = tmp.orderBy(Table.asc(0, true));
+           Table t3 = tmp.orderBy(OrderByArg.asc(0, true));
            HostColumnVector groupCol = t3.getColumn(0).copyToHost();
            HostColumnVector countCol = t3.getColumn(1).copyToHost();
            HostColumnVector nullCountCol = t3.getColumn(2).copyToHost();
@@ -3615,7 +3615,7 @@ public class TableTest extends CudfTestBase {
       try (Table t3 = t1.groupBy(0, 1)
               .aggregate(Aggregation.argMax().onColumn(2));
            Table sorted = t3
-              .orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+              .orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            Table expected = new Table.TestBuilder()
                    .column(1, 1, 1, 1)
                    .column(0, 1, 2, 3)
@@ -3637,7 +3637,7 @@ public class TableTest extends CudfTestBase {
       try (Table t3 = t1.groupBy(0, 1)
               .aggregate(Aggregation.argMin().onColumn(2));
            Table sorted = t3
-                   .orderBy(Table.asc(0), Table.asc(1), Table.asc(2));
+                   .orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            Table expected = new Table.TestBuilder()
                    .column(1, 1, 1, 1)
                    .column(0, 1, 2, 3)
@@ -3654,7 +3654,7 @@ public class TableTest extends CudfTestBase {
         .column(true, null, false, true, null, null)
         .column(   1,    1,     2,    2,    3,    3).build();
          Table other = t1.groupBy(1).aggregate(min(0));
-         Table ordered = other.orderBy(Table.asc(0));
+         Table ordered = other.orderBy(OrderByArg.asc(0));
          Table expected = new Table.TestBuilder()
              .column(1, 2, 3)
              .column (true, false, null)
@@ -3669,7 +3669,7 @@ public class TableTest extends CudfTestBase {
         .column(false, null, false, true, null, null)
         .column(   1,    1,     2,    2,    3,    3).build();
          Table other = t1.groupBy(1).aggregate(max(0));
-         Table ordered = other.orderBy(Table.asc(0));
+         Table ordered = other.orderBy(OrderByArg.asc(0));
          Table expected = new Table.TestBuilder()
              .column(1, 2, 3)
              .column (false, true, null)
@@ -3695,7 +3695,7 @@ public class TableTest extends CudfTestBase {
              .column(   1,    2,    2,    1).build()) {
       try (Table t3 = t1.groupBy(0, 1)
           .aggregate(max(2), min(2), min(2), max(2), min(2), count(1));
-          Table t4 = t3.orderBy(Table.asc(2))) {
+          Table t4 = t3.orderBy(OrderByArg.asc(2))) {
         // verify t4
         assertEquals(4, t4.getRowCount());
         assertTablesAreEqual(t4, expected);


### PR DESCRIPTION
This is to address an issue we found in the Spark out of core sorting implementation.