### PR TITLE
Add JNI for splitting groups in a table after groupby [skip-ci]

### DIFF
--- a/java/rmm_log.txt
+++ b/java/rmm_log.txt
@@ -1,0 +1,6 @@
+[  5195][16:41:05:791632][info  ] ----- RMM LOG BEGIN [PTDS DISABLED] -----
+[  5195][16:41:05:791649][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
+[  5195][16:41:05:791670][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
+[  5195][16:41:05:791681][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
+[  5195][16:41:07:123919][error ] [A][Stream 0x1][Upstream 1024B][FAILURE maximum pool size exceeded]
+[  5195][16:41:13:124742][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]

--- a/java/rmm_log.txt
+++ b/java/rmm_log.txt
@@ -1,6 +1,0 @@
-[  5195][16:41:05:791632][info  ] ----- RMM LOG BEGIN [PTDS DISABLED] -----
-[  5195][16:41:05:791649][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
-[  5195][16:41:05:791670][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
-[  5195][16:41:05:791681][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
-[  5195][16:41:07:123919][error ] [A][Stream 0x1][Upstream 1024B][FAILURE maximum pool size exceeded]
-[  5195][16:41:13:124742][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]

--- a/java/src/main/java/ai/rapids/cudf/GroupByOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/GroupByOptions.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,20 +19,38 @@
 package ai.rapids.cudf;
 
 /**
- * Options for group by (see cudf::groupby::Options)
+ * Options for groupby (see cudf::groupby::groupby's constructor)
  */
 public class GroupByOptions {
 
   public static GroupByOptions DEFAULT = new GroupByOptions(new Builder());
 
   private final boolean ignoreNullKeys;
+  private final boolean keysSorted;
+  private final boolean[] keysDescending;
+  private final boolean[] keysNullSmallest;
 
   private GroupByOptions(Builder builder) {
     ignoreNullKeys = builder.ignoreNullKeys;
+    keysSorted = builder.keysSorted;
+    keysDescending = builder.keysDescending;
+    keysNullSmallest = builder.keysNullSmallest;
   }
 
   boolean getIgnoreNullKeys() {
     return ignoreNullKeys;
+  }
+
+  boolean getKeySorted() {
+    return keysSorted;
+  }
+
+  boolean[] getKeysDescending() {
+    return keysDescending;
+  }
+
+  boolean[] getKeysNullSmallest() {
+    return keysNullSmallest;
   }
 
   public static Builder builder() {
@@ -41,6 +59,9 @@ public class GroupByOptions {
 
   public static class Builder {
     private boolean ignoreNullKeys = false;
+    private boolean keysSorted = false;
+    private boolean[] keysDescending = new boolean[0];
+    private boolean[] keysNullSmallest = new boolean[0];
 
     /**
      * If true, the cudf groupby will ignore grouping keys that are null.
@@ -49,6 +70,50 @@ public class GroupByOptions {
      */
     public Builder withIgnoreNullKeys(boolean ignoreNullKeys) {
       this.ignoreNullKeys = ignoreNullKeys;
+      return this;
+    }
+
+    /**
+     * Indicates whether rows in `keys` are already sorted.
+     * The default value is false.
+     *
+     * If the `keys` are already sorted, better performance may be achieved by
+     * passing `keysSorted == true` and indicating the ascending/descending
+     * order of each column and null order by calling `withKeysDescending` and
+     * `withKeysNullSmallest`, respectively.
+     */
+    public Builder withKeysSorted(boolean keysSorted) {
+      this.keysSorted = keysSorted;
+      return this;
+    }
+
+    /**
+     * If `keysSorted == true`, indicates whether each
+     * column is ascending/descending. If empty or null, assumes all columns are
+     * ascending. Ignored if `keysSorted == false`.
+     */
+    public Builder withKeysDescending(boolean... keysDescending) {
+      if (keysDescending == null) {
+        // Use empty array instead of null
+        this.keysDescending = new boolean[0];
+      } else {
+        this.keysDescending = keysDescending;
+      }
+      return this;
+    }
+
+    /**
+     * If `keysSorted == true`, indicates the ordering
+     * of null values in each column. If empty or null, assumes all columns
+     * use 'null smallest'. Ignored if `keysSorted == false`.
+     */
+    public Builder withKeysNullSmallest(boolean... keysNullSmallest) {
+      if (keysNullSmallest == null) {
+        // Use empty array instead of null
+        this.keysNullSmallest = new boolean[0];
+      } else {
+        this.keysNullSmallest = keysNullSmallest;
+      }
       return this;
     }
 

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -452,7 +452,9 @@ public final class Table implements AutoCloseable {
   private static native void readArrowIPCEnd(long handle);
 
   private static native long[] groupByAggregate(long inputTable, int[] keyIndices, int[] aggColumnsIndices,
-                                                long[] aggInstances, boolean ignoreNullKeys) throws CudfException;
+                                                long[] aggInstances, boolean ignoreNullKeys,
+                                                boolean keySorted, boolean[] keysDescending,
+                                                boolean[] keysNullSmallest) throws CudfException;
 
   private static native long[] rollingWindowAggregate(
       long inputTable,
@@ -1649,8 +1651,12 @@ public final class Table implements AutoCloseable {
 
   /**
    * Returns aggregate operations grouped by columns provided in indices
-   * null is considered as key while grouping.
-   * @param indices columnns to be considered for groupBy
+   * with default options as below:
+   *  - null is considered as key while grouping.
+   *  - keys are not presorted.
+   *  - empty key order array.
+   *  - empty null order array.
+   * @param indices columns to be considered for groupBy
    */
   public GroupByOperation groupBy(int... indices) {
     return groupByInternal(GroupByOptions.builder().withIgnoreNullKeys(false).build(),
@@ -2386,7 +2392,10 @@ public final class Table implements AutoCloseable {
             operation.indices,
             aggColumnIndexes,
             aggOperationInstances,
-            groupByOptions.getIgnoreNullKeys()))) {
+            groupByOptions.getIgnoreNullKeys(),
+            groupByOptions.getKeySorted(),
+            groupByOptions.getKeysDescending(),
+            groupByOptions.getKeysNullSmallest()))) {
           // prepare the final table
           ColumnVector[] finalCols = new ColumnVector[keysLength + aggregates.length];
 

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -543,6 +543,13 @@ public final class Table implements AutoCloseable {
 
   private static native long[] columnViewsFromPacked(ByteBuffer metadata, long dataAddress);
 
+  private static native ContiguousTable[] contiguousSplitGroups(long inputTable,
+                                                                int[] keyIndices,
+                                                                boolean ignoreNullKeys,
+                                                                boolean keySorted,
+                                                                boolean[] keysDescending,
+                                                                boolean[] keysNullSmallest);
+
   /////////////////////////////////////////////////////////////////////////////
   // TABLE CREATION APIs
   /////////////////////////////////////////////////////////////////////////////
@@ -1636,7 +1643,7 @@ public final class Table implements AutoCloseable {
    * @param groupByOptions Options provided in the builder
    * @param indices columns to be considered for groupBy
    */
-  public AggregateOperation groupBy(GroupByOptions groupByOptions, int... indices) {
+  public GroupByOperation groupBy(GroupByOptions groupByOptions, int... indices) {
     return groupByInternal(groupByOptions, indices);
   }
 
@@ -1645,14 +1652,14 @@ public final class Table implements AutoCloseable {
    * null is considered as key while grouping.
    * @param indices columnns to be considered for groupBy
    */
-  public AggregateOperation groupBy(int... indices) {
+  public GroupByOperation groupBy(int... indices) {
     return groupByInternal(GroupByOptions.builder().withIgnoreNullKeys(false).build(),
         indices);
   }
 
-  private AggregateOperation groupByInternal(GroupByOptions groupByOptions, int[] indices) {
+  private GroupByOperation groupByInternal(GroupByOptions groupByOptions, int[] indices) {
     int[] operationIndicesArray = copyAndValidate(indices);
-    return new AggregateOperation(this, groupByOptions, operationIndicesArray);
+    return new GroupByOperation(this, groupByOptions, operationIndicesArray);
   }
 
   /**
@@ -2315,14 +2322,14 @@ public final class Table implements AutoCloseable {
   }
 
   /**
-   * Class representing aggregate operations
+   * Class representing groupby operations
    */
-  public static final class AggregateOperation {
+  public static final class GroupByOperation {
 
     private final Operation operation;
     private final GroupByOptions groupByOptions;
 
-    AggregateOperation(final Table table, GroupByOptions groupByOptions, final int... indices) {
+    GroupByOperation(final Table table, GroupByOptions groupByOptions, final int... indices) {
       operation = new Operation(table, indices);
       this.groupByOptions = groupByOptions;
     }
@@ -2657,6 +2664,47 @@ public final class Table implements AutoCloseable {
       } finally {
         Aggregation.close(aggInstances);
       }
+    }
+
+    /**
+     * Splits the groups in a single table into separate tables according to the grouping keys.
+     * Each split table represents a single group.
+     *
+     * This API will be used by some grouping related operators to process the data
+     * group by group.
+     *
+     * Example:
+     *   Grouping column index: 0
+     *   Input: A table of 3 rows (two groups)
+     *             a    1
+     *             b    2
+     *             b    3
+     *
+     * Result:
+     *   Two tables, one group one table.
+     *   Result[0]:
+     *              a    1
+     *
+     *   Result[1]:
+     *              b    2
+     *              b    3
+     *
+     * Note, the order of the groups returned is NOT always the same with that in the input table.
+     * The split is done in native to avoid copying the offset array to JVM.
+     *
+     * @return The tables split according to the groups in the table. NOTE: It is the
+     * responsibility of the caller to close the result. Each table and column holds a
+     * reference to the original buffer. But both the buffer and the table must be closed
+     * for the memory to be released.
+     */
+    public ContiguousTable[] contiguousSplitGroups() {
+      return Table.contiguousSplitGroups(
+          operation.table.nativeHandle,
+          operation.indices,
+          groupByOptions.getIgnoreNullKeys(),
+          groupByOptions.getKeySorted(),
+          groupByOptions.getKeysDescending(),
+          groupByOptions.getKeysNullSmallest());
     }
   }
 

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -2501,10 +2501,10 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplitGroups(J
       grouped_cols.at(value_id) = std::move(*value_view_it);
       value_view_it ++;
     }
+    cudf::table_view grouped_table(grouped_cols);
     // When no key columns, uses the input table instead, because the output
     // of 'get_groups' is empty.
-    auto grouped_table = key_indices.empty() ? *input_table
-                                             : cudf::table_view(grouped_cols);
+    auto& grouped_view = key_indices.empty() ? *input_table : grouped_table;
 
     // Resolves the split indices from offsets vector directly to avoid copying. Since
     // the offsets vector may be very large if there are too many small groups.
@@ -2516,7 +2516,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplitGroups(J
 
     // 2) Splits the groups.
     std::vector<cudf::packed_table> result =
-        cudf::contiguous_split(grouped_table, split_indices);
+        cudf::contiguous_split(grouped_view, split_indices);
     // Release the grouped table right away after split done.
     groups.keys.reset(nullptr);
     groups.values.reset(nullptr);

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -4345,6 +4345,65 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
+  void testGroupByContiguousSplitGroups() {
+    ContiguousTable[] splits = null;
+    try (Table table = new Table.TestBuilder()
+        .column(   1,    1,    1,    1,    1,    1)
+        .column(   1,    3,    3,    5,    5,    5)
+        .column(  12,   14,   13,   17,   16,   18)
+        .column("s1", "s2", "s3", "s4", "s5", "s6")
+        .build()) {
+      // Normal case with primitive types.
+      try (Table expected1 = new Table.TestBuilder()
+              .column(   1)
+              .column(   1)
+              .column(  12)
+              .column("s1").build();
+           Table expected2 = new Table.TestBuilder()
+              .column(   1,    1)
+              .column(   3,    3)
+              .column(  14,   13)
+              .column("s2", "s3").build();
+           Table expected3 = new Table.TestBuilder()
+              .column(   1,    1,    1)
+              .column(   5,    5,    5)
+              .column(  17,   16,   18)
+              .column("s4", "s5", "s6").build()) {
+        try {
+          splits = table.groupBy(0, 1).contiguousSplitGroups();
+          assertEquals(3, splits.length);
+          for (ContiguousTable ct : splits) {
+            if (ct.getRowCount() == 1) {
+              assertTablesAreEqual(expected1, ct.getTable());
+            } else if (ct.getRowCount() == 2) {
+              assertTablesAreEqual(expected2, ct.getTable());
+            } else {
+              assertTablesAreEqual(expected3, ct.getTable());
+            }
+          }
+        } finally {
+          if (splits != null) {
+            for (ContiguousTable t : splits) { t.close(); }
+          }
+          splits = null;
+        }
+      }
+
+      // Empty key columns, the whole table is a group.
+      try {
+        splits = table.groupBy().contiguousSplitGroups();
+        assertEquals(1, splits.length);
+        assertTablesAreEqual(table, splits[0].getTable());
+      } finally {
+        if (splits != null) {
+          for (ContiguousTable t : splits) { t.close(); }
+        }
+      }
+
+    }
+  }
+
+  @Test
   void testRowBitCount() {
     try (Table t = new Table.TestBuilder()
         .column(0, 1, null, 3)                 // 33 bits per row (4 bytes + valid bit)


### PR DESCRIPTION
This PR is to add an API named `contiguousSplitGroups` in JNI which will split the groups in a table after a `groupby` operation, instead of executing an aggregate on each group, along with its unit tests.

This API will be used by some Spark operators ( e.g. Python UDFs ) to process the data group by group.

Other changes:

- Renames the `AggregateOperation` to `GroupByOperation` which sounds better, since it is retuned from exactly a `groupby` call.
- Adds some additional fields to `GroupByOptions` which will be used by native `groupby` to propably achieve a better performance.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
