### PR TITLE
Fixed documentation bug in groupby agg method

### DIFF
--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -136,10 +136,10 @@ class GroupBy(Serializable):
         >>> a = cudf.DataFrame(
             {'a': [1, 1, 2], 'b': [1, 2, 3], 'c': [2, 2, 1]})
         >>> a.groupby('a').agg('sum')
-           b
+           b  c
         a
-        2  3
-        1  3
+        2  3  1
+        1  3  4
 
         Specifying a list of aggregations to perform on each column.
 

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -343,7 +343,7 @@ class GroupBy(Serializable):
         >>> import cudf
         >>> df = cudf.DataFrame({'A': ['a', 'b', 'a', 'b'], 'B': [1, 2, 3, 4]})
         >>> df
-        A  B
+           A  B
         0  a  1
         1  b  2
         2  a  3
@@ -353,7 +353,7 @@ class GroupBy(Serializable):
         in one pass, you can do
 
         >>> df.groupby('A').pipe(lambda x: x.max() - x.min())
-        B
+           B
         A
         a  2
         b  2


### PR DESCRIPTION
This is a non-functional documentation update.
The output of the c column is missing in the result of the first example in agg method:
python/cudf/cudf/core/groupby/groupby.py
I added the values of the c columns.
