### PR TITLE
Fix interleave_columns on ListType with nullable child

### DIFF
--- a/cpp/src/lists/interleave_columns.cu
+++ b/cpp/src/lists/interleave_columns.cu
@@ -167,15 +167,15 @@ struct interleave_list_entries_fn {
     column_view const& output_list_offsets,
     size_type num_output_lists,
     size_type num_output_entries,
-    bool has_null_mask,
+    bool data_has_null_mask,
     rmm::cuda_stream_view stream,
     rmm::mr::device_memory_resource* mr) const noexcept
   {
     auto const table_dv_ptr = table_device_view::create(input);
     auto const comp_fn      = compute_string_sizes_and_interleave_lists_fn{
-      *table_dv_ptr, output_list_offsets.template begin<offset_type>(), has_null_mask};
+      *table_dv_ptr, output_list_offsets.template begin<offset_type>(), data_has_null_mask};
 
-    if (has_null_mask) {
+    if (data_has_null_mask) {
       auto [offsets_column, chars_column, null_mask, null_count] =
         cudf::strings::detail::make_strings_children_with_null_mask(
           comp_fn, num_output_lists, num_output_entries, stream, mr);
@@ -205,7 +205,7 @@ struct interleave_list_entries_fn {
     column_view const& output_list_offsets,
     size_type num_output_lists,
     size_type num_output_entries,
-    bool has_null_mask,
+    bool data_has_null_mask,
     rmm::cuda_stream_view stream,
     rmm::mr::device_memory_resource* mr) const noexcept
   {
@@ -222,7 +222,8 @@ struct interleave_list_entries_fn {
     auto output_dv_ptr = mutable_column_device_view::create(*output);
 
     // The array of int8_t to store entry validities.
-    auto validities = rmm::device_uvector<int8_t>(has_null_mask ? num_output_entries : 0, stream);
+    auto validities =
+      rmm::device_uvector<int8_t>(data_has_null_mask ? num_output_entries : 0, stream);
 
     thrust::for_each_n(
       rmm::exec_policy(stream),
@@ -233,7 +234,7 @@ struct interleave_list_entries_fn {
        d_validities = validities.begin(),
        d_offsets    = output_list_offsets.template begin<offset_type>(),
        d_output     = output_dv_ptr->template begin<T>(),
-       has_null_mask] __device__(size_type const idx) {
+       data_has_null_mask] __device__(size_type const idx) {
         auto const col_id     = idx % num_cols;
         auto const list_id    = idx / num_cols;
         auto const& lists_col = table_dv.column(col_id);
@@ -248,7 +249,7 @@ struct interleave_list_entries_fn {
         auto const write_start = d_offsets[idx];
 
         // Fill the validities array if necessary.
-        if (has_null_mask) {
+        if (data_has_null_mask) {
           for (auto read_idx = start_idx, write_idx = write_start; read_idx < end_idx;
                ++read_idx, ++write_idx) {
             d_validities[write_idx] = static_cast<int8_t>(data_col.is_valid(read_idx));
@@ -263,7 +264,7 @@ struct interleave_list_entries_fn {
           thrust::seq, input_ptr, input_ptr + sizeof(T) * (end_idx - start_idx), output_ptr);
       });
 
-    if (has_null_mask) {
+    if (data_has_null_mask) {
       auto [null_mask, null_count] = cudf::detail::valid_if(
         validities.begin(), validities.end(), thrust::identity<int8_t>{}, stream, mr);
       if (null_count > 0) { output->set_null_mask(null_mask, null_count); }
@@ -323,13 +324,17 @@ std::unique_ptr<column> interleave_columns(table_view const& input,
   auto const num_output_lists = input.num_rows() * input.num_columns();
   auto const num_output_entries =
     cudf::detail::get_value<offset_type>(offsets_view, num_output_lists, stream);
+  auto const data_has_null_mask =
+    std::any_of(std::cbegin(input), std::cend(input), [](auto const& col) {
+      return col.child(lists_column_view::child_column_index).nullable();
+    });
   auto list_entries = type_dispatcher<dispatch_storage_type>(entry_type,
                                                              interleave_list_entries_fn{},
                                                              input,
                                                              offsets_view,
                                                              num_output_lists,
                                                              num_output_entries,
-                                                             has_null_mask,
+                                                             data_has_null_mask,
                                                              stream,
                                                              mr);
 


### PR DESCRIPTION
Current PR is to fix `interleave_columns` on ListType with nullable child column. The problem is regarding `list_has_null_mask` as `data_has_null_mask` by mistake. This problem also breaks `cudf::lists::concatenate_rows`.

