### PR TITLE
Handle pre-sliced nested columns in contiguous_split.

### DIFF
--- a/cpp/tests/copying/pack_tests.cu
+++ b/cpp/tests/copying/pack_tests.cu
@@ -419,6 +419,35 @@ TEST_F(PackUnpackTest, NestedEmpty)
     this->run_test(src_table);
   }
 }
+
+TEST_F(PackUnpackTest, NestedSliced)
+{ 
+  auto valids =
+    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+
+  using LCW = cudf::test::lists_column_wrapper<int>;
+
+  cudf::test::lists_column_wrapper<int> col0{ {{{1, 2, 3}, valids}, {4, 5}},
+                                              {{LCW{}, LCW{}, {7, 8}, LCW{}}, valids},                                              
+                                              {{6, 12}},
+                                              {{{7, 8}, {{9, 10, 11}, valids}, LCW{}}, valids},
+                                              {{LCW{}, {-1, -2, -3, -4, -5}}, valids},
+                                              {LCW{}},
+                                              {{-10}, {-100, -200}} };
+
+  cudf::test::strings_column_wrapper col1{"Vimes", "Carrot", "Angua", "Cheery", "Detritus", "Slant", "Fred"};
+  cudf::test::fixed_width_column_wrapper<float> col2{ 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f };
+
+  std::vector<std::unique_ptr<cudf::column>> children;
+  children.push_back(std::make_unique<cudf::column>(col2));
+  children.push_back(std::make_unique<cudf::column>(col0));
+  children.push_back(std::make_unique<cudf::column>(col1));
+  auto col3 = cudf::make_structs_column(static_cast<cudf::column_view>(col0).size(), std::move(children), 0, rmm::device_buffer{});
+  
+  cudf::table_view t({col0, col1, col2, *col3});
+  this->run_test(t);
+}
+
 // clang-format on
 
 }  // namespace test

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -1500,6 +1500,57 @@ TEST_F(ContiguousSplitTableCornerCases, MixedColumnTypes)
 
 TEST_F(ContiguousSplitTableCornerCases, PreSplitTable)
 {
+  auto valids =
+    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+
+  using LCW = cudf::test::lists_column_wrapper<int>;
+
+  cudf::test::lists_column_wrapper<int> col0{{{{1, 2, 3}, valids}, {4, 5}},
+                                             {{LCW{}, LCW{}, {7, 8}, LCW{}}, valids},
+                                             {{{6}}},
+                                             {{{7, 8}, {{9, 10, 11}, valids}, LCW{}}, valids},
+                                             {{LCW{}, {-1, -2, -3, -4, -5}}, valids},
+                                             {LCW{}},
+                                             {{-10}, {-100, -200}}};
+
+  cudf::test::strings_column_wrapper col1{
+    "Vimes", "Carrot", "Angua", "Cheery", "Detritus", "Slant", "Fred"};
+  cudf::test::fixed_width_column_wrapper<float> col2{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
+
+  std::vector<std::unique_ptr<cudf::column>> children;
+  children.push_back(std::make_unique<cudf::column>(col2));
+  children.push_back(std::make_unique<cudf::column>(col0));
+  children.push_back(std::make_unique<cudf::column>(col1));
+  auto col3 = cudf::make_structs_column(
+    static_cast<cudf::column_view>(col0).size(), std::move(children), 0, rmm::device_buffer{});
+
+  {
+    cudf::table_view t({col0, col1, col2, *col3});
+    std::vector<cudf::size_type> splits{1, 4};
+
+    auto result   = cudf::contiguous_split(t, splits);
+    auto expected = cudf::split(t, splits);
+
+    for (size_t index = 0; index < expected.size(); index++) {
+      CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected[index], result[index].table);
+    }
+  }
+
+  {
+    cudf::table_view t({col0, col1, col2, *col3});
+    std::vector<cudf::size_type> splits{0, 6};
+
+    auto result   = cudf::contiguous_split(t, splits);
+    auto expected = cudf::split(t, splits);
+
+    for (size_t index = 0; index < expected.size(); index++) {
+      CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected[index], result[index].table);
+    }
+  }
+}
+
+TEST_F(ContiguousSplitTableCornerCases, PreSplitTableLarge)
+{
   // test splitting a table that is already split (has an offset)
   cudf::size_type start        = 0;
   cudf::size_type presplit_pos = 47;


### PR DESCRIPTION
The computation that applied offsets down a hierarchy of nested columns was starting with the wrong base offset in the case of nested columns.

Note:  marking as Do Not Merge for the time being so it gets some more non-CI testing.  Specifically: this PR https://github.com/rapidsai/cudf/pull/8153