### PR TITLE
Bug/correct unused parameters in reshape and text

### DIFF
--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -34,10 +34,10 @@ struct byte_list_conversion {
    */
   template <typename T>
   std::enable_if_t<!std::is_integral<T>::value and !is_floating_point<T>(), std::unique_ptr<column>>
-  operator()(column_view const& input_column,
-             flip_endianness configuration,
-             rmm::cuda_stream_view stream,
-             rmm::mr::device_memory_resource* mr) const
+  operator()(column_view const&,
+             flip_endianness,
+             rmm::cuda_stream_view,
+             rmm::mr::device_memory_resource*) const
   {
     CUDF_FAIL("Unsupported non-numeric and non-string column");
   }
@@ -87,7 +87,7 @@ struct byte_list_conversion {
 template <>
 std::unique_ptr<cudf::column> byte_list_conversion::operator()<string_view>(
   column_view const& input_column,
-  flip_endianness configuration,
+  flip_endianness,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr) const
 {

--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -34,7 +34,7 @@ struct interleave_columns_functor {
                      not std::is_same<T, cudf::string_view>::value and
                      not std::is_same<T, cudf::list_view>::value,
                    std::unique_ptr<cudf::column>>
-  operator()(Args&&... args)
+  operator()(Args&&...)
   {
     CUDF_FAIL("Called `interleave_columns` on none-supported data type.");
   }

--- a/cpp/src/text/detokenize.cu
+++ b/cpp/src/text/detokenize.cu
@@ -124,7 +124,7 @@ struct token_row_offsets_fn {
 
   // non-integral types throw an exception
   template <typename T, typename... Args, std::enable_if_t<not cudf::is_index_type<T>()>* = nullptr>
-  std::unique_ptr<rmm::device_uvector<cudf::size_type>> operator()(Args&&... args) const
+  std::unique_ptr<rmm::device_uvector<cudf::size_type>> operator()(Args&&...) const
   {
     CUDF_FAIL("The detokenize indices parameter must be an integer type.");
   }

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -129,7 +129,6 @@ struct codepoint_to_utf8_fn {
       if (!d_chars) d_offsets[idx] = 0;
       return;
     }
-    auto const d_str  = d_strings.element<cudf::string_view>(idx);
     auto const offset = d_cp_offsets[idx];
     auto const count  = d_cp_offsets[idx + 1] - offset;  // number of code-points
     auto str_cps      = cp_data + offset;                // code-points for this string

--- a/cpp/src/text/stemmer.cu
+++ b/cpp/src/text/stemmer.cu
@@ -138,7 +138,7 @@ struct dispatch_is_letter_fn {
   }
 
   template <typename T, typename... Args, std::enable_if_t<not cudf::is_index_type<T>()>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(Args&&... args) const
+  std::unique_ptr<cudf::column> operator()(Args&&...) const
   {
     CUDF_FAIL("The is_letter indices parameter must be an integer type.");
   }


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.

This corrects issues found by this warning in reshape and text algorithms