### PR TITLE
[REVIEW] Introduces `make_optional_iterator` for nullable column and scalars

### DIFF
--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -1228,7 +1228,6 @@ struct value_accessor {
  *
  * @throws cudf::logic_error if column datatype and template T type mismatch.
  * @throws cudf::logic_error if the column is not nullable, and `with_nulls=true`
- * @throws cudf::logic_error if column datatype and template T type mismatch.
  *
  *
  * @tparam T The type of elements in the column

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -541,12 +541,14 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
    *
    * optional_begin with mode `DYNAMIC` defers the assumption of nullability to
    * runtime, with the user stating on construction of the iterator if column has nulls.
+   * `DYNAMIC` mode is nice when an algorithm is going to execute on mutliple
+   * iterators and you don't want to compile all the combinations of iterator types
    *
    * Example:
    *
    * \code{.cpp}
    * template<typename T>
-   * void some_function( cudf::column_view<T> const& col_view, bool has_nulls){
+   * void some_function(cudf::column_view<T> const& col_view, bool has_nulls){
    *    auto d_col = cudf::column_device_view::create(col_view);
    *    // Create a `DYNAMIC` optional iterator
    *    auto optional_iterator = d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{}, has_nulls);
@@ -578,6 +580,22 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
    * optional_begin with mode `YES` means that the column supports nulls and
    * potentially has null values, therefore the optional might not contain a value
    *
+   * Example:
+   *
+   * \code{.cpp}
+   * template<typename T, bool has_nulls>
+   * void some_function(cudf::column_view<T> const& col_view){
+   *    auto d_col = cudf::column_device_view::create(col_view);
+   *    if constexpr(has_nulls) {
+   *      auto optional_iterator = d_col->optional_begin<T>(cudf::contains_nulls::YES{});
+   *      //use optional_iterator
+   *    } else {
+   *      auto optional_iterator = d_col->optional_begin<T>(cudf::contains_nulls::NO{});
+   *      //use optional_iterator
+   *    }
+   * }
+   * \endcode
+   *
    * This function does not participate in overload resolution if
    * `column_device_view::has_element_accessor<T>()` is false.
    *
@@ -601,6 +619,22 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
    *
    * optional_begin with mode `NO` means that the column has no null values,
    * therefore the optional will always contain a value.
+   *
+   * Example:
+   *
+   * \code{.cpp}
+   * template<typename T, bool has_nulls>
+   * void some_function(cudf::column_view<T> const& col_view){
+   *    auto d_col = cudf::column_device_view::create(col_view);
+   *    if constexpr(has_nulls) {
+   *      auto optional_iterator = d_col->optional_begin<T>(cudf::contains_nulls::YES{});
+   *      //use optional_iterator
+   *    } else {
+   *      auto optional_iterator = d_col->optional_begin<T>(cudf::contains_nulls::NO{});
+   *      //use optional_iterator
+   *    }
+   * }
+   * \endcode
    *
    * This function does not participate in overload resolution if
    * `column_device_view::has_element_accessor<T>()` is false.

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -549,20 +549,12 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
    *         the user has stated nulls exist
    * @throws cudf::logic_error if column datatype and Element type mismatch.
    */
-  /**@{*/
   template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
   auto optional_begin(contains_nulls::DYNAMIC, bool has_nulls) const
   {
     return const_optional_iterator<T, contains_nulls::DYNAMIC>{
       count_it{0}, detail::optional_accessor<T, contains_nulls::DYNAMIC>{*this, has_nulls}};
   }
-  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
-  auto optional_begin(contains_nulls::DYNAMIC) const
-  {
-    return const_optional_iterator<T, contains_nulls::DYNAMIC>{
-      count_it{0}, detail::optional_accessor<T, contains_nulls::DYNAMIC>{*this}};
-  }
-  /**@}*/
 
   /**
    * @brief Return an optional iterator to the first element of the column.
@@ -682,20 +674,12 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
    *         the user has stated nulls exist
    * @throws cudf::logic_error if column datatype and Element type mismatch.
    */
-  /**@{*/
   template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
   auto optional_end(contains_nulls::DYNAMIC, bool has_nulls) const
   {
     return const_optional_iterator<T, contains_nulls::DYNAMIC>{
       count_it{size()}, detail::optional_accessor<T, contains_nulls::DYNAMIC>{*this, has_nulls}};
   }
-  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
-  auto optional_end(contains_nulls::DYNAMIC) const
-  {
-    return const_optional_iterator<T, contains_nulls::DYNAMIC>{
-      count_it{size()}, detail::optional_accessor<T, contains_nulls::DYNAMIC>{*this}};
-  }
-  /**@}*/
 
   /**
    * @brief Return an optional iterator to the element following the last element of
@@ -1231,16 +1215,6 @@ template <typename T>
 struct optional_accessor<T, contains_nulls::DYNAMIC> {
   column_device_view const col;  ///< column view of column in device
   bool has_nulls;
-
-  /**
-   * @brief constructor
-   * @param[in] _col column device view of cudf column
-   */
-  optional_accessor(column_device_view const& _col)
-    : col{_col}, has_nulls{_col.nullable()}
-  {
-    CUDF_EXPECTS(type_id_matches_device_storage_type<T>(col.type().id()), "the data type mismatch");
-  }
 
   /**
    * @brief constructor

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -548,11 +548,11 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
    *
    * \code{.cpp}
    * template<typename T>
-   * void some_function(cudf::column_view<T> const& col_view, bool has_nulls){
+   * void some_function(cudf::column_view<T> const& col_view){
    *    auto d_col = cudf::column_device_view::create(col_view);
    *    // Create a `DYNAMIC` optional iterator
    *    auto optional_iterator = d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{},
-   *                                                      has_nulls);
+   *                                                      col_view.has_nulls());
    * }
    * \endcode
    *

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -551,7 +551,8 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
    * void some_function(cudf::column_view<T> const& col_view, bool has_nulls){
    *    auto d_col = cudf::column_device_view::create(col_view);
    *    // Create a `DYNAMIC` optional iterator
-   *    auto optional_iterator = d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{}, has_nulls);
+   *    auto optional_iterator = d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{},
+   *                                                      has_nulls);
    * }
    * \endcode
    *

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -1232,6 +1232,7 @@ struct value_accessor {
  *
  *
  * @tparam T The type of elements in the column
+ * @tparam contains_nulls_mode Specifies if nulls are checked at runtime or compile time.
  */
 template <typename T, typename contains_nulls_mode>
 struct optional_accessor {

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -542,6 +542,17 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
    * optional_begin with mode `DYNAMIC` defers the assumption of nullability to
    * runtime, with the user stating on construction of the iterator if column has nulls.
    *
+   * Example:
+   *
+   * \code{.cpp}
+   * template<typename T>
+   * void some_function( cudf::column_view<T> const& col_view, bool has_nulls){
+   *    auto d_col = cudf::column_device_view::create(col_view);
+   *    // Create a `DYNAMIC` optional iterator
+   *    auto optional_iterator = d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{}, has_nulls);
+   * }
+   * \endcode
+   *
    * This function does not participate in overload resolution if
    * `column_device_view::has_element_accessor<T>()` is false.
    *

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -31,6 +31,7 @@
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
+#include <thrust/optional.h>
 
 #include <algorithm>
 
@@ -40,6 +41,28 @@
  */
 
 namespace cudf {
+
+/**
+ * @brief Policy for what assumptions the optional iterator has about null values
+ *
+ * - `YES` means that the column supports nulls and has null values, therefore
+ *    the optional might not contain a value
+ *
+ * - `NO` means that the column has no null values, therefore the optional will
+ *    always have a value
+ *
+ * - `DYNAMIC` defers the assumption of nullability to runtime with the users stating
+ *    on construction of the iterator if column has nulls.
+ */
+namespace contains_nulls {
+struct YES {
+};
+struct NO {
+};
+struct DYNAMIC {
+};
+}  // namespace contains_nulls
+
 namespace detail {
 /**
  * @brief An immutable, non-owning view of device data as a column of elements
@@ -255,10 +278,11 @@ class alignas(16) column_device_view_base {
     : std::true_type {
   };
 };
-
 // Forward declaration
 template <typename T>
 struct value_accessor;
+template <typename T, typename contains_nulls_mode>
+struct optional_accessor;
 template <typename T, bool has_nulls>
 struct pair_accessor;
 template <typename T, bool has_nulls>
@@ -485,6 +509,13 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
   }
 
   /**
+   * @brief optional iterator for navigating this column
+   */
+  template <typename T, typename contains_nulls_mode>
+  using const_optional_iterator =
+    thrust::transform_iterator<detail::optional_accessor<T, contains_nulls_mode>, count_it>;
+
+  /**
    * @brief Pair iterator for navigating this column
    */
   template <typename T, bool has_nulls>
@@ -499,6 +530,86 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
   template <typename T, bool has_nulls>
   using const_pair_rep_iterator =
     thrust::transform_iterator<detail::pair_rep_accessor<T, has_nulls>, count_it>;
+
+  /**
+   * @brief Return an optional iterator to the first element of the column.
+   *
+   * Dereferencing the returned iterator returns a `thrust::optional<T>`.
+   *
+   * When the element of an iterator contextually converted to bool, the conversion returns true
+   * if the object contains a value and false if it does not contain a value.
+   *
+   * optional_begin with mode `DYNAMIC` defers the assumption of nullability to
+   * runtime, with the user stating on construction of the iterator if column has nulls.
+   *
+   * This function does not participate in overload resolution if
+   * `column_device_view::has_element_accessor<T>()` is false.
+   *
+   * @throws cudf::logic_error if the column is not nullable, and `DYNAMIC` mode used and
+   *         the user has stated nulls exist
+   * @throws cudf::logic_error if column datatype and Element type mismatch.
+   */
+  /**@{*/
+  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
+  auto optional_begin(contains_nulls::DYNAMIC, bool has_nulls) const
+  {
+    return const_optional_iterator<T, contains_nulls::DYNAMIC>{
+      count_it{0}, detail::optional_accessor<T, contains_nulls::DYNAMIC>{*this, has_nulls}};
+  }
+  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
+  auto optional_begin(contains_nulls::DYNAMIC) const
+  {
+    return const_optional_iterator<T, contains_nulls::DYNAMIC>{
+      count_it{0}, detail::optional_accessor<T, contains_nulls::DYNAMIC>{*this}};
+  }
+  /**@}*/
+
+  /**
+   * @brief Return an optional iterator to the first element of the column.
+   *
+   * Dereferencing the returned iterator returns a `thrust::optional<T>`.
+   *
+   * When the element of an iterator contextually converted to bool, the conversion returns true
+   * if the object contains a value and false if it does not contain a value.
+   *
+   * optional_begin with mode `YES` means that the column supports nulls and
+   * potentially has null values, therefore the optional might not contain a value
+   *
+   * This function does not participate in overload resolution if
+   * `column_device_view::has_element_accessor<T>()` is false.
+   *
+   * @throws cudf::logic_error if the column is not nullable, and `YES` mode used
+   * @throws cudf::logic_error if column datatype and Element type mismatch.
+   */
+  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
+  auto optional_begin(contains_nulls::YES) const
+  {
+    return const_optional_iterator<T, contains_nulls::YES>{
+      count_it{0}, detail::optional_accessor<T, contains_nulls::YES>{*this}};
+  }
+
+  /**
+   * @brief Return an optional iterator to the first element of the column.
+   *
+   * Dereferencing the returned iterator returns a `thrust::optional<T>`.
+   *
+   * When the element of an iterator contextually converted to bool, the conversion returns true
+   * if the object contains a value and false if it does not contain a value.
+   *
+   * optional_begin with mode `NO` means that the column has no null values,
+   * therefore the optional will always contain a value.
+   *
+   * This function does not participate in overload resolution if
+   * `column_device_view::has_element_accessor<T>()` is false.
+   *
+   * @throws cudf::logic_error if column datatype and Element type mismatch.
+   */
+  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
+  auto optional_begin(contains_nulls::NO) const
+  {
+    return const_optional_iterator<T, contains_nulls::NO>{
+      count_it{0}, detail::optional_accessor<T, contains_nulls::NO>{*this}};
+  }
 
   /**
    * @brief Return a pair iterator to the first element of the column.
@@ -556,6 +667,71 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
   {
     return const_pair_rep_iterator<T, has_nulls>{count_it{0},
                                                  detail::pair_rep_accessor<T, has_nulls>{*this}};
+  }
+
+  /**
+   * @brief Return an optional iterator to the element following the last element of
+   * the column.
+   *
+   * Dereferencing the returned iterator returns a `thrust::optional<T>`.
+   *
+   * This function does not participate in overload resolution if
+   * `column_device_view::has_element_accessor<T>()` is false.
+   *
+   * @throws cudf::logic_error if the column is not nullable, and `DYNAMIC` mode used and
+   *         the user has stated nulls exist
+   * @throws cudf::logic_error if column datatype and Element type mismatch.
+   */
+  /**@{*/
+  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
+  auto optional_end(contains_nulls::DYNAMIC, bool has_nulls) const
+  {
+    return const_optional_iterator<T, contains_nulls::DYNAMIC>{
+      count_it{size()}, detail::optional_accessor<T, contains_nulls::DYNAMIC>{*this, has_nulls}};
+  }
+  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
+  auto optional_end(contains_nulls::DYNAMIC) const
+  {
+    return const_optional_iterator<T, contains_nulls::DYNAMIC>{
+      count_it{size()}, detail::optional_accessor<T, contains_nulls::DYNAMIC>{*this}};
+  }
+  /**@}*/
+
+  /**
+   * @brief Return an optional iterator to the element following the last element of
+   * the column.
+   *
+   * Dereferencing the returned iterator returns a `thrust::optional<T>`.
+   *
+   * This function does not participate in overload resolution if
+   * `column_device_view::has_element_accessor<T>()` is false.
+   *
+   * @throws cudf::logic_error if the column is not nullable, and `YES` mode used
+   * @throws cudf::logic_error if column datatype and Element type mismatch.
+   */
+  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
+  auto optional_end(contains_nulls::YES) const
+  {
+    return const_optional_iterator<T, contains_nulls::YES>{
+      count_it{size()}, detail::optional_accessor<T, contains_nulls::YES>{*this}};
+  }
+
+  /**
+   * @brief Return an optional iterator to the element following the last element of
+   * the column.
+   *
+   * Dereferencing the returned iterator returns a `thrust::optional<T>`.
+   *
+   * This function does not participate in overload resolution if
+   * `column_device_view::has_element_accessor<T>()` is false.
+   *
+   * @throws cudf::logic_error if column datatype and Element type mismatch.
+   */
+  template <typename T, CUDF_ENABLE_IF(column_device_view::has_element_accessor<T>())>
+  auto optional_end(contains_nulls::NO) const
+  {
+    return const_optional_iterator<T, contains_nulls::NO>{
+      count_it{size()}, detail::optional_accessor<T, contains_nulls::NO>{*this}};
   }
 
   /**
@@ -997,6 +1173,92 @@ struct value_accessor {
   }
 
   __device__ T operator()(cudf::size_type i) const { return col.element<T>(i); }
+};
+
+/**
+ * @brief optional accessor of a column
+ *
+ *
+ * The optional_accessor always returns a thrust::optional of column[i]. The validity
+ * of the optional is determined by the contains_nulls_mode template parameter
+ * which has the following modes:
+ *
+ * - `YES` means that the column supports nulls and has null values, therefore
+ *    the optional might be valid or invalid
+ *
+ * - `NO` the user has attested that the column has no null values,
+ *    no checks will occur and `thrust::optional{column[i]}` will be
+ *    return for each `i`.
+ *
+ * - `DYNAMIC` defers the assumption of nullability to runtime with the users stating
+ *    on construction of the iterator if column has nulls.
+ *    When `with_nulls=true` the return value validity will be determined if column[i]
+ *    is not null.
+ *    When `with_nulls=false` the return value will always be valid
+ *
+ * @throws cudf::logic_error if column datatype and template T type mismatch.
+ * @throws cudf::logic_error if the column is not nullable, and `with_nulls=true`
+ * @throws cudf::logic_error if column datatype and template T type mismatch.
+ *
+ *
+ * @tparam T The type of elements in the column
+ */
+template <typename T, typename contains_nulls_mode>
+struct optional_accessor {
+  column_device_view const col;  ///< column view of column in device
+
+  /**
+   * @brief constructor
+   * @param[in] _col column device view of cudf column
+   */
+  optional_accessor(column_device_view const& _col) : col{_col}
+  {
+    CUDF_EXPECTS(type_id_matches_device_storage_type<T>(col.type().id()), "the data type mismatch");
+  }
+
+  CUDA_DEVICE_CALLABLE
+  thrust::optional<T> operator()(cudf::size_type i) const
+  {
+    if constexpr (std::is_same_v<contains_nulls_mode, contains_nulls::YES>) {
+      return (col.is_valid_nocheck(i)) ? thrust::optional<T>{col.element<T>(i)}
+                                       : thrust::optional<T>{thrust::nullopt};
+    }
+    return thrust::optional<T>{col.element<T>(i)};
+  }
+};
+
+template <typename T>
+struct optional_accessor<T, contains_nulls::DYNAMIC> {
+  column_device_view const col;  ///< column view of column in device
+  bool has_nulls;
+
+  /**
+   * @brief constructor
+   * @param[in] _col column device view of cudf column
+   */
+  optional_accessor(column_device_view const& _col)
+    : col{_col}, has_nulls{_col.nullable()}
+  {
+    CUDF_EXPECTS(type_id_matches_device_storage_type<T>(col.type().id()), "the data type mismatch");
+  }
+
+  /**
+   * @brief constructor
+   * @param[in] _col column device view of cudf column
+   */
+  optional_accessor(column_device_view const& _col, bool with_nulls)
+    : col{_col}, has_nulls{with_nulls}
+  {
+    CUDF_EXPECTS(type_id_matches_device_storage_type<T>(col.type().id()), "the data type mismatch");
+    if (with_nulls) { CUDF_EXPECTS(_col.nullable(), "Unexpected non-nullable column."); }
+  }
+
+  CUDA_DEVICE_CALLABLE
+  thrust::optional<T> operator()(cudf::size_type i) const
+  {
+    return (has_nulls and col.is_null_nocheck(i)) ? thrust::optional<T>{thrust::nullopt}
+                                                  : thrust::optional<T>{col.element<T>(i)};
+  }
 };
 
 /**

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -184,11 +184,12 @@ auto make_null_replacement_iterator(column_device_view const& column,
  *
  * \code{.cpp}
  * template<typename T>
- * void some_function(cudf::column_view<T> const& col_view, bool has_nulls){
+ * void some_function(cudf::column_view<T> const& col_view){
  *    auto d_col = cudf::column_device_view::create(col_view);
  *    // Create a `DYNAMIC` optional iterator
  *    auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col,
- *                                                cudf::contains_nulls::DYNAMIC{}, has_nulls);
+ *                                                cudf::contains_nulls::DYNAMIC{},
+ *                                                col_view.has_nulls());
  * }
  * \endcode
  *

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -198,9 +198,8 @@ auto make_null_replacement_iterator(column_device_view const& column,
  * @throws cudf::logic_error if column datatype and Element type mismatch.
  *
  * @tparam Element The type of elements in the column
- * @tparam MODE The null_mode of the iterator
  * @param column The column to iterate
- * @return auto Iterator that returns valid column elements, and validity of the
+ * @return Iterator that returns valid column elements and the validity of the
  * element in a thrust::optional
  */
 template <typename Element>
@@ -244,7 +243,6 @@ auto make_optional_iterator(column_device_view const& column,
  * @throws cudf::logic_error if column datatype and Element type mismatch.
  *
  * @tparam Element The type of elements in the column
- * @tparam mode The has_nulls mode of the iterator
  * @param column The column to iterate
  * @return Iterator that returns column elements and the validity of the
  * element as a thrust::optional
@@ -287,9 +285,8 @@ auto make_optional_iterator(column_device_view const& column, contains_nulls::YE
  * @throws cudf::logic_error if column datatype and Element type mismatch.
  *
  * @tparam Element The type of elements in the column
- * @tparam mode The has_nulls mode of the iterator
  * @param column The column to iterate
- * @return auto Iterator that returns column elements, and validity of the
+ * @return Iterator that returns column elements and the validity of the
  * element in a thrust::optional
  */
 template <typename Element>
@@ -655,7 +652,6 @@ struct scalar_representation_pair_accessor : public scalar_value_accessor<Elemen
  * @throws cudf::logic_error if scalar datatype and Element type mismatch.
  *
  * @tparam Element The type of elements in the scalar
- * @tparam mode The has_nulls mode of the iterator
  * @tparam has_nulls If the scalar value will have a null at runtime
  * @param scalar_value The scalar to iterate
  * @return Iterator that returns scalar elements and validity of the
@@ -714,7 +710,7 @@ auto inline make_optional_iterator(scalar const& scalar_value,
  *
  * @tparam Element The type of elements in the scalar
  * @param scalar_value The scalar to iterate
- * @return auto Iterator that returns scalar elements, and validity of the
+ * @return Iterator that returns scalar elements and the validity of the
  * element in a thrust::optional
  */
 template <typename Element>
@@ -766,7 +762,7 @@ auto inline make_optional_iterator(scalar const& scalar_value, contains_nulls::Y
  *
  * @tparam Element The type of elements in the scalar
  * @param scalar_value The scalar to iterate
- * @return auto Iterator that returns scalar elements, and validity of the
+ * @return Iterator that returns scalar elements and the validity of the
  * element in a thrust::optional
  */
 template <typename Element>

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -187,7 +187,8 @@ auto make_null_replacement_iterator(column_device_view const& column,
  * void some_function(cudf::column_view<T> const& col_view, bool has_nulls){
  *    auto d_col = cudf::column_device_view::create(col_view);
  *    // Create a `DYNAMIC` optional iterator
- *    auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::DYNAMIC{}, has_nulls);
+ *    auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+ *                                                cudf::contains_nulls::DYNAMIC{}, has_nulls);
  * }
  * \endcode
  *
@@ -227,10 +228,12 @@ auto make_optional_iterator(column_device_view const& column,
  * void some_function(cudf::column_view<T> const& col_view){
  *    auto d_col = cudf::column_device_view::create(col_view);
  *    if constexpr(has_nulls) {
- *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::YES{});
+ *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+ *                                                  cudf::contains_nulls::YES{});
  *      //use optional_iterator
  *    } else {
- *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::NO{});
+ *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+ *                                                  cudf::contains_nulls::NO{});
  *      //use optional_iterator
  *    }
  * }
@@ -269,10 +272,12 @@ auto make_optional_iterator(column_device_view const& column, contains_nulls::YE
  * void some_function(cudf::column_view<T> const& col_view){
  *    auto d_col = cudf::column_device_view::create(col_view);
  *    if constexpr(has_nulls) {
- *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::YES{});
+ *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+ *                                                  cudf::contains_nulls::YES{});
  *      //use optional_iterator
  *    } else {
- *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::NO{});
+ *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+ *                                                  cudf::contains_nulls::NO{});
  *      //use optional_iterator
  *    }
  * }
@@ -636,8 +641,10 @@ struct scalar_representation_pair_accessor : public scalar_value_accessor<Elemen
  *                    scalar const& scalar_value,
  *                    bool col_has_nulls){
  *    auto d_col = cudf::column_device_view::create(col_view);
- *    auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::DYNAMIC{}, col_has_nulls);
- *    auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::DYNAMIC{}, scalar_value.is_valid());
+ *    auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+                                      cudf::contains_nulls::DYNAMIC{}, col_has_nulls);
+ *    auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value,
+                                      cudf::contains_nulls::DYNAMIC{}, scalar_value.is_valid());
  *    //use iterators
  * }
  * \endcode
