### PR TITLE
Handle nested column types properly for empty parquet files.

### DIFF
--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -37,8 +37,6 @@
 #include <numeric>
 #include <regex>
 
-#include <cudf_test/column_utilities.hpp>
-
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -37,6 +37,8 @@
 #include <numeric>
 #include <regex>
 
+#include <cudf_test/column_utilities.hpp>
+
 namespace cudf {
 namespace io {
 namespace detail {
@@ -1572,7 +1574,8 @@ table_with_metadata reader::impl::read(size_type skip_rows,
   // Create empty columns as needed (this can happen if we've ended up with no actual data to read)
   for (size_t i = out_columns.size(); i < _output_columns.size(); ++i) {
     out_metadata.schema_info.push_back(column_name_info{""});
-    out_columns.emplace_back(make_empty_column(_output_columns[i].type));
+    out_columns.emplace_back(cudf::io::detail::empty_like(
+      _output_columns[i], &out_metadata.schema_info.back(), stream, _mr));
   }
 
   // Return column names (must match order of returned columns)

--- a/cpp/src/io/utilities/column_buffer.cpp
+++ b/cpp/src/io/utilities/column_buffer.cpp
@@ -21,6 +21,7 @@
 
 #include "column_buffer.hpp"
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/strings/detail/utilities.hpp>
 
 namespace cudf {
 namespace io {
@@ -54,15 +55,7 @@ void column_buffer::create(size_type _size,
 }
 
 /**
- * @brief Creates a column from an existing set of device memory buffers.
- *
- * @throws std::bad_alloc if device memory allocation fails
- *
- * @param buffer Column buffer descriptors
- * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr Device memory resource used to allocate the returned column's device memory
- *
- * @return `std::unique_ptr<cudf::column>` Column from the existing device data
+ * @copydoc cudf::io::detail::make_column
  */
 std::unique_ptr<column> make_column(column_buffer& buffer,
                                     column_name_info* schema_info,
@@ -136,6 +129,71 @@ std::unique_ptr<column> make_column(column_buffer& buffer,
                                       std::move(buffer._null_mask),
                                       buffer._null_count);
     }
+  }
+}
+
+/**
+ * @copydoc cudf::io::detail::empty_like
+ */
+std::unique_ptr<column> empty_like(column_buffer& buffer,
+                                   column_name_info* schema_info,
+                                   rmm::cuda_stream_view stream,
+                                   rmm::mr::device_memory_resource* mr)
+{
+  if (schema_info != nullptr) { schema_info->name = buffer.name; }
+
+  switch (buffer.type.id()) {
+    case type_id::LIST: {
+      // make offsets column
+      auto offsets = cudf::make_empty_column(data_type{type_id::INT32});
+
+      column_name_info* child_info = nullptr;
+      if (schema_info != nullptr) {
+        schema_info->children.push_back(column_name_info{"offsets"});
+        schema_info->children.push_back(column_name_info{""});
+        child_info = &schema_info->children.back();
+      }
+
+      // make child column
+      CUDF_EXPECTS(buffer.children.size() > 0, "Encountered malformed column_buffer");
+      auto child = empty_like(buffer.children[0], child_info, stream, mr);
+
+      // make the final list column
+      return make_lists_column(0,
+                               std::move(offsets),
+                               std::move(child),
+                               buffer._null_count,
+                               std::move(buffer._null_mask),
+                               stream,
+                               mr);
+    } break;
+
+    case type_id::STRUCT: {
+      std::vector<std::unique_ptr<cudf::column>> output_children;
+      output_children.reserve(buffer.children.size());
+      std::transform(buffer.children.begin(),
+                     buffer.children.end(),
+                     std::back_inserter(output_children),
+                     [&](column_buffer& col) {
+                       column_name_info* child_info = nullptr;
+                       if (schema_info != nullptr) {
+                         schema_info->children.push_back(column_name_info{""});
+                         child_info = &schema_info->children.back();
+                       }
+                       return empty_like(col, child_info, stream, mr);
+                     });
+
+      return make_structs_column(0,
+                                 std::move(output_children),
+                                 buffer._null_count,
+                                 std::move(buffer._null_mask),
+                                 stream,
+                                 mr);
+    } break;
+
+    case type_id::STRING: return cudf::strings::detail::make_empty_strings_column(stream, mr);
+
+    default: return cudf::make_empty_column(buffer.type);
   }
 }
 

--- a/cpp/src/io/utilities/column_buffer.hpp
+++ b/cpp/src/io/utilities/column_buffer.hpp
@@ -123,7 +123,38 @@ struct column_buffer {
   std::string name;
 };
 
+/**
+ * @brief Creates a column from an existing set of device memory buffers.
+ *
+ * @throws std::bad_alloc if device memory allocation fails
+ *
+ * @param buffer Column buffer descriptors
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ *
+ * @return `std::unique_ptr<cudf::column>` Column from the existing device data
+ */
 std::unique_ptr<column> make_column(
+  column_buffer& buffer,
+  column_name_info* schema_info       = nullptr,
+  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/**
+ * @brief Creates an equivalent empty column from an existing set of device memory buffers.
+ *
+ * This function preserves nested column type information by producing complete/identical
+ * column hierarchies.
+ *
+ * @throws std::bad_alloc if device memory allocation fails
+ *
+ * @param buffer Column buffer descriptors
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ *
+ * @return `std::unique_ptr<cudf::column>` Column from the existing device data
+ */
+std::unique_ptr<column> empty_like(
   column_buffer& buffer,
   column_name_info* schema_info       = nullptr,
   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -2861,4 +2861,40 @@ TEST_F(ParquetReaderTest, DecimalRead)
   }
 }
 
+TEST_F(ParquetReaderTest, EmptyOutput)
+{
+  cudf::test::fixed_width_column_wrapper<int> c0;
+  cudf::test::strings_column_wrapper c1;
+  cudf::test::fixed_point_column_wrapper<int> c2({}, numeric::scale_type{2});
+  cudf::test::lists_column_wrapper<float> _c3{{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}};
+  auto c3 = cudf::empty_like(_c3);
+
+  cudf::test::fixed_width_column_wrapper<int> sc0;
+  cudf::test::strings_column_wrapper sc1;
+  cudf::test::lists_column_wrapper<int> _sc2{{1, 2}};
+  std::vector<std::unique_ptr<cudf::column>> struct_children;
+  struct_children.push_back(sc0.release());
+  struct_children.push_back(sc1.release());
+  struct_children.push_back(cudf::empty_like(_sc2));
+  cudf::test::structs_column_wrapper c4(std::move(struct_children));
+
+  table_view expected({c0, c1, c2, *c3, c4});
+
+  // set precision on the decimal column
+  cudf_io::table_input_metadata expected_metadata(expected);
+  expected_metadata.column_metadata[2].set_decimal_precision(1);
+
+  auto filepath = temp_env->get_temp_filepath("EmptyOutput.parquet");
+  cudf_io::parquet_writer_options out_args =
+    cudf_io::parquet_writer_options::builder(cudf_io::sink_info{filepath}, expected);
+  out_args.set_metadata(&expected_metadata);
+  cudf_io::write_parquet(out_args);
+
+  cudf_io::parquet_reader_options read_args =
+    cudf::io::parquet_reader_options::builder(cudf_io::source_info{filepath});
+  auto result = cudf_io::read_parquet(read_args);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
+}
+
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
Fixes:  https://github.com/rapidsai/cudf/issues/8323

Also fixes a recently introduced bug in the test column equality checker.  The code was previously relying on accesses to device memory being transparently handled by `thrust::device_vector`