### PR TITLE
Fix compiler warning about non-POD types passed through ellipsis

### DIFF
--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -142,8 +142,8 @@ void gather_helper(InputItr source_itr,
 // Error case when no other overload or specialization is available
 template <typename Element, typename Enable = void>
 struct column_gatherer_impl {
-  template <typename...>
-  std::unique_ptr<column> operator()(...)
+  template <typename... Args>
+  std::unique_ptr<column> operator()(Args&&...)
   {
     CUDF_FAIL("Unsupported type in gather.");
   }

--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -142,7 +142,11 @@ void gather_helper(InputItr source_itr,
 // Error case when no other overload or specialization is available
 template <typename Element, typename Enable = void>
 struct column_gatherer_impl {
-  std::unique_ptr<column> operator()(...) { CUDF_FAIL("Unsupported type in gather."); }
+  template <typename...>
+  std::unique_ptr<column> operator()(...)
+  {
+    CUDF_FAIL("Unsupported type in gather.");
+  }
 };
 
 /**

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -81,8 +81,8 @@ auto scatter_to_gather(MapIterator scatter_map_begin,
 
 template <typename Element, typename Enable = void>
 struct column_scatterer_impl {
-  template <typename...>
-  std::unique_ptr<column> operator()(...) const
+  template <typename... Args>
+  std::unique_ptr<column> operator()(Args&&...) const
   {
     CUDF_FAIL("Unsupported type for scatter.");
   }

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -81,7 +81,11 @@ auto scatter_to_gather(MapIterator scatter_map_begin,
 
 template <typename Element, typename Enable = void>
 struct column_scatterer_impl {
-  std::unique_ptr<column> operator()(...) const { CUDF_FAIL("Unsupported type for scatter."); }
+  template <typename...>
+  std::unique_ptr<column> operator()(...) const
+  {
+    CUDF_FAIL("Unsupported type for scatter.");
+  }
 };
 
 template <typename Element>

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -31,8 +31,8 @@ namespace {
 
 template <typename T, typename Enable = void>
 struct copy_if_else_functor_impl {
-  template <typename...>
-  std::unique_ptr<column> operator()(...)
+  template <typename... Args>
+  std::unique_ptr<column> operator()(Args&&...)
   {
     CUDF_FAIL("Unsupported type for copy_if_else.");
   }

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -31,7 +31,11 @@ namespace {
 
 template <typename T, typename Enable = void>
 struct copy_if_else_functor_impl {
-  std::unique_ptr<column> operator()(...) { CUDF_FAIL("Unsupported type for copy_if_else."); }
+  template <typename...>
+  std::unique_ptr<column> operator()(...)
+  {
+    CUDF_FAIL("Unsupported type for copy_if_else.");
+  }
 };
 
 template <typename T>


### PR DESCRIPTION
In https://github.com/rapidsai/cudf/pull/7725/ I updated some of the fall through error cases to use old, [C-style ellipsis variadics ](https://github.com/jrhemstad/cudf/blob/f92d4626c7a4296075c5aa6240d6e3b88049abe6/cpp/include/cudf/detail/gather.cuh#L145 
)since we don't care about the parameters in the error case. Turns out C++ forbids passing "non-POD" types through this kind of variadic ellipsis, which ends up generating a compiler warning:

> warning: non-POD class type passed through ellipsis 

