### PR TITLE
Update codeowners for benchmarks / tests CMake [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,9 @@ notebooks/         @rapidsai/cudf-python-codeowners
 python/dask_cudf/  @rapidsai/cudf-dask-codeowners
 
 #cmake code owners
-**/CMakeLists.txt  @rapidsai/cudf-cmake-codeowners
-**/cmake/          @rapidsai/cudf-cmake-codeowners
+cpp/CMakeLists.txt               @rapidsai/cudf-cmake-codeowners
+cpp/libcudf_kafka/CMakeLists.txt @rapidsai/cudf-cmake-codeowners
+**/cmake/                        @rapidsai/cudf-cmake-codeowners
 
 #java code owners
 java/              @rapidsai/cudf-java-codeowners


### PR DESCRIPTION
Updates the github CODEOWNERS file to make the benchmarks and tests CMake files fall under the cpp codeowners instead of the cmake codeowners.