### PR TITLE
Fix exclusive scan when including nulls and improve testing

### DIFF
--- a/cpp/include/cudf_test/type_lists.hpp
+++ b/cpp/include/cudf_test/type_lists.hpp
@@ -72,7 +72,7 @@ constexpr auto types_to_ids()
 }  // namespace detail
 
 /**
- * @brief Convert numeric values type T to numeric vector of type TypeParam.
+ * @brief Convert numeric values of type T to numeric vector of type TypeParam.
  *
  * This will also convert negative values to positive values if the output type is unsigned.
  *
@@ -95,6 +95,12 @@ make_type_param_vector(std::initializer_list<T> const& init_list)
   return vec;
 }
 
+/**
+ * @brief Convert numeric values of type T to timestamp vector
+ *
+ * @param init_list Values used to create the output vector
+ * @return Vector of TypeParam with the values specified
+ */
 template <typename TypeParam, typename T>
 typename std::enable_if<cudf::is_timestamp_t<TypeParam>::value,
                         thrust::host_vector<TypeParam>>::type
@@ -106,6 +112,13 @@ make_type_param_vector(std::initializer_list<T> const& init_list)
   });
   return vec;
 }
+
+/**
+ * @brief Convert numeric values of type T to vector of std::string
+ *
+ * @param init_list Values used to create the output vector
+ * @return Vector of TypeParam with the values specified
+ */
 
 template <typename TypeParam, typename T>
 typename std::enable_if<std::is_same_v<TypeParam, std::string>,

--- a/cpp/include/cudf_test/type_lists.hpp
+++ b/cpp/include/cudf_test/type_lists.hpp
@@ -29,6 +29,7 @@
 
 #include <array>
 #include <tuple>
