### PR TITLE
Correct unused parameter warnings in partitioning and stream compact

### DIFF
--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -699,14 +699,10 @@ struct dispatch_map_type {
     return std::make_pair(std::move(scattered), std::move(partition_offsets));
   }
 
-  template <typename MapType>
+  template <typename MapType, typename... Args>
   std::enable_if_t<not is_index_type<MapType>(),
                    std::pair<std::unique_ptr<table>, std::vector<size_type>>>
-  operator()(table_view const& t,
-             column_view const& partition_map,
-             size_type num_partitions,
-             rmm::cuda_stream_view stream,
-             rmm::mr::device_memory_resource* mr) const
+  operator()(Args&&...) const
   {
     CUDF_FAIL("Unexpected, non-integral partition map.");
   }

--- a/cpp/src/stream_compaction/drop_nans.cu
+++ b/cpp/src/stream_compaction/drop_nans.cu
@@ -37,7 +37,7 @@ struct dispatch_is_not_nan {
 
   template <typename T>
   std::enable_if_t<not std::is_floating_point<T>::value, bool> __device__
-  operator()(cudf::column_device_view col_device_view, cudf::size_type i)
+  operator()(cudf::column_device_view, cudf::size_type)
   {
     return true;
   }


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.

This corrects issues found by this warning in partition and stream compaction algorithms