### PR TITLE
Fix bug: allow `lists::copy_slice` from an valid row that has an empty list

### DIFF
--- a/cpp/src/lists/copying/copying.cu
+++ b/cpp/src/lists/copying/copying.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/lists/copying/copying.cu
+++ b/cpp/src/lists/copying/copying.cu
@@ -35,7 +35,7 @@ std::unique_ptr<cudf::column> copy_slice(lists_column_view const& lists,
                                          rmm::cuda_stream_view stream,
                                          rmm::mr::device_memory_resource* mr)
 {
-  if (lists.is_empty()) { return cudf::empty_like(lists.parent()); }
+  if (lists.is_empty() or start == end) { return cudf::empty_like(lists.parent()); }
   if (end < 0 || end > lists.size()) end = lists.size();
   CUDF_EXPECTS(((start >= 0) && (start < end)), "Invalid slice range.");
   auto lists_count   = end - start;
@@ -45,10 +45,14 @@ std::unique_ptr<cudf::column> copy_slice(lists_column_view const& lists,
   start += lists.offset();
   end += lists.offset();
 
+  std::cout << start << " " << end << std::endl;
+
   // Offsets at the beginning and end of the slice:
   auto offsets_data = lists.offsets().data<cudf::size_type>();
   auto start_offset = cudf::detail::get_value<size_type>(lists.offsets(), start, stream);
   auto end_offset   = cudf::detail::get_value<size_type>(lists.offsets(), end, stream);
+
+  std::cout << start_offset << " " << end_offset << std::endl;
 
   rmm::device_uvector<cudf::size_type> out_offsets(offsets_count, stream);
 

--- a/cpp/src/lists/copying/copying.cu
+++ b/cpp/src/lists/copying/copying.cu
@@ -45,14 +45,10 @@ std::unique_ptr<cudf::column> copy_slice(lists_column_view const& lists,
   start += lists.offset();
   end += lists.offset();
 
-  std::cout << start << " " << end << std::endl;
-
   // Offsets at the beginning and end of the slice:
   auto offsets_data = lists.offsets().data<cudf::size_type>();
   auto start_offset = cudf::detail::get_value<size_type>(lists.offsets(), start, stream);
   auto end_offset   = cudf::detail::get_value<size_type>(lists.offsets(), end, stream);
-
-  std::cout << start_offset << " " << end_offset << std::endl;
 
   rmm::device_uvector<cudf::size_type> out_offsets(offsets_count, stream);
 

--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -15,6 +15,7 @@
  */
 
 #include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/detail/iterator.cuh>
@@ -432,6 +433,81 @@ TYPED_TEST(ListsColumnTest, ListsSlicedColumnViewConstructor)
   auto result = std::make_unique<cudf::column>(sliced);
 
   cudf::test::expect_columns_equal(expect, result->view());
+}
+
+TYPED_TEST(ListsColumnTest, ListsSlicedIncludesEmpty)
+{
+  cudf::test::lists_column_wrapper<TypeParam> list{{1, 2}, {}, {3, 4}, {8, 9}};
+  cudf::test::lists_column_wrapper<TypeParam> expect{{}, {3, 4}};
+
+  auto sliced = cudf::slice(list, {1, 3}).front();
+  auto result = std::make_unique<cudf::column>(sliced);
+
+  cudf::test::expect_columns_equal(expect, result->view());
+}
+
+TYPED_TEST(ListsColumnTest, ListsSlicedNonNestedEmpty)
+{
+  using LCW = cudf::test::lists_column_wrapper<TypeParam>;
+
+  // Column of List<int>
+  LCW list{{1, 2}, {}, {3, 4}, {8, 9}};
+  // Column of 1 row, an empty List<int>
+  LCW expect{LCW{}};
+
+  auto sliced = cudf::slice(list, {1, 2}).front();
+  auto result = std::make_unique<cudf::column>(sliced);
+
+  cudf::test::expect_columns_equal(expect, result->view());
+}
+
+TYPED_TEST(ListsColumnTest, ListsSlicedNestedEmpty)
+{
+  using LCW     = cudf::test::lists_column_wrapper<TypeParam>;
+  using FWCW_SZ = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+
+  // Column of List<List<int>>, with incomplete hierarchy
+  LCW list{{LCW{1}, LCW{2}},
+           {},  // < ----------- empty List<List<int>>, slice this
+           {LCW{3}, LCW{4, 5}}};
+
+  // Make 1-row column of type List<List<int>>, the row data contains 0 element.
+  // Well-formed memory layout:
+  // type: List<List<int>>
+  // Length: 1
+  // Mask: 1
+  // Offsets: 0, 0
+  //    List<int>
+  //    Length: 0
+  //    Offset:
+  //        INT
+  //        Length: 0
+  auto leaf      = std::make_unique<cudf::column>(cudf::column(LCW{}));
+  auto offset    = std::make_unique<cudf::column>(cudf::column(FWCW_SZ{0, 0}));
+  auto null_mask = cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED);
+  auto expect =
+    cudf::make_lists_column(1, std::move(offset), std::move(leaf), 0, std::move(null_mask));
+
+  auto sliced = cudf::slice(list, {1, 2}).front();
+  auto result = std::make_unique<cudf::column>(sliced);
+
+  cudf::test::expect_columns_equal(*expect, result->view());
+}
+
+TYPED_TEST(ListsColumnTest, ListsSlicedZeroSliceLength)
+{
+  using LCW     = cudf::test::lists_column_wrapper<TypeParam>;
+  using FWCW_SZ = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+
+  // Column of List<List<int>>, with incomplete hierarchy
+  LCW list{{LCW{1}, LCW{2}}, {}, {LCW{3}, LCW{4, 5}}};
+
+  auto expect = cudf::empty_like(list);
+
+  auto sliced = cudf::slice(list, {0, 0}).front();
+  auto result = std::make_unique<cudf::column>(sliced);
+
+  cudf::test::expect_columns_equal(*expect, result->view());
 }
 
 TYPED_TEST(ListsColumnTest, ListsSlicedColumnViewConstructorWithNulls)

--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -494,13 +494,28 @@ TYPED_TEST(ListsColumnTest, ListsSlicedNestedEmpty)
   cudf::test::expect_columns_equal(*expect, result->view());
 }
 
