### PR TITLE
fixed documentation bug in groupby agg method

### DIFF
--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -123,10 +123,10 @@ class GroupBy(Serializable):
         >>> a = cudf.DataFrame(
             {'a': [1, 1, 2], 'b': [1, 2, 3], 'c': [2, 2, 1]})
         >>> a.groupby('a').agg('sum')
-           b
+           b  c
         a
-        2  3
-        1  3
+        2  3  1
+        1  3  4
 
         Specifying a list of aggregations to perform on each column.
 


### PR DESCRIPTION
This is a non-functional documentation update. 
The output of the c column is missing in the result of the first example in agg method: 
python/cudf/cudf/core/groupby/groupby.py
I added the values of the c columns. 
