### PR TITLE
[REVIEW] Fix slow decompression performance

### DIFF
--- a/cpp/src/io/comp/gpuinflate.cu
+++ b/cpp/src/io/comp/gpuinflate.cu
@@ -512,13 +512,10 @@ __device__ void decode_symbols(inflate_state_s *s)
 #if ENABLE_PREFETCH
     // Wait for prefetcher to fetch a worst-case of 48 bits per symbol
     while ((*(volatile int32_t *)&s->pref.cur_p - (int32_t)(size_t)cur < batch_size * 6) ||
-           (s->x.batch_len[batch] != 0))
+           (s->x.batch_len[batch] != 0)) {}
 #else
-    while (s->x.batch_len[batch] != 0)
+    while (s->x.batch_len[batch] != 0) {}
 #endif
-    {
-      nanosleep(100);
-    }
     batch_len = 0;
 #if ENABLE_PREFETCH
     if (cur + (bitpos >> 3) >= end) {
@@ -662,7 +659,7 @@ __device__ void decode_symbols(inflate_state_s *s)
     if (batch_len != 0) batch = (batch + 1) & (batch_count - 1);
   } while (sym != 256);
 
-  while (s->x.batch_len[batch] != 0) { nanosleep(150); }
+  while (s->x.batch_len[batch] != 0) {}
   s->x.batch_len[batch] = -1;
   s->bitbuf             = bitbuf;
   s->bitpos             = bitpos;
@@ -779,7 +776,7 @@ __device__ void process_symbols(inflate_state_s *s, int t)
     uint32_t lit_mask;
 
     if (t == 0) {
-      while ((batch_len = s->x.batch_len[batch]) == 0) { nanosleep(100); }
+      while ((batch_len = s->x.batch_len[batch]) == 0) {}
     } else {
       batch_len = 0;
     }
@@ -962,8 +959,6 @@ __device__ void prefetch_warp(volatile inflate_state_s *s, int t)
         s->pref.cur_p = cur_p;
         __threadfence_block();
       }
-    } else if (t == 0) {
-      nanosleep(150);
     }
   }
 }

--- a/cpp/src/io/comp/unsnap.cu
+++ b/cpp/src/io/comp/unsnap.cu
@@ -99,7 +99,6 @@ __device__ void snappy_prefetch_bytestream(unsnap_state_s *s, int t)
           blen = 0;
           break;
         }
-        nanosleep(100);
       }
     }
     blen = shuffle(blen);
@@ -281,7 +280,7 @@ __device__ void snappy_decode_symbols(unsnap_state_s *s, uint32_t t)
     if (t == 0) {
       s->q.prefetch_rdpos = cur;
 #pragma unroll(1)  // We don't want unrolling here
-      while (s->q.prefetch_wrpos < min(cur + 5 * batch_size, end)) { nanosleep(50); }
+      while (s->q.prefetch_wrpos < min(cur + 5 * batch_size, end)) {}
       b = &s->q.batch[batch * batch_size];
     }
     // Process small symbols in parallel: for data that does not get good compression,
@@ -441,7 +440,7 @@ __device__ void snappy_decode_symbols(unsnap_state_s *s, uint32_t t)
           // Wait for prefetcher
           s->q.prefetch_rdpos = cur;
 #pragma unroll(1)  // We don't want unrolling here
-          while (s->q.prefetch_wrpos < min(cur + 5 * batch_size, end)) { nanosleep(50); }
+          while (s->q.prefetch_wrpos < min(cur + 5 * batch_size, end)) {}
           dst_pos += blen;
           if (bytes_left < blen) break;
           bytes_left -= blen;
@@ -457,7 +456,7 @@ __device__ void snappy_decode_symbols(unsnap_state_s *s, uint32_t t)
     }
     batch_len = shuffle(batch_len);
     if (t == 0) {
-      while (s->q.batch_len[batch] != 0) { nanosleep(100); }
+      while (s->q.batch_len[batch] != 0) {}
     }
     if (batch_len != batch_size) { break; }
   }
