### PR TITLE
Fix Java nightly build [skip ci]

### DIFF
--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -50,9 +50,7 @@ message(VERBOSE "CUDF_JNI: Statically link the CUDA runtime: ${CUDA_STATIC_RUNTI
 message(VERBOSE "CUDF_JNI: Build with GPUDirect Storage support: ${USE_GDS}")
 
 set(CUDF_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../../../cpp")
-if (NOT CUDF_CPP_BUILD_DIR)
-    set(CUDF_CPP_BUILD_DIR "${CUDF_SOURCE_DIR}/build")
-endif()
+set(CUDF_CPP_BUILD_DIR "${CUDF_SOURCE_DIR}/build")
 
 set(CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/"


### PR DESCRIPTION
#7998 made a change to the Java native CMakeLists.txt that breaks the Java nightly builds.  Reverting that specific change to restore the build.