### PR TITLE
Update cudf to use the latest version of CPM ( 0.32.0 )

### DIFF
--- a/cpp/cmake/thirdparty/CUDF_GetCPM.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetCPM.cmake
@@ -1,6 +1,8 @@
-set(CPM_DOWNLOAD_VERSION 3b404296b539e596f39421c4e92bc803b299d964) # v0.27.5
+set(CPM_DOWNLOAD_VERSION 4fad2eac0a3741df3d9c44b791f9163b74aa7b07) # 0.32.0
 
 if(CPM_SOURCE_CACHE)
+  # Expand relative path. This is important if the provided path contains a tilde (~)
+  get_filename_component(CPM_SOURCE_CACHE ${CPM_SOURCE_CACHE} ABSOLUTE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 elseif(DEFINED ENV{CPM_SOURCE_CACHE})
   set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
@@ -12,7 +14,7 @@ if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
   message(VERBOSE "CUDF: Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
   file(
     DOWNLOAD
-    https://raw.githubusercontent.com/TheLartians/CPM.cmake/${CPM_DOWNLOAD_VERSION}/cmake/CPM.cmake
+    https://raw.githubusercontent.com/cpm-cmake/CPM.cmake/${CPM_DOWNLOAD_VERSION}/cmake/CPM.cmake
     ${CPM_DOWNLOAD_LOCATION})
 endif()
 

--- a/cpp/cmake/thirdparty/CUDF_GetRMM.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetRMM.cmake
@@ -14,19 +14,6 @@
 # limitations under the License.
 #=============================================================================
 
-function(cudf_save_if_enabled var)
-    if(CUDF_${var})
-        unset(${var} PARENT_SCOPE)
-        unset(${var} CACHE)
-    endif()
-endfunction()
-
-function(cudf_restore_if_enabled var)
-    if(CUDF_${var})
-        set(${var} ON CACHE INTERNAL "" FORCE)
-    endif()
-endfunction()
-
 function(find_and_configure_rmm VERSION)
 
     if(TARGET rmm::rmm)
@@ -37,9 +24,6 @@ function(find_and_configure_rmm VERSION)
     # 1. Pass `-D CPM_rmm_SOURCE=/path/to/rmm` to build a local RMM source tree
     # 2. Pass `-D CMAKE_PREFIX_PATH=/path/to/rmm/build` to use an existing local
     #    RMM build directory as the install location for find_package(rmm)
-    cudf_save_if_enabled(BUILD_TESTS)
-    cudf_save_if_enabled(BUILD_BENCHMARKS)
-
     CPMFindPackage(NAME rmm
         VERSION         ${VERSION}
         GIT_REPOSITORY  https://github.com/rapidsai/rmm.git
@@ -50,8 +34,6 @@ function(find_and_configure_rmm VERSION)
                         "CUDA_STATIC_RUNTIME ${CUDA_STATIC_RUNTIME}"
                         "DISABLE_DEPRECATION_WARNING ${DISABLE_DEPRECATION_WARNING}"
     )
-    cudf_restore_if_enabled(BUILD_TESTS)
-    cudf_restore_if_enabled(BUILD_BENCHMARKS)
 
     # Make sure consumers of cudf can also see rmm::rmm
     fix_cmake_global_defaults(rmm::rmm)

--- a/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
+++ b/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
@@ -14,22 +14,7 @@
 # limitations under the License.
 #=============================================================================
 
-function(cudfkafka_save_if_enabled var)
-    if(CUDF_KAFKA_${var})
-        unset(${var} PARENT_SCOPE)
-        unset(${var} CACHE)
-    endif()
-endfunction()
-
-function(cudfkafka_restore_if_enabled var)
-    if(CUDF_KAFKA_${var})
-        set(${var} ON CACHE INTERNAL "" FORCE)
-    endif()
-endfunction()
-
 function(find_and_configure_cudf VERSION)
-    cudfkafka_save_if_enabled(BUILD_TESTS)
-    cudfkafka_save_if_enabled(BUILD_BENCHMARKS)
     CPMFindPackage(NAME cudf
         VERSION         ${VERSION}
         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
@@ -38,8 +23,6 @@ function(find_and_configure_cudf VERSION)
         SOURCE_SUBDIR   cpp
         OPTIONS         "BUILD_TESTS OFF"
                         "BUILD_BENCHMARKS OFF")
-    cudfkafka_restore_if_enabled(BUILD_TESTS)
-    cudfkafka_restore_if_enabled(BUILD_BENCHMARKS)
     if(cudf_ADDED)
         set(cudf_ADDED TRUE PARENT_SCOPE)
     endif()


### PR DESCRIPTION
The latest version of cudf improves behavior in two major ways:

- First it fixes how options provided to the cpm'ed project behave.
  Previously any option would be set as a CMake cache variable, and
  therefore influence the callers or other cpm projects behavior if
  they had a variable with the same name

- Improved runtime performance of checkout when CPM_SOURCE_CACHE
  alreadys has the project
