### PR TITLE
Implement `groupby::merge` for `collect_list` and `collect_set`

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -195,6 +195,7 @@ add_library(cudf
     src/groupby/sort/group_argmin.cu
     src/groupby/sort/aggregate.cpp
     src/groupby/sort/group_collect.cu
+    src/groupby/sort/group_collect_merge.cu
     src/groupby/sort/group_count.cu
     src/groupby/sort/group_max.cu
     src/groupby/sort/group_min.cu

--- a/cpp/include/cudf/detail/groupby.hpp
+++ b/cpp/include/cudf/detail/groupby.hpp
@@ -39,6 +39,14 @@ namespace hash {
  */
 bool can_use_hash_groupby(table_view const& keys, host_span<aggregation_request const> requests);
 
+/**
+ * TODO
+ * @brief is_hash_aggregation
+ * @param t
+ * @return
+ */
+bool is_hash_aggregation(aggregation::Kind t);
+
 // Hash-based groupby
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby(
   table_view const& keys,

--- a/cpp/include/cudf/groupby.hpp
+++ b/cpp/include/cudf/groupby.hpp
@@ -282,6 +282,27 @@ class groupby {
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
+   * @brief Merge multiple results of previous groupby aggregations together.
+   *
+   * Since the results of different aggregations may have dirferent sizes (number of rows),
+   * we cannot call `aggregate` to merge them.
+   *
+   * Currently only support COLLECT_LIST.
+   * Due to COLLECT_LIST is a sort-based aggregation, the keys tables must be sorted.
+   *
+   * TODO: Rewrite doxygen
+   *
+   * @return Pair containing the table with each group's unique key and
+   * an aggregation_result containing the merged result of all provided results.
+   *
+   */
+  std::pair<std::unique_ptr<table>, std::unique_ptr<column>> merge(
+    aggregation const& agg,
+    host_span<table_view const> agg_keys,
+    host_span<column_view const> agg_results,
+    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
+
+  /**
    * @brief The grouped data corresponding to a groupby operation on a set of values.
    *
    * A `groups` object holds two tables of identical number of rows:
@@ -391,6 +412,13 @@ class groupby {
     host_span<aggregation_request const> requests,
     rmm::cuda_stream_view stream,
     rmm::mr::device_memory_resource* mr);
+
+  std::pair<std::unique_ptr<table>, std::unique_ptr<column>> merge_sort_aggregates(
+    aggregation const& agg,
+    host_span<table_view const> agg_keys,
+    host_span<column_view const> agg_results,
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource* mr) const;
 };
 /** @} */
 }  // namespace groupby

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -87,19 +87,6 @@ constexpr bool array_contains(std::array<T, N> const& haystack, T needle)
   return false;
 }
 
-/**
- * @brief Indicates whether the specified aggregation operation can be computed
- * with a hash-based implementation.
- *
- * @param t The aggregation operation to verify
- * @return true `t` is valid for a hash based groupby
- * @return false `t` is invalid for a hash based groupby
- */
-bool constexpr is_hash_aggregation(aggregation::Kind t)
-{
-  return array_contains(hash_aggregations, t);
-}
-
 class groupby_simple_aggregations_collector final
   : public cudf::detail::simple_aggregations_collector {
  public:
@@ -630,6 +617,16 @@ std::unique_ptr<table> groupby_null_templated(table_view const& keys,
 }
 
 }  // namespace
+
+/**
+ * @brief Indicates whether the specified aggregation operation can be computed
+ * with a hash-based implementation.
+ *
+ * @param t The aggregation operation to verify
+ * @return true `t` is valid for a hash based groupby
+ * @return false `t` is invalid for a hash based groupby
+ */
+bool is_hash_aggregation(aggregation::Kind t) { return array_contains(hash_aggregations, t); }
 
 /**
  * @brief Indicates if a set of aggregation requests can be satisfied with a

--- a/cpp/src/groupby/sort/functors.hpp
+++ b/cpp/src/groupby/sort/functors.hpp
@@ -91,6 +91,29 @@ struct store_result_functor {
   std::unique_ptr<column> sorted_values;   ///< Memoised grouped and sorted values
   std::unique_ptr<column> grouped_values;  ///< Memoised grouped values
 };
+
+/**
+ * @brief
+ *
+ * TODO
+ */
+struct merge_aggregates_functor {
+  template <aggregation::Kind k>
+  std::pair<std::unique_ptr<table>, std::unique_ptr<column>> operator()(
+    aggregation const&, host_span<table_view const>, host_span<column_view const>) const
+  {
+    CUDF_FAIL("Unsupported aggregation.");
+  }
+
+  // private:
+  // TODO make const
+  null_policy null_handling;                ///< TODO
+  std::vector<order> column_order;          ///< TODO
+  std::vector<null_order> null_precedence;  ///< TODO
+  rmm::cuda_stream_view stream;             ///< CUDA stream on which to execute kernels
+  rmm::mr::device_memory_resource* mr;      ///< Memory resource to allocate space for results
+};
+
 }  // namespace detail
 }  // namespace groupby
 }  // namespace cudf

