### PR TITLE
Correct unused parameter warnings in io algorithms

### DIFF
--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -246,7 +246,7 @@ struct column_to_strings_fn {
   //
   template <typename column_type>
   std::enable_if_t<is_not_handled<column_type>(), std::unique_ptr<column>> operator()(
-    column_view const& column) const
+    column_view const&) const
   {
     CUDF_FAIL("Unsupported column type.");
   }

--- a/cpp/src/io/json/json_gpu.cu
+++ b/cpp/src/io/json/json_gpu.cu
@@ -223,12 +223,12 @@ __inline__ __device__ cudf::timestamp_ns decode_value(const char *begin,
 }
 
 #ifndef DURATION_DECODE_VALUE
-#define DURATION_DECODE_VALUE(Type)                                     \
-  template <>                                                           \
-  __inline__ __device__ Type decode_value(                              \
-    const char *begin, const char *end, parse_options_view const &opts) \
-  {                                                                     \
-    return Type{to_time_delta<Type>(begin, end)};                       \
+#define DURATION_DECODE_VALUE(Type)                                 \
+  template <>                                                       \
+  __inline__ __device__ Type decode_value(                          \
+    const char *begin, const char *end, parse_options_view const &) \
+  {                                                                 \
+    return Type{to_time_delta<Type>(begin, end)};                   \
   }
 #endif
 DURATION_DECODE_VALUE(duration_D)
@@ -239,48 +239,48 @@ DURATION_DECODE_VALUE(duration_ns)
 
 // The purpose of these is merely to allow compilation ONLY
 template <>
-__inline__ __device__ cudf::string_view decode_value(const char *begin,
-                                                     const char *end,
-                                                     parse_options_view const &opts)
+__inline__ __device__ cudf::string_view decode_value(const char *,
+                                                     const char *,
+                                                     parse_options_view const &)
 {
   return cudf::string_view{};
 }
 
 template <>
-__inline__ __device__ cudf::dictionary32 decode_value(const char *begin,
-                                                      const char *end,
-                                                      parse_options_view const &opts)
+__inline__ __device__ cudf::dictionary32 decode_value(const char *,
+                                                      const char *,
+                                                      parse_options_view const &)
 {
   return cudf::dictionary32{};
 }
 
 template <>
-__inline__ __device__ cudf::list_view decode_value(const char *begin,
-                                                   const char *end,
-                                                   parse_options_view const &opts)
+__inline__ __device__ cudf::list_view decode_value(const char *,
+                                                   const char *,
+                                                   parse_options_view const &)
 {
   return cudf::list_view{};
 }
 template <>
-__inline__ __device__ cudf::struct_view decode_value(const char *begin,
-                                                     const char *end,
-                                                     parse_options_view const &opts)
+__inline__ __device__ cudf::struct_view decode_value(const char *,
+                                                     const char *,
+                                                     parse_options_view const &)
 {
   return cudf::struct_view{};
 }
 
 template <>
-__inline__ __device__ numeric::decimal32 decode_value(const char *begin,
-                                                      const char *end,
-                                                      parse_options_view const &opts)
+__inline__ __device__ numeric::decimal32 decode_value(const char *,
+                                                      const char *,
+                                                      parse_options_view const &)
 {
   return numeric::decimal32{};
 }
 
 template <>
-__inline__ __device__ numeric::decimal64 decode_value(const char *begin,
-                                                      const char *end,
-                                                      parse_options_view const &opts)
+__inline__ __device__ numeric::decimal64 decode_value(const char *,
+                                                      const char *,
+                                                      parse_options_view const &)
 {
   return numeric::decimal64{};
 }

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -30,7 +30,7 @@ constexpr T divCeil(T dividend, T divisor) noexcept
  * @brief Sets the specified element of the array to the passed value
  */
 template <class T, class V>
-__device__ __forceinline__ void setElement(T* array, cudf::size_type idx, const T& t, const V& v)
+__device__ __forceinline__ void setElement(T* array, cudf::size_type idx, const T& t, const V&)
 {
   array[idx] = t;
 }
@@ -53,7 +53,7 @@ __device__ __forceinline__ void setElement(thrust::pair<T, V>* array,
  * Does not do anything, indexing is not allowed with void* arrays.
  */
 template <class T, class V>
-__device__ __forceinline__ void setElement(void* array, cudf::size_type idx, const T& t, const V& v)
+__device__ __forceinline__ void setElement(void*, cudf::size_type, const T&, const V&)
 {
 }
 


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.