### PR TITLE
Replace device_vector with device_uvector in sort_impl

### DIFF
--- a/cpp/include/cudf/detail/utilities/vector_factories.hpp
+++ b/cpp/include/cudf/detail/utilities/vector_factories.hpp
@@ -28,6 +28,8 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
+#include <vector>
+
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -130,8 +130,8 @@ std::unique_ptr<column> sorted_order(table_view input,
   auto const d_column_order = make_device_uvector_async(std::get<1>(flattened), stream);
 
   if (has_nulls(input_flattened)) {
-    auto d_null_precedence = make_device_uvector_async(std::get<2>(flattened), stream);
-    auto comparator        = row_lexicographic_comparator<true>(
+    auto const d_null_precedence = make_device_uvector_async(std::get<2>(flattened), stream);
+    auto const comparator        = row_lexicographic_comparator<true>(
       *device_table, *device_table, d_column_order.data(), d_null_precedence.data());
     if (stable) {
       thrust::stable_sort(rmm::exec_policy(stream),
@@ -147,7 +147,7 @@ std::unique_ptr<column> sorted_order(table_view input,
     // protection for temporary d_column_order and d_null_precedence
     stream.synchronize();
   } else {
-    auto comparator =
+    auto const comparator =
       row_lexicographic_comparator<false>(*device_table, *device_table, d_column_order.data());
     if (stable) {
       thrust::stable_sort(rmm::exec_policy(stream),

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -18,10 +18,12 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/gather.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/table/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
+
 #include <structs/utilities.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -123,14 +125,14 @@ std::unique_ptr<column> sorted_order(table_view input,
   }
 
   auto flattened = structs::detail::flatten_nested_columns(input, column_order, null_precedence);
-  auto& input_flattened = std::get<0>(flattened);
-  auto device_table     = table_device_view::create(input_flattened, stream);
-  rmm::device_vector<order> d_column_order(std::get<1>(flattened));
+  auto& input_flattened     = std::get<0>(flattened);
+  auto device_table         = table_device_view::create(input_flattened, stream);
+  auto const d_column_order = make_device_uvector_async(std::get<1>(flattened), stream);
 
   if (has_nulls(input_flattened)) {
-    rmm::device_vector<null_order> d_null_precedence(std::get<2>(flattened));
-    auto comparator = row_lexicographic_comparator<true>(
-      *device_table, *device_table, d_column_order.data().get(), d_null_precedence.data().get());
+    auto d_null_precedence = make_device_uvector_async(std::get<2>(flattened), stream);
+    auto comparator        = row_lexicographic_comparator<true>(
+      *device_table, *device_table, d_column_order.data(), d_null_precedence.data());
     if (stable) {
       thrust::stable_sort(rmm::exec_policy(stream),
                           mutable_indices_view.begin<size_type>(),
@@ -142,9 +144,11 @@ std::unique_ptr<column> sorted_order(table_view input,
                    mutable_indices_view.end<size_type>(),
                    comparator);
     }
+    // protection for temporary d_column_order and d_null_precedence
+    stream.synchronize();
   } else {
-    auto comparator = row_lexicographic_comparator<false>(
-      *device_table, *device_table, d_column_order.data().get());
+    auto comparator =
+      row_lexicographic_comparator<false>(*device_table, *device_table, d_column_order.data());
     if (stable) {
       thrust::stable_sort(rmm::exec_policy(stream),
                           mutable_indices_view.begin<size_type>(),
@@ -156,6 +160,8 @@ std::unique_ptr<column> sorted_order(table_view input,
                    mutable_indices_view.end<size_type>(),
                    comparator);
     }
+    // protection for temporary d_column_order
+    stream.synchronize();
   }
 
   return sorted_indices;


### PR DESCRIPTION
Reference #7287

This replaces usages of `rmm::device_vector` with `rmm::device_uvector` in `cpp/src/sort/sort_impl.cuh` which is used internally by the `cudf::sort` APIs.
The `make_device_uvector_async` utility are called to convert a `std::vector` to a temporary `rmm::device_uvector`.

Also updated `vector_factories.hpp` utility to add the missing `include <vector>`.
