### PR TITLE
Update io util to convert path like object to string

### DIFF
--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from uuid import uuid4
 
 from fsspec.core import get_fs_token_paths
-from fsspec.utils import stringify_path
 from pyarrow import dataset as ds, parquet as pq
 
 import cudf
@@ -203,7 +202,11 @@ def read_parquet(
     for source in filepath_or_buffer:
         if ioutils.is_directory(source, **kwargs):
             fs = _ensure_filesystem(passed_filesystem=None, path=source)
-            source = stringify_path(source)
+            source = (
+                source.__fspath__()
+                if hasattr(source, "__fspath__")
+                else source
+            )
             source = fs.sep.join([source, "*.parquet"])
 
         tmp_source, compression = ioutils.get_filepath_or_buffer(

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1051,7 +1051,11 @@ def _is_local_filesystem(fs):
 def ensure_single_filepath_or_buffer(path_or_data, **kwargs):
     """Return False if `path_or_data` resolves to multiple filepaths or buffers
     """
-    path_or_data = fsspec.utils.stringify_path(path_or_data)
+    path_or_data = (
+        path_or_data.__fspath__()
+        if hasattr(path_or_data, "__fspath__")
+        else path_or_data
+    )
     if isinstance(path_or_data, str):
         storage_options = kwargs.get("storage_options")
         path_or_data = os.path.expanduser(path_or_data)
@@ -1076,7 +1080,11 @@ def ensure_single_filepath_or_buffer(path_or_data, **kwargs):
 def is_directory(path_or_data, **kwargs):
     """Returns True if the provided filepath is a directory
     """
-    path_or_data = fsspec.utils.stringify_path(path_or_data)
+    path_or_data = (
+        path_or_data.__fspath__()
+        if hasattr(path_or_data, "__fspath__")
+        else path_or_data
+    )
     if isinstance(path_or_data, str):
         storage_options = kwargs.get("storage_options")
         path_or_data = os.path.expanduser(path_or_data)
@@ -1121,7 +1129,11 @@ def get_filepath_or_buffer(
     compression : str
         Type of compression algorithm for the content
     """
-    path_or_data = fsspec.utils.stringify_path(path_or_data)
+    path_or_data = (
+        path_or_data.__fspath__()
+        if hasattr(path_or_data, "__fspath__")
+        else path_or_data
+    )
 
     if isinstance(path_or_data, str):
         storage_options = kwargs.get("storage_options")


### PR DESCRIPTION
Fixes failing dask-cudf s3 test introduced from changes to `fsspec.stringify_path` in their 2021.5.0 release.

Problem description:
While reading remote files with dask-cudf the `path_or_object` param is populated with remote file objects such as `s3fs.s3File` or `gcsfs.GCSFile`. Updates to the `fsspec.stringify_path` util results in returning the string path for such objects resulting in cudf looking for those file paths locally. 

Fix:
Fix uses one of the branches from the original `stringify_path` util that checks if a `path like` object implement the `fsspath` protocol and gets the string representation from that. 
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
