### PR TITLE
Don't install Thrust examples, tests, docs, and python files

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -583,7 +583,14 @@ install(DIRECTORY
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libcudf)
 
 install(DIRECTORY ${Thrust_SOURCE_DIR}/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust
+  PATTERN "*.py" EXCLUDE
+  PATTERN "benchmark" EXCLUDE
+  PATTERN "build" EXCLUDE
+  PATTERN "doc" EXCLUDE
+  PATTERN "examples" EXCLUDE
+  PATTERN "test" EXCLUDE
+  PATTERN "testing" EXCLUDE)
 
 include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
Prune the amount of Thrust source tree that we install. On top of reducing the size of cudf's install tree, this fixes an
issue where when using cudf via conda-build, conda presumes that all python files inside cudf are valid and part of the package, and fails to parse them.