--- a/cpp/src/groupby/sort/group_collect.cu
+++ b/cpp/src/groupby/sort/group_collect.cu
@@ -117,6 +117,7 @@ std::unique_ptr<column> group_collect(column_view const &values,
                            stream,
                            mr);
 }
+
 }  // namespace detail
 }  // namespace groupby
 }  // namespace cudf

--- a/cpp/src/groupby/sort/group_collect_merge.cu
+++ b/cpp/src/groupby/sort/group_collect_merge.cu
@@ -45,8 +45,8 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<column>> group_collect_merge(
   auto const default_mr = rmm::mr::get_current_device_resource();
 
   //
-  // Warning: Below is just a workaround.
-  // This is a more efficient merging API that is WIP by Dave Baranec, and will be adopted here
+  // Warning: Below is just a work-around.
+  // There is a more efficient merging API that is WIP by Dave Baranec, and will be adopted here
   // after finished.
   //
 

--- a/cpp/src/groupby/sort/group_collect_merge.cu
+++ b/cpp/src/groupby/sort/group_collect_merge.cu
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/detail/copy_if.cuh>
+#include <cudf/detail/gather.cuh>
+#include <cudf/strings/detail/utilities.cuh>
+#include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
+
+// TODO: Reorganize
+#include <cudf/concatenate.hpp>
+#include <cudf/groupby.hpp>
+#include <cudf/lists/combine.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+namespace cudf {
+namespace groupby {
+namespace detail {
+std::pair<std::unique_ptr<table>, std::unique_ptr<column>> group_collect_merge(
+  host_span<table_view const> agg_keys,
+  host_span<column_view const> agg_results,
+  null_policy null_handling,
+  std::vector<order> column_order,
+  std::vector<null_order> null_precedence,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr)
+{
+  auto const default_mr = rmm::mr::get_current_device_resource();
+
+  //
+  // Warning: Below is just a workaround.
+  // This is a more efficient merging API that is WIP by Dave Baranec, and will be adopted here
+  // after finished.
+  //
+
+  // Vertically merge all keys tables and result columns.
+  auto const keys    = concatenate(agg_keys);
+  auto const results = concatenate(agg_results);
+
+  // Perform groupby on the merged keys and results
+  std::vector<cudf::groupby::aggregation_request> requests;
+  requests.emplace_back(cudf::groupby::aggregation_request());
+  requests[0].values = results->view();
+  requests[0].aggregations.emplace_back(make_collect_list_aggregation());
+
+  auto gb_obj = groupby(keys->view(), null_handling, sorted::NO, column_order, null_precedence);
+  auto result = gb_obj.aggregate(requests, mr);
+  auto merged_lists =
+    lists::concatenate_list_elements(result.second.front().results.front()->view());
+  return {std::move(result.first), std::move(merged_lists)};
+}
+
+}  // namespace detail
+}  // namespace groupby
+}  // namespace cudf

--- a/cpp/src/groupby/sort/group_reductions.hpp
+++ b/cpp/src/groupby/sort/group_reductions.hpp
@@ -369,6 +369,27 @@ std::unique_ptr<column> group_collect(column_view const& values,
                                       rmm::cuda_stream_view stream,
                                       rmm::mr::device_memory_resource* mr);
 
