### PR TITLE
 Correct unused parameter warnings in transform and unary ops

### DIFF
--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -332,9 +332,10 @@ struct dispatch_unary_cast_to {
   template <typename TargetT,
             typename SourceT                                                      = _SourceT,
             typename std::enable_if_t<not is_supported_cast<SourceT, TargetT>()>* = nullptr>
-  std::unique_ptr<column> operator()(data_type type,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::mr::device_memory_resource* mr)
+  std::unique_ptr<column> operator()(data_type,
+                                     rmm::cuda_stream_view,
+                                     rmm::mr::device_memory_resource*)
+
   {
     if (!cudf::is_fixed_width<TargetT>())
       CUDF_FAIL("Column type must be numeric or chrono or decimal32/64");
@@ -360,10 +361,8 @@ struct dispatch_unary_cast_from {
     return type_dispatcher(type, dispatch_unary_cast_to<T>{input}, type, stream, mr);
   }
 
-  template <typename T, typename std::enable_if_t<!cudf::is_fixed_width<T>()>* = nullptr>
-  std::unique_ptr<column> operator()(data_type type,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::mr::device_memory_resource* mr)
+  template <typename T, typename... Args>
+  std::enable_if_t<!cudf::is_fixed_width<T>(), std::unique_ptr<column>> operator()(Args&&...)
   {
     CUDF_FAIL("Column type must be numeric or chrono or decimal32/64");
   }

--- a/cpp/src/unary/math_ops.cu
+++ b/cpp/src/unary/math_ops.cu
@@ -370,10 +370,9 @@ struct MathOpDispatcher {
       return transform_fn<T, UFN>(input, stream, mr);
     }
 
-    template <typename T, typename std::enable_if_t<!std::is_arithmetic<T>::value>* = nullptr>
-    std::unique_ptr<cudf::column> operator()(cudf::dictionary_column_view const& input,
-                                             rmm::cuda_stream_view stream,
-                                             rmm::mr::device_memory_resource* mr)
+    template <typename T, typename... Args>
+    std::enable_if_t<!std::is_arithmetic<T>::value, std::unique_ptr<cudf::column>> operator()(
+      Args&&...)
     {
       CUDF_FAIL("dictionary keys must be numeric for this operation");
     }
@@ -392,12 +391,10 @@ struct MathOpDispatcher {
       dictionary_col.keys().type(), dictionary_dispatch{}, dictionary_col, stream, mr);
   }
 
-  template <typename T,
-            typename std::enable_if_t<!std::is_arithmetic<T>::value and
-                                      !std::is_same<T, dictionary32>::value>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           rmm::cuda_stream_view stream,
-                                           rmm::mr::device_memory_resource* mr)
+  template <typename T, typename... Args>
+  std::enable_if_t<!std::is_arithmetic<T>::value and !std::is_same<T, dictionary32>::value,
+                   std::unique_ptr<cudf::column>>
+  operator()(Args&&...)
   {
     CUDF_FAIL("Unsupported data type for operation");
   }
@@ -427,10 +424,9 @@ struct BitwiseOpDispatcher {
       return transform_fn<T, UFN>(input, stream, mr);
     }
 
-    template <typename T, typename std::enable_if_t<!std::is_integral<T>::value>* = nullptr>
-    std::unique_ptr<cudf::column> operator()(cudf::dictionary_column_view const& input,
-                                             rmm::cuda_stream_view stream,
-                                             rmm::mr::device_memory_resource* mr)
+    template <typename T, typename... Args>
+    std::enable_if_t<!std::is_integral<T>::value, std::unique_ptr<cudf::column>> operator()(
+      Args&&...)
     {
       CUDF_FAIL("dictionary keys type not supported for this operation");
     }
@@ -449,12 +445,10 @@ struct BitwiseOpDispatcher {
       dictionary_col.keys().type(), dictionary_dispatch{}, dictionary_col, stream, mr);
   }
 
-  template <typename T,
-            typename std::enable_if_t<!std::is_integral<T>::value and
-                                      !std::is_same<T, dictionary32>::value>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           rmm::cuda_stream_view stream,
-                                           rmm::mr::device_memory_resource* mr)
+  template <typename T, typename... Args>
+  std::enable_if_t<!std::is_integral<T>::value and !std::is_same<T, dictionary32>::value,
+                   std::unique_ptr<cudf::column>>
+  operator()(Args&&...)
   {
     CUDF_FAIL("Unsupported datatype for operation");
   }
@@ -500,10 +494,8 @@ struct LogicalOpDispatcher {
                                      mr);
     }
 
-    template <typename T, typename std::enable_if_t<!is_supported<T>()>* = nullptr>
-    std::unique_ptr<cudf::column> operator()(cudf::dictionary_column_view const& input,
-                                             rmm::cuda_stream_view stream,
-                                             rmm::mr::device_memory_resource* mr)
+    template <typename T, typename... Args>
+    std::enable_if_t<!is_supported<T>(), std::unique_ptr<cudf::column>> operator()(Args&&...)
     {
       CUDF_FAIL("dictionary keys type not supported for this operation");
     }
@@ -522,13 +514,10 @@ struct LogicalOpDispatcher {
       dictionary_col.keys().type(), dictionary_dispatch{}, dictionary_col, stream, mr);
   }
 
-  // template <typename T, typename std::enable_if_t<!is_supported<T>()>* = nullptr>
-  template <typename T,
-            typename std::enable_if_t<!is_supported<T>() and
-                                      !std::is_same<T, dictionary32>::value>* = nullptr>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           rmm::cuda_stream_view stream,
-                                           rmm::mr::device_memory_resource* mr)
+  template <typename T, typename... Args>
+  std::enable_if_t<!is_supported<T>() and !std::is_same<T, dictionary32>::value,
+                   std::unique_ptr<cudf::column>>
+  operator()(Args&&...)
   {
     CUDF_FAIL("Unsupported datatype for operation");
   }
@@ -536,8 +525,7 @@ struct LogicalOpDispatcher {
 
 struct FixedPointOpDispatcher {
   template <typename T, typename... Args>
-  std::enable_if_t<not cudf::is_fixed_point<T>(), std::unique_ptr<column>> operator()(
-    Args&&... args)
+  std::enable_if_t<not cudf::is_fixed_point<T>(), std::unique_ptr<column>> operator()(Args&&...)
   {
     CUDF_FAIL("FixedPointOpDispatcher only for fixed_point");
   }


### PR DESCRIPTION
Starting in CUDA 11.3, nvcc will start to unconditionally warn about unused parameters on functions/methods that are in anonymous namespaces.

This corrects issues found by this warning in transform and unary op algorithms