### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -72,6 +72,7 @@ RUN cd /repos/ && git clone https://github.com/rapidsai/rmm.git && cd /repos/rmm
 ADD . /repos/cudf/
 
 # Build env for CUDF build
+ENV CUDF_HOME=/repos/cudf/
 ENV CUDF_ROOT=/repos/cudf/cpp/build/
 
 # Install cudf from source

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -89,6 +89,12 @@ install_requires.append(
     "cupy-cuda" + get_cuda_version_from_header(cuda_include_dir)
 )
 
+CUDF_HOME = os.environ.get(
+    "CUDF_HOME",
+    os.path.abspath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
+    ),
+)
 CUDF_ROOT = os.environ.get(
     "CUDF_ROOT",
     os.path.abspath(
@@ -161,8 +167,8 @@ extensions = [
         "*",
         sources=cython_files,
         include_dirs=[
-            os.path.abspath(os.path.join(CUDF_ROOT, "../include/cudf")),
-            os.path.abspath(os.path.join(CUDF_ROOT, "../include")),
+            os.path.abspath(os.path.join(CUDF_HOME, "cpp/include/cudf")),
+            os.path.abspath(os.path.join(CUDF_HOME, "cpp/include")),
             os.path.abspath(os.path.join(CUDF_ROOT, "include")),
             os.path.join(CUDF_ROOT, "_deps/libcudacxx-src/include"),
             os.path.join(CUDF_ROOT, "_deps/dlpack-src/include"),


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.