### PR TITLE
replace_nulls properly propagates memory resource to gather calls

### DIFF
--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -366,7 +366,7 @@ std::unique_ptr<cudf::column> replace_nulls_scalar_kernel_forwarder::operator()<
 std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const& input,
                                                         cudf::replace_policy const& replace_policy,
                                                         rmm::cuda_stream_view stream,
-                                                        rmm::mr::device_memory_resource*)
+                                                        rmm::mr::device_memory_resource* mr)
 {
   auto device_in = cudf::column_device_view::create(input);
   auto index     = thrust::make_counting_iterator<cudf::size_type>(0);
@@ -392,7 +392,8 @@ std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const&
                                      gather_map.begin(),
                                      gather_map.end(),
                                      cudf::out_of_bounds_policy::DONT_CHECK,
-                                     stream);
+                                     stream,
+                                     mr);
 
   return std::move(output->release()[0]);
 }


### PR DESCRIPTION
As noted in https://github.com/rapidsai/cudf/pull/8483/files/48b4d97824a6dffd50fe795f698bc1876575f6c2#r650155797 the original code forgot to propagate the device_memory_resource to the `detail::gather` call. 
