### PR TITLE
[REVIEW] Explicitly re-running CMake won't cause unnecessary recompilation

### DIFF
--- a/cpp/cmake/thirdparty/CUDF_GetThrust.cmake
+++ b/cpp/cmake/thirdparty/CUDF_GetThrust.cmake
@@ -15,12 +15,23 @@
 #=============================================================================
 
 function(find_and_configure_thrust VERSION)
+    # We only want to set `UPDATE_DISCONNECTED` while
+    # the GIT tag hasn't moved from the last time we cloned
+    set(cpm_thrust_disconnect_update "UPDATE_DISCONNECTED TRUE")
+    set(CPM_THRUST_CURRENT_VERSION ${VERSION} CACHE STRING "version of thrust we checked out")
+    if(NOT VERSION VERSION_EQUAL CPM_THRUST_CURRENT_VERSION)
+        set(CPM_THRUST_CURRENT_VERSION ${VERSION} CACHE STRING "version of thrust we checked out" FORCE)
+        set(cpm_thrust_disconnect_update "")
+    endif()
+
     CPMAddPackage(NAME Thrust
         VERSION         ${VERSION}
         GIT_REPOSITORY  https://github.com/NVIDIA/thrust.git
         GIT_TAG         ${VERSION}
         GIT_SHALLOW     TRUE
-        PATCH_COMMAND   patch -p1 -N < ${CUDF_SOURCE_DIR}/cmake/thrust.patch || true)
+        ${cpm_thrust_disconnect_update}
+        PATCH_COMMAND   patch --reject-file=- -p1 -N < ${CUDF_SOURCE_DIR}/cmake/thrust.patch || true
+        )
 
     thrust_create_target(cudf::Thrust FROM_OPTIONS)
     set(THRUST_LIBRARY "cudf::Thrust" PARENT_SCOPE)


### PR DESCRIPTION
Explicitly re-running CMake won't unnecessary recompilation
    
The Thrust package was being patched each time CMake was executed. This caused the `thrust/system/cuda/detail/sort.h` header to have a new mtime. This new mtime meant that any cudf source that used thrust/sort needed to be recompiled.
    
Now we tell CPM to not do an update/patch step while the Thrust version hasn't changed.