+/**
+ * @brief group_collect_merge
+ *
+ * @param agg_keys
+ * @param agg_results
+ * @param null_precedence
+ * @param column_order
+ * @param null_handling
+ * @param stream
+ * @param mr
+ * @return
+ */
+std::pair<std::unique_ptr<table>, std::unique_ptr<column>> group_collect_merge(
+  host_span<table_view const> agg_keys,
+  host_span<column_view const> agg_results,
+  null_policy null_handling,
+  std::vector<order> column_order,
+  std::vector<null_order> null_precedence,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr);
+
 /** @endinternal
  *
  */

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ ConfigureTest(GROUPBY_TEST
     groupby/argmin_tests.cpp
     groupby/argmax_tests.cpp
     groupby/collect_list_tests.cpp
+    groupby/collect_list_merge_tests.cpp
     groupby/collect_set_tests.cpp
     groupby/count_scan_tests.cpp
     groupby/count_tests.cpp

--- a/cpp/tests/groupby/collect_list_merge_tests.cpp
+++ b/cpp/tests/groupby/collect_list_merge_tests.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tests/groupby/groupby_test_util.hpp>
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/groupby.hpp>
+#include <cudf/table/table_view.hpp>
+
+constexpr bool print_all{false};  // For debugging
+constexpr int32_t null{0};        // Mark for null child elements
+constexpr int32_t XXX{0};         // Mark for null struct elements
+
+template <typename V>
+struct GroupbyCollectListMergeTest : public cudf::test::BaseFixture {
+};
+
+using FixedWidthTypesNotBool = cudf::test::Concat<cudf::test::IntegralTypesNotBool,
+                                                  cudf::test::FloatingPointTypes,
+                                                  cudf::test::TimestampTypes>;
+TYPED_TEST_CASE(GroupbyCollectListMergeTest, FixedWidthTypesNotBool);
+
+namespace {
+auto merge(std::vector<cudf::table_view> const& keys, std::vector<cudf::column_view> const& lists)
+{
+  // A new groupby object is constructed using an arbitrary keys table.
+  // In practice, this object can be reused from the previous `collect_list` aggregation.
+  // By using the same groupby object, we can make sure that the null handling parameters used for
+  // merging are the same as the parameters that were used for `collect_list` aggregation.
+  auto const gb_obj = cudf::groupby::groupby(keys.front());
+  auto const agg    = cudf::make_collect_list_aggregation();
+  return gb_obj.merge(*agg, keys, lists);
+}
+
+auto merge(std::vector<cudf::column_view> const& keys, std::vector<cudf::column_view> const& lists)
+{
+  std::vector<cudf::table_view> tbl_keys;
+  for (auto const& key : keys) { tbl_keys.push_back(cudf::table_view{{key}}); }
+  return merge(tbl_keys, lists);
+}
+
+}  // namespace
+
+TYPED_TEST(GroupbyCollectListMergeTest, MergeWithoutNulls)
+{
+  using keys_col  = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using lists_col = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+
+  auto const keys1  = keys_col{1, 2};
+  auto const keys2  = keys_col{1, 3};
+  auto const keys3  = keys_col{2, 3, 4};
+  auto const lists1 = lists_col{{1, 2, 3}, {4, 5, 6}};
+  auto const lists2 = lists_col{{10, 11}, {11, 12}};
+  auto const lists3 = lists_col{{20, 21, 22}, {23, 24, 25}, {24, 25, 26}};
+
+  auto const result        = merge({keys1, keys2, keys3}, {lists1, lists2, lists3});
+  auto const expected_keys = keys_col{1, 2, 3, 4};
+  auto const expected_lists =
+    lists_col{{1, 2, 3, 10, 11}, {4, 5, 6, 20, 21, 22}, {11, 12, 23, 24, 25}, {24, 25, 26}};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_keys, result.first->get_column(0), print_all);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_lists, *result.second, print_all);
+}


### PR DESCRIPTION
Groupby aggregations can be performed for distributed computing by the following approach:
 * Divide the dataset into batches
 * Run separate (distributed) aggregations on those batches
 * Merge the results of the step above into one final result

This PR supports merging operations for `collect_list` and `collect_set`.

Closes #7839.


### PS: This is a WIP and not ready for review.