### PR TITLE
update Java bindings version to 0.20 [skip ci]

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -38,12 +38,12 @@ In some cases there may be a classifier to indicate the version of cuda required
 Build From Source section below for more information about when this can happen. No official
 release of the jar will have a classifier on it.
 
-CUDA 10.0:
+CUDA 11.0:
 ```xml
 <dependency>
     <groupId>ai.rapids</groupId>
     <artifactId>cudf</artifactId>
-    <classifier>cuda10</classifier>
+    <classifier>cuda11</classifier>
     <version>${cudf.version}</version>
 </dependency>
 ```

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -14,7 +14,7 @@ In the root path of cuDF repo, run below command to build the docker image.
 docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.0 -t cudf-build:11.0-devel-centos7 .
 ```
 
-We support different CUDA versions as below:
+The following CUDA versions are supported:
 * CUDA 11.0
 
 Change the --build-arg CUDA_VERSION to what you need.

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -11,16 +11,14 @@
 
 In the root path of cuDF repo, run below command to build the docker image.
 ```bash
-docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=10.1 -t cudf-build:10.1-devel-centos7 .
+docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.0 -t cudf-build:11.0-devel-centos7 .
 ```
 
 We support different CUDA versions as below:
-* CUDA 10.1
-* CUDA 10.2
 * CUDA 11.0
 
 Change the --build-arg CUDA_VERSION to what you need.
-You can replace the tag "cudf-build:10.1-devel-centos7" with another name you like.
+You can replace the tag "cudf-build:11.0-devel-centos7" with another name you like.
 
 ## Start the docker then build
 
@@ -28,7 +26,7 @@ You can replace the tag "cudf-build:10.1-devel-centos7" with another name you li
 
 Run below command to start a docker container with GPU.
 ```bash
-nvidia-docker run -it cudf-build:10.1-devel-centos7 bash
+nvidia-docker run -it cudf-build:11.0-devel-centos7 bash
 ```
 
 ### Download the cuDF source code
@@ -36,7 +34,7 @@ nvidia-docker run -it cudf-build:10.1-devel-centos7 bash
 You can download the cuDF repo in the docker container or you can mount it into the container.
 Here I choose to download again in the container.
 ```bash
-git clone --recursive https://github.com/rapidsai/cudf.git -b branch-0.19
+git clone --recursive https://github.com/rapidsai/cudf.git -b branch-0.20
 ```
 
 ### Build cuDF jar with devtoolset
@@ -49,5 +47,5 @@ scl enable devtoolset-8 "java/ci/build-in-docker.sh"
 
 ### The output
 
-You can find the cuDF jar in java/target/ like cudf-0.19-SNAPSHOT-cuda10-1.jar.
+You can find the cuDF jar in java/target/ like cudf-0.20-SNAPSHOT-cuda11.jar.
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ai.rapids</groupId>
     <artifactId>cudf</artifactId>
-    <version>0.19-SNAPSHOT</version>
+    <version>0.20-SNAPSHOT</version>
 
     <name>cudfjni</name>
     <description>


### PR DESCRIPTION
Updating the Java bindings package version to match the libcudf version for 0.20

also as [Deprecation announcement for CUDA 10.1 & 10.2 in v0.19](https://docs.rapids.ai/notices/rsn0005/), to update README to drop cuda 10.1 and cuda 10.2.

Please let me know if we are going to support other cuda version 11.x except 11.0