### PR TITLE
Rename some copying_test source files .cu to .cpp

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -202,10 +202,10 @@ ConfigureTest(COPYING_TEST
     copying/copy_range_tests.cpp
     copying/copy_tests.cu
     copying/detail_gather_tests.cu
+    copying/gather_list_tests.cpp
+    copying/gather_str_tests.cpp
     copying/gather_struct_tests.cpp
     copying/gather_tests.cpp
-    copying/gather_str_tests.cpp
-    copying/gather_list_tests.cpp
     copying/get_value_tests.cpp
     copying/pack_tests.cpp
     copying/sample_tests.cpp

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -202,12 +202,12 @@ ConfigureTest(COPYING_TEST
     copying/copy_range_tests.cpp
     copying/copy_tests.cu
     copying/detail_gather_tests.cu
-    copying/gather_struct_tests.cu
-    copying/gather_tests.cu
-    copying/gather_str_tests.cu
-    copying/gather_list_tests.cu
+    copying/gather_struct_tests.cpp
+    copying/gather_tests.cpp
+    copying/gather_str_tests.cpp
+    copying/gather_list_tests.cpp
     copying/get_value_tests.cpp
-    copying/pack_tests.cu
+    copying/pack_tests.cpp
     copying/sample_tests.cpp
     copying/scatter_tests.cpp
     copying/scatter_list_tests.cpp

--- a/cpp/tests/copying/gather_list_tests.cpp
+++ b/cpp/tests/copying/gather_list_tests.cpp
@@ -17,7 +17,6 @@
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/gather.cuh>
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/lists/lists_column_view.hpp>

--- a/cpp/tests/copying/gather_struct_tests.cpp
+++ b/cpp/tests/copying/gather_struct_tests.cpp
@@ -23,7 +23,6 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/detail/iterator.cuh>
-#include <cudf/detail/utilities/device_operators.cuh>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/structs/structs_column_view.hpp>

--- a/cpp/tests/copying/gather_tests.cpp
+++ b/cpp/tests/copying/gather_tests.cpp
@@ -17,8 +17,6 @@
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/gather.cuh>
-#include <cudf/detail/gather.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>

--- a/cpp/tests/copying/pack_tests.cpp
+++ b/cpp/tests/copying/pack_tests.cpp
@@ -125,11 +125,11 @@ std::vector<std::unique_ptr<column>> generate_lists(bool include_validity)
 
     cudf::test::lists_column_wrapper<int> list1{{{{1, 2, 3}, valids}, {4, 5}},
                                           {{LCW{}, LCW{}, {7, 8}, LCW{}}, valids},
-                                          {{LCW{6}}},                                                                                    
+                                          {LCW{6}},
                                           {{{7, 8}, {{9, 10, 11}, valids}, LCW{}}, valids},
                                           {{LCW{}, {-1, -2, -3, -4, -5}}, valids},
-                                          {{LCW{}}},
-                                          {{-10}, {-100, -200}},
+                                          {LCW{}},
+                                          {LCW{-10}, {-100, -200}},
                                           {{-10, -200}, LCW{}, {8, 9}},
                                           {LCW{8}, LCW{}, LCW{9}, {5, 6}}};
 
@@ -151,17 +151,17 @@ std::vector<std::unique_ptr<column>> generate_lists(bool include_validity)
 
   cudf::test::lists_column_wrapper<int> list1{{{1, 2, 3}, {4, 5}},
                                         {LCW{}, LCW{}, {7, 8}, LCW{}},
-                                        {{LCW{6}}},                                                                                    
+                                        {LCW{6}},                                                                                    
                                         {{7, 8}, {9, 10, 11}, LCW{}},
                                         {LCW{}, {-1, -2, -3, -4, -5}},
-                                        {{LCW{}}},
+                                        {LCW{}},
                                         {{-10}, {-100, -200}},
                                         {{-10, -200}, LCW{}, {8, 9}},
                                         {LCW{8}, LCW{}, LCW{9}, {5, 6}}};
 
   std::vector<std::unique_ptr<column>> out;
   out.push_back(list0.release());
-  out.push_back(list1.release());
+  //out.push_back(list1.release());
   return out;
 }
 
@@ -217,15 +217,17 @@ std::vector<std::unique_ptr<column>> generate_struct_of_list()
   // 3. List column
   using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
   std::vector<bool> list_validity{1, 1, 1, 1, 1, 0, 1, 0, 1};
-  lists_column_wrapper<cudf::string_view> list({{{"abc", "d", "edf"}, {"jjj"}},
+  lists_column_wrapper<cudf::string_view> list({
+                                                {{"abc", "d", "edf"}, {"jjj"}},
                                                 {{"dgaer", "-7"}, LCW{}},
-                                                {{LCW{}}},
+                                                {LCW{}},
                                                 {{"qwerty"}, {"ral", "ort", "tal"}, {"five", "six"}},
                                                 {LCW{}, LCW{}, {"eight", "nine"}},
-                                                {{LCW{}}},
+                                                {LCW{}},
                                                 {{"fun"}, {"a", "bc", "def", "ghij", "klmno", "pqrstu"}},
                                                 {{"seven", "zz"}, LCW{}, {"xyzzy"}},
-                                                {{LCW{"negative 3", "  ", "cleveland"}}} },
+                                                {LCW{"negative 3", "  ", "cleveland"}}
+                                                 },
                                             list_validity.begin());
 
   // Assemble struct column.

--- a/cpp/tests/copying/pack_tests.cpp
+++ b/cpp/tests/copying/pack_tests.cpp
@@ -79,6 +79,7 @@ TEST_F(PackUnpackTest, MultiColumnWithStrings)
 
   this->run_test({col1, col2, col3});
 }
+// clang-format on
 
 TEST_F(PackUnpackTest, EmptyColumns)
 {
@@ -87,10 +88,10 @@ TEST_F(PackUnpackTest, EmptyColumns)
     cudf::table_view src_table({static_cast<cudf::column_view>(*empty_string)});
     this->run_test(src_table);
   }
-  
+
   {
     cudf::test::strings_column_wrapper str{"abc"};
-    auto empty_string = cudf::empty_like(str);    
+    auto empty_string = cudf::empty_like(str);
     cudf::table_view src_table({static_cast<cudf::column_view>(*empty_string)});
     this->run_test(src_table);
   }
@@ -111,53 +112,47 @@ std::vector<std::unique_ptr<column>> generate_lists(bool include_validity)
 {
   using LCW = cudf::test::lists_column_wrapper<int>;
 
-  if(include_validity){
-    auto valids = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  if (include_validity) {
+    auto valids =
+      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
     cudf::test::lists_column_wrapper<int> list0{{1, 2, 3},
-                                          {4, 5},
-                                          {6},
-                                          {{7, 8}, valids},
-                                          {9, 10, 11},
-                                          LCW{},
-                                          LCW{},
-                                          {{-1, -2, -3, -4, -5}, valids},
-                                          {{100, -200}, valids}};
+                                                {4, 5},
+                                                {6},
+                                                {{7, 8}, valids},
+                                                {9, 10, 11},
+                                                LCW{},
+                                                LCW{},
+                                                {{-1, -2, -3, -4, -5}, valids},
+                                                {{100, -200}, valids}};
 
     cudf::test::lists_column_wrapper<int> list1{{{{1, 2, 3}, valids}, {4, 5}},
-                                          {{LCW{}, LCW{}, {7, 8}, LCW{}}, valids},
-                                          {LCW{6}},
-                                          {{{7, 8}, {{9, 10, 11}, valids}, LCW{}}, valids},
-                                          {{LCW{}, {-1, -2, -3, -4, -5}}, valids},
-                                          {LCW{}},
-                                          {LCW{-10}, {-100, -200}},
-                                          {{-10, -200}, LCW{}, {8, 9}},
-                                          {LCW{8}, LCW{}, LCW{9}, {5, 6}}};
+                                                {{LCW{}, LCW{}, {7, 8}, LCW{}}, valids},
+                                                {LCW{6}},
+                                                {{{7, 8}, {{9, 10, 11}, valids}, LCW{}}, valids},
+                                                {{LCW{}, {-1, -2, -3, -4, -5}}, valids},
+                                                {LCW{}},
+                                                {LCW{-10}, {-100, -200}},
+                                                {{-10, -200}, LCW{}, {8, 9}},
+                                                {LCW{8}, LCW{}, LCW{9}, {5, 6}}};
 
     std::vector<std::unique_ptr<column>> out;
     out.push_back(list0.release());
     out.push_back(list1.release());
     return out;
   }
-  
-  cudf::test::lists_column_wrapper<int> list0{{1, 2, 3},
-                                        {4, 5},
-                                        {6},
-                                        {7, 8},
-                                        {9, 10, 11},
-                                        LCW{},
-                                        LCW{},
-                                        {-1, -2, -3, -4, -5},
-                                        {-100, -200}};
+
+  cudf::test::lists_column_wrapper<int> list0{
+    {1, 2, 3}, {4, 5}, {6}, {7, 8}, {9, 10, 11}, LCW{}, LCW{}, {-1, -2, -3, -4, -5}, {-100, -200}};
 
   cudf::test::lists_column_wrapper<int> list1{{{1, 2, 3}, {4, 5}},
-                                        {LCW{}, LCW{}, {7, 8}, LCW{}},
-                                        {LCW{6}},                                                                                    
-                                        {{7, 8}, {9, 10, 11}, LCW{}},
-                                        {LCW{}, {-1, -2, -3, -4, -5}},
-                                        {LCW{}},
-                                        {{-10}, {-100, -200}},
-                                        {{-10, -200}, LCW{}, {8, 9}},
-                                        {LCW{8}, LCW{}, LCW{9}, {5, 6}}};
+                                              {LCW{}, LCW{}, {7, 8}, LCW{}},
+                                              {LCW{6}},
+                                              {{7, 8}, {9, 10, 11}, LCW{}},
+                                              {LCW{}, {-1, -2, -3, -4, -5}},
+                                              {LCW{}},
+                                              {{-10}, {-100, -200}},
+                                              {{-10, -200}, LCW{}, {8, 9}},
+                                              {LCW{8}, LCW{}, LCW{9}, {5, 6}}};
 
   std::vector<std::unique_ptr<column>> out;
   out.push_back(list0.release());
