### PR TITLE
Fix reductions gtests failing for debug build

### DIFF
--- a/cpp/src/reductions/std.cu
+++ b/cpp/src/reductions/std.cu
@@ -40,8 +40,8 @@ std::unique_ptr<cudf::scalar> cudf::reduction::standard_deviation(
     cudf::is_dictionary(col.type()) ? dictionary_column_view(col).keys().type() : col.type();
   return cudf::type_dispatcher(col_type, reducer(), col, output_dtype, ddof, stream, mr);
 #else
-  // workaround for bug 200529165 which causes compilation error only at device
-  // debug build the bug will be fixed at cuda 10.2
+  // workaround for bug 200529165 which causes compilation error only at device debug build
+  // hopefully the bug will be fixed in future cuda version (still failing in 11.2)
   CUDF_FAIL("var/std reductions are not supported at debug build.");
 #endif
 }

--- a/cpp/src/reductions/var.cu
+++ b/cpp/src/reductions/var.cu
@@ -39,8 +39,8 @@ std::unique_ptr<cudf::scalar> cudf::reduction::variance(column_view const& col,
     cudf::is_dictionary(col.type()) ? dictionary_column_view(col).keys().type() : col.type();
   return cudf::type_dispatcher(col_type, reducer(), col, output_dtype, ddof, stream, mr);
 #else
-  // workaround for bug 200529165 which causes compilation error only at device
-  // debug build the bug will be fixed at cuda 10.2
+  // workaround for bug 200529165 which causes compilation error only at device debug build
+  // hopefully the bug will be fixed in future cuda version (still failing in 11.2)
   CUDF_FAIL("var/std reductions are not supported at debug build.");
 #endif
 }

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -402,7 +402,13 @@ TYPED_TEST(MultiStepReductionTest, Mean)
                        cudf::data_type(cudf::type_id::FLOAT64));
 }
 
+// This test is disabled for only a Debug build because a compiler error
+// documented in cpp/src/reductions/std.cu and cpp/src/reductions/var.cu
+#ifdef NDEBUG
 TYPED_TEST(MultiStepReductionTest, var_std)
+#else
+TYPED_TEST(MultiStepReductionTest, DISABLED_var_std)
+#endif
 {
   using T = TypeParam;
   std::vector<int> int_values({-3, 2, 1, 0, 5, -3, -2, 28});
@@ -471,7 +477,13 @@ struct ReductionMultiStepErrorCheck : public ReductionTest<T> {
 
 TYPED_TEST_CASE(ReductionMultiStepErrorCheck, cudf::test::AllTypes);
 
+// This test is disabled for only a Debug build because a compiler error
+// documented in cpp/src/reductions/std.cu and cpp/src/reductions/var.cu
+#ifdef NDEBUG
 TYPED_TEST(ReductionMultiStepErrorCheck, ErrorHandling)
+#else
+TYPED_TEST(ReductionMultiStepErrorCheck, DISABLED_ErrorHandling)
+#endif
 {
   using T = TypeParam;
   std::vector<int> int_values({-3, 2});
@@ -700,7 +712,13 @@ struct ReductionParamTest : public ReductionTest<double>,
 
 INSTANTIATE_TEST_CASE_P(ddofParam, ReductionParamTest, ::testing::Range(1, 5));
 
+// This test is disabled for only a Debug build because a compiler error
+// documented in cpp/src/reductions/std.cu and cpp/src/reductions/var.cu
+#ifdef NDEBUG
 TEST_P(ReductionParamTest, std_var)
+#else
+TEST_P(ReductionParamTest, DISABLED_std_var)
+#endif
 {
   int ddof = GetParam();
   std::vector<double> int_values({-3, 2, 1, 0, 5, -3, -2, 28});
@@ -1681,7 +1699,11 @@ TYPED_TEST(DictionaryReductionTest, Mean)
                        output_type);
 }
 
+#ifdef NDEBUG
 TYPED_TEST(DictionaryReductionTest, VarStd)
+#else
+TYPED_TEST(DictionaryReductionTest, DISABLED_VarStd)
+#endif
 {
   using T = TypeParam;
   std::vector<int> int_values({-3, 2, 1, 0, 5, -3, -2, 28});


### PR DESCRIPTION
Due to an nvcc compiler bug (200529165), the standard-deviation and variance aggregations source for the `cudf::reduce` API is disabled only for a libcudf Debug build. The comments in the `std.cu` and `var.cu` indicates this bug should be fixed in 10.2 but I've verified it still occurs in 11.0, 11.1, and 11.2. The comments have been updated in this PR.

Unfortunately, the disabled source causes thet REDUCTIONS_TEST to fail for those gtests that use these two aggregation types. This PR disables those gtests when also built with Debug. This allows the gtests to complete but marked as disabled. A comment is included in the `reduction_tests.cpp` explain why the tests are disabled.