### PR TITLE
Update cudfjni version to 21.06.0 [skip ci]

### DIFF
--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -49,5 +49,5 @@ scl enable devtoolset-9 "java/ci/build-in-docker.sh"
 
 ### The output
 
-You can find the cuDF jar in java/target/ like cudf-21.06-SNAPSHOT-cuda11.jar.
+You can find the cuDF jar in java/target/ like cudf-21.06.0-SNAPSHOT-cuda11.jar.
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ai.rapids</groupId>
     <artifactId>cudf</artifactId>
-    <version>21.06-SNAPSHOT</version>
+    <version>21.06.0-SNAPSHOT</version>
 
     <name>cudfjni</name>
     <description>


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

supplement to #8267, 
as discussed, cudf JNI  and plugin will follow pattern YY.MM.P