### PR TITLE
Convert cudf::merge to use device_uvector instead of device_vector

### DIFF
--- a/cpp/benchmarks/merge/merge_benchmark.cpp
+++ b/cpp/benchmarks/merge/merge_benchmark.cpp
@@ -88,7 +88,7 @@ void BM_merge(benchmark::State& state)
 #define MBM_BENCHMARK_DEFINE(name)                                                 \
   BENCHMARK_DEFINE_F(Merge, name)(::benchmark::State & state) { BM_merge(state); } \
   BENCHMARK_REGISTER_F(Merge, name)                                                \
-    ->Unit(benchmark::kNanosecond)                                                 \
+    ->Unit(benchmark::kMillisecond)                                                \
     ->UseManualTime()                                                              \
     ->RangeMultiplier(2)                                                           \
     ->Ranges({{2, 128}});

--- a/cpp/benchmarks/string/factory_benchmark.cu
+++ b/cpp/benchmarks/string/factory_benchmark.cu
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include "rmm/cuda_stream_view.hpp"
 #include "string_bench_args.hpp"
 
 #include <benchmark/benchmark.h>
@@ -26,6 +25,7 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf_test/column_wrapper.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/execution_policy.h>

--- a/cpp/benchmarks/string/factory_benchmark.cu
+++ b/cpp/benchmarks/string/factory_benchmark.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "rmm/cuda_stream_view.hpp"
 #include "string_bench_args.hpp"
 
 #include <benchmark/benchmark.h>
@@ -55,7 +56,7 @@ static void BM_factory(benchmark::State& state)
   auto const table =
     create_random_table({cudf::type_id::STRING}, 1, row_count{n_rows}, table_profile);
   auto d_column = cudf::column_device_view::create(table->view().column(0));
