### PR TITLE
Correct unused parameter warnings in filling algorithms

### DIFF
--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -89,7 +89,7 @@ struct count_checker {
   }
 
   template <typename T>
-  std::enable_if_t<not std::is_integral<T>::value, void> operator()(rmm::cuda_stream_view stream)
+  std::enable_if_t<not std::is_integral<T>::value, void> operator()(rmm::cuda_stream_view)
   {
     CUDF_FAIL("count value type should be integral.");
   }

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -114,8 +114,6 @@ struct sequence_functor {
   {
     CUDF_FAIL("Unsupported sequence scalar type");
   }
-
-
 };
 
 }  // anonymous namespace

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -85,18 +85,6 @@ struct sequence_functor {
 
   template <
     typename T,
-    typename std::enable_if_t<not cudf::is_numeric<T>() or cudf::is_boolean<T>()>* = nullptr>
-  std::unique_ptr<column> operator()(size_type size,
-                                     scalar const& init,
-                                     scalar const& step,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::mr::device_memory_resource* mr)
-  {
-    CUDF_FAIL("Unsupported sequence scalar type");
-  }
-
-  template <
-    typename T,
     typename std::enable_if_t<cudf::is_numeric<T>() and not cudf::is_boolean<T>()>* = nullptr>
   std::unique_ptr<column> operator()(size_type size,
                                      scalar const& init,
@@ -120,16 +108,14 @@ struct sequence_functor {
     return result;
   }
 
-  template <
-    typename T,
-    typename std::enable_if_t<not cudf::is_numeric<T>() or cudf::is_boolean<T>()>* = nullptr>
-  std::unique_ptr<column> operator()(size_type size,
-                                     scalar const& init,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::mr::device_memory_resource* mr)
+  template <typename T, typename... Args>
+  std::enable_if_t<not cudf::is_numeric<T>() or cudf::is_boolean<T>(), std::unique_ptr<column>>
+  operator()(Args&&...)
   {
     CUDF_FAIL("Unsupported sequence scalar type");
   }
+
+
 };
 
 }  // anonymous namespace


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.