### PR TITLE
use address and length for GDS reads/writes [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -78,11 +78,26 @@ public class CuFile {
    * @param path        The file path to copy to.
    * @param file_offset The file offset from which to write the buffer.
    * @param buffer      The device buffer to copy from.
-   * @return The file offset from which the buffer was appended.
+   * @deprecated Use writeDeviceMemoryToFile instead.
    */
   public static void writeDeviceBufferToFile(File path, long file_offset,
                                              BaseDeviceMemoryBuffer buffer) {
-    writeToFile(path.getAbsolutePath(), file_offset, buffer.getAddress(), buffer.getLength());
+    writeDeviceMemoryToFile(path, file_offset, buffer.getAddress(), buffer.getLength());
+  }
+
+  /**
+   * Write device memory to a given file path synchronously.
+   * <p>
+   * This method is NOT thread safe if the path points to the same file on disk.
+   *
+   * @param path        The file path to copy to.
+   * @param file_offset The file offset from which to write the buffer.
+   * @param address     The device memory address to copy from.
+   * @param length      The length to copy.
+   */
+  public static void writeDeviceMemoryToFile(File path, long file_offset, long address,
+                                             long length) {
+    writeToFile(path.getAbsolutePath(), file_offset, address, length);
   }
 
   /**
@@ -93,9 +108,24 @@ public class CuFile {
    * @param path   The file path to copy to.
    * @param buffer The device buffer to copy from.
    * @return The file offset from which the buffer was appended.
+   * @deprecated Use appendDeviceMemoryToFile instead.
    */
   public static long appendDeviceBufferToFile(File path, BaseDeviceMemoryBuffer buffer) {
-    return appendToFile(path.getAbsolutePath(), buffer.getAddress(), buffer.getLength());
+    return appendDeviceMemoryToFile(path, buffer.getAddress(), buffer.getLength());
+  }
+
+  /**
+   * Append device memory to a given file path synchronously.
+   * <p>
+   * This method is NOT thread safe if the path points to the same file on disk.
+   *
+   * @param path    The file path to copy to.
+   * @param address The device memory address to copy from.
+   * @param length  The length to copy.
+   * @return The file offset from which the buffer was appended.
+   */
+  public static long appendDeviceMemoryToFile(File path, long address, long length) {
+    return appendToFile(path.getAbsolutePath(), address, length);
   }
 
   /**
@@ -106,10 +136,25 @@ public class CuFile {
    * @param buffer     The device buffer to copy into.
    * @param path       The file path to copy from.
    * @param fileOffset The file offset from which to copy the content.
+   * @deprecated Use readFileToDeviceMemory instead.
    */
   public static void readFileToDeviceBuffer(BaseDeviceMemoryBuffer buffer, File path,
                                             long fileOffset) {
-    readFromFile(buffer.getAddress(), buffer.getLength(), path.getAbsolutePath(), fileOffset);
+    readFileToDeviceMemory(buffer.getAddress(), buffer.getLength(), path, fileOffset);
+  }
+
+  /**
+   * Read a file into device memory synchronously.
+   * <p>
+   * This method is NOT thread safe if the path points to the same file on disk.
+   *
+   * @param address The device memory address to read into.
+   * @param length  The length to read.
+   * @param path       The file path to copy from.
+   * @param fileOffset The file offset from which to copy the content.
+   */
+  public static void readFileToDeviceMemory(long address, long length, File path, long fileOffset) {
+    readFromFile(address, length, path.getAbsolutePath(), fileOffset);
   }
 
   private static native void writeToFile(String path, long file_offset, long address, long length);

--- a/java/src/main/java/ai/rapids/cudf/CuFile.java
+++ b/java/src/main/java/ai/rapids/cudf/CuFile.java
@@ -78,7 +78,6 @@ public class CuFile {
    * @param path        The file path to copy to.
    * @param file_offset The file offset from which to write the buffer.
    * @param buffer      The device buffer to copy from.
-   * @deprecated Use writeDeviceMemoryToFile instead.
    */
   public static void writeDeviceBufferToFile(File path, long file_offset,
                                              BaseDeviceMemoryBuffer buffer) {
@@ -108,7 +107,6 @@ public class CuFile {
    * @param path   The file path to copy to.
    * @param buffer The device buffer to copy from.
    * @return The file offset from which the buffer was appended.
-   * @deprecated Use appendDeviceMemoryToFile instead.
    */
   public static long appendDeviceBufferToFile(File path, BaseDeviceMemoryBuffer buffer) {
     return appendDeviceMemoryToFile(path, buffer.getAddress(), buffer.getLength());
@@ -136,7 +134,6 @@ public class CuFile {
    * @param buffer     The device buffer to copy into.
    * @param path       The file path to copy from.
    * @param fileOffset The file offset from which to copy the content.
-   * @deprecated Use readFileToDeviceMemory instead.
    */
   public static void readFileToDeviceBuffer(BaseDeviceMemoryBuffer buffer, File path,
                                             long fileOffset) {

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -73,8 +73,8 @@ public class CuFileTest extends CudfTestBase {
          HostMemoryBuffer dest = HostMemoryBuffer.allocate(16)) {
       orig.setLong(0, 123456789);
       from.copyFromHostBuffer(orig);
-      CuFile.writeDeviceMemoryToFile(tempFile, 0, from.address, from.length);
-      CuFile.readFileToDeviceMemory(to.address, to.length, tempFile, 0);
+      CuFile.writeDeviceBufferToFile(tempFile, 0, from);
+      CuFile.readFileToDeviceBuffer(to, tempFile, 0);
       dest.copyFromDeviceBuffer(to);
       assertEquals(123456789, dest.getLong(0));
     }
@@ -87,17 +87,17 @@ public class CuFileTest extends CudfTestBase {
          HostMemoryBuffer dest = HostMemoryBuffer.allocate(16)) {
       orig.setLong(0, 123456789);
       from.copyFromHostBuffer(orig);
-      assertEquals(0, CuFile.appendDeviceMemoryToFile(tempFile, from.address, from.length));
+      assertEquals(0, CuFile.appendDeviceBufferToFile(tempFile, from));
 
       orig.setLong(0, 987654321);
       from.copyFromHostBuffer(orig);
-      assertEquals(16, CuFile.appendDeviceMemoryToFile(tempFile, from.address, from.length));
+      assertEquals(16, CuFile.appendDeviceBufferToFile(tempFile, from));
 
-      CuFile.readFileToDeviceMemory(to.address, to.length, tempFile, 0);
+      CuFile.readFileToDeviceBuffer(to, tempFile, 0);
       dest.copyFromDeviceBuffer(to);
       assertEquals(123456789, dest.getLong(0));
 
-      CuFile.readFileToDeviceMemory(to.address, to.length, tempFile, 16);
+      CuFile.readFileToDeviceBuffer(to, tempFile, 16);
       dest.copyFromDeviceBuffer(to);
       assertEquals(987654321, dest.getLong(0));
     }

--- a/java/src/test/java/ai/rapids/cudf/CuFileTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CuFileTest.java
@@ -73,8 +73,8 @@ public class CuFileTest extends CudfTestBase {
          HostMemoryBuffer dest = HostMemoryBuffer.allocate(16)) {
       orig.setLong(0, 123456789);
       from.copyFromHostBuffer(orig);
-      CuFile.writeDeviceBufferToFile(tempFile, 0, from);
-      CuFile.readFileToDeviceBuffer(to, tempFile, 0);
+      CuFile.writeDeviceMemoryToFile(tempFile, 0, from.address, from.length);
+      CuFile.readFileToDeviceMemory(to.address, to.length, tempFile, 0);
       dest.copyFromDeviceBuffer(to);
       assertEquals(123456789, dest.getLong(0));
     }
@@ -87,17 +87,17 @@ public class CuFileTest extends CudfTestBase {
          HostMemoryBuffer dest = HostMemoryBuffer.allocate(16)) {
       orig.setLong(0, 123456789);
       from.copyFromHostBuffer(orig);
-      assertEquals(0, CuFile.appendDeviceBufferToFile(tempFile, from));
+      assertEquals(0, CuFile.appendDeviceMemoryToFile(tempFile, from.address, from.length));
 
       orig.setLong(0, 987654321);
       from.copyFromHostBuffer(orig);
-      assertEquals(16, CuFile.appendDeviceBufferToFile(tempFile, from));
+      assertEquals(16, CuFile.appendDeviceMemoryToFile(tempFile, from.address, from.length));
 
-      CuFile.readFileToDeviceBuffer(to, tempFile, 0);
+      CuFile.readFileToDeviceMemory(to.address, to.length, tempFile, 0);
       dest.copyFromDeviceBuffer(to);
       assertEquals(123456789, dest.getLong(0));
 
-      CuFile.readFileToDeviceBuffer(to, tempFile, 16);
+      CuFile.readFileToDeviceMemory(to.address, to.length, tempFile, 16);
       dest.copyFromDeviceBuffer(to);
       assertEquals(987654321, dest.getLong(0));
     }


### PR DESCRIPTION
Since we want GDS reads/writes to be 4 KiB aligned, sometimes we can't use the `DeviceMemoryBuffer` as is and need to adjust the size written. This change makes the JNI APIs more flexible to accommodate those.