### PR TITLE
Convert cudf::repeat to use device_uvector instead of device_vector

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -119,6 +119,11 @@ ConfigureBench(REDUCTION_BENCH
   reduction/minmax_benchmark.cpp)
 
 ###################################################################################################
+# - filling benchmark -----------------------------------------------------------------------------
+ConfigureBench(FILL_BENCH
+  filling/repeat_benchmark.cpp)
+
+###################################################################################################
 # - groupby benchmark -----------------------------------------------------------------------------
 ConfigureBench(GROUPBY_BENCH
   groupby/group_sum_benchmark.cu

--- a/cpp/benchmarks/common/generate_benchmark_input.cpp
+++ b/cpp/benchmarks/common/generate_benchmark_input.cpp
@@ -18,6 +18,7 @@
 #include "random_distribution_factory.hpp"
 
 #include <cudf/column/column.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/bit.hpp>
 
@@ -26,7 +27,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/device_vector.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <future>
 #include <memory>
@@ -413,9 +414,9 @@ std::unique_ptr<cudf::column> create_random_column<cudf::string_view>(data_profi
     }
   }
 
-  rmm::device_vector<char> d_chars(out_col.chars);
-  rmm::device_vector<cudf::size_type> d_offsets(out_col.offsets);
-  rmm::device_vector<cudf::bitmask_type> d_null_mask(out_col.null_mask);
+  auto d_chars     = cudf::detail::make_device_uvector_sync(out_col.chars);
+  auto d_offsets   = cudf::detail::make_device_uvector_sync(out_col.offsets);
+  auto d_null_mask = cudf::detail::make_device_uvector_sync(out_col.null_mask);
   return cudf::make_strings_column(d_chars, d_offsets, d_null_mask);
 }
 

--- a/cpp/benchmarks/filling/repeat_benchmark.cpp
+++ b/cpp/benchmarks/filling/repeat_benchmark.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <cudf/filling.hpp>
+#include <cudf/null_mask.hpp>
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+
+#include <random>
+
+#include "../fixture/benchmark_fixture.hpp"
+#include "../synchronization/synchronization.hpp"
+
+class Repeat : public cudf::benchmark {
+};
+
+template <class TypeParam, bool nulls>
+void BM_repeat(benchmark::State& state)
+{
+  using column_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
+  auto const n_rows    = static_cast<cudf::size_type>(state.range(0));
+  auto const n_cols    = static_cast<cudf::size_type>(state.range(1));
+
+  auto idx_begin = thrust::make_counting_iterator<cudf::size_type>(0);
+  auto idx_end   = thrust::make_counting_iterator<cudf::size_type>(n_rows);
+
+  std::vector<column_wrapper> columns;
+  columns.reserve(n_rows);
+  std::generate_n(std::back_inserter(columns), n_cols, [&]() {
+    return nulls ? column_wrapper(
+                     idx_begin,
+                     idx_end,
+                     thrust::make_transform_iterator(idx_begin, [](auto idx) { return true; }))
+                 : column_wrapper(idx_begin, idx_end);
+  });
+
+  // repeat counts
+  std::default_random_engine generator;
+  std::uniform_int_distribution<int> distribution(0, 3);
+
+  std::vector<cudf::size_type> host_repeat_count(n_rows);
+  std::generate(
+    host_repeat_count.begin(), host_repeat_count.end(), [&] { return distribution(generator); });
+
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> repeat_count(host_repeat_count.begin(),
+                                                                       host_repeat_count.end());
+
+  // Create column views
+  auto const column_views = std::vector<cudf::column_view>(columns.begin(), columns.end());
+
+  // Create table view
+  auto input = cudf::table_view(column_views);
+
+  // warm up
+  auto output = cudf::repeat(input, repeat_count);
+
+  for (auto _ : state) {
+    cuda_event_timer raii(state, true);  // flush_l2_cache = true, stream = 0
+    cudf::repeat(input, repeat_count);
+  }
+
+  auto data_bytes =
+    (input.num_columns() * input.num_rows() + output->num_columns() * output->num_rows()) *
+    sizeof(TypeParam);
+  auto null_bytes =
+    nulls ? input.num_columns() * cudf::bitmask_allocation_size_bytes(input.num_rows()) +
+              output->num_columns() * cudf::bitmask_allocation_size_bytes(output->num_rows())
+          : 0;
+  state.SetBytesProcessed(state.iterations() * (data_bytes + null_bytes));
+}
+
+#define REPEAT_BENCHMARK_DEFINE(name, type, nulls)                                                \
+  BENCHMARK_DEFINE_F(Repeat, name)(::benchmark::State & state) { BM_repeat<type, nulls>(state); } \
+  BENCHMARK_REGISTER_F(Repeat, name)                                                              \
+    ->RangeMultiplier(8)                                                                          \
+    ->Ranges({{1 << 10, 1 << 26}, {1, 8}})                                                        \
+    ->UseManualTime()                                                                             \
+    ->Unit(benchmark::kMillisecond);
+
+REPEAT_BENCHMARK_DEFINE(double_nulls, double, true);
+REPEAT_BENCHMARK_DEFINE(double_no_nulls, double, false);

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -29,7 +29,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_vector.hpp>
+#include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 
@@ -72,36 +72,24 @@ struct count_accessor {
   }
 };
 
