### PR TITLE
[gpuCI] Forward-merge branch-21.06 to branch-21.08 [skip ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -80,7 +80,7 @@ gpuci_conda_retry install -y \
                   "rapids-notebook-env=$MINOR_VERSION.*" \
                   "dask-cuda=${MINOR_VERSION}" \
                   "rmm=$MINOR_VERSION.*" \
-                  "ucx-py=${MINOR_VERSION}"
+                  "ucx-py=0.20.*"
 
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.06` that creates a PR to keep `branch-21.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.