@@ -686,12 +693,16 @@ auto inline make_optional_iterator(scalar const& scalar_value,
  * void some_function(cudf::column_view<T> const& col_view, scalar const& scalar_value){
  *    auto d_col = cudf::column_device_view::create(col_view);
  *    if constexpr(any_nulls) {
- *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::YES{});
- *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::YES{});
+ *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+ *                                                cudf::contains_nulls::YES{});
+ *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value,
+ *                                                cudf::contains_nulls::YES{});
  *      //use iterators
  *    } else {
- *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::NO{});
- *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::NO{});
+ *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+ *                                                cudf::contains_nulls::NO{});
+ *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value,
+ *                                                cudf::contains_nulls::NO{});
  *      //use iterators
  *    }
  * }
@@ -735,12 +746,16 @@ auto inline make_optional_iterator(scalar const& scalar_value, contains_nulls::Y
  * void some_function(cudf::column_view<T> const& col_view, scalar const& scalar_value){
  *    auto d_col = cudf::column_device_view::create(col_view);
  *    if constexpr(any_nulls) {
- *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::YES{});
- *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::YES{});
+ *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+ *                                                cudf::contains_nulls::YES{});
+ *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value,
+ *                                                cudf::contains_nulls::YES{});
  *      //use iterators
  *    } else {
- *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::NO{});
- *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::NO{});
+ *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col,
+ *                                                cudf::contains_nulls::NO{});
+ *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value,
+ *                                                cudf::contains_nulls::NO{});
  *      //use iterators
  *    }
  * }

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -188,7 +188,6 @@ auto make_null_replacement_iterator(column_device_view const& column,
  * @return auto Iterator that returns valid column elements, and validity of the
  * element in a thrust::optional
  */
-/**@{*/
 template <typename Element>
 auto make_optional_iterator(column_device_view const& column,
                             contains_nulls::DYNAMIC,
@@ -196,13 +195,6 @@ auto make_optional_iterator(column_device_view const& column,
 {
   return column.optional_begin<Element>(contains_nulls::DYNAMIC{}, has_nulls);
 }
-template <typename Element>
-auto make_optional_iterator(column_device_view const& column,
-                            contains_nulls::DYNAMIC)
-{
-  return column.optional_begin<Element>(contains_nulls::DYNAMIC{});
-}
-/**@}*/
 
 /**
  * @brief Constructs an optional iterator over a column's values and its validity.
@@ -470,11 +462,6 @@ struct scalar_optional_accessor<Element, cudf::contains_nulls::DYNAMIC>
   using value_type = thrust::optional<Element>;
   bool has_nulls;
 
-  scalar_optional_accessor(scalar const& scalar_value)
-    : scalar_value_accessor<Element>(scalar_value), has_nulls{scalar_value.is_valid()}
-  {
-  }
-
   scalar_optional_accessor(scalar const& scalar_value, bool with_nulls)
     : scalar_value_accessor<Element>(scalar_value), has_nulls{with_nulls}
   {
@@ -607,7 +594,6 @@ struct scalar_representation_pair_accessor : public scalar_value_accessor<Elemen
  * @return auto Iterator that returns scalar elements, and validity of the
  * element in a thrust::optional
  */
-/**@{*/
 template <typename Element>
 auto inline make_optional_iterator(scalar const& scalar_value,
                                    contains_nulls::DYNAMIC, bool has_nulls)
@@ -618,17 +604,6 @@ auto inline make_optional_iterator(scalar const& scalar_value,
     thrust::make_constant_iterator<size_type>(0),
     scalar_optional_accessor<Element, contains_nulls::DYNAMIC>{scalar_value, has_nulls});
 }
-template <typename Element>
-auto inline make_optional_iterator(scalar const& scalar_value,
-                                   contains_nulls::DYNAMIC)
-{
-  CUDF_EXPECTS(type_id_matches_device_storage_type<Element>(scalar_value.type().id()),
-               "the data type mismatch");
-  return thrust::make_transform_iterator(thrust::make_constant_iterator<size_type>(0),
-                                         scalar_optional_accessor<Element, contains_nulls::DYNAMIC>{
-                                           scalar_value});
-}
-/**@}*/
 
 
 /**

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -168,6 +168,94 @@ auto make_null_replacement_iterator(column_device_view const& column,
 }
 
 /**
+ * @brief Constructs an optional iterator over a column's values and its validity.
+ *
+ * Dereferencing the returned iterator returns a `thrust::optional<Element>`.
+ *
+ * When the element of an iterator contextually converted to bool, the conversion returns true
+ * if the object contains a value and false if it does not contain a value.
+ *
+ * make_optional_iterator with mode `DYNAMIC` defers the assumption of nullability to
+ * runtime, with the user stating on construction of the iterator if column has nulls.
+ *
+ * @throws cudf::logic_error if the column is not nullable, and `DYNAMIC` mode used and
+ *         the user has stated nulls exist
+ * @throws cudf::logic_error if column datatype and Element type mismatch.
+ *
+ * @tparam Element The type of elements in the column
+ * @tparam MODE The null_mode of the iterator
+ * @param column The column to iterate
+ * @return auto Iterator that returns valid column elements, and validity of the
+ * element in a thrust::optional
+ */
+/**@{*/
+template <typename Element>
+auto make_optional_iterator(column_device_view const& column,
+                            contains_nulls::DYNAMIC,
+                            bool has_nulls)
+{
+  return column.optional_begin<Element>(contains_nulls::DYNAMIC{}, has_nulls);
+}
+template <typename Element>
+auto make_optional_iterator(column_device_view const& column,
+                            contains_nulls::DYNAMIC)
+{
+  return column.optional_begin<Element>(contains_nulls::DYNAMIC{});
+}
+/**@}*/
+
+/**
+ * @brief Constructs an optional iterator over a column's values and its validity.
+ *
+ * Dereferencing the returned iterator returns a `thrust::optional<Element>`.
+ *
+ * When the element of an iterator contextually converted to bool, the conversion returns true
+ * if the object contains a value and false if it does not contain a value.
+ *
+ * make_optional_iterator ith mode `YES` means that the column supports nulls and
+ * potentially has null values, therefore the optional might not contain a value
+ *
+ * @throws cudf::logic_error if the column is not nullable, and `YES` mode used
+ * @throws cudf::logic_error if column datatype and Element type mismatch.
+ *
+ * @tparam Element The type of elements in the column
+ * @tparam mode The has_nulls mode of the iterator
+ * @param column The column to iterate
+ * @return auto Iterator that returns column elements, and validity of the
+ * element in a thrust::optional
+ */
+template <typename Element>
+auto make_optional_iterator(column_device_view const& column, contains_nulls::YES)
+{
+  return column.optional_begin<Element>(contains_nulls::YES{});
+}
+
+/**
+ * @brief Constructs an optional iterator over a column's values and its validity.
+ *
+ * Dereferencing the returned iterator returns a `thrust::optional<Element>`.
+ *
+ * When the element of an iterator contextually converted to bool, the conversion returns true
+ * if the object contains a value and false if it does not contain a value.
+ *
+ * make_optional_iterator with mode `NO` means that the column has no null values,
+ * therefore the optional will always contain a value.
+ *
+ * @throws cudf::logic_error if column datatype and Element type mismatch.
+ *
+ * @tparam Element The type of elements in the column
+ * @tparam mode The has_nulls mode of the iterator
+ * @param column The column to iterate
+ * @return auto Iterator that returns column elements, and validity of the
+ * element in a thrust::optional
+ */
+template <typename Element>
+auto make_optional_iterator(column_device_view const& column, contains_nulls::NO)
+{
+  return column.optional_begin<Element>(contains_nulls::NO{});
+}
+
+/**
  * @brief Constructs a pair iterator over a column's values and its validity.
  *
  * Dereferencing the returned iterator returns a `thrust::pair<Element, bool>`.
@@ -320,6 +408,86 @@ auto inline make_scalar_iterator(scalar const& scalar_value)
                                          scalar_value_accessor<Element>{scalar_value});
 }
 
+template <typename Element, typename contains_nulls_mode>
+struct scalar_optional_accessor;
+
+/**
+ * @brief optional accessor of a maybe-nullable scalar
+ *
+ * The scalar_optional_accessor always returns a thrust::optional of the scalar.
+ * The validity of the optional is determined by the contains_nulls_mode template parameter
+ * which has the following modes:
+ *
+ * `DYNAMIC`: Defer nullability checks to runtime
+ *
+ *  - When `with_nulls=true` the return value will be a `thrust::optional{scalar}`
+ *    when scalar is valid, and `thrust::optional{}` when the scalar is invalid.
+ *
+ *  - When `with_nulls=false` the return value will always be `thrust::optional{scalar}`
+ *
+ * `NO`: No null values will occur for this scalar, no checks will occur
+ *  and `thrust::optional{scalar}` will always be returned.
+ *
+ * `YES`: null values will occur for this scalar,
+ *  and `thrust::optional{scalar}` will always be returned.
+ *
+ * @throws `cudf::logic_error` if scalar datatype and Element type mismatch.
+ *
+ * @tparam Element The type of return type of functor
+ */
+template <typename Element, typename contains_nulls_mode>
+struct scalar_optional_accessor : public scalar_value_accessor<Element> {
+  using super_t    = scalar_value_accessor<Element>;
+  using value_type = thrust::optional<Element>;
+
+  scalar_optional_accessor(scalar const& scalar_value)
+    : scalar_value_accessor<Element>(scalar_value)
+  {
+  }
+
+  /**
+   * @brief returns a thrust::optional<Element>.
+   *
+   * @throw `cudf::logic_error` if this function is called in host.
+   *
+   * @return a thrust::optional<Element> for the scalar value.
+   */
+  CUDA_HOST_DEVICE_CALLABLE
+  const value_type operator()(size_type) const
+  {
+    if constexpr (std::is_same_v<contains_nulls_mode, contains_nulls::YES>) {
+      return (super_t::dscalar.is_valid()) ? Element{super_t::dscalar.value()}
+                                           : value_type{thrust::nullopt};
+    }
+    return Element{super_t::dscalar.value()};
+  }
+};
+
+template <typename Element>
+struct scalar_optional_accessor<Element, cudf::contains_nulls::DYNAMIC>
+  : public scalar_value_accessor<Element> {
+  using super_t    = scalar_value_accessor<Element>;
+  using value_type = thrust::optional<Element>;
+  bool has_nulls;
+
+  scalar_optional_accessor(scalar const& scalar_value)
+    : scalar_value_accessor<Element>(scalar_value), has_nulls{scalar_value.is_valid()}
+  {
+  }
+
+  scalar_optional_accessor(scalar const& scalar_value, bool with_nulls)
+    : scalar_value_accessor<Element>(scalar_value), has_nulls{with_nulls}
+  {
+  }
+
+  CUDA_HOST_DEVICE_CALLABLE
+  const value_type operator()(size_type) const
+  {
+    return (has_nulls and !super_t::dscalar.is_valid()) ? value_type{thrust::nullopt}
+                                                        : Element{super_t::dscalar.value()};
+  }
+};
+
 /**
  * @brief pair accessor for scalar.
  * The unary functor returns a pair of data of Element type and bool validity of the scalar.
@@ -414,6 +582,117 @@ struct scalar_representation_pair_accessor : public scalar_value_accessor<Elemen
     return dscalar.rep();
   }
 };
+
+/**
+ * @brief Constructs an optional iterator over a scalar's values and its validity.
+ *
+ * Dereferencing the returned iterator returns a `thrust::optional<Element>`.
+ *
+ * When the element of an iterator contextually converted to bool, the conversion returns true
+ * if the object contains a value and false if it does not contain a value.
+ *
+ * The iterator behavior is undefined if the scalar is destroyed before iterator dereferencing.
+ *
+ * make_optional_iterator with mode `DYNAMIC` defers the assumption of nullability to
+ * runtime, with the user stating on construction of the iterator if scalar has nulls.
+ *
+ * @throws cudf::logic_error if the scalar is not nullable, and `DYNAMIC` mode used and
+ *         the user has stated nulls exist
+ * @throws cudf::logic_error if scalar datatype and Element type mismatch.
+ *
+ * @tparam Element The type of elements in the scalar
+ * @tparam mode The has_nulls mode of the iterator
+ * @tparam has_nulls If the scalar value will have a null at runtime
+ * @param scalar_value The scalar to iterate
+ * @return auto Iterator that returns scalar elements, and validity of the
+ * element in a thrust::optional
+ */
+/**@{*/
+template <typename Element>
+auto inline make_optional_iterator(scalar const& scalar_value,
+                                   contains_nulls::DYNAMIC, bool has_nulls)
+{
+  CUDF_EXPECTS(type_id_matches_device_storage_type<Element>(scalar_value.type().id()),
+               "the data type mismatch");
+  return thrust::make_transform_iterator(
+    thrust::make_constant_iterator<size_type>(0),
+    scalar_optional_accessor<Element, contains_nulls::DYNAMIC>{scalar_value, has_nulls});
+}
+template <typename Element>
+auto inline make_optional_iterator(scalar const& scalar_value,
+                                   contains_nulls::DYNAMIC)
+{
+  CUDF_EXPECTS(type_id_matches_device_storage_type<Element>(scalar_value.type().id()),
+               "the data type mismatch");
+  return thrust::make_transform_iterator(thrust::make_constant_iterator<size_type>(0),
+                                         scalar_optional_accessor<Element, contains_nulls::DYNAMIC>{
+                                           scalar_value});
+}
+/**@}*/
+
+
+/**
+ * @brief Constructs an optional iterator over a scalar's values and its validity.
+ *
+ * Dereferencing the returned iterator returns a `thrust::optional<Element>`.
+ *
+ * When the element of an iterator contextually converted to bool, the conversion returns true
+ * if the object contains a value and false if it does not contain a value.
+ *
+ * The iterator behavior is undefined if the scalar is destroyed before iterator dereferencing.
+ *
+ * make_optional_iterator ith mode `YES` means that the scalar supports nulls and
+ * potentially has null values, therefore the optional might not contain a value
+ *
+ * @throws cudf::logic_error if the scalar is not nullable, and `YES` mode used
+ * @throws cudf::logic_error if scalar datatype and Element type mismatch.
+ *
+ * @tparam Element The type of elements in the scalar
+ * @tparam mode The has_nulls mode of the iterator
+ * @param scalar_value The scalar to iterate
+ * @return auto Iterator that returns scalar elements, and validity of the
+ * element in a thrust::optional
+ */
+template <typename Element>
+auto inline make_optional_iterator(scalar const& scalar_value, contains_nulls::YES)
+{
+  CUDF_EXPECTS(type_id_matches_device_storage_type<Element>(scalar_value.type().id()),
+               "the data type mismatch");
+  return thrust::make_transform_iterator(
+    thrust::make_constant_iterator<size_type>(0),
+    scalar_optional_accessor<Element, contains_nulls::YES>{scalar_value});
+}
+
+/**
+ * @brief Constructs an optional iterator over a scalar's values and its validity.
+ *
+ * Dereferencing the returned iterator returns a `thrust::optional<Element>`.
+ *
+ * When the element of an iterator contextually converted to bool, the conversion returns true
+ * if the object contains a value and false if it does not contain a value.
+ *
+ * The iterator behavior is undefined if the scalar is destroyed before iterator dereferencing.
+ *
+ * make_optional_iterator with mode `NO` means that the scalar has no null values,
+ * therefore the optional will always contain a value.
+ *
+ * @throws cudf::logic_error if scalar datatype and Element type mismatch.
+ *
+ * @tparam Element The type of elements in the scalar
+ * @tparam mode The has_nulls mode of the iterator
+ * @param scalar_value The scalar to iterate
+ * @return auto Iterator that returns scalar elements, and validity of the
+ * element in a thrust::optional
+ */
+template <typename Element>
+auto inline make_optional_iterator(scalar const& scalar_value, contains_nulls::NO)
+{
+  CUDF_EXPECTS(type_id_matches_device_storage_type<Element>(scalar_value.type().id()),
+               "the data type mismatch");
+  return thrust::make_transform_iterator(
+    thrust::make_constant_iterator<size_type>(0),
+    scalar_optional_accessor<Element, contains_nulls::NO>{scalar_value});
+}
 
 /**
  * @brief Constructs a constant device pair iterator over a scalar's value and its validity.

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -628,6 +628,20 @@ struct scalar_representation_pair_accessor : public scalar_value_accessor<Elemen
  * make_optional_iterator with mode `DYNAMIC` defers the assumption of nullability to
  * runtime, with the user stating on construction of the iterator if scalar has nulls.
  *
+ * Example:
+ *
+ * \code{.cpp}
+ * template<typename T>
+ * void some_function(cudf::column_view<T> const& col_view,
+ *                    scalar const& scalar_value,
+ *                    bool col_has_nulls){
+ *    auto d_col = cudf::column_device_view::create(col_view);
+ *    auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::DYNAMIC{}, col_has_nulls);
+ *    auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::DYNAMIC{}, scalar_value.is_valid());
+ *    //use iterators
+ * }
+ * \endcode
+ *
  * @throws cudf::logic_error if the scalar is not nullable, and `DYNAMIC` mode used and
  *         the user has stated nulls exist
  * @throws cudf::logic_error if scalar datatype and Element type mismatch.
@@ -663,12 +677,30 @@ auto inline make_optional_iterator(scalar const& scalar_value,
  *
  * make_optional_iterator ith mode `YES` means that the scalar supports nulls and
  * potentially has null values, therefore the optional might not contain a value
+ * therefore the optional will always contain a value.
+ *
+ * Example:
+ *
+ * \code{.cpp}
+ * template<typename T, bool any_nulls>
+ * void some_function(cudf::column_view<T> const& col_view, scalar const& scalar_value){
+ *    auto d_col = cudf::column_device_view::create(col_view);
+ *    if constexpr(any_nulls) {
+ *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::YES{});
+ *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::YES{});
+ *      //use iterators
+ *    } else {
+ *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::NO{});
+ *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::NO{});
+ *      //use iterators
+ *    }
+ * }
+ * \endcode
  *
  * @throws cudf::logic_error if the scalar is not nullable, and `YES` mode used
  * @throws cudf::logic_error if scalar datatype and Element type mismatch.
  *
  * @tparam Element The type of elements in the scalar
- * @tparam mode The has_nulls mode of the iterator
  * @param scalar_value The scalar to iterate
  * @return auto Iterator that returns scalar elements, and validity of the
  * element in a thrust::optional
@@ -696,10 +728,27 @@ auto inline make_optional_iterator(scalar const& scalar_value, contains_nulls::Y
  * make_optional_iterator with mode `NO` means that the scalar has no null values,
  * therefore the optional will always contain a value.
  *
+ * Example:
+ *
+ * \code{.cpp}
+ * template<typename T, bool any_nulls>
+ * void some_function(cudf::column_view<T> const& col_view, scalar const& scalar_value){
+ *    auto d_col = cudf::column_device_view::create(col_view);
+ *    if constexpr(any_nulls) {
+ *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::YES{});
+ *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::YES{});
+ *      //use iterators
+ *    } else {
+ *      auto column_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::NO{});
+ *      auto scalar_iterator = cudf::detail::make_optional_iterator<T>(scalar_value, cudf::contains_nulls::NO{});
+ *      //use iterators
+ *    }
+ * }
+ * \endcode
+ *
  * @throws cudf::logic_error if scalar datatype and Element type mismatch.
  *
  * @tparam Element The type of elements in the scalar
- * @tparam mode The has_nulls mode of the iterator
  * @param scalar_value The scalar to iterate
  * @return auto Iterator that returns scalar elements, and validity of the
  * element in a thrust::optional

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -596,7 +596,8 @@ struct scalar_representation_pair_accessor : public scalar_value_accessor<Elemen
  */
 template <typename Element>
 auto inline make_optional_iterator(scalar const& scalar_value,
-                                   contains_nulls::DYNAMIC, bool has_nulls)
+                                   contains_nulls::DYNAMIC,
+                                   bool has_nulls)
 {
   CUDF_EXPECTS(type_id_matches_device_storage_type<Element>(scalar_value.type().id()),
                "the data type mismatch");
@@ -604,7 +605,6 @@ auto inline make_optional_iterator(scalar const& scalar_value,
     thrust::make_constant_iterator<size_type>(0),
     scalar_optional_accessor<Element, contains_nulls::DYNAMIC>{scalar_value, has_nulls});
 }
-
 
 /**
  * @brief Constructs an optional iterator over a scalar's values and its validity.

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -177,6 +177,19 @@ auto make_null_replacement_iterator(column_device_view const& column,
  *
  * make_optional_iterator with mode `DYNAMIC` defers the assumption of nullability to
  * runtime, with the user stating on construction of the iterator if column has nulls.
+ * `DYNAMIC` mode is nice when an algorithm is going to execute on mutliple
+ * iterators and you don't want to compile all the combinations of iterator types
+ *
+ * Example:
+ *
+ * \code{.cpp}
+ * template<typename T>
+ * void some_function(cudf::column_view<T> const& col_view, bool has_nulls){
+ *    auto d_col = cudf::column_device_view::create(col_view);
+ *    // Create a `DYNAMIC` optional iterator
+ *    auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::DYNAMIC{}, has_nulls);
+ * }
+ * \endcode
  *
  * @throws cudf::logic_error if the column is not nullable, and `DYNAMIC` mode used and
  *         the user has stated nulls exist
@@ -204,8 +217,24 @@ auto make_optional_iterator(column_device_view const& column,
  * When the element of an iterator contextually converted to bool, the conversion returns true
  * if the object contains a value and false if it does not contain a value.
  *
- * make_optional_iterator ith mode `YES` means that the column supports nulls and
+ * make_optional_iterator with mode `YES` means that the column supports nulls and
  * potentially has null values, therefore the optional might not contain a value
+ *
+ * Example:
+ *
+ * \code{.cpp}
+ * template<typename T, bool has_nulls>
+ * void some_function(cudf::column_view<T> const& col_view){
+ *    auto d_col = cudf::column_device_view::create(col_view);
+ *    if constexpr(has_nulls) {
+ *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::YES{});
+ *      //use optional_iterator
+ *    } else {
+ *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::NO{});
+ *      //use optional_iterator
+ *    }
+ * }
+ * \endcode
  *
  * @throws cudf::logic_error if the column is not nullable, and `YES` mode used
  * @throws cudf::logic_error if column datatype and Element type mismatch.
@@ -232,6 +261,22 @@ auto make_optional_iterator(column_device_view const& column, contains_nulls::YE
  *
  * make_optional_iterator with mode `NO` means that the column has no null values,
  * therefore the optional will always contain a value.
+ *
+ * Example:
+ *
+ * \code{.cpp}
+ * template<typename T, bool has_nulls>
+ * void some_function(cudf::column_view<T> const& col_view){
+ *    auto d_col = cudf::column_device_view::create(col_view);
+ *    if constexpr(has_nulls) {
+ *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::YES{});
+ *      //use optional_iterator
+ *    } else {
+ *      auto optional_iterator = cudf::detail::make_optional_iterator<T>(d_col, cudf::contains_nulls::NO{});
+ *      //use optional_iterator
+ *    }
+ * }
+ * \endcode
  *
  * @throws cudf::logic_error if column datatype and Element type mismatch.
  *

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -657,7 +657,7 @@ struct scalar_representation_pair_accessor : public scalar_value_accessor<Elemen
  * @tparam mode The has_nulls mode of the iterator
  * @tparam has_nulls If the scalar value will have a null at runtime
  * @param scalar_value The scalar to iterate
- * @return auto Iterator that returns scalar elements, and validity of the
+ * @return Iterator that returns scalar elements and validity of the
  * element in a thrust::optional
  */
 template <typename Element>

--- a/cpp/include/cudf/detail/iterator.cuh
+++ b/cpp/include/cudf/detail/iterator.cuh
@@ -245,8 +245,8 @@ auto make_optional_iterator(column_device_view const& column,
  * @tparam Element The type of elements in the column
  * @tparam mode The has_nulls mode of the iterator
  * @param column The column to iterate
- * @return auto Iterator that returns column elements, and validity of the
- * element in a thrust::optional
+ * @return Iterator that returns column elements and the validity of the
+ * element as a thrust::optional
  */
 template <typename Element>
 auto make_optional_iterator(column_device_view const& column, contains_nulls::YES)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -228,10 +228,11 @@ ConfigureTest(SPAN_TEST utilities_tests/span_tests.cu)
 ###################################################################################################
 # - iterator tests --------------------------------------------------------------------------------
 ConfigureTest(ITERATOR_TEST
-    iterator/optional_iterator_test.cu
+    iterator/value_iterator_test.cu
     iterator/pair_iterator_test.cu
     iterator/scalar_iterator_test.cu
-    iterator/value_iterator_test.cu)
+    iterator/optional_iterator_test.cu
+    )
 
 ###################################################################################################
 # - device atomics tests --------------------------------------------------------------------------

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -228,9 +228,10 @@ ConfigureTest(SPAN_TEST utilities_tests/span_tests.cu)
 ###################################################################################################
 # - iterator tests --------------------------------------------------------------------------------
 ConfigureTest(ITERATOR_TEST
-    iterator/value_iterator_test.cu
+    iterator/optional_iterator_test.cu
     iterator/pair_iterator_test.cu
-    iterator/scalar_iterator_test.cu)
+    iterator/scalar_iterator_test.cu
+    iterator/value_iterator_test.cu)
 
 ###################################################################################################
 # - device atomics tests --------------------------------------------------------------------------

