### PR TITLE
Add dispatch_to_invoke for better type dispatching 

### DIFF
--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -460,14 +460,11 @@ struct column_gatherer_impl<struct_view> {
                    std::back_inserter(output_struct_members),
                    [&gather_map_begin, &gather_map_end, nullify_out_of_bounds, stream, mr](
                      cudf::column_view const& col) {
-                     return cudf::type_dispatcher<dispatch_storage_type>(col.type(),
-                                                                         column_gatherer{},
-                                                                         col,
-                                                                         gather_map_begin,
-                                                                         gather_map_end,
-                                                                         nullify_out_of_bounds,
-                                                                         stream,
-                                                                         mr);
+                     auto const out_of_bounds = nullify_out_of_bounds
+                                                  ? out_of_bounds_policy::NULLIFY
+                                                  : out_of_bounds_policy::DONT_CHECK;
+                     return cudf::detail::gather(
+                       col, gather_map_begin, gather_map_end, out_of_bounds, stream, mr);
                    });
 
     auto const nullable = std::any_of(structs_column.child_begin(),

--- a/cpp/include/cudf/utilities/type_dispatcher.hpp
+++ b/cpp/include/cudf/utilities/type_dispatcher.hpp
@@ -539,7 +539,7 @@ struct dispatched_invoke {
  * @param dtype The `cudf::data_type` whose `id()` determines which template
  * instantiation is invoked
  * @param args Parameter pack of arguments forwarded to `Invoker<T>::invoke`
- * @return The result of `Invoker<T>::invoke(std::forward<Ts>(args)...)` 
+ * @return The result of `Invoker<T>::invoke(std::forward<Ts>(args)...)`
  */
 template <template <typename> typename Invoker,
           template <cudf::type_id> typename IdTypeMap = id_to_type_impl,
@@ -547,14 +547,13 @@ template <template <typename> typename Invoker,
 CUDA_HOST_DEVICE_CALLABLE constexpr decltype(auto) dispatch_to_invoke(cudf::data_type dtype,
                                                                       Ts&&... args)
 {
-  return type_dispatcher<IdTypeMap>(dtype, detail::dispatched_invoke<Invoker>{}, std::forward<Ts>(args)...);
+  return type_dispatcher<IdTypeMap>(
+    dtype, detail::dispatched_invoke<Invoker>{}, std::forward<Ts>(args)...);
 }
 
-
-  namespace detail
-{
-  template <typename T1>
-  struct double_type_dispatcher_second_type {
+namespace detail {
+template <typename T1>
+struct double_type_dispatcher_second_type {
 #pragma nv_exec_check_disable
   template <typename T2, typename F, typename... Ts>
   CUDA_HOST_DEVICE_CALLABLE decltype(auto) operator()(F&& f, Ts&&... args) const

--- a/cpp/include/cudf/utilities/type_dispatcher.hpp
+++ b/cpp/include/cudf/utilities/type_dispatcher.hpp
@@ -519,6 +519,7 @@ CUDA_HOST_DEVICE_CALLABLE constexpr decltype(auto) type_dispatcher(cudf::data_ty
 namespace detail {
 template <template <typename...> typename Invoker>
 struct dispatched_invoke {
+#pragma nv_exec_check_disable
   template <typename T, typename... Args>
   CUDA_HOST_DEVICE_CALLABLE constexpr decltype(auto) operator()(Args&&... args)
   {
@@ -541,6 +542,7 @@ struct dispatched_invoke {
  * @param args Parameter pack of arguments forwarded to `Invoker<T>::invoke`
  * @return The result of `Invoker<T>::invoke(std::forward<Ts>(args)...)`
  */
+#pragma nv_exec_check_disable
 template <template <typename> typename Invoker,
           template <cudf::type_id> typename IdTypeMap = id_to_type_impl,
           typename... Ts>

--- a/cpp/include/cudf/utilities/type_dispatcher.hpp
+++ b/cpp/include/cudf/utilities/type_dispatcher.hpp
@@ -520,7 +520,7 @@ namespace detail {
 template <template <typename...> typename Invoker>
 struct dispatched_invoke {
   template <typename T, typename... Args>
-  decltype(auto) operator()(Args&&... args)
+  CUDA_HOST_DEVICE_CALLABLE constexpr decltype(auto) operator()(Args&&... args)
   {
     return Invoker<T>::invoke(std::forward<Args>(args)...);
   }

--- a/cpp/include/cudf/utilities/type_dispatcher.hpp
+++ b/cpp/include/cudf/utilities/type_dispatcher.hpp
@@ -517,8 +517,44 @@ CUDA_HOST_DEVICE_CALLABLE constexpr decltype(auto) type_dispatcher(cudf::data_ty
 }
 
 namespace detail {
-template <typename T1>
-struct double_type_dispatcher_second_type {
+template <template <typename...> typename Invoker>
+struct dispatched_invoke {
+  template <typename T, typename... Args>
+  decltype(auto) operator()(Args&&... args)
+  {
+    return Invoker<T>::invoke(std::forward<Args>(args)...);
+  }
+};
+}  // namespace detail
+
+/**
+ * @brief Instantiates a type template `Invoker<T>` where `T` is dispatched based on the specified
+ * `dtype` and invokes `Invoker<T>::invoke` with forwarded `args`.
+ *
+ * @tparam Invoker A type template with a single non-deduced type parameter and static `invoke`
+ * member function
+ * @tparam IdTypeMap A type template with a single cudf::type_id non-type parameter that determines
+ * the mapping between a given `type_id` and its concrete, dispatched type.
+ * @tparam Ts Template parameter pack for `args`
+ * @param dtype The `cudf::data_type` whose `id()` determines which template
+ * instantiation is invoked
+ * @param args Parameter pack of arguments forwarded to `Invoker<T>::invoke`
+ * @return The result of `Invoker<T>::invoke(std::forward<Ts>(args)...)` 
+ */
+template <template <typename> typename Invoker,
+          template <cudf::type_id> typename IdTypeMap = id_to_type_impl,
+          typename... Ts>
+CUDA_HOST_DEVICE_CALLABLE constexpr decltype(auto) dispatch_to_invoke(cudf::data_type dtype,
+                                                                      Ts&&... args)
+{
+  return type_dispatcher<IdTypeMap>(dtype, detail::dispatched_invoke<Invoker>{}, std::forward<Ts>(args)...);
+}
+
+
+  namespace detail
+{
+  template <typename T1>
+  struct double_type_dispatcher_second_type {
 #pragma nv_exec_check_disable
   template <typename T2, typename F, typename... Ts>
   CUDA_HOST_DEVICE_CALLABLE decltype(auto) operator()(F&& f, Ts&&... args) const

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -432,15 +432,7 @@ struct copy_block_partitions_dispatcher {
                                          grid_size,
                                          stream);
 
-    // Use gather instead for non-fixed width types
-    return type_dispatcher(input.type(),
-                           detail::column_gatherer{},
-                           input,
-                           gather_map.begin(),
-                           gather_map.end(),
-                           false,
-                           stream,
-                           mr);
+    return gather(input, gather_map.begin(), gather_map.end(), out_of_bounds_policy::DONT_CHECK, stream, mr);
   }
 };
 

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -432,7 +432,8 @@ struct copy_block_partitions_dispatcher {
                                          grid_size,
                                          stream);
 
-    return gather(input, gather_map.begin(), gather_map.end(), out_of_bounds_policy::DONT_CHECK, stream, mr);
+    return gather(
+      input, gather_map.begin(), gather_map.end(), out_of_bounds_policy::DONT_CHECK, stream, mr);
   }
 };
 


### PR DESCRIPTION
- [x] Added `dispatch_to_invoke` which wraps a `type_dispatcher` call and invoking a type template's static `invoke` member function
- [x] Updated `gather` to use `dispatch_to_invoke` as an example
- [x] Cleaned up places that were reusing gather's dispatched function object instead of calling gather directly
- [x] Added an overload of `detail::gather` that accepts and returns a column
- [ ] Update developer guide for `dispatch_to_invoke`