### PR TITLE
Fix dask_cudf metadata-inference when first ORC path is empty 

### DIFF
--- a/python/dask_cudf/dask_cudf/io/orc.py
+++ b/python/dask_cudf/dask_cudf/io/orc.py
@@ -85,7 +85,12 @@ def read_orc(path, columns=None, filters=None, storage_options=None, **kwargs):
         columns = list(schema)
 
     with fs.open(paths[0], "rb") as f:
-        meta = cudf.read_orc(f, stripes=[0], columns=columns, **kwargs)
+        meta = cudf.read_orc(
+            f,
+            stripes=[0] if nstripes_per_file[0] else None,
+            columns=columns,
+            **kwargs,
+        )
 
     name = "read-orc-" + tokenize(fs_token, path, columns, **kwargs)
     dsk = {}


### PR DESCRIPTION
Closes #8011 

Dask-cuDF currently reads a single stripe to infer metadata in `read_orc`.  When the first path corresponds to an empty file, there is no stripe "0" to read.  This PR includes a simple fix (and test coverage).
