### PR TITLE
Properly retrieve last column when `-1` is specified for column index

### DIFF
--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -362,7 +362,7 @@ class ColumnAccessor(MutableMapping):
             start, stop, step = index.indices(len(self._data))
             keys = self.names[start:stop:step]
         elif pd.api.types.is_integer(index):
-            keys = self.names[index : index + 1]
+            keys = [self.names[index]]
         else:
             keys = (self.names[i] for i in index)
         data = {k: self._data[k] for k in keys}

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -661,7 +661,6 @@ def test_dataframe_iloc(nelem):
     assert_eq(gdf.iloc[np.array([0])], pdf.loc[np.array([0])])
 
 
-@pytest.mark.xfail(raises=AssertionError, reason="Series.index are different")
 def test_dataframe_iloc_tuple():
     gdf = cudf.DataFrame()
     nelem = 123
@@ -674,11 +673,8 @@ def test_dataframe_iloc_tuple():
     pdf["a"] = ha
     pdf["b"] = hb
 
-    # We don't support passing the column names into the index quite yet
-    got = gdf.iloc[1, [1]]
-    expect = pdf.iloc[1, [1]]
-
-    assert_eq(got, expect)
+    assert_eq(gdf.iloc[1, [1]], pdf.iloc[1, [1]], check_dtype=False)
+    assert_eq(gdf.iloc[:, -1], pdf.iloc[:, -1])
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
Closes #8501

This PR fixes the bug when indexing columns with -1 in `column_acccessor.select_by_index`, the last column is not properly retrieved.