### PR TITLE
Correct unused parameter warnings in replace algorithms

### DIFF
--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -42,7 +42,7 @@ namespace {
 template <typename Transformer>
 std::pair<std::unique_ptr<column>, std::unique_ptr<column>> form_offsets_and_char_column(
   cudf::column_device_view input,
-  size_type null_count,
+  size_type,
   Transformer offsets_transformer,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr)
@@ -64,7 +64,6 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> form_offsets_and_cha
       offsets_transformer_itr, offsets_transformer_itr + strings_count, stream, mr);
   }
 
-  auto d_offsets = offsets_column->view().template data<size_type>();
   // build chars column
   auto const bytes =
     cudf::detail::get_value<int32_t>(offsets_column->view(), strings_count, stream);

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -104,8 +104,7 @@ struct replace_nans_functor {
   }
 
   template <typename T, typename... Args>
-  std::enable_if_t<!std::is_floating_point<T>::value, std::unique_ptr<column>> operator()(
-    Args&&...)
+  std::enable_if_t<!std::is_floating_point<T>::value, std::unique_ptr<column>> operator()(Args&&...)
   {
     CUDF_FAIL("NAN is not supported in a Non-floating point type column");
   }

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -105,7 +105,7 @@ struct replace_nans_functor {
 
   template <typename T, typename... Args>
   std::enable_if_t<!std::is_floating_point<T>::value, std::unique_ptr<column>> operator()(
-    Args&&... args)
+    Args&&...)
   {
     CUDF_FAIL("NAN is not supported in a Non-floating point type column");
   }
@@ -192,10 +192,8 @@ struct normalize_nans_and_zeros_kernel_forwarder {
   }
 
   // if we get in here for anything but a float or double, that's a problem.
-  template <typename T, std::enable_if_t<not std::is_floating_point<T>::value>* = nullptr>
-  void operator()(cudf::column_device_view in,
-                  cudf::mutable_column_device_view out,
-                  rmm::cuda_stream_view stream)
+  template <typename T, typename... Args>
+  std::enable_if_t<not std::is_floating_point<T>::value, void> operator()(Args&&...)
   {
     CUDF_FAIL("Unexpected non floating-point type.");
   }

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -198,10 +198,10 @@ struct replace_nulls_column_kernel_forwarder {
   }
 
   template <typename col_type, CUDF_ENABLE_IF(not cudf::is_rep_layout_compatible<col_type>())>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           cudf::column_view const& replacement,
-                                           rmm::cuda_stream_view stream,
-                                           rmm::mr::device_memory_resource* mr)
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const&,
+                                           cudf::column_view const&,
+                                           rmm::cuda_stream_view,
+                                           rmm::mr::device_memory_resource*)
   {
     CUDF_FAIL("No specialization exists for the given type.");
   }
@@ -253,7 +253,6 @@ std::unique_ptr<cudf::column> replace_nulls_column_kernel_forwarder::operator()<
     cudf::detail::get_value<int32_t>(offsets_view, offsets_view.size() - 1, stream);
 
   // Allocate chars array and output null mask
-  cudf::size_type null_count = input.size() - valid_counter.value(stream);
   std::unique_ptr<cudf::column> output_chars =
     cudf::strings::detail::create_chars_child_column(input.size(), bytes, stream, mr);
 
@@ -327,10 +326,10 @@ struct replace_nulls_scalar_kernel_forwarder {
   }
 
   template <typename col_type, std::enable_if_t<not cudf::is_fixed_width<col_type>()>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           cudf::scalar const& replacement,
-                                           rmm::cuda_stream_view stream,
-                                           rmm::mr::device_memory_resource* mr)
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const&,
+                                           cudf::scalar const&,
+                                           rmm::cuda_stream_view,
+                                           rmm::mr::device_memory_resource*)
   {
     CUDF_FAIL("No specialization exists for the given type.");
   }
@@ -367,7 +366,7 @@ std::unique_ptr<cudf::column> replace_nulls_scalar_kernel_forwarder::operator()<
 std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const& input,
                                                         cudf::replace_policy const& replace_policy,
                                                         rmm::cuda_stream_view stream,
-                                                        rmm::mr::device_memory_resource* mr)
+                                                        rmm::mr::device_memory_resource*)
 {
   auto device_in = cudf::column_device_view::create(input);
   auto index     = thrust::make_counting_iterator<cudf::size_type>(0);

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -87,7 +87,7 @@ __device__ auto get_new_value(cudf::size_type idx,
 __device__ int get_new_string_value(cudf::size_type idx,
                                     cudf::column_device_view& input,
                                     cudf::column_device_view& values_to_replace,
-                                    cudf::column_device_view& replacement_values)
+                                    cudf::column_device_view&)
 {
   cudf::string_view input_string = input.element<cudf::string_view>(idx);
   int match                      = -1;
@@ -342,11 +342,11 @@ struct replace_kernel_forwarder {
   }
 
   template <typename col_type, std::enable_if_t<not cudf::is_fixed_width<col_type>()>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input_col,
-                                           cudf::column_view const& values_to_replace,
-                                           cudf::column_view const& replacement_values,
-                                           rmm::cuda_stream_view stream,
-                                           rmm::mr::device_memory_resource* mr)
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const&,
+                                           cudf::column_view const&,
+                                           cudf::column_view const&,
+                                           rmm::cuda_stream_view,
+                                           rmm::mr::device_memory_resource*)
   {
     CUDF_FAIL("No specialization exists for this type");
   }


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.