### PR TITLE
Make java rolling window operation APIs consistent [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -1299,13 +1299,15 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
 
     long nativePtr = agg.createNativeInstance();
     try {
+      Scalar p = options.getPrecedingScalar();
+      Scalar f = options.getFollowingScalar();
       return new ColumnVector(
           rollingWindow(this.getNativeView(),
               agg.getDefaultOutput(),
               options.getMinPeriods(),
               nativePtr,
-              options.getPreceding(),
-              options.getFollowing(),
+              p == null || !p.isValid() ? 0 : p.getInt(),
+              f == null || !f.isValid() ? 0 : f.getInt(),
               options.getPrecedingCol() == null ? 0 : options.getPrecedingCol().getNativeView(),
               options.getFollowingCol() == null ? 0 : options.getFollowingCol().getNativeView()));
     } finally {

--- a/java/src/main/java/ai/rapids/cudf/WindowOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/WindowOptions.java
@@ -26,8 +26,6 @@ public class WindowOptions implements AutoCloseable {
   enum FrameType {ROWS, RANGE}
 
   private final int minPeriods;
-  private final int preceding;
-  private final int following;
   private final Scalar precedingScalar;
   private final Scalar followingScalar;
   private final ColumnVector precedingCol;
@@ -38,11 +36,8 @@ public class WindowOptions implements AutoCloseable {
   private final boolean isUnboundedPreceding;
   private final boolean isUnboundedFollowing;
 
-
   private WindowOptions(Builder builder) {
     this.minPeriods = builder.minPeriods;
-    this.preceding = builder.preceding;
-    this.following = builder.following;
     this.precedingScalar = builder.precedingScalar;
     if (precedingScalar != null) {
       precedingScalar.incRefCount();
@@ -73,9 +68,7 @@ public class WindowOptions implements AutoCloseable {
       return true;
     } else if (other instanceof WindowOptions) {
       WindowOptions o = (WindowOptions) other;
-      boolean ret = this.preceding == o.preceding &&
-              this.following == o.following &&
-              this.minPeriods == o.minPeriods &&
+      boolean ret = this.minPeriods == o.minPeriods &&
               this.orderByColumnIndex == o.orderByColumnIndex &&
               this.orderByOrderAscending == o.orderByOrderAscending &&
               this.frameType == o.frameType &&
@@ -101,8 +94,6 @@ public class WindowOptions implements AutoCloseable {
   @Override
   public int hashCode() {
     int ret = 7;
-    ret = 31 * ret + preceding;
-    ret = 31 * ret + following;
     ret = 31 * ret + minPeriods;
     ret = 31 * ret + orderByColumnIndex;
     ret = 31 * ret + Boolean.hashCode(orderByOrderAscending);
@@ -130,10 +121,6 @@ public class WindowOptions implements AutoCloseable {
 
   int getMinPeriods() { return  this.minPeriods; }
 
-  int getPreceding() { return this.preceding; }
-
-  int getFollowing() { return this.following; }
-
   Scalar getPrecedingScalar() { return this.precedingScalar; }
 
   Scalar getFollowingScalar() { return this.followingScalar; }
@@ -160,8 +147,6 @@ public class WindowOptions implements AutoCloseable {
 
   public static class Builder {
     private int minPeriods = 1;
-    private int preceding = 0;
-    private int following = 1;
     // for range window
     private Scalar precedingScalar = null;
     private Scalar followingScalar = null;
@@ -210,10 +195,15 @@ public class WindowOptions implements AutoCloseable {
      *                        the followingScalar will be live outside of WindowOptions
      */
     public Builder window(Scalar precedingScalar, Scalar followingScalar) {
-      assert (precedingScalar != null && precedingScalar.isValid());
-      assert (followingScalar != null && followingScalar.isValid());
+      if (precedingScalar == null || !precedingScalar.isValid()) {
+        throw new IllegalArgumentException("preceding cannot be null");
+      }
+      if (followingScalar == null || !followingScalar.isValid()) {
+        throw new IllegalArgumentException("following cannot be null");
+      }
       this.precedingScalar = precedingScalar;
       this.followingScalar = followingScalar;
+      staticSet = true;
       return this;
     }
 
@@ -266,44 +256,22 @@ public class WindowOptions implements AutoCloseable {
       return this;
     }
 
-    public Builder preceding(int preceding) {
-      this.preceding = preceding;
-      return this;
-    }
-
-    public Builder following(int following) {
-      this.following = following;
-      return this;
-    }
-
     /**
      * Set the relative number preceding the current row for range window
-     * @param preceding
-     * @return Builder
+     * @return this for chaining
      */
     public Builder preceding(Scalar preceding) {
       this.precedingScalar = preceding;
+      staticSet = true;
       return this;
     }
 
     /**
      * Set the relative number following the current row for range window
-     * @param following
-     * @return Builder
+     * @return this for chaining
      */
     public Builder following(Scalar following) {
       this.followingScalar = following;
-      return this;
-    }
-
-    /**
-     * Set the size of the window.
-     * @param preceding the number of rows preceding the current row
-     * @param following the number of rows following the current row.
-     */
-    public Builder window(int preceding, int following) {
-      this.preceding = preceding;
-      this.following = following;
       staticSet = true;
       return this;
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -2380,11 +2380,10 @@ public class ColumnVectorTest extends CudfTestBase {
          Scalar two = Scalar.fromInt(2);
          Scalar three = Scalar.fromInt(3);
          ColumnVector arraywindowCol = ColumnVector.fromBoxedInts(1, 2, 3 ,1, 1)) {
-      assertThrows(IllegalArgumentException.class, () -> {
+      assertThrows(IllegalStateException.class, () -> {
         try (WindowOptions options = WindowOptions.builder()
             .window(three, two).minPeriods(3)
             .window(arraywindowCol, arraywindowCol).build()) {
-
         }
       });
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -2263,8 +2263,11 @@ public class ColumnVectorTest extends CudfTestBase {
 
   @Test
   void testWindowStatic() {
-    try (WindowOptions options = WindowOptions.builder().window(2, 1)
-        .minPeriods(2).build()) {
+    try (Scalar one = Scalar.fromInt(1);
+         Scalar two = Scalar.fromInt(2);
+         WindowOptions options = WindowOptions.builder()
+             .window(two, one)
+             .minPeriods(2).build()) {
       try (ColumnVector v1 = ColumnVector.fromInts(5, 4, 7, 6, 8)) {
         try (ColumnVector expected = ColumnVector.fromLongs(9, 16, 17, 21, 14);
              ColumnVector result = v1.rollingWindow(Aggregation.sum(), options)) {
@@ -2308,8 +2311,11 @@ public class ColumnVectorTest extends CudfTestBase {
 
   @Test
   void testWindowStaticCounts() {
-    try (WindowOptions options = WindowOptions.builder().window(2, 1)
-            .minPeriods(2).build()) {
+    try (Scalar one = Scalar.fromInt(1);
+         Scalar two = Scalar.fromInt(2);
+         WindowOptions options = WindowOptions.builder()
+             .window(two, one)
+             .minPeriods(2).build()) {
       try (ColumnVector v1 = ColumnVector.fromBoxedInts(5, 4, null, 6, 8)) {
         try (ColumnVector expected = ColumnVector.fromInts(2, 2, 2, 2, 2);
              ColumnVector result = v1.rollingWindow(Aggregation.count(NullPolicy.EXCLUDE), options)) {
@@ -2340,8 +2346,11 @@ public class ColumnVectorTest extends CudfTestBase {
 
   @Test
   void testWindowLag() {
-    try (WindowOptions window = WindowOptions.builder().minPeriods(1)
-        .window(2, -1).build()) {
+    try (Scalar negOne = Scalar.fromInt(-1);
+         Scalar two = Scalar.fromInt(2);
+         WindowOptions window = WindowOptions.builder()
+             .minPeriods(1)
+             .window(two, negOne).build()) {
       try (ColumnVector v1 = ColumnVector.fromInts(5, 4, 7, 6, 8);
            ColumnVector expected = ColumnVector.fromBoxedInts(null, 5, 4, 7, 6);
            ColumnVector result = v1.rollingWindow(Aggregation.max(), window)) {
@@ -2367,10 +2376,13 @@ public class ColumnVectorTest extends CudfTestBase {
 
   @Test
   void testWindowThrowsException() {
-    try (ColumnVector arraywindowCol = ColumnVector.fromBoxedInts(1, 2, 3 ,1, 1)) {
+    try (Scalar one = Scalar.fromInt(1);
+         Scalar two = Scalar.fromInt(2);
+         Scalar three = Scalar.fromInt(3);
+         ColumnVector arraywindowCol = ColumnVector.fromBoxedInts(1, 2, 3 ,1, 1)) {
       assertThrows(IllegalArgumentException.class, () -> {
         try (WindowOptions options = WindowOptions.builder()
-            .window(3, 2).minPeriods(3)
+            .window(three, two).minPeriods(3)
             .window(arraywindowCol, arraywindowCol).build()) {
 
         }
@@ -2378,7 +2390,7 @@ public class ColumnVectorTest extends CudfTestBase {
 
       assertThrows(IllegalArgumentException.class, () -> {
         try (WindowOptions options = WindowOptions.builder()
-            .window(2, 1)
+            .window(two, one)
             .minPeriods(1)
             .orderByColumnIndex(0)
             .build()) {

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -2744,7 +2744,9 @@ public class TableTest extends CudfTestBase {
         .build()) {
       try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            Table decSorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(4), OrderByArg.asc(5));
-           ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
+           ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
+           Scalar two = Scalar.fromInt(2);
+           Scalar one = Scalar.fromInt(1)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
         ColumnVector decSortedAggColumn = decSorted.getColumn(3);
@@ -2752,7 +2754,7 @@ public class TableTest extends CudfTestBase {
 
         try (WindowOptions window = WindowOptions.builder()
             .minPeriods(1)
-            .window(2, 1)
+            .window(two, one)
             .build()) {
 
           try (Table windowAggResults = sorted.groupBy(0, 1)
@@ -2782,7 +2784,9 @@ public class TableTest extends CudfTestBase {
       try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            Table decSorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(4), OrderByArg.asc(5));
            ColumnVector expectSortedAggCol = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
-           ColumnVector expectDecSortedAggCol = ColumnVector.decimalFromLongs(2, 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
+           ColumnVector expectDecSortedAggCol = ColumnVector.decimalFromLongs(2, 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
+           Scalar two = Scalar.fromInt(2);
+           Scalar one = Scalar.fromInt(1)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggCol, sortedAggColumn);
         ColumnVector decSortedAggColumn = decSorted.getColumn(6);
@@ -2790,7 +2794,7 @@ public class TableTest extends CudfTestBase {
 
         try (WindowOptions window = WindowOptions.builder()
             .minPeriods(1)
-            .window(2, 1)
+            .window(two, one)
             .build()) {
 
           try (Table windowAggResults = sorted.groupBy(0, 1)
@@ -2821,7 +2825,9 @@ public class TableTest extends CudfTestBase {
       try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
            Table decSorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(4), OrderByArg.asc(5));
            ColumnVector expectSortedAggCol = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
-           ColumnVector expectDecSortedAggCol = ColumnVector.decimalFromLongs(2, 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
+           ColumnVector expectDecSortedAggCol = ColumnVector.decimalFromLongs(2, 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
+           Scalar two = Scalar.fromInt(2);
+           Scalar one = Scalar.fromInt(1)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggCol, sortedAggColumn);
         ColumnVector decSortedAggColumn = decSorted.getColumn(6);
@@ -2829,7 +2835,7 @@ public class TableTest extends CudfTestBase {
 
         try (WindowOptions window = WindowOptions.builder()
             .minPeriods(1)
-            .window(2, 1)
+            .window(two, one)
             .build()) {
 
           try (Table windowAggResults = sorted.groupBy(0, 1)
@@ -2855,13 +2861,15 @@ public class TableTest extends CudfTestBase {
         .column(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6) // Agg Column
         .build()) {
       try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), OrderByArg.asc(1), OrderByArg.asc(2));
-           ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
+           ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
+           Scalar two = Scalar.fromInt(2);
+           Scalar one = Scalar.fromInt(1)) {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
 
         try (WindowOptions window = WindowOptions.builder()
             .minPeriods(1)
-            .window(2, 1)
+            .window(two, one)
             .build()) {
 
           try (Table windowAggResults = sorted.groupBy(0, 1)
@@ -2896,8 +2904,10 @@ public class TableTest extends CudfTestBase {
 
         WindowOptions.Builder windowBuilder = WindowOptions.builder().minPeriods(1);
 
-        try (WindowOptions options = windowBuilder.window(2, 1).build();
-        WindowOptions options1 = windowBuilder.window(2, 1).build()) {
+        try (Scalar two = Scalar.fromInt(2);
+             Scalar one = Scalar.fromInt(1);
+             WindowOptions options = windowBuilder.window(two, one).build();
+             WindowOptions options1 = windowBuilder.window(two, one).build()) {
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation
                   .rowNumber()
@@ -2914,8 +2924,10 @@ public class TableTest extends CudfTestBase {
           }
         }
 
-        try (WindowOptions options = windowBuilder.window(3, 2).build();
-        WindowOptions options1 = windowBuilder.window(3, 2).build()) {
+        try (Scalar three = Scalar.fromInt(3);
+             Scalar two = Scalar.fromInt(2);
+             WindowOptions options = windowBuilder.window(three, two).build();
+             WindowOptions options1 = windowBuilder.window(three, two).build()) {
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation
                   .rowNumber()
@@ -2932,8 +2944,10 @@ public class TableTest extends CudfTestBase {
           }
         }
 
-        try (WindowOptions options = windowBuilder.window(4, 3).build();
-        WindowOptions options1 = windowBuilder.window(4, 3).build()) {
+        try (Scalar four = Scalar.fromInt(4);
+             Scalar three = Scalar.fromInt(3);
+             WindowOptions options = windowBuilder.window(four, three).build();
+             WindowOptions options1 = windowBuilder.window(four, three).build()) {
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation
                   .rowNumber()
@@ -2957,10 +2971,12 @@ public class TableTest extends CudfTestBase {
   void testWindowingCollectList() {
     Aggregation aggCollectWithNulls = Aggregation.collectList(NullPolicy.INCLUDE);
     Aggregation aggCollect = Aggregation.collectList();
-    try (WindowOptions winOpts = WindowOptions.builder()
-        .minPeriods(1)
-        .window(2, 1)
-        .build()) {
+    try (Scalar two = Scalar.fromInt(2);
+         Scalar one = Scalar.fromInt(1);
+         WindowOptions winOpts = WindowOptions.builder()
+             .minPeriods(1)
+             .window(two, one)
+             .build()) {
       StructType nestedType = new StructType(false,
           new BasicType(false, DType.INT32), new BasicType(false, DType.STRING));
       try (Table raw = new Table.TestBuilder()
@@ -3050,8 +3066,10 @@ public class TableTest extends CudfTestBase {
 
         WindowOptions.Builder windowBuilder = WindowOptions.builder().minPeriods(1);
 
-        try (WindowOptions options = windowBuilder.window(2, 1).build();
-        WindowOptions options1 = windowBuilder.window(2, 1).build()) {
+        try (Scalar two = Scalar.fromInt(2);
+             Scalar one = Scalar.fromInt(1);
+             WindowOptions options = windowBuilder.window(two, one).build();
+             WindowOptions options1 = windowBuilder.window(two, one).build()) {
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation
                   .lead(0)
@@ -3069,8 +3087,10 @@ public class TableTest extends CudfTestBase {
           }
         }
 
-        try (WindowOptions options = windowBuilder.window(0,1).build();
-        WindowOptions options1 = windowBuilder.window(0,1).build()) {
+        try (Scalar zero = Scalar.fromInt(0);
+             Scalar one = Scalar.fromInt(1);
+             WindowOptions options = windowBuilder.window(zero, one).build();
+             WindowOptions options1 = windowBuilder.window(zero, one).build()) {
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation
                   .lead(1)
@@ -3088,8 +3108,10 @@ public class TableTest extends CudfTestBase {
           }
         }
 
-        try (WindowOptions options = windowBuilder.window(0,1).build();
-        WindowOptions options1 = windowBuilder.window(0,1).build()) {
+        try (Scalar zero = Scalar.fromInt(0);
+             Scalar one = Scalar.fromInt(1);
+             WindowOptions options = windowBuilder.window(zero, one).build();
+             WindowOptions options1 = windowBuilder.window(zero, one).build()) {
           try (ColumnVector defaultOutput = ColumnVector.fromBoxedInts(0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
                ColumnVector decDefaultOutput = ColumnVector.decimalFromLongs(-2, 0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
                Table windowAggResults = sorted.groupBy(0, 1)
@@ -3110,8 +3132,10 @@ public class TableTest extends CudfTestBase {
         }
 
         // Outside bounds
-        try (WindowOptions options = windowBuilder.window(0,1).build();
-        WindowOptions options1 = windowBuilder.window(0,1).build()) {
+        try (Scalar zero = Scalar.fromInt(0);
+             Scalar one = Scalar.fromInt(1);
+             WindowOptions options = windowBuilder.window(zero, one).build();
+             WindowOptions options1 = windowBuilder.window(zero, one).build()) {
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation
                   .lead(3)
@@ -3155,8 +3179,10 @@ public class TableTest extends CudfTestBase {
 
         WindowOptions.Builder windowBuilder = WindowOptions.builder().minPeriods(1);
 
-        try (WindowOptions options = windowBuilder.window(2,1).build();
-        WindowOptions options1 = windowBuilder.window(2,1).build()) {
+        try (Scalar two = Scalar.fromInt(2);
+             Scalar one = Scalar.fromInt(1);
+             WindowOptions options = windowBuilder.window(two, one).build();
+             WindowOptions options1 = windowBuilder.window(two, one).build()) {
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation
                   .lag(0)
@@ -3174,8 +3200,10 @@ public class TableTest extends CudfTestBase {
           }
         }
 
-        try (WindowOptions options = windowBuilder.window(2,0).build();
-        WindowOptions options1 = windowBuilder.window(2,0).build()) {
+        try (Scalar zero = Scalar.fromInt(0);
+             Scalar two = Scalar.fromInt(2);
+             WindowOptions options = windowBuilder.window(two, zero).build();
+             WindowOptions options1 = windowBuilder.window(two, zero).build()) {
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation
                   .lag(1)
@@ -3193,8 +3221,10 @@ public class TableTest extends CudfTestBase {
           }
         }
 
-        try (WindowOptions options = windowBuilder.window(2, 0).build();
-        WindowOptions options1 = windowBuilder.window(2, 0).build()) {
+        try (Scalar zero = Scalar.fromInt(0);
+             Scalar two = Scalar.fromInt(2);
+             WindowOptions options = windowBuilder.window(two, zero).build();
+             WindowOptions options1 = windowBuilder.window(two, zero).build()) {
           try (ColumnVector defaultOutput = ColumnVector.fromBoxedInts(0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
                ColumnVector decDefaultOutput = ColumnVector.decimalFromLongs(-2, 0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
                Table windowAggResults = sorted.groupBy(0, 1)
@@ -3215,8 +3245,10 @@ public class TableTest extends CudfTestBase {
         }
 
         // Outside bounds
-        try (WindowOptions options = windowBuilder.window(1, 0).build();
-        WindowOptions options1 = windowBuilder.window(1, 0).build()) {
+        try (Scalar zero = Scalar.fromInt(0);
+             Scalar one = Scalar.fromInt(1);
+             WindowOptions options = windowBuilder.window(one, zero).build();
+             WindowOptions options1 = windowBuilder.window(one, zero).build()) {
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation
                   .lag(3)
@@ -3249,10 +3281,12 @@ public class TableTest extends CudfTestBase {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectedSortedAggCol, sortedAggColumn);
 
-        try (WindowOptions window = WindowOptions.builder()
-            .minPeriods(1)
-            .window(2, 1)
-            .build();) {
+        try (Scalar one = Scalar.fromInt(1);
+             Scalar two = Scalar.fromInt(2);
+             WindowOptions window = WindowOptions.builder()
+                 .minPeriods(1)
+                 .window(two, one)
+                 .build()) {
 
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(Aggregation.mean().onColumn(3).overWindow(window));
@@ -3266,7 +3300,8 @@ public class TableTest extends CudfTestBase {
 
   @Test
   void testWindowingOnMultipleDifferentColumns() {
-    try (Table unsorted = new Table.TestBuilder().column( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) // GBY Key
+    try (Table unsorted = new Table.TestBuilder()
+        .column( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) // GBY Key
         .column( 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3) // GBY Key
         .column( 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6) // OBY Key
         .column( 7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6) // Agg Column
@@ -3276,24 +3311,26 @@ public class TableTest extends CudfTestBase {
         ColumnVector sortedAggColumn = sorted.getColumn(3);
         assertColumnsAreEqual(expectedSortedAggCol, sortedAggColumn);
 
-        try (
-        // Window (1,1), with a minimum of 1 reading.
-        WindowOptions window_1 = WindowOptions.builder()
-            .minPeriods(1)
-            .window(2, 1)
-            .build();
+        try (Scalar one = Scalar.fromInt(1);
+             Scalar two = Scalar.fromInt(2);
+             Scalar three = Scalar.fromInt(3);
+             // Window (1,1), with a minimum of 1 reading.
+             WindowOptions window_1 = WindowOptions.builder()
+                 .minPeriods(1)
+                 .window(two, one)
+                 .build();
 
-        // Window (2,2), with a minimum of 2 readings.
-        WindowOptions window_2 = WindowOptions.builder()
-            .minPeriods(2)
-            .window(3, 2)
-            .build();
+             // Window (2,2), with a minimum of 2 readings.
+             WindowOptions window_2 = WindowOptions.builder()
+                 .minPeriods(2)
+                 .window(three, two)
+                 .build();
 
-        // Window (1,1), with a minimum of 3 readings.
-        WindowOptions window_3 = WindowOptions.builder()
-            .minPeriods(3)
-            .window(2, 1)
-            .build();) {
+             // Window (1,1), with a minimum of 3 readings.
+             WindowOptions window_3 = WindowOptions.builder()
+                 .minPeriods(3)
+                 .window(two, one)
+                 .build()) {
 
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(
@@ -3327,10 +3364,12 @@ public class TableTest extends CudfTestBase {
         ColumnVector sortedAggColumn = sorted.getColumn(1);
         assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
 
-        try (WindowOptions window = WindowOptions.builder()
-            .minPeriods(1)
-            .window(2, 1)
-            .build();) {
+        try (Scalar one = Scalar.fromInt(1);
+             Scalar two = Scalar.fromInt(2);
+             WindowOptions window = WindowOptions.builder()
+                 .minPeriods(1)
+                 .window(two, one)
+                 .build()) {
 
           try (Table windowAggResults = sorted.groupBy().aggregateWindows(
               Aggregation.sum().onColumn(1).overWindow(window));
@@ -3504,10 +3543,12 @@ public class TableTest extends CudfTestBase {
               }
             }
 
-            try (WindowOptions window = WindowOptions.builder()
-                .minPeriods(1)
-                .window(2, 1)
-                .build();) {
+            try (Scalar one = Scalar.fromInt(1);
+                 Scalar two = Scalar.fromInt(2);
+                 WindowOptions window = WindowOptions.builder()
+                     .minPeriods(1)
+                     .window(two, one)
+                     .build()) {
 
               try (Table windowAggResults = sorted.groupBy(0, 1)
                   .aggregateWindows(Aggregation.max().onColumn(2).overWindow(window));
@@ -3675,11 +3716,12 @@ public class TableTest extends CudfTestBase {
         .column(true, false, true, false, true, false, true, false, false, false, false, false, false) // orderBy Key
         .build()) {
 
-      try (WindowOptions rangeBasedWindow = WindowOptions.builder()
-          .minPeriods(1)
-          .window(1, 1)
-          .orderByColumnIndex(3)
-          .build();) {
+      try (Scalar one = Scalar.fromInt(1);
+           WindowOptions rangeBasedWindow = WindowOptions.builder()
+               .minPeriods(1)
+               .window(one, one)
+               .orderByColumnIndex(3)
+               .build()) {
 
         assertThrows(IllegalArgumentException.class,
             () -> table
@@ -3691,18 +3733,27 @@ public class TableTest extends CudfTestBase {
 
   @Test
   void testInvalidWindowTypeExceptions() {
-    try (Table table = new Table.TestBuilder().column(             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) // GBY Key
-        .column(             0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2) // GBY Key
-        .timestampDayColumn( 1, 1, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7) // Timestamp Key
-        .column(             7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8) // Agg Column
-        .build()) {
+    try (Scalar one = Scalar.fromInt(1);
+         Table table = new Table.TestBuilder()
+             .column(             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) // GBY Key
+             .column(             0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2) // GBY Key
+             .timestampDayColumn( 1, 1, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7) // Timestamp Key
+             .column(             7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6, 8) // Agg Column
+             .build()) {
 
 
-      try (WindowOptions rowBasedWindow = WindowOptions.builder().minPeriods(1).window(1,1).build();) {
+      try (WindowOptions rowBasedWindow = WindowOptions.builder()
+          .minPeriods(1)
+          .window(one, one)
+          .build()) {
         assertThrows(IllegalArgumentException.class, () -> table.groupBy(0, 1).aggregateWindowsOverRanges(Aggregation.max().onColumn(3).overWindow(rowBasedWindow)));
       }
 
-      try (WindowOptions rangeBasedWindow = WindowOptions.builder().minPeriods(1).window(1,1).orderByColumnIndex(2).build();) {
+      try (WindowOptions rangeBasedWindow = WindowOptions.builder()
+          .minPeriods(1)
+          .window(one, one)
+          .orderByColumnIndex(2)
+          .build()) {
         assertThrows(IllegalArgumentException.class, () -> table.groupBy(0, 1).aggregateWindows(Aggregation.max().onColumn(3).overWindow(rangeBasedWindow)));
       }
     }


### PR DESCRIPTION
There were some recent changes to the rolling window java APIs that made it so there were multiple different ways to set preceding and following and they were inconsistent with each other. What is more if you used the wrong one, you got either the wrong answer or your program crashed with a seg fault trying to dereference a null pointer.

This removes the ambiguity, but it is a breaking change. Because of this I am going to keep this in draft until Monday.