### PR TITLE
Fix `cudf_test/iterator_utilities.hpp`

### DIFF
--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -49,7 +49,7 @@ namespace test {
  * @return auto Validity iterator
  */
 template <typename Iter>
-static auto iterator_with_null_at(Iter index_start, Iter index_end)
+auto iterator_with_null_at(Iter index_start, Iter index_end)
 {
   using index_type = typename std::iterator_traits<Iter>::value_type;
 
@@ -77,7 +77,7 @@ static auto iterator_with_null_at(Iter index_start, Iter index_end)
  * @param indices The indices for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-static auto iterator_with_null_at(cudf::host_span<cudf::size_type const> const& indices)
+inline auto iterator_with_null_at(cudf::host_span<cudf::size_type const> const& indices)
 {
   return iterator_with_null_at(indices.begin(), indices.end());
 }
@@ -97,9 +97,19 @@ static auto iterator_with_null_at(cudf::host_span<cudf::size_type const> const& 
  * @param index The index for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-static auto iterator_with_null_at(cudf::size_type const& index)
+inline auto iterator_with_null_at(cudf::size_type const& index)
 {
   return iterator_with_null_at(std::vector<size_type>{index});
+}
+
+/**
+ * @brief Bool iterator for marking all elements are null
+ *
+ * @return auto Validity iterator which always yields `false`
+ */
+inline auto iterator_all_nulls()
+{
+  return cudf::detail::make_counting_transform_iterator(0, [](auto) { return false; });
 }
 
 }  // namespace test

--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -112,5 +112,15 @@ inline auto iterator_all_nulls()
   return cudf::detail::make_counting_transform_iterator(0, [](auto) { return false; });
 }
 
+/**
+ * @brief Bool iterator for marking all elements are valid (non-null)
+ *
+ * @return auto Validity iterator which always yields `true`
+ */
+inline auto iterator_no_nulls()
+{
+  return cudf::detail::make_counting_transform_iterator(0, [](auto) { return true; });
+}
+
 }  // namespace test
 }  // namespace cudf

--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -77,7 +77,7 @@ template <typename Iter>
  * @param indices The indices for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-[[maybe_unused]] auto iterator_with_null_at(cudf::host_span<cudf::size_type const> const& indices)
+[[maybe_unused]] auto iterator_with_null_at(cudf::host_span<cudf::size_type const> indices)
 {
   return iterator_with_null_at(indices.begin(), indices.end());
 }
@@ -97,7 +97,7 @@ template <typename Iter>
  * @param index The index for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-[[maybe_unused]] auto iterator_with_null_at(cudf::size_type const& index)
+[[maybe_unused]] auto iterator_with_null_at(cudf::size_type index)
 {
   return iterator_with_null_at(std::vector<size_type>{index});
 }

--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -107,20 +107,14 @@ inline auto iterator_with_null_at(cudf::size_type const& index)
  *
  * @return auto Validity iterator which always yields `false`
  */
-inline auto iterator_all_nulls()
-{
-  return cudf::detail::make_counting_transform_iterator(0, [](auto) { return false; });
-}
+inline auto iterator_all_nulls() { return thrust::make_constant_iterator(false); }
 
 /**
  * @brief Bool iterator for marking all elements are valid (non-null)
  *
  * @return auto Validity iterator which always yields `true`
  */
-inline auto iterator_no_null()
-{
-  return cudf::detail::make_counting_transform_iterator(0, [](auto) { return true; });
-}
+inline auto iterator_no_null() { return thrust::make_constant_iterator(true); }
 
 }  // namespace test
 }  // namespace cudf

