### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/conda/environments/cudf_dev_cuda10.1.yml
+++ b/conda/environments/cudf_dev_cuda10.1.yml
@@ -42,8 +42,8 @@ dependencies:
   - mypy=0.782
   - typing_extensions
   - pre_commit
-  - dask>=2021.3.1
-  - distributed>=2.22.0
+  - dask==2021.3.1
+  - distributed>=2.22.0,<=2021.3.1
   - streamz
   - dlpack
   - arrow-cpp=1.0.1

--- a/conda/environments/cudf_dev_cuda10.2.yml
+++ b/conda/environments/cudf_dev_cuda10.2.yml
@@ -42,8 +42,8 @@ dependencies:
   - mypy=0.782
   - typing_extensions
   - pre_commit
-  - dask>=2021.3.1
-  - distributed>=2.22.0
+  - dask==2021.3.1
+  - distributed>=2.22.0,<=2021.3.1
   - streamz
   - dlpack
   - arrow-cpp=1.0.1

--- a/conda/environments/cudf_dev_cuda11.0.yml
+++ b/conda/environments/cudf_dev_cuda11.0.yml
@@ -42,8 +42,8 @@ dependencies:
   - mypy=0.782
   - typing_extensions
   - pre_commit
-  - dask>=2021.3.1
-  - distributed>=2.22.0
+  - dask==2021.3.1
+  - distributed>=2.22.0,<=2021.3.1
   - streamz
   - dlpack
   - arrow-cpp=1.0.1

--- a/conda/environments/cudf_dev_cuda11.1.yml
+++ b/conda/environments/cudf_dev_cuda11.1.yml
@@ -42,8 +42,8 @@ dependencies:
   - mypy=0.782
   - typing_extensions
   - pre_commit
-  - dask>=2021.3.1
-  - distributed>=2.22.0
+  - dask==2021.3.1
+  - distributed>=2.22.0,<=2021.3.1
   - streamz
   - dlpack
   - arrow-cpp=1.0.1

--- a/conda/environments/cudf_dev_cuda11.2.yml
+++ b/conda/environments/cudf_dev_cuda11.2.yml
@@ -42,8 +42,8 @@ dependencies:
   - mypy=0.782
   - typing_extensions
   - pre_commit
-  - dask>=2021.3.1
-  - distributed>=2.22.0
+  - dask==2021.3.1
+  - distributed>=2.22.0,<=2021.3.1
   - streamz
   - dlpack
   - arrow-cpp=1.0.1

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - streamz 
     - cudf {{ version }}
     - dask >=2.22.0
-    - distributed >=2.22.0
+    - distributed >=2.22.0,<=2021.3.1
     - python-confluent-kafka
     - cudf_kafka {{ version }}
 

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -23,13 +23,13 @@ requirements:
   host:
     - python
     - cudf {{ version }}
-    - dask>=2021.3.1
-    - distributed >=2.22.0
+    - dask==2021.3.1
+    - distributed >=2.22.0,<=2021.3.1
   run:
     - python
     - cudf {{ version }}
-    - dask>=2021.3.1
-    - distributed >=2.22.0
+    - dask==2021.3.1
+    - distributed >=2.22.0,<=2021.3.1
   
 test:
   requires:

--- a/python/custreamz/dev_requirements.txt
+++ b/python/custreamz/dev_requirements.txt
@@ -3,8 +3,8 @@
 flake8==3.8.3
 black==19.10b0
 isort==5.0.7
-dask>=2021.3.1
-distributed>=2.22.0
+dask==2021.3.1
+distributed>=2.22.0,<=2021.3.1
 streamz
 python-confluent-kafka
 pytest

--- a/python/dask_cudf/dev_requirements.txt
+++ b/python/dask_cudf/dev_requirements.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, NVIDIA CORPORATION.
 
-dask>=2021.3.1
-distributed>=2.22.0
+dask==2021.3.1
+distributed>=2.22.0,<=2021.3.1
 fsspec>=0.6.0
 numba>=0.49.0,!=0.51.0
 numpy

--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -10,8 +10,8 @@ import versioneer
 
 install_requires = [
     "cudf",
-    "dask>=2021.3.1",
-    "distributed>=2.22.0",
+    "dask==2021.3.1",
+    "distributed>=2.22.0,<=2021.3.1",
     "fsspec>=0.6.0",
     "numpy",
     "pandas>=1.0,<1.3.0dev0",
@@ -23,8 +23,8 @@ extras_require = {
         "pandas>=1.0,<1.3.0dev0",
         "pytest",
         "numba>=0.49.0,!=0.51.0",
-        "dask>=2021.3.1",
-        "distributed>=2.22.0",
+        "dask==2021.3.1",
+        "distributed>=2.22.0,<=2021.3.1",
     ]
 }
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.