### PR TITLE
Numba version and deprecation updates

### DIFF
--- a/conda/environments/cudf_dev_cuda11.0.yml
+++ b/conda/environments/cudf_dev_cuda11.0.yml
@@ -15,7 +15,7 @@ dependencies:
   - cmake>=3.14
   - cmake_setuptools>=0.1.3
   - python>=3.7,<3.9
-  - numba>=0.49,!=0.51.0
+  - numba>=0.53.1
   - numpy
   - pandas>=1.0,<1.3.0dev0
   - pyarrow=1.0.1

--- a/conda/environments/cudf_dev_cuda11.1.yml
+++ b/conda/environments/cudf_dev_cuda11.1.yml
@@ -15,7 +15,7 @@ dependencies:
   - cmake>=3.14
   - cmake_setuptools>=0.1.3
   - python>=3.7,<3.9
-  - numba>=0.49,!=0.51.0
+  - numba>=0.53.1
   - numpy
   - pandas>=1.0,<1.3.0dev0
   - pyarrow=1.0.1

--- a/conda/environments/cudf_dev_cuda11.2.yml
+++ b/conda/environments/cudf_dev_cuda11.2.yml
@@ -15,7 +15,7 @@ dependencies:
   - cmake>=3.14
   - cmake_setuptools>=0.1.3
   - python>=3.7,<3.9
-  - numba>=0.49,!=0.51.0
+  - numba>=0.53.1
   - numpy
   - pandas>=1.0,<1.3.0dev0
   - pyarrow=1.0.1

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - python
     - cython >=0.29,<0.30
     - setuptools
-    - numba >=0.49.0
+    - numba >=0.53.1
     - dlpack
     - pyarrow 1.0.1
     - libcudf {{ version }}
@@ -37,7 +37,7 @@ requirements:
     - typing_extensions
     - pandas >=1.0,<1.3.0dev0
     - cupy >7.1.0,<9.0.0a0
-    - numba >=0.49.0
+    - numba >=0.53.1
     - numpy
     - {{ pin_compatible('pyarrow', max_pin='x.x.x') }}
     - fastavro >=0.22.0

--- a/python/cudf/cudf/_lib/aggregation.pyx
+++ b/python/cudf/cudf/_lib/aggregation.pyx
@@ -19,12 +19,7 @@ from cudf._lib.types cimport (
 )
 from cudf._lib.types import Interpolation
 
-try:
-    # Numba >= 0.49
-    from numba.np import numpy_support
-except ImportError:
-    # Numba <= 0.49
-    from numba import numpy_support
+from numba.np import numpy_support
 
 cimport cudf._lib.cpp.types as libcudf_types
 cimport cudf._lib.cpp.aggregation as libcudf_aggregation

--- a/python/cudf/cudf/_lib/transform.pyx
+++ b/python/cudf/cudf/_lib/transform.pyx
@@ -29,12 +29,7 @@ from cudf._lib.cpp.column.column_view cimport column_view
 from cudf._lib.cpp.table.table cimport table
 from cudf._lib.cpp.table.table_view cimport table_view
 
-try:
-    # Numba >= 0.49
-    from numba.np import numpy_support
-except ImportError:
-    # Numba <= 0.49
-    from numba import numpy_support
+from numba.np import numpy_support
 
 cimport cudf._lib.cpp.transform as libcudf_transform
 

--- a/python/cudf/cudf/tests/test_udf_binops.py
+++ b/python/cudf/cudf/tests/test_udf_binops.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 from __future__ import division
 
-import numba
 import numpy as np
 import pytest
 
@@ -9,12 +8,8 @@ from cudf import _lib as libcudf
 from cudf.core import Series
 from cudf.utils import dtypes as dtypeutils
 
