### PR TITLE
Check if a map contains a specific key [skip ci]

### DIFF
--- a/java/rmm_log.txt
+++ b/java/rmm_log.txt
@@ -1,0 +1,6 @@
+[ 36761][16:10:56:695952][info  ] ----- RMM LOG BEGIN [PTDS DISABLED] -----
+[ 36761][16:10:56:695976][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
+[ 36761][16:10:56:696008][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
+[ 36761][16:10:56:696028][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
+[ 36761][16:10:56:732564][error ] [A][Stream 0x1][Upstream 1024B][FAILURE maximum pool size exceeded]
+[ 36761][16:10:56:875676][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]

--- a/java/rmm_log.txt
+++ b/java/rmm_log.txt
@@ -1,6 +1,0 @@
-[ 36761][16:10:56:695952][info  ] ----- RMM LOG BEGIN [PTDS DISABLED] -----
-[ 36761][16:10:56:695976][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
-[ 36761][16:10:56:696008][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
-[ 36761][16:10:56:696028][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]
-[ 36761][16:10:56:732564][error ] [A][Stream 0x1][Upstream 1024B][FAILURE maximum pool size exceeded]
-[ 36761][16:10:56:875676][error ] [A][Stream 0x1][Upstream 3458764513820540928B][FAILURE maximum pool size exceeded]

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2527,7 +2527,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /** For a column of type List<Struct<String, String>> and a passed in String key, return a boolean
-   * scalar for all keys in the structs, true if the key exists in all maps in the column.
+   * column for all keys in the structs, true if the key exists in all maps in the column.
    * @param key the String scalar to lookup in the column
    * @return a boolean column based on the lookup result
    */
@@ -2861,7 +2861,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Native method for check the existence of a key over a column of List<Struct<String,String>>
    * @param columnView the column view handle of the map
    * @param key the string scalar that is the key for lookup
-   * @return an boolean column handle of the resultant
+   * @return boolean column handle of the result
    * @throws CudfException
    */
   private static native long mapContains(long columnView, long key) throws CudfException;

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2529,14 +2529,14 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   /** For a column of type List<Struct<String, String>> and a passed in String key, return a boolean
    * scalar for all keys in the structs, true if the key exists in all maps in the column.
    * @param key the String scalar to lookup in the column
-   * @return a boolean scalar based on the lookup result
+   * @return a boolean column based on the lookup result
    */
-  public final Scalar getMapKeyExistence(Scalar key) {
+  public final ColumnVector getMapKeyExistence(Scalar key) {
     assert type.equals(DType.LIST) : "column type must be a LIST";
     assert key != null : "target string may not be null";
     assert key.getType().equals(DType.STRING) : "target must be a string scalar";
 
-    return new Scalar(DType.BOOL8, mapContains(getNativeView(), key.getScalarHandle()));
+    return new ColumnVector(mapContains(getNativeView(), key.getScalarHandle()));
   }
 
   /**
@@ -2861,7 +2861,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Native method for check the existence of a key over a column of List<Struct<String,String>>
    * @param columnView the column view handle of the map
    * @param key the string scalar that is the key for lookup
-   * @return an boolean scalar handle of the resultant
+   * @return an boolean column handle of the resultant
    * @throws CudfException
    */
   private static native long mapContains(long columnView, long key) throws CudfException;

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2526,8 +2526,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     return new ColumnVector(mapLookup(getNativeView(), key.getScalarHandle()));
   }
 
-  /** For a column of type List<Struct<String, String>> and a passed in String key, return an int column
-   * for all the offsets(index) in the struct for key, -1 if the key doesn't exist.
+  /** For a column of type List<Struct<String, String>> and a passed in String key, return a boolean
+   * column for all keys in the structs, false if the key doesn't exist.
    * @param key the String scalar to lookup in the column
    * @return a boolean column based on the lookup result
    */

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2527,16 +2527,16 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /** For a column of type List<Struct<String, String>> and a passed in String key, return a boolean
-   * column for all keys in the structs, false if the key doesn't exist.
+   * scalar for all keys in the structs, true if the key exists in all maps in the column.
    * @param key the String scalar to lookup in the column
-   * @return a boolean column based on the lookup result
+   * @return a boolean scalar based on the lookup result
    */
-  public final ColumnVector getMapKeyExistence(Scalar key) {
+  public final Scalar getMapKeyExistence(Scalar key) {
     assert type.equals(DType.LIST) : "column type must be a LIST";
     assert key != null : "target string may not be null";
     assert key.getType().equals(DType.STRING) : "target must be a string scalar";
 
-    return new ColumnVector(mapContains(getNativeView(), key.getScalarHandle()));
+    return new Scalar(DType.BOOL8, mapContains(getNativeView(), key.getScalarHandle()));
   }
 
   /**
@@ -2861,7 +2861,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Native method for check the existence of a key over a column of List<Struct<String,String>>
    * @param columnView the column view handle of the map
    * @param key the string scalar that is the key for lookup
-   * @return an boolean column handle of the resultant
+   * @return an boolean scalar handle of the resultant
    * @throws CudfException
    */
   private static native long mapContains(long columnView, long key) throws CudfException;

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2527,7 +2527,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /** For a column of type List<Struct<String, String>> and a passed in String key, return a boolean
-   * column for all keys in the structs, true if the key exists in all maps in the column.
+   * column for all keys in the structs, It is true if the key exists in the corresponding map for
+   * that row, false otherwise. It will never return null for a row.
    * @param key the String scalar to lookup in the column
    * @return a boolean column based on the lookup result
    */

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2526,10 +2526,15 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     return new ColumnVector(mapLookup(getNativeView(), key.getScalarHandle()));
   }
 
+  /** For a column of type List<Struct<String, String>> and a passed in String key, return an int column
+   * for all the offsets(index) in the struct for key, -1 if the key doesn't exist.
+   * @param key the String scalar to lookup in the column
+   * @return a boolean column based on the lookup result
+   */
   public final ColumnVector getMapKeyExistence(Scalar key) {
     assert type.equals(DType.LIST) : "column type must be a LIST";
     assert key != null : "target string may not be null";
-    assert key.getType().equals(DType.STRING) : "target string must be a string scalar";
+    assert key.getType().equals(DType.STRING) : "target must be a string scalar";
 
     return new ColumnVector(mapContains(getNativeView(), key.getScalarHandle()));
   }
@@ -2852,6 +2857,13 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    */
   private static native long mapLookup(long columnView, long key) throws CudfException;
 
+  /**
+   * Native method for check the existence of a key over a column of List<Struct<String,String>>
+   * @param columnView the column view handle of the map
+   * @param key the string scalar that is the key for lookup
+   * @return an boolean column handle of the resultant
+   * @throws CudfException
+   */
   private static native long mapContains(long columnView, long key) throws CudfException;
   /**
    * Native method to add zeros as padding to the left of each string.

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2526,6 +2526,13 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     return new ColumnVector(mapLookup(getNativeView(), key.getScalarHandle()));
   }
 
+  public final ColumnVector getMapKeyExistence(Scalar key) {
+    assert type.equals(DType.LIST) : "column type must be a LIST";
+    assert key != null : "target string may not be null";
+    assert key.getType().equals(DType.STRING) : "target string must be a string scalar";
+
+    return new ColumnVector(mapContains(getNativeView(), key.getScalarHandle()));
+  }
 
   /**
    * Create a new struct column view of existing column views. Note that this will NOT copy
@@ -2844,6 +2851,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @throws CudfException
    */
   private static native long mapLookup(long columnView, long key) throws CudfException;
+
+  private static native long mapContains(long columnView, long key) throws CudfException;
   /**
    * Native method to add zeros as padding to the left of each string.
    */

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1169,6 +1169,22 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapLookup(JNIEnv *env, jc
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapSearchKey(JNIEnv *env, jclass,
+                                                                 jlong map_column_view,
+                                                                 jlong lookup_key) {
+  JNI_NULL_CHECK(env, map_column_view, "column is null", 0);
+  JNI_NULL_CHECK(env, lookup_key, "target string scalar is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(map_column_view);
+    cudf::string_scalar *ss_key = reinterpret_cast<cudf::string_scalar *>(lookup_key);
+
+    std::unique_ptr<cudf::column> result = cudf::jni::map_search_key(*cv, *ss_key);
+    return reinterpret_cast<jlong>(result.release());
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplaceWithBackrefs(JNIEnv *env,
                                                                                  jclass,
                                                                                  jlong column_view,

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1169,7 +1169,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapLookup(JNIEnv *env, jc
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapSearchKey(JNIEnv *env, jclass,
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapContains(JNIEnv *env, jclass,
                                                                  jlong map_column_view,
                                                                  jlong lookup_key) {
   JNI_NULL_CHECK(env, map_column_view, "column is null", 0);
@@ -1179,7 +1179,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapSearchKey(JNIEnv *env,
     cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(map_column_view);
     cudf::string_scalar *ss_key = reinterpret_cast<cudf::string_scalar *>(lookup_key);
 
-    std::unique_ptr<cudf::column> result = cudf::jni::map_search_key(*cv, *ss_key);
+    std::unique_ptr<cudf::column> result = cudf::jni::map_contains(*cv, *ss_key);
     return reinterpret_cast<jlong>(result.release());
   }
   CATCH_STD(env, 0);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1170,8 +1170,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapLookup(JNIEnv *env, jc
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapContains(JNIEnv *env, jclass,
-                                                                 jlong map_column_view,
-                                                                 jlong lookup_key) {
+                                                                   jlong map_column_view,
+                                                                   jlong lookup_key) {
   JNI_NULL_CHECK(env, map_column_view, "column is null", 0);
   JNI_NULL_CHECK(env, lookup_key, "target string scalar is null", 0);
   try {
@@ -1179,7 +1179,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapContains(JNIEnv *env, 
     cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(map_column_view);
     cudf::string_scalar *ss_key = reinterpret_cast<cudf::string_scalar *>(lookup_key);
 
-    std::unique_ptr<cudf::column> result = cudf::jni::map_contains(*cv, *ss_key);
+    std::unique_ptr<cudf::scalar> result = cudf::jni::map_contains(*cv, *ss_key);
     return reinterpret_cast<jlong>(result.release());
   }
   CATCH_STD(env, 0);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1179,7 +1179,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapContains(JNIEnv *env, 
     cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(map_column_view);
     cudf::string_scalar *ss_key = reinterpret_cast<cudf::string_scalar *>(lookup_key);
 
-    std::unique_ptr<cudf::scalar> result = cudf::jni::map_contains(*cv, *ss_key);
+    std::unique_ptr<cudf::column> result = cudf::jni::map_contains(*cv, *ss_key);
     return reinterpret_cast<jlong>(result.release());
   }
   CATCH_STD(env, 0);

--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -19,7 +19,6 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
-#include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/lists/contains.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/replace.hpp>

--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -30,7 +30,6 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/exec_policy.hpp>
 
 namespace cudf {
 namespace {

--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -128,7 +128,7 @@ get_gather_map_for_map_values(column_view const &input, string_scalar &lookup_ke
 
 namespace jni {
 
-std::unique_ptr<column> map_search_key(column_view const &map_column, string_scalar lookup_key,
+std::unique_ptr<column> map_contains(column_view const &map_column, string_scalar lookup_key,
                                         bool has_nulls, rmm::cuda_stream_view stream,
                                         rmm::mr::device_memory_resource *mr) {
   // Defensive checks.

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/column/column.hpp>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
 
 namespace cudf {
 
@@ -66,12 +67,12 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
  *
  * @param map_column The input "map" column to be searched. Must be of
  *                   type list_view<struct_view<string_view, string_view>>.
- * @param lookup_key The search key, whose value is to be returned for each list row
+ * @param lookup_key The search key, whose index(offset) is to be returned for each list row
  * @param has_nulls  Whether the input column might contain null list-rows, or null keys.
  * @param stream     The CUDA stream
  * @param mr         The device memory resource to be used for allocations
- * @return           A string_view column with the value from the first match in each list.
- *                   A null row is returned for any row where the lookup_key is not found.
+ * @return           An boolean_view column reflecting the existence for the key in each list.
+ *                   false means the lookup_key is not found.
  * @throw cudf::logic_error If the input column is not of type
  *                          list_view<struct_view<string_view, string_view>>
  */

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -62,7 +62,7 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
  *                         <---KEY--->  <--VALUE-->
  *
  * The string_view struct members are the key and value, respectively.
- * For each row in the input list column. If the key is not found, -1 is returned.
+ * For any row in the input list column, if the key is not found, false will be returned.
  *
  * @param map_column The input "map" column to be searched. Must be of
  *                   type list_view<struct_view<string_view, string_view>>.
@@ -70,12 +70,12 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
  * @param has_nulls  Whether the input column might contain null list-rows, or null keys.
  * @param stream     The CUDA stream
  * @param mr         The device memory resource to be used for allocations
- * @return           An boolean_view column reflecting the existence for the key in each list.
- *                   false means the lookup_key is not found.
+ * @return           An boolean scalar reflecting the existence of the key in the map column.
+ *                   True means the lookup_key is found in all of the rows in the column.
  * @throw cudf::logic_error If the input column is not of type
  *                          list_view<struct_view<string_view, string_view>>
  */
-std::unique_ptr<column>
+std::unique_ptr<scalar>
 map_contains(column_view const &map_column, string_scalar lookup_key, bool has_nulls = true,
            rmm::cuda_stream_view stream = rmm::cuda_stream_default,
            rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -76,7 +76,7 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
  *                          list_view<struct_view<string_view, string_view>>
  */
 std::unique_ptr<column>
-map_search_key(column_view const &map_column, string_scalar lookup_key, bool has_nulls = true,
+map_contains(column_view const &map_column, string_scalar lookup_key, bool has_nulls = true,
            rmm::cuda_stream_view stream = rmm::cuda_stream_default,
            rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -54,7 +54,7 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
 
 /**
  * @brief Looks up a "map" column by specified key to see if the key exists or not,
- *        and returns a cudf scalar of bool value.
+ *        and returns a cudf column of bool value.
  *
  * The map-column is represented as follows:
  *
@@ -64,6 +64,8 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
  * The string_view struct members are the key and value, respectively.
  * For each row in the input list column, if the key is not found, false will be returned for that 
  * row.
+ * Note: when search for the scalar key of "null", a column full of "false" will be returned because 
+ *       of cudf::list:contains
  *
  * @param map_column The input "map" column to be searched. Must be of
  *                   type list_view<struct_view<string_view, string_view>>.

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -62,7 +62,8 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
  *                         <---KEY--->  <--VALUE-->
  *
  * The string_view struct members are the key and value, respectively.
- * For any row in the input list column, if the key is not found, false will be returned.
+ * For each row in the input list column, if the key is not found, false will be returned for that 
+ * row.
  *
  * @param map_column The input "map" column to be searched. Must be of
  *                   type list_view<struct_view<string_view, string_view>>.
@@ -70,12 +71,12 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
  * @param has_nulls  Whether the input column might contain null list-rows, or null keys.
  * @param stream     The CUDA stream
  * @param mr         The device memory resource to be used for allocations
- * @return           An boolean scalar reflecting the existence of the key in the map column.
- *                   True means the lookup_key is found in all of the rows in the column.
+ * @return           An boolean column reflecting the existence of the key in each row in the map
+ *                   column. True means the lookup_key is found in that row.
  * @throw cudf::logic_error If the input column is not of type
  *                          list_view<struct_view<string_view, string_view>>
  */
-std::unique_ptr<scalar>
+std::unique_ptr<column>
 map_contains(column_view const &map_column, string_scalar lookup_key, bool has_nulls = true,
            rmm::cuda_stream_view stream = rmm::cuda_stream_default,
            rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -51,6 +51,35 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
            rmm::cuda_stream_view stream = rmm::cuda_stream_default,
            rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
+
+/**
+ * @brief Looks up a "map" column by specified key to see if the key exists or not,
+ *        and returns a column of int values.
+ *
+ * The map-column is represented as follows:
+ *
+ *  list_view<struct_view< string_view, string_view > >.
+ *                         <---KEY--->  <--VALUE-->
+ *
+ * The string_view struct members are the key and value, respectively.
+ * For each row in the input list column. If the key is not found, -1 is returned.
+ *
+ * @param map_column The input "map" column to be searched. Must be of
+ *                   type list_view<struct_view<string_view, string_view>>.
+ * @param lookup_key The search key, whose value is to be returned for each list row
+ * @param has_nulls  Whether the input column might contain null list-rows, or null keys.
+ * @param stream     The CUDA stream
+ * @param mr         The device memory resource to be used for allocations
+ * @return           A string_view column with the value from the first match in each list.
+ *                   A null row is returned for any row where the lookup_key is not found.
+ * @throw cudf::logic_error If the input column is not of type
+ *                          list_view<struct_view<string_view, string_view>>
+ */
+std::unique_ptr<column>
+map_search_key(column_view const &map_column, string_scalar lookup_key, bool has_nulls = true,
+           rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+           rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+
 } // namespace jni
 
 } // namespace cudf

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -54,7 +54,7 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
 
 /**
  * @brief Looks up a "map" column by specified key to see if the key exists or not,
- *        and returns a column of int values.
+ *        and returns a cudf scalar of bool value.
  *
  * The map-column is represented as follows:
  *

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -62,10 +62,10 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
  *                         <---KEY--->  <--VALUE-->
  *
  * The string_view struct members are the key and value, respectively.
- * For each row in the input list column, if the key is not found, false will be returned for that 
+ * For each row in the input list column, if the key is not found, false will be returned for that
  * row.
- * Note: when search for the scalar key of "null", a column full of "false" will be returned because 
- *       of cudf::list:contains
+ * Note: when search for the scalar key of "null", a column full of "false" will be returned because
+ *       map_contains is leveraging cudf::list:contains.
  *
  * @param map_column The input "map" column to be searched. Must be of
  *                   type list_view<struct_view<string_view, string_view>>.

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -18,7 +18,6 @@
 
 #include <cudf/column/column.hpp>
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_uvector.hpp>
 
 namespace cudf {
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4422,8 +4422,7 @@ public class ColumnVectorTest extends CudfTestBase {
                 new HostColumnVector.BasicType(true, DType.STRING)));
         try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6);
              ColumnVector res = cv.getMapKeyExistence(Scalar.fromString("a"));
-             ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, true, false);
-        ) {
+             ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, true, false)) {
             assertColumnsAreEqual(expected, res);
         }
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4423,7 +4423,7 @@ public class ColumnVectorTest extends CudfTestBase {
                 new HostColumnVector.BasicType(true, DType.STRING)));
         try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);
              ColumnVector res = cv.getMapKeyExistence(Scalar.fromString("a"));
-             ColumnVector expected = ColumnVector.fromInts(0, 1, -1, 3, -1, 5, -1)) {
+             ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, false, true, false)) {
             assertColumnsAreEqual(expected, res);
         }
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4410,6 +4410,23 @@ public class ColumnVectorTest extends CudfTestBase {
       assertColumnsAreEqual(expected, res);
     }
   }
+    @Test
+    void testGetMapKeyExistence() {
+        List<HostColumnVector.StructData> list1 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("a", "b")));
+        List<HostColumnVector.StructData> list2 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("a", "c")));
+        List<HostColumnVector.StructData> list3 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("e", "d")));
+        List<HostColumnVector.StructData> list4 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("a", "g")));
+        List<HostColumnVector.StructData> list5 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("f", "h")));
+        List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("a", null)));
+        List<HostColumnVector.StructData> list7 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList(null, null)));
+        HostColumnVector.StructType structType = new HostColumnVector.StructType(true, Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
+                new HostColumnVector.BasicType(true, DType.STRING)));
+        try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);
+             ColumnVector res = cv.getMapKeyExistence(Scalar.fromString("a"));
+             ColumnVector expected = ColumnVector.fromInts(0, 1, -1, 3, -1, 5, -1)) {
+            assertColumnsAreEqual(expected, res);
+        }
+    }
 
   @Test
   void testListOfStructsOfStructs() {

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4416,15 +4416,22 @@ public class ColumnVectorTest extends CudfTestBase {
         List<HostColumnVector.StructData> list2 = Arrays.asList(new HostColumnVector.StructData("a", "c"));
         List<HostColumnVector.StructData> list3 = Arrays.asList(new HostColumnVector.StructData("e", "d"));
         List<HostColumnVector.StructData> list4 = Arrays.asList(new HostColumnVector.StructData("a", "g"));
-        List<HostColumnVector.StructData> list5 = Arrays.asList(new HostColumnVector.StructData("f", "h"));
-        List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData("a", null));
-        List<HostColumnVector.StructData> list7 = Arrays.asList(new HostColumnVector.StructData(null, null));
+        List<HostColumnVector.StructData> list5 = Arrays.asList(new HostColumnVector.StructData("a", null));
+        List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData(null, null));
         HostColumnVector.StructType structType = new HostColumnVector.StructType(true, Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
                 new HostColumnVector.BasicType(true, DType.STRING)));
-        try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);
-             ColumnVector res = cv.getMapKeyExistence(Scalar.fromString("a"));
-             ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, false, true, false)) {
-            assertColumnsAreEqual(expected, res);
+        try (ColumnVector cv_1 = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list4, list5);
+             ColumnVector cv_2 = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3);
+             ColumnVector cv_3 = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list4, list5, list6);
+             Scalar res_1 = cv_1.getMapKeyExistence(Scalar.fromString("a"));
+             Scalar res_2 = cv_2.getMapKeyExistence(Scalar.fromString("a"));
+             Scalar res_3 = cv_3.getMapKeyExistence(Scalar.fromString("a"));
+             Scalar expectedTrue = Scalar.fromBool(true);
+             Scalar expectedFalse = Scalar.fromBool(false)
+        ) {
+            assertEquals(expectedTrue, res_1);
+            assertEquals(expectedFalse, res_2);
+            assertEquals(expectedFalse, res_3);
         }
     }
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4410,22 +4410,55 @@ public class ColumnVectorTest extends CudfTestBase {
       assertColumnsAreEqual(expected, res);
     }
   }
-    @Test
-    void testGetMapKeyExistence() {
-        List<HostColumnVector.StructData> list1 = Arrays.asList(new HostColumnVector.StructData("a", "b"));
-        List<HostColumnVector.StructData> list2 = Arrays.asList(new HostColumnVector.StructData("a", "c"));
-        List<HostColumnVector.StructData> list3 = Arrays.asList(new HostColumnVector.StructData("e", "d"));
-        List<HostColumnVector.StructData> list4 = Arrays.asList(new HostColumnVector.StructData("a", "g"));
-        List<HostColumnVector.StructData> list5 = Arrays.asList(new HostColumnVector.StructData("a", null));
-        List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData(null, null));
-        HostColumnVector.StructType structType = new HostColumnVector.StructType(true, Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
-                new HostColumnVector.BasicType(true, DType.STRING)));
-        try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6);
-             ColumnVector res = cv.getMapKeyExistence(Scalar.fromString("a"));
-             ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, true, false)) {
-            assertColumnsAreEqual(expected, res);
-        }
+
+  @Test
+  void testGetMapKeyExistence() {
+    List<HostColumnVector.StructData> list1 = Arrays.asList(new HostColumnVector.StructData("a", "b"));
+    List<HostColumnVector.StructData> list2 = Arrays.asList(new HostColumnVector.StructData("a", "c"));
+    List<HostColumnVector.StructData> list3 = Arrays.asList(new HostColumnVector.StructData("e", "d"));
+    List<HostColumnVector.StructData> list4 = Arrays.asList(new HostColumnVector.StructData("a", "g"));
+    List<HostColumnVector.StructData> list5 = Arrays.asList(new HostColumnVector.StructData("a", null));
+    List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData(null, null));
+    List<HostColumnVector.StructData> list7 = Arrays.asList(new HostColumnVector.StructData());
+    HostColumnVector.StructType structType = new HostColumnVector.StructType(true, Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
+            new HostColumnVector.BasicType(true, DType.STRING)));
+    try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);
+         ColumnVector resValidKey = cv.getMapKeyExistence(Scalar.fromString("a"));
+         ColumnVector expectedValid = ColumnVector.fromBoxedBooleans(true, true, false, true, true, false, false);
+         ColumnVector expectedNull = ColumnVector.fromBoxedBooleans(false, false, false, false, false, false, false);
+         ColumnVector resNullKey = cv.getMapKeyExistence(Scalar.fromNull(DType.STRING))) {
+      assertColumnsAreEqual(expectedValid, resValidKey);
+      assertColumnsAreEqual(expectedNull, resNullKey);
     }
+
+//    Exception e = assertThrows(IllegalArgumentException.class, () -> {
+//      try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);
+//           ColumnVector resNullKey = cv.getMapKeyExistence(null)) {
+//      }
+//    });
+//    assertTrue(e.getMessage().contains("target string scalar is null"));
+
+  }
+
+  @Test
+  void testGetMapKeyExistenceForNullKey() {
+    List<HostColumnVector.StructData> list1 = Arrays.asList(new HostColumnVector.StructData("a", "b"));
+    List<HostColumnVector.StructData> list2 = Arrays.asList(new HostColumnVector.StructData("a", "c"));
+    List<HostColumnVector.StructData> list3 = Arrays.asList(new HostColumnVector.StructData("e", "d"));
+    List<HostColumnVector.StructData> list4 = Arrays.asList(new HostColumnVector.StructData("a", "g"));
+    List<HostColumnVector.StructData> list5 = Arrays.asList(new HostColumnVector.StructData("a", null));
+    List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData(null, null));
+    List<HostColumnVector.StructData> list7 = Arrays.asList(new HostColumnVector.StructData());
+    HostColumnVector.StructType structType = new HostColumnVector.StructType(true, Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
+            new HostColumnVector.BasicType(true, DType.STRING)));
+    try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);
+         ColumnVector resValidKey = cv.getMapKeyExistence(Scalar.fromString("a"));
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, true, false, false)) {
+      assertColumnsAreEqual(expected, resValidKey);
+    }
+  }
+
+
 
   @Test
   void testListOfStructsOfStructs() {

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4431,33 +4431,14 @@ public class ColumnVectorTest extends CudfTestBase {
       assertColumnsAreEqual(expectedNull, resNullKey);
     }
 
-//    Exception e = assertThrows(IllegalArgumentException.class, () -> {
-//      try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);
-//           ColumnVector resNullKey = cv.getMapKeyExistence(null)) {
-//      }
-//    });
-//    assertTrue(e.getMessage().contains("target string scalar is null"));
-
+    AssertionError e = assertThrows(AssertionError.class, () -> {
+      try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);
+           ColumnVector resNullKey = cv.getMapKeyExistence(null)) {
+      }
+    });
+    System.out.println(e.getMessage());
+    assertTrue(e.getMessage().contains("target string may not be null"));
   }
-
-  @Test
-  void testGetMapKeyExistenceForNullKey() {
-    List<HostColumnVector.StructData> list1 = Arrays.asList(new HostColumnVector.StructData("a", "b"));
-    List<HostColumnVector.StructData> list2 = Arrays.asList(new HostColumnVector.StructData("a", "c"));
-    List<HostColumnVector.StructData> list3 = Arrays.asList(new HostColumnVector.StructData("e", "d"));
-    List<HostColumnVector.StructData> list4 = Arrays.asList(new HostColumnVector.StructData("a", "g"));
-    List<HostColumnVector.StructData> list5 = Arrays.asList(new HostColumnVector.StructData("a", null));
-    List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData(null, null));
-    List<HostColumnVector.StructData> list7 = Arrays.asList(new HostColumnVector.StructData());
-    HostColumnVector.StructType structType = new HostColumnVector.StructType(true, Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
-            new HostColumnVector.BasicType(true, DType.STRING)));
-    try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);
-         ColumnVector resValidKey = cv.getMapKeyExistence(Scalar.fromString("a"));
-         ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, true, false, false)) {
-      assertColumnsAreEqual(expected, resValidKey);
-    }
-  }
-
 
 
   @Test

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4436,7 +4436,6 @@ public class ColumnVectorTest extends CudfTestBase {
            ColumnVector resNullKey = cv.getMapKeyExistence(null)) {
       }
     });
-    System.out.println(e.getMessage());
     assertTrue(e.getMessage().contains("target string may not be null"));
   }
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4412,13 +4412,13 @@ public class ColumnVectorTest extends CudfTestBase {
   }
     @Test
     void testGetMapKeyExistence() {
-        List<HostColumnVector.StructData> list1 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("a", "b")));
-        List<HostColumnVector.StructData> list2 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("a", "c")));
-        List<HostColumnVector.StructData> list3 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("e", "d")));
-        List<HostColumnVector.StructData> list4 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("a", "g")));
-        List<HostColumnVector.StructData> list5 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("f", "h")));
-        List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList("a", null)));
-        List<HostColumnVector.StructData> list7 = Arrays.asList(new HostColumnVector.StructData(Arrays.asList(null, null)));
+        List<HostColumnVector.StructData> list1 = Arrays.asList(new HostColumnVector.StructData("a", "b"));
+        List<HostColumnVector.StructData> list2 = Arrays.asList(new HostColumnVector.StructData("a", "c"));
+        List<HostColumnVector.StructData> list3 = Arrays.asList(new HostColumnVector.StructData("e", "d"));
+        List<HostColumnVector.StructData> list4 = Arrays.asList(new HostColumnVector.StructData("a", "g"));
+        List<HostColumnVector.StructData> list5 = Arrays.asList(new HostColumnVector.StructData("f", "h"));
+        List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData("a", null));
+        List<HostColumnVector.StructData> list7 = Arrays.asList(new HostColumnVector.StructData(null, null));
         HostColumnVector.StructType structType = new HostColumnVector.StructType(true, Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
                 new HostColumnVector.BasicType(true, DType.STRING)));
         try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6, list7);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4420,18 +4420,11 @@ public class ColumnVectorTest extends CudfTestBase {
         List<HostColumnVector.StructData> list6 = Arrays.asList(new HostColumnVector.StructData(null, null));
         HostColumnVector.StructType structType = new HostColumnVector.StructType(true, Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
                 new HostColumnVector.BasicType(true, DType.STRING)));
-        try (ColumnVector cv_1 = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list4, list5);
-             ColumnVector cv_2 = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3);
-             ColumnVector cv_3 = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list4, list5, list6);
-             Scalar res_1 = cv_1.getMapKeyExistence(Scalar.fromString("a"));
-             Scalar res_2 = cv_2.getMapKeyExistence(Scalar.fromString("a"));
-             Scalar res_3 = cv_3.getMapKeyExistence(Scalar.fromString("a"));
-             Scalar expectedTrue = Scalar.fromBool(true);
-             Scalar expectedFalse = Scalar.fromBool(false)
+        try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType), list1, list2, list3, list4, list5, list6);
+             ColumnVector res = cv.getMapKeyExistence(Scalar.fromString("a"));
+             ColumnVector expected = ColumnVector.fromBoxedBooleans(true, true, false, true, true, false);
         ) {
-            assertEquals(expectedTrue, res_1);
-            assertEquals(expectedFalse, res_2);
-            assertEquals(expectedFalse, res_3);
+            assertColumnsAreEqual(expected, res);
         }
     }
 


### PR DESCRIPTION
To close https://github.com/rapidsai/cudf/issues/8120

As required in Spark 3.1.1, when ANSI mode is enabled, GetMapValue should throw an exception when the key is not found in the map in a row. 
So plugin side needs to check if a map column contains the specific key in all rows.

The new added method `mapContains` in this PR should return a column of boolean, where _false_ means key is not found.



