### PR TITLE
Update ORC statistics API to use C++17 standard library 

### DIFF
--- a/cpp/include/cudf/io/orc_metadata.hpp
+++ b/cpp/include/cudf/io/orc_metadata.hpp
@@ -23,6 +23,8 @@
 
 #include <cudf/io/types.hpp>
 
+#include <optional>
+#include <variant>
 #include <vector>
 
 namespace cudf {
@@ -61,20 +63,9 @@ struct raw_orc_statistics {
 raw_orc_statistics read_raw_orc_statistics(source_info const& src_info);
 
 /**
- * @brief Enumerator for types of column statistics that can be included in `column_statistics`.
- *
- * The statistics type depends on the column data type.
+ * @brief Monostate type for the statistics variant.
  */
-enum class statistics_type {
-  NONE,
-  INT,
-  DOUBLE,
-  STRING,
-  BUCKET,
-  DECIMAL,
-  DATE,
-  BINARY,
-  TIMESTAMP,
+struct no_statistics {
 };
 
 /**
@@ -84,13 +75,8 @@ enum class statistics_type {
  */
 template <typename T>
 struct minmax_statistics {
-  std::unique_ptr<T> _minimum;
-  std::unique_ptr<T> _maximum;
-
-  auto has_minimum() const { return _minimum != nullptr; }
-  auto has_maximum() const { return _maximum != nullptr; }
-  auto minimum() const { return _minimum.get(); }
-  auto maximum() const { return _maximum.get(); }
+  std::optional<T> minimum;
+  std::optional<T> maximum;
 };
 
 /**
@@ -100,24 +86,19 @@ struct minmax_statistics {
  */
 template <typename T>
 struct sum_statistics {
-  std::unique_ptr<T> _sum;
-
-  auto has_sum() const { return _sum != nullptr; }
-  auto sum() const { return _sum.get(); }
+  std::optional<T> sum;
 };
 
 /**
  * @brief Statistics for integral columns.
  */
 struct integer_statistics : minmax_statistics<int64_t>, sum_statistics<int64_t> {
-  static constexpr statistics_type type = statistics_type::INT;
 };
 
 /**
  * @brief Statistics for floating point columns.
  */
 struct double_statistics : minmax_statistics<double>, sum_statistics<double> {
-  static constexpr statistics_type type = statistics_type::DOUBLE;
 };
 
 /**
@@ -128,7 +109,6 @@ struct double_statistics : minmax_statistics<double>, sum_statistics<double> {
  * Note: According to ORC specs, the sum should be signed, but pyarrow uses unsigned value
  */
 struct string_statistics : minmax_statistics<std::string>, sum_statistics<uint64_t> {
-  static constexpr statistics_type type = statistics_type::STRING;
 };
 
 /**
@@ -137,34 +117,26 @@ struct string_statistics : minmax_statistics<std::string>, sum_statistics<uint64
  * The `count` array includes the count of `false` and `true` values.
  */
 struct bucket_statistics {
-  static constexpr statistics_type type = statistics_type::BUCKET;
-  std::vector<uint64_t> _count;
-
-  auto count(size_t index) const { return &_count.at(index); }
+  std::vector<uint64_t> count;
 };
 
 /**
  * @brief Statistics for decimal columns.
  */
 struct decimal_statistics : minmax_statistics<std::string>, sum_statistics<std::string> {
-  static constexpr statistics_type type = statistics_type::DECIMAL;
 };
 
 /**
  * @brief Statistics for date(time) columns.
  */
-struct date_statistics : minmax_statistics<int32_t> {
-  static constexpr statistics_type type = statistics_type::DATE;
-};
+using date_statistics = minmax_statistics<int32_t>;
 
 /**
  * @brief Statistics for binary columns.
  *
  * The `sum` is the total number of bytes across all elements.
  */
-struct binary_statistics : sum_statistics<int64_t> {
-  static constexpr statistics_type type = statistics_type::BINARY;
-};
+using binary_statistics = sum_statistics<int64_t>;
 
 /**
  * @brief Statistics for timestamp columns.
@@ -173,14 +145,8 @@ struct binary_statistics : sum_statistics<int64_t> {
  * the UNIX epoch. The `minimum_utc` and `maximum_utc` are the same values adjusted to UTC.
  */
 struct timestamp_statistics : minmax_statistics<int64_t> {
-  static constexpr statistics_type type = statistics_type::TIMESTAMP;
-  std::unique_ptr<int64_t> _minimum_utc;
-  std::unique_ptr<int64_t> _maximum_utc;
-
-  auto has_minimum_utc() const { return _minimum_utc != nullptr; }
-  auto has_maximum_utc() const { return _maximum_utc != nullptr; }
-  auto minimum_utc() const { return _minimum_utc.get(); }
-  auto maximum_utc() const { return _maximum_utc.get(); }
+  std::optional<int64_t> minimum_utc;
+  std::optional<int64_t> maximum_utc;
 };
 
 namespace orc {
@@ -196,40 +162,20 @@ struct column_statistics;
  * All columns can have the `number_of_values` statistics. Depending on the data type, a column can
  * have additional statistics, accessible through `type_specific_stats` accessor.
  */
-class column_statistics {
- private:
-  std::unique_ptr<uint64_t> _number_of_values;
-  statistics_type _type      = statistics_type::NONE;
-  void* _type_specific_stats = nullptr;
+struct column_statistics {
+  std::optional<uint64_t> number_of_values;
+  std::variant<no_statistics,
+               integer_statistics,
+               double_statistics,
+               string_statistics,
+               bucket_statistics,
+               decimal_statistics,
+               date_statistics,
+               binary_statistics,
+               timestamp_statistics>
+    type_specific_stats;
 
- public:
-  column_statistics() = default;
-  column_statistics(cudf::io::orc::column_statistics&& other);
-
-  column_statistics& operator=(column_statistics&&) noexcept;
-  column_statistics(column_statistics&&) noexcept;
-
-  auto has_number_of_values() const { return _number_of_values != nullptr; }
-  auto number_of_values() const { return _number_of_values.get(); }
-
-  auto type() const { return _type; }
-
-  /**
-   * @brief Returns a non-owning pointer to the type-specific statistics of the given type.
-   *
-   * Returns null if the requested statistics type does not match the type of the currently held
-   * type-specific statistics.
-   *
-   * @tparam T the statistics type
-   */
-  template <typename T>
-  T const* type_specific_stats() const
-  {
-    if (T::type != _type) return nullptr;
-    return static_cast<T*>(_type_specific_stats);
-  }
-
-  ~column_statistics();
+  column_statistics(cudf::io::orc::column_statistics&& detail_statistics);
 };
 
 /**

--- a/cpp/include/cudf/io/orc_metadata.hpp
+++ b/cpp/include/cudf/io/orc_metadata.hpp
@@ -63,10 +63,9 @@ struct raw_orc_statistics {
 raw_orc_statistics read_raw_orc_statistics(source_info const& src_info);
 
 /**
- * @brief Monostate type for the statistics variant.
+ * @brief Monostate type alias for the statistics variant.
  */
-struct no_statistics {
-};
+using no_statistics = std::monostate;
 
 /**
  * @brief Base class for column statistics that include optional minimum and maximum.

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -237,76 +237,23 @@ raw_orc_statistics read_raw_orc_statistics(source_info const& src_info)
 
 column_statistics::column_statistics(cudf::io::orc::column_statistics&& cs)
 {
-  _number_of_values = std::move(cs.number_of_values);
-  if (cs.int_stats.get()) {
-    _type                = statistics_type::INT;
-    _type_specific_stats = cs.int_stats.release();
-  } else if (cs.double_stats.get()) {
-    _type                = statistics_type::DOUBLE;
-    _type_specific_stats = cs.double_stats.release();
-  } else if (cs.string_stats.get()) {
-    _type                = statistics_type::STRING;
-    _type_specific_stats = cs.string_stats.release();
-  } else if (cs.bucket_stats.get()) {
-    _type                = statistics_type::BUCKET;
-    _type_specific_stats = cs.bucket_stats.release();
-  } else if (cs.decimal_stats.get()) {
-    _type                = statistics_type::DECIMAL;
-    _type_specific_stats = cs.decimal_stats.release();
-  } else if (cs.date_stats.get()) {
-    _type                = statistics_type::DATE;
-    _type_specific_stats = cs.date_stats.release();
-  } else if (cs.binary_stats.get()) {
-    _type                = statistics_type::BINARY;
-    _type_specific_stats = cs.binary_stats.release();
-  } else if (cs.timestamp_stats.get()) {
-    _type                = statistics_type::TIMESTAMP;
-    _type_specific_stats = cs.timestamp_stats.release();
-  }
-}
-
-column_statistics& column_statistics::operator=(column_statistics&& other) noexcept
-{
-  _number_of_values    = std::move(other._number_of_values);
-  _type                = other._type;
-  _type_specific_stats = other._type_specific_stats;
-
-  other._type                = statistics_type::NONE;
-  other._type_specific_stats = nullptr;
-
-  return *this;
-}
-
-column_statistics::column_statistics(column_statistics&& other) noexcept
-{
-  *this = std::move(other);
-}
-
-column_statistics::~column_statistics()
-{
-  switch (_type) {
-    case statistics_type::NONE:  // error state, but can't throw from a destructor.
-      break;
-    case statistics_type::INT: delete static_cast<integer_statistics*>(_type_specific_stats); break;
-    case statistics_type::DOUBLE:
-      delete static_cast<double_statistics*>(_type_specific_stats);
-      break;
-    case statistics_type::STRING:
-      delete static_cast<string_statistics*>(_type_specific_stats);
-      break;
-    case statistics_type::BUCKET:
-      delete static_cast<bucket_statistics*>(_type_specific_stats);
-      break;
-    case statistics_type::DECIMAL:
-      delete static_cast<decimal_statistics*>(_type_specific_stats);
-      break;
-    case statistics_type::DATE: delete static_cast<date_statistics*>(_type_specific_stats); break;
-    case statistics_type::BINARY:
-      delete static_cast<binary_statistics*>(_type_specific_stats);
-      break;
-    case statistics_type::TIMESTAMP:
-      delete static_cast<timestamp_statistics*>(_type_specific_stats);
-      break;
+  number_of_values = cs.number_of_values;
+  if (cs.int_stats) {
+    type_specific_stats = *cs.int_stats;
+  } else if (cs.double_stats) {
+    type_specific_stats = *cs.double_stats;
+  } else if (cs.string_stats) {
+    type_specific_stats = *cs.string_stats;
+  } else if (cs.bucket_stats) {
+    type_specific_stats = *cs.bucket_stats;
+  } else if (cs.decimal_stats) {
+    type_specific_stats = *cs.decimal_stats;
+  } else if (cs.date_stats) {
+    type_specific_stats = *cs.date_stats;
+  } else if (cs.binary_stats) {
+    type_specific_stats = *cs.binary_stats;
+  } else if (cs.timestamp_stats) {
+    type_specific_stats = *cs.timestamp_stats;
   }
 }
 

--- a/cpp/src/io/orc/orc.cpp
+++ b/cpp/src/io/orc/orc.cpp
@@ -118,60 +118,56 @@ void ProtobufReader::read(ColumnEncoding &s, size_t maxlen)
 
 void ProtobufReader::read(integer_statistics &s, size_t maxlen)
 {
-  auto op = std::make_tuple(make_field_reader(1, s._minimum),
-                            make_field_reader(2, s._maximum),
-                            make_field_reader(3, s._sum));
+  auto op = std::make_tuple(
+    make_field_reader(1, s.minimum), make_field_reader(2, s.maximum), make_field_reader(3, s.sum));
   function_builder(s, maxlen, op);
 }
 
 void ProtobufReader::read(double_statistics &s, size_t maxlen)
 {
-  auto op = std::make_tuple(make_field_reader(1, s._minimum),
-                            make_field_reader(2, s._maximum),
-                            make_field_reader(3, s._sum));
+  auto op = std::make_tuple(
+    make_field_reader(1, s.minimum), make_field_reader(2, s.maximum), make_field_reader(3, s.sum));
   function_builder(s, maxlen, op);
 }
 
 void ProtobufReader::read(string_statistics &s, size_t maxlen)
 {
-  auto op = std::make_tuple(make_field_reader(1, s._minimum),
-                            make_field_reader(2, s._maximum),
-                            make_field_reader(3, s._sum));
+  auto op = std::make_tuple(
+    make_field_reader(1, s.minimum), make_field_reader(2, s.maximum), make_field_reader(3, s.sum));
   function_builder(s, maxlen, op);
 }
 
 void ProtobufReader::read(bucket_statistics &s, size_t maxlen)
 {
-  auto op = std::make_tuple(make_packed_field_reader(1, s._count));
+  auto op = std::make_tuple(make_packed_field_reader(1, s.count));
   function_builder(s, maxlen, op);
 }
 
 void ProtobufReader::read(decimal_statistics &s, size_t maxlen)
 {
-  auto op = std::make_tuple(make_field_reader(1, s._minimum),
-                            make_field_reader(2, s._maximum),
-                            make_field_reader(3, s._sum));
+  auto op = std::make_tuple(
+    make_field_reader(1, s.minimum), make_field_reader(2, s.maximum), make_field_reader(3, s.sum));
   function_builder(s, maxlen, op);
 }
 
 void ProtobufReader::read(date_statistics &s, size_t maxlen)
 {
-  auto op = std::make_tuple(make_field_reader(1, s._minimum), make_field_reader(2, s._maximum));
+  auto op = std::make_tuple(make_field_reader(1, s.minimum), make_field_reader(2, s.maximum));
   function_builder(s, maxlen, op);
 }
 
 void ProtobufReader::read(binary_statistics &s, size_t maxlen)
 {
-  auto op = std::make_tuple(make_field_reader(1, s._sum));
+  auto op = std::make_tuple(make_field_reader(1, s.sum));
   function_builder(s, maxlen, op);
 }
 
 void ProtobufReader::read(timestamp_statistics &s, size_t maxlen)
 {
-  auto op = std::make_tuple(make_field_reader(1, s._minimum),
-                            make_field_reader(2, s._maximum),
-                            make_field_reader(3, s._minimum_utc),
-                            make_field_reader(4, s._maximum_utc));
+  auto op = std::make_tuple(make_field_reader(1, s.minimum),
+                            make_field_reader(2, s.maximum),
+                            make_field_reader(3, s.minimum_utc),
+                            make_field_reader(4, s.maximum_utc));
   function_builder(s, maxlen, op);
 }
 

--- a/cpp/src/io/orc/orc.h
+++ b/cpp/src/io/orc/orc.h
@@ -107,18 +107,18 @@ struct StripeFooter {
 /**
  * @brief Contains per-column ORC statistics.
  *
- * At most one of the `***_statistics` members has a non-null value.
+ * At most one of the `***_statistics` members has a value.
  */
 struct column_statistics {
-  std::unique_ptr<uint64_t> number_of_values;
-  std::unique_ptr<integer_statistics> int_stats;
-  std::unique_ptr<double_statistics> double_stats;
-  std::unique_ptr<string_statistics> string_stats;
-  std::unique_ptr<bucket_statistics> bucket_stats;
-  std::unique_ptr<decimal_statistics> decimal_stats;
-  std::unique_ptr<date_statistics> date_stats;
-  std::unique_ptr<binary_statistics> binary_stats;
-  std::unique_ptr<timestamp_statistics> timestamp_stats;
+  std::optional<uint64_t> number_of_values;
+  std::optional<integer_statistics> int_stats;
+  std::optional<double_statistics> double_stats;
+  std::optional<string_statistics> string_stats;
+  std::optional<bucket_statistics> bucket_stats;
+  std::optional<decimal_statistics> decimal_stats;
+  std::optional<date_statistics> date_stats;
+  std::optional<binary_statistics> binary_stats;
+  std::optional<timestamp_statistics> timestamp_stats;
   // TODO: hasNull (issue #7087)
 };
 

--- a/cpp/src/io/orc/orc.h
+++ b/cpp/src/io/orc/orc.h
@@ -23,12 +23,11 @@
 #include <cudf/io/orc_metadata.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <thrust/optional.h>
-
 #include <stddef.h>
 #include <stdint.h>
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -87,9 +86,10 @@ struct Stream {
 
   // Returns index of the column in the table, if any
   // Stream of the 'column 0' does not have a corresponding column in the table
-  thrust::optional<uint32_t> column_index() const noexcept
+  std::optional<uint32_t> column_index() const noexcept
   {
-    return column_id.value_or(0) > 0 ? thrust::optional<uint32_t>{*column_id - 1} : thrust::nullopt;
+    return column_id.value_or(0) > 0 ? std::optional<uint32_t>{*column_id - 1}
+                                     : std::optional<uint32_t>{};
   }
 };
 
@@ -229,15 +229,6 @@ class ProtobufReader {
 
   // optional fields don't change the field number encoding
   template <typename T,
-            typename std::enable_if_t<
-              std::is_same<T, std::unique_ptr<typename T::element_type>>::value> * = nullptr>
-  int static constexpr encode_field_number(int field_number) noexcept
-  {
-    return encode_field_number_base<typename T::element_type>(field_number);
-  }
-
-  // optional fields don't change the field number encoding
-  template <typename T,
             typename std::enable_if_t<std::is_same<T, std::optional<typename T::value_type>>::value>
               * = nullptr>
   int static constexpr encode_field_number(int field_number) noexcept
@@ -285,16 +276,6 @@ class ProtobufReader {
     auto const size = read_field_size(end);
     value.emplace_back();
     read(value.back(), size);
-  }
-
-  template <typename T,
-            typename std::enable_if_t<
-              std::is_same<T, std::unique_ptr<typename T::element_type>>::value> * = nullptr>
-  void read_field(T &value, const uint8_t *end)
-  {
-    typename T::element_type contained_value;
-    read_field(contained_value, end);
-    value = std::make_unique<typename T::element_type>(std::move(contained_value));
   }
 
   template <typename T,

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -978,47 +978,41 @@ TEST_F(OrcStatisticsTest, Basic)
 
   auto validate_statistics = [&](std::vector<cudf_io::column_statistics> const& stats) {
     auto& s0 = stats[0];
-    EXPECT_EQ(s0.type(), cudf_io::statistics_type::NONE);
-    EXPECT_EQ(*s0.number_of_values(), 9ul);
+    EXPECT_EQ(*s0.number_of_values, 9ul);
 
     auto& s1 = stats[1];
-    EXPECT_EQ(s1.type(), cudf_io::statistics_type::INT);
-    EXPECT_EQ(*s1.number_of_values(), 4ul);
-    auto ts1 = s1.type_specific_stats<cudf_io::integer_statistics>();
-    EXPECT_EQ(*ts1->minimum(), 1);
-    EXPECT_EQ(*ts1->maximum(), 7);
-    EXPECT_EQ(*ts1->sum(), 16);
+    EXPECT_EQ(*s1.number_of_values, 4ul);
+    auto& ts1 = std::get<cudf_io::integer_statistics>(s1.type_specific_stats);
+    EXPECT_EQ(*ts1.minimum, 1);
+    EXPECT_EQ(*ts1.maximum, 7);
+    EXPECT_EQ(*ts1.sum, 16);
 
     auto& s2 = stats[2];
-    EXPECT_EQ(s2.type(), cudf_io::statistics_type::DOUBLE);
-    EXPECT_EQ(*s2.number_of_values(), 4ul);
-    auto ts2 = s2.type_specific_stats<cudf_io::double_statistics>();
-    EXPECT_EQ(*ts2->minimum(), 1.);
-    EXPECT_EQ(*ts2->maximum(), 7.);
+    EXPECT_EQ(*s2.number_of_values, 4ul);
+    auto& ts2 = std::get<cudf_io::double_statistics>(s2.type_specific_stats);
+    EXPECT_EQ(*ts2.minimum, 1.);
+    EXPECT_EQ(*ts2.maximum, 7.);
     // No sum ATM, filed #7087
-    EXPECT_EQ(ts2->sum(), nullptr);
+    ASSERT_FALSE(ts2.sum);
 
     auto& s3 = stats[3];
-    EXPECT_EQ(s3.type(), cudf_io::statistics_type::STRING);
-    EXPECT_EQ(*s3.number_of_values(), 9ul);
-    auto ts3 = s3.type_specific_stats<cudf_io::string_statistics>();
-    EXPECT_EQ(*ts3->minimum(), "Friday");
-    EXPECT_EQ(*ts3->maximum(), "Wednesday");
-    EXPECT_EQ(*ts3->sum(), 58ul);
+    EXPECT_EQ(*s3.number_of_values, 9ul);
+    auto& ts3 = std::get<cudf_io::string_statistics>(s3.type_specific_stats);
+    EXPECT_EQ(*ts3.minimum, "Friday");
+    EXPECT_EQ(*ts3.maximum, "Wednesday");
+    EXPECT_EQ(*ts3.sum, 58ul);
 
     auto& s4 = stats[4];
-    EXPECT_EQ(s4.type(), cudf_io::statistics_type::BUCKET);
-    EXPECT_EQ(*s4.number_of_values(), 9ul);
-    EXPECT_EQ(*s4.type_specific_stats<cudf_io::bucket_statistics>()->count(0), 8ul);
+    EXPECT_EQ(*s4.number_of_values, 9ul);
+    EXPECT_EQ(std::get<cudf_io::bucket_statistics>(s4.type_specific_stats).count[0], 8ul);
 
     auto& s5 = stats[5];
-    EXPECT_EQ(s5.type(), cudf_io::statistics_type::TIMESTAMP);
-    EXPECT_EQ(*s5.number_of_values(), 4ul);
-    auto ts5 = s5.type_specific_stats<cudf_io::timestamp_statistics>();
-    EXPECT_EQ(*ts5->minimum_utc(), 1000);
-    EXPECT_EQ(*ts5->maximum_utc(), 7000);
-    EXPECT_EQ(ts5->minimum(), nullptr);
-    EXPECT_EQ(ts5->maximum(), nullptr);
+    EXPECT_EQ(*s5.number_of_values, 4ul);
+    auto& ts5 = std::get<cudf_io::timestamp_statistics>(s5.type_specific_stats);
+    EXPECT_EQ(*ts5.minimum_utc, 1000);
+    EXPECT_EQ(*ts5.maximum_utc, 7000);
+    ASSERT_FALSE(ts5.minimum);
+    ASSERT_FALSE(ts5.maximum);
   };
 
   validate_statistics(stats.file_stats);


### PR DESCRIPTION
Uses `std::optional` instead of `std::unique_ptr` for optional ORC statistics fields, and `std::variant` instead of the manually implemented type erasure. 
Removes a lot of code that simulated `std::optional` and `std::variant` when it wasn't available. 