### PR TITLE
Update cudf_kafka buildsystem to use rapids-cmake

### DIFF
--- a/cpp/libcudf_kafka/CMakeLists.txt
+++ b/cpp/libcudf_kafka/CMakeLists.txt
@@ -15,12 +15,10 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
-include(FetchContent)
-FetchContent_Declare(
-  rapids-cmake
-  GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
-  GIT_TAG origin/branch-21.08)
-FetchContent_MakeAvailable(rapids-cmake)
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.10/RAPIDS.cmake
+     ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-cuda)

--- a/cpp/libcudf_kafka/CMakeLists.txt
+++ b/cpp/libcudf_kafka/CMakeLists.txt
@@ -13,9 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+
+include(FetchContent)
+FetchContent_Declare(
+  rapids-cmake
+  GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
+  GIT_TAG origin/branch-21.08)
+FetchContent_MakeAvailable(rapids-cmake)
+include(rapids-cmake)
+include(rapids-cpm)
+include(rapids-cuda)
+include(rapids-export)
+include(rapids-find)
 
 project(CUDA_KAFKA VERSION 21.10.00 LANGUAGES CXX)
+
+# Set a default build type if none was specified
+rapids_cmake_build_type(Release)
 
 ###################################################################################################
 # - Build options
@@ -26,14 +41,11 @@ message(VERBOSE "CUDF_KAFKA: Build gtests: ${BUILD_TESTS}")
 ###################################################################################################
 # - Dependencies
 
-# CPM
+# add third party dependencies using CPM
 include(../cmake/thirdparty/CUDF_GetCPM.cmake)
 
-# libcudf
-include(cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake)
-
-# librdkafka
-include(cmake/thirdparty/CUDF_KAFKA_GetRDKafka.cmake)
+include(cmake/thirdparty/get_cudf.cmake)
+include(cmake/thirdparty/get_rdkafka.cmake)
 
 # # GTests if enabled
 if (BUILD_TESTS)
@@ -46,32 +58,46 @@ if (BUILD_TESTS)
 endif()
 
 ###################################################################################################
-# - include paths ---------------------------------------------------------------------------------
+# - library target --------------------------------------------------------------------------------
+add_library(cudf_kafka SHARED
+    src/kafka_consumer.cpp)
 
-include_directories("${CMAKE_BINARY_DIR}/include"
-                    "${CMAKE_SOURCE_DIR}/include"
-                    "${CMAKE_SOURCE_DIR}/src")
+###################################################################################################
+# - include paths ---------------------------------------------------------------------------------
+target_include_directories(cudf_kafka
+                PUBLIC
+                    "$<BUILD_INTERFACE:${CUDA_KAFKA_SOURCE_DIR}/include>"
+                    "$<INSTALL_INTERFACE:include>")
 
 ###################################################################################################
 # - library paths ---------------------------------------------------------------------------------
+target_link_libraries(cudf_kafka PUBLIC cudf::cudf RDKAFKA::RDKAFKA)
 
-link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
-                 "${CMAKE_BINARY_DIR}/lib"
-                 "${CMAKE_BINARY_DIR}")
-
-###################################################################################################
-# - library target --------------------------------------------------------------------------------
-
-add_library(cudf_kafka SHARED
-    src/kafka_consumer.cpp
-)
+set_target_properties(cudf_kafka
+    PROPERTIES BUILD_RPATH                         "\$ORIGIN"
+               INSTALL_RPATH                       "\$ORIGIN"
+               # set target compile options
+               CXX_STANDARD                        17
+               CXX_STANDARD_REQUIRED               ON)
 
 ###################################################################################################
 # - cudf_kafka Install ----------------------------------------------------------------------------
-target_link_libraries(cudf_kafka cudf::cudf RDKAFKA::RDKAFKA)
 
 install(TARGETS cudf_kafka
-        DESTINATION lib)
+        DESTINATION lib
+        EXPORT cudf_kafka-exports)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
         DESTINATION include)
+
+rapids_export(INSTALL cudf_kafka
+    EXPORT_SET cudf_kafka-exports
+    GLOBAL_TARGETS cudf_kafka
+    NAMESPACE cudf_kafka::
+    )
+
+rapids_export(BUILD cudf_kafka
+    EXPORT_SET cudf_kafka-exports
+    GLOBAL_TARGETS cudf_kafka
+    NAMESPACE cudf_kafka::
+    )

--- a/cpp/libcudf_kafka/cmake/thirdparty/get_cudf.cmake
+++ b/cpp/libcudf_kafka/cmake/thirdparty/get_cudf.cmake
@@ -15,24 +15,37 @@
 #=============================================================================
 
 function(find_and_configure_cudf VERSION)
