### PR TITLE
Statically link libnvcomp into libcudfjni [skip ci]

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -422,14 +422,6 @@
                                 fail("Could not find cudf as a dependency of libcudfjni out> $sout err> $serr")
                             }
 
-                            def libnvcomp = ~/libnvcomp\\.so\\s+=>\\s+(.*)libnvcomp.*\\.so\\s+.*/
-                            def nvcompm = libnvcomp.matcher(sout)
-                            if (nvcompm.find()) {
-                                pom.properties['native.nvcomp.path'] = nvcompm.group(1)
-                            } else {
-                                fail("Could not find nvcomp as a dependency of libcudfjni out> $sout err> $serr")
-                            }
-
                             def libcudart = ~/libcudart\\.so\\.(.*)\\s+=>.*/
                             def cm = libcudart.matcher(sout)
                             if (cm.find()) {
@@ -512,13 +504,6 @@
                                     <directory>${native.cudf.path}</directory>
                                     <includes>
                                         <include>libcudf.so</include>
-                                    </includes>
-                                </resource>
-                                <resource>
-                                    <!--Set by groovy script-->
-                                    <directory>${native.nvcomp.path}</directory>
-                                    <includes>
-                                        <include>libnvcomp.so</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -55,7 +55,6 @@ public class NativeDepsLoader {
    */
   private static final String[][] loadOrder = new String[][]{
       new String[]{
-          "nvcomp",
           "cudf"
       },
       new String[]{

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -292,4 +292,4 @@ target_compile_definitions(cudfjni PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(cudfjni ${CUDF_LIB} ${ARROW_LIBRARY} ${NVCOMP_LIB} ${CUDART_LIBRARY} cuda)
+target_link_libraries(cudfjni ${NVCOMP_LIB} ${CUDF_LIB} ${ARROW_LIBRARY} ${CUDART_LIBRARY} cuda)

--- a/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
+++ b/java/src/main/native/cmake/Templates/Nvcomp.CMakeLists.txt.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ ExternalProject_Add(nvcomp
     SOURCE_DIR      "${NVCOMP_ROOT}/nvcomp"
     BINARY_DIR      "${NVCOMP_ROOT}/build"
     INSTALL_DIR     "${NVCOMP_ROOT}/install"
+    PATCH_COMMAND   patch --reject-file=- -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/cmake/nvcomp.patch || true
     CMAKE_ARGS      ${NVCOMP_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${NVCOMP_ROOT}/install
     BUILD_COMMAND   ${CMAKE_COMMAND} --build . --target nvcomp
     INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping nvcomp install step.")

--- a/java/src/main/native/cmake/nvcomp.patch
+++ b/java/src/main/native/cmake/nvcomp.patch
@@ -1,0 +1,15 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 32f48ef..a2e3125 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -10,7 +10,9 @@ endif()
+ file(GLOB CUDA_SOURCES *.cu)
+ file(GLOB CPP_SOURCES *.cpp)
+ 
+-add_library(nvcomp SHARED ${CUDA_SOURCES} ${CPP_SOURCES})
++
++add_library(nvcomp STATIC ${CUDA_SOURCES} ${CPP_SOURCES})
++set_property(TARGET nvcomp PROPERTY POSITION_INDEPENDENT_CODE True)
+ set_property(TARGET nvcomp PROPERTY CUDA_ARCHITECTURES ${GPU_ARCHS})
+ target_compile_options(nvcomp PRIVATE
+     $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda -Xcompiler -pthread>)


### PR DESCRIPTION
Updates the Java bindings to nvcomp to statically link libnvcomp.  This will help avoid libnvcomp v1.x and v2.x conflicts when libcudf starts pulling in libnvcomp 2.x as part of #8229.

Switching to a statically-linked libnvcomp requires a small patch to the nvcomp source, as it is hard-coded to only produce a shared library. The patch changes the target to a static library compiled with position-independent code so it can be linked into a shared object like libcudfjni.so.