@@ -217,18 +212,17 @@ std::vector<std::unique_ptr<column>> generate_struct_of_list()
   // 3. List column
   using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
   std::vector<bool> list_validity{1, 1, 1, 1, 1, 0, 1, 0, 1};
-  lists_column_wrapper<cudf::string_view> list({
-                                                {{"abc", "d", "edf"}, {"jjj"}},
-                                                {{"dgaer", "-7"}, LCW{}},
-                                                {LCW{}},
-                                                {{"qwerty"}, {"ral", "ort", "tal"}, {"five", "six"}},
-                                                {LCW{}, LCW{}, {"eight", "nine"}},
-                                                {LCW{}},
-                                                {{"fun"}, {"a", "bc", "def", "ghij", "klmno", "pqrstu"}},
-                                                {{"seven", "zz"}, LCW{}, {"xyzzy"}},
-                                                {LCW{"negative 3", "  ", "cleveland"}}
-                                                 },
-                                            list_validity.begin());
+  lists_column_wrapper<cudf::string_view> list(
+    {{{"abc", "d", "edf"}, {"jjj"}},
+     {{"dgaer", "-7"}, LCW{}},
+     {LCW{}},
+     {{"qwerty"}, {"ral", "ort", "tal"}, {"five", "six"}},
+     {LCW{}, LCW{}, {"eight", "nine"}},
+     {LCW{}},
+     {{"fun"}, {"a", "bc", "def", "ghij", "klmno", "pqrstu"}},
+     {{"seven", "zz"}, LCW{}, {"xyzzy"}},
+     {LCW{"negative 3", "  ", "cleveland"}}},
+    list_validity.begin());
 
   // Assemble struct column.
   auto const struct_validity = std::vector<bool>{1, 1, 1, 1, 1, 0, 0, 1, 0};