--- a/cpp/tests/iterator/optional_iterator_test.cu
+++ b/cpp/tests/iterator/optional_iterator_test.cu
@@ -43,14 +43,7 @@ struct sum_if_not_null {
   CUDA_HOST_DEVICE_CALLABLE thrust::optional<T> operator()(const thrust::optional<T>& lhs,
                                                            const thrust::optional<T>& rhs)
   {
-    if (lhs.has_value() and rhs.has_value())
-      return thrust::optional<T>{*lhs + *rhs};
-    else if (lhs.has_value())
-      return lhs;
-    else if (rhs.has_value())
-      return rhs;
-    else
-      return thrust::optional<T>{};
+    return lhs.value_or(T{0}) + rhs.value_or(T{0});
   }
 };
 

--- a/cpp/tests/iterator/optional_iterator_test.cu
+++ b/cpp/tests/iterator/optional_iterator_test.cu
@@ -187,9 +187,6 @@ TYPED_TEST(IteratorTest, null_optional_iterator)
   this->iterator_test_thrust(optional_values,
                              d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{}, true),
                              host_values.size());
-  this->iterator_test_thrust(optional_values,
-                             d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{}),
-                             host_values.size());
 
   this->iterator_test_thrust(
     optional_values, d_col->optional_begin<T>(cudf::contains_nulls::YES{}), host_values.size());

