### PR TITLE
Correct unused parameter warnings in string algorithms

### DIFF
--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -911,14 +911,9 @@ struct dispatch_from_timestamps_fn {
                        d_timestamps.size(),
                        pfn);
   }
-  template <typename T, std::enable_if_t<not cudf::is_timestamp<T>()>* = nullptr>
-  void operator()(column_device_view const&,
-                  format_item const*,
-                  size_type,
-                  timestamp_units,
-                  const int32_t*,
-                  char* d_chars,
-                  rmm::cuda_stream_view stream) const
+
+  template <typename T, typename... Args>
+  std::enable_if_t<not cudf::is_timestamp<T>(), void> operator()(Args&&...) const
   {
     CUDF_FAIL("Only timestamps type are expected");
   }

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -271,7 +271,7 @@ struct duration_to_string_fn : public duration_to_string_size_fn<T> {
     return str;
   }
 
-  __device__ char* int_to_2digitstr(char* str, int, int8_t value)
+  __device__ char* int_to_2digitstr(char* str, int8_t value)
   {
     assert(value >= -99 && value <= 99);
     value  = std::abs(value);
@@ -287,11 +287,11 @@ struct duration_to_string_fn : public duration_to_string_size_fn<T> {
 
   inline __device__ char* hour_12(char* ptr, duration_component const* timeparts)
   {
-    return int_to_2digitstr(ptr, 2, timeparts->hour % 12);
+    return int_to_2digitstr(ptr, timeparts->hour % 12);
   }
   inline __device__ char* hour_24(char* ptr, duration_component const* timeparts)
   {
-    return int_to_2digitstr(ptr, 2, timeparts->hour);
+    return int_to_2digitstr(ptr, timeparts->hour);
   }
   inline __device__ char* am_or_pm(char* ptr, duration_component const* timeparts)
   {
@@ -301,11 +301,11 @@ struct duration_to_string_fn : public duration_to_string_size_fn<T> {
   }
   inline __device__ char* minute(char* ptr, duration_component const* timeparts)
   {
-    return int_to_2digitstr(ptr, 2, timeparts->minute);
+    return int_to_2digitstr(ptr, timeparts->minute);
   }
   inline __device__ char* second(char* ptr, duration_component const* timeparts)
   {
-    return int_to_2digitstr(ptr, 2, timeparts->second);
+    return int_to_2digitstr(ptr, timeparts->second);
   }
 
   inline __device__ char* subsecond(char* ptr, duration_component const* timeparts)
@@ -447,7 +447,7 @@ struct dispatch_from_durations_fn {
 
   // non-duration types throw an exception
   template <typename T, typename... Args>
-  std::enable_if_t<not  cudf::is_duration<T>(), std::unique_ptr<column>> operator()(Args&&...) const
+  std::enable_if_t<not cudf::is_duration<T>(), std::unique_ptr<column>> operator()(Args&&...) const
   {
     CUDF_FAIL("Values for from_durations function must be a duration type.");
   }

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -271,7 +271,7 @@ struct duration_to_string_fn : public duration_to_string_size_fn<T> {
     return str;
   }
 
-  __device__ char* int_to_2digitstr(char* str, int min_digits, int8_t value)
+  __device__ char* int_to_2digitstr(char* str, int, int8_t value)
   {
     assert(value >= -99 && value <= 99);
     value  = std::abs(value);
@@ -446,11 +446,8 @@ struct dispatch_from_durations_fn {
   }
 
   // non-duration types throw an exception
-  template <typename T, std::enable_if_t<not cudf::is_duration<T>()>* = nullptr>
-  std::unique_ptr<column> operator()(column_view const&,
-                                     std::string const& format,
-                                     rmm::cuda_stream_view,
-                                     rmm::mr::device_memory_resource*) const
+  template <typename T, typename... Args>
+  std::enable_if_t<not  cudf::is_duration<T>(), std::unique_ptr<column>> operator()(Args&&...) const
   {
     CUDF_FAIL("Values for from_durations function must be a duration type.");
   }

--- a/cpp/src/strings/split/split.cu
+++ b/cpp/src/strings/split/split.cu
@@ -519,22 +519,19 @@ std::unique_ptr<table> split_fn(strings_column_view const& strings_column,
                      });
 
   // get the positions for every token using the delimiter positions
-  thrust::for_each_n(rmm::exec_policy(stream),
-                     thrust::make_counting_iterator<size_type>(0),
-                     delimiter_count,
-                     [tokenizer,
-                      d_token_counts,
-                      d_positions,
-                      delimiter_count,
-                      d_string_indices,
-                      d_tokens] __device__(size_type idx) {
-                       tokenizer.process_tokens(idx,
-                                                d_token_counts,
-                                                d_positions,
-                                                delimiter_count,
-                                                d_string_indices,
-                                                d_tokens);
-                     });
+  thrust::for_each_n(
+    rmm::exec_policy(stream),
+    thrust::make_counting_iterator<size_type>(0),
+    delimiter_count,
+    [tokenizer,
+     d_token_counts,
+     d_positions,
+     delimiter_count,
+     d_string_indices,
+     d_tokens] __device__(size_type idx) {
+      tokenizer.process_tokens(
+        idx, d_token_counts, d_positions, delimiter_count, d_string_indices, d_tokens);
+    });
 
   // Create each column.
   // - Each pair points to the strings for that column for each row.
@@ -776,13 +773,12 @@ std::unique_ptr<table> whitespace_split_fn(size_type strings_count,
                d_tokens,
                d_tokens + (columns_count * strings_count),
                string_index_pair{nullptr, 0});
-  thrust::for_each_n(
-    rmm::exec_policy(stream),
-    thrust::make_counting_iterator<size_type>(0),
-    strings_count,
-    [tokenizer, d_token_counts, d_tokens] __device__(size_type idx) {
-      tokenizer.process_tokens(idx, d_token_counts, d_tokens);
-    });
+  thrust::for_each_n(rmm::exec_policy(stream),
+                     thrust::make_counting_iterator<size_type>(0),
+                     strings_count,
+                     [tokenizer, d_token_counts, d_tokens] __device__(size_type idx) {
+                       tokenizer.process_tokens(idx, d_token_counts, d_tokens);
+                     });
 
   // Create each column.
   // - Each pair points to a string for that column for each row.

--- a/cpp/src/strings/split/split.cu
+++ b/cpp/src/strings/split/split.cu
@@ -124,7 +124,6 @@ struct split_tokenizer_fn : base_split_tokenizer {
    * for string at `string_index`.
    *
    * @param idx Index of the delimiter in the chars column
-   * @param column_count Number of output columns
    * @param d_token_counts Token counts for each string
    * @param d_positions The beginning byte position of each delimiter
    * @param positions_count Number of delimiters
@@ -132,7 +131,6 @@ struct split_tokenizer_fn : base_split_tokenizer {
    * @param d_all_tokens All output tokens for the strings column
    */
   __device__ void process_tokens(size_type idx,
-                                 size_type column_count,
                                  size_type const* d_token_counts,
                                  size_type const* d_positions,
                                  size_type positions_count,
@@ -253,7 +251,6 @@ struct rsplit_tokenizer_fn : base_split_tokenizer {
    * for string at `string_index`.
    *
    * @param idx Index of the delimiter in the chars column
-   * @param column_count Number of output columns
    * @param d_token_counts Token counts for each string
    * @param d_positions The ending byte position of each delimiter
    * @param positions_count Number of delimiters
@@ -261,7 +258,6 @@ struct rsplit_tokenizer_fn : base_split_tokenizer {
    * @param d_all_tokens All output tokens for the strings column
    */
   __device__ void process_tokens(size_type idx,                    // delimiter position index
-                                 size_type column_count,           // number of output columns
                                  size_type const* d_token_counts,  // token counts for each string
                                  size_type const* d_positions,     // end of each delimiter
                                  size_type positions_count,        // total number of delimiters
@@ -301,10 +297,9 @@ struct rsplit_tokenizer_fn : base_split_tokenizer {
    *
    * @param idx Index of a byte in the chars column.
    * @param d_offsets Offsets values to locate the chars ranges.
-   * @param chars_bytes Total number of characters to process.
    * @return true if delimiter is found ending at position `idx`
    */
-  __device__ bool is_delimiter(size_type idx, int32_t const* d_offsets, size_type chars_bytes) const
+  __device__ bool is_delimiter(size_type idx, int32_t const* d_offsets, size_type) const
   {
     auto delim_length = d_delimiter.size_bytes();
     if (idx < delim_length - 1) return false;
@@ -528,14 +523,12 @@ std::unique_ptr<table> split_fn(strings_column_view const& strings_column,
                      thrust::make_counting_iterator<size_type>(0),
                      delimiter_count,
                      [tokenizer,
-                      columns_count,
                       d_token_counts,
                       d_positions,
                       delimiter_count,
                       d_string_indices,
                       d_tokens] __device__(size_type idx) {
                        tokenizer.process_tokens(idx,
-                                                columns_count,
                                                 d_token_counts,
                                                 d_positions,
                                                 delimiter_count,
@@ -609,12 +602,10 @@ struct whitespace_split_tokenizer_fn : base_whitespace_split_tokenizer {
    * for string at `string_index`.
    *
    * @param idx Index of the string to process
-   * @param column_count Number of output columns
    * @param d_token_counts Token counts for each string
    * @param d_all_tokens All output tokens for the strings column
    */
   __device__ void process_tokens(size_type idx,
-                                 size_type column_count,
                                  size_type const* d_token_counts,
                                  string_index_pair* d_all_tokens) const
   {
@@ -660,12 +651,10 @@ struct whitespace_rsplit_tokenizer_fn : base_whitespace_split_tokenizer {
    * for string at `string_index`.
    *
    * @param idx Index of the string to process
-   * @param column_count Number of output columns
    * @param d_token_counts Token counts for each string
    * @param d_all_tokens All output tokens for the strings column
    */
   __device__ void process_tokens(size_type idx,  // string position index
-                                 size_type column_count,
                                  size_type const* d_token_counts,
                                  string_index_pair* d_all_tokens) const
   {
@@ -791,8 +780,8 @@ std::unique_ptr<table> whitespace_split_fn(size_type strings_count,
     rmm::exec_policy(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
-    [tokenizer, columns_count, d_token_counts, d_tokens] __device__(size_type idx) {
-      tokenizer.process_tokens(idx, columns_count, d_token_counts, d_tokens);
+    [tokenizer, d_token_counts, d_tokens] __device__(size_type idx) {
+      tokenizer.process_tokens(idx, d_token_counts, d_tokens);
     });
 
   // Create each column.

--- a/cpp/src/strings/substring.cu
+++ b/cpp/src/strings/substring.cu
@@ -238,7 +238,7 @@ void compute_substring_indices(column_device_view const& d_column,
                                size_type* start_char_pos,
                                size_type* end_char_pos,
                                rmm::cuda_stream_view stream,
-                               rmm::mr::device_memory_resource* mr)
+                               rmm::mr::device_memory_resource*)
 {
   auto strings_count = d_column.size();
 


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.

This corrects issues found by this warning in string algorithms