### PR TITLE
Use rmm::device_uvector in place of rmm::device_vector in cuIO

### DIFF
--- a/cpp/include/cudf/io/detail/avro.hpp
+++ b/cpp/include/cudf/io/detail/avro.hpp
@@ -47,7 +47,8 @@ class reader {
    */
   explicit reader(std::vector<std::string> const &filepaths,
                   avro_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Constructor from an array of datasources
@@ -58,7 +59,8 @@ class reader {
    */
   explicit reader(std::vector<std::unique_ptr<cudf::io::datasource>> &&sources,
                   avro_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Destructor explicitly-declared to avoid inlined in header

--- a/cpp/include/cudf/io/detail/csv.hpp
+++ b/cpp/include/cudf/io/detail/csv.hpp
@@ -42,7 +42,8 @@ class reader {
    */
   explicit reader(std::vector<std::string> const &filepaths,
                   csv_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Constructor from an array of datasources
@@ -53,7 +54,8 @@ class reader {
    */
   explicit reader(std::vector<std::unique_ptr<cudf::io::datasource>> &&sources,
                   csv_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Destructor explicitly-declared to avoid inlined in header

--- a/cpp/include/cudf/io/detail/json.hpp
+++ b/cpp/include/cudf/io/detail/json.hpp
@@ -55,7 +55,8 @@ class reader {
    */
   explicit reader(std::vector<std::string> const &filepaths,
                   json_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Constructor from an array of datasources
@@ -66,7 +67,8 @@ class reader {
    */
   explicit reader(std::vector<std::unique_ptr<cudf::io::datasource>> &&sources,
                   json_reader_options const &options,
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Destructor explicitly-declared to avoid inlined in header

--- a/cpp/include/cudf/io/detail/orc.hpp
+++ b/cpp/include/cudf/io/detail/orc.hpp
@@ -56,7 +56,8 @@ class reader {
    */
   explicit reader(std::vector<std::string> const& filepaths,
                   orc_reader_options const& options,
-                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Constructor from an array of datasources
@@ -67,7 +68,8 @@ class reader {
    */
   explicit reader(std::vector<std::unique_ptr<cudf::io::datasource>>&& sources,
                   orc_reader_options const& options,
-                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Destructor explicitly declared to avoid inlining in header

--- a/cpp/include/cudf/io/detail/parquet.hpp
+++ b/cpp/include/cudf/io/detail/parquet.hpp
@@ -58,7 +58,8 @@ class reader {
    */
   explicit reader(std::vector<std::string> const& filepaths,
                   parquet_reader_options const& options,
-                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Constructor from an array of datasources
@@ -69,7 +70,8 @@ class reader {
    */
   explicit reader(std::vector<std::unique_ptr<cudf::io::datasource>>&& sources,
                   parquet_reader_options const& options,
-                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(),
+                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default);
 
   /**
    * @brief Destructor explicitly-declared to avoid inlined in header

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -473,7 +473,8 @@ table_with_metadata reader::impl::read(avro_reader_options const &options,
 // Forward to implementation
 reader::reader(std::vector<std::string> const &filepaths,
                avro_reader_options const &options,
-               rmm::mr::device_memory_resource *mr)
+               rmm::mr::device_memory_resource *mr,
+               rmm::cuda_stream_view stream)
 {
   CUDF_EXPECTS(filepaths.size() == 1, "Only a single source is currently supported.");
   _impl = std::make_unique<impl>(datasource::create(filepaths[0]), options, mr);
@@ -482,7 +483,8 @@ reader::reader(std::vector<std::string> const &filepaths,
 // Forward to implementation
 reader::reader(std::vector<std::unique_ptr<cudf::io::datasource>> &&sources,
                avro_reader_options const &options,
-               rmm::mr::device_memory_resource *mr)
+               rmm::mr::device_memory_resource *mr,
+               rmm::cuda_stream_view stream)
 {
   CUDF_EXPECTS(sources.size() == 1, "Only a single source is currently supported.");
   _impl = std::make_unique<impl>(std::move(sources[0]), options, mr);

--- a/cpp/src/io/csv/reader_impl.hpp
+++ b/cpp/src/io/csv/reader_impl.hpp
@@ -75,11 +75,13 @@ class reader::impl {
    * @param filepath Filepath if reading dataset from a file
    * @param options Settings for controlling reading behavior
    * @param mr Device memory resource to use for device memory allocation
+   * @param stream TODO
    */
   explicit impl(std::unique_ptr<datasource> source,
                 std::string filepath,
                 csv_reader_options const &options,
-                rmm::mr::device_memory_resource *mr);
+                rmm::mr::device_memory_resource *mr,
+                rmm::cuda_stream_view stream);
 
   /**
    * @brief Read an entire set or a subset of data and returns a set of columns.

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -109,10 +109,11 @@ namespace {
 template <typename reader, typename reader_options>
 std::unique_ptr<reader> make_reader(source_info const& src_info,
                                     reader_options const& options,
-                                    rmm::mr::device_memory_resource* mr)
+                                    rmm::mr::device_memory_resource* mr,
+                  rmm::cuda_stream_view stream)
 {
   if (src_info.type == io_type::FILEPATH) {
-    return std::make_unique<reader>(src_info.filepaths, options, mr);
+    return std::make_unique<reader>(src_info.filepaths, options, mr, stream);
   }
 
   std::vector<std::unique_ptr<datasource>> datasources;
@@ -155,7 +156,7 @@ table_with_metadata read_avro(avro_reader_options const& opts, rmm::mr::device_m
   namespace avro = cudf::io::detail::avro;
 
   CUDF_FUNC_RANGE();
-  auto reader = make_reader<avro::reader>(opts.get_source(), opts, mr);
+  auto reader = make_reader<avro::reader>(opts.get_source(), opts, mr, rmm::cuda_stream_default);
   return reader->read(opts);
 }
 
@@ -164,7 +165,7 @@ table_with_metadata read_json(json_reader_options const& opts, rmm::mr::device_m
   namespace json = cudf::io::detail::json;
 
   CUDF_FUNC_RANGE();
-  auto reader = make_reader<json::reader>(opts.get_source(), opts, mr);
+  auto reader = make_reader<json::reader>(opts.get_source(), opts, mr, rmm::cuda_stream_default);
   return reader->read(opts);
 }
 
@@ -173,7 +174,8 @@ table_with_metadata read_csv(csv_reader_options const& options, rmm::mr::device_
   namespace csv = cudf::io::detail::csv;
 
   CUDF_FUNC_RANGE();
-  auto reader = make_reader<csv::reader>(options.get_source(), options, mr);
+  auto reader =
+    make_reader<csv::reader>(options.get_source(), options, mr, rmm::cuda_stream_default);
 
   return reader->read();
 }
@@ -345,7 +347,7 @@ parsed_orc_statistics read_parsed_orc_statistics(source_info const& src_info)
 table_with_metadata read_orc(orc_reader_options const& options, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  auto reader = make_reader<detail_orc::reader>(options.get_source(), options, mr);
+  auto reader = make_reader<detail_orc::reader>(options.get_source(), options, mr, rmm::cuda_stream_default);
 
   return reader->read(options);
 }
@@ -404,7 +406,7 @@ table_with_metadata read_parquet(parquet_reader_options const& options,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  auto reader = make_reader<detail_parquet::reader>(options.get_source(), options, mr);
+  auto reader = make_reader<detail_parquet::reader>(options.get_source(), options, mr, rmm::cuda_stream_default);
 
   return reader->read(options);
 }

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -303,9 +303,9 @@ void reader::impl::set_record_starts(rmm::cuda_stream_view stream)
   // If not starting at an offset, add an extra row to account for the first row in the file
   cudf::size_type prefilter_count = ((byte_range_offset_ == 0) ? 1 : 0);
   if (load_whole_file_) {
-    prefilter_count += count_all_from_set(data_, chars_to_count);
+    prefilter_count += count_all_from_set(data_, chars_to_count, stream);
   } else {
-    prefilter_count += count_all_from_set(uncomp_data_, uncomp_size_, chars_to_count);
+    prefilter_count += count_all_from_set(uncomp_data_, uncomp_size_, chars_to_count, stream);
   }
 
   rec_starts_.resize(prefilter_count);
@@ -321,9 +321,9 @@ void reader::impl::set_record_starts(rmm::cuda_stream_view stream)
   if (allow_newlines_in_strings_) { chars_to_find.push_back('\"'); }
   // Passing offset = 1 to return positions AFTER the found character
   if (load_whole_file_) {
-    find_all_from_set(data_, chars_to_find, 1, find_result_ptr);
+    find_all_from_set(data_, chars_to_find, 1, find_result_ptr, stream);
   } else {
-    find_all_from_set(uncomp_data_, uncomp_size_, chars_to_find, 1, find_result_ptr);
+    find_all_from_set(uncomp_data_, uncomp_size_, chars_to_find, 1, find_result_ptr, stream);
   }
 
   // Previous call stores the record pinput_file.typeositions as encountered by all threads

--- a/cpp/src/io/json/reader_impl.hpp
+++ b/cpp/src/io/json/reader_impl.hpp
@@ -34,8 +34,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
-
-#include <thrust/device_vector.h>
+#include <rmm/device_uvector.hpp>
 
 namespace cudf {
 namespace io {
@@ -67,7 +66,6 @@ class reader::impl {
   // Used when the input data is compressed, to ensure the allocated uncompressed data is freed
   std::vector<char> uncomp_data_owner_;
   rmm::device_buffer data_;
-  rmm::device_vector<uint64_t> rec_starts_;
 
   size_t byte_range_offset_ = 0;
   size_t byte_range_size_   = 0;
@@ -120,7 +118,7 @@ class reader::impl {
    * @return Array of keys and a map that maps their hash values to column indices
    */
   std::pair<std::vector<std::string>, col_map_ptr_type> get_json_object_keys_hashes(
-    rmm::cuda_stream_view stream);
+    device_span<uint64_t const> rec_starts, rmm::cuda_stream_view stream);
 
   /**
    * @brief Decompress the input data, if needed
@@ -130,13 +128,14 @@ class reader::impl {
   void decompress_input(rmm::cuda_stream_view stream);
 
   /**
-   * @brief Finds all record starts in the file and stores them in rec_starts_
+   * @brief Finds all record starts in the file.
    *
    * Does not upload the entire file to the GPU
    *
    * @param[in] stream CUDA stream used for device memory operations and kernel launches.
+   * @return Record starts in the device memory
    */
-  void set_record_starts(rmm::cuda_stream_view stream);
+  rmm::device_uvector<uint64_t> find_record_starts(rmm::cuda_stream_view stream);
 
   /**
    * @brief Uploads the relevant segment of the input json data onto the GPU.
@@ -145,34 +144,39 @@ class reader::impl {
    * Only rows that need to be parsed are copied, based on the byte range
    * Also updates the array of record starts to match the device data offset.
    */
-  void upload_data_to_device(rmm::cuda_stream_view stream);
+  void upload_data_to_device(rmm::device_uvector<uint64_t> &rec_starts,
+                             rmm::cuda_stream_view stream);
 
   /**
    * @brief Parse the first row to set the column name
    *
    * Sets the column_names_ data member
    *
+   * @param[in] rec_starts Record starts in device memory
    * @param[in] stream CUDA stream used for device memory operations and kernel launches.
    */
-  void set_column_names(rmm::cuda_stream_view stream);
+  void set_column_names(device_span<uint64_t const> rec_starts, rmm::cuda_stream_view stream);
 
   /**
    * @brief Set the data type array data member
    *
    * If user does not pass the data types, deduces types from the file content
    *
+   * @param[in] rec_starts Record starts in device memory
    * @param[in] stream CUDA stream used for device memory operations and kernel launches.
    */
-  void set_data_types(rmm::cuda_stream_view stream);
+  void set_data_types(device_span<uint64_t const> rec_starts, rmm::cuda_stream_view stream);
 
   /**
    * @brief Parse the input data and store results a table
    *
+   * @param[in] rec_starts Record starts in device memory
    * @param[in] stream CUDA stream used for device memory operations and kernel launches.
    *
    * @return Table and its metadata
    */
-  table_with_metadata convert_data_to_table(rmm::cuda_stream_view stream);
+  table_with_metadata convert_data_to_table(device_span<uint64_t const> rec_starts,
+                                            rmm::cuda_stream_view stream);
 
  public:
   /**

--- a/cpp/src/io/json/reader_impl.hpp
+++ b/cpp/src/io/json/reader_impl.hpp
@@ -185,7 +185,8 @@ class reader::impl {
   explicit impl(std::unique_ptr<datasource> source,
                 std::string filepath,
                 json_reader_options const &options,
-                rmm::mr::device_memory_resource *mr);
+                rmm::mr::device_memory_resource *mr,
+                rmm::cuda_stream_view stream);
 
   /**
    * @brief Read an entire set or a subset of data from the source

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -621,7 +621,8 @@ table_with_metadata reader::impl::read(size_type skip_rows,
 // Forward to implementation
 reader::reader(std::vector<std::string> const &filepaths,
                orc_reader_options const &options,
-               rmm::mr::device_memory_resource *mr)
+               rmm::mr::device_memory_resource *mr,
+               rmm::cuda_stream_view stream)
 {
   CUDF_EXPECTS(filepaths.size() == 1, "Only a single source is currently supported.");
   _impl = std::make_unique<impl>(datasource::create(filepaths[0]), options, mr);
@@ -630,7 +631,8 @@ reader::reader(std::vector<std::string> const &filepaths,
 // Forward to implementation
 reader::reader(std::vector<std::unique_ptr<cudf::io::datasource>> &&sources,
                orc_reader_options const &options,
-               rmm::mr::device_memory_resource *mr)
+               rmm::mr::device_memory_resource *mr,
+               rmm::cuda_stream_view stream)
 {
   CUDF_EXPECTS(sources.size() == 1, "Only a single source is currently supported.");
   _impl = std::make_unique<impl>(std::move(sources[0]), options, mr);

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -1591,7 +1591,8 @@ table_with_metadata reader::impl::read(size_type skip_rows,
 // Forward to implementation
 reader::reader(std::vector<std::string> const &filepaths,
                parquet_reader_options const &options,
-               rmm::mr::device_memory_resource *mr)
+               rmm::mr::device_memory_resource *mr,
+               rmm::cuda_stream_view stream)
   : _impl(std::make_unique<impl>(datasource::create(filepaths), options, mr))
 {
 }
@@ -1599,7 +1600,8 @@ reader::reader(std::vector<std::string> const &filepaths,
 // Forward to implementation
 reader::reader(std::vector<std::unique_ptr<cudf::io::datasource>> &&sources,
                parquet_reader_options const &options,
-               rmm::mr::device_memory_resource *mr)
+               rmm::mr::device_memory_resource *mr,
+               rmm::cuda_stream_view stream)
   : _impl(std::make_unique<impl>(std::move(sources), options, mr))
 {
 }

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -1,12 +1,10 @@
+#include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/io/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <thrust/device_vector.h>
 #include <thrust/pair.h>
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/device_vector.hpp>
-
-#include <cudf/io/types.hpp>
 
 #include <algorithm>
 
@@ -105,7 +103,8 @@ template <class T>
 cudf::size_type find_all_from_set(const rmm::device_buffer& d_data,
                                   const std::vector<char>& keys,
                                   uint64_t result_offset,
-                                  T* positions)
+                                  T* positions,
+                                  rmm::cuda_stream_view stream)
 {
   int block_size    = 0;  // suggested thread count to use
   int min_grid_size = 0;  // minimum block count required
@@ -113,17 +112,18 @@ cudf::size_type find_all_from_set(const rmm::device_buffer& d_data,
     cudaOccupancyMaxPotentialBlockSize(&min_grid_size, &block_size, count_and_set_positions<T>));
   const int grid_size = divCeil(d_data.size(), (size_t)block_size);
 
-  rmm::device_vector<cudf::size_type> d_count(1, 0);
+  auto d_count = cudf::detail::make_zeroed_device_uvector_async<cudf::size_type>(1, stream);
   for (char key : keys) {
-    count_and_set_positions<T><<<grid_size, block_size>>>(static_cast<const char*>(d_data.data()),
-                                                          d_data.size(),
-                                                          result_offset,
-                                                          key,
-                                                          d_count.data().get(),
-                                                          positions);
+    count_and_set_positions<T>
+      <<<grid_size, block_size, 0, stream.value()>>>(static_cast<const char*>(d_data.data()),
+                                                     d_data.size(),
+                                                     result_offset,
+                                                     key,
+                                                     d_count.data(),
+                                                     positions);
   }
 
-  return d_count[0];
+  return cudf::detail::make_std_vector_sync(d_count, stream)[0];
 }
 
 template <class T>
@@ -131,10 +131,11 @@ cudf::size_type find_all_from_set(const char* h_data,
                                   size_t h_size,
                                   const std::vector<char>& keys,
                                   uint64_t result_offset,
-                                  T* positions)
+                                  T* positions,
+                                  rmm::cuda_stream_view stream)
 {
-  rmm::device_buffer d_chunk(std::min(max_chunk_bytes, h_size));
-  rmm::device_vector<cudf::size_type> d_count(1, 0);
+  rmm::device_buffer d_chunk(std::min(max_chunk_bytes, h_size), stream);
+  auto d_count = cudf::detail::make_zeroed_device_uvector_async<cudf::size_type>(1, stream);
 
   int block_size    = 0;  // suggested thread count to use
   int min_grid_size = 0;  // minimum block count required
@@ -150,51 +151,62 @@ cudf::size_type find_all_from_set(const char* h_data,
     const int grid_size     = divCeil(chunk_bits, block_size);
 
     // Copy chunk to device
-    CUDA_TRY(cudaMemcpyAsync(d_chunk.data(), h_chunk, chunk_bytes, cudaMemcpyDefault));
+    CUDA_TRY(
+      cudaMemcpyAsync(d_chunk.data(), h_chunk, chunk_bytes, cudaMemcpyDefault, stream.value()));
 
     for (char key : keys) {
-      count_and_set_positions<T><<<grid_size, block_size>>>(static_cast<char*>(d_chunk.data()),
-                                                            chunk_bytes,
-                                                            chunk_offset + result_offset,
-                                                            key,
-                                                            d_count.data().get(),
-                                                            positions);
+      count_and_set_positions<T>
+        <<<grid_size, block_size, 0, stream.value()>>>(static_cast<char*>(d_chunk.data()),
+                                                       chunk_bytes,
+                                                       chunk_offset + result_offset,
+                                                       key,
+                                                       d_count.data(),
+                                                       positions);
     }
   }
 
-  return d_count[0];
+  return cudf::detail::make_std_vector_sync(d_count, stream)[0];
 }
 
 template cudf::size_type find_all_from_set<uint64_t>(const rmm::device_buffer& d_data,
                                                      const std::vector<char>& keys,
                                                      uint64_t result_offset,
-                                                     uint64_t* positions);
+                                                     uint64_t* positions,
+                                                     rmm::cuda_stream_view stream);
 
 template cudf::size_type find_all_from_set<pos_key_pair>(const rmm::device_buffer& d_data,
                                                          const std::vector<char>& keys,
                                                          uint64_t result_offset,
-                                                         pos_key_pair* positions);
+                                                         pos_key_pair* positions,
+                                                         rmm::cuda_stream_view stream);
 
 template cudf::size_type find_all_from_set<uint64_t>(const char* h_data,
                                                      size_t h_size,
                                                      const std::vector<char>& keys,
                                                      uint64_t result_offset,
-                                                     uint64_t* positions);
+                                                     uint64_t* positions,
+                                                     rmm::cuda_stream_view stream);
 
 template cudf::size_type find_all_from_set<pos_key_pair>(const char* h_data,
                                                          size_t h_size,
                                                          const std::vector<char>& keys,
                                                          uint64_t result_offset,
-                                                         pos_key_pair* positions);
+                                                         pos_key_pair* positions,
+                                                         rmm::cuda_stream_view stream);
 
-cudf::size_type count_all_from_set(const rmm::device_buffer& d_data, const std::vector<char>& keys)
+cudf::size_type count_all_from_set(const rmm::device_buffer& d_data,
+                                   const std::vector<char>& keys,
+                                   rmm::cuda_stream_view stream)
 {
-  return find_all_from_set<void>(d_data, keys, 0, nullptr);
+  return find_all_from_set<void>(d_data, keys, 0, nullptr, stream);
 }
 
-cudf::size_type count_all_from_set(const char* h_data, size_t h_size, const std::vector<char>& keys)
+cudf::size_type count_all_from_set(const char* h_data,
+                                   size_t h_size,
+                                   const std::vector<char>& keys,
+                                   rmm::cuda_stream_view stream)
 {
-  return find_all_from_set<void>(h_data, h_size, keys, 0, nullptr);
+  return find_all_from_set<void>(h_data, h_size, keys, 0, nullptr, stream);
 }
 
 std::string infer_compression_type(

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -388,7 +388,8 @@ template <class T>
 cudf::size_type find_all_from_set(const rmm::device_buffer& d_data,
                                   const std::vector<char>& keys,
                                   uint64_t result_offset,
-                                  T* positions);
+                                  T* positions,
+                                  rmm::cuda_stream_view stream);
 
 /**
  * @brief Searches the input character array for each of characters in a set.
@@ -411,7 +412,8 @@ cudf::size_type find_all_from_set(const char* h_data,
                                   size_t h_size,
                                   const std::vector<char>& keys,
                                   uint64_t result_offset,
-                                  T* positions);
+                                  T* positions,
+                                  rmm::cuda_stream_view stream);
 
 /**
  * @brief Searches the input character array for each of characters in a set
@@ -422,7 +424,9 @@ cudf::size_type find_all_from_set(const char* h_data,
  *
  * @return cudf::size_type total number of occurrences
  */
-cudf::size_type count_all_from_set(const rmm::device_buffer& d_data, const std::vector<char>& keys);
+cudf::size_type count_all_from_set(const rmm::device_buffer& d_data,
+                                   const std::vector<char>& keys,
+                                   rmm::cuda_stream_view stream);
 
 /**
  * @brief Searches the input character array for each of characters in a set
@@ -439,7 +443,8 @@ cudf::size_type count_all_from_set(const rmm::device_buffer& d_data, const std::
  */
 cudf::size_type count_all_from_set(const char* h_data,
                                    size_t h_size,
-                                   const std::vector<char>& keys);
+                                   const std::vector<char>& keys,
+                                   rmm::cuda_stream_view stream);
 
 /**
  * @brief Infer file compression type based on user supplied arguments.


### PR DESCRIPTION
Issue #7287

Replaces `device_vector` with `device_uvector`. Additional changes were needed to provide the stream parameter at construction time. Reduced the mutable state of the JSON reader.

Performance impact: TBD