### PR TITLE
Fix type dispatch for columnar replace_nulls

### DIFF
--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -426,7 +426,7 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
   if (input.is_empty()) { return cudf::empty_like(input); }
   if (!input.has_nulls()) { return std::make_unique<cudf::column>(input); }
 
-  return cudf::type_dispatcher(
+  return cudf::type_dispatcher<dispatch_storage_type>(
     input.type(), replace_nulls_column_kernel_forwarder{}, input, replacement, stream, mr);
 }
 


### PR DESCRIPTION
Fixes #7766 

Fixes a type dispatch problem where cudf::replace_nulls was not dispatching on the appropriate type, causing a "No specialization exists for the given type" to be thrown when using its columnar form with fixed-point types.