### PR TITLE
Fix concatenate_rows issue with lists of all empty strings

### DIFF
--- a/cpp/src/lists/concatenate_rows.cu
+++ b/cpp/src/lists/concatenate_rows.cu
@@ -224,8 +224,8 @@ struct compute_string_sizes_and_concatenate_lists_fn {
               start_byte;
             auto const output_ptr = d_chars + d_offsets[write_idx];
             thrust::copy(thrust::seq, input_ptr, input_ptr + end_byte - start_byte, output_ptr);
-            write_idx += end_str_idx - start_str_idx;
           }
+          write_idx += end_str_idx - start_str_idx;
         }
       });
   }

--- a/cpp/tests/lists/concatenate_rows_tests.cpp
+++ b/cpp/tests/lists/concatenate_rows_tests.cpp
@@ -286,6 +286,44 @@ TEST_F(ListConcatenateRowsTest, SimpleInputStringsColumnsWithNulls)
   }
 }
 
+TEST_F(ListConcatenateRowsTest, SimpleInputStringsColumnsWithEmptyLists)
+{
+  auto const col1 =
+    StrListsCol{StrListsCol{{"" /*NULL*/}, null_at(0)}, StrListsCol{"One"}}.release();
+  auto const col2 = StrListsCol{
+    StrListsCol{{"Tomato", "" /*NULL*/, "Apple"}, null_at(1)},
+    StrListsCol{
+      "Two"}}.release();
+  auto const col3 =
+    StrListsCol{{StrListsCol{"Lemon", "Peach"}, StrListsCol{"Three"} /*NULL*/}, null_at(1)}
+      .release();
+
+  // Ignore null list elements
+  {
+    auto const results =
+      cudf::lists::concatenate_rows(TView{{col1->view(), col2->view(), col3->view()}});
+    auto const expected = StrListsCol{
+      StrListsCol{{"" /*NULL*/, "Tomato", "" /*NULL*/, "Apple", "Lemon", "Peach"}, null_at({0, 2})},
+      StrListsCol{"One",
+                  "Two"}}.release();
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, print_all);
+  }
+
+  // Null list rows result in null list rows
+  {
+    auto const results =
+      cudf::lists::concatenate_rows(TView{{col1->view(), col2->view(), col3->view()}},
+                                    cudf::lists::concatenate_null_policy::NULLIFY_OUTPUT_ROW);
+    auto const expected =
+      StrListsCol{{StrListsCol{{"" /*NULL*/, "Tomato", "" /*NULL*/, "Apple", "Lemon", "Peach"},
+                               null_at({0, 2})},
+                   StrListsCol{""} /*NULL*/},
+                  null_at(1)}
+        .release();
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, print_all);
+  }
+}
+
 TYPED_TEST(ListConcatenateRowsTypedTest, SlicedColumnsInputNoNull)
 {
   using ListsCol = cudf::test::lists_column_wrapper<TypeParam>;


### PR DESCRIPTION
Current PR is to fix a tiny bug in `compute_string_sizes_and_concatenate_lists_fn`, who serves concatenating list of string rows with nullify policy.  The bug can be triggered by some corner cases involving lists of all empty strings, such as:
 ```concatenate_with_nullifying_rows(["", ""], ["a", "b", "c"], ["d", "e"], ["f"])``` 