### PR TITLE
add GDS user-space lib to cudfjni build dockerfile [skip ci]

### DIFF
--- a/java/ci/Dockerfile.centos7
+++ b/java/ci/Dockerfile.centos7
@@ -17,7 +17,7 @@
 ###
 # Build the image for cudf development environment.
 #
-# Arguments: CUDA_VERSION=10.1, 10.2 or 11.0
+# Arguments: CUDA_VERSION=11.0, 11.1, 11.2.0 or 11.2.2
 #
 ###
 ARG CUDA_VERSION
@@ -38,3 +38,10 @@ RUN cd /rapids/ && wget https://dl.bintray.com/boostorg/release/1.72.0/source/bo
 
 RUN cd /usr/local/ && wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.tar.gz && \
    tar zxf cmake-3.19.0-Linux-x86_64.tar.gz
+
+# get GDS user-space lib
+RUN cd /tmp/ && wget https://developer.download.nvidia.com/gds/redist/rel-0.95.0/gds-redistrib-0.95.0.tgz && \
+    tar zxf gds-redistrib-0.95.0.tgz && \
+    cp -R ./gds-redistrib-0.95.0/targets/x86_64-linux/lib/* /usr/local/cuda/targets/x86_64-linux/lib && \
+    cp -R ./gds-redistrib-0.95.0/targets/x86_64-linux/include/* /usr/local/cuda/targets/x86_64-linux/include && \
+    rm -rf gds-redistrib-0.95.0*


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

add the GDS user-space components to dockerfile, 
so people could enable build w/ GDS by setting `ENABLE_GDS=ON`