### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numba >=0.49.0
     - dlpack
     - pyarrow 1.0.1
-    - libcudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - libcudf {{ version }}
     - rmm {{ minor_version }}
     - cudatoolkit {{ cuda_version }}
   run:

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -29,12 +29,12 @@ requirements:
     - python
     - cython >=0.29,<0.30
     - setuptools
-    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
-    - libcudf_kafka {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - cudf {{ version }}
+    - libcudf_kafka {{ version }}
   run:
-    - libcudf_kafka {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - libcudf_kafka {{ version }}
     - python-confluent-kafka
-    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - cudf {{ version }}
 
 test:
   requires:

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -23,15 +23,15 @@ requirements:
   host:
     - python
     - python-confluent-kafka
-    - cudf_kafka {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - cudf_kafka {{ version }}
   run:
     - python
-    - streamz
-    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - streamz 
+    - cudf {{ version }}
     - dask >=2.22.0
     - distributed >=2.22.0
     - python-confluent-kafka
-    - cudf_kafka {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - cudf_kafka {{ version }}
 
 test:
   requires:

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -22,15 +22,15 @@ build:
 requirements:
   host:
     - python
-    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - cudf {{ version }}
     - dask>=2021.3.1
     - distributed >=2.22.0
   run:
     - python
-    - cudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - cudf {{ version }}
     - dask>=2021.3.1
     - distributed >=2.22.0
-
+  
 test:
   requires:
     - cudatoolkit {{ cuda_version }}.*

--- a/conda/recipes/libcudf_kafka/meta.yaml
+++ b/conda/recipes/libcudf_kafka/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   build:
     - cmake >=3.17.0
   host:
-    - libcudf {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - libcudf {{ version }}
     - librdkafka >=1.5.0,<1.5.3
   run:
     - {{ pin_compatible('librdkafka', max_pin='x.x') }} #TODO: librdkafka should be automatically included here by run_exports but is not


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.