### PR TITLE
Added decimal writing for CSV writer

### DIFF
--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -119,7 +119,8 @@ struct column_to_strings_fn {
     return not((std::is_same<column_type, cudf::string_view>::value) ||
                (std::is_integral<column_type>::value) ||
                (std::is_floating_point<column_type>::value) ||
-               (cudf::is_timestamp<column_type>()) || (cudf::is_duration<column_type>()));
+               (cudf::is_fixed_point<column_type>()) || (cudf::is_timestamp<column_type>()) ||
+               (cudf::is_duration<column_type>()));
   }
 
   explicit column_to_strings_fn(
@@ -187,6 +188,15 @@ struct column_to_strings_fn {
     column_view const& column) const
   {
     return cudf::strings::detail::from_floats(column, stream_, mr_);
+  }
+
+  // fixed point:
+  //
+  template <typename column_type>
+  std::enable_if_t<cudf::is_fixed_point<column_type>(), std::unique_ptr<column>> operator()(
+    column_view const& column) const
+  {
+    return cudf::strings::detail::from_fixed_point(column, stream_, mr_);
   }
 
   // timestamps:

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -352,7 +352,7 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumn)
 
   read_result_file.close();
 
-  ASSERT_EQ(result_strings, reference_strings);
+  EXPECT_EQ(result_strings, reference_strings);
 }
 
 TEST_F(CsvReaderTest, MultiColumn)

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -362,8 +362,6 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnNegativeScale)
             std::istream_iterator<std::string>(),
             std::back_inserter(result_strings));
 
-  read_result_file.close();
-
   EXPECT_EQ(result_strings, reference_strings);
 }
 
@@ -409,8 +407,6 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnPositiveScale)
   std::copy(std::istream_iterator<std::string>(read_result_file),
             std::istream_iterator<std::string>(),
             std::back_inserter(result_strings));
-
-  read_result_file.close();
 
   EXPECT_EQ(result_strings, reference_strings);
 }

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -22,9 +22,11 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/iterator.cuh>
+#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/io/csv.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/strings/convert/convert_datetime.hpp>
+#include <cudf/strings/convert/convert_fixed_point.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
@@ -60,6 +62,16 @@ using table_view = cudf::table_view;
 // Global environment for temporary files
 auto const temp_env = static_cast<cudf::test::TempDirTestEnvironment*>(
   ::testing::AddGlobalTestEnvironment(new cudf::test::TempDirTestEnvironment));
+
+// Base test fixture for tests
+struct CsvWriterTest : public cudf::test::BaseFixture {
+};
+
+template <typename T>
+struct CsvFixedPointWriterTest : public CsvWriterTest {
+};
+
+TYPED_TEST_CASE(CsvFixedPointWriterTest, cudf::test::FixedPointTypes);
 
 // Base test fixture for tests
 struct CsvReaderTest : public cudf::test::BaseFixture {
@@ -305,6 +317,42 @@ TYPED_TEST(CsvReaderNumericTypeTest, SingleColumn)
 
   const auto view = result.tbl->view();
   expect_column_data_equal(std::vector<TypeParam>(sequence, sequence + num_rows), view.column(0));
+}
+
+TYPED_TEST(CsvFixedPointWriterTest, SingleColumn)
+{
+  std::vector<std::string> reference_strings = {
+    "1.23", "-8.76", "5.43", "-0.12", "0.25", "-0.23", "-0.27", "0.00", "0.00"};
+
+  cudf::test::strings_column_wrapper strings(reference_strings.begin(), reference_strings.end());
+
+  using DecimalType = TypeParam;
+  auto input_column = cudf::strings::to_fixed_point(
+    cudf::strings_column_view(strings),
+    cudf::data_type{cudf::type_to_id<DecimalType>(), numeric::scale_type{-2}});
+
+  auto input_table = cudf::table_view{std::vector<cudf::column_view>{*input_column}};
+
+  auto filepath = temp_env->get_temp_dir() + "FixedPointSingleColumn.csv";
+
+  cudf_io::csv_writer_options writer_options =
+    cudf_io::csv_writer_options::builder(cudf_io::sink_info(filepath), input_table);
+
+  cudf_io::write_csv(writer_options);
+
+  std::vector<std::string> result_strings;
+  result_strings.reserve(reference_strings.size());
+
+  std::ifstream read_result_file(filepath);
+  assert(read_result_file.is_open());
+
+  std::copy(std::istream_iterator<std::string>(read_result_file),
+            std::istream_iterator<std::string>(),
+            std::back_inserter(result_strings));
+
+  read_result_file.close();
+
+  ASSERT_EQ(result_strings, reference_strings);
 }
 
 TEST_F(CsvReaderTest, MultiColumn)


### PR DESCRIPTION
Addresses #7110 

column_to_strings_fn was specialized for fixed point type to enable support for csv writer. A test was added to validate output file created by csv writer for decimal type column.