### PR TITLE
Convert  hashing, partitioning, and nested_loop_join APIs to use device_uvector

### DIFF
--- a/cpp/include/cudf/detail/hashing.hpp
+++ b/cpp/include/cudf/detail/hashing.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,17 +29,17 @@ namespace detail {
  */
 std::unique_ptr<column> hash(
   table_view const& input,
-  hash_id hash_function                     = hash_id::HASH_MURMUR3,
-  std::vector<uint32_t> const& initial_hash = {},
-  uint32_t seed                             = 0,
-  rmm::cuda_stream_view stream              = rmm::cuda_stream_default,
-  rmm::mr::device_memory_resource* mr       = rmm::mr::get_current_device_resource());
+  hash_id hash_function                        = hash_id::HASH_MURMUR3,
+  cudf::host_span<uint32_t const> initial_hash = {},
+  uint32_t seed                                = 0,
+  rmm::cuda_stream_view stream                 = rmm::cuda_stream_default,
+  rmm::mr::device_memory_resource* mr          = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<column> murmur_hash3_32(
   table_view const& input,
-  std::vector<uint32_t> const& initial_hash = {},
-  rmm::cuda_stream_view stream              = rmm::cuda_stream_default,
-  rmm::mr::device_memory_resource* mr       = rmm::mr::get_current_device_resource());
+  cudf::host_span<uint32_t const> initial_hash = {},
+  rmm::cuda_stream_view stream                 = rmm::cuda_stream_default,
+  rmm::mr::device_memory_resource* mr          = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<column> md5_hash(
   table_view const& input,

--- a/cpp/include/cudf/hashing.hpp
+++ b/cpp/include/cudf/hashing.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/span.hpp>
 
 namespace cudf {
 /**
@@ -29,18 +30,18 @@ namespace cudf {
  * @brief Computes the hash value of each row in the input set of columns.
  *
  * @param input The table of columns to hash
- * @param initial_hash Optional vector of initial hash values for each column.
- * If this vector is empty then each element will be hashed as-is.
+ * @param initial_hash Optional host_span of initial hash values for each column.
+ * If this span is empty then each element will be hashed as-is.
  * @param mr Device memory resource used to allocate the returned column's device memory.
  *
  * @returns A column where each row is the hash of a column from the input
  */
 std::unique_ptr<column> hash(
   table_view const& input,
-  hash_id hash_function                     = hash_id::HASH_MURMUR3,
-  std::vector<uint32_t> const& initial_hash = {},
-  uint32_t seed                             = DEFAULT_HASH_SEED,
-  rmm::mr::device_memory_resource* mr       = rmm::mr::get_current_device_resource());
+  hash_id hash_function                        = hash_id::HASH_MURMUR3,
+  cudf::host_span<uint32_t const> initial_hash = {},
+  uint32_t seed                                = DEFAULT_HASH_SEED,
+  rmm::mr::device_memory_resource* mr          = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group
 }  // namespace cudf

--- a/cpp/include/cudf/lists/detail/scatter.cuh
+++ b/cpp/include/cudf/lists/detail/scatter.cuh
@@ -46,8 +46,8 @@ namespace {
  *        also holding a reference to the list column.
  *
  * Analogous to the list_view, this class is default constructable,
- * and can thus be stored in rmm::device_vector. It is used to represent
- * the results of a `scatter()` operation; a device_vector may hold
+ * and can thus be stored in rmm::device_uvector. It is used to represent
+ * the results of a `scatter()` operation; a device_uvector may hold
  * several instances of unbound_list_view, each with a flag indicating
  * whether it came from the scatter source or target. Each instance
  * may later be "bound" to the appropriate source/target column, to
@@ -131,7 +131,7 @@ struct unbound_list_view {
   }
 
  private:
-  // Note: Cannot store reference to list column, because of storage in device_vector.
+  // Note: Cannot store reference to list column, because of storage in device_uvector.
   // Only keep track of whether this list row came from the source or target of scatter.
 
   label_type _label{
@@ -247,7 +247,7 @@ void print(std::string const& msg,
  * The protocol is as follows:
  *
  * Inputs:
- *  1. list_vector:  A device_vector of unbound_list_view, with each element
+ *  1. list_vector:  A device_uvector of unbound_list_view, with each element
  *                   indicating the position, size, and which column the list
  *                   row came from.
  *  2. list_offsets: The offsets column for the (outer) lists column, each offset

--- a/cpp/src/join/nested_loop_join.cuh
+++ b/cpp/src/join/nested_loop_join.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -22,11 +22,13 @@
 #include <cudf/detail/scatter.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/hash_functions.cuh>
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/partitioning.hpp>
 #include <cudf/table/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 namespace cudf {
@@ -355,20 +357,20 @@ void copy_block_partitions_impl(InputIter const input,
     scanned_block_partition_sizes);
 }
 
-rmm::device_vector<size_type> compute_gather_map(size_type num_rows,
-                                                 size_type num_partitions,
-                                                 size_type const* row_partition_numbers,
-                                                 size_type const* row_partition_offset,
-                                                 size_type const* block_partition_sizes,
-                                                 size_type const* scanned_block_partition_sizes,
-                                                 size_type grid_size,
-                                                 rmm::cuda_stream_view stream)
+rmm::device_uvector<size_type> compute_gather_map(size_type num_rows,
+                                                  size_type num_partitions,
+                                                  size_type const* row_partition_numbers,
+                                                  size_type const* row_partition_offset,
+                                                  size_type const* block_partition_sizes,
+                                                  size_type const* scanned_block_partition_sizes,
+                                                  size_type grid_size,
+                                                  rmm::cuda_stream_view stream)
 {
   auto sequence = thrust::make_counting_iterator(0);
-  rmm::device_vector<size_type> gather_map(num_rows);
+  rmm::device_uvector<size_type> gather_map(num_rows, stream);
 
   copy_block_partitions_impl(sequence,
-                             gather_map.data().get(),
+                             gather_map.begin(),
                              num_rows,
                              num_partitions,
                              row_partition_numbers,
@@ -464,7 +466,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
   auto grid_size = util::div_rounding_up_safe(num_rows, rows_per_block);
 
   // Allocate array to hold which partition each row belongs to
-  auto row_partition_numbers = rmm::device_vector<size_type>(num_rows);
+  auto row_partition_numbers = rmm::device_uvector<size_type>(num_rows, stream);
 
   // Array to hold the size of each partition computed by each block
   //  i.e., { {block0 partition0 size, block1 partition0 size, ...},
@@ -472,14 +474,17 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
   //          ...
   //          {block0 partition(num_partitions-1) size, block1
   //          partition(num_partitions -1) size, ...} }
-  auto block_partition_sizes = rmm::device_vector<size_type>(grid_size * num_partitions);
+  auto block_partition_sizes = rmm::device_uvector<size_type>(grid_size * num_partitions, stream);
 
-  auto scanned_block_partition_sizes = rmm::device_vector<size_type>(grid_size * num_partitions);
+  auto scanned_block_partition_sizes =
+    rmm::device_uvector<size_type>(grid_size * num_partitions, stream);
 
   // Holds the total number of rows in each partition
-  auto global_partition_sizes = rmm::device_vector<size_type>(num_partitions, size_type{0});
+  auto global_partition_sizes =
+    cudf::detail::make_zeroed_device_uvector_async<size_type>(num_partitions, stream);
 
-  auto row_partition_offset = rmm::device_vector<size_type>(num_rows);
+  auto row_partition_offset =
+    cudf::detail::make_zeroed_device_uvector_async<size_type>(num_rows, stream);
 
   auto const device_input = table_device_view::create(table_to_hash, stream);
   auto const hasher       = row_hasher<hash_function, hash_has_nulls>(*device_input, seed);
@@ -502,10 +507,10 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
                                                       num_rows,
                                                       num_partitions,
                                                       partitioner_type(num_partitions),
-                                                      row_partition_numbers.data().get(),
-                                                      row_partition_offset.data().get(),
-                                                      block_partition_sizes.data().get(),
-                                                      global_partition_sizes.data().get());
+                                                      row_partition_numbers.data(),
+                                                      row_partition_offset.data(),
+                                                      block_partition_sizes.data(),
+                                                      global_partition_sizes.data());
   } else {
     // Determines how the mapping between hash value and partition number is
     // computed
@@ -522,10 +527,10 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
                                                       num_rows,
                                                       num_partitions,
                                                       partitioner_type(num_partitions),
-                                                      row_partition_numbers.data().get(),
-                                                      row_partition_offset.data().get(),
-                                                      block_partition_sizes.data().get(),
-                                                      global_partition_sizes.data().get());
+                                                      row_partition_numbers.data(),
+                                                      row_partition_offset.data(),
+                                                      block_partition_sizes.data(),
+                                                      global_partition_sizes.data());
   }
 
   // Compute exclusive scan of all blocks' partition sizes in-place to determine
@@ -533,25 +538,20 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
   thrust::exclusive_scan(rmm::exec_policy(stream),
                          block_partition_sizes.begin(),
                          block_partition_sizes.end(),
-                         scanned_block_partition_sizes.data().get());
+                         scanned_block_partition_sizes.data());
 
   // Compute exclusive scan of size of each partition to determine offset
   // location of each partition in final output.
   // TODO This can be done independently on a separate stream
