### PR TITLE
Fix string length in stripe dictionary building

### DIFF
--- a/cpp/src/io/orc/dict_enc.cu
+++ b/cpp/src/io/orc/dict_enc.cu
@@ -398,7 +398,7 @@ __global__ void __launch_bounds__(block_size)
     bool is_dupe     = false;
     if (i + t < num_strings) {
       current_string = s->stripe.leaf_column->element<string_view>(cur);
-      cur_len        = current_string.size_byte();
+      cur_len        = current_string.size_bytes();
     }
     if (i + t != 0 && i + t < num_strings) {
       uint32_t prev = dict_data[i + t - 1];

--- a/cpp/src/io/orc/dict_enc.cu
+++ b/cpp/src/io/orc/dict_enc.cu
@@ -396,7 +396,10 @@ __global__ void __launch_bounds__(block_size)
     uint32_t cur     = (i + t < num_strings) ? dict_data[i + t] : 0;
     uint32_t cur_len = 0;
     bool is_dupe     = false;
-    if (i + t < num_strings) { current_string = s->stripe.leaf_column->element<string_view>(cur); }
+    if (i + t < num_strings) {
+      current_string = s->stripe.leaf_column->element<string_view>(cur);
+      cur_len        = current_string.size_byte();
+    }
     if (i + t != 0 && i + t < num_strings) {
       uint32_t prev = dict_data[i + t - 1];
       is_dupe       = (current_string == (s->stripe.leaf_column->element<string_view>(prev)));


### PR DESCRIPTION
In PR #7676 the length of the current string being referred to while building stripe dictionaries was always set to 0 while incrementing the dictionary character count of a StripeDictionary. This led to corrupted strings when the dictionary encoding was used as noted in issue #7741. This has been fixed in this PR.

Fixes #7741 