### PR TITLE
[Review] Correct unused parameter warnings in dictonary algorithms

### DIFF
--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -174,7 +174,7 @@ struct dispatch_compute_indices {
                             std::unique_ptr<column>>
   operator()(Args&&...)
   {
-    CUDF_FAIL("list_view as keys for dictionary not supported");
+    CUDF_FAIL("dictionary concatenate not supported for this column type");
   }
 };
 

--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -169,16 +169,10 @@ struct dispatch_compute_indices {
     return result;
   }
 
-  template <typename Element>
+  template <typename Element, typename... Args>
   typename std::enable_if_t<!cudf::is_relationally_comparable<Element, Element>(),
                             std::unique_ptr<column>>
-  operator()(column_view const&,
-             column_view const&,
-             column_view const&,
-             offsets_pair const*,
-             size_type const*,
-             rmm::cuda_stream_view stream,
-             rmm::mr::device_memory_resource*)
+  operator()(Args&&...)
   {
     CUDF_FAIL("list_view as keys for dictionary not supported");
   }

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -99,15 +99,8 @@ struct find_index_fn {
                                      rmm::cuda_stream_view,
                                      rmm::mr::device_memory_resource*) const
   {
-    if constexpr (std::is_same_v<Element, dictionary32>) {
-      CUDF_FAIL("dictionary column cannot be the keys column of a dictionary");
-    }
-    if constexpr (std::is_same_v<Element, list_view>) {
-      CUDF_FAIL("list_view column cannot be the keys column of a dictionary");
-    }
-    if constexpr (std::is_same_v<Element, struct_view>) {
-      CUDF_FAIL("struct_view column cannot be the keys column of a dictionary");
-    }
+    CUDF_FAIL(
+      "dictionary, list_view, and struct_view columns cannot be the keys column of a dictionary");
   }
 };
 
@@ -148,15 +141,8 @@ struct find_insert_index_fn {
                                      rmm::cuda_stream_view,
                                      rmm::mr::device_memory_resource*) const
   {
-    if constexpr (std::is_same_v<Element, dictionary32>) {
-      CUDF_FAIL("dictionary column cannot be the keys for a dictionary");
-    }
-    if constexpr (std::is_same_v<Element, list_view>) {
-      CUDF_FAIL("list_view column cannot be the keys for a dictionary");
-    }
-    if constexpr (std::is_same_v<Element, struct_view>) {
-      CUDF_FAIL("struct_view column cannot be the keys for a dictionary");
-    }
+    CUDF_FAIL("dictionary, list_view, and struct_view columns cannot be the keys for a dictionary");
+  }
   }
 };
 

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -143,10 +143,9 @@ struct find_insert_index_fn {
   {
     CUDF_FAIL("dictionary, list_view, and struct_view columns cannot be the keys for a dictionary");
   }
-}
-};  // namespace
+};
 
-}  // namespace detail
+}  // namespace
 
 std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
                                   scalar const& key,
@@ -170,7 +169,7 @@ std::unique_ptr<scalar> get_insert_index(dictionary_column_view const& dictionar
     dictionary.keys().type(), find_insert_index_fn(), dictionary, key, stream, mr);
 }
 
-}  // namespace dictionary
+}  // namespace detail
 
 // external API
 
@@ -182,5 +181,5 @@ std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
   return detail::get_index(dictionary, key, rmm::cuda_stream_default, mr);
 }
 
-}  // namespace cudf
+}  // namespace dictionary
 }  // namespace cudf

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -143,10 +143,10 @@ struct find_insert_index_fn {
   {
     CUDF_FAIL("dictionary, list_view, and struct_view columns cannot be the keys for a dictionary");
   }
-  }
-};
+}
+};  // namespace
 
-}  // namespace
+}  // namespace detail
 
 std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
                                   scalar const& key,
@@ -170,7 +170,7 @@ std::unique_ptr<scalar> get_insert_index(dictionary_column_view const& dictionar
     dictionary.keys().type(), find_insert_index_fn(), dictionary, key, stream, mr);
 }
 
-}  // namespace detail
+}  // namespace dictionary
 
 // external API
 
@@ -182,5 +182,5 @@ std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
   return detail::get_index(dictionary, key, rmm::cuda_stream_default, mr);
 }
 
-}  // namespace dictionary
+}  // namespace cudf
 }  // namespace cudf

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -90,7 +90,7 @@ struct dispatch_compute_indices {
                             std::unique_ptr<column>>
   operator()(Args&&...)
   {
-    CUDF_FAIL("list_view dictionary set_keys not supported yet");
+    CUDF_FAIL("dictionary set_keys not supported for this column type");
   }
 };
 

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -85,13 +85,10 @@ struct dispatch_compute_indices {
     return result;
   }
 
-  template <typename Element>
+  template <typename Element, typename... Args>
   typename std::enable_if_t<!cudf::is_relationally_comparable<Element, Element>(),
                             std::unique_ptr<column>>
-  operator()(dictionary_column_view const& input,
-             column_view const& new_keys,
-             rmm::cuda_stream_view stream,
-             rmm::mr::device_memory_resource* mr)
+  operator()(Args&&...)
   {
     CUDF_FAIL("list_view dictionary set_keys not supported yet");
   }


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.