### PR TITLE
Correct unused parameter warnings in groupby

### DIFF
--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -106,7 +106,7 @@ class groupby_simple_aggregations_collector final
   using cudf::detail::simple_aggregations_collector::visit;
 
   std::vector<std::unique_ptr<aggregation>> visit(data_type col_type,
-                                                  cudf::detail::min_aggregation const& agg) override
+                                                  cudf::detail::min_aggregation const&) override
   {
     std::vector<std::unique_ptr<aggregation>> aggs;
     aggs.push_back(col_type.id() == type_id::STRING ? make_argmin_aggregation()
@@ -115,7 +115,7 @@ class groupby_simple_aggregations_collector final
   }
 
   std::vector<std::unique_ptr<aggregation>> visit(data_type col_type,
-                                                  cudf::detail::max_aggregation const& agg) override
+                                                  cudf::detail::max_aggregation const&) override
   {
     std::vector<std::unique_ptr<aggregation>> aggs;
     aggs.push_back(col_type.id() == type_id::STRING ? make_argmax_aggregation()
@@ -123,9 +123,10 @@ class groupby_simple_aggregations_collector final
     return aggs;
   }
 
-  std::vector<std::unique_ptr<aggregation>> visit(
-    data_type col_type, cudf::detail::mean_aggregation const& agg) override
+  std::vector<std::unique_ptr<aggregation>> visit(data_type col_type,
+                                                  cudf::detail::mean_aggregation const&) override
   {
+    (void)col_type;
     CUDF_EXPECTS(is_fixed_width(col_type), "MEAN aggregation expects fixed width type");
     std::vector<std::unique_ptr<aggregation>> aggs;
     aggs.push_back(make_sum_aggregation());
@@ -135,8 +136,8 @@ class groupby_simple_aggregations_collector final
     return aggs;
   }
 
-  std::vector<std::unique_ptr<aggregation>> visit(data_type col_type,
-                                                  cudf::detail::var_aggregation const& agg) override
+  std::vector<std::unique_ptr<aggregation>> visit(data_type,
+                                                  cudf::detail::var_aggregation const&) override
   {
     std::vector<std::unique_ptr<aggregation>> aggs;
     aggs.push_back(make_sum_aggregation());
@@ -146,8 +147,8 @@ class groupby_simple_aggregations_collector final
     return aggs;
   }
 
-  std::vector<std::unique_ptr<aggregation>> visit(data_type col_type,
-                                                  cudf::detail::std_aggregation const& agg) override
+  std::vector<std::unique_ptr<aggregation>> visit(data_type,
+                                                  cudf::detail::std_aggregation const&) override
   {
     std::vector<std::unique_ptr<aggregation>> aggs;
     aggs.push_back(make_sum_aggregation());
@@ -203,7 +204,7 @@ class hash_compound_agg_finalizer final : public cudf::detail::aggregation_final
   auto to_dense_agg_result(cudf::aggregation const& agg)
   {
     auto s                  = sparse_results->get_result(col_idx, agg);
-    auto dense_result_table = cudf::detail::gather(table_view({s}),
+    auto dense_result_table = cudf::detail::gather(table_view({std::move(s)}),
                                                    gather_map.begin(),
                                                    gather_map.begin() + map_size,
                                                    out_of_bounds_policy::DONT_CHECK,

--- a/cpp/src/groupby/sort/group_nunique.cu
+++ b/cpp/src/groupby/sort/group_nunique.cu
@@ -93,15 +93,9 @@ struct nunique_functor {
     return result;
   }
 
-  template <typename T>
+  template <typename T, typename... Args>
   typename std::enable_if_t<!cudf::is_equality_comparable<T, T>(), std::unique_ptr<column>>
-  operator()(column_view const& values,
-             cudf::device_span<size_type const> group_labels,
-             size_type const num_groups,
-             cudf::device_span<size_type const> group_offsets,
-             null_policy null_handling,
-             rmm::cuda_stream_view stream,
-             rmm::mr::device_memory_resource* mr)
+  operator()(Args&&...)
   {
     CUDF_FAIL("list_view group_nunique not supported yet");
   }

--- a/cpp/src/groupby/sort/group_quantiles.cu
+++ b/cpp/src/groupby/sort/group_quantiles.cu
@@ -136,7 +136,7 @@ struct quantiles_functor {
 
   template <typename T, typename... Args>
   std::enable_if_t<!std::is_arithmetic<T>::value, std::unique_ptr<column>> operator()(
-    Args&&... args)
+    Args&&...)
   {
     CUDF_FAIL("Only arithmetic types are supported in quantiles");
   }

--- a/cpp/src/groupby/sort/group_quantiles.cu
+++ b/cpp/src/groupby/sort/group_quantiles.cu
@@ -135,8 +135,7 @@ struct quantiles_functor {
   }
 
   template <typename T, typename... Args>
-  std::enable_if_t<!std::is_arithmetic<T>::value, std::unique_ptr<column>> operator()(
-    Args&&...)
+  std::enable_if_t<!std::is_arithmetic<T>::value, std::unique_ptr<column>> operator()(Args&&...)
   {
     CUDF_FAIL("Only arithmetic types are supported in quantiles");
   }

--- a/cpp/src/groupby/sort/group_std.cu
+++ b/cpp/src/groupby/sort/group_std.cu
@@ -110,7 +110,6 @@ struct var_functor {
     auto values_view = column_device_view::create(values, stream);
     auto d_values    = *values_view;
 
-    auto d_group_labels = group_labels.data();
     auto d_means        = group_means.data<ResultType>();
     auto d_group_sizes  = group_sizes.data<size_type>();
     auto d_result       = result->mutable_view().data<ResultType>();
@@ -146,7 +145,7 @@ struct var_functor {
 
   template <typename T, typename... Args>
   std::enable_if_t<!std::is_arithmetic<T>::value, std::unique_ptr<column>> operator()(
-    Args&&... args)
+    Args&&...)
   {
     CUDF_FAIL("Only numeric types are supported in std/variance");
   }

--- a/cpp/src/groupby/sort/group_std.cu
+++ b/cpp/src/groupby/sort/group_std.cu
@@ -110,9 +110,9 @@ struct var_functor {
     auto values_view = column_device_view::create(values, stream);
     auto d_values    = *values_view;
 
-    auto d_means        = group_means.data<ResultType>();
-    auto d_group_sizes  = group_sizes.data<size_type>();
-    auto d_result       = result->mutable_view().data<ResultType>();
+    auto d_means       = group_means.data<ResultType>();
+    auto d_group_sizes = group_sizes.data<size_type>();
+    auto d_result      = result->mutable_view().data<ResultType>();
 
     if (!cudf::is_dictionary(values.type())) {
       auto values_iter = d_values.begin<T>();
@@ -144,8 +144,7 @@ struct var_functor {
   }
 
   template <typename T, typename... Args>
-  std::enable_if_t<!std::is_arithmetic<T>::value, std::unique_ptr<column>> operator()(
-    Args&&...)
+  std::enable_if_t<!std::is_arithmetic<T>::value, std::unique_ptr<column>> operator()(Args&&...)
   {
     CUDF_FAIL("Only numeric types are supported in std/variance");
   }


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.