### PR TITLE
constexpr all is_*_impl::operator()<T>()

### DIFF
--- a/cpp/include/cudf/utilities/traits.hpp
+++ b/cpp/include/cudf/utilities/traits.hpp
@@ -140,7 +140,7 @@ constexpr inline bool is_numeric()
 
 struct is_numeric_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_numeric<T>();
   }
@@ -181,7 +181,7 @@ constexpr inline bool is_index_type()
 
 struct is_index_type_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_index_type<T>();
   }
@@ -218,7 +218,7 @@ constexpr inline bool is_unsigned()
 
 struct is_unsigned_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_unsigned<T>();
   }
@@ -264,7 +264,7 @@ constexpr inline bool is_floating_point()
 
 struct is_floating_point_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_floating_point<T>();
   }
@@ -332,7 +332,7 @@ constexpr inline bool is_timestamp()
 
 struct is_timestamp_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_timestamp<T>();
   }
@@ -367,7 +367,7 @@ constexpr inline bool is_fixed_point()
 
 struct is_fixed_point_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_fixed_point<T>();
   }
@@ -400,7 +400,7 @@ constexpr inline bool is_duration()
 
 struct is_duration_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_duration<T>();
   }
@@ -435,7 +435,7 @@ constexpr inline bool is_chrono()
 
 struct is_chrono_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_chrono<T>();
   }
@@ -488,7 +488,7 @@ constexpr inline bool is_dictionary()
 
 struct is_dictionary_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_dictionary<T>();
   }
@@ -524,7 +524,7 @@ constexpr inline bool is_fixed_width()
 
 struct is_fixed_width_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_fixed_width<T>();
   }
@@ -567,7 +567,7 @@ constexpr inline bool is_compound()
 
 struct is_compound_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_compound<T>();
   }
@@ -609,7 +609,7 @@ constexpr inline bool is_nested()
 
 struct is_nested_impl {
   template <typename T>
-  bool operator()()
+  constexpr bool operator()()
   {
     return is_nested<T>();
   }


### PR DESCRIPTION
`is_dictionary(datatype)` is `constexpr`, but its implementation is not. 
Without constexpr on calling function, `constexpr cudf::is_dictionary(datatype)` yields wrong results in device code.
Same applies for all `cudf::is_*(datatype)`

This PR fixes this bug.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
