### PR TITLE
CMake jit_preprocess_files function only runs when needed

### DIFF
--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -14,10 +14,7 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.18)
-
 # Create `jitify_preprocess` executable
-project(jitify_preprocess VERSION 2.0 LANGUAGES CXX CUDA)
 add_executable(jitify_preprocess "${JITIFY_INCLUDE_DIR}/jitify2_preprocess.cpp")
 
 target_link_libraries(jitify_preprocess CUDA::cudart ${CMAKE_DL_LIBS})

--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -33,7 +33,7 @@ function(jit_preprocess_files)
                           )
 
     foreach(ARG_FILE ${ARG_FILES})
-        set(ARG_OUTPUT ${CUDF_GENERATED_INCLUDE_DIR}/include/jit_preprocessed_files/${ARG_FILE}.jit)
+        set(ARG_OUTPUT ${CUDF_GENERATED_INCLUDE_DIR}/include/jit_preprocessed_files/${ARG_FILE}.jit.hpp)
         list(APPEND JIT_PREPROCESSED_FILES "${ARG_OUTPUT}")
         add_custom_command(WORKING_DIRECTORY ${ARG_SOURCE_DIRECTORY}
                            DEPENDS jitify_preprocess

--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -16,8 +16,6 @@
 
 cmake_minimum_required(VERSION 3.18)
 
-file(MAKE_DIRECTORY "${CUDF_GENERATED_INCLUDE_DIR}/include/jit_preprocessed_files")
-
 # Create `jitify_preprocess` executable
 project(jitify_preprocess VERSION 2.0 LANGUAGES CXX CUDA)
 add_executable(jitify_preprocess "${JITIFY_INCLUDE_DIR}/jitify2_preprocess.cpp")
@@ -34,11 +32,13 @@ function(jit_preprocess_files)
 
     foreach(ARG_FILE ${ARG_FILES})
         set(ARG_OUTPUT ${CUDF_GENERATED_INCLUDE_DIR}/include/jit_preprocessed_files/${ARG_FILE}.jit.hpp)
+        get_filename_component(jit_output_directory "${ARG_OUTPUT}" DIRECTORY )
         list(APPEND JIT_PREPROCESSED_FILES "${ARG_OUTPUT}")
         add_custom_command(WORKING_DIRECTORY ${ARG_SOURCE_DIRECTORY}
                            DEPENDS jitify_preprocess "${ARG_SOURCE_DIRECTORY}/${ARG_FILE}"
                            OUTPUT ${ARG_OUTPUT}
                            VERBATIM
+                           COMMAND ${CMAKE_COMMAND} -E make_directory "${jit_output_directory}"
                            COMMAND jitify_preprocess ${ARG_FILE}
                                     -o ${CUDF_GENERATED_INCLUDE_DIR}/include/jit_preprocessed_files
                                     -v

--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -36,7 +36,7 @@ function(jit_preprocess_files)
         set(ARG_OUTPUT ${CUDF_GENERATED_INCLUDE_DIR}/include/jit_preprocessed_files/${ARG_FILE}.jit.hpp)
         list(APPEND JIT_PREPROCESSED_FILES "${ARG_OUTPUT}")
         add_custom_command(WORKING_DIRECTORY ${ARG_SOURCE_DIRECTORY}
-                           DEPENDS jitify_preprocess
+                           DEPENDS jitify_preprocess "${ARG_SOURCE_DIRECTORY}/${ARG_FILE}"
                            OUTPUT ${ARG_OUTPUT}
                            VERBATIM
                            COMMAND jitify_preprocess ${ARG_FILE}


### PR DESCRIPTION
This correct a couple of issues with the `jit_preprocess_files` function.

1. It now always makes sure that the output directory that the jit headers are going into will exist before executing. So if a user deletes `<build_dir>/include` everything will work as expected
2. The output of the jitify tool are files that end in `.jit.hpp` not `.jit`. This is required to allow generators to build the minimal incremental compilation graph
3. Mark the input source files as a dependency so when that file is modified, the build-system knows to recompile the jit file.