### PR TITLE
Fix scatter output size for structs.

### DIFF
--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -317,7 +317,7 @@ struct column_scatterer_impl<struct_view> {
 
     // Need to put the result column in a vector to call `gather_bitmask`
     std::vector<std::unique_ptr<column>> result;
-    result.emplace_back(cudf::make_structs_column(source.size(),
+    result.emplace_back(cudf::make_structs_column(target.size(),
                                                   std::move(output_struct_members),
                                                   0,
                                                   rmm::device_buffer{0, stream, mr},

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -206,8 +206,8 @@ ConfigureTest(COPYING_TEST
     copying/pack_tests.cu
     copying/sample_tests.cpp
     copying/scatter_tests.cpp
-    copying/scatter_list_tests.cu
-    copying/scatter_struct_tests.cu
+    copying/scatter_list_tests.cpp
+    copying/scatter_struct_tests.cpp
     copying/segmented_gather_list_tests.cpp
     copying/shift_tests.cpp
     copying/slice_tests.cpp

--- a/cpp/tests/copying/scatter_list_tests.cpp
+++ b/cpp/tests/copying/scatter_list_tests.cpp
@@ -18,8 +18,6 @@
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/iterator.cuh>
-#include <cudf/detail/scatter.cuh>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>

--- a/cpp/tests/copying/scatter_struct_tests.cpp
+++ b/cpp/tests/copying/scatter_struct_tests.cpp
@@ -291,3 +291,24 @@ TYPED_TEST(TypedStructScatterTest, ScatterStructOfListsTest)
   auto const scatter_map = int32s_col{-3, -2, -1, 5, 4, 3, 2}.release();
   test_scatter(structs_src, structs_tgt, structs_expected, scatter_map);
 }
+
+TYPED_TEST(TypedStructScatterTest, ScatterSourceSmallerThanTarget)
+{
+  using namespace cudf;
+  using namespace cudf::test;
+
+  using fixed_width     = fixed_width_column_wrapper<TypeParam, int32_t>;
+  using structs_col     = structs_column_wrapper;
+  using scatter_map_col = fixed_width_column_wrapper<offset_type, int32_t>;
+
+  auto source_child   = fixed_width{22, 55};
+  auto target_child   = fixed_width{0, 1, 2, 3, 4, 5, 6};
+  auto expected_child = fixed_width{0, 1, 22, 3, 4, 55, 6};
+
+  auto const source      = structs_col{{source_child}}.release();
+  auto const target      = structs_col{{target_child}}.release();
+  auto const scatter_map = scatter_map_col{2, 5}.release();
+  auto const expected    = structs_col{{expected_child}}.release();
+
+  test_scatter(source, target, expected, scatter_map);
+}


### PR DESCRIPTION
Fixes #8150, which causes CUDF failures if the `scatter()` source struct column has a different size from that of the target. It turns out that the implementation was erroneously using the source column's size to construct the result, instead of the target's.

The following changes were made in this commit:

1. Scatter output's size was set to target's size instead of source.
2. Test case for the above.
3. Peripherally, `scatter_lists_test` and `scatter_struct_test` were moved from `.cu` to `.cpp`, for faster compile.