### PR TITLE
cudf and cudf_kafka 0.20 now request 0.20 dependencies, and report as 0.20

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -47,10 +47,13 @@ function sed_runner() {
 }
 
 # cpp update
-sed_runner 's/'"CUDA_DATAFRAME VERSION .* LANGUAGES"'/'"CUDA_DATAFRAME VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
+sed_runner 's/'"CUDF VERSION .* LANGUAGES"'/'"CUDF VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
 
 # cpp libcudf_kafka update
 sed_runner 's/'"CUDA_KAFKA VERSION .* LANGUAGES"'/'"CUDA_KAFKA VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/libcudf_kafka/CMakeLists.txt
+
+# cpp cudf_jni update
+sed_runner 's/'"CUDF_JNI VERSION .* LANGUAGES"'/'"CUDF_JNI VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' java/src/main/native/CMakeLists.txt
 
 # doxyfile update
 sed_runner 's/PROJECT_NUMBER         = .*/PROJECT_NUMBER         = '${NEXT_FULL_TAG}'/g' cpp/doxygen/Doxyfile

--- a/conda/environments/cudf_dev_cuda11.1.yml
+++ b/conda/environments/cudf_dev_cuda11.1.yml
@@ -11,7 +11,7 @@ dependencies:
   - clang=8.0.1
   - clang-tools=8.0.1
   - cupy>7.1.0,<9.0.0a0
-  - rmm=0.19.*
+  - rmm=0.20.*
   - cmake>=3.14
   - cmake_setuptools>=0.1.3
   - python>=3.7,<3.9

--- a/conda/environments/cudf_dev_cuda11.2.yml
+++ b/conda/environments/cudf_dev_cuda11.2.yml
@@ -11,7 +11,7 @@ dependencies:
   - clang=8.0.1
   - clang-tools=8.0.1
   - cupy>7.1.0,<9.0.0a0
-  - rmm=0.19.*
+  - rmm=0.20.*
   - cmake>=3.14
   - cmake_setuptools>=0.1.3
   - python>=3.7,<3.9

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -28,7 +28,7 @@ elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "")
   set(CUDF_BUILD_FOR_DETECTED_ARCHS TRUE)
 endif()
 
-project(CUDF VERSION 0.19.0 LANGUAGES C CXX)
+project(CUDF VERSION 0.20.0 LANGUAGES C CXX)
 
 # Needed because GoogleBenchmark changes the state of FindThreads.cmake,
 # causing subsequent runs to have different values for the `Threads::Threads` target.

--- a/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
+++ b/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
@@ -45,8 +45,8 @@ function(find_and_configure_cudf VERSION)
     endif()
 endfunction()
 
-set(CUDF_KAFKA_MIN_VERSION_cudf "${CUDF_KAFKA_VERSION_MAJOR}.${CUDF_KAFKA_VERSION_MINOR}")
-find_and_configure_cudf(${CUDF_KAFKA_MIN_VERSION_cudf})
+set(CUDA_KAFKA_MIN_VERSION_cudf "${CUDA_KAFKA_VERSION_MAJOR}.${CUDA_KAFKA_VERSION_MINOR}")
+find_and_configure_cudf(${CUDA_KAFKA_MIN_VERSION_cudf})
 
 if(cudf_ADDED)
     # Since we are building cudf as part of ourselves we need

--- a/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
+++ b/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
@@ -42,5 +42,5 @@ function(find_and_configure_cudf VERSION)
     cudfkafka_restore_if_enabled(BUILD_BENCHMARKS)
 endfunction()
 
-set(CUDF_KAFKA_MIN_VERSION_cudf 0.19)
+set(CUDF_KAFKA_MIN_VERSION_cudf "${CUDF_KAFKA_VERSION_MAJOR}.${CUDF_KAFKA_VERSION_MINOR}")
 find_and_configure_cudf(${CUDF_KAFKA_MIN_VERSION_cudf})

--- a/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
+++ b/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
@@ -40,7 +40,16 @@ function(find_and_configure_cudf VERSION)
                         "BUILD_BENCHMARKS OFF")
     cudfkafka_restore_if_enabled(BUILD_TESTS)
     cudfkafka_restore_if_enabled(BUILD_BENCHMARKS)
+    if(cudf_ADDED)
+        set(cudf_ADDED TRUE PARENT_SCOPE)
+    endif()
 endfunction()
 
 set(CUDF_KAFKA_MIN_VERSION_cudf "${CUDF_KAFKA_VERSION_MAJOR}.${CUDF_KAFKA_VERSION_MINOR}")
 find_and_configure_cudf(${CUDF_KAFKA_MIN_VERSION_cudf})
+
+if(cudf_ADDED)
+    # Since we are building cudf as part of ourselves we need
+    # to enable the CUDA language in the top-most scope
+    enable_language(CUDA)
+endif()

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -32,7 +32,7 @@ elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "")
   set(CUDF_JNI_BUILD_FOR_DETECTED_ARCHS TRUE)
 endif()
 
-project(CUDF_JNI VERSION 0.19 LANGUAGES C CXX)
+project(CUDF_JNI VERSION 0.20.0 LANGUAGES C CXX)
 
 ###################################################################################################
 # - build options ---------------------------------------------------------------------------------


### PR DESCRIPTION
Both cudf and cudf_kafka had a couple of issues when moving from version 0.19 to 0.20:

- cudf was still reporting as 0.19
- cudf was requesting rmm-0.19 for some conda packages
- cudf_kafka was requesting cudf version 0.19 