-    CPMFindPackage(NAME cudf
-        VERSION         ${VERSION}
-        GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
-        GIT_TAG         branch-${VERSION}
-        GIT_SHALLOW     TRUE
-        SOURCE_SUBDIR   cpp
-        OPTIONS         "BUILD_TESTS OFF"
-                        "BUILD_BENCHMARKS OFF")
-    if(cudf_ADDED)
-        set(cudf_ADDED TRUE PARENT_SCOPE)
+    rapids_cmake_parse_version(MAJOR_MINOR ${VERSION} major_minor)
+    rapids_cpm_find(cudf ${VERSION}
+        BUILD_EXPORT_SET cudf_kafka-exports
+        INSTALL_EXPORT_SET cudf_kafka-exports
+        CPM_ARGS
+            GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
+            GIT_TAG         branch-${major_minor}
+            GIT_SHALLOW     TRUE
+            SOURCE_SUBDIR   cpp
+            OPTIONS         "BUILD_TESTS OFF"
+                            "BUILD_BENCHMARKS OFF")
+    # If after loading cudf we now have the CMAKE_CUDA_COMPILER
+    # variable we know that we need to re-enable the cuda language
+    if(CMAKE_CUDA_COMPILER)
+        set(cudf_REQUIRES_CUDA TRUE PARENT_SCOPE)
     endif()
 endfunction()
 
 set(CUDA_KAFKA_MIN_VERSION_cudf "${CUDA_KAFKA_VERSION_MAJOR}.${CUDA_KAFKA_VERSION_MINOR}.${CUDA_KAFKA_VERSION_PATCH}")
 find_and_configure_cudf(${CUDA_KAFKA_MIN_VERSION_cudf})
 
-if(cudf_ADDED)
+if(cudf_REQUIRES_CUDA)
+    rapids_cuda_init_architectures(CUDA_KAFKA)
+
     # Since we are building cudf as part of ourselves we need
     # to enable the CUDA language in the top-most scope
     enable_language(CUDA)
+
+    # Since CUDA_KAFKA only enables CUDA optionally we need to manually include the file that
+    # rapids_cuda_init_architectures relies on `project` calling
+    if(DEFINED CMAKE_PROJECT_CUDA_KAFKA_INCLUDE)
+        include("${CMAKE_PROJECT_CUDA_KAFKA_INCLUDE}")
+    endif()
 endif()

--- a/cpp/libcudf_kafka/cmake/thirdparty/get_rdkafka.cmake
+++ b/cpp/libcudf_kafka/cmake/thirdparty/get_rdkafka.cmake
@@ -14,12 +14,28 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(RDKAFKA_INCLUDE "librdkafka" HINTS "$ENV{RDKAFKA_ROOT}/include")
-find_library(RDKAFKA++_LIBRARY "rdkafka++" HINTS "$ENV{RDKAFKA_ROOT}/lib" "$ENV{RDKAFKA_ROOT}/build")
 
-if(RDKAFKA_INCLUDE AND RDKAFKA++_LIBRARY)
-  add_library(rdkafka INTERFACE)
-  target_link_libraries(rdkafka INTERFACE "${RDKAFKA++_LIBRARY}")
-  target_include_directories(rdkafka INTERFACE "${RDKAFKA_INCLUDE}")
-  add_library(RDKAFKA::RDKAFKA ALIAS rdkafka)
-endif()
+function( get_RDKafka )
+  rapids_find_generate_module(RDKAFKA
+    HEADER_NAMES rdkafkacpp.h
+    INCLUDE_SUFFIXES librdkafka
+    LIBRARY_NAMES rdkafka++
+    BUILD_EXPORT_SET cudf_kafka-exports
+    INSTALL_EXPORT_SET cudf_kafka-exports
+    )
+
+  if(DEFINED ENV{RDKAFKA_ROOT})
+    # Since this is inside a function the modification of
+    # CMAKE_PREFIX_PATH won't leak to other callers/users
+    list(APPEND CMAKE_PREFIX_PATH "$ENV{RDKAFKA_ROOT}")
+    list(APPEND CMAKE_PREFIX_PATH "$ENV{RDKAFKA_ROOT}/build")
+  endif()
+
+
+  rapids_find_package(RDKAFKA REQUIRED
+    BUILD_EXPORT_SET cudf_kafka-exports
+    INSTALL_EXPORT_SET cudf_kafka-exports)
+
+endfunction()
+
+get_RDKafka()

--- a/cpp/libcudf_kafka/tests/CMakeLists.txt
+++ b/cpp/libcudf_kafka/tests/CMakeLists.txt
@@ -17,22 +17,16 @@
 ###################################################################################################
 # - compiler function -----------------------------------------------------------------------------
 
-function(ConfigureTest CMAKE_TEST_NAME )
-    add_executable(${CMAKE_TEST_NAME} ${ARGN})
-    set_target_properties(${CMAKE_TEST_NAME}
+function(ConfigureTest test_name )
+    add_executable(${test_name} ${ARGN})
+    set_target_properties(${test_name}
         PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUDA_KAFKA_BINARY_DIR}/gtests>")
-    target_link_libraries(${CMAKE_TEST_NAME} PRIVATE GTest::gmock_main GTest::gtest_main cudf_kafka)
-    target_include_directories(${CMAKE_TEST_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-    add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
+    target_link_libraries(${test_name} PRIVATE GTest::gmock_main GTest::gtest_main cudf_kafka)
+
+    add_test(NAME ${test_name} COMMAND ${test_name})
 endfunction()
 
 ###################################################################################################
 # - Kafka host tests ----------------------------------------------------------------------------------
 ConfigureTest(KAFKA_HOST_TEST
     kafka_consumer_tests.cpp)
-
-###################################################################################################
-### enable testing ################################################################################
-###################################################################################################
-
-enable_testing()


### PR DESCRIPTION
rapids-cmake provides all the functionality of cudf_kafka existing CMake modules.
This will allow RAPIDS to deploy build-system fixes easily across all projects.