### PR TITLE
Fix returned column type when extracting from an empty list column

### DIFF
--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ std::unique_ptr<column> extract_list_element(lists_column_view lists_column,
                                              rmm::cuda_stream_view stream,
                                              rmm::mr::device_memory_resource* mr)
 {
-  if (lists_column.is_empty()) return empty_like(lists_column.parent());
+  if (lists_column.is_empty()) return empty_like(lists_column.child());
   auto const offsets_column = lists_column.offsets();
 
   // create a column_view with attributes of the parent and data from the offsets

--- a/cpp/tests/lists/extract_tests.cpp
+++ b/cpp/tests/lists/extract_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,6 +215,7 @@ TEST_F(ListsExtractTest, ExtractElementEmpty)
 
   LCW empty{};
   auto result = cudf::lists::extract_list_element(cudf::lists_column_view(empty), 1);
+  EXPECT_EQ(cudf::data_type{cudf::type_id::STRING}, result->type());
   EXPECT_EQ(0, result->size());
 
   LCW empty_strings({LCW{"", "", ""}});


### PR DESCRIPTION
Fixes #8024

Fixes `cudf::lists::extract_list_element` to return an empty column of the list's child column type when the list column is empty.
