### PR TITLE
Add option to treat nulls like nans when doing comparisons

### DIFF
--- a/python/cudf/cudf/__init__.py
+++ b/python/cudf/cudf/__init__.py
@@ -8,7 +8,7 @@ from numba import cuda
 
 import rmm
 
-from cudf import core, datasets, testing
+from cudf import _config, core, datasets, testing
 from cudf._version import get_versions
 from cudf.api.extensions import (
     register_dataframe_accessor,

--- a/python/cudf/cudf/_config/__init__.py
+++ b/python/cudf/cudf/_config/__init__.py
@@ -1,0 +1,1 @@
+from .config import get_option, option_context, set_option

--- a/python/cudf/cudf/_config/config.py
+++ b/python/cudf/cudf/_config/config.py
@@ -1,0 +1,32 @@
+from contextlib import contextmanager
+
+_OPTIONS = {
+    # nulls compare like NaN/NaT in numeric/datetime comparisons
+    "_nulls_compare_like_nans": False
+}
+
+
+@contextmanager
+def option_context(*args):
+    global _OPTIONS
+    original_options = _OPTIONS.copy()
+    try:
+        for opt, val in zip(args[::2], args[1::2]):
+            if opt not in _OPTIONS:
+                raise ValueError(f"Invalid option {opt}")
+            _OPTIONS[opt] = val
+        yield
+    finally:
+        _OPTIONS = original_options
+
+
+def get_option(key):
+    if key not in _OPTIONS:
+        raise ValueError(f"Invalid option {key}")
+    return _OPTIONS[key]
+
+
+def set_option(key, value):
+    if key not in _OPTIONS:
+        raise ValueError(f"Invalid option {key}")
+    _OPTIONS[key] = value

--- a/python/cudf/cudf/_config/config.py
+++ b/python/cudf/cudf/_config/config.py
@@ -12,9 +12,7 @@ def option_context(*args):
     original_options = _OPTIONS.copy()
     try:
         for opt, val in zip(args[::2], args[1::2]):
-            if opt not in _OPTIONS:
-                raise ValueError(f"Invalid option {opt}")
-            _OPTIONS[opt] = val
+            set_option(opt, val)
         yield
     finally:
         _OPTIONS = original_options
@@ -22,11 +20,11 @@ def option_context(*args):
 
 def get_option(key):
     if key not in _OPTIONS:
-        raise ValueError(f"Invalid option {key}")
+        raise KeyError(f"Invalid option {key}")
     return _OPTIONS[key]
 
 
 def set_option(key, value):
     if key not in _OPTIONS:
-        raise ValueError(f"Invalid option {key}")
+        raise KeyError(f"Invalid option {key}")
     _OPTIONS[key] = value

--- a/python/cudf/cudf/_config/config.py
+++ b/python/cudf/cudf/_config/config.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 _OPTIONS = {
     # nulls compare like NaN/NaT in numeric/datetime comparisons
-    "_nulls_compare_like_nans": False
+    "nulls_compare_like_nans": False
 }
 
 

--- a/python/cudf/cudf/_lib/binaryop.pyx
+++ b/python/cudf/cudf/_lib/binaryop.pyx
@@ -161,6 +161,7 @@ def binaryop(lhs, rhs, op, dtype):
     """
     Dispatches a binary op call to the appropriate libcudf function:
     """
+    from cudf._config import get_option
 
     op = BinaryOperation[op.upper()]
     cdef binary_operator c_op = <binary_operator> (
@@ -197,6 +198,12 @@ def binaryop(lhs, rhs, op, dtype):
             c_op,
             c_dtype
         )
+
+    if (
+        op.name.lower() in {"lt", "gt", "le", "ge", "eq", "ne", "null_equals"}
+        and get_option("_nulls_compare_like_nans")
+    ):
+        result = result.fillna(op.name.lower() == "ne")
     return result
 
 

--- a/python/cudf/cudf/_lib/binaryop.pyx
+++ b/python/cudf/cudf/_lib/binaryop.pyx
@@ -201,7 +201,7 @@ def binaryop(lhs, rhs, op, dtype):
 
     if (
         op.name.lower() in {"lt", "gt", "le", "ge", "eq", "ne", "null_equals"}
-        and get_option("_nulls_compare_like_nans")
+        and get_option("nulls_compare_like_nans")
     ):
         result = result.fillna(op.name.lower() == "ne")
     return result

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -3713,6 +3713,16 @@ class SingleColumnFrame(Frame):
 
         if output_mask is not None:
             output._column = output._column.set_mask(output_mask)
+            if cudf._config.get_option("_nulls_compare_like_nans") and fn in {
+                "lt",
+                "gt",
+                "le",
+                "ge",
+                "eq",
+                "ne",
+                "null_equals",
+            }:
+                output._column = output._column.fillna(fn == "ne")
         return output
 
     def _normalize_binop_value(self, other):

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -3713,7 +3713,7 @@ class SingleColumnFrame(Frame):
 
         if output_mask is not None:
             output._column = output._column.set_mask(output_mask)
-            if cudf._config.get_option("_nulls_compare_like_nans") and fn in {
+            if cudf._config.get_option("nulls_compare_like_nans") and fn in {
                 "lt",
                 "gt",
                 "le",

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -2886,7 +2886,7 @@ def test_series_compare_nulls_nan_comparison(cmpop, dtypes):
     expect = cmpop(lser, rser)
     got = cmpop(lser, rser)
 
-    with cudf._config.option_context("_nulls_compare_like_nans", True):
+    with cudf._config.option_context("nulls_compare_like_nans", True):
         utils.assert_eq(expect, got)
 
 
@@ -2901,6 +2901,6 @@ def test_decimal_compare_nan_comparison(op):
 
     expect = op(lser.to_pandas(), rser.to_pandas())
 
-    with cudf._config.option_context("_nulls_compare_like_nans", True):
+    with cudf._config.option_context("nulls_compare_like_nans", True):
         got = op(lser, rser)
     utils.assert_eq(expect, got)


### PR DESCRIPTION
https://github.com/rapidsai/cudf/issues/7066 introduced a breaking change wherein comparison operations involving `N/A` return `N/A`, rather than True/False, as was being done previously.

While this is the appropriate behaviour and compatible with Pandas nullable types (which are really the equivalent of what cuDF supports), it breaks compatibility with Pandas _non-nullable_ types.

This PR introduces a runtime configuration option `"nulls_compare_like_nans"`. When set to `True`, cuDF treats `N/A` like `nan` when doing comparisons, thus returning True/False rather than `N/A`.

```python
In [1]: import cudf

In [2]: s = cudf.Series([1, 2, None])

In [3]: s > 1
Out[3]:
0    False
1     True
2     <NA>
dtype: bool

In [4]: with cudf._config.option_context("nulls_compare_like_nans", True):
   ...:     print(s > 1)
   ...:
   ...:
0    False
1     True
2    False
dtype: bool
```