### PR TITLE
Correct unused parameter warnings in reduction algorithms

### DIFF
--- a/cpp/src/reductions/scan/scan_exclusive.cu
+++ b/cpp/src/reductions/scan/scan_exclusive.cu
@@ -50,9 +50,9 @@ struct scan_dispatcher {
    * @param mr Device memory resource used to allocate the returned column's device memory
    * @return Output column with scan results
    */
-  template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, T>* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
   std::unique_ptr<column> operator()(column_view const& input,
-                                     null_policy null_handling,
+                                     null_policy,
                                      rmm::cuda_stream_view stream,
                                      rmm::mr::device_memory_resource* mr)
   {
@@ -71,11 +71,8 @@ struct scan_dispatcher {
     return output_column;
   }
 
-  template <typename T, typename std::enable_if_t<!std::is_arithmetic<T>::value, T>* = nullptr>
-  std::unique_ptr<column> operator()(const column_view& input,
-                                     null_policy null_handling,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::mr::device_memory_resource* mr)
+  template <typename T, typename... Args>
+  std::enable_if_t<!std::is_arithmetic<T>::value, std::unique_ptr<column>> operator()(Args&&...)
   {
     CUDF_FAIL("Non-arithmetic types not supported for exclusive scan");
   }


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.