### PR TITLE
Fix groupby reduce_functor for fixed-point result-type

### DIFF
--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -65,7 +65,7 @@ struct reduce_functor {
     using OpType     = cudf::detail::corresponding_operator_t<K>;
     using ResultType = cudf::detail::target_type_t<T, K>;
 
-    auto result_type = is_fixed_point<T>()
+    auto result_type = is_fixed_point<ResultType>()
                          ? data_type{type_to_id<ResultType>(), values.type().scale()}
                          : data_type{type_to_id<ResultType>()};
 


### PR DESCRIPTION
The following error was found with a libcudf debug build when running its GROUPBY_TEST
```
  [ RUN      ] groupby_argmin_test/21.basic
  GROUPBY_TEST: ../include/cudf/types.hpp:267: cudf::data_type::data_type(cudf::type_id, int32_t): Assertion `id == type_id::DECIMAL32 || id == type_id::DECIMAL64' failed.
```

This PR corrects the logic error causing this assert.
The assert only occurs with a debug build so the failure was hidden but apparently benign since the `data_type` is still created properly.
