### PR TITLE
Compilation fix: Remove redefinition for `std::is_same_v()`

### DIFF
--- a/cpp/tests/utilities_tests/type_list_tests.cpp
+++ b/cpp/tests/utilities_tests/type_list_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/utilities_tests/type_list_tests.cpp
+++ b/cpp/tests/utilities_tests/type_list_tests.cpp
@@ -19,11 +19,6 @@
 
 using namespace cudf::test;  // this will make reading code way easier
 
-namespace std {
-template <class T, class U>
-constexpr bool is_same_v = std::is_same<T, U>::value;
-}
-
 namespace {
 // Work around to remove parentheses surrounding a type
 template <typename T>


### PR DESCRIPTION
With `nvcc-11.2` + `gcc-10.2`, one sees the following compilation errors in `type_list_tests.cpp`:

```
../tests/utilities_tests/type_list_tests.cpp:24:16: error: redefinition of ‘template<class T, class U> constexpr const bool std::is_same_v’
   24 | constexpr bool is_same_v = std::is_same<T, U>::value;
      |                ^~~~~~~~~
In file included from /usr/include/c++/10/bits/move.h:57,
                 from /usr/include/c++/10/bits/stl_pair.h:59,
                 from /usr/include/c++/10/bits/stl_algobase.h:64,
                 from /usr/include/c++/10/memory:63,
                 from _deps/gtest-src/googletest/include/gtest/internal/gtest-port.h:251,
                 from _deps/gtest-src/googletest/include/gtest/internal/gtest-type-util.h:47,
                 from ../include/cudf_test/cudf_gtest.hpp:42,
                 from ../tests/utilities_tests/type_list_tests.cpp:17:
/usr/include/c++/10/type_traits:3182:25: note: ‘template<class _Tp, class _Up> constexpr const bool std::is_same_v<_Tp, _Up>’ previously declared here
 3182 |   inline constexpr bool is_same_v = _GLIBCXX_BUILTIN_IS_SAME_AS(_Tp, _Up);
      |                         ^~~~~~~~~
```
I'm not sure why this doesn't turn up with `gcc-9`, even though we're using `--std=c++17` on both.

This commit removes the redefinition of `is_same_v()`.