-  rmm::device_vector<string_pair> pairs(d_column->size());
+  rmm::device_uvector<string_pair> pairs(d_column->size(), rmm::cuda_stream_default);
   thrust::transform(thrust::device,
                     d_column->pair_begin<cudf::string_view, true>(),
                     d_column->pair_end<cudf::string_view, true>(),

--- a/cpp/benchmarks/string/filter_benchmark.cpp
+++ b/cpp/benchmarks/string/filter_benchmark.cpp
@@ -73,7 +73,7 @@ static void generate_bench_args(benchmark::internal::Benchmark* b)
     for (int rowlen = min_rowlen; rowlen <= max_rowlen; rowlen *= len_mult) {
       // avoid generating combinations that exceed the cudf column limit
       size_t total_chars = static_cast<size_t>(row_count) * rowlen;
-      if (total_chars < std::numeric_limits<cudf::size_type>::max()) {
+      if (total_chars < static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
         b->Args({row_count, rowlen});
       }
     }

--- a/cpp/benchmarks/string/find_benchmark.cpp
+++ b/cpp/benchmarks/string/find_benchmark.cpp
@@ -73,7 +73,7 @@ static void generate_bench_args(benchmark::internal::Benchmark* b)
     for (int rowlen = min_rowlen; rowlen <= max_rowlen; rowlen *= len_mult) {
       // avoid generating combinations that exceed the cudf column limit
       size_t total_chars = static_cast<size_t>(row_count) * rowlen;
-      if (total_chars < std::numeric_limits<cudf::size_type>::max()) {
+      if (total_chars < static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
         b->Args({row_count, rowlen});
       }
     }

--- a/cpp/benchmarks/string/split_benchmark.cpp
+++ b/cpp/benchmarks/string/split_benchmark.cpp
@@ -68,7 +68,7 @@ static void generate_bench_args(benchmark::internal::Benchmark* b)
     for (int rowlen = min_rowlen; rowlen <= max_rowlen; rowlen *= len_mult) {
       // avoid generating combinations that exceed the cudf column limit
       size_t total_chars = static_cast<size_t>(row_count) * rowlen;
-      if (total_chars < std::numeric_limits<cudf::size_type>::max()) {
+      if (total_chars < static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
         b->Args({row_count, rowlen});
       }
     }

--- a/cpp/benchmarks/string/string_bench_args.hpp
+++ b/cpp/benchmarks/string/string_bench_args.hpp
@@ -48,7 +48,7 @@ inline void generate_string_bench_args(benchmark::internal::Benchmark* b,
     for (int rowlen = min_rowlen; rowlen <= max_rowlen; rowlen *= rowlen_mult) {
       // avoid generating combinations that exceed the cudf column limit
       size_t total_chars = static_cast<size_t>(row_count) * rowlen;
-      if (total_chars < std::numeric_limits<cudf::size_type>::max()) {
+      if (total_chars < static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
         b->Args({row_count, rowlen});
       }
     }

--- a/cpp/benchmarks/text/normalize_benchmark.cpp
+++ b/cpp/benchmarks/text/normalize_benchmark.cpp
@@ -60,7 +60,7 @@ static void generate_bench_args(benchmark::internal::Benchmark* b)
     for (int rowlen = min_rowlen; rowlen <= max_rowlen; rowlen *= len_mult) {
       // avoid generating combinations that exceed the cudf column limit
       size_t total_chars = static_cast<size_t>(row_count) * rowlen * 4;
-      if (total_chars < std::numeric_limits<cudf::size_type>::max()) {
+      if (total_chars < static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
         b->Args({row_count, rowlen});
       }
     }

--- a/cpp/include/cudf/detail/merge.cuh
+++ b/cpp/include/cudf/detail/merge.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/detail/merge.cuh
+++ b/cpp/include/cudf/detail/merge.cuh
@@ -30,12 +30,12 @@ enum class side : bool { LEFT, RIGHT };
  * @brief Tagged index type: `thrust::get<0>` indicates left/right side,
  * `thrust::get<1>` indicates the row index
  */
-using index_type = thrust::tuple<side, cudf::size_type>;
+using index_type = thrust::pair<side, cudf::size_type>;
 
 /**
  * @brief Vector of `index_type` values.
  */
-using index_vector = rmm::device_vector<index_type>;
+using index_vector = rmm::device_uvector<index_type>;
 
 /**
  * @brief tagged_element_relational_comparator uses element_relational_comparator to provide
@@ -80,11 +80,11 @@ struct tagged_element_relational_comparator {
   __device__ weak_ordering compare(index_type lhs_tagged_index, index_type rhs_tagged_index) const
     noexcept
   {
-    side l_side = thrust::get<0>(lhs_tagged_index);
-    side r_side = thrust::get<0>(rhs_tagged_index);
+    side const l_side = thrust::get<0>(lhs_tagged_index);
+    side const r_side = thrust::get<0>(rhs_tagged_index);
 
-    cudf::size_type l_indx = thrust::get<1>(lhs_tagged_index);
-    cudf::size_type r_indx = thrust::get<1>(rhs_tagged_index);
+    cudf::size_type const l_indx = thrust::get<1>(lhs_tagged_index);
+    cudf::size_type const r_indx = thrust::get<1>(rhs_tagged_index);
 
     column_device_view const* ptr_left_dview{l_side == side::LEFT ? &lhs : &rhs};
 


### PR DESCRIPTION
Converts `cudf::merge` to use `device_uvector`.

Contributes to #7287

Performance is improved: 

```
Comparing /home/mharris/rapids/cudf/cpp/build/merge_before.json to /home/mharris/rapids/cudf/cpp/build/merge_after.json
Benchmark                                          Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------
Merge/pow2tables/2/manual_time                  -0.0831         -0.0791             0             0             0             0
Merge/pow2tables/4/manual_time                  -0.0924         -0.0930             1             1             1             1
Merge/pow2tables/8/manual_time                  -0.0813         -0.0808             4             3             4             3
Merge/pow2tables/16/manual_time                 -0.1172         -0.1170             9             8             9             8
Merge/pow2tables/32/manual_time                 -0.0790         -0.0790            19            18            20            18
Merge/pow2tables/64/manual_time                 -0.0757         -0.0757            46            43            46            43
Merge/pow2tables/128/manual_time                -0.0730         -0.0730           111           103           111           103
```