### PR TITLE
disable verbose output for jitify_preprocess

### DIFF
--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -41,7 +41,6 @@ function(jit_preprocess_files)
                            VERBATIM
                            COMMAND jitify_preprocess ${ARG_FILE}
                                     -o ${CUDF_GENERATED_INCLUDE_DIR}/include/jit_preprocessed_files
-                                    -v
                                     -i
                                     -m
                                     -std=c++14


### PR DESCRIPTION
Remove `-v` option from `jitify_preprocess` invocation to reduce "Found #include ..."-like output during builds.