-struct compute_offsets {
-  cudf::column_view const* p_column = nullptr;
+struct count_checker {
+  cudf::column_view const& count;
 
   template <typename T>
-  std::enable_if_t<std::is_integral<T>::value, rmm::device_vector<cudf::size_type>> operator()(
-    bool check_count, rmm::cuda_stream_view stream)
+  std::enable_if_t<std::is_integral<T>::value, void> operator()(rmm::cuda_stream_view stream)
   {
     // static_cast is necessary due to bool
-    if (check_count && static_cast<int64_t>(std::numeric_limits<T>::max()) >
-                         std::numeric_limits<cudf::size_type>::max()) {
-      auto max = thrust::reduce(p_column->begin<T>(), p_column->end<T>(), 0, thrust::maximum<T>());
+    if (static_cast<int64_t>(std::numeric_limits<cudf::size_type>::max()) >
+        std::numeric_limits<cudf::size_type>::max()) {
+      auto max = thrust::reduce(
+        rmm::exec_policy(stream), count.begin<T>(), count.end<T>(), 0, thrust::maximum<T>());
       CUDF_EXPECTS(max <= std::numeric_limits<cudf::size_type>::max(),
                    "count should not have values larger than size_type's limit.");
     }
-    rmm::device_vector<cudf::size_type> offsets(p_column->size());
-    thrust::inclusive_scan(
-      rmm::exec_policy(stream), p_column->begin<T>(), p_column->end<T>(), offsets.begin());
-    if (check_count == true) {
-      CUDF_EXPECTS(
-        thrust::is_sorted(rmm::exec_policy(stream), offsets.begin(), offsets.end()) == true,
-        "count has negative values or the resulting table has more \
-                    rows than size_type's limit.");
-    }
-
-    return offsets;
   }
 
   template <typename T>
-  std::enable_if_t<not std::is_integral<T>::value, rmm::device_vector<cudf::size_type>> operator()(
-    bool check_count, rmm::cuda_stream_view stream)
+  std::enable_if_t<not std::is_integral<T>::value, void> operator()(rmm::cuda_stream_view stream)
   {
     CUDF_FAIL("count value should be a integral type.");
   }
@@ -122,10 +110,22 @@ std::unique_ptr<table> repeat(table_view const& input_table,
 
   if (input_table.num_rows() == 0) { return cudf::empty_like(input_table); }
 
-  auto offsets = cudf::type_dispatcher(count.type(), compute_offsets{&count}, check_count, stream);
+  if (check_count) { cudf::type_dispatcher(count.type(), count_checker{count}, stream); }
 
-  size_type output_size{offsets.back()};
-  rmm::device_vector<size_type> indices(output_size);
+  auto count_iter = cudf::detail::indexalator_factory::make_input_iterator(count);
+
+  rmm::device_uvector<cudf::size_type> offsets(count.size(), stream);
+  thrust::inclusive_scan(
+    rmm::exec_policy(stream), count_iter, count_iter + count.size(), offsets.begin());
+
+  if (check_count) {
+    CUDF_EXPECTS(thrust::is_sorted(rmm::exec_policy(stream), offsets.begin(), offsets.end()),
+                 "count has negative values or the resulting table has more \
+                    rows than size_type's limit.");
+  }
+
+  size_type output_size{offsets.back_element(stream)};
+  rmm::device_uvector<size_type> indices(output_size, stream);
   thrust::upper_bound(rmm::exec_policy(stream),
                       offsets.begin(),
                       offsets.end(),
@@ -150,8 +150,8 @@ std::unique_ptr<table> repeat(table_view const& input_table,
   if ((input_table.num_rows() == 0) || (count == 0)) { return cudf::empty_like(input_table); }
 
   auto output_size = input_table.num_rows() * count;
-  auto map_begin   = thrust::make_transform_iterator(
-    thrust::make_counting_iterator(0), [count] __device__(auto i) { return i / count; });
+  auto map_begin   = cudf::detail::make_counting_transform_iterator(
+    0, [count] __device__(auto i) { return i / count; });
   auto map_end = map_begin + output_size;
 
   return gather(input_table, map_begin, map_end, out_of_bounds_policy::DONT_CHECK, stream, mr);


### PR DESCRIPTION
Converts `cudf::repeat` to use device_uvector as much as possible, and converts to using indexalator for computing offsets from repeat counts. 

Also adds a benchmark for `cudf::repeat`.

Contributes to #7287 


Performance is improved:

```
Comparing /home/mharris/rapids/cudf/cpp/build/repeat_before.json to /home/mharris/rapids/cudf/cpp/build/repeat_after.json
Benchmark                                                       Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------
Repeat/double_nulls/1024/1/manual_time                       -0.1681         -0.1361             0             0             0             0
Repeat/double_nulls/4096/1/manual_time                       -0.1663         -0.1329             0             0             0             0
Repeat/double_nulls/32768/1/manual_time                      -0.1702         -0.1372             0             0             0             0
Repeat/double_nulls/262144/1/manual_time                     -0.1347         -0.1159             0             0             0             0
Repeat/double_nulls/2097152/1/manual_time                    -0.1053         -0.1010             0             0             0             0
Repeat/double_nulls/16777216/1/manual_time                   -0.0931         -0.0926             3             3             3             3
Repeat/double_nulls/67108864/1/manual_time                   -0.0869         -0.0868            12            11            12            11
Repeat/double_nulls/1024/8/manual_time                       -0.0539         -0.0462             0             0             0             0
Repeat/double_nulls/4096/8/manual_time                       -0.0951         -0.0839             0             0             0             0
Repeat/double_nulls/32768/8/manual_time                      -0.0905         -0.0821             0             0             0             0
Repeat/double_nulls/262144/8/manual_time                     -0.0499         -0.0453             0             0             0             0
Repeat/double_nulls/2097152/8/manual_time                    -0.0322         -0.0325             1             1             1             1
Repeat/double_nulls/16777216/8/manual_time                   -0.0267         -0.0272            10             9            10             9
Repeat/double_nulls/67108864/8/manual_time                   -0.0276         -0.0267            39            38            39            38
Repeat/double_no_nulls/1024/1/manual_time                    -0.2183         -0.1590             0             0             0             0
Repeat/double_no_nulls/4096/1/manual_time                    -0.2308         -0.1711             0             0             0             0
Repeat/double_no_nulls/32768/1/manual_time                   -0.2374         -0.1820             0             0             0             0
Repeat/double_no_nulls/262144/1/manual_time                  -0.1886         -0.1571             0             0             0             0
Repeat/double_no_nulls/2097152/1/manual_time                 -0.1266         -0.1200             0             0             0             0
Repeat/double_no_nulls/16777216/1/manual_time                -0.1045         -0.1039             3             2             3             2
Repeat/double_no_nulls/67108864/1/manual_time                -0.0945         -0.0944            11            10            11            10
Repeat/double_no_nulls/1024/8/manual_time                    -0.0595         -0.0490             0             0             0             0
Repeat/double_no_nulls/4096/8/manual_time                    -0.1201         -0.1028             0             0             0             0
Repeat/double_no_nulls/32768/8/manual_time                   -0.1085         -0.0968             0             0             0             0
Repeat/double_no_nulls/262144/8/manual_time                  -0.0670         -0.0635             0             0             0             0
Repeat/double_no_nulls/2097152/8/manual_time                 -0.0405         -0.0400             1             1             1             1
Repeat/double_no_nulls/16777216/8/manual_time                -0.0352         -0.0354             8             8             8             8
Repeat/double_no_nulls/67108864/8/manual_time                -0.0295         -0.0295            32            31            32            31
```