### PR TITLE
update cudfjni CXX_STANDARD to 17 [skip ci]

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -78,8 +78,7 @@ There is experimental work to try and remove that requirement but it is not full
 you can build cuDF with `-DCUDA_STATIC_RUNTIME=ON` when running cmake, and similarly 
 `-DCUDA_STATIC_RUNTIME=ON` when running maven.  This will statically link in the CUDA runtime
 and result in a jar with no classifier that should run on any host that has a version of the
-driver new enough to support the runtime that this was built with. Unfortunately `libnvrtc` is still
-required for runtime code generation which also is tied to a specific version of cuda.
+driver new enough to support the runtime that this was built with.
 
 To build with maven for dynamic linking you would run.
 

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -11,7 +11,7 @@
 
 In the root path of cuDF repo, run below command to build the docker image.
 ```bash
-docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.0 -t cudf-build:11.0-devel-centos7 .
+docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.2.2 -t cudf-build:11.2.2-devel-centos7 .
 ```
 
 The following CUDA versions are supported:
@@ -20,7 +20,7 @@ The following CUDA versions are supported:
 * CUDA 11.2
 
 Change the --build-arg CUDA_VERSION to what you need.
-You can replace the tag "cudf-build:11.0-devel-centos7" with another name you like.
+You can replace the tag "cudf-build:11.2.2-devel-centos7" with another name you like.
 
 ## Start the docker then build
 
@@ -28,7 +28,7 @@ You can replace the tag "cudf-build:11.0-devel-centos7" with another name you li
 
 Run below command to start a docker container with GPU.
 ```bash
-nvidia-docker run -it cudf-build:11.0-devel-centos7 bash
+nvidia-docker run -it cudf-build:11.2.2-devel-centos7 bash
 ```
 
 ### Download the cuDF source code

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -252,7 +252,14 @@ set(SOURCE_FILES
 add_library(cudfjni SHARED ${SOURCE_FILES})
 
 #Override RPATH for cudfjni
-SET_TARGET_PROPERTIES(cudfjni PROPERTIES BUILD_RPATH "\$ORIGIN")
+SET_TARGET_PROPERTIES(cudfjni
+    PROPERTIES BUILD_RPATH "\$ORIGIN"
+               # set target compile options
+               CXX_STANDARD                        17
+               CXX_STANDARD_REQUIRED               ON
+               CUDA_STANDARD                       17
+               CUDA_STANDARD_REQUIRED              ON
+)
 
 target_compile_options(cudfjni
             PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_FLAGS}>"

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -291,4 +291,4 @@ target_compile_definitions(cudfjni PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(cudfjni ${CUDF_LIB} ${ARROW_LIBRARY} ${NVCOMP_LIB} ${CUDART_LIBRARY} cuda nvrtc)
+target_link_libraries(cudfjni ${CUDF_LIB} ${ARROW_LIBRARY} ${NVCOMP_LIB} ${CUDART_LIBRARY} cuda)


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

seeing `error: namespace "std" has no member "clamp"` using default c++ std setup,
bump up c++ standard version for cudfjni build, compiling works locally.

also removed link to nvrtc, please let me know if any code still require that
