### PR TITLE
update cudfJni build env to gcc 9.3+ [skip ci]

### DIFF
--- a/java/ci/Dockerfile.centos7
+++ b/java/ci/Dockerfile.centos7
@@ -25,7 +25,7 @@ FROM nvidia/cuda:$CUDA_VERSION-devel-centos7
 
 ### Install basic requirements
 RUN yum install -y centos-release-scl
-RUN yum install -y devtoolset-8 epel-release
+RUN yum install -y devtoolset-9 epel-release
 RUN yum install -y git zlib-devel maven tar wget patch
 
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
@@ -34,7 +34,7 @@ RUN mkdir /usr/local/rapids && mkdir /rapids && chmod 777 /usr/local/rapids && c
 RUN cd /rapids/ && wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz && \
    tar zxf boost_1_72_0.tar.gz && \
    cd boost_1_72_0 && \
-   scl enable devtoolset-8 "./bootstrap.sh --prefix=/usr && ./b2 install --with-filesystem threading=multi link=static cxxflags=-fPIC; exit 0"
+   scl enable devtoolset-9 "./bootstrap.sh --prefix=/usr && ./b2 install --with-filesystem threading=multi link=static cxxflags=-fPIC; exit 0"
 
 RUN cd /usr/local/ && wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.tar.gz && \
    tar zxf cmake-3.19.0-Linux-x86_64.tar.gz

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -42,7 +42,7 @@ git clone --recursive https://github.com/rapidsai/cudf.git -b branch-0.20
 ```bash
 cd cudf
 export WORKSPACE=`pwd`
-scl enable devtoolset-8 "java/ci/build-in-docker.sh"
+scl enable devtoolset-9 "java/ci/build-in-docker.sh"
 ```
 
 ### The output

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -16,6 +16,8 @@ docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.0 -t cudf
 
 The following CUDA versions are supported:
 * CUDA 11.0
+* CUDA 11.1
+* CUDA 11.2
 
 Change the --build-arg CUDA_VERSION to what you need.
 You can replace the tag "cudf-build:11.0-devel-centos7" with another name you like.


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

update cudfjni build env to gcc 9.3+ as required.