### PR TITLE
Update conda recipes pinning of repo dependencies

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numba >=0.49.0
     - dlpack
     - pyarrow 1.0.1
-    - libcudf {{ version }}
+    - libcudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - rmm {{ minor_version }}
     - cudatoolkit {{ cuda_version }}
   run:

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -29,12 +29,12 @@ requirements:
     - python
     - cython >=0.29,<0.30
     - setuptools
-    - cudf {{ version }}
-    - libcudf_kafka {{ version }}
+    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - libcudf_kafka {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
   run:
-    - libcudf_kafka {{ version }}
+    - libcudf_kafka {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - python-confluent-kafka
-    - cudf {{ version }}
+    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
 
 test:
   requires:

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -23,15 +23,15 @@ requirements:
   host:
     - python
     - python-confluent-kafka
-    - cudf_kafka {{ version }}
+    - cudf_kafka {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
   run:
     - python
-    - streamz 
-    - cudf {{ version }}
+    - streamz
+    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - dask >=2.22.0
     - distributed >=2.22.0
     - python-confluent-kafka
-    - cudf_kafka {{ version }}
+    - cudf_kafka {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
 
 test:
   requires:

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -22,15 +22,15 @@ build:
 requirements:
   host:
     - python
-    - cudf {{ version }}
+    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - dask >=2.22.0
     - distributed >=2.22.0
   run:
     - python
-    - cudf {{ version }}
+    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - dask >=2.22.0
     - distributed >=2.22.0
-  
+
 test:
   requires:
     - cudatoolkit {{ cuda_version }}.*

--- a/conda/recipes/libcudf_kafka/meta.yaml
+++ b/conda/recipes/libcudf_kafka/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   build:
     - cmake >=3.17.0
   host:
-    - libcudf {{ version }}
+    - libcudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - librdkafka >=1.5.0,<1.5.3
   run:
     - {{ pin_compatible('librdkafka', max_pin='x.x') }} #TODO: librdkafka should be automatically included here by run_exports but is not


### PR DESCRIPTION
Ensure all conda packages created in this repo that depend on other packages are all version pinned to the same build number. This way it prevents a conda solve from picking mismatched versions of `cudf` and `libcudf` among others that can break this repo and others.