### PR TITLE
JNI bindings for sort_lists [skip ci]

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Aggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/Aggregation.java
@@ -300,10 +300,6 @@ public abstract class Aggregation {
         }
     }
 
-    /**
-     * WARNING: For now, NullEquality of UNEQUAL and NaNEquality of ALL_EQUAL doesn't work,
-     * because of incorrect parameter passing in libcudf (https://github.com/rapidsai/cudf/issues/8405).
-     */
     public static final class CollectSetAggregation extends Aggregation
         implements RollingAggregation<CollectSetAggregation> {
         private final NullPolicy nullPolicy;
@@ -722,8 +718,6 @@ public abstract class Aggregation {
 
     /**
      * Collect the values into a set.
-     * WARNING: Due to the bug in libcudf (https://github.com/rapidsai/cudf/issues/8405),
-     * NullEquality of UNEQUAL and NaNEquality of ALL_EQUAL doesn't work properly under rolling window.
      *
      * @param nullPolicy   Indicates whether to include/exclude nulls during collection.
      * @param nullEquality Flag to specify whether null entries within each list should be considered equal.

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2738,6 +2738,19 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     return new ColumnVector(listContainsColumn(getNativeView(), key.getNativeView()));
   }
 
+  /**
+   * Segmented sort of the elements within a list in each row of a list column.
+   * NOTICE: list columns with nested child are NOT supported yet.
+   *
+   * @param isDescending   whether sorting each row with descending order (or ascending order)
+   * @param isNullSmallest whether to regard the null value as the min value (or the max value)
+   * @return a List ColumnVector with elements in each list sorted
+   */
+  public final ColumnVector listSortRows(boolean isDescending, boolean isNullSmallest) {
+    assert type.equals(DType.LIST) : "column type must be a LIST";
+    return new ColumnVector(listSortRows(getNativeView(), isDescending, isNullSmallest));
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // INTERNAL/NATIVE ACCESS
   /////////////////////////////////////////////////////////////////////////////
@@ -3041,6 +3054,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @return column handle of the resultant
    */
   private static native long listContainsColumn(long nativeView, long keyColumn);
+
+  private static native long listSortRows(long nativeView, boolean isDescending, boolean isNullSmallest);
 
   private static native long castTo(long nativeHandle, int type, int scale);
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2749,6 +2749,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   public final ColumnVector listSortRows(boolean isDescending, boolean isNullSmallest) {
     assert type.equals(DType.LIST) : "column type must be a LIST";
     return new ColumnVector(listSortRows(getNativeView(), isDescending, isNullSmallest));
+  }
 
   /**
    * Get a single item from the column at the specified index as a Scalar.

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -26,6 +26,7 @@
 #include <cudf/lists/count_elements.hpp>
 #include <cudf/lists/detail/concatenate.hpp>
 #include <cudf/lists/extract.hpp>
+#include <cudf/lists/sorting.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/quantiles.hpp>
 #include <cudf/reduction.hpp>
@@ -382,6 +383,22 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listContainsColumn(JNIEnv
     cudf::column_view *lookup_cv = reinterpret_cast<cudf::column_view *>(lookup_key_cv);
 
     std::unique_ptr<cudf::column> ret = cudf::lists::contains(lcv, *lookup_cv);
+    return reinterpret_cast<jlong>(ret.release());
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listSortRows(JNIEnv *env, jclass,
+                                                                    jlong column_view,
+                                                                    jboolean is_descending,
+                                                                    jboolean is_null_smallest) {
+  JNI_NULL_CHECK(env, column_view, "column is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    auto sort_order = is_descending ? cudf::order::DESCENDING : cudf::order::ASCENDING;
+    auto null_order = is_null_smallest ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
+    auto *cv = reinterpret_cast<cudf::column_view *>(column_view);
+    auto ret = cudf::lists::sort_lists(cudf::lists_column_view(*cv), sort_order, null_order);
     return reinterpret_cast<jlong>(ret.release());
   }
   CATCH_STD(env, 0);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -3912,6 +3912,118 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testListSortRowsWithIntChild() {
+    List<Integer> list1 = Arrays.asList(1, 3, 0, 2);
+    List<Integer> ascSortedList1 = Arrays.asList(0, 1, 2, 3);
+    List<Integer> decSortedList1 = Arrays.asList(3, 2, 1, 0);
+
+    List<Integer> list2 = Arrays.asList(7, 5, 6, 4);
+    List<Integer> ascSortedList2 = Arrays.asList(4, 5, 6, 7);
+    List<Integer> decSortedList2 = Arrays.asList(7, 6, 5, 4);
+
+    List<Integer> list3 = Arrays.asList(-8, null, -9, -10);
+    List<Integer> ascSortedList3 = Arrays.asList(-10, -9, -8, null);
+    List<Integer> ascSortedNullMinList3 = Arrays.asList(null, -10, -9, -8);
+    List<Integer> decSortedList3 = Arrays.asList(null, -8, -9, -10);
+    List<Integer> decSortedNullMinList3 = Arrays.asList(-8, -9, -10, null);
+
+    List<Integer> list4 = Arrays.asList(null, -12, null, 11);
+    List<Integer> ascSortedList4 = Arrays.asList(-12, 11, null, null);
+    List<Integer> ascSortedNullMinList4 = Arrays.asList(null, null, -12, 11);
+    List<Integer> decSortedList4 = Arrays.asList(null, null, 11, -12);
+    List<Integer> decSortedNullMinList4 = Arrays.asList(11, -12, null, null);
+
+    List<Integer> list5 = null;
+
+    HostColumnVector.ListType listType = new HostColumnVector.ListType(true,
+        new HostColumnVector.BasicType(true, DType.INT32));
+    // Ascending + NullLargest
+    try (ColumnVector v = ColumnVector.fromLists(listType, list1, list2, list3, list4, list5);
+         ColumnVector expected = ColumnVector.fromLists(listType,
+             ascSortedList1, ascSortedList2, ascSortedList3, ascSortedList4, list5);
+         ColumnVector result = v.listSortRows(false, false)) {
+      assertColumnsAreEqual(expected, result);
+    }
+    // Descending + NullLargest
+    try (ColumnVector v = ColumnVector.fromLists(listType, list1, list2, list3, list4, list5);
+         ColumnVector expected = ColumnVector.fromLists(listType,
+             decSortedList1, decSortedList2, decSortedList3, decSortedList4, list5);
+         ColumnVector result = v.listSortRows(true, false)) {
+      assertColumnsAreEqual(expected, result);
+    }
+    // Ascending + NullSmallest
+    try (ColumnVector v = ColumnVector.fromLists(listType, list1, list2, list3, list4, list5);
+         ColumnVector expected = ColumnVector.fromLists(listType,
+             ascSortedList1, ascSortedList2, ascSortedNullMinList3, ascSortedNullMinList4, list5);
+         ColumnVector result = v.listSortRows(false, true)) {
+      assertColumnsAreEqual(expected, result);
+    }
+    // Descending + NullSmallest
+    try (ColumnVector v = ColumnVector.fromLists(listType, list1, list2, list3, list4, list5);
+         ColumnVector expected = ColumnVector.fromLists(listType,
+             decSortedList1, decSortedList2, decSortedNullMinList3, decSortedNullMinList4, list5);
+         ColumnVector result = v.listSortRows(true, true)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void testListSortRowsWithStringChild() {
+    List<String> list1 = Arrays.asList("b", "d", "a", "c");
+    List<String> ascSortedList1 = Arrays.asList("a", "b", "c", "d");
+    List<String> decSortedList1 = Arrays.asList("d", "c", "b", "a");
+
+    List<String> list2 = Arrays.asList("h", "f", "g", "e");
+    List<String> ascSortedList2 = Arrays.asList("e", "f", "g", "h");
+    List<String> decSortedList2 = Arrays.asList("h", "g", "f", "e");
+
+    List<String> list3 = Arrays.asList("C", null, "B", "A");
+    List<String> ascSortedList3 = Arrays.asList("A", "B", "C", null);
+    List<String> ascSortedNullMinList3 = Arrays.asList(null, "A", "B", "C");
+    List<String> decSortedList3 = Arrays.asList(null, "C", "B", "A");
+    List<String> decSortedNullMinList3 = Arrays.asList("C", "B", "A", null);
+
+    List<String> list4 = Arrays.asList(null, "D", null, "d");
+    List<String> ascSortedList4 = Arrays.asList("D", "d", null, null);
+    List<String> ascSortedNullMinList4 = Arrays.asList(null, null, "D", "d");
+    List<String> decSortedList4 = Arrays.asList(null, null, "d", "D");
+    List<String> decSortedNullMinList4 = Arrays.asList("d", "D", null, null);
+
+    List<String> list5 = null;
+
+    HostColumnVector.ListType listType = new HostColumnVector.ListType(true,
+        new HostColumnVector.BasicType(true, DType.STRING));
+    // Ascending + NullLargest
+    try (ColumnVector v = ColumnVector.fromLists(listType, list1, list2, list3, list4, list5);
+         ColumnVector expected = ColumnVector.fromLists(listType,
+             ascSortedList1, ascSortedList2, ascSortedList3, ascSortedList4, list5);
+         ColumnVector result = v.listSortRows(false, false)) {
+      assertColumnsAreEqual(expected, result);
+    }
+    // Descending + NullLargest
+    try (ColumnVector v = ColumnVector.fromLists(listType, list1, list2, list3, list4, list5);
+         ColumnVector expected = ColumnVector.fromLists(listType,
+             decSortedList1, decSortedList2, decSortedList3, decSortedList4, list5);
+         ColumnVector result = v.listSortRows(true, false)) {
+      assertColumnsAreEqual(expected, result);
+    }
+    // Ascending + NullSmallest
+    try (ColumnVector v = ColumnVector.fromLists(listType, list1, list2, list3, list4, list5);
+         ColumnVector expected = ColumnVector.fromLists(listType,
+             ascSortedList1, ascSortedList2, ascSortedNullMinList3, ascSortedNullMinList4, list5);
+         ColumnVector result = v.listSortRows(false, true)) {
+      assertColumnsAreEqual(expected, result);
+    }
+    // Descending + NullSmallest
+    try (ColumnVector v = ColumnVector.fromLists(listType, list1, list2, list3, list4, list5);
+         ColumnVector expected = ColumnVector.fromLists(listType,
+             decSortedList1, decSortedList2, decSortedNullMinList3, decSortedNullMinList4, list5);
+         ColumnVector result = v.listSortRows(true, true)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
   void testStringSplitRecord() {
       try (ColumnVector v = ColumnVector.fromStrings("Héllo there", "thésé", "null", "", "ARé some", "test strings");
            ColumnVector expected = ColumnVector.fromLists(

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -3073,7 +3073,7 @@ public class TableTest extends CudfTestBase {
           assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
 
           // Primitive type: INT32
-          //  a) excluding nulls
+          //  a) excluding NULLs
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(aggCollect.onColumn(3).overWindow(winOpts));
                ColumnVector expected = ColumnVector.fromLists(
@@ -3083,7 +3083,7 @@ public class TableTest extends CudfTestBase {
                    Arrays.asList(), Arrays.asList(6), Arrays.asList(6, 7), Arrays.asList(6, 7))) {
             assertColumnsAreEqual(expected, windowAggResults.getColumn(0));
           }
-          //  b) including nulls AND nulls are equal
+          //  b) including NULLs AND NULLs are equal
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(aggCollectWithEqNulls.onColumn(3).overWindow(winOpts));
                ColumnVector expected = ColumnVector.fromLists(
@@ -3093,7 +3093,7 @@ public class TableTest extends CudfTestBase {
                    Arrays.asList((Integer) null), Arrays.asList(6, null), Arrays.asList(6, 7, null), Arrays.asList(6, 7))) {
             assertColumnsAreEqual(expected, windowAggResults.getColumn(0));
           }
-          //  c) including nulls AND nulls are unequal
+          //  c) including NULLs AND NULLs are unequal
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(aggCollectWithUnEqNulls.onColumn(3).overWindow(winOpts));
                ColumnVector expected = ColumnVector.fromLists(
@@ -3105,7 +3105,7 @@ public class TableTest extends CudfTestBase {
           }
 
           // Primitive type: FLOAT64
-          //  a) excluding nulls
+          //  a) excluding NULLs
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(aggCollect.onColumn(4).overWindow(winOpts));
                ColumnVector expected = ColumnVector.fromLists(
@@ -3117,7 +3117,7 @@ public class TableTest extends CudfTestBase {
                    Arrays.asList(Double.NaN, Double.NaN), Arrays.asList(Double.NaN, Double.NaN))) {
             assertColumnsAreEqual(expected, windowAggResults.getColumn(0));
           }
-          //  b) including nulls AND nulls are equal
+          //  b) including NULLs AND NULLs are equal
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(aggCollectWithEqNulls.onColumn(4).overWindow(winOpts));
                ColumnVector expected = ColumnVector.fromLists(
@@ -3129,7 +3129,7 @@ public class TableTest extends CudfTestBase {
                    Arrays.asList(Double.NaN, Double.NaN, null), Arrays.asList(Double.NaN, Double.NaN))) {
             assertColumnsAreEqual(expected, windowAggResults.getColumn(0));
           }
-          //  c) including nulls AND nulls are equal AND nans are equal
+          //  c) including NULLs AND NULLs are equal AND NaNs are equal
           try (Table windowAggResults = sorted.groupBy(0, 1)
               .aggregateWindows(aggCollectWithEqNaNs.onColumn(4).overWindow(winOpts));
                ColumnVector expected = ColumnVector.fromLists(


### PR DESCRIPTION
This PR is to provide JNI wrapper for `cudf::lists::sort_lists', which sorts each row inside list_column. This feature is required by https://github.com/NVIDIA/spark-rapids/issues/2557.

In addition, this PR also update comments and tests on NaNEquality/NullEquality of rolling_collect_set. 