### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -424,7 +424,7 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
   CUDF_EXPECTS(replacement.size() == input.size(), "Column size mismatch");
 
   if (input.is_empty()) { return cudf::empty_like(input); }
-  if (!input.has_nulls()) { return std::make_unique<cudf::column>(input); }
+  if (!input.has_nulls()) { return std::make_unique<cudf::column>(input, stream, mr); }
 
   return cudf::type_dispatcher<dispatch_storage_type>(
     input.type(), replace_nulls_column_kernel_forwarder{}, input, replacement, stream, mr);


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.