-TYPED_TEST(ListsColumnTest, ListsSlicedZeroSliceLength)
+TYPED_TEST(ListsColumnTest, ListsSlicedZeroSliceLengthNested)
 {
   using LCW     = cudf::test::lists_column_wrapper<TypeParam>;
   using FWCW_SZ = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
 
   // Column of List<List<int>>, with incomplete hierarchy
   LCW list{{LCW{1}, LCW{2}}, {}, {LCW{3}, LCW{4, 5}}};
+
+  auto expect = cudf::empty_like(list);
+
+  auto sliced = cudf::slice(list, {0, 0}).front();
+  auto result = std::make_unique<cudf::column>(sliced);
+
+  cudf::test::expect_columns_equal(*expect, result->view());
+}
+
+TYPED_TEST(ListsColumnTest, ListsSlicedZeroSliceLengthNonNested)
+{
+  using LCW     = cudf::test::lists_column_wrapper<TypeParam>;
+  using FWCW_SZ = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+
+  LCW list{{1, 2}, {}, {3, 4}, {8, 9}};
 
   auto expect = cudf::empty_like(list);
 


### PR DESCRIPTION
Previously, `lists::detail::copy_slice` rejects inputs with `start == end`.

However, this is a valid input. This is a special case, which can happen when user wants to slice a row that has 0 elements in a nested column:
```c++
using LCW     = cudf::test::lists_column_wrapper<TypeParam>;
// Column of List<List<int>>, with incomplete hierarchy
LCW list{{LCW{1}, LCW{2}},
        {},  // < ----------- empty List<List<int>>, slice this
        {LCW{3}, LCW{4, 5}}};
```
And since the `start_offset` and `end_offset` for this row is 2 and 2, it gets rejected by the function:
```
C++ exception with description "cuDF failure at: ../../../../src/lists/copying/copying.cu:40: Invalid slice range." thrown in the test body.
```

Even when user specifies a zero-length slice:
```
copy_slice(input, 0, 0)
```
This is still considered as valid. The expected return is an empty column the same type as `input`.

This PR permits such case and adds tests for it.