### PR TITLE
fix literal zero cuda_stream_view argument in JNI [skip ci]

### DIFF
--- a/java/src/main/native/src/row_conversion.cu
+++ b/java/src/main/native/src/row_conversion.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/row_conversion.cu
+++ b/java/src/main/native/src/row_conversion.cu
@@ -404,7 +404,7 @@ static std::unique_ptr<cudf::column> fixed_width_convert_to_rows(
       input_data->data(), input_nm->data(), data->mutable_view().data<int8_t>());
 
   return cudf::make_lists_column(num_rows, std::move(offsets), std::move(data), 0,
-                                 rmm::device_buffer{0, 0, mr}, stream, mr);
+                                 rmm::device_buffer{0, rmm::cuda_stream_default, mr}, stream, mr);
 }
 
 static cudf::data_type get_data_type(const cudf::column_view &v) {


### PR DESCRIPTION
Eliminates literal zero arguments to `cuda_stream_view` parameters in libcudfjni, replacing them with `rmm::cuda_stream_default`

Followup to rapidsai/rmm#740

CC @harrism 