### PR TITLE
add null order support to detail::drop_duplicates

### DIFF
--- a/cpp/include/cudf/detail/stream_compaction.hpp
+++ b/cpp/include/cudf/detail/stream_compaction.hpp
@@ -71,6 +71,7 @@ std::unique_ptr<table> drop_duplicates(
   std::vector<size_type> const& keys,
   duplicate_keep_option keep,
   null_equality nulls_equal           = null_equality::EQUAL,
+  null_order null_precedence          = null_order::BEFORE,
   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 

--- a/cpp/include/cudf/stream_compaction.hpp
+++ b/cpp/include/cudf/stream_compaction.hpp
@@ -227,8 +227,9 @@ enum class duplicate_keep_option {
  * @param[in] input           input table_view to copy only unique rows
  * @param[in] keys            vector of indices representing key columns from `input`
  * @param[in] keep            keep first entry, last entry, or no entries if duplicates found
- * @param[in] nulls_equal     flag to denote nulls are equal if null_equality::EQUAL,
- * nulls are not equal if null_equality::UNEQUAL
+ * @param[in] nulls_equal     flag to denote nulls are equal if null_equality::EQUAL, nulls are not
+ *                            equal if null_equality::UNEQUAL
+ * @param[in] null_precedence flag to denote nulls should appear before or after non-null items
  * @param[in] mr              Device memory resource used to allocate the returned table's device
  * memory
  *
@@ -239,6 +240,7 @@ std::unique_ptr<table> drop_duplicates(
   std::vector<size_type> const& keys,
   duplicate_keep_option keep,
   null_equality nulls_equal           = null_equality::EQUAL,
+  null_order null_precedence          = null_order::BEFORE,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/src/dictionary/add_keys.cu
+++ b/cpp/src/dictionary/add_keys.cu
@@ -63,6 +63,7 @@ std::unique_ptr<column> add_keys(
                                                   std::vector<size_type>{0},  // only one key column
                                                   duplicate_keep_option::KEEP_FIRST,
                                                   null_equality::EQUAL,
+                                                  null_order::BEFORE,
                                                   stream,
                                                   mr)
                       ->release();

--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -213,6 +213,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
                                                   std::vector<size_type>{0},
                                                   duplicate_keep_option::KEEP_FIRST,
                                                   null_equality::EQUAL,
+                                                  null_order::BEFORE,
                                                   stream,
                                                   mr)
                       ->release();

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -115,6 +115,7 @@ std::unique_ptr<column> set_keys(
                                                   std::vector<size_type>{0},
                                                   duplicate_keep_option::KEEP_FIRST,
                                                   null_equality::EQUAL,
+                                                  null_order::BEFORE,
                                                   stream,
                                                   mr)
                       ->release();

--- a/cpp/src/stream_compaction/drop_duplicates.cu
+++ b/cpp/src/stream_compaction/drop_duplicates.cu
@@ -133,14 +133,16 @@ column_view get_unique_ordered_indices(cudf::table_view const& keys,
                                        cudf::mutable_column_view& unique_indices,
                                        duplicate_keep_option keep,
                                        null_equality nulls_equal,
+                                       null_order null_precedence,
                                        rmm::cuda_stream_view stream)
 {
   // sort only indices
-  auto sorted_indices = sorted_order(keys,
-                                     std::vector<order>{},
-                                     std::vector<null_order>{},
-                                     stream,
-                                     rmm::mr::get_current_device_resource());
+  auto sorted_indices = sorted_order(
+    keys,
+    std::vector<order>{},
+    std::vector<null_order>{static_cast<uint64_t>(keys.num_columns()), null_precedence},
+    stream,
+    rmm::mr::get_current_device_resource());
 
   // extract unique indices
   auto device_input_table = cudf::table_device_view::create(keys, stream);
@@ -180,6 +182,7 @@ std::unique_ptr<table> drop_duplicates(table_view const& input,
                                        std::vector<size_type> const& keys,
                                        duplicate_keep_option keep,
                                        null_equality nulls_equal,
+                                       null_order null_precedence,
                                        rmm::cuda_stream_view stream,
                                        rmm::mr::device_memory_resource* mr)
 {
@@ -196,7 +199,7 @@ std::unique_ptr<table> drop_duplicates(table_view const& input,
   // This is just slice of `unique_indices` but with different size as per the
   // keys_view has been processed in `get_unique_ordered_indices`
   auto unique_indices_view = detail::get_unique_ordered_indices(
-    keys_view, mutable_unique_indices_view, keep, nulls_equal, stream);
+    keys_view, mutable_unique_indices_view, keep, nulls_equal, null_precedence, stream);
 
   // run gather operation to establish new order
   return detail::gather(input,
@@ -216,7 +219,8 @@ std::unique_ptr<table> drop_duplicates(table_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::drop_duplicates(input, keys, keep, nulls_equal, rmm::cuda_stream_default, mr);
+  return detail::drop_duplicates(
+    input, keys, keep, nulls_equal, null_order::BEFORE, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/drop_duplicates.cu
+++ b/cpp/src/stream_compaction/drop_duplicates.cu
@@ -123,7 +123,7 @@ OutputIterator unique_copy(InputIterator first,
  * @param[out] unique_indices Column to store the index with unique rows
  * @param[in] keep            keep first entry, last entry, or no entries if duplicates found
  * @param[in] nulls_equal     flag to denote nulls are equal if null_equality::EQUAL,
- * @param[in] null_order      flag to denote nulls should appear before or after non-null items,
+ * @param[in] null_precedence flag to denote nulls should appear before or after non-null items,
  *                            nulls are not equal if null_equality::UNEQUAL
  * @param[in] stream          CUDA stream used for device memory operations and kernel launches.
  *
@@ -217,11 +217,12 @@ std::unique_ptr<table> drop_duplicates(table_view const& input,
                                        std::vector<size_type> const& keys,
                                        duplicate_keep_option const keep,
                                        null_equality nulls_equal,
+                                       null_order null_precedence,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::drop_duplicates(
-    input, keys, keep, nulls_equal, null_order::BEFORE, rmm::cuda_stream_default, mr);
+    input, keys, keep, nulls_equal, null_precedence, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/drop_duplicates.cu
+++ b/cpp/src/stream_compaction/drop_duplicates.cu
@@ -123,6 +123,7 @@ OutputIterator unique_copy(InputIterator first,
  * @param[out] unique_indices Column to store the index with unique rows
  * @param[in] keep            keep first entry, last entry, or no entries if duplicates found
  * @param[in] nulls_equal     flag to denote nulls are equal if null_equality::EQUAL,
+ * @param[in] null_order      flag to denote nulls should appear before or after non-null items,
  *                            nulls are not equal if null_equality::UNEQUAL
  * @param[in] stream          CUDA stream used for device memory operations and kernel launches.
  *

--- a/cpp/src/transform/encode.cu
+++ b/cpp/src/transform/encode.cu
@@ -44,44 +44,13 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<column>> encode(
   // side effects of this function we are now dependent on:
   // - resulting column elements are sorted ascending
   // - nulls are sorted to the beginning
-  auto keys_table = cudf::detail::drop_duplicates(
-    input_table, drop_keys, duplicate_keep_option::KEEP_FIRST, null_equality::EQUAL, stream, mr);
-
-  if (cudf::has_nulls(keys_table->view())) {
-    // Rows with nulls appear at the top of `keys_table`, but we want them to appear at
-    // the bottom. Below, we rearrange the rows so that nulls appear at the bottom:
-    // TODO: we should be able to get rid of this logic once
-    // https://github.com/rapidsai/cudf/issues/6144 is resolved
-
-    auto num_rows = keys_table->num_rows();
-    auto mask     = cudf::detail::bitmask_and(keys_table->view(), stream);
-    auto num_rows_with_nulls =
-      cudf::count_unset_bits(reinterpret_cast<bitmask_type*>(mask.data()), 0, num_rows);
-
-    rmm::device_uvector<cudf::size_type> gather_map(num_rows, stream);
-
-    thrust::transform(rmm::exec_policy(stream),
-                      thrust::make_counting_iterator<cudf::size_type>(0),
-                      thrust::make_counting_iterator<cudf::size_type>(num_rows),
-                      gather_map.begin(),
-                      [num_rows, num_rows_with_nulls] __device__(cudf::size_type i) {
-                        if (i < (num_rows - num_rows_with_nulls)) {
-                          return num_rows_with_nulls + i;
-                        } else {
-                          return num_rows - i - 1;
-                        }
-                      });
-
-    cudf::column_view gather_map_column(
-      cudf::data_type{type_id::INT32}, num_rows, thrust::raw_pointer_cast(gather_map.data()));
-
-    keys_table = cudf::detail::gather(keys_table->view(),
-                                      gather_map_column,
-                                      cudf::out_of_bounds_policy::DONT_CHECK,
-                                      cudf::detail::negative_index_policy::NOT_ALLOWED,
-                                      stream,
-                                      mr);
-  }
+  auto keys_table = cudf::detail::drop_duplicates(input_table,
+                                                  drop_keys,
+                                                  duplicate_keep_option::KEEP_FIRST,
+                                                  null_equality::EQUAL,
+                                                  null_order::AFTER,
+                                                  stream,
+                                                  mr);
 
   auto indices_column =
     cudf::detail::lower_bound(keys_table->view(),


### PR DESCRIPTION
Fixes #6144

Saves us a couple of kernel calls inside `cudf::encode` by ensuring nulls are always in the expected order.