-try:
-    # Numba >= 0.49
-    from numba.np import numpy_support
-except ImportError:
-    # Numba <= 0.49
-    from numba import numpy_support
+from numba.cuda import compile_ptx
+from numba.np import numpy_support
 
 
 @pytest.mark.parametrize(
@@ -30,22 +25,19 @@ def test_generic_ptx(dtype):
     rhs_arr = np.random.random(size).astype(dtype)
     rhs_col = Series(rhs_arr)._column
 
-    @numba.cuda.jit(device=True)
     def generic_function(a, b):
         return a ** 3 + b
 
     nb_type = numpy_support.from_dtype(np.dtype(dtype))
     type_signature = (nb_type, nb_type)
 
-    result = generic_function.compile(type_signature)
-    ptx = generic_function.inspect_ptx(type_signature)
-    ptx_code = ptx.decode("utf-8")
-
-    output_type = numpy_support.as_dtype(result.signature.return_type)
-
-    out_col = libcudf.binaryop.binaryop_udf(
-        lhs_col, rhs_col, ptx_code, output_type.type
+    ptx_code, output_type = compile_ptx(
+        generic_function, type_signature, device=True
     )
+
+    dtype = numpy_support.as_dtype(output_type).type
+
+    out_col = libcudf.binaryop.binaryop_udf(lhs_col, rhs_col, ptx_code, dtype)
 
     result = lhs_arr ** 3 + rhs_arr
 

--- a/python/cudf/cudf/utils/applyutils.py
+++ b/python/cudf/cudf/utils/applyutils.py
@@ -11,12 +11,7 @@ from cudf.core.column import column
 from cudf.utils import utils
 from cudf.utils.docutils import docfmt_partial
 
-try:
-    # Numba >= 0.49
-    from numba.core.utils import pysignature
-except ImportError:
-    # Numba <= 0.49
-    from numba.utils import pysignature
+from numba.core.utils import pysignature
 
 
 _doc_applyparams = """

--- a/python/cudf/requirements/cuda-11.0/dev_requirements.txt
+++ b/python/cudf/requirements/cuda-11.0/dev_requirements.txt
@@ -16,7 +16,7 @@ hypothesis
 mimesis
 mypy==0.782
 nbsphinx
-numba>=0.49.0,!=0.51.0
+numba>=0.53.1
 numpy
 numpydoc
 nvtx>=0.2.1

--- a/python/cudf/requirements/cuda-11.1/dev_requirements.txt
+++ b/python/cudf/requirements/cuda-11.1/dev_requirements.txt
@@ -16,7 +16,7 @@ hypothesis
 mimesis
 mypy==0.782
 nbsphinx
-numba>=0.49.0,!=0.51.0
+numba>=>=0.53.1
 numpy
 numpydoc
 nvtx>=0.2.1

--- a/python/cudf/requirements/cuda-11.1/dev_requirements.txt
+++ b/python/cudf/requirements/cuda-11.1/dev_requirements.txt
@@ -16,7 +16,7 @@ hypothesis
 mimesis
 mypy==0.782
 nbsphinx
-numba>=>=0.53.1
+numba>=0.53.1
 numpy
 numpydoc
 nvtx>=0.2.1

--- a/python/cudf/requirements/cuda-11.2/dev_requirements.txt
+++ b/python/cudf/requirements/cuda-11.2/dev_requirements.txt
@@ -16,7 +16,7 @@ hypothesis
 mimesis
 mypy==0.782
 nbsphinx
-numba>=0.49.0,!=0.51.0
+numba>=0.53.1
 numpy
 numpydoc
 nvtx>=0.2.1

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -19,7 +19,7 @@ from setuptools.extension import Extension
 import versioneer
 
 install_requires = [
-    "numba>=0.49.0,!=0.51.0",
+    "numba>=0.53.1",
     "Cython>=0.29,<0.30",
     "fastavro>=0.22.9",
     "fsspec>=0.6.0",

--- a/python/dask_cudf/dev_requirements.txt
+++ b/python/dask_cudf/dev_requirements.txt
@@ -3,7 +3,7 @@
 dask==2021.4.0
 distributed>=2.22.0,<=2021.4.0
 fsspec>=0.6.0
-numba>=0.49.0,!=0.51.0
+numba>=0.53.1
 numpy
 pandas>=1.0,<1.3.0dev0
 pytest

--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -22,7 +22,7 @@ extras_require = {
         "numpy",
         "pandas>=1.0,<1.3.0dev0",
         "pytest",
-        "numba>=0.49.0,!=0.51.0",
+        "numba>=0.53.1",
         "dask==2021.4.0",
         "distributed>=2.22.0,<=2021.4.0",
     ]


### PR DESCRIPTION
Some small Numba-related changes:

- Testing on CI appears to be picking up Numba 0.53.1, and there have been quite a lot of CUDA changes between Numba 0.49 (the old minimum) and 0.53.1 - increase the minimum required Numba version to 0.53.1
  accordingly.
- Remove old import guards and alternatives for Numba versions < 0.49 - these were needed because of Numba's internals refactor between 0.48 and 0.49.
- Replace the use of `inspect_ptx()` with `compile_ptx()` in `test_ptx_generic()` - `inspect_ptx()` has always had various issues so it is being deprecated and will be removed in a later version. `compile_ptx()` provides a better alternative. See https://github.com/numba/numba/pull/6953

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