--- a/cpp/tests/iterator/optional_iterator_test.cu
+++ b/cpp/tests/iterator/optional_iterator_test.cu
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <tests/iterator/iterator_tests.cuh>
+#include <type_traits>
+
+// to print meanvar for debug.
+template <typename T>
+std::ostream& operator<<(std::ostream& os, cudf::meanvar<T> const& rhs)
+{
+  return os << "[" << rhs.value << ", " << rhs.value_squared << ", " << rhs.count << "] ";
+};
+
+// Transformers and Operators for optional_iterator test
+template <typename ElementType>
+struct transformer_optional_meanvar {
+  using ResultType = thrust::optional<cudf::meanvar<ElementType>>;
+
+  CUDA_HOST_DEVICE_CALLABLE
+  ResultType operator()(thrust::optional<ElementType> const& optional)
+  {
+    if (optional.has_value()) {
+      auto v = *optional;
+      return cudf::meanvar<ElementType>{v, static_cast<ElementType>(v * v), 1};
+    }
+    return thrust::nullopt;
+  }
+};
+
+struct sum_if_not_null {
+  template <typename T>
+  CUDA_HOST_DEVICE_CALLABLE thrust::optional<T> operator()(const thrust::optional<T>& lhs,
+                                                           const thrust::optional<T>& rhs)
+  {
+    if (lhs.has_value() and rhs.has_value())
+      return thrust::optional<T>{*lhs + *rhs};
+    else if (lhs.has_value())
+      return lhs;
+    else if (rhs.has_value())
+      return rhs;
+    else
+      return thrust::optional<T>{};
+  }
+};
+
+template <typename T>
+struct OptionalIteratorTest : public cudf::test::BaseFixture {
+};
+TYPED_TEST_CASE(OptionalIteratorTest, cudf::test::NumericTypes);
+// TODO: enable this test also at __CUDACC_DEBUG__
+// This test causes fatal compilation error only at device debug mode.
+// Workaround: exclude this test only at device debug mode.
+#if !defined(__CUDACC_DEBUG__)
+// This test computes `count`, `sum`, `sum_of_squares` at a single reduction call.
+// It would be useful for `var`, `std` operation
+TYPED_TEST(OptionalIteratorTest, mean_var_output)
+{
+  using T        = TypeParam;
+  using T_output = cudf::meanvar<T>;
+  transformer_optional_meanvar<T> transformer{};
+
+  const int column_size{50};
+  const T init{0};
+
+  // data and valid arrays
+  std::vector<T> host_values(column_size);
+  std::vector<bool> host_bools(column_size);
+
+  cudf::test::UniformRandomGenerator<T> rng;
+  cudf::test::UniformRandomGenerator<bool> rbg;
+  std::generate(host_values.begin(), host_values.end(), [&rng]() { return rng.generate(); });
+  std::generate(host_bools.begin(), host_bools.end(), [&rbg]() { return rbg.generate(); });
+
+  cudf::test::fixed_width_column_wrapper<TypeParam> w_col(
+    host_values.begin(), host_values.end(), host_bools.begin());
+  auto d_col = cudf::column_device_view::create(w_col);
+
+  // calculate expected values by CPU
+  T_output expected_value;
+
+  expected_value.count = d_col->size() - static_cast<cudf::column_view>(w_col).null_count();
+
+  std::vector<T> replaced_array(d_col->size());
+  std::transform(host_values.begin(),
+                 host_values.end(),
+                 host_bools.begin(),
+                 replaced_array.begin(),
+                 [&](T x, bool b) { return (b) ? static_cast<T>(x) : init; });
+
+  expected_value.count = d_col->size() - static_cast<cudf::column_view>(w_col).null_count();
+  expected_value.value = std::accumulate(replaced_array.begin(), replaced_array.end(), T{0});
+  expected_value.value_squared = std::accumulate(
+    replaced_array.begin(), replaced_array.end(), T{0}, [](T acc, T i) { return acc + i * i; });
+
+  std::cout << "expected <mixed_output> = " << expected_value << std::endl;
+
+  // GPU test
+  auto it_dev         = d_col->optional_begin<T>(cudf::contains_nulls::YES{});
+  auto it_dev_squared = thrust::make_transform_iterator(it_dev, transformer);
+  auto result         = thrust::reduce(it_dev_squared,
+                               it_dev_squared + d_col->size(),
+                               thrust::optional<T_output>{T_output{}},
+                               sum_if_not_null{});
+  if (not std::is_floating_point<T>()) {
+    EXPECT_EQ(expected_value, *result) << "optional iterator reduction sum";
+  } else {
+    EXPECT_NEAR(expected_value.value, result->value, 1e-3) << "optional iterator reduction sum";
+    EXPECT_NEAR(expected_value.value_squared, result->value_squared, 1e-3)
+      << "optional iterator reduction sum squared";
+    EXPECT_EQ(expected_value.count, result->count) << "optional iterator reduction count";
+  }
+}
+#endif
+
+using TestingTypes = cudf::test::AllTypes;
+
+TYPED_TEST_CASE(IteratorTest, TestingTypes);
+
+TYPED_TEST(IteratorTest, nonull_optional_iterator)
+{
+  using T = TypeParam;
+  // data and valid arrays
+  auto host_values_std =
+    cudf::test::make_type_param_vector<T>({0, 6, 0, -14, 13, 64, -13, -20, 45});
+  thrust::host_vector<T> host_values(host_values_std);
+
+  // create a column
+  cudf::test::fixed_width_column_wrapper<T> w_col(host_values.begin(), host_values.end());
+  auto d_col = cudf::column_device_view::create(w_col);
+
+  // calculate the expected value by CPU.
+  thrust::host_vector<thrust::optional<T>> replaced_array(host_values.size());
+  std::transform(host_values.begin(), host_values.end(), replaced_array.begin(), [](auto s) {
+    return thrust::optional<T>{s};
+  });
+
+  // GPU test
+  this->iterator_test_thrust(
+    replaced_array,
+    cudf::detail::make_optional_iterator<T>(*d_col, cudf::contains_nulls::DYNAMIC{}, false),
+    host_values.size());
+  this->iterator_test_thrust(
+    replaced_array,
+    cudf::detail::make_optional_iterator<T>(*d_col, cudf::contains_nulls::NO{}),
+    host_values.size());
+}
+
+TYPED_TEST(IteratorTest, null_optional_iterator)
+{
+  using T = TypeParam;
+  // data and valid arrays
+  auto host_values = cudf::test::make_type_param_vector<T>({0, 6, 0, -14, 13, 64, -13, -20, 45});
+  thrust::host_vector<bool> host_bools(std::vector<bool>({1, 1, 0, 1, 1, 1, 0, 1, 1}));
+
+  // create a column with bool vector
+  cudf::test::fixed_width_column_wrapper<T> w_col(
+    host_values.begin(), host_values.end(), host_bools.begin());
+  auto d_col = cudf::column_device_view::create(w_col);
+
+  // calculate the expected value by CPU.
+  thrust::host_vector<thrust::optional<T>> optional_values(host_values.size());
+  std::transform(host_values.begin(),
+                 host_values.end(),
+                 host_bools.begin(),
+                 optional_values.begin(),
+                 [](auto s, bool b) { return b ? thrust::optional<T>{s} : thrust::optional<T>{}; });
+
+  thrust::host_vector<thrust::optional<T>> value_all_valid(host_values.size());
+  std::transform(host_values.begin(),
+                 host_values.end(),
+                 host_bools.begin(),
+                 value_all_valid.begin(),
+                 [](auto s, bool b) { return thrust::optional<T>{s}; });
+
+  // GPU test for correct null mapping
+  this->iterator_test_thrust(optional_values,
+                             d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{}, true),
+                             host_values.size());
+  this->iterator_test_thrust(optional_values,
+                             d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{}),
+                             host_values.size());
+
+  this->iterator_test_thrust(
+    optional_values, d_col->optional_begin<T>(cudf::contains_nulls::YES{}), host_values.size());
+  this->iterator_test_thrust(
+    optional_values, d_col->optional_begin<T>(cudf::contains_nulls::YES{}), host_values.size());
+
+  // GPU test for ignoring null mapping
+  this->iterator_test_thrust(value_all_valid,
+                             d_col->optional_begin<T>(cudf::contains_nulls::DYNAMIC{}, false),
+                             host_values.size());
+
+  this->iterator_test_thrust(
+    value_all_valid, d_col->optional_begin<T>(cudf::contains_nulls::NO{}), host_values.size());
+  this->iterator_test_thrust(
+    value_all_valid, d_col->optional_begin<T>(cudf::contains_nulls::NO{}), host_values.size());
+}


### PR DESCRIPTION
Introduces `make_optional_iterator` for nullable column and scalars, as the first step in fixing issues brought up in #6952 and #7573.

The iterator produces `thrust::optional<T>` to better represent nullable column elements and scalars.

`make_optional_iterator` supports three different `contains_null` modes:

    - `YES` means that the column supports nulls and has null values, therefore
     the optional might not contain a value

    - `NO` means that the column has no null values, therefore the optional will
     always have a value

    - `DYNAMIC` defers the assumption of nullability to runtime with the users stating
     on construction of the iterator if column has nulls.
