### PR TITLE
don't throw an exception when cuFile jni can't be loaded [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -55,7 +55,8 @@ public class CuFile {
         }));
         initialized = true;
       } catch (Throwable t) {
-        throw new RuntimeException(t);
+        // Cannot throw an exception here as the CI/CD machine may not have GDS installed.
+        log.error("Could not load cuFile jni library...", t);
       }
     }
   }


### PR DESCRIPTION
The CI/CD machine may not have GDS installed and need to skip cuFile JNI tests, so can't throw an exception.