### PR TITLE
enable all aggregations for dictionary type

### DIFF
--- a/cpp/include/cudf/detail/aggregation/aggregation.cuh
+++ b/cpp/include/cudf/detail/aggregation/aggregation.cuh
@@ -140,8 +140,6 @@ struct update_target_element<Source,
                              column_device_view source,
                              size_type source_index) const noexcept
   {
-#if (__CUDACC_VER_MAJOR__ != 10) or (__CUDACC_VER_MINOR__ != 2)
-
     if (source_has_nulls and source.is_null(source_index)) { return; }
 
     using Target       = target_type_t<Source, aggregation::MIN>;
@@ -152,8 +150,6 @@ struct update_target_element<Source,
               static_cast<DeviceTarget>(source.element<DeviceSource>(source_index)));
 
     if (target_has_nulls and target.is_null(target_index)) { target.set_valid(target_index); }
-
-#endif
   }
 };
 
@@ -190,8 +186,6 @@ struct update_target_element<Source,
                              column_device_view source,
                              size_type source_index) const noexcept
   {
-#if (__CUDACC_VER_MAJOR__ != 10) or (__CUDACC_VER_MINOR__ != 2)
-
     if (source_has_nulls and source.is_null(source_index)) { return; }
 
     using Target       = target_type_t<Source, aggregation::MAX>;
@@ -202,8 +196,6 @@ struct update_target_element<Source,
               static_cast<DeviceTarget>(source.element<DeviceSource>(source_index)));
 
     if (target_has_nulls and target.is_null(target_index)) { target.set_valid(target_index); }
-
-#endif
   }
 };
 
@@ -240,8 +232,6 @@ struct update_target_element<Source,
                              column_device_view source,
                              size_type source_index) const noexcept
   {
-#if (__CUDACC_VER_MAJOR__ != 10) or (__CUDACC_VER_MINOR__ != 2)
-
     if (source_has_nulls and source.is_null(source_index)) { return; }
 
     using Target       = target_type_t<Source, aggregation::SUM>;
@@ -252,7 +242,6 @@ struct update_target_element<Source,
               static_cast<DeviceTarget>(source.element<DeviceSource>(source_index)));
 
     if (target_has_nulls and target.is_null(target_index)) { target.set_valid(target_index); }
-#endif
   }
 };
 

--- a/cpp/include/cudf/detail/aggregation/aggregation.cuh
+++ b/cpp/include/cudf/detail/aggregation/aggregation.cuh
@@ -313,8 +313,6 @@ struct update_target_element<
       target_index,
       source.child(cudf::dictionary_column_view::keys_column_index),
       static_cast<cudf::size_type>(source.element<dictionary32>(source_index)));
-
-    if (target_has_nulls and target.is_null(target_index)) { target.set_valid(target_index); }
   }
 };
 

--- a/cpp/include/cudf/detail/aggregation/aggregation.cuh
+++ b/cpp/include/cudf/detail/aggregation/aggregation.cuh
@@ -252,7 +252,7 @@ struct update_target_element<Source,
  * SFINAE is used to prevent recursion for dictionary type. Dictionary keys cannot be a dictionary.
  *
  */