@@ -243,9 +237,22 @@ std::vector<std::unique_ptr<column>> generate_struct_of_list()
 std::vector<std::unique_ptr<column>> generate_list_of_struct()
 {
   // 1. String "names" column.
-  std::vector<std::string> names{
-    "Vimes", "Carrot", "Angua", "Cheery", "Detritus", "Slant", "Fred", "Todd", "Kevin",
-    "Abc", "Def", "Xyz", "Five", "Seventeen", "Dol", "Est"};
+  std::vector<std::string> names{"Vimes",
+                                 "Carrot",
+                                 "Angua",
+                                 "Cheery",
+                                 "Detritus",
+                                 "Slant",
+                                 "Fred",
+                                 "Todd",
+                                 "Kevin",
+                                 "Abc",
+                                 "Def",
+                                 "Xyz",
+                                 "Five",
+                                 "Seventeen",
+                                 "Dol",
+                                 "Est"};
   std::vector<bool> names_validity{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1};
   strings_column_wrapper names_column(names.begin(), names.end());
 
@@ -257,16 +264,18 @@ std::vector<std::unique_ptr<column>> generate_list_of_struct()
 
   // Assemble struct column.
   auto const struct_validity = std::vector<bool>{1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1};
-  auto struct_column =
-    structs_column_wrapper({names_column, ages_column}, struct_validity.begin());
-
+  auto struct_column = structs_column_wrapper({names_column, ages_column}, struct_validity.begin());
 
   // 3. List column
   std::vector<bool> list_validity{1, 1, 1, 1, 1, 0, 1, 0, 1};
 
   cudf::test::fixed_width_column_wrapper<int> offsets{0, 1, 4, 5, 7, 7, 10, 13, 14, 16};
-  auto list = cudf::make_lists_column(9, offsets.release(), struct_column.release(), 
-                                      2, cudf::test::detail::make_null_mask(list_validity.begin(), list_validity.begin() + 9));
+  auto list = cudf::make_lists_column(
+    9,
+    offsets.release(),
+    struct_column.release(),
+    2,
+    cudf::test::detail::make_null_mask(list_validity.begin(), list_validity.begin() + 9));
 
   std::vector<std::unique_ptr<column>> out;
   out.push_back(std::move(list));
@@ -274,14 +283,16 @@ std::vector<std::unique_ptr<column>> generate_list_of_struct()
 }
 
 TEST_F(PackUnpackTest, Lists)