+#include <type_traits>
 
 /**
  * @filename type_lists.hpp
@@ -85,8 +86,8 @@ typename std::enable_if<cudf::is_fixed_width<TypeParam>() &&
 make_type_param_vector(std::initializer_list<T> const& init_list)
 {
   thrust::host_vector<TypeParam> vec(init_list.size());
-  std::transform(std::cbegin(init_list), std::cend(init_list), std::begin(vec), [](auto const& e) {
-    if (std::is_unsigned<TypeParam>::value)
+  std::transform(std::cbegin(init_list), std::cend(init_list), std::begin(vec), [](T const& e) {
+    if constexpr (std::is_unsigned<TypeParam>::value)
       return static_cast<TypeParam>(std::abs(e));
     else
       return static_cast<TypeParam>(e);
@@ -102,6 +103,18 @@ make_type_param_vector(std::initializer_list<T> const& init_list)
   thrust::host_vector<TypeParam> vec(init_list.size());
   std::transform(std::cbegin(init_list), std::cend(init_list), std::begin(vec), [](auto const& e) {
     return TypeParam{typename TypeParam::duration{e}};
+  });
+  return vec;
+}
+
+template <typename TypeParam, typename T>
+typename std::enable_if<std::is_same_v<TypeParam, std::string>,
+                        thrust::host_vector<std::string>>::type
+make_type_param_vector(std::initializer_list<T> const& init_list)
+{
+  thrust::host_vector<std::string> vec(init_list.size());
+  std::transform(std::cbegin(init_list), std::cend(init_list), std::begin(vec), [](auto const& e) {
+    return std::to_string(e);
   });
   return vec;
 }

--- a/cpp/include/cudf_test/type_lists.hpp
+++ b/cpp/include/cudf_test/type_lists.hpp
@@ -86,11 +86,11 @@ typename std::enable_if<cudf::is_fixed_width<TypeParam>() &&
 make_type_param_vector(std::initializer_list<T> const& init_list)
 {
   thrust::host_vector<TypeParam> vec(init_list.size());
-  std::transform(std::cbegin(init_list), std::cend(init_list), std::begin(vec), [](T const& e) {
-    if constexpr (std::is_unsigned<TypeParam>::value)
+  std::transform(std::cbegin(init_list), std::cend(init_list), std::begin(vec), [](auto const& e) {
+    if constexpr (std::is_unsigned<TypeParam>::value) {
       return static_cast<TypeParam>(std::abs(e));
-    else
-      return static_cast<TypeParam>(e);
+    }
+    return static_cast<TypeParam>(e);
   });
   return vec;
 }

--- a/cpp/src/reductions/scan/scan.cuh
+++ b/cpp/src/reductions/scan/scan.cuh
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/detail/utilities/device_operators.cuh>
+#include <cudf/reduction.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -25,6 +26,12 @@
 
 namespace cudf {
 namespace detail {
+
+// logical-and scan of the null mask of the input view
+rmm::device_buffer mask_scan(const column_view& input_view,
+                             cudf::scan_type inclusive,
+                             rmm::cuda_stream_view stream,
+                             rmm::mr::device_memory_resource* mr);
 
 template <template <typename> typename DispatchFn>
 std::unique_ptr<column> scan_agg_dispatch(const column_view& input,

--- a/cpp/src/reductions/scan/scan_exclusive.cu
+++ b/cpp/src/reductions/scan/scan_exclusive.cu
@@ -93,6 +93,9 @@ std::unique_ptr<column> scan_exclusive(const column_view& input,
 
   if (null_handling == null_policy::EXCLUDE) {
     output->set_null_mask(detail::copy_bitmask(input, stream, mr), input.null_count());
+  } else if (input.nullable()) {
+    output->set_null_mask(mask_scan(input, scan_type::EXCLUSIVE, stream, mr),
+                          cudf::UNKNOWN_NULL_COUNT);
   }
 
   return output;

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/null_mask.hpp>
+#include <cudf/reduction.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
@@ -31,27 +32,39 @@
 
 namespace cudf {
 namespace detail {
-namespace {
 
-rmm::device_buffer mask_inclusive_scan(const column_view& input_view,
-                                       rmm::cuda_stream_view stream,
-                                       rmm::mr::device_memory_resource* mr)
+// logical-and scan of the null mask of the input view
+rmm::device_buffer mask_scan(const column_view& input_view,
+                             cudf::scan_type inclusive,
+                             rmm::cuda_stream_view stream,
+                             rmm::mr::device_memory_resource* mr)
 {
   rmm::device_buffer mask =
     detail::create_null_mask(input_view.size(), mask_state::UNINITIALIZED, stream, mr);
   auto d_input   = column_device_view::create(input_view, stream);
   auto valid_itr = detail::make_validity_iterator(*d_input);
 
-  auto first_null_position = thrust::find_if_not(rmm::exec_policy(stream),
-                                                 valid_itr,
-                                                 valid_itr + input_view.size(),
-                                                 thrust::identity<bool>{}) -
-                             valid_itr;
-  cudf::set_null_mask(static_cast<cudf::bitmask_type*>(mask.data()), 0, first_null_position, true);
-  cudf::set_null_mask(
-    static_cast<cudf::bitmask_type*>(mask.data()), first_null_position, input_view.size(), false);
+  auto first_null_position = [&] {
+    size_type const first_null = thrust::find_if_not(rmm::exec_policy(stream),
+                                                     valid_itr,
+                                                     valid_itr + input_view.size(),
+                                                     thrust::identity<bool>{}) -
+                                 valid_itr;
+    size_type const exclusive_offset = (inclusive == scan_type::EXCLUSIVE) ? 1 : 0;
+    return std::min(input_view.size(), first_null + exclusive_offset);
+  }();
+
+  cudf::detail::set_null_mask(
+    static_cast<cudf::bitmask_type*>(mask.data()), 0, first_null_position, true, stream);
+  cudf::detail::set_null_mask(static_cast<cudf::bitmask_type*>(mask.data()),
+                              first_null_position,
+                              input_view.size(),
+                              false,
+                              stream);
   return mask;
 }
+
+namespace {
 
 /**
  * @brief Dispatcher for running Scan operation on input column
@@ -159,7 +172,8 @@ std::unique_ptr<column> scan_inclusive(
   if (null_handling == null_policy::EXCLUDE) {
     output->set_null_mask(detail::copy_bitmask(input, stream, mr), input.null_count());
   } else if (input.nullable()) {
-    output->set_null_mask(mask_inclusive_scan(input, stream, mr), cudf::UNKNOWN_NULL_COUNT);
+    output->set_null_mask(mask_scan(input, scan_type::INCLUSIVE, stream, mr),
+                          cudf::UNKNOWN_NULL_COUNT);
   }
 
   return output;

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -27,11 +27,13 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <iterator>
 #include <numeric>
 #include <type_traits>
 #include <vector>
+#include "cudf/strings/string_view.hpp"
 
 using aggregation = cudf::aggregation;
 using cudf::column_view;
@@ -52,6 +54,16 @@ struct value_or {
   T operator()(T const& value, bool mask) { return mask ? value : _or; }
 };
 
+template <typename T>
+struct TypeParam_to_host_type {
+  using type = T;
+};
+
+template <>
+struct TypeParam_to_host_type<cudf::string_view> {
+  using type = std::string;
+};
+
 template <typename I, typename I2, typename O, typename ZipOp, typename BinOp>
 void zip_inclusive_scan(I first, I last, I2 first2, O output, ZipOp zipop, BinOp binop)
 {
@@ -70,10 +82,28 @@ void zip_inclusive_scan(I first, I last, I2 first2, O output, ZipOp zipop, BinOp
                  });
 }
 
+template <typename TypeParam, typename T>
+typename std::enable_if<std::is_same_v<TypeParam, cudf::string_view>,
+                        thrust::host_vector<std::string>>::type
+make_vector(std::initializer_list<T> const& init)
+{
+  return cudf::test::make_type_param_vector<std::string, T>(init);
+}
+
+template <typename TypeParam, typename T>
+typename std::enable_if<not std::is_same_v<TypeParam, cudf::string_view>,
+                        thrust::host_vector<TypeParam>>::type
+make_vector(std::initializer_list<T> const& init)
+{
+  return cudf::test::make_type_param_vector<TypeParam, T>(init);
+}
+
 // This is the main test feature
 template <typename T>
 struct ScanTest : public cudf::test::BaseFixture {
-  void scan_test(cudf::host_span<T const> v,
+  typedef typename TypeParam_to_host_type<T>::type HostType;
+
+  void scan_test(cudf::host_span<HostType const> v,
                  cudf::host_span<bool const> b,
                  std::unique_ptr<aggregation> const& agg,
                  scan_type inclusive,
@@ -81,17 +111,14 @@ struct ScanTest : public cudf::test::BaseFixture {
   {
     bool const do_print = false;
 
-    auto col_in = (b.size() > 0)
-                    ? cudf::test::fixed_width_column_wrapper<T>(v.begin(), v.end(), b.begin())
-                    : cudf::test::fixed_width_column_wrapper<T>(v.begin(), v.end());
-
-    auto expected_col_out = this->get_expected(v, b, agg, inclusive, null_handling);
-    auto col_out          = cudf::scan(col_in, agg, inclusive, null_handling);
+    auto col_in           = this->make_column(v, b);
+    auto expected_col_out = this->make_expected(v, b, agg, inclusive, null_handling);
+    auto col_out          = cudf::scan(*col_in, agg, inclusive, null_handling);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_col_out, *col_out);
 
     if constexpr (do_print) {
-      auto int_values      = cudf::test::to_host<T>(col_in);
+      auto int_values      = cudf::test::to_host<T>(*col_in);
       auto expected_values = cudf::test::to_host<T>(*expected_col_out);
       auto host_result     = cudf::test::to_host<T>(*col_out);
       this->print(std::get<0>(int_values), "input = ");
@@ -100,37 +127,85 @@ struct ScanTest : public cudf::test::BaseFixture {
     }
   }
 
-  std::unique_ptr<cudf::column> get_expected(cudf::host_span<T const> v,
-                                             cudf::host_span<bool const> b,
-                                             std::unique_ptr<aggregation> const& agg,
-                                             scan_type inclusive,
-                                             null_policy null_handling)
+  std::unique_ptr<cudf::column> make_column(cudf::host_span<HostType const> v,
+                                            cudf::host_span<bool const> b = {})
   {
-    auto op = [&agg]() -> std::function<T(T, T)> {
+    if constexpr (std::is_same_v<T, cudf::string_view>) {
+      auto col_in = (b.size() > 0)
+                      ? cudf::test::strings_column_wrapper(v.begin(), v.end(), b.begin())
+                      : cudf::test::strings_column_wrapper(v.begin(), v.end());
+      return col_in.release();
+    } else {
+      auto col_in = (b.size() > 0)
+                      ? cudf::test::fixed_width_column_wrapper<T>(v.begin(), v.end(), b.begin())
+                      : cudf::test::fixed_width_column_wrapper<T>(v.begin(), v.end());
+      return col_in.release();
+    }
+  }
+
+  std::function<HostType(HostType, HostType)> make_agg(std::unique_ptr<aggregation> const& agg)
+  {
+    if constexpr (std::is_same_v<T, cudf::string_view>) {
+      switch (agg->kind) {
+        case cudf::aggregation::MIN: return [](HostType a, HostType b) { return std::min(a, b); };
+        case cudf::aggregation::MAX: return [](HostType a, HostType b) { return std::max(a, b); };
+        default: {
+          CUDF_FAIL("Unsupported aggregation");
+          return [](HostType a, HostType b) { return std::min(a, b); };
+        }
+      }
+    } else {
       switch (agg->kind) {
         case cudf::aggregation::SUM: return std::plus<T>{};
         case cudf::aggregation::PRODUCT: return std::multiplies<T>{};
         case cudf::aggregation::MIN: return [](T a, T b) { return std::min(a, b); };
         case cudf::aggregation::MAX: return [](T a, T b) { return std::max(a, b); };
-        default: CUDF_FAIL("Unsupported aggregation");
+        default: {
+          CUDF_FAIL("Unsupported aggregation");
+          return [](HostType a, HostType b) { return std::min(a, b); };
+        }
       }
-    }();
+    }
+  }
 
-    auto identity = [&agg] {
+  HostType make_identity(std::unique_ptr<aggregation> const& agg)
+  {
+    if constexpr (std::is_same_v<T, cudf::string_view>) {
       switch (agg->kind) {
-        case cudf::aggregation::SUM: return T{0};
-        case cudf::aggregation::PRODUCT: return T{1};
-        case cudf::aggregation::MIN: return std::numeric_limits<T>::max();
-        case cudf::aggregation::MAX: return std::numeric_limits<T>::lowest();
-        default: CUDF_FAIL("Unsupported aggregation");
+        case cudf::aggregation::MIN: return std::string{"\xF7\xBF\xBF\xBF"};
+        case cudf::aggregation::MAX: return std::string{};
+        default: {
+          CUDF_FAIL("Unsupported aggregation");
+          return HostType{};
+        }
       }
-    }();
+    } else {
+      switch (agg->kind) {
+        case cudf::aggregation::SUM: return HostType{0};
+        case cudf::aggregation::PRODUCT: return HostType{1};
+        case cudf::aggregation::MIN: return std::numeric_limits<HostType>::max();
+        case cudf::aggregation::MAX: return std::numeric_limits<HostType>::lowest();
+        default: {
+          CUDF_FAIL("Unsupported aggregation");
+          return HostType{};
+        }
+      }
+    }
+  }
 
-    std::vector<T> expected(v.size());
+  std::unique_ptr<cudf::column> make_expected(cudf::host_span<HostType const> v,
+                                              cudf::host_span<bool const> b,
+                                              std::unique_ptr<aggregation> const& agg,
+                                              scan_type inclusive,
+                                              null_policy null_handling)
+  {
+    auto op       = this->make_agg(agg);
+    auto identity = this->make_identity(agg);
+
+    thrust::host_vector<HostType> expected(v.size());
+    thrust::host_vector<bool> b_out(b.begin(), b.end());
 
     bool const nullable = (b.size() > 0);
-
-    thrust::host_vector<bool> b_out(b.begin(), b.end());
 
     if (inclusive == cudf::scan_type::INCLUSIVE) {
       if (nullable) {
@@ -140,7 +215,7 @@ struct ScanTest : public cudf::test::BaseFixture {
           expected.begin(),
           op,
           [id = identity](auto const& z) {
-            return value_or<T>{id}(thrust::get<0>(z), thrust::get<1>(z));
+            return value_or<HostType>{id}(thrust::get<0>(z), thrust::get<1>(z));
           });
 
         if (null_handling == null_policy::INCLUDE) {
@@ -158,7 +233,7 @@ struct ScanTest : public cudf::test::BaseFixture {
           identity,
           op,
           [id = identity](auto const& z) {
-            return value_or<T>{id}(thrust::get<0>(z), thrust::get<1>(z));
+            return value_or<HostType>{id}(thrust::get<0>(z), thrust::get<1>(z));
           });
 
         if (null_handling == null_policy::INCLUDE) {
@@ -169,12 +244,7 @@ struct ScanTest : public cudf::test::BaseFixture {
       }
     }
 
-    auto ret =
-      nullable
-        ? cudf::test::fixed_width_column_wrapper<T>(expected.begin(), expected.end(), b_out.begin())
-        : cudf::test::fixed_width_column_wrapper<T>(expected.begin(), expected.end());
-
-    return ret.release();
+    return nullable ? this->make_column(expected, b_out) : this->make_column(expected);
   }
 
   template <typename Ti>
@@ -186,111 +256,140 @@ struct ScanTest : public cudf::test::BaseFixture {
   }
 };
 
-using Types = cudf::test::NumericTypes;
+using Types = cudf::test::Concat<cudf::test::NumericTypes, cudf::test::Types<cudf::string_view>>;
 
 TYPED_TEST_CASE(ScanTest, Types);
 
 TYPED_TEST(ScanTest, Min)
 {
-  auto const v =
-    cudf::test::make_type_param_vector<TypeParam>({123, 64, 63, 99, -5, 123, -16, -120, -111});
+  auto const v = make_vector<TypeParam>({123, 64, 63, 99, -5, 123, -16, -120, -111});
   auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 0, 1, 1, 1, 1, 0, 0, 1});
 
   // no nulls
   this->scan_test(v, {}, cudf::make_min_aggregation(), scan_type::INCLUSIVE);
-  this->scan_test(v, {}, cudf::make_min_aggregation(), scan_type::EXCLUSIVE);
   // skipna = true (default)
   this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
-  this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
   // skipna = false
   this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  // this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE,
-  // null_policy::INCLUDE);
+
+  // strings only support inclusive scan
+  if constexpr (not std::is_same_v<TypeParam, cudf::string_view>) {
+    // no nulls
+    this->scan_test(v, {}, cudf::make_min_aggregation(), scan_type::EXCLUSIVE);
+    // skipna = true (default)
+    this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+    // skipna = false
+    this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+  }
 }
 
 TYPED_TEST(ScanTest, Max)
 {
-  auto const v =
-    cudf::test::make_type_param_vector<TypeParam>({-120, 5, 0, -120, -111, 64, 63, 99, 123, -16});
+  auto const v = make_vector<TypeParam>({-120, 5, 0, -120, -111, 64, 63, 99, 123, -16});
   auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 0, 1, 1, 1, 1, 0, 1, 0, 1});
 
   // no nulls
   this->scan_test(v, {}, cudf::make_max_aggregation(), scan_type::INCLUSIVE);
-  this->scan_test(v, {}, cudf::make_max_aggregation(), scan_type::EXCLUSIVE);
   // skipna = true (default)
   this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
-  this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
   // skipna = false
   this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+
+  // strings only support inclusive scan
+  if constexpr (not std::is_same_v<TypeParam, cudf::string_view>) {
+    // no nulls
+    this->scan_test(v, {}, cudf::make_max_aggregation(), scan_type::EXCLUSIVE);
+    // skipna = true (default)
+    this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+    // skipna = false
+    this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+  }
 }
 
 TYPED_TEST(ScanTest, Product)
 {
-  auto const v = cudf::test::make_type_param_vector<TypeParam>({5, -1, 1, 3, -2, 4});
-  auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 1, 1, 0, 1, 1});
+  if constexpr (not std::is_same_v<cudf::string_view, TypeParam>) {
+    auto const v = make_vector<TypeParam>({5, -1, 1, 3, -2, 4});
+    auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 1, 1, 0, 1, 1});
 
-  // no nulls
-  this->scan_test(v, {}, cudf::make_product_aggregation(), scan_type::INCLUSIVE);
-  this->scan_test(v, {}, cudf::make_product_aggregation(), scan_type::EXCLUSIVE);
-  // skipna = true (default)
-  this->scan_test(
-    v, b, cudf::make_product_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
-  this->scan_test(
-    v, b, cudf::make_product_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
-  // skipna = false
-  this->scan_test(
-    v, b, cudf::make_product_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  this->scan_test(
-    v, b, cudf::make_product_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+    // no nulls
+    this->scan_test(v, {}, cudf::make_product_aggregation(), scan_type::INCLUSIVE);
+    this->scan_test(v, {}, cudf::make_product_aggregation(), scan_type::EXCLUSIVE);
+    // skipna = true (default)
+    this->scan_test(
+      v, b, cudf::make_product_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
+    this->scan_test(
+      v, b, cudf::make_product_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+    // skipna = false
+    this->scan_test(
+      v, b, cudf::make_product_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+    this->scan_test(
+      v, b, cudf::make_product_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+  }
 }
 
 TYPED_TEST(ScanTest, Sum)
 {
-  auto const v = [] {
-    if (std::is_signed<TypeParam>::value)
-      return cudf::test::make_type_param_vector<TypeParam>(
-        {-120, 5, 6, 113, -111, 64, -63, 9, 34, -16});
-    return cudf::test::make_type_param_vector<TypeParam>({12, 5, 6, 13, 11, 14, 3, 9, 34, 16});
-  }();
-  auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 0, 1, 1, 0, 0, 1, 1, 1, 1});
+  if constexpr (not std::is_same_v<cudf::string_view, TypeParam>) {
+    auto const v = [] {
+      if (std::is_signed<TypeParam>::value)
+        return make_vector<TypeParam>({-120, 5, 6, 113, -111, 64, -63, 9, 34, -16});
+      return make_vector<TypeParam>({12, 5, 6, 13, 11, 14, 3, 9, 34, 16});
+    }();
+    auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 0, 1, 1, 0, 0, 1, 1, 1, 1});
 
-  // no nulls
-  this->scan_test(v, {}, cudf::make_sum_aggregation(), scan_type::INCLUSIVE);
-  this->scan_test(v, {}, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE);
-  // skipna = true (default)
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
-  // skipna = false
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+    // no nulls
+    this->scan_test(v, {}, cudf::make_sum_aggregation(), scan_type::INCLUSIVE);
+    // skipna = true (default)
+    this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
+    // skipna = false
+    this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+
+    // no nulls
+    this->scan_test(v, {}, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE);
+    // skipna = true (default)
+    this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+    // skipna = false
+    this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+  }
 }
 
 TYPED_TEST(ScanTest, EmptyColumn)
 {
-  auto const v = thrust::host_vector<TypeParam>{};
+  auto const v = thrust::host_vector<typename TypeParam_to_host_type<TypeParam>::type>{};
   auto const b = thrust::host_vector<bool>{};
 
   // skipna = true (default)
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+  this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
   // skipna = false
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+  this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+
+  if constexpr (not std::is_same_v<cudf::string_view, TypeParam>) {
+    // skipna = true (default)
+    this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+    // skipna = false
+    this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+  }
 }
 
 TYPED_TEST(ScanTest, LeadingNulls)
 {
-  auto const v = cudf::test::make_type_param_vector<TypeParam>({100, 200, 300});
+  auto const v = make_vector<TypeParam>({100, 200, 300});
   auto const b = thrust::host_vector<bool>(std::vector<bool>{0, 1, 1});
 
   // skipna = true (default)
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+  this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
   // skipna = false
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+  this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+
+  if constexpr (not std::is_same_v<cudf::string_view, TypeParam>) {
+    // skipna = true (default)
+    this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+    // skipna = false
+    this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+  }
 }
+
 struct ScanStringTest : public cudf::test::BaseFixture {
   void scan_test(cudf::test::strings_column_wrapper const& col_in,
                  cudf::test::strings_column_wrapper const& expected_col_out,
@@ -323,116 +422,6 @@ struct ScanStringTest : public cudf::test::BaseFixture {
     }
   }
 };
-
-TEST_F(ScanStringTest, Min)
-{
-  std::vector<std::string> v = {
-    "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"};
-  std::vector<bool> b = {1, 0, 1, 1, 0, 0, 1, 0, 1};
-  std::vector<std::string> expected(v.size());
-
-  std::partial_sum(v.cbegin(), v.cend(), expected.begin(), [](auto const& a, auto const& b) {
-    return std::min(a, b);
-  });
-
-  // string column without nulls
-  cudf::test::strings_column_wrapper col_nonulls(v.begin(), v.end());
-  cudf::test::strings_column_wrapper expected1(expected.begin(), expected.end());
-  this->scan_test(col_nonulls, expected1, cudf::make_min_aggregation(), scan_type::INCLUSIVE);
-
-  auto const STRING_MAX = std::string("\xF7\xBF\xBF\xBF");
-
-  zip_inclusive_scan(v.cbegin(),
-                     v.cend(),
-                     b.cbegin(),
-                     expected.begin(),
-                     value_or<std::string>{STRING_MAX},
-                     [](auto const& a, auto const& b) { return std::min(a, b); });
-
-  // string column with nulls
-  cudf::test::strings_column_wrapper col_nulls(v.begin(), v.end(), b.begin());
-  cudf::test::strings_column_wrapper expected2(expected.begin(), expected.end(), b.begin());
-  this->scan_test(col_nulls, expected2, cudf::make_min_aggregation(), scan_type::INCLUSIVE);
-}
-
-TEST_F(ScanStringTest, Max)
-{
-  std::vector<std::string> v = {
-    "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"};
-  std::vector<bool> b = {1, 0, 1, 1, 0, 0, 1, 1, 1};
-  std::vector<std::string> expected(v.size());
-
-  std::partial_sum(v.cbegin(), v.cend(), expected.begin(), [](auto const& a, auto const& b) {
-    return std::max(a, b);
-  });
-
-  // string column without nulls
-  cudf::test::strings_column_wrapper col_nonulls(v.begin(), v.end());
-  cudf::test::strings_column_wrapper expected1(expected.begin(), expected.end());
-  this->scan_test(col_nonulls, expected1, cudf::make_max_aggregation(), scan_type::INCLUSIVE);
-
-  auto const STRING_MIN = std::string{};
-
-  zip_inclusive_scan(v.cbegin(),
-                     v.cend(),
-                     b.cbegin(),
-                     expected.begin(),
-                     value_or<std::string>{STRING_MIN},
-                     [](auto const& a, auto const& b) { return std::max(a, b); });
-
-  // string column with nulls
-  cudf::test::strings_column_wrapper col_nulls(v.begin(), v.end(), b.begin());
-  cudf::test::strings_column_wrapper expected2(expected.begin(), expected.end(), b.begin());
-  this->scan_test(col_nulls, expected2, cudf::make_max_aggregation(), scan_type::INCLUSIVE);
-}
-
-TEST_F(ScanStringTest, skip_nulls)
-{
-  bool do_print = false;
-  // data and valid arrays
-  std::vector<std::string> v(
-    {"one", "two", "three", "four", "five", "six", "seven", "eight", "nine"});
-  std::vector<bool> b({1, 1, 1, 0, 0, 0, 1, 1, 1});
-  std::vector<std::string> expected(v.size());
-  std::vector<bool> out_b(v.size());
-
-  auto const STRING_MIN = std::string(1, char(0));
-
-  zip_inclusive_scan(v.cbegin(),
-                     v.cend(),
-                     b.cbegin(),
-                     expected.begin(),
-                     value_or<std::string>{STRING_MIN},
-                     [](auto const& a, auto const& b) { return std::max(a, b); });
-
-  std::partial_sum(b.cbegin(), b.cend(), out_b.begin(), std::logical_and<bool>{});
-
-  // string column with nulls
-  cudf::test::strings_column_wrapper col_nulls(v.begin(), v.end(), b.begin());
-  cudf::test::strings_column_wrapper expected2(expected.begin(), expected.end(), out_b.begin());
-  std::unique_ptr<cudf::column> col_out;
-  // skipna=false
-  CUDF_EXPECT_NO_THROW(
-    col_out = cudf::scan(
-      col_nulls, cudf::make_max_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE));
-  if (do_print) {
-    print_view(expected2, "expect = ");
-    print_view(col_out->view(), "result = ");
-  }
-  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(expected2, col_out->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, col_out->view());
-
-  // Exclusive scan string not supported.
-  CUDF_EXPECT_THROW_MESSAGE(
-    (cudf::scan(
-      col_nulls, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE)),
-    "Non-arithmetic types not supported for exclusive scan");
-
-  CUDF_EXPECT_THROW_MESSAGE(
-    (cudf::scan(
-      col_nulls, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE)),
-    "Non-arithmetic types not supported for exclusive scan");
-}
 
 template <typename T>
 struct FixedPointTestBothReps : public cudf::test::BaseFixture {

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -14,21 +14,25 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <cstdlib>
-#include <iostream>
-#include <iterator>
-#include <type_traits>
-#include <vector>
-
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/column/column.hpp>
+#include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/reduction.hpp>
 
-#include <cudf/detail/aggregation/aggregation.hpp>
+#include <thrust/host_vector.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <type_traits>
+#include <vector>
+
 using aggregation = cudf::aggregation;
 using cudf::column_view;
 using cudf::null_policy;
@@ -41,64 +45,15 @@ void print_view(column_view const& view, const char* msg = nullptr)
   std::cout << "}\n";
 }
 
-// This is the main test feature
 template <typename T>
-struct ScanTest : public cudf::test::BaseFixture {
-  void scan_test(cudf::test::fixed_width_column_wrapper<T> const col_in,
-                 cudf::test::fixed_width_column_wrapper<T> const expected_col_out,
-                 std::unique_ptr<aggregation> const& agg,
-                 scan_type inclusive)
-  {
-    bool do_print = false;
-
-    auto int_values   = cudf::test::to_host<T>(col_in);
-    auto exact_values = cudf::test::to_host<T>(expected_col_out);
-    this->val_check(std::get<0>(int_values), do_print, "input = ");
-    this->val_check(std::get<0>(exact_values), do_print, "exact = ");
-
-    const column_view input_view = col_in;
-    std::unique_ptr<cudf::column> col_out;
-
-    CUDF_EXPECT_NO_THROW(col_out = cudf::scan(input_view, agg, inclusive));
-    const column_view result_view = col_out->view();
-
-    CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(input_view, result_view);
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_col_out, result_view);
-
-    auto host_result = cudf::test::to_host<T>(result_view);
-    this->val_check(std::get<0>(host_result), do_print, "result = ");
-  }
-
-  template <typename Ti>
-  void val_check(thrust::host_vector<Ti> const& v, bool do_print = false, const char* msg = nullptr)
-  {
-    if (do_print) {
-      std::cout << msg << " {";
-      std::for_each(v.begin(), v.end(), [](Ti i) { std::cout << ", " << i; });
-      std::cout << "}" << std::endl;
-    }
-    range_check(v);
-  }
-
-  // make sure all elements in the range of sint8([-128, 127])
-  template <typename Ti>
-  void range_check(thrust::host_vector<Ti> const& v)
-  {
-    std::for_each(v.begin(), v.end(), [](Ti i) {
-      ASSERT_GE(static_cast<int>(i), -128);
-      ASSERT_LT(static_cast<int>(i), 128);
-    });
-  }
+struct value_or {
+  T _or;
+  explicit value_or(T value) : _or{value} {}
+  T operator()(T const& value, bool mask) { return mask ? value : _or; }
 };
 
-using Types = cudf::test::NumericTypes;
-
-TYPED_TEST_CASE(ScanTest, Types);
-
-// ------------------------------------------------------------------------
-
 template <typename I, typename I2, typename O, typename ZipOp, typename BinOp>
-void zip_scan(I first, I last, I2 first2, O output, ZipOp zipop, BinOp binop)
+void zip_inclusive_scan(I first, I last, I2 first2, O output, ZipOp zipop, BinOp binop)
 {
   // this could be implemented with a call to std::transform and then a
   // subsequent call to std::partial_sum but that you be less memory efficient
@@ -115,96 +70,179 @@ void zip_scan(I first, I last, I2 first2, O output, ZipOp zipop, BinOp binop)
                  });
 }
 
+// This is the main test feature
 template <typename T>
-struct value_or {
-  T _or;
-  explicit value_or(T value) : _or{value} {}
-  T operator()(T const& value, bool mask) { return mask ? value : _or; }
+struct ScanTest : public cudf::test::BaseFixture {
+  void scan_test(cudf::host_span<T const> v,
+                 cudf::host_span<bool const> b,
+                 std::unique_ptr<aggregation> const& agg,
+                 scan_type inclusive,
+                 null_policy null_handling = null_policy::EXCLUDE)
+  {
+    bool const do_print = false;
+
+    auto col_in = (b.size() > 0)
+                    ? cudf::test::fixed_width_column_wrapper<T>(v.begin(), v.end(), b.begin())
+                    : cudf::test::fixed_width_column_wrapper<T>(v.begin(), v.end());
+
+    auto expected_col_out = this->get_expected(v, b, agg, inclusive, null_handling);
+    auto col_out          = cudf::scan(col_in, agg, inclusive, null_handling);
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_col_out, *col_out);
+
+    if constexpr (do_print) {
+      auto int_values      = cudf::test::to_host<T>(col_in);
+      auto expected_values = cudf::test::to_host<T>(*expected_col_out);
+      auto host_result     = cudf::test::to_host<T>(*col_out);
+      this->print(std::get<0>(int_values), "input = ");
+      this->print(std::get<0>(expected_values), "expected = ");
+      this->print(std::get<0>(host_result), "result = ");
+    }
+  }
+
+  std::unique_ptr<cudf::column> get_expected(cudf::host_span<T const> v,
+                                             cudf::host_span<bool const> b,
+                                             std::unique_ptr<aggregation> const& agg,
+                                             scan_type inclusive,
+                                             null_policy null_handling)
+  {
+    auto op = [&agg]() -> std::function<T(T, T)> {
+      switch (agg->kind) {
+        case cudf::aggregation::SUM: return std::plus<T>{};
+        case cudf::aggregation::PRODUCT: return std::multiplies<T>{};
+        case cudf::aggregation::MIN: return [](T a, T b) { return std::min(a, b); };
+        case cudf::aggregation::MAX: return [](T a, T b) { return std::max(a, b); };
+        default: CUDF_FAIL("Unsupported aggregation");
+      }
+    }();
+
+    auto identity = [&agg] {
+      switch (agg->kind) {
+        case cudf::aggregation::SUM: return T{0};
+        case cudf::aggregation::PRODUCT: return T{1};
+        case cudf::aggregation::MIN: return std::numeric_limits<T>::max();
+        case cudf::aggregation::MAX: return std::numeric_limits<T>::lowest();
+        default: CUDF_FAIL("Unsupported aggregation");
+      }
+    }();
+
+    std::vector<T> expected(v.size());
+
+    bool const nullable = (b.size() > 0);
+
+    thrust::host_vector<bool> b_out(b.begin(), b.end());
+
+    if (inclusive == cudf::scan_type::INCLUSIVE) {
+      if (nullable) {
+        std::transform_inclusive_scan(
+          thrust::make_zip_iterator(thrust::make_tuple(v.begin(), b.begin())),
+          thrust::make_zip_iterator(thrust::make_tuple(v.end(), b.end())),
+          expected.begin(),
+          op,
+          [id = identity](auto const& z) {
+            return value_or<T>{id}(thrust::get<0>(z), thrust::get<1>(z));
+          });
+
+        if (null_handling == null_policy::INCLUDE) {
+          std::inclusive_scan(b.begin(), b.end(), b_out.begin(), std::logical_and<bool>{});
+        }
+      } else {
+        std::inclusive_scan(v.begin(), v.end(), expected.begin(), op);
+      }
+    } else {
+      if (nullable) {
+        std::transform_exclusive_scan(
+          thrust::make_zip_iterator(thrust::make_tuple(v.begin(), b.begin())),
+          thrust::make_zip_iterator(thrust::make_tuple(v.end(), b.end())),
+          expected.begin(),
+          identity,
+          op,
+          [id = identity](auto const& z) {
+            return value_or<T>{id}(thrust::get<0>(z), thrust::get<1>(z));
+          });
+
+        if (null_handling == null_policy::INCLUDE) {
+          std::exclusive_scan(b.begin(), b.end(), b_out.begin(), true, std::logical_and<bool>{});
+        }
+      } else {
+        std::exclusive_scan(v.begin(), v.end(), expected.begin(), identity, op);
+      }
+    }
+
+    auto ret =
+      nullable
+        ? cudf::test::fixed_width_column_wrapper<T>(expected.begin(), expected.end(), b_out.begin())
+        : cudf::test::fixed_width_column_wrapper<T>(expected.begin(), expected.end());
+
+    return ret.release();
+  }
+
+  template <typename Ti>
+  void print(thrust::host_vector<Ti> const& v, const char* msg = nullptr)
+  {
+    std::cout << msg << " {";
+    std::for_each(v.begin(), v.end(), [](Ti i) { std::cout << ", " << i; });
+    std::cout << "}" << std::endl;
+  }
 };
+
+using Types = cudf::test::NumericTypes;
+
+TYPED_TEST_CASE(ScanTest, Types);
 
 TYPED_TEST(ScanTest, Min)
 {
   auto const v =
     cudf::test::make_type_param_vector<TypeParam>({123, 64, 63, 99, -5, 123, -16, -120, -111});
-  auto const b = std::vector<bool>{1, 0, 1, 1, 1, 1, 0, 0, 1};
-  std::vector<TypeParam> exact(v.size());
+  auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 0, 1, 1, 1, 1, 0, 0, 1});
 
-  std::partial_sum(
-    v.cbegin(), v.cend(), exact.begin(), [](auto a, auto b) { return std::min(a, b); });
-
-  this->scan_test(cudf::test::fixed_width_column_wrapper<TypeParam>(v.begin(), v.end()),
-                  cudf::test::fixed_width_column_wrapper<TypeParam>(exact.begin(), exact.end()),
-                  cudf::make_min_aggregation(),
-                  scan_type::INCLUSIVE);
-
-  zip_scan(v.cbegin(),
-           v.cend(),
-           b.cbegin(),
-           exact.begin(),
-           value_or<TypeParam>{std::numeric_limits<TypeParam>::max()},
-           [](auto a, auto b) { return std::min(a, b); });
-
-  this->scan_test(
-    cudf::test::fixed_width_column_wrapper<TypeParam>(v.begin(), v.end(), b.begin()),
-    cudf::test::fixed_width_column_wrapper<TypeParam>(exact.begin(), exact.end(), b.begin()),
-    cudf::make_min_aggregation(),
-    scan_type::INCLUSIVE);
+  // no nulls
+  this->scan_test(v, {}, cudf::make_min_aggregation(), scan_type::INCLUSIVE);
+  this->scan_test(v, {}, cudf::make_min_aggregation(), scan_type::EXCLUSIVE);
+  // skipna = true (default)
+  this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
+  this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+  // skipna = false
+  this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+  // this->scan_test(v, b, cudf::make_min_aggregation(), scan_type::EXCLUSIVE,
+  // null_policy::INCLUDE);
 }
 
 TYPED_TEST(ScanTest, Max)
 {
   auto const v =
     cudf::test::make_type_param_vector<TypeParam>({-120, 5, 0, -120, -111, 64, 63, 99, 123, -16});
-  auto const b = std::vector<bool>{1, 0, 1, 1, 1, 1, 0, 1, 0, 1};
-  std::vector<TypeParam> exact(v.size());
+  auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 0, 1, 1, 1, 1, 0, 1, 0, 1});
 
-  std::partial_sum(
-    v.cbegin(), v.cend(), exact.begin(), [](auto a, auto b) { return std::max(a, b); });
-
-  this->scan_test(cudf::test::fixed_width_column_wrapper<TypeParam>(v.begin(), v.end()),
-                  cudf::test::fixed_width_column_wrapper<TypeParam>(exact.begin(), exact.end()),
-                  cudf::make_max_aggregation(),
-                  scan_type::INCLUSIVE);
-
-  zip_scan(v.cbegin(),
-           v.cend(),
-           b.cbegin(),
-           exact.begin(),
-           value_or<TypeParam>{std::numeric_limits<TypeParam>::lowest()},
-           [](auto a, auto b) { return std::max(a, b); });
-
-  this->scan_test(
-    cudf::test::fixed_width_column_wrapper<TypeParam>(v.begin(), v.end(), b.begin()),
-    cudf::test::fixed_width_column_wrapper<TypeParam>(exact.begin(), exact.end(), b.begin()),
-    cudf::make_max_aggregation(),
-    scan_type::INCLUSIVE);
+  // no nulls
+  this->scan_test(v, {}, cudf::make_max_aggregation(), scan_type::INCLUSIVE);
+  this->scan_test(v, {}, cudf::make_max_aggregation(), scan_type::EXCLUSIVE);
+  // skipna = true (default)
+  this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
+  this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+  // skipna = false
+  this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+  this->scan_test(v, b, cudf::make_max_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
 }
 
 TYPED_TEST(ScanTest, Product)
 {
   auto const v = cudf::test::make_type_param_vector<TypeParam>({5, -1, 1, 3, -2, 4});
-  auto const b = std::vector<bool>{1, 1, 1, 0, 1, 1};
-  std::vector<TypeParam> exact(v.size());
+  auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 1, 1, 0, 1, 1});
 
-  std::partial_sum(v.cbegin(), v.cend(), exact.begin(), std::multiplies<TypeParam>{});
-
-  this->scan_test(cudf::test::fixed_width_column_wrapper<TypeParam>(v.begin(), v.end()),
-                  cudf::test::fixed_width_column_wrapper<TypeParam>(exact.begin(), exact.end()),
-                  cudf::make_product_aggregation(),
-                  scan_type::INCLUSIVE);
-
-  zip_scan(v.cbegin(),
-           v.cend(),
-           b.cbegin(),
-           exact.begin(),
-           value_or<TypeParam>{1},
-           std::multiplies<TypeParam>{});
-
+  // no nulls
+  this->scan_test(v, {}, cudf::make_product_aggregation(), scan_type::INCLUSIVE);
+  this->scan_test(v, {}, cudf::make_product_aggregation(), scan_type::EXCLUSIVE);
+  // skipna = true (default)
   this->scan_test(
-    cudf::test::fixed_width_column_wrapper<TypeParam>(v.begin(), v.end(), b.begin()),
-    cudf::test::fixed_width_column_wrapper<TypeParam>(exact.begin(), exact.end(), b.begin()),
-    cudf::make_product_aggregation(),
-    scan_type::INCLUSIVE);
+    v, b, cudf::make_product_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
+  this->scan_test(
+    v, b, cudf::make_product_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+  // skipna = false
+  this->scan_test(
+    v, b, cudf::make_product_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+  this->scan_test(
+    v, b, cudf::make_product_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
 }
 
 TYPED_TEST(ScanTest, Sum)
@@ -215,30 +253,44 @@ TYPED_TEST(ScanTest, Sum)
         {-120, 5, 6, 113, -111, 64, -63, 9, 34, -16});
     return cudf::test::make_type_param_vector<TypeParam>({12, 5, 6, 13, 11, 14, 3, 9, 34, 16});
   }();
-  auto const b = std::vector<bool>{1, 0, 1, 1, 0, 0, 1, 1, 1, 1};
-  std::vector<TypeParam> exact(v.size());
+  auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 0, 1, 1, 0, 0, 1, 1, 1, 1});
 
-  std::partial_sum(v.cbegin(), v.cend(), exact.begin(), std::plus<TypeParam>{});
-
-  this->scan_test(cudf::test::fixed_width_column_wrapper<TypeParam>(v.begin(), v.end()),
-                  cudf::test::fixed_width_column_wrapper<TypeParam>(exact.begin(), exact.end()),
-                  cudf::make_sum_aggregation(),
-                  scan_type::INCLUSIVE);
-
-  zip_scan(v.cbegin(),
-           v.cend(),
-           b.cbegin(),
-           exact.begin(),
-           value_or<TypeParam>{0},
-           std::plus<TypeParam>{});
-
-  this->scan_test(
-    cudf::test::fixed_width_column_wrapper<TypeParam>(v.begin(), v.end(), b.begin()),
-    cudf::test::fixed_width_column_wrapper<TypeParam>(exact.begin(), exact.end(), b.begin()),
-    cudf::make_sum_aggregation(),
-    scan_type::INCLUSIVE);
+  // no nulls
+  this->scan_test(v, {}, cudf::make_sum_aggregation(), scan_type::INCLUSIVE);
+  this->scan_test(v, {}, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE);
+  // skipna = true (default)
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+  // skipna = false
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
 }
 
+TYPED_TEST(ScanTest, EmptyColumn)
+{
+  auto const v = thrust::host_vector<TypeParam>{};
+  auto const b = thrust::host_vector<bool>{};
+
+  // skipna = true (default)
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+  // skipna = false
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+}
+
+TYPED_TEST(ScanTest, LeadingNulls)
+{
+  auto const v = cudf::test::make_type_param_vector<TypeParam>({100, 200, 300});
+  auto const b = thrust::host_vector<bool>(std::vector<bool>{0, 1, 1});
+
+  // skipna = true (default)
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE);
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::EXCLUDE);
+  // skipna = false
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
+  this->scan_test(v, b, cudf::make_sum_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE);
+}
 struct ScanStringTest : public cudf::test::BaseFixture {
   void scan_test(cudf::test::strings_column_wrapper const& col_in,
                  cudf::test::strings_column_wrapper const& expected_col_out,
@@ -277,29 +329,29 @@ TEST_F(ScanStringTest, Min)
   std::vector<std::string> v = {
     "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"};
   std::vector<bool> b = {1, 0, 1, 1, 0, 0, 1, 0, 1};
-  std::vector<std::string> exact(v.size());
+  std::vector<std::string> expected(v.size());
 
-  std::partial_sum(v.cbegin(), v.cend(), exact.begin(), [](auto const& a, auto const& b) {
+  std::partial_sum(v.cbegin(), v.cend(), expected.begin(), [](auto const& a, auto const& b) {
     return std::min(a, b);
   });
 
   // string column without nulls
   cudf::test::strings_column_wrapper col_nonulls(v.begin(), v.end());
-  cudf::test::strings_column_wrapper expected1(exact.begin(), exact.end());
+  cudf::test::strings_column_wrapper expected1(expected.begin(), expected.end());
   this->scan_test(col_nonulls, expected1, cudf::make_min_aggregation(), scan_type::INCLUSIVE);
 
   auto const STRING_MAX = std::string("\xF7\xBF\xBF\xBF");
 
-  zip_scan(v.cbegin(),
-           v.cend(),
-           b.cbegin(),
-           exact.begin(),
-           value_or<std::string>{STRING_MAX},
-           [](auto const& a, auto const& b) { return std::min(a, b); });
+  zip_inclusive_scan(v.cbegin(),
+                     v.cend(),
+                     b.cbegin(),
+                     expected.begin(),
+                     value_or<std::string>{STRING_MAX},
+                     [](auto const& a, auto const& b) { return std::min(a, b); });
 
   // string column with nulls
   cudf::test::strings_column_wrapper col_nulls(v.begin(), v.end(), b.begin());
-  cudf::test::strings_column_wrapper expected2(exact.begin(), exact.end(), b.begin());
+  cudf::test::strings_column_wrapper expected2(expected.begin(), expected.end(), b.begin());
   this->scan_test(col_nulls, expected2, cudf::make_min_aggregation(), scan_type::INCLUSIVE);
 }
 
@@ -308,79 +360,30 @@ TEST_F(ScanStringTest, Max)
   std::vector<std::string> v = {
     "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"};
   std::vector<bool> b = {1, 0, 1, 1, 0, 0, 1, 1, 1};
-  std::vector<std::string> exact(v.size());
+  std::vector<std::string> expected(v.size());
 
-  std::partial_sum(v.cbegin(), v.cend(), exact.begin(), [](auto const& a, auto const& b) {
+  std::partial_sum(v.cbegin(), v.cend(), expected.begin(), [](auto const& a, auto const& b) {
     return std::max(a, b);
   });
 
   // string column without nulls
   cudf::test::strings_column_wrapper col_nonulls(v.begin(), v.end());
-  cudf::test::strings_column_wrapper expected1(exact.begin(), exact.end());
+  cudf::test::strings_column_wrapper expected1(expected.begin(), expected.end());
   this->scan_test(col_nonulls, expected1, cudf::make_max_aggregation(), scan_type::INCLUSIVE);
 
   auto const STRING_MIN = std::string{};
 
-  zip_scan(v.cbegin(),
-           v.cend(),
-           b.cbegin(),
-           exact.begin(),
-           value_or<std::string>{STRING_MIN},
-           [](auto const& a, auto const& b) { return std::max(a, b); });
+  zip_inclusive_scan(v.cbegin(),
+                     v.cend(),
+                     b.cbegin(),
+                     expected.begin(),
+                     value_or<std::string>{STRING_MIN},
+                     [](auto const& a, auto const& b) { return std::max(a, b); });
 
   // string column with nulls
   cudf::test::strings_column_wrapper col_nulls(v.begin(), v.end(), b.begin());
-  cudf::test::strings_column_wrapper expected2(exact.begin(), exact.end(), b.begin());
+  cudf::test::strings_column_wrapper expected2(expected.begin(), expected.end(), b.begin());
   this->scan_test(col_nulls, expected2, cudf::make_max_aggregation(), scan_type::INCLUSIVE);
-}
-
-TYPED_TEST(ScanTest, skip_nulls)
-{
-  bool do_print = false;
-  auto const v  = cudf::test::make_type_param_vector<TypeParam>({1, 2, 3, 4, 5, 6, 7, 8, 1, 1});
-  auto const b  = std::vector<bool>{1, 1, 1, 1, 1, 0, 1, 0, 1, 1};
-  cudf::test::fixed_width_column_wrapper<TypeParam> const col_in(v.begin(), v.end(), b.begin());
-  const column_view input_view = col_in;
-  std::unique_ptr<cudf::column> col_out;
-
-  // test output calculation
-  std::vector<TypeParam> out_v(input_view.size());
-  std::vector<bool> out_b(input_view.size());
-
-  zip_scan(v.cbegin(),
-           v.cend(),
-           b.cbegin(),
-           out_v.begin(),
-           value_or<TypeParam>{0},
-           std::plus<TypeParam>{});
-
-  std::partial_sum(b.cbegin(), b.cend(), out_b.begin(), std::logical_and<bool>{});
-
-  // skipna=true (default)
-  CUDF_EXPECT_NO_THROW(
-    col_out = cudf::scan(
-      input_view, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE));
-  cudf::test::fixed_width_column_wrapper<TypeParam> expected_col_out1(
-    out_v.begin(), out_v.end(), b.cbegin());
-  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(expected_col_out1, col_out->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_col_out1, col_out->view());
-  if (do_print) {
-    print_view(expected_col_out1, "expect = ");
-    print_view(col_out->view(), "result = ");
-  }
-
-  // skipna=false
-  CUDF_EXPECT_NO_THROW(
-    col_out = cudf::scan(
-      input_view, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE));
-  cudf::test::fixed_width_column_wrapper<TypeParam> expected_col_out2(
-    out_v.begin(), out_v.end(), out_b.begin());
-  if (do_print) {
-    print_view(expected_col_out2, "expect = ");
-    print_view(col_out->view(), "result = ");
-  }
-  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(expected_col_out2, col_out->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_col_out2, col_out->view());
 }
 
 TEST_F(ScanStringTest, skip_nulls)
@@ -390,23 +393,23 @@ TEST_F(ScanStringTest, skip_nulls)
   std::vector<std::string> v(
     {"one", "two", "three", "four", "five", "six", "seven", "eight", "nine"});
   std::vector<bool> b({1, 1, 1, 0, 0, 0, 1, 1, 1});
-  std::vector<std::string> exact(v.size());
+  std::vector<std::string> expected(v.size());
   std::vector<bool> out_b(v.size());
 
   auto const STRING_MIN = std::string(1, char(0));
 
-  zip_scan(v.cbegin(),
-           v.cend(),
-           b.cbegin(),
-           exact.begin(),
-           value_or<std::string>{STRING_MIN},
-           [](auto const& a, auto const& b) { return std::max(a, b); });
+  zip_inclusive_scan(v.cbegin(),
+                     v.cend(),
+                     b.cbegin(),
+                     expected.begin(),
+                     value_or<std::string>{STRING_MIN},
+                     [](auto const& a, auto const& b) { return std::max(a, b); });
 
   std::partial_sum(b.cbegin(), b.cend(), out_b.begin(), std::logical_and<bool>{});
 
   // string column with nulls
   cudf::test::strings_column_wrapper col_nulls(v.begin(), v.end(), b.begin());
-  cudf::test::strings_column_wrapper expected2(exact.begin(), exact.end(), out_b.begin());
+  cudf::test::strings_column_wrapper expected2(expected.begin(), expected.end(), out_b.begin());
   std::unique_ptr<cudf::column> col_out;
   // skipna=false
   CUDF_EXPECT_NO_THROW(
@@ -429,66 +432,6 @@ TEST_F(ScanStringTest, skip_nulls)
     (cudf::scan(
       col_nulls, cudf::make_min_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE)),
     "Non-arithmetic types not supported for exclusive scan");
-}
-
-TYPED_TEST(ScanTest, EmptyColumnskip_nulls)
-{
-  bool do_print = false;
-  std::vector<TypeParam> v{};
-  std::vector<bool> b{};
-  cudf::test::fixed_width_column_wrapper<TypeParam> const col_in(v.begin(), v.end(), b.begin());
-  std::unique_ptr<cudf::column> col_out;
-
-  // test output calculation
-  std::vector<TypeParam> out_v(v.size());
-  std::vector<bool> out_b(v.size());
-
-  // skipna=true (default)
-  CUDF_EXPECT_NO_THROW(
-    col_out =
-      cudf::scan(col_in, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::EXCLUDE));
-  cudf::test::fixed_width_column_wrapper<TypeParam> expected_col_out1(
-    out_v.begin(), out_v.end(), b.cbegin());
-  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(expected_col_out1, col_out->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_col_out1, col_out->view());
-  if (do_print) {
-    print_view(expected_col_out1, "expect = ");
-    print_view(col_out->view(), "result = ");
-  }
-
-  // skipna=false
-  CUDF_EXPECT_NO_THROW(
-    col_out =
-      cudf::scan(col_in, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE));
-  cudf::test::fixed_width_column_wrapper<TypeParam> expected_col_out2(
-    out_v.begin(), out_v.end(), out_b.begin());
-  if (do_print) {
-    print_view(expected_col_out2, "expect = ");
-    print_view(col_out->view(), "result = ");
-  }
-  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(expected_col_out2, col_out->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_col_out2, col_out->view());
-}
-
-TYPED_TEST(ScanTest, LeadingNulls)
-{
-  auto const v = cudf::test::make_type_param_vector<TypeParam>({100, 200, 300});
-  auto const b = std::vector<bool>{0, 1, 1};
-  cudf::test::fixed_width_column_wrapper<TypeParam> const col_in(v.begin(), v.end(), b.begin());
-  std::unique_ptr<cudf::column> col_out;
-
-  // expected outputs
-  std::vector<TypeParam> out_v(v.size());
-  std::vector<bool> out_b(v.size(), 0);
-
-  // skipna=false
-  CUDF_EXPECT_NO_THROW(
-    col_out =
-      cudf::scan(col_in, cudf::make_sum_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE));
-  cudf::test::fixed_width_column_wrapper<TypeParam> expected_col_out(
-    out_v.begin(), out_v.end(), out_b.begin());
-  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(expected_col_out, col_out->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_col_out, col_out->view());
 }
 
 template <typename T>

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -99,7 +99,7 @@ struct ScanTest : public cudf::test::BaseFixture {
                  null_policy null_handling,
                  numeric::scale_type scale)
   {
-    bool const do_print = false;
+    bool const do_print = false;  // set true for debugging
 
     auto col_in = this->make_column(v, b, scale);
     std::unique_ptr<cudf::column> col_out;
@@ -111,15 +111,16 @@ struct ScanTest : public cudf::test::BaseFixture {
       expected_col_out = this->make_expected(v, b, agg, inclusive, null_handling, scale);
       col_out          = cudf::scan(*col_in, agg, inclusive, null_handling);
       CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_col_out, *col_out);
-    }
 
-    if constexpr (do_print) {
-      auto int_values      = cudf::test::to_host<T>(*col_in);
-      auto expected_values = cudf::test::to_host<T>(*expected_col_out);
-      auto host_result     = cudf::test::to_host<T>(*col_out);
-      this->print(std::get<0>(int_values), "input = ");
-      this->print(std::get<0>(expected_values), "expected = ");
-      this->print(std::get<0>(host_result), "result = ");
+      if constexpr (do_print) {
+        std::cout << "input = ";
+        cudf::test::print(*col_in);
+        std::cout << "expected = ";
+        cudf::test::print(*expected_col_out);
+        std::cout << "result = ";
+        cudf::test::print(*col_out);
+        std::cout << std::endl;
+      }
     }
   }
 
@@ -286,14 +287,6 @@ struct ScanTest : public cudf::test::BaseFixture {
 
     return nullable ? this->make_column(expected, b_out, scale)
                     : this->make_column(expected, {}, scale);
-  }
-
-  template <typename Ti>
-  void print(thrust::host_vector<Ti> const& v, const char* msg = nullptr)
-  {
-    std::cout << msg << " {";
-    std::for_each(v.begin(), v.end(), [](Ti i) { std::cout << ", " << i; });
-    std::cout << "}" << std::endl;
   }
 };
 


### PR DESCRIPTION
Fixes #8462 by generalizing the existing `mask_inclusive_scan` used in `inclusive_scan` so it can be applied the same way in `exclusive_scan`. #8462 demonstrated holes in test coverage, so this PR also reorganizes `scan_tests` test infrastructure to enable a single set of tests to be applied to all supported data types and parameters, correctly expecting exceptions in unsupported cases (e.g. no product scans on fixed-point, only min/max inclusive scans on strings).