-template <bool target_has_nulls = true, bool source_has_nulls = true>
+template <bool target_has_nulls = true>
 struct update_target_from_dictionary {
   template <typename Source,
             aggregation::Kind k,
@@ -262,7 +262,7 @@ struct update_target_from_dictionary {
                              column_device_view source,
                              size_type source_index) const noexcept
   {
-    update_target_element<Source, k, target_has_nulls, source_has_nulls>{}(
+    update_target_element<Source, k, target_has_nulls, false>{}(
       target, target_index, source, source_index);
   }
   template <typename Source,
@@ -308,7 +308,7 @@ struct update_target_element<
     dispatch_type_and_aggregation(
       source.child(cudf::dictionary_column_view::keys_column_index).type(),
       k,
-      update_target_from_dictionary<target_has_nulls, false>{},
+      update_target_from_dictionary<target_has_nulls>{},
       target,
       target_index,
       source.child(cudf::dictionary_column_view::keys_column_index),

--- a/cpp/include/cudf/detail/aggregation/aggregation.cuh
+++ b/cpp/include/cudf/detail/aggregation/aggregation.cuh
@@ -283,8 +283,8 @@ struct update_target_from_dictionary {
  * dictionary's keys child column and maps the input source index through
  * the dictionary's indices child column to pass to the `update_target_element`
  * in the above `update_target_from_dictionary` using the type-dispatcher to
- * resolve the keys column type. 
- * 
+ * resolve the keys column type.
+ *
  * `update_target_element( target, target_index, source.keys(), source.indices()[source_index] )`
  *
  * @tparam target_has_nulls Indicates presence of null elements in `target`

--- a/cpp/tests/groupby/group_argmax_test.cpp
+++ b/cpp/tests/groupby/group_argmax_test.cpp
@@ -27,148 +27,138 @@ namespace test {
 template <typename V>
 struct groupby_argmax_test : public cudf::test::BaseFixture {
 };
+using K = int32_t;
 
 TYPED_TEST_CASE(groupby_argmax_test, cudf::test::FixedWidthTypes);
 
-// clang-format off
 TYPED_TEST(groupby_argmax_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
 
-    if (std::is_same<V, bool>::value) return;
+  if (std::is_same<V, bool>::value) return;
 
-    fixed_width_column_wrapper<K> keys { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V, int32_t> vals({9, 8, 7, 6, 5, 4, 3, 2, 1, 0});
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-    fixed_width_column_wrapper<R> expect_vals { 0, 1, 2 };
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  fixed_width_column_wrapper<R> expect_vals{0, 1, 2};
 
-    auto agg = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmax_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
 
-    if (std::is_same<V, bool>::value) return;
+  if (std::is_same<V, bool>::value) return;
 
-    fixed_width_column_wrapper<K> keys ( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5});
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmax_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
 
-    if (std::is_same<V, bool>::value) return;
+  if (std::is_same<V, bool>::value) return;
 
-    fixed_width_column_wrapper<K> keys   { 1, 1, 1};
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmax_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
 
-    if (std::is_same<V, bool>::value) return;
+  if (std::is_same<V, bool>::value) return;
 
-    fixed_width_column_wrapper<K> keys({ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                       { 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1});
-    fixed_width_column_wrapper<V, int32_t> vals({9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 4},
-                                                {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 4},
+                                     {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 6, 3,     5, 4, 0,   2, 1,    -}
-    fixed_width_column_wrapper<R> expect_vals({ 3,        4,         7,       0},
-                                              { 1,        1,         1,       0});
+  //  {1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  {6, 3,     5, 4, 0,   2, 1,    -}
+  fixed_width_column_wrapper<R> expect_vals({3, 4, 7, 0}, {1, 1, 1, 0});
 
-    auto agg = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
-
-struct groupby_argmax_string_test : public cudf::test::BaseFixture {};
+struct groupby_argmax_string_test : public cudf::test::BaseFixture {
+};
 
 TEST_F(groupby_argmax_string_test, basic)
 {
-    using K = int32_t;
-    using V = string_view;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using V = string_view;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
 
-    fixed_width_column_wrapper<K> keys        {     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-    strings_column_wrapper        vals        { "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-    fixed_width_column_wrapper<R> expect_vals({ 0, 4, 2 });
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  fixed_width_column_wrapper<R> expect_vals({0, 4, 2});
 
-    auto agg = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TEST_F(groupby_argmax_string_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = string_view;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using V = string_view;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    strings_column_wrapper        vals      ( { "año", "bit", "₹1"}, all_null() );
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  strings_column_wrapper vals({"año", "bit", "₹1"}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmax_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmax_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
-
-// clang-format on
 
 struct groupby_dictionary_argmax_test : public cudf::test::BaseFixture {
 };
 
 TEST_F(groupby_dictionary_argmax_test, basic)
 {
-  using K = int32_t;
   using V = std::string;
   using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
 

--- a/cpp/tests/groupby/group_argmin_test.cpp
+++ b/cpp/tests/groupby/group_argmin_test.cpp
@@ -27,154 +27,145 @@ namespace test {
 template <typename V>
 struct groupby_argmin_test : public cudf::test::BaseFixture {
 };
+using K = int32_t;
 
 TYPED_TEST_CASE(groupby_argmin_test, cudf::test::FixedWidthTypes);
 
-// clang-format off
 TYPED_TEST(groupby_argmin_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
 
-    if (std::is_same<V, bool>::value) return;
+  if (std::is_same<V, bool>::value) return;
 
-    fixed_width_column_wrapper<K> keys { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V, int32_t> vals({9, 8, 7, 6, 5, 4, 3, 2, 1, 0});
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-    fixed_width_column_wrapper<R> expect_vals { 6, 9, 8 };
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  fixed_width_column_wrapper<R> expect_vals{6, 9, 8};
 
-    auto agg = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmin_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
 
-    if (std::is_same<V, bool>::value) return;
+  if (std::is_same<V, bool>::value) return;
 
-    fixed_width_column_wrapper<K> keys ( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5});
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmin_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
 
-    if (std::is_same<V, bool>::value) return;
+  if (std::is_same<V, bool>::value) return;
 
-    fixed_width_column_wrapper<K> keys   { 1, 1, 1};
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmin_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
 
-    if (std::is_same<V, bool>::value) return;
+  if (std::is_same<V, bool>::value) return;
 
-    fixed_width_column_wrapper<K> keys({ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                       { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V, int32_t> vals({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 4},
-                                                { 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 4},
+                                     {1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 9, 6,     8, 5, 0,   7, 1,    -}
-    fixed_width_column_wrapper<R> expect_vals({ 3,        9,         8,       0},
-                                              { 1,        1,         1,       0});
+  //  { 1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  { 9, 6,     8, 5, 0,   7, 1,    -}
+  fixed_width_column_wrapper<R> expect_vals({3, 9, 8, 0}, {1, 1, 1, 0});
 
-    auto agg = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    // TODO: explore making this a gtest parameter
-    auto agg2 = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  // TODO: explore making this a gtest parameter
+  auto agg2 = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
-
-struct groupby_argmin_string_test : public cudf::test::BaseFixture {};
+struct groupby_argmin_string_test : public cudf::test::BaseFixture {
+};
 
 TEST_F(groupby_argmin_string_test, basic)
 {
-    using K = int32_t;
-    using V = string_view;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using V = string_view;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
 
-    fixed_width_column_wrapper<K> keys        {     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-    strings_column_wrapper        vals        { "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-    fixed_width_column_wrapper<R> expect_vals({ 3, 5, 7 });
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  fixed_width_column_wrapper<R> expect_vals({3, 5, 7});
 
-    auto agg = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TEST_F(groupby_argmin_string_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = string_view;
-    using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using V = string_view;
+  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    strings_column_wrapper        vals      ( { "año", "bit", "₹1"}, all_null() );
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  strings_column_wrapper vals({"año", "bit", "₹1"}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_argmin_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_argmin_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
-// clang-format on
 
 struct groupby_dictionary_argmin_test : public cudf::test::BaseFixture {
 };
 
 TEST_F(groupby_dictionary_argmin_test, basic)
 {
-  using K = int32_t;
   using V = std::string;
   using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-  dictionary_column_wrapper<V>  vals{ "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+  fixed_width_column_wrapper<K> keys{    1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
+  dictionary_column_wrapper<V>  vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
   fixed_width_column_wrapper<K> expect_keys({ 1, 2, 3 });
   fixed_width_column_wrapper<R> expect_vals({ 3, 5, 7 });
   // clang-format on

--- a/cpp/tests/groupby/group_count_test.cpp
+++ b/cpp/tests/groupby/group_count_test.cpp
@@ -27,143 +27,141 @@ namespace test {
 template <typename V>
 struct groupby_count_test : public cudf::test::BaseFixture {
 };
+using K = int32_t;
 
 TYPED_TEST_CASE(groupby_count_test, cudf::test::AllTypes);
 
-// clang-format off
 TYPED_TEST(groupby_count_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
-    fixed_width_column_wrapper<K> keys { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V, int> vals { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-    fixed_width_column_wrapper<R, int> expect_vals { 3, 4, 3 };
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  fixed_width_column_wrapper<R> expect_vals{3, 4, 3};
 
-    auto agg = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg1 = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
+  auto agg1 = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 
-    auto agg2 = cudf::make_count_aggregation(null_policy::INCLUDE);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2));
+  auto agg2 = cudf::make_count_aggregation(null_policy::INCLUDE);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
 TYPED_TEST(groupby_count_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V> vals;
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals;
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals;
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals;
 
-    auto agg = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg1 = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
+  auto agg1 = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_count_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
-    fixed_width_column_wrapper<K> keys( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V, int> vals  { 3, 4, 5};
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R, int> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg1 = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
+  auto agg1 = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 
-    auto agg2 = cudf::make_count_aggregation(null_policy::INCLUDE);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2));
+  auto agg2 = cudf::make_count_aggregation(null_policy::INCLUDE);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
 TYPED_TEST(groupby_count_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
-    fixed_width_column_wrapper<K> keys   { 1, 1, 1};
-    fixed_width_column_wrapper<V, int> vals ( { 3, 4, 5}, all_null() );
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R, int> expect_vals { 0 };
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals{0};
 
-    auto agg = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg1 = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
+  auto agg1 = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 
-    fixed_width_column_wrapper<R, int> expect_vals2 { 3 };
-    auto agg2 = cudf::make_count_aggregation(null_policy::INCLUDE);
-    test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
+  fixed_width_column_wrapper<R> expect_vals2{3};
+  auto agg2 = cudf::make_count_aggregation(null_policy::INCLUDE);
+  test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
 }
 
 TYPED_TEST(groupby_count_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
-    fixed_width_column_wrapper<K> keys({ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                       { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V, int> vals({ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                       { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    -}
-    fixed_width_column_wrapper<R, int> expect_vals { 2,        3,         2,       0};
+  // clang-format off
+  //                                        {1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, all_valid());
+  //                                        {3, 6,     1, 4, 9,   2, 8,    -}
+  fixed_width_column_wrapper<R> expect_vals({2,        3,         2,       0});
+  // clang-format on
 
-    auto agg = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg1 = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
+  auto agg1 = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 
-    fixed_width_column_wrapper<R, int> expect_vals2{ 3,        4,         2,       1};
-    auto agg2 = cudf::make_count_aggregation(null_policy::INCLUDE);
-    test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
-
+  fixed_width_column_wrapper<R> expect_vals2{3, 4, 2, 1};
+  auto agg2 = cudf::make_count_aggregation(null_policy::INCLUDE);
+  test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
 }
 
-struct groupby_count_string_test : public cudf::test::BaseFixture {};
+struct groupby_count_string_test : public cudf::test::BaseFixture {
+};
 
 TEST_F(groupby_count_string_test, basic)
 {
-    using K = int32_t;
-    using V = cudf::string_view;
-    using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using V = cudf::string_view;
+  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
-    fixed_width_column_wrapper<K> keys        {   1,   3,   3,   5,   5,   0};
-    strings_column_wrapper        vals        { "1", "1", "1", "1", "1", "1"};
+  // clang-format off
+  fixed_width_column_wrapper<K> keys{1,    3,  3,   5,   5,   0};
+  strings_column_wrapper        vals{"1", "1", "1", "1", "1", "1"};
+  // clang-format on
 
-    fixed_width_column_wrapper<K> expect_keys   {   0,   1,   3,   5};
-    fixed_width_column_wrapper<R, int> expect_vals   {   1,   1,   2,   2};
+  fixed_width_column_wrapper<K> expect_keys{0, 1, 3, 5};
+  fixed_width_column_wrapper<R> expect_vals{1, 1, 2, 2};
 
-    auto agg = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg1 = cudf::make_count_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
+  auto agg1 = cudf::make_count_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 }
 // clang-format on
 
@@ -180,7 +178,6 @@ TYPED_TEST(FixedPointTestBothReps, GroupByCount)
   using RepType    = cudf::device_storage_type_t<decimalXX>;
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
 
-  using K = int32_t;
   using V = decimalXX;
   using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
@@ -189,7 +186,7 @@ TYPED_TEST(FixedPointTestBothReps, GroupByCount)
   auto const vals  = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
 
   auto const expect_keys = fixed_width_column_wrapper<K>{1, 2, 3};
-  auto const expect_vals = fixed_width_column_wrapper<R, int>{3, 4, 3};
+  auto const expect_vals = fixed_width_column_wrapper<R>{3, 4, 3};
 
   auto agg = cudf::make_count_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -206,15 +203,14 @@ struct groupby_dictionary_count_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_dictionary_count_test, basic)
 {
-  using K = int32_t;
   using V = std::string;
   using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
   // clang-format off
-  strings_column_wrapper       keys{"1", "3", "3", "5", "5", "0"};
-  dictionary_column_wrapper<K> vals{ 1,   1,   1,   1,   1,   1};
-  strings_column_wrapper             expect_keys{"0", "1", "3", "5"};
-  fixed_width_column_wrapper<R, int> expect_vals{ 1,   1,   2,   2};
+  strings_column_wrapper        keys{"1", "3", "3", "5", "5", "0"};
+  dictionary_column_wrapper<K>  vals{1, 1, 1, 1, 1, 1};
+  strings_column_wrapper        expect_keys{"0", "1", "3", "5"};
+  fixed_width_column_wrapper<R> expect_vals{1, 1, 2, 2};
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_count_aggregation());

--- a/cpp/tests/groupby/group_max_test.cpp
+++ b/cpp/tests/groupby/group_max_test.cpp
@@ -29,153 +29,141 @@ template <typename V>
 struct groupby_max_test : public cudf::test::BaseFixture {
 };
 
+using K = int32_t;
 TYPED_TEST_CASE(groupby_max_test, cudf::test::FixedWidthTypesWithoutFixedPoint);
 
-// clang-format off
 TYPED_TEST(groupby_max_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
 
-    fixed_width_column_wrapper<K> keys { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V, int32_t> vals({ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-    fixed_width_column_wrapper<R, int32_t> expect_vals({ 6, 9, 8 });
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  fixed_width_column_wrapper<R> expect_vals({6, 9, 8});
 
-    auto agg = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_max_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V> vals        { };
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_max_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
 
-    fixed_width_column_wrapper<K> keys( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5});
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_max_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
 
-    fixed_width_column_wrapper<K> keys   { 1, 1, 1};
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R, int32_t> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_max_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
 
-    fixed_width_column_wrapper<K> keys({ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                       { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                                {1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                     {1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 0, 3,     1, 4, 5,   2, 8,    -}
-    fixed_width_column_wrapper<R, int32_t> expect_vals({ 3,        5,         8,       0},
-                                                       { 1,        1,         1,       0});
+  //  { 1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  { 0, 3,     1, 4, 5,   2, 8,    -}
+  fixed_width_column_wrapper<R> expect_vals({3, 5, 8, 0}, {1, 1, 1, 0});
 
-    auto agg = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
-
-struct groupby_max_string_test : public cudf::test::BaseFixture {};
+struct groupby_max_string_test : public cudf::test::BaseFixture {
+};
 
 TEST_F(groupby_max_string_test, basic)
 {
-    using K = int32_t;
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
 
-    fixed_width_column_wrapper<K> keys        {     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-    strings_column_wrapper        vals        { "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  strings_column_wrapper expect_vals({"año", "zit", "₹1"});
 
-    fixed_width_column_wrapper<K> expect_keys {     1,     2,    3 };
-    strings_column_wrapper        expect_vals({ "año", "zit", "₹1" });
+  auto agg = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-
-    auto agg2 = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TEST_F(groupby_max_string_test, zero_valid_values)
 {
-    using K = int32_t;
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  strings_column_wrapper vals({"año", "bit", "₹1"}, all_null());
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    strings_column_wrapper        vals      ( { "año", "bit", "₹1"}, all_null() );
+  fixed_width_column_wrapper<K> expect_keys{1};
+  strings_column_wrapper expect_vals({""}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    strings_column_wrapper        expect_vals({ "" }, all_null());
+  auto agg = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-
-    auto agg2 = cudf::make_max_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_max_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
-// clang-format on
 
 struct groupby_dictionary_max_test : public cudf::test::BaseFixture {
 };
 
 TEST_F(groupby_dictionary_max_test, basic)
 {
-  using K = int32_t;
   using V = std::string;
 
   // clang-format off
@@ -212,8 +200,10 @@ TYPED_TEST(FixedPointTestBothReps, GroupBySortMaxDecimalAsValue)
 
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
+    // clang-format off
     auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    // clang-format on
 
     auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_max = fp_wrapper{{6, 9, 8}, scale};
@@ -234,8 +224,10 @@ TYPED_TEST(FixedPointTestBothReps, GroupByHashMaxDecimalAsValue)
 
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
+    // clang-format off
     auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    // clang-format on
 
     auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_max = fp_wrapper{{6, 9, 8}, scale};

--- a/cpp/tests/groupby/group_max_test.cpp
+++ b/cpp/tests/groupby/group_max_test.cpp
@@ -224,9 +224,7 @@ TYPED_TEST(FixedPointTestBothReps, GroupBySortMaxDecimalAsValue)
   }
 }
 
-// This test will not work until the following ptxas bug is fixed in 10.2
-// https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3186317&cp=
-TYPED_TEST(FixedPointTestBothReps, DISABLED_GroupByHashMaxDecimalAsValue)
+TYPED_TEST(FixedPointTestBothReps, GroupByHashMaxDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;

--- a/cpp/tests/groupby/group_mean_test.cpp
+++ b/cpp/tests/groupby/group_mean_test.cpp
@@ -46,95 +46,94 @@ using supported_types =
   cudf::test::Concat<cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>,
                      cudf::test::DurationTypes>;
 TYPED_TEST_CASE(groupby_mean_test, supported_types);
+using K = int32_t;
 
-// clang-format off
 TYPED_TEST(groupby_mean_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
-    using RT = typename std::conditional<cudf::is_duration<R>(), int, double>::type;
+  using V  = TypeParam;
+  using R  = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using RT = typename std::conditional<cudf::is_duration<R>(), int, double>::type;
 
-    fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V, int> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    fixed_width_column_wrapper<K> expect_keys { 1,  2,     3    };
-    std::vector<RT> expect_v = convert<RT>({ 3., 19./4, 17./3});
-    fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend());
+  // clang-format off
+  fixed_width_column_wrapper<K> expect_keys{1,       2,          3};
+  //                                       {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  std::vector<RT> expect_v = convert<RT>(  {3.,      19. / 4,    17. / 3});
+  fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend());
+  // clang-format on
 
-    auto agg = cudf::make_mean_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_mean_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_mean_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V, int> vals        { };
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_mean_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_mean_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_mean_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
 
-    fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V, int> vals        { 3, 4, 5};
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_mean_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_mean_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_mean_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    fixed_width_column_wrapper<V, int> vals      ( { 3, 4, 5}, all_null() );
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R, int> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_mean_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_mean_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_mean_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
-    using RT = typename std::conditional<cudf::is_duration<R>(), int, double>::type;
+  using V  = TypeParam;
+  using R  = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using RT = typename std::conditional<cudf::is_duration<R>(), int, double>::type;
 
-    fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                              { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V, int> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                              { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    -}
-    std::vector<RT> expect_v = convert<RT>({ 4.5,      14./3,     5.,      0.});
-    fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend(),
-                                              { 1,        1,         1,       0});
+  // clang-format off
+  //                                        {1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, all_valid());
+  //                                        {3, 6,     1, 4, 9,   2, 8,    -}
+  std::vector<RT> expect_v = convert<RT>(   {4.5,      14. / 3,   5.,      0.});
+  fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend(), {1, 1, 1, 0});
+  // clang-format on
 
-    auto agg = cudf::make_mean_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_mean_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 // clang-format on
 
@@ -143,16 +142,15 @@ struct groupby_dictionary_mean_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_dictionary_mean_test, basic)
 {
-  using K = int32_t;
   using V = int16_t;
   using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
 
   // clang-format off
-  fixed_width_column_wrapper<K>     keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V, int> vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  fixed_width_column_wrapper<K>         expect_keys({ 1,    2,     3    });
-  fixed_width_column_wrapper<R, double> expect_vals({ 9./3, 19./4, 17./3});
+  fixed_width_column_wrapper<K> expect_keys(        {1,      2,       3});
+  fixed_width_column_wrapper<R, double> expect_vals({9. / 3, 19. / 4, 17. / 3});
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_mean_aggregation());

--- a/cpp/tests/groupby/group_median_test.cpp
+++ b/cpp/tests/groupby/group_median_test.cpp
@@ -28,102 +28,96 @@ template <typename V>
 struct groupby_median_test : public cudf::test::BaseFixture {
 };
 
+using K               = int32_t;
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
 
 TYPED_TEST_CASE(groupby_median_test, supported_types);
 
-// clang-format off
 TYPED_TEST(groupby_median_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                          //  { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
-    fixed_width_column_wrapper<K> expect_keys { 1,       2,          3      };
-                                          //  { 0,  3, 6, 1, 4, 5, 9, 2, 7, 8}
-    fixed_width_column_wrapper<R> expect_vals({    3.,        4.5,      7.   }, all_valid());
+  // clang-format off
+  //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys{1,       2,          3};
+  //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({3.,     4.5,        7.}, all_valid());
+  // clang-format on
 
-    auto agg = cudf::make_median_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_median_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_median_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V> vals        { };
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_median_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_median_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_median_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
-    fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V> vals        { 3, 4, 5};
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_median_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_median_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_median_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    fixed_width_column_wrapper<V> vals      ( { 3, 4, 5}, all_null() );
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_median_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_median_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_median_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
-    fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                              { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                              { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    -}
-    fixed_width_column_wrapper<R> expect_vals({  4.5,       4.,       5.,    0.},
-                                              {   1,         1,        1,     0});
+  //  { 1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  { 3, 6,     1, 4, 9,   2, 8,    -}
+  fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
-    auto agg = cudf::make_median_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_median_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
-// clang-format on
 
 TYPED_TEST(groupby_median_test, dictionary)
 {
-  using K = int32_t;
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
@@ -131,10 +125,10 @@ TYPED_TEST(groupby_median_test, dictionary)
   fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                        //  { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3      });
-                                        //  { 0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({ 3.,       4.5,       7.   }, all_valid());
+  //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys({1,       2,          3      });
+  //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({3.,       4.5,       7.     }, all_valid());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_median_aggregation());

--- a/cpp/tests/groupby/group_min_test.cpp
+++ b/cpp/tests/groupby/group_min_test.cpp
@@ -225,9 +225,7 @@ TYPED_TEST(FixedPointTestBothReps, GroupBySortMinDecimalAsValue)
   }
 }
 
-// This test will not work until the following ptxas bug is fixed in 10.2
-// https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3186317&cp=
-TYPED_TEST(FixedPointTestBothReps, DISABLED_GroupByHashMinDecimalAsValue)
+TYPED_TEST(FixedPointTestBothReps, GroupByHashMinDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;

--- a/cpp/tests/groupby/group_min_test.cpp
+++ b/cpp/tests/groupby/group_min_test.cpp
@@ -29,153 +29,141 @@ template <typename V>
 struct groupby_min_test : public cudf::test::BaseFixture {
 };
 
+using K = int32_t;
 TYPED_TEST_CASE(groupby_min_test, cudf::test::FixedWidthTypesWithoutFixedPoint);
 
-// clang-format off
 TYPED_TEST(groupby_min_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
 
-    fixed_width_column_wrapper<K> keys { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-    fixed_width_column_wrapper<R, int32_t> expect_vals({0, 1, 2 });
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  fixed_width_column_wrapper<R> expect_vals({0, 1, 2});
 
-    auto agg = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_min_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V> vals        { };
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_min_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
 
-    fixed_width_column_wrapper<K> keys( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5});
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_min_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
 
-    fixed_width_column_wrapper<K> keys   { 1, 1, 1};
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R, int32_t> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_min_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
 
-    fixed_width_column_wrapper<K> keys({ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                       { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                                {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    -}
-    fixed_width_column_wrapper<R, int32_t> expect_vals({ 3,        1,         2,       0},
-                                                       { 1,        1,         1,       0});
+  //  { 1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  { 3, 6,     1, 4, 9,   2, 8,    -}
+  fixed_width_column_wrapper<R> expect_vals({3, 1, 2, 0}, {1, 1, 1, 0});
 
-    auto agg = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
-
-struct groupby_min_string_test : public cudf::test::BaseFixture {};
+struct groupby_min_string_test : public cudf::test::BaseFixture {
+};
 
 TEST_F(groupby_min_string_test, basic)
 {
-    using K = int32_t;
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
 
-    fixed_width_column_wrapper<K> keys        {     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-    strings_column_wrapper        vals        { "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  strings_column_wrapper expect_vals({"aaa", "bat", "$1"});
 
-    fixed_width_column_wrapper<K> expect_keys {     1,     2,    3 };
-    strings_column_wrapper        expect_vals({ "aaa", "bat", "$1" });
+  auto agg = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-
-    auto agg2 = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TEST_F(groupby_min_string_test, zero_valid_values)
 {
-    using K = int32_t;
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  strings_column_wrapper vals({"año", "bit", "₹1"}, all_null());
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    strings_column_wrapper        vals      ( { "año", "bit", "₹1"}, all_null() );
+  fixed_width_column_wrapper<K> expect_keys{1};
+  strings_column_wrapper expect_vals({""}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    strings_column_wrapper        expect_vals({ "" }, all_null());
+  auto agg = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-
-    auto agg2 = cudf::make_min_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_min_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
-// clang-format on
 
 struct groupby_dictionary_min_test : public cudf::test::BaseFixture {
 };
 
 TEST_F(groupby_dictionary_min_test, basic)
 {
-  using K = int32_t;
   using V = std::string;
 
   // clang-format off
@@ -209,12 +197,12 @@ TYPED_TEST(FixedPointTestBothReps, GroupBySortMinDecimalAsValue)
   using RepType    = cudf::device_storage_type_t<decimalXX>;
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
 
-  using K = int32_t;
-
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
+    // clang-format off
     auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    // clang-format on
 
     auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_min = fp_wrapper{{0, 1, 2}, scale};
@@ -235,8 +223,10 @@ TYPED_TEST(FixedPointTestBothReps, GroupByHashMinDecimalAsValue)
 
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
+    // clang-format off
     auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    // clang-format on
 
     auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_min = fp_wrapper{{0, 1, 2}, scale};

--- a/cpp/tests/groupby/group_nunique_test.cpp
+++ b/cpp/tests/groupby/group_nunique_test.cpp
@@ -28,195 +28,183 @@ template <typename V>
 struct groupby_nunique_test : public cudf::test::BaseFixture {
 };
 
+using K = int32_t;
 TYPED_TEST_CASE(groupby_nunique_test, cudf::test::AllTypes);
 
-// clang-format off
 TYPED_TEST(groupby_nunique_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-    fixed_width_column_wrapper<K> keys { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V, int32_t> vals(
-            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-    fixed_width_column_wrapper<R> expect_vals { 3, 4, 3 };
-    fixed_width_column_wrapper<R> expect_bool_vals { 2, 1, 1 };
+  // clang-format off
+  //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  fixed_width_column_wrapper<K> expect_keys{1,        2,          3};
+  fixed_width_column_wrapper<R> expect_vals{3,        4,          3};
+  fixed_width_column_wrapper<R> expect_bool_vals{2,   1,          1};
+  // clang-format on
 
-    auto agg = cudf::make_nunique_aggregation();
-    if(std::is_same<V, bool>())
-        test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
-    else
-        test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_nunique_aggregation();
+  if (std::is_same<V, bool>())
+    test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
+  else
+    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_nunique_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V> vals        { };
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_nunique_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_nunique_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_nunique_test, basic_duplicates)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-    fixed_width_column_wrapper<K> keys { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 3, 2, 2, 9});
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 3, 2, 2, 9};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-    fixed_width_column_wrapper<R> expect_vals { 2, 4, 1 };
-    fixed_width_column_wrapper<R> expect_bool_vals { 2, 1, 1 };
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  fixed_width_column_wrapper<R> expect_vals{2, 4, 1};
+  fixed_width_column_wrapper<R> expect_bool_vals{2, 1, 1};
 
-    auto agg = cudf::make_nunique_aggregation();
-    if(std::is_same<V, bool>())
-        test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
-    else
-        test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_nunique_aggregation();
+  if (std::is_same<V, bool>())
+    test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
+  else
+    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_nunique_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-    fixed_width_column_wrapper<K> keys( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5});
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_nunique_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_nunique_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_nunique_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-    fixed_width_column_wrapper<K> keys  { 1, 1, 1};
-    fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals { 0 };
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals{0};
 
-    auto agg = cudf::make_nunique_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_nunique_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_nunique_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-    fixed_width_column_wrapper<K> keys({ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                       { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                                {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                // all unique values only //  { 3, 6,     1, 4, 9,   2, 8,    -}                                   
-    fixed_width_column_wrapper<R> expect_vals { 2,        3,         2,       0};
-    fixed_width_column_wrapper<R> expect_bool_vals { 1, 1, 1, 0};
+  //                                        {1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  // all unique values only                 {3, 6,     1, 4, 9,   2, 8,    -}
+  fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
+  fixed_width_column_wrapper<R> expect_bool_vals{1, 1, 1, 0};
 
-
-    auto agg = cudf::make_nunique_aggregation();
-    if(std::is_same<V, bool>())
-        test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
-    else 
-        test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_nunique_aggregation();
+  if (std::is_same<V, bool>())
+    test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
+  else
+    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_nunique_test, null_keys_and_values_with_duplicates)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-    fixed_width_column_wrapper<K> keys({ 1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
-                                       { 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-    fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
-                                                {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
+                                     {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
+                                     {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
-                                          //  { 1, 1,     2, 2, 2,    3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,          3,       4}, all_valid());
-                                          //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
-                                          //  unique,     with null,  dup,     dup null
-    fixed_width_column_wrapper<R> expect_vals { 2,        3,          2,       0};
-    fixed_width_column_wrapper<R> expect_bool_vals { 1, 1, 1, 0};
+  //  { 1, 1,     2, 2, 2,    3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
+  //  unique,     with null,  dup,     dup null
+  fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
+  fixed_width_column_wrapper<R> expect_bool_vals{1, 1, 1, 0};
 
-
-    auto agg = cudf::make_nunique_aggregation();
-    if(std::is_same<V, bool>())
-        test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
-    else 
-        test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_nunique_aggregation();
+  if (std::is_same<V, bool>())
+    test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
+  else
+    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
-
 
 TYPED_TEST(groupby_nunique_test, include_nulls)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-    fixed_width_column_wrapper<K> keys({ 1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
-                                       { 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-    fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
-                                                {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
+                                     {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
+                                     {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
-                                          //  { 1, 1,     2, 2, 2,    3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,          3,       4}, all_valid());
-                                          //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
-                                          //  unique,     with null,  dup,     dup null
-    fixed_width_column_wrapper<R> expect_vals { 3,        4,          2,       1};
-    fixed_width_column_wrapper<R> expect_bool_vals { 2, 2, 1, 1};
+  //  { 1, 1,     2, 2, 2,    3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
+  //  unique,     with null,  dup,     dup null
+  fixed_width_column_wrapper<R> expect_vals{3, 4, 2, 1};
+  fixed_width_column_wrapper<R> expect_bool_vals{2, 2, 1, 1};
 
-
-    auto agg = cudf::make_nunique_aggregation(null_policy::INCLUDE);
-    if(std::is_same<V, bool>())
-        test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
-    else 
-        test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_nunique_aggregation(null_policy::INCLUDE);
+  if (std::is_same<V, bool>())
+    test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
+  else
+    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
-// clang-format on
 
 TYPED_TEST(groupby_nunique_test, dictionary)
 {
-  using K = int32_t;
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K>         keys({1, 2, 3, 3, 1, 2, 2, 1, 0, 3, 2, 4, 4, 2},
-                                             {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-  dictionary_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 0, 6, 7, 8, 9, 0, 0, 0},
-                                             {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 0, 3, 2, 4, 4, 2},
+                                     {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  dictionary_column_wrapper<V>  vals({0, 1, 2, 2, 3, 4, 0, 6, 7, 8, 9, 0, 0, 0},
+                                     {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
-                                        // { 1, 1,   2, 2, 2,   3, 3,   4}
-  fixed_width_column_wrapper<K> expect_keys({1,      2,         3,      4}, all_valid());
-                                        // { 3, 6,-  1, 4, 9,-  2*, 8,  -*}
-                                        //  unique,  with null, dup,    dup null
-  fixed_width_column_wrapper<R> expect_fixed_vals({3,  4,         2,      1});
-  fixed_width_column_wrapper<R> expect_bool_vals { 2,  2,         1,      1};
+  // { 1, 1,   2, 2, 2,   3, 3,   4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  // { 3, 6,-  1, 4, 9,-  2*, 8,  -*}
+  //  unique,  with null, dup,    dup null
+  fixed_width_column_wrapper<R> expect_fixed_vals({3, 4, 2, 1});
+  fixed_width_column_wrapper<R> expect_bool_vals{2, 2, 1, 1};
   // clang-format on
 
   cudf::column_view expect_vals = (std::is_same<V, bool>()) ? cudf::column_view{expect_bool_vals}

--- a/cpp/tests/groupby/group_product_test.cpp
+++ b/cpp/tests/groupby/group_product_test.cpp
@@ -132,5 +132,24 @@ TYPED_TEST(groupby_product_test, dictionary)
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
 }
 
+TYPED_TEST(groupby_product_test, dictionary_with_nulls)
+{
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
+
+  // clang-format off
+  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  dictionary_column_wrapper<V>  vals{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+                                     {1, 0, 0, 1, 1, 1, 1, 1, 1, 1}};
+
+                                        //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
+                                        //  { 0, 3, 6,  @, 4, 5, 9,  @, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        56. }, all_valid());
+  // clang-format on
+
+  test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
+}
+
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/groupby/group_product_test.cpp
+++ b/cpp/tests/groupby/group_product_test.cpp
@@ -114,9 +114,8 @@ TYPED_TEST(groupby_product_test, null_keys_and_values)
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
 }
 
-// This test will not work until the following ptxas bug is fixed in 10.2
-// https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3186317&cp=
-TYPED_TEST(groupby_product_test, DISABLED_dictionary)
+// TODO needs an aggregation.cuh cleanup for dictionary support.
+TYPED_TEST(groupby_product_test, dictionary)
 {
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;

--- a/cpp/tests/groupby/group_product_test.cpp
+++ b/cpp/tests/groupby/group_product_test.cpp
@@ -114,7 +114,6 @@ TYPED_TEST(groupby_product_test, null_keys_and_values)
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
 }
 
-// TODO needs an aggregation.cuh cleanup for dictionary support.
 TYPED_TEST(groupby_product_test, dictionary)
 {
   using V = TypeParam;

--- a/cpp/tests/groupby/group_quantile_test.cpp
+++ b/cpp/tests/groupby/group_quantile_test.cpp
@@ -30,181 +30,163 @@ struct groupby_quantile_test : public cudf::test::BaseFixture {
 
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
 
+using K = int32_t;
 TYPED_TEST_CASE(groupby_quantile_test, supported_types);
 
-// clang-format off
 TYPED_TEST(groupby_quantile_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                          //  { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
-    fixed_width_column_wrapper<K> expect_keys { 1,       2,          3      };
-                                          //  { 0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-    fixed_width_column_wrapper<R> expect_vals({   3.,        4.5,      7.   }, all_valid());
+  // clang-format on
+  //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  //                                       {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({3., 4.5, 7.}, all_valid());
+  // clang-format on
 
-    auto agg = cudf::make_quantile_aggregation({0.5},
-                                        interpolation::LINEAR);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V> vals        { };
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_quantile_aggregation({0.5},
-                                        interpolation::LINEAR);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
-    fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V> vals        { 3, 4, 5};
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_quantile_aggregation({0.5},
-                                        interpolation::LINEAR);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    fixed_width_column_wrapper<V> vals      ( { 3, 4, 5}, all_null() );
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_quantile_aggregation({0.5},
-                                        interpolation::LINEAR);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
-    fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                              { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                              { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    -}
-    fixed_width_column_wrapper<R> expect_vals({  4.5,       4.,       5.,    0.},
-                                              {   1,         1,        1,     0});
+  //  { 1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  { 3, 6,     1, 4, 9,   2, 8,    -}
+  fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
-    auto agg = cudf::make_quantile_aggregation({0.5},
-                                        interpolation::LINEAR);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, multiple_quantile)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                          //  { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
-    fixed_width_column_wrapper<K> expect_keys { 1,       2,          3      };
-                                          //  { 0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-    fixed_width_column_wrapper<R> expect_vals({  1.5,4.5, 3.25, 6.,  4.5,7.5}, all_valid());
+  // clang-format off
+  //                                       {1, 1, 1,   2, 2, 2, 2, 3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  //                                        {0, 3, 6,  1, 4, 5, 9, 2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({1.5, 4.5, 3.25, 6.,   4.5, 7.5}, all_valid());
+  // clang-format on
 
-    auto agg = cudf::make_quantile_aggregation({0.25, 0.75},
-                                        interpolation::LINEAR);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg),
-        force_use_sort_impl::YES);
+  auto agg = cudf::make_quantile_aggregation({0.25, 0.75}, interpolation::LINEAR);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_quantile_test, interpolation_types)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 2};
-    fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 9};
 
-                                          //  { 1, 1, 1,  2, 2, 2, 2,  3, 3}
-    fixed_width_column_wrapper<K> expect_keys { 1,        2,           3   };
+  // clang-format off
+  //                                         {1, 1, 1,  2, 2, 2, 2,  3, 3}
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
+  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  fixed_width_column_wrapper<R> expect_vals1({2.4,      4.2,         4.}, all_valid());
+  auto agg1 = cudf::make_quantile_aggregation({0.4}, interpolation::LINEAR);
+  test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg1));
 
-                                           //  { 0, 3, 6,  1, 4, 5, 9,  2, 7}
-    fixed_width_column_wrapper<R> expect_vals1({  2.4,         4.2,      4. }, all_valid());
-    auto agg1 = cudf::make_quantile_aggregation({0.4},
-                                        interpolation::LINEAR);
-    test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg1));
+  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  fixed_width_column_wrapper<R> expect_vals2({3,        4,           2}, all_valid());
+  auto agg2 = cudf::make_quantile_aggregation({0.4}, interpolation::NEAREST);
+  test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
 
-                                           //  { 0, 3, 6,  1, 4, 5, 9,  2, 7}
-    fixed_width_column_wrapper<R> expect_vals2({    3,          4,        2 }, all_valid());
-    auto agg2 = cudf::make_quantile_aggregation({0.4},
-                                        interpolation::NEAREST);
-    test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
+  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  fixed_width_column_wrapper<R> expect_vals3({0,        4,          2}, all_valid());
+  auto agg3 = cudf::make_quantile_aggregation({0.4}, interpolation::LOWER);
+  test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg3));
 
-                                           //  { 0, 3, 6,  1, 4, 5, 9,  2, 7}
-    fixed_width_column_wrapper<R> expect_vals3({    0,          4,        2 }, all_valid());
-    auto agg3 = cudf::make_quantile_aggregation({0.4},
-                                        interpolation::LOWER);
-    test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg3));
+  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  fixed_width_column_wrapper<R> expect_vals4({3,        5,           7}, all_valid());
+  auto agg4 = cudf::make_quantile_aggregation({0.4}, interpolation::HIGHER);
+  test_single_agg(keys, vals, expect_keys, expect_vals4, std::move(agg4));
 
-                                           //  { 0, 3, 6,  1, 4, 5, 9,  2, 7}
-    fixed_width_column_wrapper<R> expect_vals4({    3,          5,        7 }, all_valid());
-    auto agg4 = cudf::make_quantile_aggregation({0.4},
-                                        interpolation::HIGHER);
-    test_single_agg(keys, vals, expect_keys, expect_vals4, std::move(agg4));
-
-                                           //  { 0, 3, 6,  1, 4, 5, 9,  2, 7}
-    fixed_width_column_wrapper<R> expect_vals5({  1.5,         4.5,      4.5}, all_valid());
-    auto agg5 = cudf::make_quantile_aggregation({0.4},
-                                        interpolation::MIDPOINT);
-    test_single_agg(keys, vals, expect_keys, expect_vals5, std::move(agg5));
-
+  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  fixed_width_column_wrapper<R> expect_vals5({1.5,      4.5,         4.5}, all_valid());
+  auto agg5 = cudf::make_quantile_aggregation({0.4}, interpolation::MIDPOINT);
+  test_single_agg(keys, vals, expect_keys, expect_vals5, std::move(agg5));
+  // clang-format on
 }
-// clang-format on
 
 TYPED_TEST(groupby_quantile_test, dictionary)
 {
-  using K = int32_t;
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  dictionary_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                        //  { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3      });
-                                        //  { 0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({ 3.,      4.5,        7.   }, all_valid());
+  //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3});
+  //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({3.,      4.5,        7.}, all_valid());
   // clang-format on
 
   test_single_agg(keys,

--- a/cpp/tests/groupby/group_std_test.cpp
+++ b/cpp/tests/groupby/group_std_test.cpp
@@ -144,9 +144,7 @@ TYPED_TEST(groupby_std_test, ddof_non_default)
 }
 // clang-format on
 
-// This test will not work until the following ptxas bug is fixed in 10.2
-// https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3186317&cp=
-TYPED_TEST(groupby_std_test, DISABLED_dictionary)
+TYPED_TEST(groupby_std_test, dictionary)
 {
   using K = int32_t;
   using V = TypeParam;

--- a/cpp/tests/groupby/group_std_test.cpp
+++ b/cpp/tests/groupby/group_std_test.cpp
@@ -30,134 +30,127 @@ template <typename V>
 struct groupby_std_test : public cudf::test::BaseFixture {
 };
 
+using K               = int32_t;
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
 
 TYPED_TEST_CASE(groupby_std_test, supported_types);
 
-// clang-format off
 TYPED_TEST(groupby_std_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                          //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-    fixed_width_column_wrapper<K> expect_keys { 1,        2,           3      };
-                                          //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-    fixed_width_column_wrapper<R> expect_vals({   3.,   sqrt(131./12),sqrt(31./3)}, all_valid());
+  // clang-format off
+  //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
+  fixed_width_column_wrapper<K>  expect_keys{1,        2,             3};
+  //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, all_valid());
+  // clang-format on
 
-    auto agg = cudf::make_std_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_std_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_std_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V> vals        { };
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_std_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_std_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_std_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
-    fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V> vals        { 3, 4, 5};
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_std_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_std_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_std_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    fixed_width_column_wrapper<V> vals      ( { 3, 4, 5}, all_null() );
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_std_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_std_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_std_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
-    fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                              { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                              { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,       4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,          4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,       3}
-    fixed_width_column_wrapper<R> expect_vals({3/sqrt(2), 7/sqrt(3), 3*sqrt(2), 0.},
-                                              { 1,        1,         1,          0});
+  //                                        { 1, 1,     2, 2, 2,   3, 3,       4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //                                        { 3, 6,     1, 4, 9,   2, 8,       3}
+  fixed_width_column_wrapper<R> expect_vals({3 / sqrt(2), 7 / sqrt(3), 3 * sqrt(2), 0.},
+                                            {1, 1, 1, 0});
 
-    auto agg = cudf::make_std_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_std_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_std_test, ddof_non_default)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
-    fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                              { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                              { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    3}
-    fixed_width_column_wrapper<R> expect_vals({ 0.,   7*sqrt(2./3), 0.,      0.},
-                                              { 0,        1,         0,       0});
+  //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
+  fixed_width_column_wrapper<R> expect_vals({0., 7 * sqrt(2. / 3), 0., 0.}, {0, 1, 0, 0});
 
-    auto agg = cudf::make_std_aggregation(2);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_std_aggregation(2);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
-// clang-format on
 
 TYPED_TEST(groupby_std_test, dictionary)
 {
-  using K = int32_t;
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                        //   { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
-                                        //   { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({  3.,   sqrt(131./12),sqrt(31./3)}, all_valid());
+  //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys({1,        2,             3});
+  //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, all_valid());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_std_aggregation());

--- a/cpp/tests/groupby/group_sum_of_squares_test.cpp
+++ b/cpp/tests/groupby/group_sum_of_squares_test.cpp
@@ -29,112 +29,104 @@ struct groupby_sum_of_squares_test : public cudf::test::BaseFixture {
 };
 
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
+using K               = int32_t;
 
 TYPED_TEST_CASE(groupby_sum_of_squares_test, supported_types);
 
-// clang-format off
 TYPED_TEST(groupby_sum_of_squares_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                          //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-    fixed_width_column_wrapper<K> expect_keys { 1,        2,           3      };
-                                          //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-    fixed_width_column_wrapper<R> expect_vals({   45.,       123.,      117. }, all_valid());
+  //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({45., 123., 117.}, all_valid());
 
-    auto agg = cudf::make_sum_of_squares_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_of_squares_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_sum_of_squares_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V> vals        { };
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_sum_of_squares_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_of_squares_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_sum_of_squares_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
-    fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V> vals        { 3, 4, 5};
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_sum_of_squares_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_of_squares_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_sum_of_squares_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    fixed_width_column_wrapper<V> vals      ( { 3, 4, 5}, all_null() );
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_sum_of_squares_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_of_squares_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_sum_of_squares_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
-    fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                              { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                              { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    3}
-    fixed_width_column_wrapper<R> expect_vals({ 45.,      98.,       68.,     9.},
-                                              { 1,        1,         1,       0});
+  //  { 1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  { 3, 6,     1, 4, 9,   2, 8,    3}
+  fixed_width_column_wrapper<R> expect_vals({45., 98., 68., 9.}, {1, 1, 1, 0});
 
-    auto agg = cudf::make_sum_of_squares_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_of_squares_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
-// clang-format on
 
 TYPED_TEST(groupby_sum_of_squares_test, dictionary)
 {
-  using K = int32_t;
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                        //   { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
-                                        //   { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals( { 45.,       123.,        117. }, all_valid());
+  //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
+  //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({45.,       123.,       117.   }, all_valid());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_sum_of_squares_aggregation());

--- a/cpp/tests/groupby/group_sum_of_squares_test.cpp
+++ b/cpp/tests/groupby/group_sum_of_squares_test.cpp
@@ -124,9 +124,7 @@ TYPED_TEST(groupby_sum_of_squares_test, null_keys_and_values)
 }
 // clang-format on
 
-// This test will not work until the following ptxas bug is fixed in 10.2
-// https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3186317&cp=
-TYPED_TEST(groupby_sum_of_squares_test, DISABLED_dictionary)
+TYPED_TEST(groupby_sum_of_squares_test, dictionary)
 {
   using K = int32_t;
   using V = TypeParam;

--- a/cpp/tests/groupby/group_sum_of_squares_test.cpp
+++ b/cpp/tests/groupby/group_sum_of_squares_test.cpp
@@ -28,10 +28,7 @@ template <typename V>
 struct groupby_sum_of_squares_test : public cudf::test::BaseFixture {
 };
 
-// These tests will not work for all types until the following ptxas bug is fixed in 10.2
-// https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3186317&cp=
-// using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
-using supported_types = cudf::test::Types<float, double>;
+using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
 
 TYPED_TEST_CASE(groupby_sum_of_squares_test, supported_types);
 

--- a/cpp/tests/groupby/group_sum_test.cpp
+++ b/cpp/tests/groupby/group_sum_test.cpp
@@ -189,9 +189,7 @@ TYPED_TEST(FixedPointTestBothReps, GroupBySortSumDecimalAsValue)
   }
 }
 
-// This test will not work until the following ptxas bug is fixed in 10.2
-// https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3186317&cp=
-TYPED_TEST(FixedPointTestBothReps, DISABLED_GroupByHashSumDecimalAsValue)
+TYPED_TEST(FixedPointTestBothReps, GroupByHashSumDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX    = TypeParam;

--- a/cpp/tests/groupby/group_sum_test.cpp
+++ b/cpp/tests/groupby/group_sum_test.cpp
@@ -28,126 +28,119 @@ template <typename V>
 struct groupby_sum_test : public cudf::test::BaseFixture {
 };
 
+using K = int32_t;
 using supported_types =
   cudf::test::Concat<cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>,
                      cudf::test::DurationTypes>;
 
 TYPED_TEST_CASE(groupby_sum_test, supported_types);
 
-// clang-format off
 TYPED_TEST(groupby_sum_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V, int> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    fixed_width_column_wrapper<K> expect_keys { 1, 2,  3 };
-    fixed_width_column_wrapper<R, int> expect_vals { 9, 19, 17};
+  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  fixed_width_column_wrapper<R> expect_vals{9, 19, 17};
 
-    auto agg = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_sum_test, empty_cols)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V, int> vals        { };
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R, int> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_sum_test, zero_valid_keys)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
-    fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V, int> vals        { 3, 4, 5};
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R, int> expect_vals { };
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
 
-    auto agg = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_sum_test, zero_valid_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    fixed_width_column_wrapper<V, int> vals      ( { 3, 4, 5}, all_null() );
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
 
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R, int> expect_vals({ 0 }, all_null());
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
 
-    auto agg = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_sum_test, null_keys_and_values)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
-    fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                              { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V, int> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                              { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    -}
-    fixed_width_column_wrapper<R, int> expect_vals({ 9,        14,        10,      0},
-                                              { 1,         1,         1,      0});
+  //  { 1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  //  { 3, 6,     1, 4, 9,   2, 8,    -}
+  fixed_width_column_wrapper<R> expect_vals({9, 14, 10, 0}, {1, 1, 1, 0});
 
-    auto agg = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+  auto agg = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-    auto agg2 = cudf::make_sum_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
+  auto agg2 = cudf::make_sum_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 // clang-format on
 
 TYPED_TEST(groupby_sum_test, dictionary)
 {
-  using K = int32_t;
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
   // clang-format off
-  fixed_width_column_wrapper<K>     keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V, int> vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  fixed_width_column_wrapper<K>      expect_keys{ 1, 2,  3 };
-  fixed_width_column_wrapper<R, int> expect_vals{ 9, 19, 17};
+  fixed_width_column_wrapper<K> expect_keys{ 1, 2,  3 };
+  fixed_width_column_wrapper<R> expect_vals{ 9, 19, 17};
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_sum_aggregation());
@@ -172,8 +165,10 @@ TYPED_TEST(FixedPointTestBothReps, GroupBySortSumDecimalAsValue)
 
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
+    // clang-format off
     auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    // clang-format on
 
     auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_sum = fp64_wrapper{{9, 19, 17}, scale};
@@ -200,8 +195,10 @@ TYPED_TEST(FixedPointTestBothReps, GroupByHashSumDecimalAsValue)
 
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
+    // clang-format off
     auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    // clang-format on
 
     auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_sum = fp64_wrapper{{9, 19, 17}, scale};

--- a/cpp/tests/groupby/group_sum_test.cpp
+++ b/cpp/tests/groupby/group_sum_test.cpp
@@ -136,9 +136,7 @@ TYPED_TEST(groupby_sum_test, null_keys_and_values)
 }
 // clang-format on
 
-// These tests will not work until the following ptxas bug is fixed in 10.2
-// https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3186317&cp=
-TYPED_TEST(groupby_sum_test, DISABLED_dictionary)
+TYPED_TEST(groupby_sum_test, dictionary)
 {
   using K = int32_t;
   using V = TypeParam;

--- a/cpp/tests/groupby/group_var_test.cpp
+++ b/cpp/tests/groupby/group_var_test.cpp
@@ -144,9 +144,7 @@ TYPED_TEST(groupby_var_test, ddof_non_default)
 }
 // clang-format on
 
-// This test will not work until the following ptxas bug is fixed in 10.2
-// https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3186317&cp=
-TYPED_TEST(groupby_var_test, DISABLED_dictionary)
+TYPED_TEST(groupby_var_test, dictionary)
 {
   using K = int32_t;
   using V = TypeParam;

--- a/cpp/tests/groupby/group_var_test.cpp
+++ b/cpp/tests/groupby/group_var_test.cpp
@@ -29,135 +29,132 @@ namespace test {
 template <typename V>
 struct groupby_var_test : public cudf::test::BaseFixture {
 };
+using K = int32_t;
 
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
 
 TYPED_TEST_CASE(groupby_var_test, supported_types);
 
-// clang-format off
 TYPED_TEST(groupby_var_test, basic)
 {
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
-
-    fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-
-                                          //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-    fixed_width_column_wrapper<K> expect_keys { 1,        2,           3      };
-                                          //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-    fixed_width_column_wrapper<R> expect_vals({   9.,      131./12,     31./3 }, all_valid());
-
-    auto agg = cudf::make_variance_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-}
-
-TYPED_TEST(groupby_var_test, empty_cols)
-{
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
-
-    fixed_width_column_wrapper<K> keys        { };
-    fixed_width_column_wrapper<V> vals        { };
-
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
-
-    auto agg = cudf::make_variance_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-}
-
-TYPED_TEST(groupby_var_test, zero_valid_keys)
-{
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
-
-    fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_null() );
-    fixed_width_column_wrapper<V> vals        { 3, 4, 5};
-
-    fixed_width_column_wrapper<K> expect_keys { };
-    fixed_width_column_wrapper<R> expect_vals { };
-
-    auto agg = cudf::make_variance_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-}
-
-TYPED_TEST(groupby_var_test, zero_valid_values)
-{
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
-
-    fixed_width_column_wrapper<K> keys        { 1, 1, 1};
-    fixed_width_column_wrapper<V> vals      ( { 3, 4, 5}, all_null() );
-
-    fixed_width_column_wrapper<K> expect_keys { 1 };
-    fixed_width_column_wrapper<R> expect_vals({ 0 }, all_null());
-
-    auto agg = cudf::make_variance_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-}
-
-TYPED_TEST(groupby_var_test, null_keys_and_values)
-{
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
-
-    fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                              { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                              { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    3}
-    fixed_width_column_wrapper<R> expect_vals({ 4.5,      49./3,    18.,     0.},
-                                              { 1,        1,         1,       0});
-
-    auto agg = cudf::make_variance_aggregation();
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-}
-
-TYPED_TEST(groupby_var_test, ddof_non_default)
-{
-    using K = int32_t;
-    using V = TypeParam;
-    using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
-
-    fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                              { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-    fixed_width_column_wrapper<V> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                              { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-
-                                          //  { 1, 1,     2, 2, 2,   3, 3,    4}
-    fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
-                                          //  { 3, 6,     1, 4, 9,   2, 8,    3}
-    fixed_width_column_wrapper<R> expect_vals({ 0.,       98./3,    0.,      0.},
-                                              { 0,        1,         0,       0});
-
-    auto agg = cudf::make_variance_aggregation(2);
-    test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
-}
-// clang-format on
-
-TYPED_TEST(groupby_var_test, dictionary)
-{
-  using K = int32_t;
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                        //   { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
-                                        //   { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals( { 9.,      131./12,     31./3 }, all_valid());
+  //                                       {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys{1,        2,           3};
+  //                                       {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({9.,      131. / 12,   31. / 3}, all_valid());
+  // clang-format on
+
+  auto agg = cudf::make_variance_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+}
+
+TYPED_TEST(groupby_var_test, empty_cols)
+{
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+
+  fixed_width_column_wrapper<K> keys{};
+  fixed_width_column_wrapper<V> vals{};
+
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
+
+  auto agg = cudf::make_variance_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+}
+
+TYPED_TEST(groupby_var_test, zero_valid_keys)
+{
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<V> vals{3, 4, 5};
+
+  fixed_width_column_wrapper<K> expect_keys{};
+  fixed_width_column_wrapper<R> expect_vals{};
+
+  auto agg = cudf::make_variance_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+}
+
+TYPED_TEST(groupby_var_test, zero_valid_values)
+{
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+
+  fixed_width_column_wrapper<K> keys{1, 1, 1};
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+
+  fixed_width_column_wrapper<K> expect_keys{1};
+  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+
+  auto agg = cudf::make_variance_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+}
+
+TYPED_TEST(groupby_var_test, null_keys_and_values)
+{
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+
+  // clang-format off
+  //                                        {1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, all_valid());
+  //                                        {3, 6,     1, 4, 9,   2, 8,    3}
+  fixed_width_column_wrapper<R> expect_vals({4.5,      49. / 3,   18.,     0.}, {1, 1, 1, 0});
+  // clang-format on
+
+  auto agg = cudf::make_variance_aggregation();
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+}
+
+TYPED_TEST(groupby_var_test, ddof_non_default)
+{
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+
+  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+
+  // clang-format off
+  //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
+  fixed_width_column_wrapper<K> expect_keys({1,         2,         3,       4}, all_valid());
+  //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
+  fixed_width_column_wrapper<R> expect_vals({0.,        98. / 3,   0.,      0.},
+                                            {0,         1,         0,       0});
+  // clang-format on
+
+  auto agg = cudf::make_variance_aggregation(2);
+  test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
+}
+
+TYPED_TEST(groupby_var_test, dictionary)
+{
+  using V = TypeParam;
+  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+
+  // clang-format off
+  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
+  //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
+  fixed_width_column_wrapper<R> expect_vals({9.,      131./12,      31./3  }, all_valid());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_variance_aggregation());


### PR DESCRIPTION
This PR enables all underlying type operations for dictionary type by calling the underlying type `update_target_element` except dictionary type to avoid recursion (and so only one depth of dictionary type is supported)

Few 10.2 restrictions are removed.
related disabled unit tests are enabled.
unit test reformatted, clang-format

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
