### PR TITLE
fix "incompatible redefinition" warnings

### DIFF
--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -41,7 +41,6 @@ function(jit_preprocess_files)
                            VERBATIM
                            COMMAND jitify_preprocess ${ARG_FILE}
                                     -o ${CUDF_GENERATED_INCLUDE_DIR}/include/jit_preprocessed_files
-                                    -v
                                     -i
                                     -m
                                     -std=c++14

--- a/cpp/include/cudf/utilities/bit.hpp
+++ b/cpp/include/cudf/utilities/bit.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cassert>
-#include <climits>
+#include <cuda/std/climits>
 #include <cudf/types.hpp>
 
 /**

--- a/cpp/src/jit/cache.cpp
+++ b/cpp/src/jit/cache.cpp
@@ -97,7 +97,7 @@ std::string get_program_cache_dir()
 {
 #if defined(JITIFY_USE_CACHE)
   return get_cache_dir().string();
-#elif
+#else
   return {};
 #endif
 }

--- a/cpp/tests/unary/math_ops_test.cpp
+++ b/cpp/tests/unary/math_ops_test.cpp
@@ -25,7 +25,7 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <climits>
+#include <cuda/std/climits>
 #include <vector>
 
 template <typename T>


### PR DESCRIPTION
replace `#include <climits>` with `#include <cuda/std/climits>` to eliminate "incompatible redefinition" warnings.

Also fixes a preprocessor typo.

note: while it's safe to merge this PR prior to https://github.com/rapidsai/jitify/pull/13, both are required to eliminate incompatible redefinition warnings.