### PR TITLE
fix GDS include path for version 0.95

### DIFF
--- a/cpp/cmake/Modules/FindcuFile.cmake
+++ b/cpp/cmake/Modules/FindcuFile.cmake
@@ -62,6 +62,7 @@ find_path(cuFile_INCLUDE_DIR
     cufile.h
   HINTS
     ${PKG_cuFile_INCLUDE_DIRS}
+    /usr/local/cuda/include
     /usr/local/cuda/lib64
 )
 


### PR DESCRIPTION
The GDS 0.95 release candidate moved the `cufile.h` file from the `lib64` directory to the `include` directory under `/usr/local/cuda`. Added the new directory but also kept the old one so older versions of GDS can still be built.