--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -49,7 +49,7 @@ namespace test {
  * @return auto Validity iterator
  */
 template <typename Iter>
-[[maybe_unused]] auto iterator_with_null_at(Iter index_start, Iter index_end)
+[[maybe_unused]] static auto iterator_with_null_at(Iter index_start, Iter index_end)
 {
   using index_type = typename std::iterator_traits<Iter>::value_type;
 
@@ -77,7 +77,7 @@ template <typename Iter>
  * @param indices The indices for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-[[maybe_unused]] auto iterator_with_null_at(cudf::host_span<cudf::size_type const> indices)
+[[maybe_unused]] static auto iterator_with_null_at(cudf::host_span<cudf::size_type const> indices)
 {
   return iterator_with_null_at(indices.begin(), indices.end());
 }
@@ -97,7 +97,7 @@ template <typename Iter>
  * @param index The index for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-[[maybe_unused]] auto iterator_with_null_at(cudf::size_type index)
+[[maybe_unused]] static auto iterator_with_null_at(cudf::size_type index)
 {
   return iterator_with_null_at(std::vector<size_type>{index});
 }
@@ -107,14 +107,14 @@ template <typename Iter>
  *
  * @return auto Validity iterator which always yields `false`
  */
-[[maybe_unused]] auto iterator_all_nulls() { return thrust::make_constant_iterator(false); }
+[[maybe_unused]] static auto iterator_all_nulls() { return thrust::make_constant_iterator(false); }
 
 /**
  * @brief Bool iterator for marking all elements are valid (non-null)
  *
  * @return auto Validity iterator which always yields `true`
  */
-[[maybe_unused]] auto iterator_no_null() { return thrust::make_constant_iterator(true); }
+[[maybe_unused]] static auto iterator_no_null() { return thrust::make_constant_iterator(true); }
 
 }  // namespace test
 }  // namespace cudf

--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -49,7 +49,7 @@ namespace test {
  * @return auto Validity iterator
  */
 template <typename Iter>
-auto iterator_with_null_at(Iter index_start, Iter index_end)
+[[maybe_unused]] auto iterator_with_null_at(Iter index_start, Iter index_end)
 {
   using index_type = typename std::iterator_traits<Iter>::value_type;
 
@@ -77,7 +77,7 @@ auto iterator_with_null_at(Iter index_start, Iter index_end)
  * @param indices The indices for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-inline auto iterator_with_null_at(cudf::host_span<cudf::size_type const> const& indices)
+[[maybe_unused]] auto iterator_with_null_at(cudf::host_span<cudf::size_type const> const& indices)
 {
   return iterator_with_null_at(indices.begin(), indices.end());
 }
@@ -97,7 +97,7 @@ inline auto iterator_with_null_at(cudf::host_span<cudf::size_type const> const& 
  * @param index The index for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-inline auto iterator_with_null_at(cudf::size_type const& index)
+[[maybe_unused]] auto iterator_with_null_at(cudf::size_type const& index)
 {
   return iterator_with_null_at(std::vector<size_type>{index});
 }
@@ -107,14 +107,14 @@ inline auto iterator_with_null_at(cudf::size_type const& index)
  *
  * @return auto Validity iterator which always yields `false`
  */
-inline auto iterator_all_nulls() { return thrust::make_constant_iterator(false); }
+[[maybe_unused]] auto iterator_all_nulls() { return thrust::make_constant_iterator(false); }
 
 /**
  * @brief Bool iterator for marking all elements are valid (non-null)
  *
  * @return auto Validity iterator which always yields `true`
  */
-inline auto iterator_no_null() { return thrust::make_constant_iterator(true); }
+[[maybe_unused]] auto iterator_no_null() { return thrust::make_constant_iterator(true); }
 
 }  // namespace test
 }  // namespace cudf

--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -117,7 +117,7 @@ inline auto iterator_all_nulls()
  *
  * @return auto Validity iterator which always yields `true`
  */
-inline auto iterator_no_nulls()
+inline auto iterator_no_null()
 {
   return cudf::detail::make_counting_transform_iterator(0, [](auto) { return true; });
 }


### PR DESCRIPTION
Summary:
* Replace `static` by `inline` qualifier for the functions to fix compilation error `error: ‘auto cudf::test::XXX(...)’ defined but not used`.
* Add `iterator_all_nulls` function that returns an iterator which always yields `false`.
* Add `iterator_no_null` function that returns an iterator which always yields `true`.

The two new functions are required in some PRs for testing.