-{  
+{
   // lists
-  {      
+  {
     auto cols = generate_lists(false);
     std::vector<column_view> col_views;
-    std::transform(cols.begin(), cols.end(), std::back_inserter(col_views), [](std::unique_ptr<column> const& col){
-      return static_cast<column_view>(*col);
-    });
+    std::transform(
+      cols.begin(),
+      cols.end(),
+      std::back_inserter(col_views),
+      [](std::unique_ptr<column> const& col) { return static_cast<column_view>(*col); });
     cudf::table_view src_table(col_views);
     this->run_test(src_table);
   }
@@ -290,23 +301,27 @@ TEST_F(PackUnpackTest, Lists)
   {
     auto cols = generate_lists(true);
     std::vector<column_view> col_views;
-    std::transform(cols.begin(), cols.end(), std::back_inserter(col_views), [](std::unique_ptr<column> const& col){
-      return static_cast<column_view>(*col);
-    });
+    std::transform(
+      cols.begin(),
+      cols.end(),
+      std::back_inserter(col_views),
+      [](std::unique_ptr<column> const& col) { return static_cast<column_view>(*col); });
     cudf::table_view src_table(col_views);
     this->run_test(src_table);
-  }    
+  }
 }
 
 TEST_F(PackUnpackTest, Structs)
 {
   // structs
-  {      
+  {
     auto cols = generate_structs(false);
     std::vector<column_view> col_views;
-    std::transform(cols.begin(), cols.end(), std::back_inserter(col_views), [](std::unique_ptr<column> const& col){
-      return static_cast<column_view>(*col);
-    });
+    std::transform(
+      cols.begin(),
+      cols.end(),
+      std::back_inserter(col_views),
+      [](std::unique_ptr<column> const& col) { return static_cast<column_view>(*col); });
     cudf::table_view src_table(col_views);
     this->run_test(src_table);
   }
@@ -315,38 +330,44 @@ TEST_F(PackUnpackTest, Structs)
   {
     auto cols = generate_structs(true);
     std::vector<column_view> col_views;
-    std::transform(cols.begin(), cols.end(), std::back_inserter(col_views), [](std::unique_ptr<column> const& col){
-      return static_cast<column_view>(*col);
-    });
+    std::transform(
+      cols.begin(),
+      cols.end(),
+      std::back_inserter(col_views),
+      [](std::unique_ptr<column> const& col) { return static_cast<column_view>(*col); });
     cudf::table_view src_table(col_views);
     this->run_test(src_table);
   }
 }
 
 TEST_F(PackUnpackTest, NestedTypes)
-{ 
+{
   // build one big table containing, lists, structs, structs<list>, list<struct>
   std::vector<column_view> col_views;
-  
+
   auto lists = generate_lists(true);
-  std::transform(lists.begin(), lists.end(), std::back_inserter(col_views), [](std::unique_ptr<column> const& col){
-    return static_cast<column_view>(*col);
-  });
-  
-  auto structs = generate_structs(true);    
-  std::transform(structs.begin(), structs.end(), std::back_inserter(col_views), [](std::unique_ptr<column> const& col){
-    return static_cast<column_view>(*col);
-  });
+  std::transform(lists.begin(),
+                 lists.end(),
+                 std::back_inserter(col_views),
+                 [](std::unique_ptr<column> const& col) { return static_cast<column_view>(*col); });
+
+  auto structs = generate_structs(true);
+  std::transform(structs.begin(),
+                 structs.end(),
+                 std::back_inserter(col_views),
+                 [](std::unique_ptr<column> const& col) { return static_cast<column_view>(*col); });
 
   auto struct_of_list = generate_struct_of_list();
-  std::transform(struct_of_list.begin(), struct_of_list.end(), std::back_inserter(col_views), [](std::unique_ptr<column> const& col){
-    return static_cast<column_view>(*col);
-  });
+  std::transform(struct_of_list.begin(),
+                 struct_of_list.end(),
+                 std::back_inserter(col_views),
+                 [](std::unique_ptr<column> const& col) { return static_cast<column_view>(*col); });
 
   auto list_of_struct = generate_list_of_struct();
-  std::transform(list_of_struct.begin(), list_of_struct.end(), std::back_inserter(col_views), [](std::unique_ptr<column> const& col){
-    return static_cast<column_view>(*col);
-  });
+  std::transform(list_of_struct.begin(),
+                 list_of_struct.end(),
+                 std::back_inserter(col_views),
+                 [](std::unique_ptr<column> const& col) { return static_cast<column_view>(*col); });
 
   cudf::table_view src_table(col_views);
   this->run_test(src_table);
@@ -385,8 +406,8 @@ TEST_F(PackUnpackTest, NestedEmpty)
     cudf::test::lists_column_wrapper<float> listw{{1.0f, 2.0f}, {3.0f, 4.0f}};
     auto empty_list = cudf::empty_like(listw);
     auto offsets    = cudf::test::fixed_width_column_wrapper<int>({0, 0});
-    auto list       = cudf::make_lists_column(
-      1, offsets.release(), std::move(empty_list), 0, rmm::device_buffer{});
+    auto list =
+      cudf::make_lists_column(1, offsets.release(), std::move(empty_list), 0, rmm::device_buffer{});
 
     cudf::table_view src_table({static_cast<cudf::column_view>(*list)});
     this->run_test(src_table);
@@ -398,8 +419,8 @@ TEST_F(PackUnpackTest, NestedEmpty)
     cudf::test::lists_column_wrapper<float> listw{{1.0f, 2.0f}, {3.0f, 4.0f}};
     auto empty_list = cudf::empty_like(listw);
     auto offsets    = cudf::test::fixed_width_column_wrapper<int>({0, 0});
-    auto list       = cudf::make_lists_column(
-      1, offsets.release(), std::move(empty_list), 0, rmm::device_buffer{});
+    auto list =
+      cudf::make_lists_column(1, offsets.release(), std::move(empty_list), 0, rmm::device_buffer{});
 
     cudf::table_view src_table({static_cast<cudf::column_view>(*list)});
     this->run_test(src_table);
@@ -420,7 +441,36 @@ TEST_F(PackUnpackTest, NestedEmpty)
     this->run_test(src_table);
   }
 }
-// clang-format on
+
+TEST_F(PackUnpackTest, NestedSliced)
+{
+  auto valids =
+    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+
+  using LCW = cudf::test::lists_column_wrapper<int>;
+
+  cudf::test::lists_column_wrapper<int> col0{{{{1, 2, 3}, valids}, {4, 5}},
+                                             {{LCW{}, LCW{}, {7, 8}, LCW{}}, valids},
+                                             {{6, 12}},
+                                             {{{7, 8}, {{9, 10, 11}, valids}, LCW{}}, valids},
+                                             {{LCW{}, {-1, -2, -3, -4, -5}}, valids},
+                                             {LCW{}},
+                                             {{-10}, {-100, -200}}};
+
+  cudf::test::strings_column_wrapper col1{
+    "Vimes", "Carrot", "Angua", "Cheery", "Detritus", "Slant", "Fred"};
+  cudf::test::fixed_width_column_wrapper<float> col2{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
+
+  std::vector<std::unique_ptr<cudf::column>> children;
+  children.push_back(std::make_unique<cudf::column>(col2));
+  children.push_back(std::make_unique<cudf::column>(col0));
+  children.push_back(std::make_unique<cudf::column>(col1));
+  auto col3 = cudf::make_structs_column(
+    static_cast<cudf::column_view>(col0).size(), std::move(children), 0, rmm::device_buffer{});
+
+  cudf::table_view t({col0, col1, col2, *col3});
+  this->run_test(t);
+}
 
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/copying/pack_tests.cpp
+++ b/cpp/tests/copying/pack_tests.cpp
@@ -161,7 +161,7 @@ std::vector<std::unique_ptr<column>> generate_lists(bool include_validity)
 
   std::vector<std::unique_ptr<column>> out;
   out.push_back(list0.release());
-  //out.push_back(list1.release());
+  out.push_back(list1.release());
   return out;
 }
 


### PR DESCRIPTION
Found these files could be changed from .cu to .cpp while working on a different PR.

- cpp/tests/copying/gather_struct_tests.cu
- cpp/tests/copying/gather_str_tests.cu
- cpp/tests/copying/gather_tests.cu
- cpp/tests/copying/gather_list_tests.cu
- cpp/tests/copying/pack_tets.cu

This PR renames these files and makes minimal updates (e.g removes unneeded includes of .cuh files) to make these compile and run as .cpp source files.