### PR TITLE
Support Dask + Distributed 2021.05.1

### DIFF
--- a/conda/environments/cudf_dev_cuda11.0.yml
+++ b/conda/environments/cudf_dev_cuda11.0.yml
@@ -41,8 +41,8 @@ dependencies:
   - mypy=0.782
   - typing_extensions
   - pre_commit
-  - dask>=2021.4.0,<=2021.5.0
-  - distributed>=2.22.0,<=2021.5.0
+  - dask>=2021.4.0,<=2021.5.1
+  - distributed>=2.22.0,<=2021.5.1
   - streamz
   - dlpack>=0.5,<0.6.0a0
   - arrow-cpp=1.0.1

--- a/conda/environments/cudf_dev_cuda11.2.yml
+++ b/conda/environments/cudf_dev_cuda11.2.yml
@@ -41,8 +41,8 @@ dependencies:
   - mypy=0.782
   - typing_extensions
   - pre_commit
-  - dask>=2021.4.0,<=2021.5.0
-  - distributed>=2.22.0,<=2021.5.0
+  - dask>=2021.4.0,<=2021.5.1
+  - distributed>=2.22.0,<=2021.5.1
   - streamz
   - dlpack>=0.5,<0.6.0a0
   - arrow-cpp=1.0.1

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -31,8 +31,8 @@ requirements:
     - python
     - streamz 
     - cudf {{ version }}
-    - dask>=2021.4.0,<=2021.5.0
-    - distributed>=2.22.0,<=2021.5.0
+    - dask>=2021.4.0,<=2021.5.1
+    - distributed>=2.22.0,<=2021.5.1
     - python-confluent-kafka
     - cudf_kafka {{ version }}
 

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -26,13 +26,13 @@ requirements:
   host:
     - python
     - cudf {{ version }}
-    - dask>=2021.4.0,<=2021.5.0
-    - distributed>=2.22.0,<=2021.5.0
+    - dask>=2021.4.0,<=2021.5.1
+    - distributed>=2.22.0,<=2021.5.1
   run:
     - python
     - cudf {{ version }}
-    - dask>=2021.4.0,<=2021.5.0
-    - distributed>=2.22.0,<=2021.5.0
+    - dask>=2021.4.0,<=2021.5.1
+    - distributed>=2.22.0,<=2021.5.1
   
 test:
   requires:

--- a/python/custreamz/dev_requirements.txt
+++ b/python/custreamz/dev_requirements.txt
@@ -3,8 +3,8 @@
 flake8==3.8.3
 black==19.10b0
 isort==5.0.7
-dask>=2021.4.0,<=2021.5.0
-distributed>=2.22.0,<=2021.5.0
+dask>=2021.4.0,<=2021.5.1
+distributed>=2.22.0,<=2021.5.1
 streamz
 python-confluent-kafka
 pytest

--- a/python/dask_cudf/dev_requirements.txt
+++ b/python/dask_cudf/dev_requirements.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, NVIDIA CORPORATION.
 
-dask>=2021.4.0,<=2021.5.0
-distributed>=2.22.0,<=2021.5.0
+dask>=2021.4.0,<=2021.5.1
+distributed>=2.22.0,<=2021.5.1
 fsspec>=0.6.0
 numba>=0.53.1
 numpy

--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -10,8 +10,8 @@ import versioneer
 
 install_requires = [
     "cudf",
-    "dask>=2021.4.0,<=2021.5.0",
-    "distributed>=2.22.0,<=2021.5.0",
+    "dask>=2021.4.0,<=2021.5.1",
+    "distributed>=2.22.0,<=2021.5.1",
     "fsspec>=0.6.0",
     "numpy",
     "pandas>=1.0,<1.3.0dev0",
@@ -23,8 +23,8 @@ extras_require = {
         "pandas>=1.0,<1.3.0dev0",
         "pytest",
         "numba>=0.53.1",
-        "dask>=2021.4.0,<=2021.5.0",
-        "distributed>=2.22.0,<=2021.5.0",
+        "dask>=2021.4.0,<=2021.5.1",
+        "distributed>=2.22.0,<=2021.5.1",
     ]
 }
 


### PR DESCRIPTION
Allow installing Dask + Distributed 2021.05.1 to be installed.

~~This isn't released yet, but this tees things up so we are ready to go once it comes out.~~

Associated integration PR ( https://github.com/rapidsai/integration/pull/284 )