### PR TITLE
Support setting to a new column in `DataFrame.loc`

### DIFF
--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -1157,6 +1157,21 @@ def test_dataframe_setitem_loc(key, value, pdf_gdf):
 
 
 @pytest.mark.parametrize(
+    "key, value",
+    [
+        (("one", "a"), 5),
+        ((slice(None), "a"), range(3)),
+        ((slice(None), "a"), [3, 2, 1]),
+    ],
+)
+def test_dataframe_setitem_loc_empty_df(key, value):
+    pdf, gdf = pd.DataFrame(), cudf.DataFrame()
+    pdf.loc[key] = value
+    gdf.loc[key] = value
+    assert_eq(pdf, gdf, check_dtype=False)
+
+
+@pytest.mark.parametrize(
     "key,value",
     [
         ((0, 0), 5.0),

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -1136,8 +1136,17 @@ def test_dataframe_setitem_iloc(key, value, pdf_gdf):
         (("one", "a"), 5),
         ((slice(None), "a"), 5),
         ((slice(None), "a"), range(3)),
+        ((slice(None), "a"), [3, 2, 1]),
         ((slice(None, "two"), "a"), range(2)),
+        ((slice(None, "two"), "a"), [4, 5]),
         ((["one", "two"], "a"), 5),
+        (("one", "c"), 5),
+        ((["one", "two"], "c"), 5),
+        ((slice(None), "c"), 5),
+        ((slice(None), "c"), range(3)),
+        ((slice(None), "c"), [3, 2, 1]),
+        ((slice(None, "two"), "c"), range(2)),
+        ((slice(None, "two"), "c"), [4, 5]),
     ],
 )
 def test_dataframe_setitem_loc(key, value, pdf_gdf):


### PR DESCRIPTION
closes #7628 

This PR adds support to setting a column in the dataframe when the provided column name is a new column name. The specified rows can be of a single row label, a collection of row labels, or slices. The value-to-set can be column-like object or scalar. E.g. you can now do this:

```
>>> x = cudf.DataFrame()
>>> x.loc[:, "a"] = [1, 2, 3] # set a new column with list
>>> x
   a
0  1
1  2
2  3
>>> x.loc[[1, 2], "b"] = ["abc", "cba"] # set part of the new column with list
>>> x
   a     b
0  1  <NA>
1  2   abc
2  3   cba
>>> x.loc[:, "c"] = 5 # set the new column to the scalar
>>> x
   a     b  c
0  1  <NA>  5
1  2   abc  5
2  3   cba  5
```