@@ -490,7 +489,7 @@ __device__ void snappy_process_symbols(unsnap_state_s *s, int t, Storage &temp_s
     int32_t batch_len, blen_t, dist_t;
 
     if (t == 0) {
-      while ((batch_len = s->q.batch_len[batch]) == 0) { nanosleep(100); }
+      while ((batch_len = s->q.batch_len[batch]) == 0) {}
     } else {
       batch_len = 0;
     }

--- a/cpp/src/io/utilities/block_utils.cuh
+++ b/cpp/src/io/utilities/block_utils.cuh
@@ -39,7 +39,7 @@ inline __device__ uint32_t ballot(int pred) { return __ballot_sync(~0, pred); }
 template <typename T>
 inline __device__ void nanosleep(T d)
 {
-  // TODO: nanosleep temporarily disabled 
+  // TODO: nanosleep temporarily disabled
   clock();
 }
 

--- a/cpp/src/io/utilities/block_utils.cuh
+++ b/cpp/src/io/utilities/block_utils.cuh
@@ -39,11 +39,8 @@ inline __device__ uint32_t ballot(int pred) { return __ballot_sync(~0, pred); }
 template <typename T>
 inline __device__ void nanosleep(T d)
 {
-#if (__CUDA_ARCH__ >= 700)
-  __nanosleep(d);
-#else
+  // TODO: nanosleep temporarily disabled 
   clock();
-#endif
 }
 
 // Warp reduction helpers

--- a/cpp/src/io/utilities/block_utils.cuh
+++ b/cpp/src/io/utilities/block_utils.cuh
@@ -36,13 +36,6 @@ inline __device__ void syncwarp(void) { __syncwarp(); }
 
 inline __device__ uint32_t ballot(int pred) { return __ballot_sync(~0, pred); }
 
-template <typename T>
-inline __device__ void nanosleep(T d)
-{
-  // TODO: nanosleep temporarily disabled
-  clock();
-}
-
 // Warp reduction helpers
 template <typename T>
 inline __device__ T WarpReduceOr2(T acc)


### PR DESCRIPTION
Fixes #7114 

No performance regression on Turing (T4, CUDA 11.0, driver 450.102.04):
<details><summary>Click here to see environment details</summary><pre>
nvprof --print-gpu-trace ./gbenchmarks/PARQUET_READER_BENCH --benchmark_filter="ParquetRead/integral_file_input/28/1000/1/1/0/manual_time" 2>&1

*** WITH PATCH *** 
   Start  Duration            Grid Size      Block Size     Regs*    SSMem*    DSMem*      Size  Throughput  SrcMemType  DstMemType           Device   Context    Stream  Name
3.34085s  9.8091ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [4661]
4.77212s  9.6983ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [9822]
4.88598s  9.8804ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [10833]
5.00339s  9.9037ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [11844]
5.12055s  9.8821ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [12855]
5.23300s  9.8300ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [13866]
5.34499s  9.7688ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [14877]

*** WITHOUT PATCH ***

   Start  Duration            Grid Size      Block Size     Regs*    SSMem*    DSMem*      Size  Throughput  SrcMemType  DstMemType           Device   Context    Stream  Name
3.34647s  10.088ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [4661]
4.70031s  9.6986ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [9822]
4.80015s  9.9992ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [10833]
4.90408s  9.8958ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [11844]
5.00237s  9.8824ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [12855]
5.10425s  9.9476ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [13866]
5.20341s  9.8957ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [14877]
5.30279s  9.8980ms            (954 1 1)       (128 1 1)        44  1.5938KB        0B         -           -           -           -     Tesla T4 (0)         1         7  void cudf::io::unsnap_kernel<int=128>(cudf::io::gpu_inflate_input_s*, cudf::io::gpu_inflate_status_s*) [15888]
</pre></details>

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
