### PR TITLE
[Review] CMake always explicitly specify a source files extension

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -61,8 +61,8 @@ ConfigureTest(GROUPBY_TEST
     groupby/count_scan_tests.cpp
     groupby/count_tests.cpp
     groupby/groups_tests.cpp
-    groupby/keys_tests.cpp    
-    groupby/min_tests.cpp    
+    groupby/keys_tests.cpp
+    groupby/min_tests.cpp
     groupby/max_scan_tests.cpp
     groupby/max_tests.cpp
     groupby/mean_tests.cpp
@@ -137,7 +137,7 @@ ConfigureTest(CLAMP_TEST replace/clamp_test.cpp)
 
 ###################################################################################################
 # - fixed_point tests -----------------------------------------------------------------------------
-ConfigureTest(FIXED_POINT_TEST 
+ConfigureTest(FIXED_POINT_TEST
     fixed_point/fixed_point_tests.cpp
     fixed_point/fixed_point_tests.cu)
 
@@ -330,7 +330,7 @@ ConfigureTest(STRINGS_TEST
     strings/chars_types_tests.cpp
     strings/combine/concatenate_list_elements_tests.cpp
     strings/combine/concatenate_tests.cpp
-    strings/combine/join_strings_tests
+    strings/combine/join_strings_tests.cpp
     strings/concatenate_tests.cpp
     strings/contains_tests.cpp
     strings/datetime_tests.cpp


### PR DESCRIPTION
While you can pass files without extensions to CMake this is legacy behavior that is now deprecated.
