### PR TITLE
Use dynamic cudart for nvcomp in java build [skip-ci]

### DIFF
--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -74,6 +74,9 @@ fi
 cd $WORKSPACE/java
 mvn -B clean package $BUILD_ARG
 
+###### Sanity test to check whether we have cudart statically built anywhere
+find . -name '*.so' | xargs -I{} readelf -Ws {} | grep cuInit && echo "Found statically linked CUDA runtime, this is currently not tested" && exit 1
+
 ###### Stash Jar files ######
 rm -rf $OUT_PATH
 mkdir -p $OUT_PATH

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -74,7 +74,7 @@ fi
 cd $WORKSPACE/java
 mvn -B clean package $BUILD_ARG
 
-###### Sanity test to check whether we have cudart statically built anywhere
+###### Sanity test: fail if static cudart found ######
 find . -name '*.so' | xargs -I{} readelf -Ws {} | grep cuInit && echo "Found statically linked CUDA runtime, this is currently not tested" && exit 1
 
 ###### Stash Jar files ######

--- a/java/src/main/native/cmake/Modules/ConfigureNvcomp.cmake
+++ b/java/src/main/native/cmake/Modules/ConfigureNvcomp.cmake
@@ -16,7 +16,13 @@
 
 set(NVCOMP_ROOT "${CMAKE_BINARY_DIR}/nvcomp")
 
-set(NVCOMP_CMAKE_ARGS "-DUSE_RMM=ON -DCUB_DIR=${CUB_INCLUDE}")
+if(CUDA_STATIC_RUNTIME)
+  set(NVCOMP_CUDA_RUNTIME_LIBRARY Static)
+else()
+  set(NVCOMP_CUDA_RUNTIME_LIBRARY Shared)
+endif()
+
+set(NVCOMP_CMAKE_ARGS "-DCMAKE_CUDA_RUNTIME_LIBRARY=${NVCOMP_CUDA_RUNTIME_LIBRARY} -DUSE_RMM=ON -DCUB_DIR=${CUB_INCLUDE}")
 
 configure_file("${CMAKE_SOURCE_DIR}/cmake/Templates/Nvcomp.CMakeLists.txt.cmake"
                "${NVCOMP_ROOT}/CMakeLists.txt")


### PR DESCRIPTION
This PR does two things:
- It adds a check that will fail the build if it detects that CUDA runtime was linked statically. For now, that seems like a safe bet, and if we decide to start building with a static CUDA in the future, we should remove that check. 
- As part of investigation for https://github.com/rapidsai/cudf/issues/7600, libnvcomp was the last library that had a statically linked CUDA runtime, so this PR addresses that.