### PR TITLE
[REVIEW] Fix `Series` inputs handling in `Dataframe` constructor

### DIFF
--- a/python/cudf/cudf/core/column/decimal.py
+++ b/python/cudf/cudf/core/column/decimal.py
@@ -241,6 +241,12 @@ class DecimalColumn(ColumnBase):
         header["dtype"] = dtype
         return super().deserialize(header, frames)
 
+    @property
+    def __cuda_array_interface__(self):
+        raise NotImplementedError(
+            "Decimals are not yet supported via `__cuda_array_interface__`"
+        )
+
 
 def _binop_scale(l_dtype, r_dtype, op):
     # This should at some point be hooked up to libcudf's

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -171,6 +171,12 @@ class ListColumn(ColumnBase):
             size=header["size"],
         )
 
+    @property
+    def __cuda_array_interface__(self):
+        raise NotImplementedError(
+            "Lists are not yet supported via `__cuda_array_interface__`"
+        )
+
 
 class ListMethods(ColumnMethodsMixin):
     """

--- a/python/cudf/cudf/core/column/struct.py
+++ b/python/cudf/cudf/core/column/struct.py
@@ -105,6 +105,12 @@ class StructColumn(ColumnBase):
             children=self.base_children,
         )
 
+    @property
+    def __cuda_array_interface__(self):
+        raise NotImplementedError(
+            "Structs are not yet supported via `__cuda_array_interface__`"
+        )
+
 
 class StructMethods(ColumnMethodsMixin):
     """

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -233,7 +233,14 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
             else:
                 self._data = data._data
                 self.columns = data.columns
+        elif isinstance(data, (cudf.Series, pd.Series)):
+            if isinstance(data, pd.Series):
+                data = cudf.Series.from_pandas(data)
 
+            name = data.name or 0
+            self._init_from_dict_like(
+                {name: data}, index=index, columns=columns
+            )
         elif data is None:
             if index is None:
                 self._index = RangeIndex(0)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -8562,3 +8562,26 @@ def test_dataframe_argsort(df, ascending, expected):
     actual = df.argsort(ascending=ascending)
 
     assert_eq(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "data,columns,index",
+    [
+        (pd.Series([1, 2, 3]), None, None),
+        (pd.Series(["a", "b", None, "c"], name="abc"), None, None),
+        (
+            pd.Series(["a", "b", None, "c"], name="abc"),
+            ["abc", "b"],
+            [1, 2, 3],
+        ),
+    ],
+)
+def test_dataframe_init_from_series(data, columns, index):
+    expected = pd.DataFrame(data, columns=columns, index=index)
+    actual = cudf.DataFrame(data, columns=columns, index=index)
+
+    assert_eq(
+        expected,
+        actual,
+        check_index_type=False if len(expected) == 0 else True,
+    )


### PR DESCRIPTION
Fixes: #8033 

Though we see an error when a Series of `ListDtype` is passed to `DataFrame` constructor, the issues is actually a broader one where we cannot pass a `Series` of string dtype and any series that has nulls to `DataFrame` constructor. For examples:

```python
>>> import cudf
>>> s = cudf.Series(['a', 'b', 'c'])
>>> cudf.DataFrame(s)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nvme/0/pgali/envs/cudfdev/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/nvme/0/pgali/envs/cudfdev/lib/python3.8/site-packages/cudf/core/dataframe.py", line 258, in __init__
    elif hasattr(data, "__cuda_array_interface__"):
  File "/nvme/0/pgali/envs/cudfdev/lib/python3.8/site-packages/cudf/core/series.py", line 6364, in __cuda_array_interface__
    return self._column.__cuda_array_interface__
  File "/nvme/0/pgali/envs/cudfdev/lib/python3.8/site-packages/cudf/core/column/string.py", line 5123, in __cuda_array_interface__
    raise NotImplementedError(
NotImplementedError: Strings are not yet supported via `__cuda_array_interface__`
>>> s = cudf.Series([1, 2, None])
>>> cudf.DataFrame(s)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nvme/0/pgali/envs/cudfdev/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/nvme/0/pgali/envs/cudfdev/lib/python3.8/site-packages/cudf/core/dataframe.py", line 272, in __init__
    new_df = self._from_arrays(data, index=index, columns=columns)
  File "/nvme/0/pgali/envs/cudfdev/lib/python3.8/site-packages/cudf/core/dataframe.py", line 5795, in _from_arrays
    data = cupy.asarray(data)
  File "/nvme/0/pgali/envs/cudfdev/lib/python3.8/site-packages/cupy/_creation/from_data.py", line 66, in asarray
    return core.array(a, dtype, False, order)
  File "cupy/core/core.pyx", line 2016, in cupy.core.core.array
  File "cupy/core/core.pyx", line 2046, in cupy.core.core.array
  File "cupy/core/core.pyx", line 2366, in cupy.core.core._convert_object_with_cuda_array_interface
ValueError: CuPy currently does not support masked arrays.

```

In this PR, we are introducing a special case handling for inputs that are of type `Series`.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
