### PR TITLE
Replace `all_null()` and `all_valid()` by `iterator_all_nulls()` and `iterator_no_null()` in tests

### DIFF
--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -26,6 +26,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -560,8 +561,8 @@ struct ListGetStructValueTest : public BaseFixture {
     // {int: 1, string: NULL, list: NULL}
     return this->make_test_structs_column({{1}, {1}},
                                           strings_column_wrapper({"aa"}, {false}),
-                                          LCWinner_t({{}}, all_invalid()),
-                                          all_valid());
+                                          LCWinner_t({{}}, iterator_all_nulls()),
+                                          iterator_no_null());
   }
 
   /**
@@ -570,7 +571,7 @@ struct ListGetStructValueTest : public BaseFixture {
   SCW row1()
   {
     // NULL
-    return this->make_test_structs_column({-1}, {""}, LCWinner_t{-1}, all_invalid());
+    return this->make_test_structs_column({-1}, {""}, LCWinner_t{-1}, iterator_all_nulls());
   }
 
   /**
@@ -581,8 +582,8 @@ struct ListGetStructValueTest : public BaseFixture {
     // {int: 3, string: "xyz", list: [3, 8, 4]}
     return this->make_test_structs_column({{3}, {1}},
                                           strings_column_wrapper({"xyz"}, {true}),
-                                          LCWinner_t({{3, 8, 4}}, all_valid()),
-                                          all_valid());
+                                          LCWinner_t({{3, 8, 4}}, iterator_no_null()),
+                                          iterator_no_null());
   }
 
   /**
@@ -596,9 +597,6 @@ struct ListGetStructValueTest : public BaseFixture {
     // {int: 3, string: "xyz", list: [3, 8, 4]}
     return this->concat({row0(), row1(), row2()});
   }
-
-  auto all_valid() { return thrust::make_constant_iterator(true); }
-  auto all_invalid() { return thrust::make_constant_iterator(false); }
 };
 
 TYPED_TEST_CASE(ListGetStructValueTest, FixedWidthTypes);

--- a/cpp/tests/groupby/argmax_tests.cpp
+++ b/cpp/tests/groupby/argmax_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -58,7 +59,7 @@ TYPED_TEST(groupby_argmax_test, zero_valid_keys)
 
   if (std::is_same<V, bool>::value) return;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -79,10 +80,10 @@ TYPED_TEST(groupby_argmax_test, zero_valid_values)
   if (std::is_same<V, bool>::value) return;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_argmax_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -104,7 +105,7 @@ TYPED_TEST(groupby_argmax_test, null_keys_and_values)
                                      {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0});
 
   //  {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  {6, 3,     5, 4, 0,   2, 1,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 4, 7, 0}, {1, 1, 1, 0});
 
@@ -142,10 +143,10 @@ TEST_F(groupby_argmax_string_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, all_null());
+  strings_column_wrapper vals({"año", "bit", "₹1"}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_argmax_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));

--- a/cpp/tests/groupby/argmin_tests.cpp
+++ b/cpp/tests/groupby/argmin_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -58,7 +59,7 @@ TYPED_TEST(groupby_argmin_test, zero_valid_keys)
 
   if (std::is_same<V, bool>::value) return;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -79,10 +80,10 @@ TYPED_TEST(groupby_argmin_test, zero_valid_values)
   if (std::is_same<V, bool>::value) return;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_argmin_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -104,7 +105,7 @@ TYPED_TEST(groupby_argmin_test, null_keys_and_values)
                                      {1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  { 9, 6,     8, 5, 0,   7, 1,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 9, 8, 0}, {1, 1, 1, 0});
 
@@ -143,10 +144,10 @@ TEST_F(groupby_argmin_string_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, all_null());
+  strings_column_wrapper vals({"año", "bit", "₹1"}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_argmin_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));

--- a/cpp/tests/groupby/count_scan_tests.cpp
+++ b/cpp/tests/groupby/count_scan_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -84,7 +85,7 @@ TYPED_TEST(groupby_count_scan_test, zero_valid_keys)
   using result_wrapper = typename TestFixture::result_wrapper;
 
   // clang-format off
-  key_wrapper keys( {1, 2, 3}, all_null());
+  key_wrapper keys( {1, 2, 3}, iterator_all_nulls());
   value_wrapper vals{3, 4, 5};
 
   key_wrapper expect_keys{};
@@ -102,7 +103,7 @@ TYPED_TEST(groupby_count_scan_test, zero_valid_values)
 
   // clang-format off
   key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, all_null());
+  value_wrapper vals({3, 4, 5}, iterator_all_nulls());
 
   key_wrapper expect_keys{1, 1, 1};
   result_wrapper expect_vals{0, 1, 2};
@@ -122,7 +123,7 @@ TYPED_TEST(groupby_count_scan_test, null_keys_and_values)
   value_wrapper vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                        {1, 1, 1, 2, 2, 2, 2, 3, _, 3, 4}
-  key_wrapper expect_keys(  {1, 1, 1, 2, 2, 2, 2, 3,    3, 4}, all_valid());
+  key_wrapper expect_keys(  {1, 1, 1, 2, 2, 2, 2, 3,    3, 4}, iterator_no_null());
   //                        {0, 3, 6, 1, 4, _, 9, 2, 7, 8, -}
   result_wrapper expect_vals{0, 1, 2, 0, 1,    2, 3, 0, 1, 0};
   // clang-format on

--- a/cpp/tests/groupby/count_tests.cpp
+++ b/cpp/tests/groupby/count_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -75,7 +76,7 @@ TYPED_TEST(groupby_count_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -97,7 +98,7 @@ TYPED_TEST(groupby_count_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
   fixed_width_column_wrapper<R> expect_vals{0};
@@ -125,7 +126,7 @@ TYPED_TEST(groupby_count_test, null_keys_and_values)
 
   // clang-format off
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, iterator_no_null());
   //                                        {3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({2,        3,         2,       0});
   // clang-format on

--- a/cpp/tests/groupby/groupby_test_util.hpp
+++ b/cpp/tests/groupby/groupby_test_util.hpp
@@ -125,17 +125,5 @@ inline void test_single_scan(column_view const& keys,
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect_vals, *result.second[0].results[0], true);
 }
 
-inline auto all_valid()
-{
-  auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
-  return all_valid;
-}
-
-inline auto all_null()
-{
-  auto all_null = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return false; });
-  return all_null;
-}
-
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/groupby/groups_tests.cpp
+++ b/cpp/tests/groupby/groups_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/types.hpp>
@@ -57,7 +58,7 @@ TEST_F(groupby_group_keys_test, all_null_keys)
 {
   using K = int32_t;
 
-  fixed_width_column_wrapper<K> keys({1, 1, 2, 3, 1, 2}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 1, 2, 3, 1, 2}, iterator_all_nulls());
   fixed_width_column_wrapper<K> expect_grouped_keys{};
   std::vector<size_type> expect_group_offsets = {0};
   test_groups(keys, expect_grouped_keys, expect_group_offsets);
@@ -82,7 +83,7 @@ TYPED_TEST(groupby_group_keys_and_values_test, some_nulls)
   using V = TypeParam;
 
   fixed_width_column_wrapper<K> keys({1, 1, 3, 2, 1, 2}, {1, 0, 1, 0, 0, 1});
-  fixed_width_column_wrapper<K> expect_grouped_keys({1, 2, 3}, all_valid());
+  fixed_width_column_wrapper<K> expect_grouped_keys({1, 2, 3}, iterator_no_null());
   fixed_width_column_wrapper<V> values({1, 2, 3, 4, 5, 6});
   fixed_width_column_wrapper<V> expect_grouped_values({1, 6, 3});
   std::vector<size_type> expect_group_offsets = {0, 1, 2, 3};

--- a/cpp/tests/groupby/keys_tests.cpp
+++ b/cpp/tests/groupby/keys_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -58,7 +59,7 @@ TYPED_TEST(groupby_keys_test, zero_valid_keys)
   using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_null() );
+  fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, iterator_all_nulls() );
   fixed_width_column_wrapper<V> vals        { 3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys { };
@@ -81,7 +82,7 @@ TYPED_TEST(groupby_keys_test, some_null_keys)
   fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3,  4}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4}, iterator_no_null() );
                                         //  { 0, 3, 6,  1, 4, 5, 9,  2, 8,  -}
   fixed_width_column_wrapper<R> expect_vals { 3,        4,           2,     1};
   // clang-format on
@@ -180,7 +181,7 @@ TYPED_TEST(groupby_keys_test, pre_sorted_keys_nullable)
                                             { 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1});
   fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
-  fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3,       4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3,       4}, iterator_no_null() );
   fixed_width_column_wrapper<R> expect_vals { 3,       15,         17,      4};
   // clang-format on
 

--- a/cpp/tests/groupby/max_scan_tests.cpp
+++ b/cpp/tests/groupby/max_scan_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -77,7 +78,7 @@ TYPED_TEST(groupby_max_scan_test, zero_valid_keys)
   using result_wrapper = typename TestFixture::result_wrapper;
 
   // clang-format off
-  key_wrapper keys(  {1, 2, 3}, all_null());
+  key_wrapper keys(  {1, 2, 3}, iterator_all_nulls());
   value_wrapper vals({3, 4, 5});
 
   key_wrapper expect_keys{};
@@ -95,10 +96,10 @@ TYPED_TEST(groupby_max_scan_test, zero_valid_values)
 
   // clang-format off
   key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, all_null());
+  value_wrapper vals({3, 4, 5}, iterator_all_nulls());
 
   key_wrapper expect_keys    {1, 1, 1};
-  result_wrapper expect_vals({-1, -1, -1}, all_null());
+  result_wrapper expect_vals({-1, -1, -1}, iterator_all_nulls());
   // clang-format on
 
   auto agg = cudf::make_max_aggregation();
@@ -115,7 +116,7 @@ TYPED_TEST(groupby_max_scan_test, null_keys_and_values)
   value_wrapper vals({5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                          //  {1, 1, 1, 2, 2, 2, 2, 3,   _, 3, 4}
-  key_wrapper expect_keys(   {1, 1, 1, 2, 2, 2, 2, 3,      3, 4}, all_valid());
+  key_wrapper expect_keys(   {1, 1, 1, 2, 2, 2, 2, 3,      3, 4}, iterator_no_null() );
                          //  { -, 3, 6, 1, 4,  -, 9, 2, _, 8, -}
   result_wrapper expect_vals({-1, 8, 8, 6, 9, -1, 9, 7,    7, -1},
                              { 0, 1, 1, 1, 1,  0, 1, 1,    1, 0});

--- a/cpp/tests/groupby/max_tests.cpp
+++ b/cpp/tests/groupby/max_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -73,7 +74,7 @@ TYPED_TEST(groupby_max_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::MAX>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -92,10 +93,10 @@ TYPED_TEST(groupby_max_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::MAX>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_max_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -115,7 +116,7 @@ TYPED_TEST(groupby_max_test, null_keys_and_values)
                                      {1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  { 0, 3,     1, 4, 5,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 5, 8, 0}, {1, 1, 1, 0});
 
@@ -147,10 +148,10 @@ TEST_F(groupby_max_string_test, basic)
 TEST_F(groupby_max_string_test, zero_valid_values)
 {
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, all_null());
+  strings_column_wrapper vals({"año", "bit", "₹1"}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  strings_column_wrapper expect_vals({""}, all_null());
+  strings_column_wrapper expect_vals({""}, iterator_all_nulls());
 
   auto agg = cudf::make_max_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));

--- a/cpp/tests/groupby/mean_tests.cpp
+++ b/cpp/tests/groupby/mean_tests.cpp
@@ -19,6 +19,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -88,7 +89,7 @@ TYPED_TEST(groupby_mean_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -104,10 +105,10 @@ TYPED_TEST(groupby_mean_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_mean_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -126,7 +127,7 @@ TYPED_TEST(groupby_mean_test, null_keys_and_values)
 
   // clang-format off
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, iterator_no_null());
   //                                        {3, 6,     1, 4, 9,   2, 8,    -}
   std::vector<RT> expect_v = convert<RT>(   {4.5,      14. / 3,   5.,      0.});
   fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend(), {1, 1, 1, 0});

--- a/cpp/tests/groupby/median_tests.cpp
+++ b/cpp/tests/groupby/median_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -45,7 +46,7 @@ TYPED_TEST(groupby_median_test, basic)
   //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1,       2,          3};
   //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,     4.5,        7.}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({3.,     4.5,        7.}, iterator_no_null());
   // clang-format on
 
   auto agg = cudf::make_median_aggregation();
@@ -72,7 +73,7 @@ TYPED_TEST(groupby_median_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -88,10 +89,10 @@ TYPED_TEST(groupby_median_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_median_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -108,7 +109,7 @@ TYPED_TEST(groupby_median_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
@@ -128,7 +129,7 @@ TYPED_TEST(groupby_median_test, dictionary)
   //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,       2,          3      });
   //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       4.5,       7.     }, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({3.,       4.5,       7.     }, iterator_no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_median_aggregation());

--- a/cpp/tests/groupby/min_scan_tests.cpp
+++ b/cpp/tests/groupby/min_scan_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -75,7 +76,7 @@ TYPED_TEST(groupby_min_scan_test, zero_valid_keys)
   using result_wrapper = typename TestFixture::result_wrapper;
 
   // clang-format off
-  key_wrapper keys({1, 2, 3}, all_null());
+  key_wrapper keys({1, 2, 3}, iterator_all_nulls());
   value_wrapper vals({3, 4, 5});
 
   key_wrapper expect_keys{};
@@ -93,10 +94,10 @@ TYPED_TEST(groupby_min_scan_test, zero_valid_values)
 
   // clang-format off
   key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, all_null());
+  value_wrapper vals({3, 4, 5}, iterator_all_nulls());
 
   key_wrapper expect_keys    {1, 1, 1};
-  result_wrapper expect_vals({-1, -1, -1}, all_null());
+  result_wrapper expect_vals({-1, -1, -1}, iterator_all_nulls());
   // clang-format on
 
   auto agg = cudf::make_min_aggregation();
@@ -113,7 +114,7 @@ TYPED_TEST(groupby_min_scan_test, null_keys_and_values)
   value_wrapper vals({5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                          //  { 1, 1, 1, 2, 2,  2, 2, 3, _, 3, 4}
-  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2, 2, 3,    3, 4}, all_valid());
+  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2, 2, 3,    3, 4}, iterator_no_null());
                          //  { _, 8, 1, 6, 9,  _, 4, 7, 2, 3, _}
   result_wrapper expect_vals({-1, 8, 1, 6, 6, -1, 4, 7,    3, -1},
                              { 0, 1, 1, 1, 1,  0, 1, 1,    1, 0});

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -73,7 +74,7 @@ TYPED_TEST(groupby_min_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::MIN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -92,10 +93,10 @@ TYPED_TEST(groupby_min_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::MIN>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_min_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -115,7 +116,7 @@ TYPED_TEST(groupby_min_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 1, 2, 0}, {1, 1, 1, 0});
 
@@ -147,10 +148,10 @@ TEST_F(groupby_min_string_test, basic)
 TEST_F(groupby_min_string_test, zero_valid_values)
 {
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, all_null());
+  strings_column_wrapper vals({"año", "bit", "₹1"}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  strings_column_wrapper expect_vals({""}, all_null());
+  strings_column_wrapper expect_vals({""}, iterator_all_nulls());
 
   auto agg = cudf::make_min_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));

--- a/cpp/tests/groupby/nth_element_tests.cpp
+++ b/cpp/tests/groupby/nth_element_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -141,7 +142,7 @@ TYPED_TEST(groupby_nth_element_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -158,10 +159,10 @@ TYPED_TEST(groupby_nth_element_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R, int32_t> expect_vals({3}, all_null());
+  fixed_width_column_wrapper<R, int32_t> expect_vals({3}, iterator_all_nulls());
 
   auto agg = cudf::make_nth_element_aggregation(0);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -178,7 +179,7 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
                                               {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //keys                                    {1, 1, 1   2,2,2,2    3, 3,    4}
   //vals                                    {-,3,6,    1,4,-,9,  2,8,      -}
   fixed_width_column_wrapper<R, int32_t> expect_vals({-1, 1, 2, -1}, {0, 1, 1, 0});
@@ -198,7 +199,7 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values_out_of_bounds)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
                                               {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
   //                                        {1, 1, 1    2, 2, 2,    3, 3,   4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //                                        {-,3,6,     1,4,-,9,    2,8,    -}
   //                                         value,     null,       out,    out
   fixed_width_column_wrapper<R, int32_t> expect_vals({6, -1, -1, -1}, {1, 0, 0, 0});
@@ -218,7 +219,7 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
                                               {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //keys                                    {1, 1, 1    2, 2, 2, 2      3, 3, 3    4}
   //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,   4,-}
   //                                      0  null,      value,          value,     null
@@ -260,7 +261,7 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls_negative_index)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
                                               {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //keys                                    {1, 1, 1    2, 2, 2,        3, 3,       4}
   //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,    4,-}
   //                                      0  null,      value,          value,      value

--- a/cpp/tests/groupby/nunique_tests.cpp
+++ b/cpp/tests/groupby/nunique_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -92,7 +93,7 @@ TYPED_TEST(groupby_nunique_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -108,7 +109,7 @@ TYPED_TEST(groupby_nunique_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
   fixed_width_column_wrapper<R> expect_vals{0};
@@ -128,7 +129,7 @@ TYPED_TEST(groupby_nunique_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   // all unique values only                 {3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
   fixed_width_column_wrapper<R> expect_bool_vals{1, 1, 1, 0};
@@ -151,7 +152,7 @@ TYPED_TEST(groupby_nunique_test, null_keys_and_values_with_duplicates)
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   //  { 1, 1,     2, 2, 2,    3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
   //  unique,     with null,  dup,     dup null
   fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
@@ -175,7 +176,7 @@ TYPED_TEST(groupby_nunique_test, include_nulls)
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   //  { 1, 1,     2, 2, 2,    3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
   //  unique,     with null,  dup,     dup null
   fixed_width_column_wrapper<R> expect_vals{3, 4, 2, 1};
@@ -200,7 +201,7 @@ TYPED_TEST(groupby_nunique_test, dictionary)
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   // { 1, 1,   2, 2, 2,   3, 3,   4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   // { 3, 6,-  1, 4, 9,-  2*, 8,  -*}
   //  unique,  with null, dup,    dup null
   fixed_width_column_wrapper<R> expect_fixed_vals({3, 4, 2, 1});

--- a/cpp/tests/groupby/product_tests.cpp
+++ b/cpp/tests/groupby/product_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -45,7 +46,7 @@ TYPED_TEST(groupby_product_test, basic)
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys { 1,        2,           3      };
                                         //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({   0.,       180.,      112. }, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({   0.,       180.,      112. }, iterator_no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
@@ -70,7 +71,7 @@ TYPED_TEST(groupby_product_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -85,10 +86,10 @@ TYPED_TEST(groupby_product_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
 }
@@ -105,7 +106,7 @@ TYPED_TEST(groupby_product_test, null_keys_and_values)
                                             { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                                         //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, iterator_no_null());
                                         //  { _, 3, 6,  1, 4, 9,   2, 8,    _}
   fixed_width_column_wrapper<R> expect_vals({ 18.,      36.,       16.,     3.},
                                             { 1,        1,         1,       0});
@@ -126,7 +127,7 @@ TYPED_TEST(groupby_product_test, dictionary)
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
                                         //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        112. }, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        112. }, iterator_no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
@@ -145,7 +146,7 @@ TYPED_TEST(groupby_product_test, dictionary_with_nulls)
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
                                         //  { 0, 3, 6,  @, 4, 5, 9,  @, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        56. }, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        56. }, iterator_no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());

--- a/cpp/tests/groupby/quantile_tests.cpp
+++ b/cpp/tests/groupby/quantile_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -45,7 +46,7 @@ TYPED_TEST(groupby_quantile_test, basic)
   //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //                                       {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3., 4.5, 7.}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({3., 4.5, 7.}, iterator_no_null());
   // clang-format on
 
   auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
@@ -72,7 +73,7 @@ TYPED_TEST(groupby_quantile_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -88,10 +89,10 @@ TYPED_TEST(groupby_quantile_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -108,7 +109,7 @@ TYPED_TEST(groupby_quantile_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
@@ -128,7 +129,7 @@ TYPED_TEST(groupby_quantile_test, multiple_quantile)
   //                                       {1, 1, 1,   2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //                                        {0, 3, 6,  1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({1.5, 4.5, 3.25, 6.,   4.5, 7.5}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({1.5, 4.5, 3.25, 6.,   4.5, 7.5}, iterator_no_null());
   // clang-format on
 
   auto agg = cudf::make_quantile_aggregation({0.25, 0.75}, interpolation::LINEAR);
@@ -148,27 +149,27 @@ TYPED_TEST(groupby_quantile_test, interpolation_types)
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals1({2.4,      4.2,         4.}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals1({2.4,      4.2,         4.}, iterator_no_null());
   auto agg1 = cudf::make_quantile_aggregation({0.4}, interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg1));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals2({3,        4,           2}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals2({3,        4,           2}, iterator_no_null());
   auto agg2 = cudf::make_quantile_aggregation({0.4}, interpolation::NEAREST);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals3({0,        4,          2}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals3({0,        4,          2}, iterator_no_null());
   auto agg3 = cudf::make_quantile_aggregation({0.4}, interpolation::LOWER);
   test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg3));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals4({3,        5,           7}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals4({3,        5,           7}, iterator_no_null());
   auto agg4 = cudf::make_quantile_aggregation({0.4}, interpolation::HIGHER);
   test_single_agg(keys, vals, expect_keys, expect_vals4, std::move(agg4));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals5({1.5,      4.5,         4.5}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals5({1.5,      4.5,         4.5}, iterator_no_null());
   auto agg5 = cudf::make_quantile_aggregation({0.4}, interpolation::MIDPOINT);
   test_single_agg(keys, vals, expect_keys, expect_vals5, std::move(agg5));
   // clang-format on
@@ -186,7 +187,7 @@ TYPED_TEST(groupby_quantile_test, dictionary)
   //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1, 2, 3});
   //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,      4.5,        7.}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({3.,      4.5,        7.}, iterator_no_null());
   // clang-format on
 
   test_single_agg(keys,

--- a/cpp/tests/groupby/replace_nulls_tests.cpp
+++ b/cpp/tests/groupby/replace_nulls_tests.cpp
@@ -17,14 +17,16 @@
 
 #include <tests/groupby/groupby_test_util.hpp>
 
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
+#include <cudf_test/table_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
+
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <cudf_test/base_fixture.hpp>
-#include <cudf_test/column_wrapper.hpp>
-#include <cudf_test/table_utilities.hpp>
-#include <cudf_test/type_lists.hpp>
 namespace cudf {
 namespace test {
 
@@ -56,7 +58,7 @@ TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, PrecedingFill)
   fixed_width_column_wrapper<TypeParam> val({42, 7, 24, 10, 1, 1000}, {1, 1, 1, 0, 0, 0});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({42, 24, 24, 7, 7, 7}, all_valid());
+  fixed_width_column_wrapper<TypeParam> expect_val({42, 24, 24, 7, 7, 7}, iterator_no_null());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
 }
@@ -70,7 +72,8 @@ TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, FollowingFill)
                                             {1, 0, 1, 0, 1, 0, 1, 1});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({2, 32, 32, 8, 128, 128, 128, 256}, all_valid());
+  fixed_width_column_wrapper<TypeParam> expect_val({2, 32, 32, 8, 128, 128, 128, 256},
+                                                   iterator_no_null());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
 }
@@ -115,7 +118,8 @@ TEST_F(GroupbyReplaceNullsStringsTest, PrecedingFill)
                              {true, false, true, true, true, false, true});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"y", "42", "xx", "xx", "zzz", "zzz", "one"}, all_valid());
+  strings_column_wrapper expect_val({"y", "42", "xx", "xx", "zzz", "zzz", "one"},
+                                    iterator_no_null());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
 }
@@ -129,7 +133,8 @@ TEST_F(GroupbyReplaceNullsStringsTest, FollowingFill)
                              {true, false, false, true, true, false, true});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"42", "42", "xx", "zzz", "zzz", "one", "one"}, all_valid());
+  strings_column_wrapper expect_val({"42", "42", "xx", "zzz", "zzz", "one", "one"},
+                                    iterator_no_null());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
 }

--- a/cpp/tests/groupby/std_tests.cpp
+++ b/cpp/tests/groupby/std_tests.cpp
@@ -20,6 +20,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -47,7 +48,7 @@ TYPED_TEST(groupby_std_test, basic)
   //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
   fixed_width_column_wrapper<K>  expect_keys{1,        2,             3};
   //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, iterator_no_null());
   // clang-format on
 
   auto agg = cudf::make_std_aggregation();
@@ -74,7 +75,7 @@ TYPED_TEST(groupby_std_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -90,10 +91,10 @@ TYPED_TEST(groupby_std_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_std_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -110,7 +111,7 @@ TYPED_TEST(groupby_std_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   //                                        { 1, 1,     2, 2, 2,   3, 3,       4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //                                        { 3, 6,     1, 4, 9,   2, 8,       3}
   fixed_width_column_wrapper<R> expect_vals({3 / sqrt(2), 7 / sqrt(3), 3 * sqrt(2), 0.},
                                             {1, 1, 1, 0});
@@ -130,7 +131,7 @@ TYPED_TEST(groupby_std_test, ddof_non_default)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({0., 7 * sqrt(2. / 3), 0., 0.}, {0, 1, 0, 0});
 
@@ -150,7 +151,7 @@ TYPED_TEST(groupby_std_test, dictionary)
   //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,        2,             3});
   //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, iterator_no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_std_aggregation());

--- a/cpp/tests/groupby/sum_of_squares_tests.cpp
+++ b/cpp/tests/groupby/sum_of_squares_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -44,7 +45,7 @@ TYPED_TEST(groupby_sum_of_squares_test, basic)
   //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({45., 123., 117.}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({45., 123., 117.}, iterator_no_null());
 
   auto agg = cudf::make_sum_of_squares_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -70,7 +71,7 @@ TYPED_TEST(groupby_sum_of_squares_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -86,10 +87,10 @@ TYPED_TEST(groupby_sum_of_squares_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_sum_of_squares_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -106,7 +107,7 @@ TYPED_TEST(groupby_sum_of_squares_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({45., 98., 68., 9.}, {1, 1, 1, 0});
 
@@ -126,7 +127,7 @@ TYPED_TEST(groupby_sum_of_squares_test, dictionary)
   //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
   //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({45.,       123.,       117.   }, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({45.,       123.,       117.   }, iterator_no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_sum_of_squares_aggregation());

--- a/cpp/tests/groupby/sum_scan_tests.cpp
+++ b/cpp/tests/groupby/sum_scan_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -81,7 +82,7 @@ TYPED_TEST(groupby_sum_scan_test, zero_valid_keys)
   using result_wrapper = typename TestFixture::result_wrapper;
 
   // clang-format off
-  key_wrapper keys({1, 2, 3}, all_null());
+  key_wrapper keys({1, 2, 3}, iterator_all_nulls());
   value_wrapper vals{3, 4, 5};
 
   key_wrapper expect_keys{};
@@ -99,10 +100,10 @@ TYPED_TEST(groupby_sum_scan_test, zero_valid_values)
 
   // clang-format off
   key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, all_null());
+  value_wrapper vals({3, 4, 5}, iterator_all_nulls());
 
   key_wrapper expect_keys    {1, 1, 1};
-  result_wrapper expect_vals({3, 4, 5}, all_null());
+  result_wrapper expect_vals({3, 4, 5}, iterator_all_nulls());
   // clang-format on
 
   auto agg = cudf::make_sum_aggregation();
@@ -119,7 +120,7 @@ TYPED_TEST(groupby_sum_scan_test, null_keys_and_values)
   value_wrapper vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                         { 1, 1, 1, 2, 2,  2,  2, 3, *, 3, 4};
-  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2,  2, 3,    3, 4}, all_valid());
+  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2,  2, 3,    3, 4}, iterator_no_null());
                           // { -, 3, 6, 1, 4,  -,  9, 2, _, 8, -}
   result_wrapper expect_vals({-1, 3, 9, 1, 5, -1, 14, 2,   10, -1},
                              { 0, 1, 1, 1, 1,  0,  1, 1,    1, 0});

--- a/cpp/tests/groupby/sum_tests.cpp
+++ b/cpp/tests/groupby/sum_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -76,7 +77,7 @@ TYPED_TEST(groupby_sum_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -95,10 +96,10 @@ TYPED_TEST(groupby_sum_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_sum_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -118,7 +119,7 @@ TYPED_TEST(groupby_sum_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({9, 14, 10, 0}, {1, 1, 1, 0});
 

--- a/cpp/tests/groupby/var_tests.cpp
+++ b/cpp/tests/groupby/var_tests.cpp
@@ -20,6 +20,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -47,7 +48,7 @@ TYPED_TEST(groupby_var_test, basic)
   //                                       {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1,        2,           3};
   //                                       {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({9.,      131. / 12,   31. / 3}, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({9.,      131. / 12,   31. / 3}, iterator_no_null());
   // clang-format on
 
   auto agg = cudf::make_variance_aggregation();
@@ -74,7 +75,7 @@ TYPED_TEST(groupby_var_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_null());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -90,10 +91,10 @@ TYPED_TEST(groupby_var_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_null());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_null());
+  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
 
   auto agg = cudf::make_variance_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -111,7 +112,7 @@ TYPED_TEST(groupby_var_test, null_keys_and_values)
 
   // clang-format off
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, iterator_no_null());
   //                                        {3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({4.5,      49. / 3,   18.,     0.}, {1, 1, 1, 0});
   // clang-format on
@@ -132,7 +133,7 @@ TYPED_TEST(groupby_var_test, ddof_non_default)
 
   // clang-format off
   //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,         2,         3,       4}, all_valid());
+  fixed_width_column_wrapper<K> expect_keys({1,         2,         3,       4}, iterator_no_null());
   //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({0.,        98. / 3,   0.,      0.},
                                             {0,         1,         0,       0});
@@ -154,7 +155,7 @@ TYPED_TEST(groupby_var_test, dictionary)
   //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
   //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({9.,      131./12,      31./3  }, all_valid());
+  fixed_width_column_wrapper<R> expect_vals({9.,      131./12,      31./3  }, iterator_no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_variance_aggregation());

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -31,6 +31,7 @@
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 struct ReplaceErrorTest : public cudf::test::BaseFixture {
@@ -191,7 +192,7 @@ TEST_F(ReplaceNullsPolicyStringTest, PrecedingFill)
                                            {1, 0, 0, 1, 1, 0, 1});
 
   cudf::test::strings_column_wrapper expected({"head", "head", "head", "mid", "mid", "mid", "tail"},
-                                              cudf::test::all_valid());
+                                              cudf::test::iterator_no_null());
 
   auto result = cudf::replace_nulls(input, cudf::replace_policy::PRECEDING);
 
@@ -204,7 +205,7 @@ TEST_F(ReplaceNullsPolicyStringTest, FollowingFill)
                                            {1, 0, 0, 1, 1, 0, 1});
 
   cudf::test::strings_column_wrapper expected({"head", "mid", "mid", "mid", "mid", "tail", "tail"},
-                                              cudf::test::all_valid());
+                                              cudf::test::iterator_no_null());
 
   auto result = cudf::replace_nulls(input, cudf::replace_policy::FOLLOWING);
 
@@ -388,7 +389,7 @@ TYPED_TEST(ReplaceNullsPolicyTest, PrecedingFill)
   TestReplaceNullsWithPolicy(
     cudf::test::fixed_width_column_wrapper<TypeParam>(col.begin(), col.end(), mask.begin()),
     cudf::test::fixed_width_column_wrapper<TypeParam>(
-      expect_col.begin(), expect_col.end(), cudf::test::all_valid()),
+      expect_col.begin(), expect_col.end(), cudf::test::iterator_no_null()),
     cudf::replace_policy::PRECEDING);
 }
 
@@ -402,7 +403,7 @@ TYPED_TEST(ReplaceNullsPolicyTest, FollowingFill)
   TestReplaceNullsWithPolicy(
     cudf::test::fixed_width_column_wrapper<TypeParam>(col.begin(), col.end(), mask.begin()),
     cudf::test::fixed_width_column_wrapper<TypeParam>(
-      expect_col.begin(), expect_col.end(), cudf::test::all_valid()),
+      expect_col.begin(), expect_col.end(), cudf::test::iterator_no_null()),
     cudf::replace_policy::FOLLOWING);
 }
 
@@ -659,7 +660,8 @@ TEST_F(ReplaceNullsPolicyDictionaryTest, PrecedingFill)
   auto input = cudf::dictionary::encode(input_w);
 
   cudf::test::strings_column_wrapper expected_w(
-    {"head", "head", "head", "mid1", "mid2", "tail", "tail", "tail"}, cudf::test::all_valid());
+    {"head", "head", "head", "mid1", "mid2", "tail", "tail", "tail"},
+    cudf::test::iterator_no_null());
   auto expected = cudf::dictionary::encode(expected_w);
 
   auto result = cudf::replace_nulls(*input, cudf::replace_policy::PRECEDING);
@@ -674,7 +676,8 @@ TEST_F(ReplaceNullsPolicyDictionaryTest, FollowingFill)
   auto input = cudf::dictionary::encode(input_w);
 
   cudf::test::strings_column_wrapper expected_w(
-    {"head", "mid1", "mid1", "mid1", "mid2", "tail", "tail", "tail"}, cudf::test::all_valid());
+    {"head", "mid1", "mid1", "mid1", "mid2", "tail", "tail", "tail"},
+    cudf::test::iterator_no_null());
   auto expected = cudf::dictionary::encode(expected_w);
 
   auto result = cudf::replace_nulls(*input, cudf::replace_policy::FOLLOWING);


### PR DESCRIPTION
This PR does some cleanup for tests in copying and groupby. In particular, it replace the functions `all_null()` and `all_valid()` by `iterator_all_nulls()` and `iterator_no_null()` from `iterator_utilities.hpp`. This is because the former functions (`all_null()` and `all_valid()`) are just duplicated/reimplemented of the latter ones.

There is no other change in this work.