### PR TITLE
remove decimals_as_float64 from orc benchmarks

### DIFF
--- a/cpp/benchmarks/io/orc/orc_reader_benchmark.cpp
+++ b/cpp/benchmarks/io/orc/orc_reader_benchmark.cpp
@@ -165,7 +165,7 @@ BENCHMARK_REGISTER_F(OrcRead, column_selection)
                   int32_t(column_selection::SECOND_HALF)},
                  {int32_t(row_selection::ALL)},
                  {1},
-                 {0b111},  // defaults
+                 {0b11},  // defaults
                  {int32_t(cudf::type_id::EMPTY)}})
   ->Unit(benchmark::kMillisecond)
   ->UseManualTime();
@@ -176,7 +176,7 @@ BENCHMARK_REGISTER_F(OrcRead, row_selection)
   ->ArgsProduct({{int32_t(column_selection::ALL)},
                  {int32_t(row_selection::STRIPES), int32_t(row_selection::NROWS)},
                  {1, 8},
-                 {0b111},  // defaults
+                 {0b11},  // defaults
                  {int32_t(cudf::type_id::EMPTY)}})
   ->Unit(benchmark::kMillisecond)
   ->UseManualTime();
@@ -187,7 +187,7 @@ BENCHMARK_REGISTER_F(OrcRead, misc_options)
   ->ArgsProduct({{int32_t(column_selection::ALL)},
                  {int32_t(row_selection::NROWS)},
                  {1},
-                 {0b111, 0b110, 0b101, 0b011},  // `true` is default for each boolean parameter here
+                 {0b11, 0b10, 0b01},  // `true` is default for each boolean parameter here
                  {int32_t(cudf::type_id::EMPTY), int32_t(cudf::type_id::TIMESTAMP_NANOSECONDS)}})
   ->Unit(benchmark::kMillisecond)
   ->UseManualTime();

--- a/cpp/benchmarks/io/orc/orc_reader_benchmark.cpp
+++ b/cpp/benchmarks/io/orc/orc_reader_benchmark.cpp
@@ -84,7 +84,6 @@ void BM_orc_read_varying_options(benchmark::State& state)
   auto const flags         = state.range(state_idx++);
   auto const use_index     = (flags & 1) != 0;
   auto const use_np_dtypes = (flags & 2) != 0;
-  auto const dec_as_float  = (flags & 4) != 0;
   auto const ts_type       = cudf::data_type{static_cast<cudf::type_id>(state.range(state_idx++))};
 
   auto const data_types =
@@ -107,8 +106,7 @@ void BM_orc_read_varying_options(benchmark::State& state)
       .columns(cols_to_read)
       .use_index(use_index)
       .use_np_dtypes(use_np_dtypes)
-      .timestamp_type(ts_type)
-      .decimals_as_float64(dec_as_float);
+      .timestamp_type(ts_type);
 
   auto const num_stripes              = data_size / (64 << 20);
   cudf::size_type const chunk_row_cnt = view.num_rows() / num_chunks;


### PR DESCRIPTION
`decimals_as_float64` was recently removed in https://github.com/rapidsai/cudf/pull/7970. This PR fix benchmark builds by removing it's usage from benchmarks.