### PR TITLE
ensure cuFile JNI library is loaded before any use [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -34,29 +34,24 @@ import java.io.File;
  */
 public class CuFile {
   private static final Logger log = LoggerFactory.getLogger(CuFile.class);
-  private static boolean initialized = false;
+  private static final boolean INITIALIZED = initialize();
   private static CuFileDriver driver;
-
-  static {
-    initialize();
-  }
 
   /**
    * Load the native libraries needed for libcufilejni, if not loaded already; open the cuFile
    * driver, and add a shutdown hook to close it.
    */
-  private static synchronized void initialize() {
-    if (!initialized) {
-      try {
-        NativeDepsLoader.loadNativeDeps(new String[]{"cufilejni"});
-        driver = new CuFileDriver();
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-          driver.close();
-        }));
-        initialized = true;
-      } catch (Throwable t) {
-        log.error("Could not load cuFile jni library...", t);
-      }
+  private static synchronized boolean initialize() {
+    try {
+      NativeDepsLoader.loadNativeDeps(new String[]{"cufilejni"});
+      driver = new CuFileDriver();
+      Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        driver.close();
+      }));
+      return true;
+    } catch (Throwable t) {
+      log.error("Could not load cuFile jni library...", t);
+      return false;
     }
   }
 
@@ -66,7 +61,7 @@ public class CuFile {
    * @return true if the libcufilejni library has been successfully loaded.
    */
   public static boolean libraryLoaded() {
-    return initialized;
+    return INITIALIZED;
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -55,7 +55,6 @@ public class CuFile {
         }));
         initialized = true;
       } catch (Throwable t) {
-        log.error("Could not load cuFile jni library...", t);
         throw new RuntimeException(t);
       }
     }

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -34,24 +34,30 @@ import java.io.File;
  */
 public class CuFile {
   private static final Logger log = LoggerFactory.getLogger(CuFile.class);
-  private static final boolean INITIALIZED = initialize();
+  private static boolean initialized = false;
   private static CuFileDriver driver;
+
+  static {
+    initialize();
+  }
 
   /**
    * Load the native libraries needed for libcufilejni, if not loaded already; open the cuFile
    * driver, and add a shutdown hook to close it.
    */
-  private static synchronized boolean initialize() {
-    try {
-      NativeDepsLoader.loadNativeDeps(new String[]{"cufilejni"});
-      driver = new CuFileDriver();
-      Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-        driver.close();
-      }));
-      return true;
-    } catch (Throwable t) {
-      log.error("Could not load cuFile jni library...", t);
-      return false;
+  static synchronized void initialize() {
+    if (!initialized) {
+      try {
+        NativeDepsLoader.loadNativeDeps(new String[]{"cufilejni"});
+        driver = new CuFileDriver();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+          driver.close();
+        }));
+        initialized = true;
+      } catch (Throwable t) {
+        log.error("Could not load cuFile jni library...", t);
+        throw new RuntimeException(t);
+      }
     }
   }
 
@@ -61,7 +67,7 @@ public class CuFile {
    * @return true if the libcufilejni library has been successfully loaded.
    */
   public static boolean libraryLoaded() {
-    return INITIALIZED;
+    return initialized;
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/CuFileBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFileBuffer.java
@@ -20,6 +20,8 @@ package ai.rapids.cudf;
  * Represents a cuFile buffer.
  */
 public final class CuFileBuffer extends BaseDeviceMemoryBuffer {
+  @SuppressWarnings("unused")
+  private static final boolean CU_FILE_LIBRARY_LOADED = CuFile.libraryLoaded();
   private static final int ALIGNMENT = 4096;
 
   private final DeviceMemoryBuffer deviceMemoryBuffer;

--- a/java/src/main/java/ai/rapids/cudf/CuFileBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFileBuffer.java
@@ -20,12 +20,13 @@ package ai.rapids.cudf;
  * Represents a cuFile buffer.
  */
 public final class CuFileBuffer extends BaseDeviceMemoryBuffer {
-  @SuppressWarnings("unused")
-  private static final boolean CU_FILE_LIBRARY_LOADED = CuFile.libraryLoaded();
   private static final int ALIGNMENT = 4096;
-
   private final DeviceMemoryBuffer deviceMemoryBuffer;
   private final CuFileResourceCleaner cleaner;
+
+  static {
+    CuFile.initialize();
+  }
 
   /**
    * Construct a new cuFile buffer.

--- a/java/src/main/java/ai/rapids/cudf/CuFileDriver.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFileDriver.java
@@ -19,10 +19,10 @@ package ai.rapids.cudf;
 /**
  * Represents a cuFile driver.
  */
-public final class CuFileDriver implements AutoCloseable {
+final class CuFileDriver implements AutoCloseable {
   private final CuFileResourceCleaner cleaner;
 
-  public CuFileDriver() {
+  CuFileDriver() {
     cleaner = new CuFileResourceCleaner(create(), CuFileDriver::destroy);
     MemoryCleaner.register(this, cleaner);
   }

--- a/java/src/main/java/ai/rapids/cudf/CuFileHandle.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFileHandle.java
@@ -20,6 +20,8 @@ package ai.rapids.cudf;
  * Represents a cuFile file handle.
  */
 abstract class CuFileHandle implements AutoCloseable {
+  @SuppressWarnings("unused")
+  private static final boolean CU_FILE_LIBRARY_LOADED = CuFile.libraryLoaded();
   private final CuFileResourceCleaner cleaner;
 
   protected CuFileHandle(long pointer) {

--- a/java/src/main/java/ai/rapids/cudf/CuFileHandle.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFileHandle.java
@@ -20,9 +20,11 @@ package ai.rapids.cudf;
  * Represents a cuFile file handle.
  */
 abstract class CuFileHandle implements AutoCloseable {
-  @SuppressWarnings("unused")
-  private static final boolean CU_FILE_LIBRARY_LOADED = CuFile.libraryLoaded();
   private final CuFileResourceCleaner cleaner;
+
+  static {
+    CuFile.initialize();
+  }
 
   protected CuFileHandle(long pointer) {
     cleaner = new CuFileResourceCleaner(pointer, CuFileHandle::destroy);


### PR DESCRIPTION
Followup to #8053 to make sure `libcufilejni.so` is always loaded before creating `CuFileBuffer` or `CuFileHandle`.