### PR TITLE
User resource fix for replace_nulls

### DIFF
--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -424,7 +424,7 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
   CUDF_EXPECTS(replacement.size() == input.size(), "Column size mismatch");
 
   if (input.is_empty()) { return cudf::empty_like(input); }
-  if (!input.has_nulls()) { return std::make_unique<cudf::column>(input); }
+  if (!input.has_nulls()) { return std::make_unique<cudf::column>(input, stream, mr); }
 
   return cudf::type_dispatcher(
     input.type(), replace_nulls_column_kernel_forwarder{}, input, replacement, stream, mr);


### PR DESCRIPTION
`cudf::replace_nulls` was copying the input column with the default stream and resource when there is no null. This simple PR is to make sure to pass the right stream and resource to the copy constructor.