-  size_type* scanned_global_partition_sizes{global_partition_sizes.data().get()};
   thrust::exclusive_scan(rmm::exec_policy(stream),
                          global_partition_sizes.begin(),
                          global_partition_sizes.end(),
-                         scanned_global_partition_sizes);
+                         global_partition_sizes.begin());
 
   // Copy the result of the exclusive scan to the output offsets array
   // to indicate the starting point for each partition in the output
-  std::vector<size_type> partition_offsets(num_partitions);
-  CUDA_TRY(cudaMemcpyAsync(partition_offsets.data(),
-                           scanned_global_partition_sizes,
-                           num_partitions * sizeof(size_type),
-                           cudaMemcpyDeviceToHost,
-                           stream.value()));
+  auto const partition_offsets =
+    cudf::detail::make_std_vector_async(global_partition_sizes, stream);
 
   // When the number of partitions is less than a threshold, we can apply an
   // optimization using shared memory to copy values to the output buffer.
@@ -559,23 +559,16 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
   if (use_optimization) {
     std::vector<std::unique_ptr<column>> output_cols(input.num_columns());
 
-    // NOTE these pointers are non-const to workaround lambda capture bug in
-    // gcc 5.4
-    auto row_partition_numbers_ptr{row_partition_numbers.data().get()};
-    auto row_partition_offset_ptr{row_partition_offset.data().get()};
-    auto block_partition_sizes_ptr{block_partition_sizes.data().get()};
-    auto scanned_block_partition_sizes_ptr{scanned_block_partition_sizes.data().get()};
-
     // Copy input to output by partition per column
-    std::transform(input.begin(), input.end(), output_cols.begin(), [=](auto const& col) {
+    std::transform(input.begin(), input.end(), output_cols.begin(), [&](auto const& col) {
       return cudf::type_dispatcher<dispatch_storage_type>(col.type(),
                                                           copy_block_partitions_dispatcher{},
                                                           col,
                                                           num_partitions,
-                                                          row_partition_numbers_ptr,
-                                                          row_partition_offset_ptr,
-                                                          block_partition_sizes_ptr,
-                                                          scanned_block_partition_sizes_ptr,
+                                                          row_partition_numbers.data(),
+                                                          row_partition_offset.data(),
+                                                          block_partition_sizes.data(),
+                                                          scanned_block_partition_sizes.data(),
                                                           grid_size,
                                                           stream,
                                                           mr);
@@ -585,10 +578,10 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
       // Use copy_block_partitions to compute a gather map
       auto gather_map = compute_gather_map(num_rows,
                                            num_partitions,
-                                           row_partition_numbers_ptr,
-                                           row_partition_offset_ptr,
-                                           block_partition_sizes_ptr,
-                                           scanned_block_partition_sizes_ptr,
+                                           row_partition_numbers.data(),
+                                           row_partition_offset.data(),
+                                           block_partition_sizes.data(),
+                                           scanned_block_partition_sizes.data(),
                                            grid_size,
                                            stream);
 
@@ -597,13 +590,13 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
         input, gather_map.begin(), output_cols, detail::gather_bitmask_op::DONT_CHECK, stream, mr);
     }
 
-    auto output{std::make_unique<table>(std::move(output_cols))};
-    return std::make_pair(std::move(output), std::move(partition_offsets));
+    return std::make_pair(std::make_unique<table>(std::move(output_cols)),
+                          std::move(partition_offsets));
   } else {
     // Compute a scatter map from input to output such that the output rows are
     // sorted by partition number
-    auto row_output_locations{row_partition_numbers.data().get()};
-    auto scanned_block_partition_sizes_ptr{scanned_block_partition_sizes.data().get()};
+    auto row_output_locations{row_partition_numbers.data()};
+    auto scanned_block_partition_sizes_ptr{scanned_block_partition_sizes.data()};
     compute_row_output_locations<<<grid_size,
                                    block_size,
                                    num_partitions * sizeof(size_type),
@@ -648,7 +641,7 @@ struct dispatch_map_type {
              rmm::mr::device_memory_resource* mr) const
   {
     // Build a histogram of the number of rows in each partition
-    rmm::device_vector<size_type> histogram(num_partitions + 1);
+    rmm::device_uvector<size_type> histogram(num_partitions + 1, stream);
     std::size_t temp_storage_bytes{};
     std::size_t const num_levels = num_partitions + 1;
     size_type const lower_level  = 0;
@@ -656,7 +649,7 @@ struct dispatch_map_type {
     cub::DeviceHistogram::HistogramEven(nullptr,
                                         temp_storage_bytes,
                                         partition_map.begin<MapType>(),
-                                        histogram.data().get(),
+                                        histogram.data(),
                                         num_levels,
                                         lower_level,
                                         upper_level,
@@ -668,7 +661,7 @@ struct dispatch_map_type {
     cub::DeviceHistogram::HistogramEven(temp_storage.data(),
                                         temp_storage_bytes,
                                         partition_map.begin<MapType>(),
-                                        histogram.data().get(),
+                                        histogram.data(),
                                         num_levels,
                                         lower_level,
                                         upper_level,
@@ -681,12 +674,11 @@ struct dispatch_map_type {
       rmm::exec_policy(stream), histogram.begin(), histogram.end(), histogram.begin());
 
     // Copy offsets to host
-    std::vector<size_type> partition_offsets(histogram.size());
-    thrust::copy(histogram.begin(), histogram.end(), partition_offsets.begin());
+    auto const partition_offsets = cudf::detail::make_std_vector_sync(histogram, stream);
 
     // Unfortunately need to materialize the scatter map because
     // `detail::scatter` requires multiple passes through the iterator
-    rmm::device_vector<MapType> scatter_map(partition_map.size());
+    rmm::device_uvector<MapType> scatter_map(partition_map.size(), stream);
 
     // For each `partition_map[i]`, atomically increment the corresponding
     // partition offset to determine `i`s location in the output
@@ -694,7 +686,7 @@ struct dispatch_map_type {
                       partition_map.begin<MapType>(),
                       partition_map.end<MapType>(),
                       scatter_map.begin(),
-                      [offsets = histogram.data().get()] __device__(auto partition_number) {
+                      [offsets = histogram.data()] __device__(auto partition_number) {
                         return atomicAdd(&offsets[partition_number], 1);
                       });
 
@@ -702,7 +694,10 @@ struct dispatch_map_type {
     auto scattered =
       cudf::detail::scatter(t, scatter_map.begin(), scatter_map.end(), t, false, stream, mr);
 
-    return std::make_pair(std::move(scattered), std::move(partition_offsets));
+    // Copy offsets to host and return
+    return std::make_pair(
+      std::move(scattered),
+      std::move(partition_offsets));  // cudf::detail::make_std_vector_sync(histogram, stream));
   }
 
   template <typename MapType>

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -675,7 +675,7 @@ struct dispatch_map_type {
     thrust::exclusive_scan(
       rmm::exec_policy(stream), histogram.begin(), histogram.end(), histogram.begin());
 
-    // Copy offsets to host
+    // Copy offsets to host before the transform below modifies the histogram
     auto const partition_offsets = cudf::detail::make_std_vector_sync(histogram, stream);
 
     // Unfortunately need to materialize the scatter map because
@@ -696,10 +696,7 @@ struct dispatch_map_type {
     auto scattered =
       cudf::detail::scatter(t, scatter_map.begin(), scatter_map.end(), t, false, stream, mr);
 
-    // Copy offsets to host and return
-    return std::make_pair(
-      std::move(scattered),
-      std::move(partition_offsets));  // cudf::detail::make_std_vector_sync(histogram, stream));
+    return std::make_pair(std::move(scattered), std::move(partition_offsets));
   }
 
   template <typename MapType>

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -590,6 +590,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
         input, gather_map.begin(), output_cols, detail::gather_bitmask_op::DONT_CHECK, stream, mr);
     }
 
+    stream.synchronize();  // Async D2H copy must finish before returning host vec
     return std::make_pair(std::make_unique<table>(std::move(output_cols)),
                           std::move(partition_offsets));
   } else {
@@ -607,6 +608,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
     auto output = detail::scatter(
       input, row_partition_numbers.begin(), row_partition_numbers.end(), input, false, stream, mr);
 
+    stream.synchronize();  // Async D2H copy must finish before returning host vec
     return std::make_pair(std::move(output), std::move(partition_offsets));
   }
 }

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <cudf/detail/gather.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/table/row_operators.cuh>
 #include <cudf/table/table.hpp>
@@ -27,7 +28,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_vector.hpp>
+#include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/for_each.h>
@@ -44,8 +45,7 @@
 #include <vector>
 
 namespace {
-template <typename T>
-using VectorT = rmm::device_vector<T>;
+
 /**
  * @brief Handles the "degenerate" case num_partitions >= num_rows.
  *
@@ -84,7 +84,6 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
   auto nrows = input.num_rows();
 
   // iterator for partition index rotated right by start_partition positions:
-  //
   auto rotated_iter_begin = thrust::make_transform_iterator(
     thrust::make_counting_iterator<cudf::size_type>(0),
     [num_partitions, start_partition] __device__(auto index) {
@@ -92,7 +91,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
     });
 
   if (num_partitions == nrows) {
-    VectorT<cudf::size_type> partition_offsets(num_partitions, cudf::size_type{0});
+    rmm::device_uvector<cudf::size_type> partition_offsets(num_partitions, stream);
     thrust::sequence(rmm::exec_policy(stream), partition_offsets.begin(), partition_offsets.end());
 
     auto uniq_tbl = cudf::detail::gather(input,
@@ -102,25 +101,14 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
                                          stream,
                                          mr);
 
-    auto ret_pair =
-      std::make_pair(std::move(uniq_tbl), std::vector<cudf::size_type>(num_partitions));
-
-    CUDA_TRY(cudaMemcpyAsync(ret_pair.second.data(),
-                             partition_offsets.data().get(),
-                             sizeof(cudf::size_type) * num_partitions,
-                             cudaMemcpyDeviceToHost,
-                             stream.value()));
-
-    stream.synchronize();
-
-    return ret_pair;
+    return std::make_pair(std::move(uniq_tbl),
+                          cudf::detail::make_std_vector_sync(partition_offsets, stream));
   } else {  //( num_partitions > nrows )
-    VectorT<cudf::size_type> d_row_indices(nrows, cudf::size_type{0});
+    rmm::device_uvector<cudf::size_type> d_row_indices(nrows, stream);
 
     // copy rotated right partition indexes that
     // fall in the interval [0, nrows):
     //(this relies on a _stable_ copy_if())
-    //
     thrust::copy_if(rmm::exec_policy(stream),
                     rotated_iter_begin,
                     rotated_iter_begin + num_partitions,
@@ -128,7 +116,6 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
                     [nrows] __device__(auto index) { return (index < nrows); });
 
     //...and then use the result, d_row_indices, as gather map:
-    //
     auto uniq_tbl = cudf::detail::gather(input,
                                          d_row_indices.begin(),
                                          d_row_indices.end(),  // map
@@ -136,34 +123,22 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
                                          stream,
                                          mr);
 
-    auto ret_pair =
-      std::make_pair(std::move(uniq_tbl), std::vector<cudf::size_type>(num_partitions));
-
     // offsets (part 1: compute partition sizes);
     // iterator for number of edges of the transposed bipartite graph;
     // this composes rotated_iter transform (above) iterator with
     // calculating number of edges of transposed bi-graph:
-    //
     auto nedges_iter_begin = thrust::make_transform_iterator(
       rotated_iter_begin, [nrows] __device__(auto index) { return (index < nrows ? 1 : 0); });
 
     // offsets (part 2: compute partition offsets):
-    //
-    VectorT<cudf::size_type> partition_offsets(num_partitions, cudf::size_type{0});
+    rmm::device_uvector<cudf::size_type> partition_offsets(num_partitions, stream);
     thrust::exclusive_scan(rmm::exec_policy(stream),
                            nedges_iter_begin,
                            nedges_iter_begin + num_partitions,
                            partition_offsets.begin());
 
-    CUDA_TRY(cudaMemcpyAsync(ret_pair.second.data(),
-                             partition_offsets.data().get(),
-                             sizeof(cudf::size_type) * num_partitions,
-                             cudaMemcpyDeviceToHost,
-                             stream.value()));
-
-    stream.synchronize();
-
-    return ret_pair;
+    return std::make_pair(std::move(uniq_tbl),
+                          cudf::detail::make_std_vector_sync(partition_offsets, stream));
   }
 }
 }  // namespace

--- a/cpp/tests/partitioning/hash_partition_test.cpp
+++ b/cpp/tests/partitioning/hash_partition_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
+#include "cudf/detail/utilities/vector_factories.hpp"
 
 using cudf::test::fixed_width_column_wrapper;
 using cudf::test::strings_column_wrapper;
@@ -310,15 +311,15 @@ void run_fixed_width_test(size_t cols,
 
   // Compute the partition number for each row
   cudf::size_type partition = 0;
-  thrust::host_vector<cudf::size_type> partitions;
+  std::vector<cudf::size_type> partitions;
   std::for_each(offsets1.begin() + 1, offsets1.end(), [&](cudf::size_type const& count) {
     std::fill_n(std::back_inserter(partitions), count, partition++);
   });
 
   // Make a table view of the partition numbers
   constexpr cudf::data_type dtype{cudf::type_id::INT32};
-  rmm::device_vector<cudf::size_type> d_partitions(partitions);
-  cudf::column_view partitions_col(dtype, rows, d_partitions.data().get());
+  auto d_partitions = cudf::detail::make_device_uvector_sync(partitions);
+  cudf::column_view partitions_col(dtype, rows, d_partitions.data());
   cudf::table_view partitions_table({partitions_col});
 
   // Sort partition numbers by the corresponding row hashes of each output


### PR DESCRIPTION
Converts internals of cudf::partition/hash_partition, hashing, and nested_loop_join to use device_uvector instead of device_vector.

Changes `cudf::hash` API to take a `host_span` instead of a `std::vector`, hence marked as a breaking change.

Contributes to #7287

Performance is improved in hash_partition for smaller sizes, and is similar for larger sizes.

```
(rapids) rapids@compose:~/cudf/cpp/build/release$ _deps/benchmark-src/tools/compare.py benchmarks ~/cudf/cpp/build/hashing_before.json ~/cudf/cpp/build/hashing_after.json
Comparing /home/mharris/rapids/cudf/cpp/build/hashing_before.json to /home/mharris/rapids/cudf/cpp/build/hashing_after.json
Benchmark                                                             Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------
Hashing/hash_partition/131072/1/64/manual_time                     -0.2817         -0.2422             0             0             0             0
Hashing/hash_partition/262144/1/64/manual_time                     -0.2561         -0.2208             0             0             0             0
Hashing/hash_partition/524288/1/64/manual_time                     -0.2269         -0.1992             0             0             0             0
Hashing/hash_partition/1048576/1/64/manual_time                    -0.1864         -0.1683             0             0             0             0
Hashing/hash_partition/2097152/1/64/manual_time                    -0.1394         -0.1323             0             0             0             0
Hashing/hash_partition/131072/1/128/manual_time                    -0.2732         -0.2340             0             0             0             0
Hashing/hash_partition/262144/1/128/manual_time                    -0.2561         -0.2218             0             0             0             0
Hashing/hash_partition/524288/1/128/manual_time                    -0.2223         -0.1946             0             0             0             0
Hashing/hash_partition/1048576/1/128/manual_time                   -0.1847         -0.1664             0             0             0             0
Hashing/hash_partition/2097152/1/128/manual_time                   -0.1345         -0.1260             0             0             0             0
Hashing/hash_partition/131072/1/256/manual_time                    -0.2626         -0.2280             0             0             0             0
Hashing/hash_partition/262144/1/256/manual_time                    -0.2545         -0.2206             0             0             0             0
Hashing/hash_partition/524288/1/256/manual_time                    -0.2178         -0.1918             0             0             0             0
Hashing/hash_partition/1048576/1/256/manual_time                   -0.1739         -0.1577             0             0             0             0
Hashing/hash_partition/2097152/1/256/manual_time                   -0.1389         -0.1316             0             0             0             0
Hashing/hash_partition/131072/1/512/manual_time                    -0.2492         -0.2171             0             0             0             0
Hashing/hash_partition/262144/1/512/manual_time                    -0.2383         -0.2060             0             0             0             0
Hashing/hash_partition/524288/1/512/manual_time                    -0.1971         -0.1758             0             0             0             0
Hashing/hash_partition/1048576/1/512/manual_time                   -0.1679         -0.1529             0             0             0             0
Hashing/hash_partition/2097152/1/512/manual_time                   -0.1426         -0.1394             0             0             0             0
Hashing/hash_partition/131072/1/1024/manual_time                   -0.2246         -0.1952             0             0             0             0
Hashing/hash_partition/262144/1/1024/manual_time                   -0.2153         -0.1880             0             0             0             0
Hashing/hash_partition/524288/1/1024/manual_time                   -0.1851         -0.1664             0             0             0             0
Hashing/hash_partition/1048576/1/1024/manual_time                  -0.1456         -0.1350             0             0             0             0
Hashing/hash_partition/2097152/1/1024/manual_time                  -0.1190         -0.1141             0             0             0             0
Hashing/hash_partition/131072/16/64/manual_time                    -0.0639         -0.0638             0             0             0             0
Hashing/hash_partition/262144/16/64/manual_time                    -0.0462         -0.0450             0             0             0             0
Hashing/hash_partition/524288/16/64/manual_time                    -0.0354         -0.0368             1             1             1             1
Hashing/hash_partition/1048576/16/64/manual_time                   -0.0152         -0.0182             1             1             1             1
Hashing/hash_partition/2097152/16/64/manual_time                   -0.0142         -0.0151             2             2             2             2
Hashing/hash_partition/131072/16/128/manual_time                   -0.0618         -0.0604             0             0             0             0
Hashing/hash_partition/262144/16/128/manual_time                   -0.0472         -0.0463             0             0             0             0
Hashing/hash_partition/524288/16/128/manual_time                   -0.0383         -0.0383             1             1             1             1
Hashing/hash_partition/1048576/16/128/manual_time                  -0.0172         -0.0173             1             1             1             1
Hashing/hash_partition/2097152/16/128/manual_time                  -0.0034         -0.0037             2             2             2             2
Hashing/hash_partition/131072/16/256/manual_time                   -0.0542         -0.0539             0             0             0             0
Hashing/hash_partition/262144/16/256/manual_time                   -0.0472         -0.0463             0             0             0             0
Hashing/hash_partition/524288/16/256/manual_time                   -0.0382         -0.0391             1             1             1             1
Hashing/hash_partition/1048576/16/256/manual_time                  -0.0304         -0.0306             1             1             1             1
Hashing/hash_partition/2097152/16/256/manual_time                  -0.0178         -0.0187             2             2             2             2
Hashing/hash_partition/131072/16/512/manual_time                   +0.0108         +0.0198             0             0             0             0
Hashing/hash_partition/262144/16/512/manual_time                   -0.0391         -0.0391             1             0             1             1
Hashing/hash_partition/524288/16/512/manual_time                   -0.0310         -0.0311             1             1             1             1
Hashing/hash_partition/1048576/16/512/manual_time                  -0.0273         -0.0372             1             1             1             1
Hashing/hash_partition/2097152/16/512/manual_time                  -0.0043         -0.0050             2             2             2             2
Hashing/hash_partition/131072/16/1024/manual_time                  -0.0426         -0.0435             1             1             1             1
Hashing/hash_partition/262144/16/1024/manual_time                  -0.0318         -0.0319             1             1             1             1
Hashing/hash_partition/524288/16/1024/manual_time                  -0.0267         -0.0273             1             1             1             1
Hashing/hash_partition/1048576/16/1024/manual_time                 -0.0169         -0.0179             2             2             2             2
Hashing/hash_partition/2097152/16/1024/manual_time                 -0.0120         -0.0127             3             3             3             3
Hashing/hash_partition/131072/256/64/manual_time                   +0.0106         +0.0098             4             4             4             4
Hashing/hash_partition/262144/256/64/manual_time                   +0.0084         +0.0073             6             6             6             6
Hashing/hash_partition/524288/256/64/manual_time                   +0.0054         +0.0055             9             9             9             9
Hashing/hash_partition/1048576/256/64/manual_time                  +0.0160         +0.0154            17            17            17            17
Hashing/hash_partition/2097152/256/64/manual_time                  -0.0066         -0.0067            33            32            33            32
Hashing/hash_partition/131072/256/128/manual_time                  +0.0121         +0.0118             4             4             4             4
Hashing/hash_partition/262144/256/128/manual_time                  +0.0071         +0.0068             6             6             6             6
Hashing/hash_partition/524288/256/128/manual_time                  +0.0042         +0.0041             9             9             9             9
Hashing/hash_partition/1048576/256/128/manual_time                 +0.0039         +0.0039            17            17            17            17
Hashing/hash_partition/2097152/256/128/manual_time                 +0.0074         +0.0073            33            33            33            33
Hashing/hash_partition/131072/256/256/manual_time                  +0.0276         +0.0264             5             5             5             5
Hashing/hash_partition/262144/256/256/manual_time                  +0.0072         +0.0068             6             6             6             6
Hashing/hash_partition/524288/256/256/manual_time                  +0.0022         +0.0020             9             9             9             9
Hashing/hash_partition/1048576/256/256/manual_time                 -0.0035         -0.0036            17            17            17            17
Hashing/hash_partition/2097152/256/256/manual_time                 -0.0042         -0.0042            34            34            34            34
Hashing/hash_partition/131072/256/512/manual_time                  -0.0526         -0.0588             6             6             6             6
Hashing/hash_partition/262144/256/512/manual_time                  +0.0065         +0.0059             7             7             7             7
Hashing/hash_partition/524288/256/512/manual_time                  +0.0058         +0.0054            11            11            11            11
Hashing/hash_partition/1048576/256/512/manual_time                 -0.0030         -0.0030            20            20            20            20
Hashing/hash_partition/2097152/256/512/manual_time                 +0.0042         +0.0041            37            37            37            37
Hashing/hash_partition/131072/256/1024/manual_time                 +0.0075         +0.0066             7             8             7             8
Hashing/hash_partition/262144/256/1024/manual_time                 +0.0033         +0.0025             9             9             9             9
Hashing/hash_partition/524288/256/1024/manual_time                 +0.0025         +0.0019            14            14            14            14
Hashing/hash_partition/2097152/256/1024/manual_time                +0.0046         +0.0045            46            46            46            46
```