### PR TITLE
Refactor `tests/iterator_utilities.hpp` functions

### DIFF
--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -34,7 +34,7 @@ namespace iterators {
  *
  * @code
  * auto indices = std::vector<size_type>{8,9};
- * auto iter = null_at(indices.cbegin(), indices.end());
+ * auto iter = nulls_at(indices.cbegin(), indices.end());
  * iter[6] == true;  // i.e. Valid row at index 6.
  * iter[7] == true;  // i.e. Valid row at index 7.
  * iter[8] == false; // i.e. Invalid row at index 8.
@@ -48,7 +48,7 @@ namespace iterators {
  * @return auto Validity iterator
  */
 template <typename Iter>
-[[maybe_unused]] static auto null_at(Iter index_start, Iter index_end)
+[[maybe_unused]] static auto nulls_at(Iter index_start, Iter index_end)
 {
   using index_type = typename std::iterator_traits<Iter>::value_type;
 
@@ -65,7 +65,7 @@ template <typename Iter>
  * and yields `true` (to mark valid rows) for all other indices. E.g.
  *
  * @code
- * auto iter = null_at({8,9});
+ * auto iter = nulls_at({8,9});
  * iter[6] == true;  // i.e. Valid row at index 6.
  * iter[7] == true;  // i.e. Valid row at index 7.
  * iter[8] == false; // i.e. Invalid row at index 8.
@@ -75,9 +75,11 @@ template <typename Iter>
  * @param indices The indices for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-[[maybe_unused]] static auto null_at(std::vector<cudf::size_type> const& indices)
+[[maybe_unused]] static auto nulls_at(std::vector<cudf::size_type> const& indices)
 {
-  return null_at(indices.begin(), indices.end());
+  return cudf::detail::make_counting_transform_iterator(0, [&indices](auto i) {
+    return std::find(indices.cbegin(), indices.cend(), i) == indices.cend();
+  });
 }
 
 /**
@@ -97,7 +99,7 @@ template <typename Iter>
  */
 [[maybe_unused]] static auto null_at(cudf::size_type index)
 {
-  return null_at(std::vector<cudf::size_type>{index});
+  return nulls_at(std::vector<cudf::size_type>{index});
 }
 
 /**
@@ -112,20 +114,20 @@ template <typename Iter>
  *
  * @return auto Validity iterator which always yields `true`
  */
-[[maybe_unused]] static auto no_null() { return thrust::make_constant_iterator(true); }
+[[maybe_unused]] static auto no_nulls() { return thrust::make_constant_iterator(true); }
 
 /**
  * @brief Bool iterator for marking null elements from pointers of data
  *
  * The returned iterator yields `false` (to mark `null`) at the indices corresponding to the
- * pointers having `nullptr` value and `true` for the remaining indices.
+ * pointers having `nullptr` values and `true` for the remaining indices.
  *
  * @tparam T the data type
  * @param ptrs The data pointers for which the validity iterator is computed
  * @return auto Validity iterator
  */
 template <class T>
-[[maybe_unused]] static auto nulls_from_nullptr(std::vector<T const*> const& ptrs)
+[[maybe_unused]] static auto nulls_from_nullptrs(std::vector<T const*> const& ptrs)
 {
   return thrust::make_transform_iterator(ptrs.begin(), [](auto ptr) { return ptr != nullptr; });
 }

--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -77,9 +77,7 @@ template <typename Iter>
  */
 [[maybe_unused]] static auto nulls_at(std::vector<cudf::size_type> const& indices)
 {
-  return cudf::detail::make_counting_transform_iterator(0, [&indices](auto i) {
-    return std::find(indices.cbegin(), indices.cend(), i) == indices.cend();
-  });
+  return nulls_at(indices.cbegin(), indices.cend());
 }
 
 /**
@@ -129,7 +127,8 @@ template <typename Iter>
 template <class T>
 [[maybe_unused]] static auto nulls_from_nullptrs(std::vector<T const*> const& ptrs)
 {
-  return thrust::make_transform_iterator(ptrs.begin(), [](auto ptr) { return ptr != nullptr; });
+  // The vector `indices` is copied into the lambda as it can be destroyed at the caller site.
+  return thrust::make_transform_iterator(ptrs.begin(), [ptrs](auto ptr) { return ptr != nullptr; });
 }
 
 }  // namespace iterators

--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -18,7 +18,6 @@
 
 #include <cudf/detail/iterator.cuh>
 #include <cudf/types.hpp>
-#include <cudf/utilities/span.hpp>
 
 #include <thrust/iterator/transform_iterator.h>
 
@@ -26,7 +25,7 @@
 
 namespace cudf {
 namespace test {
-
+namespace iterators {
 /**
  * @brief Bool iterator for marking (possibly multiple) null elements in a column_wrapper.
  *
@@ -35,7 +34,7 @@ namespace test {
  *
  * @code
  * auto indices = std::vector<size_type>{8,9};
- * auto iter = iterator_with_null_at(indices.cbegin(), indices.end());
+ * auto iter = null_at(indices.cbegin(), indices.end());
  * iter[6] == true;  // i.e. Valid row at index 6.
  * iter[7] == true;  // i.e. Valid row at index 7.
  * iter[8] == false; // i.e. Invalid row at index 8.
@@ -49,7 +48,7 @@ namespace test {
  * @return auto Validity iterator
  */
 template <typename Iter>
-[[maybe_unused]] static auto iterator_with_null_at(Iter index_start, Iter index_end)
+[[maybe_unused]] static auto null_at(Iter index_start, Iter index_end)
 {
   using index_type = typename std::iterator_traits<Iter>::value_type;
 
@@ -66,8 +65,7 @@ template <typename Iter>
  * and yields `true` (to mark valid rows) for all other indices. E.g.
  *
  * @code
- * using host_span = cudf::host_span<cudf::size_type const>;
- * auto iter = iterator_with_null_at(host_span{std::vector<size_type>{8,9}});
+ * auto iter = null_at({8,9});
  * iter[6] == true;  // i.e. Valid row at index 6.
  * iter[7] == true;  // i.e. Valid row at index 7.
  * iter[8] == false; // i.e. Invalid row at index 8.
@@ -77,9 +75,9 @@ template <typename Iter>
  * @param indices The indices for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-[[maybe_unused]] static auto iterator_with_null_at(cudf::host_span<cudf::size_type const> indices)
+[[maybe_unused]] static auto null_at(std::vector<cudf::size_type> const& indices)
 {
-  return iterator_with_null_at(indices.begin(), indices.end());
+  return null_at(indices.begin(), indices.end());
 }
 
 /**
@@ -89,7 +87,7 @@ template <typename Iter>
  * and yields `true` (to mark valid rows) for all other indices. E.g.
  *
  * @code
- * auto iter = iterator_with_null_at(8);
+ * auto iter = null_at(8);
  * iter[7] == true;  // i.e. Valid row at index 7.
  * iter[8] == false; // i.e. Invalid row at index 8.
  * @endcode
@@ -97,9 +95,9 @@ template <typename Iter>
  * @param index The index for which the validity iterator must return `false` (i.e. null)
  * @return auto Validity iterator
  */
-[[maybe_unused]] static auto iterator_with_null_at(cudf::size_type index)
+[[maybe_unused]] static auto null_at(cudf::size_type index)
 {
-  return iterator_with_null_at(std::vector<size_type>{index});
+  return null_at(std::vector<cudf::size_type>{index});
 }
 
 /**
@@ -107,14 +105,31 @@ template <typename Iter>
  *
  * @return auto Validity iterator which always yields `false`
  */
-[[maybe_unused]] static auto iterator_all_nulls() { return thrust::make_constant_iterator(false); }
+[[maybe_unused]] static auto all_nulls() { return thrust::make_constant_iterator(false); }
 
 /**
  * @brief Bool iterator for marking all elements are valid (non-null)
  *
  * @return auto Validity iterator which always yields `true`
  */
-[[maybe_unused]] static auto iterator_no_null() { return thrust::make_constant_iterator(true); }
+[[maybe_unused]] static auto no_null() { return thrust::make_constant_iterator(true); }
 
+/**
+ * @brief Bool iterator for marking null elements from pointers of data
+ *
+ * The returned iterator yields `false` (to mark `null`) at the indices corresponding to the
+ * pointers having `nullptr` value and `true` for the remaining indices.
+ *
+ * @tparam T the data type
+ * @param ptrs The data pointers for which the validity iterator is computed
+ * @return auto Validity iterator
+ */
+template <class T>
+[[maybe_unused]] static auto nulls_from_nullptr(std::vector<T const*> const& ptrs)
+{
+  return thrust::make_transform_iterator(ptrs.begin(), [](auto ptr) { return ptr != nullptr; });
+}
+
+}  // namespace iterators
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/copying/copy_if_else_nested_tests.cpp
+++ b/cpp/tests/copying/copy_if_else_nested_tests.cpp
@@ -94,8 +94,8 @@ TYPED_TEST(TypedCopyIfElseNestedTest, StructsWithNulls)
   auto result_column =
     copy_if_else(lhs_structs_column->view(), rhs_structs_column->view(), selector_column->view());
 
-  auto null_at_0_3 = null_at(std::vector<size_type>{0, 3});
-  auto null_at_3_5 = null_at(std::vector<size_type>{3, 5});
+  auto null_at_0_3 = nulls_at(std::vector<size_type>{0, 3});
+  auto null_at_3_5 = nulls_at(std::vector<size_type>{3, 5});
 
   auto expected_ints    = ints{{-1, 1, 22, 3, 4, 55, 6}, null_at_0_3};
   auto expected_strings = strings{{"0", "1", "22", "", "4", "", "6"}, null_at_3_5};
@@ -124,7 +124,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, LongerStructsWithNulls)
           86, 125, 0,   0,   0,   75,  -49, 125, 60,  116, 118,  64,   20,  -70, -18, 0,   -25,
           22, -46, -89, -9,  27,  -56, -77, 123, 0,   -90, 87,   -113, -37, 22,  -22, -53, 73,
           99, 113, -2,  -24, 113, 75,  6,   82,  -58, 122, -123, -127, 19,  -62, -24},
-         null_at(std::vector<size_type>{13, 19, 20, 21, 32, 42})};
+         nulls_at(std::vector<size_type>{13, 19, 20, 21, 32, 42})};
 
   auto lhs_structs_column = structs{{lhs_child_1}}.release();
   auto result_column =
@@ -176,7 +176,6 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithNulls)
   using lcw = lists_column_wrapper<T, int32_t>;
 
   auto null_at_0 = null_at(0);
-  auto null_at_2 = null_at(2);
   auto null_at_4 = null_at(4);
   auto null_at_5 = null_at(5);
 
@@ -204,7 +203,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithNulls)
 
   auto result_column = copy_if_else(lhs->view(), rhs->view(), selector_column->view());
 
-  auto null_at_4_5 = null_at(std::vector{4, 5});
+  auto null_at_4_5 = nulls_at(std::vector{4, 5});
 
   auto expected_output =
     lcw{{{0, 0}, {1, 1}, {22, 22}, lcw{{3, 3, 3}, null_at_0}, {}, {}, {6, 6, 6, 6, 6, 6}},
@@ -259,7 +258,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
 
   auto result_column = copy_if_else(lhs->view(), rhs->view(), selector_column->view());
 
-  auto const null_at_6_9 = null_at(std::vector{6, 9});
+  auto const null_at_6_9 = nulls_at(std::vector{6, 9});
   auto expected_ints     = ints{{0, 1, 0, 11, 22, 33, 4, 5, -1, 77}, null_at_8};
   auto expected_strings =
     strings{{"0", "1", "00", "11", "22", "33", "", "5", "66", ""}, null_at_6_9};

--- a/cpp/tests/copying/copy_if_else_nested_tests.cpp
+++ b/cpp/tests/copying/copy_if_else_nested_tests.cpp
@@ -22,6 +22,8 @@
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+using namespace cudf::test::iterators;
+
 struct CopyIfElseNestedTest : cudf::test::BaseFixture {
 };
 
@@ -75,9 +77,9 @@ TYPED_TEST(TypedCopyIfElseNestedTest, StructsWithNulls)
   using structs = structs_column_wrapper;
   using bools   = fixed_width_column_wrapper<bool, int32_t>;
 
-  auto null_at_0 = iterator_with_null_at(0);
-  auto null_at_3 = iterator_with_null_at(3);
-  auto null_at_5 = iterator_with_null_at(5);
+  auto null_at_0 = null_at(0);
+  auto null_at_3 = null_at(3);
+  auto null_at_5 = null_at(5);
 
   auto lhs_ints_child     = ints{{0, 1, 2, 3, 4, 5, 6}, null_at_0};
   auto lhs_strings_child  = strings{"0", "1", "2", "3", "4", "5", "6"};
@@ -92,8 +94,8 @@ TYPED_TEST(TypedCopyIfElseNestedTest, StructsWithNulls)
   auto result_column =
     copy_if_else(lhs_structs_column->view(), rhs_structs_column->view(), selector_column->view());
 
-  auto null_at_0_3 = iterator_with_null_at(std::vector<size_type>{0, 3});
-  auto null_at_3_5 = iterator_with_null_at(std::vector<size_type>{3, 5});
+  auto null_at_0_3 = null_at(std::vector<size_type>{0, 3});
+  auto null_at_3_5 = null_at(std::vector<size_type>{3, 5});
 
   auto expected_ints    = ints{{-1, 1, 22, 3, 4, 55, 6}, null_at_0_3};
   auto expected_strings = strings{{"0", "1", "22", "", "4", "", "6"}, null_at_3_5};
@@ -122,7 +124,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, LongerStructsWithNulls)
           86, 125, 0,   0,   0,   75,  -49, 125, 60,  116, 118,  64,   20,  -70, -18, 0,   -25,
           22, -46, -89, -9,  27,  -56, -77, 123, 0,   -90, 87,   -113, -37, 22,  -22, -53, 73,
           99, 113, -2,  -24, 113, 75,  6,   82,  -58, 122, -123, -127, 19,  -62, -24},
-         iterator_with_null_at(std::vector<size_type>{13, 19, 20, 21, 32, 42})};
+         null_at(std::vector<size_type>{13, 19, 20, 21, 32, 42})};
 
   auto lhs_structs_column = structs{{lhs_child_1}}.release();
   auto result_column =
@@ -173,10 +175,10 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithNulls)
 
   using lcw = lists_column_wrapper<T, int32_t>;
 
-  auto null_at_0 = iterator_with_null_at(0);
-  auto null_at_2 = iterator_with_null_at(2);
-  auto null_at_4 = iterator_with_null_at(4);
-  auto null_at_5 = iterator_with_null_at(5);
+  auto null_at_0 = null_at(0);
+  auto null_at_2 = null_at(2);
+  auto null_at_4 = null_at(4);
+  auto null_at_5 = null_at(5);
 
   auto lhs = lcw{{{0, 0},
                   {1, 1},
@@ -202,7 +204,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithNulls)
 
   auto result_column = copy_if_else(lhs->view(), rhs->view(), selector_column->view());
 
-  auto null_at_4_5 = iterator_with_null_at(std::vector{4, 5});
+  auto null_at_4_5 = null_at(std::vector{4, 5});
 
   auto expected_output =
     lcw{{{0, 0}, {1, 1}, {22, 22}, lcw{{3, 3, 3}, null_at_0}, {}, {}, {6, 6, 6, 6, 6, 6}},
@@ -225,12 +227,12 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
   using bools   = fixed_width_column_wrapper<bool, int32_t>;
   using offsets = fixed_width_column_wrapper<offset_type, int32_t>;
 
-  auto const null_at_0 = iterator_with_null_at(0);
-  auto const null_at_3 = iterator_with_null_at(3);
-  auto const null_at_4 = iterator_with_null_at(4);
-  auto const null_at_6 = iterator_with_null_at(6);
-  auto const null_at_7 = iterator_with_null_at(7);
-  auto const null_at_8 = iterator_with_null_at(8);
+  auto const null_at_0 = null_at(0);
+  auto const null_at_3 = null_at(3);
+  auto const null_at_4 = null_at(4);
+  auto const null_at_6 = null_at(6);
+  auto const null_at_7 = null_at(7);
+  auto const null_at_8 = null_at(8);
 
   auto lhs_ints    = ints{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, null_at_3};
   auto lhs_strings = strings{{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}, null_at_4};
@@ -257,7 +259,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
 
   auto result_column = copy_if_else(lhs->view(), rhs->view(), selector_column->view());
 
-  auto const null_at_6_9 = iterator_with_null_at(std::vector{6, 9});
+  auto const null_at_6_9 = null_at(std::vector{6, 9});
   auto expected_ints     = ints{{0, 1, 0, 11, 22, 33, 4, 5, -1, 77}, null_at_8};
   auto expected_strings =
     strings{{"0", "1", "00", "11", "22", "33", "", "5", "66", ""}, null_at_6_9};

--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -564,7 +564,7 @@ struct ListGetStructValueTest : public BaseFixture {
     return this->make_test_structs_column({{1}, {1}},
                                           strings_column_wrapper({"aa"}, {false}),
                                           LCWinner_t({{}}, all_nulls()),
-                                          no_null());
+                                          no_nulls());
   }
 
   /**
@@ -584,8 +584,8 @@ struct ListGetStructValueTest : public BaseFixture {
     // {int: 3, string: "xyz", list: [3, 8, 4]}
     return this->make_test_structs_column({{3}, {1}},
                                           strings_column_wrapper({"xyz"}, {true}),
-                                          LCWinner_t({{3, 8, 4}}, no_null()),
-                                          no_null());
+                                          LCWinner_t({{3, 8, 4}}, no_nulls()),
+                                          no_nulls());
   }
 
   /**

--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -30,6 +30,8 @@
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 
@@ -561,8 +563,8 @@ struct ListGetStructValueTest : public BaseFixture {
     // {int: 1, string: NULL, list: NULL}
     return this->make_test_structs_column({{1}, {1}},
                                           strings_column_wrapper({"aa"}, {false}),
-                                          LCWinner_t({{}}, iterator_all_nulls()),
-                                          iterator_no_null());
+                                          LCWinner_t({{}}, all_nulls()),
+                                          no_null());
   }
 
   /**
@@ -571,7 +573,7 @@ struct ListGetStructValueTest : public BaseFixture {
   SCW row1()
   {
     // NULL
-    return this->make_test_structs_column({-1}, {""}, LCWinner_t{-1}, iterator_all_nulls());
+    return this->make_test_structs_column({-1}, {""}, LCWinner_t{-1}, all_nulls());
   }
 
   /**
@@ -582,8 +584,8 @@ struct ListGetStructValueTest : public BaseFixture {
     // {int: 3, string: "xyz", list: [3, 8, 4]}
     return this->make_test_structs_column({{3}, {1}},
                                           strings_column_wrapper({"xyz"}, {true}),
-                                          LCWinner_t({{3, 8, 4}}, iterator_no_null()),
-                                          iterator_no_null());
+                                          LCWinner_t({{3, 8, 4}}, no_null()),
+                                          no_null());
   }
 
   /**

--- a/cpp/tests/copying/scatter_struct_tests.cpp
+++ b/cpp/tests/copying/scatter_struct_tests.cpp
@@ -145,7 +145,7 @@ TYPED_TEST(TypedStructScatterTest, SimpleScatterTests)
 
   // Expected data
   auto child_col_expected2     = col_wrapper{{1, null, 70, 3, 0, 2}, null_at(1)};
-  auto const structs_expected2 = structs_col{{child_col_expected2}, no_null()}.release();
+  auto const structs_expected2 = structs_col{{child_col_expected2}, no_nulls()}.release();
   auto const scatter_map2      = int32s_col{-2, 0, 5, 3}.release();
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(
     *structs_expected2, scatter_structs(structs_src, structs_tgt, scatter_map2), print_all);
@@ -158,7 +158,7 @@ TYPED_TEST(TypedStructScatterTest, ComplexDataScatterTest)
 
   // Source data
   auto names_column_src =
-    strings_col{{"Newton", "Washington", "Cherry", "Kiwi", "Lemon", "Tomato" /*XXX*/}, no_null()};
+    strings_col{{"Newton", "Washington", "Cherry", "Kiwi", "Lemon", "Tomato" /*XXX*/}, no_nulls()};
   auto ages_column_src = col_wrapper{{5, 10, 15, 20, null, XXX}, null_at(4)};
   auto is_human_col_src =
     bools_col{{true, true, false, false /*null*/, false, false /*XXX*/}, null_at(3)};
@@ -170,7 +170,7 @@ TYPED_TEST(TypedStructScatterTest, ComplexDataScatterTest)
     {"String 0" /*null*/, "String 1", "String 2" /*XXX*/, "String 3", "String 4", "String 5"},
     null_at(0)};
   auto ages_column_tgt  = col_wrapper{{50, null, XXX, 80, 90, 100}, null_at(1)};
-  auto is_human_col_tgt = bools_col{{true, true, true /*XXX*/, true, true, true}, no_null()};
+  auto is_human_col_tgt = bools_col{{true, true, true /*XXX*/, true, true, true}, no_nulls()};
   auto const structs_tgt =
     structs_col{{names_column_tgt, ages_column_tgt, is_human_col_tgt}, null_at(2)}.release();
 
@@ -181,7 +181,7 @@ TYPED_TEST(TypedStructScatterTest, ComplexDataScatterTest)
   auto is_human_col_expected =
     bools_col{{true, false, false /*null*/, false, true, true}, null_at(2)};
   auto const structs_expected =
-    structs_col{{names_column_expected, ages_column_expected, is_human_col_expected}, no_null()}
+    structs_col{{names_column_expected, ages_column_expected, is_human_col_expected}, no_nulls()}
       .release();
 
   // The first element of the target is not overwritten

--- a/cpp/tests/copying/scatter_struct_tests.cpp
+++ b/cpp/tests/copying/scatter_struct_tests.cpp
@@ -24,6 +24,8 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table_view.hpp>
 
+using namespace cudf::test::iterators;
+
 using bools_col   = cudf::test::fixed_width_column_wrapper<bool>;
 using int32s_col  = cudf::test::fixed_width_column_wrapper<int32_t>;
 using structs_col = cudf::test::structs_column_wrapper;
@@ -45,10 +47,6 @@ using TestTypes = cudf::test::Concat<cudf::test::IntegralTypes,
 TYPED_TEST_CASE(TypedStructScatterTest, TestTypes);
 
 namespace {
-auto no_null() { return cudf::test::iterator_no_null(); }
-
-auto null_at(cudf::size_type idx) { return cudf::test::iterator_with_null_at(idx); }
-
 auto scatter_structs(std::unique_ptr<cudf::column> const& structs_src,
                      std::unique_ptr<cudf::column> const& structs_tgt,
                      std::unique_ptr<cudf::column> const& scatter_map)

--- a/cpp/tests/groupby/argmax_tests.cpp
+++ b/cpp/tests/groupby/argmax_tests.cpp
@@ -107,7 +107,7 @@ TYPED_TEST(groupby_argmax_test, null_keys_and_values)
                                      {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0});
 
   //  {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  {6, 3,     5, 4, 0,   2, 1,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 4, 7, 0}, {1, 1, 1, 0});
 

--- a/cpp/tests/groupby/argmax_tests.cpp
+++ b/cpp/tests/groupby/argmax_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -59,7 +61,7 @@ TYPED_TEST(groupby_argmax_test, zero_valid_keys)
 
   if (std::is_same<V, bool>::value) return;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -80,10 +82,10 @@ TYPED_TEST(groupby_argmax_test, zero_valid_values)
   if (std::is_same<V, bool>::value) return;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_argmax_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -105,7 +107,7 @@ TYPED_TEST(groupby_argmax_test, null_keys_and_values)
                                      {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0});
 
   //  {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  {6, 3,     5, 4, 0,   2, 1,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 4, 7, 0}, {1, 1, 1, 0});
 
@@ -143,10 +145,10 @@ TEST_F(groupby_argmax_string_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, iterator_all_nulls());
+  strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_argmax_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));

--- a/cpp/tests/groupby/argmin_tests.cpp
+++ b/cpp/tests/groupby/argmin_tests.cpp
@@ -107,7 +107,7 @@ TYPED_TEST(groupby_argmin_test, null_keys_and_values)
                                      {1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 9, 6,     8, 5, 0,   7, 1,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 9, 8, 0}, {1, 1, 1, 0});
 

--- a/cpp/tests/groupby/argmin_tests.cpp
+++ b/cpp/tests/groupby/argmin_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -59,7 +61,7 @@ TYPED_TEST(groupby_argmin_test, zero_valid_keys)
 
   if (std::is_same<V, bool>::value) return;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -80,10 +82,10 @@ TYPED_TEST(groupby_argmin_test, zero_valid_values)
   if (std::is_same<V, bool>::value) return;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_argmin_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -105,7 +107,7 @@ TYPED_TEST(groupby_argmin_test, null_keys_and_values)
                                      {1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  { 9, 6,     8, 5, 0,   7, 1,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 9, 8, 0}, {1, 1, 1, 0});
 
@@ -144,10 +146,10 @@ TEST_F(groupby_argmin_string_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, iterator_all_nulls());
+  strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_argmin_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));

--- a/cpp/tests/groupby/count_scan_tests.cpp
+++ b/cpp/tests/groupby/count_scan_tests.cpp
@@ -125,7 +125,7 @@ TYPED_TEST(groupby_count_scan_test, null_keys_and_values)
   value_wrapper vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                        {1, 1, 1, 2, 2, 2, 2, 3, _, 3, 4}
-  key_wrapper expect_keys(  {1, 1, 1, 2, 2, 2, 2, 3,    3, 4}, no_null());
+  key_wrapper expect_keys(  {1, 1, 1, 2, 2, 2, 2, 3,    3, 4}, no_nulls());
   //                        {0, 3, 6, 1, 4, _, 9, 2, 7, 8, -}
   result_wrapper expect_vals{0, 1, 2, 0, 1,    2, 3, 0, 1, 0};
   // clang-format on

--- a/cpp/tests/groupby/count_scan_tests.cpp
+++ b/cpp/tests/groupby/count_scan_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 using K           = int32_t;
@@ -85,7 +87,7 @@ TYPED_TEST(groupby_count_scan_test, zero_valid_keys)
   using result_wrapper = typename TestFixture::result_wrapper;
 
   // clang-format off
-  key_wrapper keys( {1, 2, 3}, iterator_all_nulls());
+  key_wrapper keys( {1, 2, 3}, all_nulls());
   value_wrapper vals{3, 4, 5};
 
   key_wrapper expect_keys{};
@@ -103,7 +105,7 @@ TYPED_TEST(groupby_count_scan_test, zero_valid_values)
 
   // clang-format off
   key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, iterator_all_nulls());
+  value_wrapper vals({3, 4, 5}, all_nulls());
 
   key_wrapper expect_keys{1, 1, 1};
   result_wrapper expect_vals{0, 1, 2};
@@ -123,7 +125,7 @@ TYPED_TEST(groupby_count_scan_test, null_keys_and_values)
   value_wrapper vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                        {1, 1, 1, 2, 2, 2, 2, 3, _, 3, 4}
-  key_wrapper expect_keys(  {1, 1, 1, 2, 2, 2, 2, 3,    3, 4}, iterator_no_null());
+  key_wrapper expect_keys(  {1, 1, 1, 2, 2, 2, 2, 3,    3, 4}, no_null());
   //                        {0, 3, 6, 1, 4, _, 9, 2, 7, 8, -}
   result_wrapper expect_vals{0, 1, 2, 0, 1,    2, 3, 0, 1, 0};
   // clang-format on

--- a/cpp/tests/groupby/count_tests.cpp
+++ b/cpp/tests/groupby/count_tests.cpp
@@ -128,7 +128,7 @@ TYPED_TEST(groupby_count_test, null_keys_and_values)
 
   // clang-format off
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_nulls());
   //                                        {3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({2,        3,         2,       0});
   // clang-format on

--- a/cpp/tests/groupby/count_tests.cpp
+++ b/cpp/tests/groupby/count_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -76,7 +78,7 @@ TYPED_TEST(groupby_count_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -98,7 +100,7 @@ TYPED_TEST(groupby_count_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
   fixed_width_column_wrapper<R> expect_vals{0};
@@ -126,7 +128,7 @@ TYPED_TEST(groupby_count_test, null_keys_and_values)
 
   // clang-format off
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_null());
   //                                        {3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({2,        3,         2,       0});
   // clang-format on

--- a/cpp/tests/groupby/groups_tests.cpp
+++ b/cpp/tests/groupby/groups_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/types.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 struct groupby_group_keys_test : public BaseFixture {
@@ -58,7 +60,7 @@ TEST_F(groupby_group_keys_test, all_null_keys)
 {
   using K = int32_t;
 
-  fixed_width_column_wrapper<K> keys({1, 1, 2, 3, 1, 2}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 1, 2, 3, 1, 2}, all_nulls());
   fixed_width_column_wrapper<K> expect_grouped_keys{};
   std::vector<size_type> expect_group_offsets = {0};
   test_groups(keys, expect_grouped_keys, expect_group_offsets);
@@ -83,7 +85,7 @@ TYPED_TEST(groupby_group_keys_and_values_test, some_nulls)
   using V = TypeParam;
 
   fixed_width_column_wrapper<K> keys({1, 1, 3, 2, 1, 2}, {1, 0, 1, 0, 0, 1});
-  fixed_width_column_wrapper<K> expect_grouped_keys({1, 2, 3}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_grouped_keys({1, 2, 3}, no_null());
   fixed_width_column_wrapper<V> values({1, 2, 3, 4, 5, 6});
   fixed_width_column_wrapper<V> expect_grouped_values({1, 6, 3});
   std::vector<size_type> expect_group_offsets = {0, 1, 2, 3};

--- a/cpp/tests/groupby/groups_tests.cpp
+++ b/cpp/tests/groupby/groups_tests.cpp
@@ -85,7 +85,7 @@ TYPED_TEST(groupby_group_keys_and_values_test, some_nulls)
   using V = TypeParam;
 
   fixed_width_column_wrapper<K> keys({1, 1, 3, 2, 1, 2}, {1, 0, 1, 0, 0, 1});
-  fixed_width_column_wrapper<K> expect_grouped_keys({1, 2, 3}, no_null());
+  fixed_width_column_wrapper<K> expect_grouped_keys({1, 2, 3}, no_nulls());
   fixed_width_column_wrapper<V> values({1, 2, 3, 4, 5, 6});
   fixed_width_column_wrapper<V> expect_grouped_values({1, 6, 3});
   std::vector<size_type> expect_group_offsets = {0, 1, 2, 3};

--- a/cpp/tests/groupby/keys_tests.cpp
+++ b/cpp/tests/groupby/keys_tests.cpp
@@ -84,7 +84,7 @@ TYPED_TEST(groupby_keys_test, some_null_keys)
   fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3,  4}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4}, no_null() );
+  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4}, no_nulls() );
                                         //  { 0, 3, 6,  1, 4, 5, 9,  2, 8,  -}
   fixed_width_column_wrapper<R> expect_vals { 3,        4,           2,     1};
   // clang-format on
@@ -183,7 +183,7 @@ TYPED_TEST(groupby_keys_test, pre_sorted_keys_nullable)
                                             { 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1});
   fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
-  fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3,       4}, no_null() );
+  fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3,       4}, no_nulls() );
   fixed_width_column_wrapper<R> expect_vals { 3,       15,         17,      4};
   // clang-format on
 

--- a/cpp/tests/groupby/keys_tests.cpp
+++ b/cpp/tests/groupby/keys_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -59,7 +61,7 @@ TYPED_TEST(groupby_keys_test, zero_valid_keys)
   using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, iterator_all_nulls() );
+  fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_nulls() );
   fixed_width_column_wrapper<V> vals        { 3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys { };
@@ -82,7 +84,7 @@ TYPED_TEST(groupby_keys_test, some_null_keys)
   fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3,  4}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4}, iterator_no_null() );
+  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4}, no_null() );
                                         //  { 0, 3, 6,  1, 4, 5, 9,  2, 8,  -}
   fixed_width_column_wrapper<R> expect_vals { 3,        4,           2,     1};
   // clang-format on
@@ -181,7 +183,7 @@ TYPED_TEST(groupby_keys_test, pre_sorted_keys_nullable)
                                             { 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1});
   fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
-  fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3,       4}, iterator_no_null() );
+  fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3,       4}, no_null() );
   fixed_width_column_wrapper<R> expect_vals { 3,       15,         17,      4};
   // clang-format on
 

--- a/cpp/tests/groupby/max_scan_tests.cpp
+++ b/cpp/tests/groupby/max_scan_tests.cpp
@@ -118,7 +118,7 @@ TYPED_TEST(groupby_max_scan_test, null_keys_and_values)
   value_wrapper vals({5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                          //  {1, 1, 1, 2, 2, 2, 2, 3,   _, 3, 4}
-  key_wrapper expect_keys(   {1, 1, 1, 2, 2, 2, 2, 3,      3, 4}, no_null() );
+  key_wrapper expect_keys(   {1, 1, 1, 2, 2, 2, 2, 3,      3, 4}, no_nulls() );
                          //  { -, 3, 6, 1, 4,  -, 9, 2, _, 8, -}
   result_wrapper expect_vals({-1, 8, 8, 6, 9, -1, 9, 7,    7, -1},
                              { 0, 1, 1, 1, 1,  0, 1, 1,    1, 0});

--- a/cpp/tests/groupby/max_scan_tests.cpp
+++ b/cpp/tests/groupby/max_scan_tests.cpp
@@ -24,6 +24,8 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/dictionary/update_keys.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 using K           = int32_t;
@@ -78,7 +80,7 @@ TYPED_TEST(groupby_max_scan_test, zero_valid_keys)
   using result_wrapper = typename TestFixture::result_wrapper;
 
   // clang-format off
-  key_wrapper keys(  {1, 2, 3}, iterator_all_nulls());
+  key_wrapper keys(  {1, 2, 3}, all_nulls());
   value_wrapper vals({3, 4, 5});
 
   key_wrapper expect_keys{};
@@ -96,10 +98,10 @@ TYPED_TEST(groupby_max_scan_test, zero_valid_values)
 
   // clang-format off
   key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, iterator_all_nulls());
+  value_wrapper vals({3, 4, 5}, all_nulls());
 
   key_wrapper expect_keys    {1, 1, 1};
-  result_wrapper expect_vals({-1, -1, -1}, iterator_all_nulls());
+  result_wrapper expect_vals({-1, -1, -1}, all_nulls());
   // clang-format on
 
   auto agg = cudf::make_max_aggregation();
@@ -116,7 +118,7 @@ TYPED_TEST(groupby_max_scan_test, null_keys_and_values)
   value_wrapper vals({5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                          //  {1, 1, 1, 2, 2, 2, 2, 3,   _, 3, 4}
-  key_wrapper expect_keys(   {1, 1, 1, 2, 2, 2, 2, 3,      3, 4}, iterator_no_null() );
+  key_wrapper expect_keys(   {1, 1, 1, 2, 2, 2, 2, 3,      3, 4}, no_null() );
                          //  { -, 3, 6, 1, 4,  -, 9, 2, _, 8, -}
   result_wrapper expect_vals({-1, 8, 8, 6, 9, -1, 9, 7,    7, -1},
                              { 0, 1, 1, 1, 1,  0, 1, 1,    1, 0});

--- a/cpp/tests/groupby/max_tests.cpp
+++ b/cpp/tests/groupby/max_tests.cpp
@@ -118,7 +118,7 @@ TYPED_TEST(groupby_max_test, null_keys_and_values)
                                      {1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 0, 3,     1, 4, 5,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 5, 8, 0}, {1, 1, 1, 0});
 

--- a/cpp/tests/groupby/max_tests.cpp
+++ b/cpp/tests/groupby/max_tests.cpp
@@ -24,6 +24,8 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/dictionary/update_keys.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -74,7 +76,7 @@ TYPED_TEST(groupby_max_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::MAX>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -93,10 +95,10 @@ TYPED_TEST(groupby_max_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::MAX>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_max_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -116,7 +118,7 @@ TYPED_TEST(groupby_max_test, null_keys_and_values)
                                      {1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  { 0, 3,     1, 4, 5,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 5, 8, 0}, {1, 1, 1, 0});
 
@@ -148,10 +150,10 @@ TEST_F(groupby_max_string_test, basic)
 TEST_F(groupby_max_string_test, zero_valid_values)
 {
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, iterator_all_nulls());
+  strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  strings_column_wrapper expect_vals({""}, iterator_all_nulls());
+  strings_column_wrapper expect_vals({""}, all_nulls());
 
   auto agg = cudf::make_max_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));

--- a/cpp/tests/groupby/mean_tests.cpp
+++ b/cpp/tests/groupby/mean_tests.cpp
@@ -129,7 +129,7 @@ TYPED_TEST(groupby_mean_test, null_keys_and_values)
 
   // clang-format off
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_nulls());
   //                                        {3, 6,     1, 4, 9,   2, 8,    -}
   std::vector<RT> expect_v = convert<RT>(   {4.5,      14. / 3,   5.,      0.});
   fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend(), {1, 1, 1, 0});

--- a/cpp/tests/groupby/mean_tests.cpp
+++ b/cpp/tests/groupby/mean_tests.cpp
@@ -30,6 +30,8 @@
 #include <type_traits>
 #include <vector>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -89,7 +91,7 @@ TYPED_TEST(groupby_mean_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -105,10 +107,10 @@ TYPED_TEST(groupby_mean_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_mean_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -127,7 +129,7 @@ TYPED_TEST(groupby_mean_test, null_keys_and_values)
 
   // clang-format off
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_null());
   //                                        {3, 6,     1, 4, 9,   2, 8,    -}
   std::vector<RT> expect_v = convert<RT>(   {4.5,      14. / 3,   5.,      0.});
   fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend(), {1, 1, 1, 0});

--- a/cpp/tests/groupby/median_tests.cpp
+++ b/cpp/tests/groupby/median_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -46,7 +48,7 @@ TYPED_TEST(groupby_median_test, basic)
   //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1,       2,          3};
   //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,     4.5,        7.}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,     4.5,        7.}, no_null());
   // clang-format on
 
   auto agg = cudf::make_median_aggregation();
@@ -73,7 +75,7 @@ TYPED_TEST(groupby_median_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -89,10 +91,10 @@ TYPED_TEST(groupby_median_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_median_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -109,7 +111,7 @@ TYPED_TEST(groupby_median_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
@@ -129,7 +131,7 @@ TYPED_TEST(groupby_median_test, dictionary)
   //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,       2,          3      });
   //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       4.5,       7.     }, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,       4.5,       7.     }, no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_median_aggregation());

--- a/cpp/tests/groupby/median_tests.cpp
+++ b/cpp/tests/groupby/median_tests.cpp
@@ -48,7 +48,7 @@ TYPED_TEST(groupby_median_test, basic)
   //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1,       2,          3};
   //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,     4.5,        7.}, no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,     4.5,        7.}, no_nulls());
   // clang-format on
 
   auto agg = cudf::make_median_aggregation();
@@ -111,7 +111,7 @@ TYPED_TEST(groupby_median_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
@@ -131,7 +131,7 @@ TYPED_TEST(groupby_median_test, dictionary)
   //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,       2,          3      });
   //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       4.5,       7.     }, no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,       4.5,       7.     }, no_nulls());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_median_aggregation());

--- a/cpp/tests/groupby/min_scan_tests.cpp
+++ b/cpp/tests/groupby/min_scan_tests.cpp
@@ -116,7 +116,7 @@ TYPED_TEST(groupby_min_scan_test, null_keys_and_values)
   value_wrapper vals({5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                          //  { 1, 1, 1, 2, 2,  2, 2, 3, _, 3, 4}
-  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2, 2, 3,    3, 4}, no_null());
+  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2, 2, 3,    3, 4}, no_nulls());
                          //  { _, 8, 1, 6, 9,  _, 4, 7, 2, 3, _}
   result_wrapper expect_vals({-1, 8, 1, 6, 6, -1, 4, 7,    3, -1},
                              { 0, 1, 1, 1, 1,  0, 1, 1,    1, 0});

--- a/cpp/tests/groupby/min_scan_tests.cpp
+++ b/cpp/tests/groupby/min_scan_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 using K           = int32_t;
@@ -76,7 +78,7 @@ TYPED_TEST(groupby_min_scan_test, zero_valid_keys)
   using result_wrapper = typename TestFixture::result_wrapper;
 
   // clang-format off
-  key_wrapper keys({1, 2, 3}, iterator_all_nulls());
+  key_wrapper keys({1, 2, 3}, all_nulls());
   value_wrapper vals({3, 4, 5});
 
   key_wrapper expect_keys{};
@@ -94,10 +96,10 @@ TYPED_TEST(groupby_min_scan_test, zero_valid_values)
 
   // clang-format off
   key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, iterator_all_nulls());
+  value_wrapper vals({3, 4, 5}, all_nulls());
 
   key_wrapper expect_keys    {1, 1, 1};
-  result_wrapper expect_vals({-1, -1, -1}, iterator_all_nulls());
+  result_wrapper expect_vals({-1, -1, -1}, all_nulls());
   // clang-format on
 
   auto agg = cudf::make_min_aggregation();
@@ -114,7 +116,7 @@ TYPED_TEST(groupby_min_scan_test, null_keys_and_values)
   value_wrapper vals({5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                          //  { 1, 1, 1, 2, 2,  2, 2, 3, _, 3, 4}
-  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2, 2, 3,    3, 4}, iterator_no_null());
+  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2, 2, 3,    3, 4}, no_null());
                          //  { _, 8, 1, 6, 9,  _, 4, 7, 2, 3, _}
   result_wrapper expect_vals({-1, 8, 1, 6, 6, -1, 4, 7,    3, -1},
                              { 0, 1, 1, 1, 1,  0, 1, 1,    1, 0});

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -118,7 +118,7 @@ TYPED_TEST(groupby_min_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 1, 2, 0}, {1, 1, 1, 0});
 

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -24,6 +24,8 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/dictionary/update_keys.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -74,7 +76,7 @@ TYPED_TEST(groupby_min_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::MIN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -93,10 +95,10 @@ TYPED_TEST(groupby_min_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::MIN>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_min_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -116,7 +118,7 @@ TYPED_TEST(groupby_min_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({3, 1, 2, 0}, {1, 1, 1, 0});
 
@@ -148,10 +150,10 @@ TEST_F(groupby_min_string_test, basic)
 TEST_F(groupby_min_string_test, zero_valid_values)
 {
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, iterator_all_nulls());
+  strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  strings_column_wrapper expect_vals({""}, iterator_all_nulls());
+  strings_column_wrapper expect_vals({""}, all_nulls());
 
   auto agg = cudf::make_min_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));

--- a/cpp/tests/groupby/nth_element_tests.cpp
+++ b/cpp/tests/groupby/nth_element_tests.cpp
@@ -24,6 +24,8 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/dictionary/update_keys.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 
@@ -142,7 +144,7 @@ TYPED_TEST(groupby_nth_element_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -159,10 +161,10 @@ TYPED_TEST(groupby_nth_element_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R, int32_t> expect_vals({3}, iterator_all_nulls());
+  fixed_width_column_wrapper<R, int32_t> expect_vals({3}, all_nulls());
 
   auto agg = cudf::make_nth_element_aggregation(0);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -179,7 +181,7 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
                                               {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //keys                                    {1, 1, 1   2,2,2,2    3, 3,    4}
   //vals                                    {-,3,6,    1,4,-,9,  2,8,      -}
   fixed_width_column_wrapper<R, int32_t> expect_vals({-1, 1, 2, -1}, {0, 1, 1, 0});
@@ -199,7 +201,7 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values_out_of_bounds)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
                                               {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
   //                                        {1, 1, 1    2, 2, 2,    3, 3,   4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //                                        {-,3,6,     1,4,-,9,    2,8,    -}
   //                                         value,     null,       out,    out
   fixed_width_column_wrapper<R, int32_t> expect_vals({6, -1, -1, -1}, {1, 0, 0, 0});
@@ -219,7 +221,7 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
                                               {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //keys                                    {1, 1, 1    2, 2, 2, 2      3, 3, 3    4}
   //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,   4,-}
   //                                      0  null,      value,          value,     null
@@ -261,7 +263,7 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls_negative_index)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
                                               {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //keys                                    {1, 1, 1    2, 2, 2,        3, 3,       4}
   //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,    4,-}
   //                                      0  null,      value,          value,      value

--- a/cpp/tests/groupby/nth_element_tests.cpp
+++ b/cpp/tests/groupby/nth_element_tests.cpp
@@ -181,7 +181,7 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
                                               {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //keys                                    {1, 1, 1   2,2,2,2    3, 3,    4}
   //vals                                    {-,3,6,    1,4,-,9,  2,8,      -}
   fixed_width_column_wrapper<R, int32_t> expect_vals({-1, 1, 2, -1}, {0, 1, 1, 0});
@@ -201,7 +201,7 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values_out_of_bounds)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
                                               {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
   //                                        {1, 1, 1    2, 2, 2,    3, 3,   4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //                                        {-,3,6,     1,4,-,9,    2,8,    -}
   //                                         value,     null,       out,    out
   fixed_width_column_wrapper<R, int32_t> expect_vals({6, -1, -1, -1}, {1, 0, 0, 0});
@@ -221,7 +221,7 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
                                               {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //keys                                    {1, 1, 1    2, 2, 2, 2      3, 3, 3    4}
   //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,   4,-}
   //                                      0  null,      value,          value,     null
@@ -263,7 +263,7 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls_negative_index)
   fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
                                               {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //keys                                    {1, 1, 1    2, 2, 2,        3, 3,       4}
   //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,    4,-}
   //                                      0  null,      value,          value,      value

--- a/cpp/tests/groupby/nunique_tests.cpp
+++ b/cpp/tests/groupby/nunique_tests.cpp
@@ -131,7 +131,7 @@ TYPED_TEST(groupby_nunique_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   // all unique values only                 {3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
   fixed_width_column_wrapper<R> expect_bool_vals{1, 1, 1, 0};
@@ -154,7 +154,7 @@ TYPED_TEST(groupby_nunique_test, null_keys_and_values_with_duplicates)
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   //  { 1, 1,     2, 2, 2,    3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
   //  unique,     with null,  dup,     dup null
   fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
@@ -178,7 +178,7 @@ TYPED_TEST(groupby_nunique_test, include_nulls)
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   //  { 1, 1,     2, 2, 2,    3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
   //  unique,     with null,  dup,     dup null
   fixed_width_column_wrapper<R> expect_vals{3, 4, 2, 1};
@@ -203,7 +203,7 @@ TYPED_TEST(groupby_nunique_test, dictionary)
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   // { 1, 1,   2, 2, 2,   3, 3,   4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   // { 3, 6,-  1, 4, 9,-  2*, 8,  -*}
   //  unique,  with null, dup,    dup null
   fixed_width_column_wrapper<R> expect_fixed_vals({3, 4, 2, 1});

--- a/cpp/tests/groupby/nunique_tests.cpp
+++ b/cpp/tests/groupby/nunique_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -93,7 +95,7 @@ TYPED_TEST(groupby_nunique_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals({3, 4, 5});
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -109,7 +111,7 @@ TYPED_TEST(groupby_nunique_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
   fixed_width_column_wrapper<R> expect_vals{0};
@@ -129,7 +131,7 @@ TYPED_TEST(groupby_nunique_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   // all unique values only                 {3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
   fixed_width_column_wrapper<R> expect_bool_vals{1, 1, 1, 0};
@@ -152,7 +154,7 @@ TYPED_TEST(groupby_nunique_test, null_keys_and_values_with_duplicates)
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   //  { 1, 1,     2, 2, 2,    3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
   //  unique,     with null,  dup,     dup null
   fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
@@ -176,7 +178,7 @@ TYPED_TEST(groupby_nunique_test, include_nulls)
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   //  { 1, 1,     2, 2, 2,    3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
   //  unique,     with null,  dup,     dup null
   fixed_width_column_wrapper<R> expect_vals{3, 4, 2, 1};
@@ -201,7 +203,7 @@ TYPED_TEST(groupby_nunique_test, dictionary)
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   // { 1, 1,   2, 2, 2,   3, 3,   4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   // { 3, 6,-  1, 4, 9,-  2*, 8,  -*}
   //  unique,  with null, dup,    dup null
   fixed_width_column_wrapper<R> expect_fixed_vals({3, 4, 2, 1});

--- a/cpp/tests/groupby/product_tests.cpp
+++ b/cpp/tests/groupby/product_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -46,7 +48,7 @@ TYPED_TEST(groupby_product_test, basic)
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys { 1,        2,           3      };
                                         //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({   0.,       180.,      112. }, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({   0.,       180.,      112. }, no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
@@ -71,7 +73,7 @@ TYPED_TEST(groupby_product_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -86,10 +88,10 @@ TYPED_TEST(groupby_product_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
 }
@@ -106,7 +108,7 @@ TYPED_TEST(groupby_product_test, null_keys_and_values)
                                             { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                                         //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, no_null());
                                         //  { _, 3, 6,  1, 4, 9,   2, 8,    _}
   fixed_width_column_wrapper<R> expect_vals({ 18.,      36.,       16.,     3.},
                                             { 1,        1,         1,       0});
@@ -127,7 +129,7 @@ TYPED_TEST(groupby_product_test, dictionary)
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
                                         //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        112. }, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        112. }, no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
@@ -146,7 +148,7 @@ TYPED_TEST(groupby_product_test, dictionary_with_nulls)
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
                                         //  { 0, 3, 6,  @, 4, 5, 9,  @, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        56. }, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        56. }, no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());

--- a/cpp/tests/groupby/product_tests.cpp
+++ b/cpp/tests/groupby/product_tests.cpp
@@ -48,7 +48,7 @@ TYPED_TEST(groupby_product_test, basic)
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys { 1,        2,           3      };
                                         //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({   0.,       180.,      112. }, no_null());
+  fixed_width_column_wrapper<R> expect_vals({   0.,       180.,      112. }, no_nulls());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
@@ -108,7 +108,7 @@ TYPED_TEST(groupby_product_test, null_keys_and_values)
                                             { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                                         //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, no_nulls());
                                         //  { _, 3, 6,  1, 4, 9,   2, 8,    _}
   fixed_width_column_wrapper<R> expect_vals({ 18.,      36.,       16.,     3.},
                                             { 1,        1,         1,       0});
@@ -129,7 +129,7 @@ TYPED_TEST(groupby_product_test, dictionary)
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
                                         //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        112. }, no_null());
+  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        112. }, no_nulls());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());
@@ -148,7 +148,7 @@ TYPED_TEST(groupby_product_test, dictionary_with_nulls)
                                         //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
                                         //  { 0, 3, 6,  @, 4, 5, 9,  @, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        56. }, no_null());
+  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        56. }, no_nulls());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_product_aggregation());

--- a/cpp/tests/groupby/quantile_tests.cpp
+++ b/cpp/tests/groupby/quantile_tests.cpp
@@ -48,7 +48,7 @@ TYPED_TEST(groupby_quantile_test, basic)
   //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //                                       {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3., 4.5, 7.}, no_null());
+  fixed_width_column_wrapper<R> expect_vals({3., 4.5, 7.}, no_nulls());
   // clang-format on
 
   auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
@@ -111,7 +111,7 @@ TYPED_TEST(groupby_quantile_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
@@ -131,7 +131,7 @@ TYPED_TEST(groupby_quantile_test, multiple_quantile)
   //                                       {1, 1, 1,   2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //                                        {0, 3, 6,  1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({1.5, 4.5, 3.25, 6.,   4.5, 7.5}, no_null());
+  fixed_width_column_wrapper<R> expect_vals({1.5, 4.5, 3.25, 6.,   4.5, 7.5}, no_nulls());
   // clang-format on
 
   auto agg = cudf::make_quantile_aggregation({0.25, 0.75}, interpolation::LINEAR);
@@ -151,27 +151,27 @@ TYPED_TEST(groupby_quantile_test, interpolation_types)
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals1({2.4,      4.2,         4.}, no_null());
+  fixed_width_column_wrapper<R> expect_vals1({2.4,      4.2,         4.}, no_nulls());
   auto agg1 = cudf::make_quantile_aggregation({0.4}, interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg1));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals2({3,        4,           2}, no_null());
+  fixed_width_column_wrapper<R> expect_vals2({3,        4,           2}, no_nulls());
   auto agg2 = cudf::make_quantile_aggregation({0.4}, interpolation::NEAREST);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals3({0,        4,          2}, no_null());
+  fixed_width_column_wrapper<R> expect_vals3({0,        4,          2}, no_nulls());
   auto agg3 = cudf::make_quantile_aggregation({0.4}, interpolation::LOWER);
   test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg3));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals4({3,        5,           7}, no_null());
+  fixed_width_column_wrapper<R> expect_vals4({3,        5,           7}, no_nulls());
   auto agg4 = cudf::make_quantile_aggregation({0.4}, interpolation::HIGHER);
   test_single_agg(keys, vals, expect_keys, expect_vals4, std::move(agg4));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals5({1.5,      4.5,         4.5}, no_null());
+  fixed_width_column_wrapper<R> expect_vals5({1.5,      4.5,         4.5}, no_nulls());
   auto agg5 = cudf::make_quantile_aggregation({0.4}, interpolation::MIDPOINT);
   test_single_agg(keys, vals, expect_keys, expect_vals5, std::move(agg5));
   // clang-format on
@@ -189,7 +189,7 @@ TYPED_TEST(groupby_quantile_test, dictionary)
   //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1, 2, 3});
   //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,      4.5,        7.}, no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,      4.5,        7.}, no_nulls());
   // clang-format on
 
   test_single_agg(keys,

--- a/cpp/tests/groupby/quantile_tests.cpp
+++ b/cpp/tests/groupby/quantile_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -46,7 +48,7 @@ TYPED_TEST(groupby_quantile_test, basic)
   //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //                                       {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3., 4.5, 7.}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({3., 4.5, 7.}, no_null());
   // clang-format on
 
   auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
@@ -73,7 +75,7 @@ TYPED_TEST(groupby_quantile_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -89,10 +91,10 @@ TYPED_TEST(groupby_quantile_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_quantile_aggregation({0.5}, interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -109,7 +111,7 @@ TYPED_TEST(groupby_quantile_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
@@ -129,7 +131,7 @@ TYPED_TEST(groupby_quantile_test, multiple_quantile)
   //                                       {1, 1, 1,   2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //                                        {0, 3, 6,  1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({1.5, 4.5, 3.25, 6.,   4.5, 7.5}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({1.5, 4.5, 3.25, 6.,   4.5, 7.5}, no_null());
   // clang-format on
 
   auto agg = cudf::make_quantile_aggregation({0.25, 0.75}, interpolation::LINEAR);
@@ -149,27 +151,27 @@ TYPED_TEST(groupby_quantile_test, interpolation_types)
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals1({2.4,      4.2,         4.}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals1({2.4,      4.2,         4.}, no_null());
   auto agg1 = cudf::make_quantile_aggregation({0.4}, interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg1));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals2({3,        4,           2}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals2({3,        4,           2}, no_null());
   auto agg2 = cudf::make_quantile_aggregation({0.4}, interpolation::NEAREST);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals3({0,        4,          2}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals3({0,        4,          2}, no_null());
   auto agg3 = cudf::make_quantile_aggregation({0.4}, interpolation::LOWER);
   test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg3));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals4({3,        5,           7}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals4({3,        5,           7}, no_null());
   auto agg4 = cudf::make_quantile_aggregation({0.4}, interpolation::HIGHER);
   test_single_agg(keys, vals, expect_keys, expect_vals4, std::move(agg4));
 
   //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals5({1.5,      4.5,         4.5}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals5({1.5,      4.5,         4.5}, no_null());
   auto agg5 = cudf::make_quantile_aggregation({0.4}, interpolation::MIDPOINT);
   test_single_agg(keys, vals, expect_keys, expect_vals5, std::move(agg5));
   // clang-format on
@@ -187,7 +189,7 @@ TYPED_TEST(groupby_quantile_test, dictionary)
   //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1, 2, 3});
   //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,      4.5,        7.}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,      4.5,        7.}, no_null());
   // clang-format on
 
   test_single_agg(keys,

--- a/cpp/tests/groupby/replace_nulls_tests.cpp
+++ b/cpp/tests/groupby/replace_nulls_tests.cpp
@@ -27,6 +27,8 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 
@@ -58,7 +60,7 @@ TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, PrecedingFill)
   fixed_width_column_wrapper<TypeParam> val({42, 7, 24, 10, 1, 1000}, {1, 1, 1, 0, 0, 0});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({42, 24, 24, 7, 7, 7}, iterator_no_null());
+  fixed_width_column_wrapper<TypeParam> expect_val({42, 24, 24, 7, 7, 7}, no_null());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
 }
@@ -72,8 +74,7 @@ TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, FollowingFill)
                                             {1, 0, 1, 0, 1, 0, 1, 1});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({2, 32, 32, 8, 128, 128, 128, 256},
-                                                   iterator_no_null());
+  fixed_width_column_wrapper<TypeParam> expect_val({2, 32, 32, 8, 128, 128, 128, 256}, no_null());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
 }
@@ -118,8 +119,7 @@ TEST_F(GroupbyReplaceNullsStringsTest, PrecedingFill)
                              {true, false, true, true, true, false, true});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"y", "42", "xx", "xx", "zzz", "zzz", "one"},
-                                    iterator_no_null());
+  strings_column_wrapper expect_val({"y", "42", "xx", "xx", "zzz", "zzz", "one"}, no_null());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
 }
@@ -133,8 +133,7 @@ TEST_F(GroupbyReplaceNullsStringsTest, FollowingFill)
                              {true, false, false, true, true, false, true});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"42", "42", "xx", "zzz", "zzz", "one", "one"},
-                                    iterator_no_null());
+  strings_column_wrapper expect_val({"42", "42", "xx", "zzz", "zzz", "one", "one"}, no_null());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
 }

--- a/cpp/tests/groupby/replace_nulls_tests.cpp
+++ b/cpp/tests/groupby/replace_nulls_tests.cpp
@@ -60,7 +60,7 @@ TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, PrecedingFill)
   fixed_width_column_wrapper<TypeParam> val({42, 7, 24, 10, 1, 1000}, {1, 1, 1, 0, 0, 0});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({42, 24, 24, 7, 7, 7}, no_null());
+  fixed_width_column_wrapper<TypeParam> expect_val({42, 24, 24, 7, 7, 7}, no_nulls());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
 }
@@ -74,7 +74,7 @@ TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, FollowingFill)
                                             {1, 0, 1, 0, 1, 0, 1, 1});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({2, 32, 32, 8, 128, 128, 128, 256}, no_null());
+  fixed_width_column_wrapper<TypeParam> expect_val({2, 32, 32, 8, 128, 128, 128, 256}, no_nulls());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
 }
@@ -119,7 +119,7 @@ TEST_F(GroupbyReplaceNullsStringsTest, PrecedingFill)
                              {true, false, true, true, true, false, true});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"y", "42", "xx", "xx", "zzz", "zzz", "one"}, no_null());
+  strings_column_wrapper expect_val({"y", "42", "xx", "xx", "zzz", "zzz", "one"}, no_nulls());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
 }
@@ -133,7 +133,7 @@ TEST_F(GroupbyReplaceNullsStringsTest, FollowingFill)
                              {true, false, false, true, true, false, true});
 
   fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"42", "42", "xx", "zzz", "zzz", "one", "one"}, no_null());
+  strings_column_wrapper expect_val({"42", "42", "xx", "zzz", "zzz", "one", "one"}, no_nulls());
 
   TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
 }

--- a/cpp/tests/groupby/std_tests.cpp
+++ b/cpp/tests/groupby/std_tests.cpp
@@ -25,6 +25,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -48,7 +50,7 @@ TYPED_TEST(groupby_std_test, basic)
   //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
   fixed_width_column_wrapper<K>  expect_keys{1,        2,             3};
   //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_null());
   // clang-format on
 
   auto agg = cudf::make_std_aggregation();
@@ -75,7 +77,7 @@ TYPED_TEST(groupby_std_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -91,10 +93,10 @@ TYPED_TEST(groupby_std_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::STD>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_std_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -111,7 +113,7 @@ TYPED_TEST(groupby_std_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   //                                        { 1, 1,     2, 2, 2,   3, 3,       4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //                                        { 3, 6,     1, 4, 9,   2, 8,       3}
   fixed_width_column_wrapper<R> expect_vals({3 / sqrt(2), 7 / sqrt(3), 3 * sqrt(2), 0.},
                                             {1, 1, 1, 0});
@@ -131,7 +133,7 @@ TYPED_TEST(groupby_std_test, ddof_non_default)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({0., 7 * sqrt(2. / 3), 0., 0.}, {0, 1, 0, 0});
 
@@ -151,7 +153,7 @@ TYPED_TEST(groupby_std_test, dictionary)
   //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,        2,             3});
   //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_std_aggregation());

--- a/cpp/tests/groupby/std_tests.cpp
+++ b/cpp/tests/groupby/std_tests.cpp
@@ -50,7 +50,7 @@ TYPED_TEST(groupby_std_test, basic)
   //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
   fixed_width_column_wrapper<K>  expect_keys{1,        2,             3};
   //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_nulls());
   // clang-format on
 
   auto agg = cudf::make_std_aggregation();
@@ -113,7 +113,7 @@ TYPED_TEST(groupby_std_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   //                                        { 1, 1,     2, 2, 2,   3, 3,       4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //                                        { 3, 6,     1, 4, 9,   2, 8,       3}
   fixed_width_column_wrapper<R> expect_vals({3 / sqrt(2), 7 / sqrt(3), 3 * sqrt(2), 0.},
                                             {1, 1, 1, 0});
@@ -133,7 +133,7 @@ TYPED_TEST(groupby_std_test, ddof_non_default)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({0., 7 * sqrt(2. / 3), 0., 0.}, {0, 1, 0, 0});
 
@@ -153,7 +153,7 @@ TYPED_TEST(groupby_std_test, dictionary)
   //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,        2,             3});
   //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_null());
+  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_nulls());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_std_aggregation());

--- a/cpp/tests/groupby/sum_of_squares_tests.cpp
+++ b/cpp/tests/groupby/sum_of_squares_tests.cpp
@@ -47,7 +47,7 @@ TYPED_TEST(groupby_sum_of_squares_test, basic)
   //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({45., 123., 117.}, no_null());
+  fixed_width_column_wrapper<R> expect_vals({45., 123., 117.}, no_nulls());
 
   auto agg = cudf::make_sum_of_squares_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -109,7 +109,7 @@ TYPED_TEST(groupby_sum_of_squares_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({45., 98., 68., 9.}, {1, 1, 1, 0});
 
@@ -129,7 +129,7 @@ TYPED_TEST(groupby_sum_of_squares_test, dictionary)
   //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
   //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({45.,       123.,       117.   }, no_null());
+  fixed_width_column_wrapper<R> expect_vals({45.,       123.,       117.   }, no_nulls());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_sum_of_squares_aggregation());

--- a/cpp/tests/groupby/sum_of_squares_tests.cpp
+++ b/cpp/tests/groupby/sum_of_squares_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -45,7 +47,7 @@ TYPED_TEST(groupby_sum_of_squares_test, basic)
   //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({45., 123., 117.}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({45., 123., 117.}, no_null());
 
   auto agg = cudf::make_sum_of_squares_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -71,7 +73,7 @@ TYPED_TEST(groupby_sum_of_squares_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -87,10 +89,10 @@ TYPED_TEST(groupby_sum_of_squares_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_sum_of_squares_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -107,7 +109,7 @@ TYPED_TEST(groupby_sum_of_squares_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({45., 98., 68., 9.}, {1, 1, 1, 0});
 
@@ -127,7 +129,7 @@ TYPED_TEST(groupby_sum_of_squares_test, dictionary)
   //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
   //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({45.,       123.,       117.   }, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({45.,       123.,       117.   }, no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_sum_of_squares_aggregation());

--- a/cpp/tests/groupby/sum_scan_tests.cpp
+++ b/cpp/tests/groupby/sum_scan_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 using K           = int32_t;
@@ -82,7 +84,7 @@ TYPED_TEST(groupby_sum_scan_test, zero_valid_keys)
   using result_wrapper = typename TestFixture::result_wrapper;
 
   // clang-format off
-  key_wrapper keys({1, 2, 3}, iterator_all_nulls());
+  key_wrapper keys({1, 2, 3}, all_nulls());
   value_wrapper vals{3, 4, 5};
 
   key_wrapper expect_keys{};
@@ -100,10 +102,10 @@ TYPED_TEST(groupby_sum_scan_test, zero_valid_values)
 
   // clang-format off
   key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, iterator_all_nulls());
+  value_wrapper vals({3, 4, 5}, all_nulls());
 
   key_wrapper expect_keys    {1, 1, 1};
-  result_wrapper expect_vals({3, 4, 5}, iterator_all_nulls());
+  result_wrapper expect_vals({3, 4, 5}, all_nulls());
   // clang-format on
 
   auto agg = cudf::make_sum_aggregation();
@@ -120,7 +122,7 @@ TYPED_TEST(groupby_sum_scan_test, null_keys_and_values)
   value_wrapper vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                         { 1, 1, 1, 2, 2,  2,  2, 3, *, 3, 4};
-  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2,  2, 3,    3, 4}, iterator_no_null());
+  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2,  2, 3,    3, 4}, no_null());
                           // { -, 3, 6, 1, 4,  -,  9, 2, _, 8, -}
   result_wrapper expect_vals({-1, 3, 9, 1, 5, -1, 14, 2,   10, -1},
                              { 0, 1, 1, 1, 1,  0,  1, 1,    1, 0});

--- a/cpp/tests/groupby/sum_scan_tests.cpp
+++ b/cpp/tests/groupby/sum_scan_tests.cpp
@@ -122,7 +122,7 @@ TYPED_TEST(groupby_sum_scan_test, null_keys_and_values)
   value_wrapper vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                         { 1, 1, 1, 2, 2,  2,  2, 3, *, 3, 4};
-  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2,  2, 3,    3, 4}, no_null());
+  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2,  2, 3,    3, 4}, no_nulls());
                           // { -, 3, 6, 1, 4,  -,  9, 2, _, 8, -}
   result_wrapper expect_vals({-1, 3, 9, 1, 5, -1, 14, 2,   10, -1},
                              { 0, 1, 1, 1, 1,  0,  1, 1,    1, 0});

--- a/cpp/tests/groupby/sum_tests.cpp
+++ b/cpp/tests/groupby/sum_tests.cpp
@@ -121,7 +121,7 @@ TYPED_TEST(groupby_sum_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({9, 14, 10, 0}, {1, 1, 1, 0});
 

--- a/cpp/tests/groupby/sum_tests.cpp
+++ b/cpp/tests/groupby/sum_tests.cpp
@@ -23,6 +23,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -77,7 +79,7 @@ TYPED_TEST(groupby_sum_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -96,10 +98,10 @@ TYPED_TEST(groupby_sum_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::SUM>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_sum_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -119,7 +121,7 @@ TYPED_TEST(groupby_sum_test, null_keys_and_values)
                                      {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_null());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
   fixed_width_column_wrapper<R> expect_vals({9, 14, 10, 0}, {1, 1, 1, 0});
 

--- a/cpp/tests/groupby/var_tests.cpp
+++ b/cpp/tests/groupby/var_tests.cpp
@@ -25,6 +25,8 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace cudf {
 namespace test {
 template <typename V>
@@ -48,7 +50,7 @@ TYPED_TEST(groupby_var_test, basic)
   //                                       {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1,        2,           3};
   //                                       {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({9.,      131. / 12,   31. / 3}, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({9.,      131. / 12,   31. / 3}, no_null());
   // clang-format on
 
   auto agg = cudf::make_variance_aggregation();
@@ -75,7 +77,7 @@ TYPED_TEST(groupby_var_test, zero_valid_keys)
   using V = TypeParam;
   using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, iterator_all_nulls());
+  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
   fixed_width_column_wrapper<V> vals{3, 4, 5};
 
   fixed_width_column_wrapper<K> expect_keys{};
@@ -91,10 +93,10 @@ TYPED_TEST(groupby_var_test, zero_valid_values)
   using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
 
   fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, iterator_all_nulls());
+  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
   fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, iterator_all_nulls());
+  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_variance_aggregation();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -112,7 +114,7 @@ TYPED_TEST(groupby_var_test, null_keys_and_values)
 
   // clang-format off
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_null());
   //                                        {3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({4.5,      49. / 3,   18.,     0.}, {1, 1, 1, 0});
   // clang-format on
@@ -133,7 +135,7 @@ TYPED_TEST(groupby_var_test, ddof_non_default)
 
   // clang-format off
   //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,         2,         3,       4}, iterator_no_null());
+  fixed_width_column_wrapper<K> expect_keys({1,         2,         3,       4}, no_null());
   //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({0.,        98. / 3,   0.,      0.},
                                             {0,         1,         0,       0});
@@ -155,7 +157,7 @@ TYPED_TEST(groupby_var_test, dictionary)
   //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
   //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({9.,      131./12,      31./3  }, iterator_no_null());
+  fixed_width_column_wrapper<R> expect_vals({9.,      131./12,      31./3  }, no_null());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_variance_aggregation());

--- a/cpp/tests/groupby/var_tests.cpp
+++ b/cpp/tests/groupby/var_tests.cpp
@@ -50,7 +50,7 @@ TYPED_TEST(groupby_var_test, basic)
   //                                       {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys{1,        2,           3};
   //                                       {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({9.,      131. / 12,   31. / 3}, no_null());
+  fixed_width_column_wrapper<R> expect_vals({9.,      131. / 12,   31. / 3}, no_nulls());
   // clang-format on
 
   auto agg = cudf::make_variance_aggregation();
@@ -114,7 +114,7 @@ TYPED_TEST(groupby_var_test, null_keys_and_values)
 
   // clang-format off
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_nulls());
   //                                        {3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({4.5,      49. / 3,   18.,     0.}, {1, 1, 1, 0});
   // clang-format on
@@ -135,7 +135,7 @@ TYPED_TEST(groupby_var_test, ddof_non_default)
 
   // clang-format off
   //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,         2,         3,       4}, no_null());
+  fixed_width_column_wrapper<K> expect_keys({1,         2,         3,       4}, no_nulls());
   //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
   fixed_width_column_wrapper<R> expect_vals({0.,        98. / 3,   0.,      0.},
                                             {0,         1,         0,       0});
@@ -157,7 +157,7 @@ TYPED_TEST(groupby_var_test, dictionary)
   //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
   fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
   //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({9.,      131./12,      31./3  }, no_null());
+  fixed_width_column_wrapper<R> expect_vals({9.,      131./12,      31./3  }, no_nulls());
   // clang-format on
 
   test_single_agg(keys, vals, expect_keys, expect_vals, cudf::make_variance_aggregation());

--- a/cpp/tests/lists/combine/concatenate_list_elements_tests.cpp
+++ b/cpp/tests/lists/combine/concatenate_list_elements_tests.cpp
@@ -21,6 +21,8 @@
 
 #include <cudf/lists/combine.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace {
 using StrListsCol = cudf::test::lists_column_wrapper<cudf::string_view>;
 using IntListsCol = cudf::test::lists_column_wrapper<int32_t>;
@@ -33,15 +35,6 @@ template <class T, class... Ts>
 auto build_lists_col(T& list, Ts&... lists)
 {
   return T(std::initializer_list<T>{std::move(list), std::move(lists)...});
-}
-
-auto all_nulls() { return cudf::test::iterator_all_nulls(); }
-
-auto null_at(cudf::size_type idx) { return cudf::test::iterator_with_null_at(idx); }
-
-auto null_at(std::vector<cudf::size_type> const& indices)
-{
-  return cudf::test::iterator_with_null_at(cudf::host_span<cudf::size_type const>{indices});
 }
 
 }  // namespace

--- a/cpp/tests/lists/combine/concatenate_list_elements_tests.cpp
+++ b/cpp/tests/lists/combine/concatenate_list_elements_tests.cpp
@@ -131,7 +131,7 @@ TYPED_TEST(ConcatenateListElementsTypedTest, SimpleInputWithNulls)
                        ListsCol{{20, null}, null_at(1)}};
   auto row2      = ListsCol{{ListsCol{{null, 2, 3, 4}, null_at(0)},
                         ListsCol{} /*NULL*/,
-                        ListsCol{{null, 21, null, null}, null_at({0, 2, 3})}},
+                        ListsCol{{null, 21, null, null}, nulls_at({0, 2, 3})}},
                        null_at(1)};
   auto row3      = ListsCol{{ListsCol{} /*NULL*/, ListsCol{{null, 18}, null_at(0)}}, null_at(0)};
   auto row4      = ListsCol{ListsCol{{1, 2, null, 4}, null_at(2)},
@@ -148,13 +148,13 @@ TYPED_TEST(ConcatenateListElementsTypedTest, SimpleInputWithNulls)
   {
     auto const results = cudf::lists::concatenate_list_elements(col);
     auto const expected =
-      ListsCol{{ListsCol{{1, null, 3, 4, 10, 11, 12, null}, null_at({1, 7})},
-                ListsCol{{null, 2, 3, 4, 13, 14, 15, 16, 17, null, 20, null}, null_at({0, 9, 11})},
-                ListsCol{{null, 2, 3, 4, null, 21, null, null}, null_at({0, 4, 6, 7})},
+      ListsCol{{ListsCol{{1, null, 3, 4, 10, 11, 12, null}, nulls_at({1, 7})},
+                ListsCol{{null, 2, 3, 4, 13, 14, 15, 16, 17, null, 20, null}, nulls_at({0, 9, 11})},
+                ListsCol{{null, 2, 3, 4, null, 21, null, null}, nulls_at({0, 4, 6, 7})},
                 ListsCol{{null, 18}, null_at(0)},
-                ListsCol{{1, 2, null, 4, 19, 20, null, 22, 23, 24, 25}, null_at({2, 6})},
+                ListsCol{{1, 2, null, 4, 19, 20, null, 22, 23, 24, 25}, nulls_at({2, 6})},
                 ListsCol{{1, 2, 3, null, null, null, null, null, null, null},
-                         null_at({3, 4, 5, 6, 7, 8, 9})},
+                         nulls_at({3, 4, 5, 6, 7, 8, 9})},
                 ListsCol{} /*NULL*/},
                null_at(6)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
@@ -166,14 +166,14 @@ TYPED_TEST(ConcatenateListElementsTypedTest, SimpleInputWithNulls)
       col, cudf::lists::concatenate_null_policy::NULLIFY_OUTPUT_ROW);
     auto const expected =
       ListsCol{{ListsCol{} /*NULL*/,
-                ListsCol{{null, 2, 3, 4, 13, 14, 15, 16, 17, null, 20, null}, null_at({0, 9, 11})},
+                ListsCol{{null, 2, 3, 4, 13, 14, 15, 16, 17, null, 20, null}, nulls_at({0, 9, 11})},
                 ListsCol{} /*NULL*/,
                 ListsCol{} /*NULL*/,
-                ListsCol{{1, 2, null, 4, 19, 20, null, 22, 23, 24, 25}, null_at({2, 6})},
+                ListsCol{{1, 2, null, 4, 19, 20, null, 22, 23, 24, 25}, nulls_at({2, 6})},
                 ListsCol{{1, 2, 3, null, null, null, null, null, null, null},
-                         null_at({3, 4, 5, 6, 7, 8, 9})},
+                         nulls_at({3, 4, 5, 6, 7, 8, 9})},
                 ListsCol{} /*NULL*/},
-               null_at({0, 2, 3, 6})};
+               nulls_at({0, 2, 3, 6})};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
   }
 }
@@ -226,9 +226,9 @@ TEST_F(ConcatenateListElementsTest, SimpleInputStringsColumnWithNulls)
 {
   auto row0 = StrListsCol{
     StrListsCol{{"Tomato", "Bear" /*NULL*/, "Apple"}, null_at(1)},
-    StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, null_at({1, 2, 3})}};
+    StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, nulls_at({1, 2, 3})}};
   auto row1 = StrListsCol{
-    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, null_at({1, 4})},
+    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, nulls_at({1, 4})},
     StrListsCol{"Lemon", "Peach"}};
   auto row2      = StrListsCol{{StrListsCol{"Coconut"}, StrListsCol{} /*NULL*/}, null_at(1)};
   auto const col = build_lists_col(row0, row1, row2);
@@ -239,9 +239,9 @@ TEST_F(ConcatenateListElementsTest, SimpleInputStringsColumnWithNulls)
     auto const expected = StrListsCol{
       StrListsCol{{"Tomato", "" /*NULL*/, "Apple", "Orange", "" /*NULL*/, "" /*NULL*/, ""
                    /*NULL*/},
-                  null_at({1, 4, 5, 6})},
+                  nulls_at({1, 4, 5, 6})},
       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/, "Lemon", "Peach"},
-                  null_at({1, 4})},
+                  nulls_at({1, 4})},
       StrListsCol{"Coconut"}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
   }
@@ -253,9 +253,9 @@ TEST_F(ConcatenateListElementsTest, SimpleInputStringsColumnWithNulls)
     auto const expected = StrListsCol{
       {StrListsCol{
          {"Tomato", "" /*NULL*/, "Apple", "Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/},
-         null_at({1, 4, 5, 6})},
+         nulls_at({1, 4, 5, 6})},
        StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/, "Lemon", "Peach"},
-                   null_at({1, 4})},
+                   nulls_at({1, 4})},
        StrListsCol{} /*NULL*/},
       null_at(2)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
@@ -263,11 +263,11 @@ TEST_F(ConcatenateListElementsTest, SimpleInputStringsColumnWithNulls)
 }
 TEST_F(ConcatenateListElementsTest, SimpleInputStringsColumnWithEmptyStringsAndNulls)
 {
-  auto row0 =
-    StrListsCol{StrListsCol{"", "", ""},
-                StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, null_at({1, 2, 3})}};
+  auto row0 = StrListsCol{
+    StrListsCol{"", "", ""},
+    StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, nulls_at({1, 2, 3})}};
   auto row1 = StrListsCol{
-    StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/}, null_at({1, 4})},
+    StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/}, nulls_at({1, 4})},
     StrListsCol{""}};
   auto row2      = StrListsCol{{StrListsCol{"Coconut"}, StrListsCol{} /*NULL*/}, null_at(1)};
   auto const col = build_lists_col(row0, row1, row2);
@@ -277,8 +277,8 @@ TEST_F(ConcatenateListElementsTest, SimpleInputStringsColumnWithEmptyStringsAndN
     auto const results  = cudf::lists::concatenate_list_elements(col);
     auto const expected = StrListsCol{
       StrListsCol{{"", "", "", "Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/},
-                  null_at({4, 5, 6})},
-      StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/, ""}, null_at({1, 4})},
+                  nulls_at({4, 5, 6})},
+      StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/, ""}, nulls_at({1, 4})},
       StrListsCol{"Coconut"}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
   }
@@ -289,8 +289,8 @@ TEST_F(ConcatenateListElementsTest, SimpleInputStringsColumnWithEmptyStringsAndN
       col, cudf::lists::concatenate_null_policy::NULLIFY_OUTPUT_ROW);
     auto const expected = StrListsCol{
       {StrListsCol{{"", "", "", "Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/},
-                   null_at({4, 5, 6})},
-       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/, ""}, null_at({1, 4})},
+                   nulls_at({4, 5, 6})},
+       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/, ""}, nulls_at({1, 4})},
        StrListsCol{} /*NULL*/},
       null_at(2)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
@@ -340,7 +340,7 @@ TYPED_TEST(ConcatenateListElementsTypedTest, SlicedColumnsInputWithNulls)
   using ListsCol = cudf::test::lists_column_wrapper<TypeParam>;
 
   auto row0 = ListsCol{ListsCol{{null, 2, 3}, null_at(0)}, ListsCol{2, 3}};
-  auto row1 = ListsCol{ListsCol{{3, null, null, 6}, null_at({1, 2})},
+  auto row1 = ListsCol{ListsCol{{3, null, null, 6}, nulls_at({1, 2})},
                        ListsCol{{5, 6, null}, null_at(2)},
                        ListsCol{},
                        ListsCol{{7, null}, null_at(1)}};
@@ -355,7 +355,7 @@ TYPED_TEST(ConcatenateListElementsTypedTest, SlicedColumnsInputWithNulls)
     auto const results = cudf::lists::concatenate_list_elements(col);
     auto const expected =
       ListsCol{ListsCol{{null, 2, 3, 2, 3}, null_at(0)},
-               ListsCol{{3, null, null, 6, 5, 6, null, 7, null}, null_at({1, 2, 6, 8})},
+               ListsCol{{3, null, null, 6, 5, 6, null, 7, null}, nulls_at({1, 2, 6, 8})},
                ListsCol{{7, 7, 7, 7, 8, null, 0, 1}, null_at(5)}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
   }
@@ -363,7 +363,7 @@ TYPED_TEST(ConcatenateListElementsTypedTest, SlicedColumnsInputWithNulls)
     auto const col     = cudf::slice(col_original, {1, 4})[0];
     auto const results = cudf::lists::concatenate_list_elements(col);
     auto const expected =
-      ListsCol{ListsCol{{3, null, null, 6, 5, 6, null, 7, null}, null_at({1, 2, 6, 8})},
+      ListsCol{ListsCol{{3, null, null, 6, 5, 6, null, 7, null}, nulls_at({1, 2, 6, 8})},
                ListsCol{{7, 7, 7, 7, 8, null, 0, 1}, null_at(5)},
                ListsCol{9, 10, 11}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
@@ -388,18 +388,18 @@ TEST_F(ConcatenateListElementsTest, SlicedStringsColumnsInputWithNulls)
 {
   auto row0 = StrListsCol{
     StrListsCol{{"Tomato", "Bear" /*NULL*/, "Apple"}, null_at(1)},
-    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, null_at({1, 4})},
+    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, nulls_at({1, 4})},
     StrListsCol{"Coconut"}};
   auto row1 = StrListsCol{
-    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, null_at({1, 4})},
+    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, nulls_at({1, 4})},
     StrListsCol{"Coconut"},
-    StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, null_at({1, 2, 3})}};
+    StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, nulls_at({1, 2, 3})}};
   auto row2 = StrListsCol{
     StrListsCol{"Coconut"},
-    StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, null_at({1, 2, 3})},
+    StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, nulls_at({1, 2, 3})},
     StrListsCol{"Lemon", "Peach"}};
   auto row3 = StrListsCol{
-    {StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, null_at({1, 2, 3})},
+    {StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, nulls_at({1, 2, 3})},
      StrListsCol{"Lemon", "Peach"},
      StrListsCol{} /*NULL*/},
     null_at(2)};
@@ -417,7 +417,7 @@ TEST_F(ConcatenateListElementsTest, SlicedStringsColumnsInputWithNulls)
                                                    "Cherry",
                                                    "" /*NULL*/,
                                                    "Coconut"},
-                                                  null_at({1, 4, 7})},
+                                                  nulls_at({1, 4, 7})},
                                       StrListsCol{{"Banana",
                                                    "" /*NULL*/,
                                                    "Kiwi",
@@ -428,7 +428,7 @@ TEST_F(ConcatenateListElementsTest, SlicedStringsColumnsInputWithNulls)
                                                    "" /*NULL*/,
                                                    "" /*NULL*/,
                                                    "" /*NULL*/},
-                                                  null_at({1, 4, 7, 8, 9})}};
+                                                  nulls_at({1, 4, 7, 8, 9})}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
   }
   {
@@ -444,7 +444,7 @@ TEST_F(ConcatenateListElementsTest, SlicedStringsColumnsInputWithNulls)
                                                    "" /*NULL*/,
                                                    "" /*NULL*/,
                                                    "" /*NULL*/},
-                                                  null_at({1, 4, 7, 8, 9})},
+                                                  nulls_at({1, 4, 7, 8, 9})},
                                       StrListsCol{{"Coconut",
                                                    "Orange",
                                                    "" /*NULL*/,
@@ -452,7 +452,7 @@ TEST_F(ConcatenateListElementsTest, SlicedStringsColumnsInputWithNulls)
                                                    "", /*NULL*/
                                                    "Lemon",
                                                    "Peach"},
-                                                  null_at({2, 3, 4})}};
+                                                  nulls_at({2, 3, 4})}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
   }
   {
@@ -465,14 +465,14 @@ TEST_F(ConcatenateListElementsTest, SlicedStringsColumnsInputWithNulls)
                                                    "", /*NULL*/
                                                    "Lemon",
                                                    "Peach"},
-                                                  null_at({2, 3, 4})},
+                                                  nulls_at({2, 3, 4})},
                                       StrListsCol{{"Orange",
                                                    "" /*NULL*/,
                                                    "" /*NULL*/,
                                                    "", /*NULL*/
                                                    "Lemon",
                                                    "Peach"},
-                                                  null_at({1, 2, 3})}};
+                                                  nulls_at({1, 2, 3})}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
   }
   {
@@ -486,7 +486,7 @@ TEST_F(ConcatenateListElementsTest, SlicedStringsColumnsInputWithNulls)
                                                     "", /*NULL*/
                                                     "Lemon",
                                                     "Peach"},
-                                                   null_at({2, 3, 4})},
+                                                   nulls_at({2, 3, 4})},
                                        StrListsCol{} /*NULL*/},
                                       null_at(1)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);

--- a/cpp/tests/lists/combine/concatenate_rows_tests.cpp
+++ b/cpp/tests/lists/combine/concatenate_rows_tests.cpp
@@ -178,7 +178,7 @@ TYPED_TEST(ListConcatenateRowsTypedTest, SimpleInputWithNulls)
                               ListsCol{{1, 2, null, 4}, null_at(2)},
                               ListsCol{{1, 2, 3, null}, null_at(3)},
                               ListsCol{} /*NULL*/},
-                             null_at({3, 6})}
+                             nulls_at({3, 6})}
                       .release();
   auto const col2 = ListsCol{{ListsCol{{10, 11, 12, null}, null_at(3)},
                               ListsCol{{13, 14, 15, 16, 17, null}, null_at(5)},
@@ -187,16 +187,16 @@ TYPED_TEST(ListConcatenateRowsTypedTest, SimpleInputWithNulls)
                               ListsCol{{19, 20, null}, null_at(2)},
                               ListsCol{{null}, null_at(0)},
                               ListsCol{} /*NULL*/},
-                             null_at({2, 6})}
+                             nulls_at({2, 6})}
                       .release();
   auto const col3 = ListsCol{{ListsCol{} /*NULL*/,
                               ListsCol{{20, null}, null_at(1)},
-                              ListsCol{{null, 21, null, null}, null_at({0, 2, 3})},
+                              ListsCol{{null, 21, null, null}, nulls_at({0, 2, 3})},
                               ListsCol{},
                               ListsCol{22, 23, 24, 25},
                               ListsCol{{null, null, null, null, null}, all_nulls()},
                               ListsCol{} /*NULL*/},
-                             null_at({0, 6})}
+                             nulls_at({0, 6})}
                       .release();
 
   // Ignore null list elements
@@ -204,13 +204,13 @@ TYPED_TEST(ListConcatenateRowsTypedTest, SimpleInputWithNulls)
     auto const results =
       cudf::lists::concatenate_rows(TView{{col1->view(), col2->view(), col3->view()}});
     auto const expected =
-      ListsCol{{ListsCol{{1, null, 3, 4, 10, 11, 12, null}, null_at({1, 7})},
-                ListsCol{{null, 2, 3, 4, 13, 14, 15, 16, 17, null, 20, null}, null_at({0, 9, 11})},
-                ListsCol{{null, 2, 3, 4, null, 21, null, null}, null_at({0, 4, 6, 7})},
+      ListsCol{{ListsCol{{1, null, 3, 4, 10, 11, 12, null}, nulls_at({1, 7})},
+                ListsCol{{null, 2, 3, 4, 13, 14, 15, 16, 17, null, 20, null}, nulls_at({0, 9, 11})},
+                ListsCol{{null, 2, 3, 4, null, 21, null, null}, nulls_at({0, 4, 6, 7})},
                 ListsCol{{null, 18}, null_at(0)},
-                ListsCol{{1, 2, null, 4, 19, 20, null, 22, 23, 24, 25}, null_at({2, 6})},
+                ListsCol{{1, 2, null, 4, 19, 20, null, 22, 23, 24, 25}, nulls_at({2, 6})},
                 ListsCol{{1, 2, 3, null, null, null, null, null, null, null},
-                         null_at({3, 4, 5, 6, 7, 8, 9})},
+                         nulls_at({3, 4, 5, 6, 7, 8, 9})},
                 ListsCol{} /*NULL*/},
                null_at(6)}
         .release();
@@ -224,14 +224,14 @@ TYPED_TEST(ListConcatenateRowsTypedTest, SimpleInputWithNulls)
                                     cudf::lists::concatenate_null_policy::NULLIFY_OUTPUT_ROW);
     auto const expected =
       ListsCol{{ListsCol{} /*NULL*/,
-                ListsCol{{null, 2, 3, 4, 13, 14, 15, 16, 17, null, 20, null}, null_at({0, 9, 11})},
+                ListsCol{{null, 2, 3, 4, 13, 14, 15, 16, 17, null, 20, null}, nulls_at({0, 9, 11})},
                 ListsCol{} /*NULL*/,
                 ListsCol{} /*NULL*/,
-                ListsCol{{1, 2, null, 4, 19, 20, null, 22, 23, 24, 25}, null_at({2, 6})},
+                ListsCol{{1, 2, null, 4, 19, 20, null, 22, 23, 24, 25}, nulls_at({2, 6})},
                 ListsCol{{1, 2, 3, null, null, null, null, null, null, null},
-                         null_at({3, 4, 5, 6, 7, 8, 9})},
+                         nulls_at({3, 4, 5, 6, 7, 8, 9})},
                 ListsCol{} /*NULL*/},
-               null_at({0, 2, 3, 6})}
+               nulls_at({0, 2, 3, 6})}
         .release();
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, print_all);
   }
@@ -241,12 +241,13 @@ TEST_F(ListConcatenateRowsTest, SimpleInputStringsColumnsWithNulls)
 {
   auto const col1 = StrListsCol{
     StrListsCol{{"Tomato", "Bear" /*NULL*/, "Apple"}, null_at(1)},
-    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, null_at({1, 4})},
+    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, nulls_at({1, 4})},
     StrListsCol{
       "Coconut"}}.release();
   auto const col2 =
     StrListsCol{
-      {StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, null_at({1, 2, 3})},
+      {StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/},
+                   nulls_at({1, 2, 3})},
        StrListsCol{"Lemon", "Peach"},
        StrListsCol{{"Deer" /*NULL*/, "Snake" /*NULL*/, "Horse" /*NULL*/}, all_nulls()}}, /*NULL*/
       null_at(2)}
@@ -257,9 +258,9 @@ TEST_F(ListConcatenateRowsTest, SimpleInputStringsColumnsWithNulls)
     auto const results  = cudf::lists::concatenate_rows(TView{{col1->view(), col2->view()}});
     auto const expected = StrListsCol{
       StrListsCol{{"Tomato", "" /*NULL*/, "Apple", "Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/},
-                  null_at({1, 4, 5, 6})},
+                  nulls_at({1, 4, 5, 6})},
       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/, "Lemon", "Peach"},
-                  null_at({1, 4})},
+                  nulls_at({1, 4})},
       StrListsCol{
         "Coconut"}}.release();
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, print_all);
@@ -274,9 +275,9 @@ TEST_F(ListConcatenateRowsTest, SimpleInputStringsColumnsWithNulls)
       StrListsCol{
         {StrListsCol{
            {"Tomato", "" /*NULL*/, "Apple", "Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/},
-           null_at({1, 4, 5, 6})},
+           nulls_at({1, 4, 5, 6})},
          StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/, "Lemon", "Peach"},
-                     null_at({1, 4})},
+                     nulls_at({1, 4})},
          StrListsCol{""} /*NULL*/},
         null_at(2)}
         .release();
@@ -301,7 +302,8 @@ TEST_F(ListConcatenateRowsTest, SimpleInputStringsColumnsWithEmptyLists)
     auto const results =
       cudf::lists::concatenate_rows(TView{{col1->view(), col2->view(), col3->view()}});
     auto const expected = StrListsCol{
-      StrListsCol{{"" /*NULL*/, "Tomato", "" /*NULL*/, "Apple", "Lemon", "Peach"}, null_at({0, 2})},
+      StrListsCol{{"" /*NULL*/, "Tomato", "" /*NULL*/, "Apple", "Lemon", "Peach"},
+                  nulls_at({0, 2})},
       StrListsCol{"One",
                   "Two"}}.release();
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, print_all);
@@ -314,7 +316,7 @@ TEST_F(ListConcatenateRowsTest, SimpleInputStringsColumnsWithEmptyLists)
                                     cudf::lists::concatenate_null_policy::NULLIFY_OUTPUT_ROW);
     auto const expected =
       StrListsCol{{StrListsCol{{"" /*NULL*/, "Tomato", "" /*NULL*/, "Apple", "Lemon", "Peach"},
-                               null_at({0, 2})},
+                               nulls_at({0, 2})},
                    StrListsCol{""} /*NULL*/},
                   null_at(1)}
         .release();
@@ -350,7 +352,7 @@ TYPED_TEST(ListConcatenateRowsTypedTest, SlicedColumnsInputWithNulls)
                                       ListsCol{},     /*NULL*/
                                       ListsCol{7},
                                       ListsCol{8, 9, 10}},
-                                     null_at({1, 3, 4})}
+                                     nulls_at({1, 3, 4})}
                               .release();
   auto const col1     = cudf::slice(col_original->view(), {0, 3})[0];
   auto const col2     = cudf::slice(col_original->view(), {1, 4})[0];
@@ -358,7 +360,7 @@ TYPED_TEST(ListConcatenateRowsTypedTest, SlicedColumnsInputWithNulls)
   auto const col4     = cudf::slice(col_original->view(), {3, 6})[0];
   auto const col5     = cudf::slice(col_original->view(), {4, 7})[0];
   auto const expected = ListsCol{
-    ListsCol{{null, 2, 3, 3, null, 5, 6}, null_at({0, 4})},
+    ListsCol{{null, 2, 3, 3, null, 5, 6}, nulls_at({0, 4})},
     ListsCol{{3, null, 5, 6, 7}, null_at(1)},
     ListsCol{{3, null, 5, 6, 7, 8, 9, 10},
              null_at(1)}}.release();
@@ -371,9 +373,11 @@ TEST_F(ListConcatenateRowsTest, SlicedStringsColumnsInputWithNulls)
   auto const col =
     StrListsCol{
       {StrListsCol{{"Tomato", "Bear" /*NULL*/, "Apple"}, null_at(1)},
-       StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, null_at({1, 4})},
+       StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/},
+                   nulls_at({1, 4})},
        StrListsCol{"Coconut"},
-       StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, null_at({1, 2, 3})},
+       StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/},
+                   nulls_at({1, 2, 3})},
        StrListsCol{"Lemon", "Peach"},
        StrListsCol{{"Deer" /*NULL*/, "Snake" /*NULL*/, "Horse" /*NULL*/}, all_nulls()}}, /*NULL*/
       null_at(5)}
@@ -385,45 +389,44 @@ TEST_F(ListConcatenateRowsTest, SlicedStringsColumnsInputWithNulls)
 
   {
     auto const results  = cudf::lists::concatenate_rows(TView{{col1, col2, col3, col4}});
-    auto const expected = StrListsCol{
-      StrListsCol{{"Tomato",
-                   "" /*NULL*/,
-                   "Apple",
-                   "Banana",
-                   "" /*NULL*/,
-                   "Kiwi",
-                   "Cherry",
-                   "" /*NULL*/,
-                   "Coconut",
-                   "Orange",
-                   "" /*NULL*/,
-                   "" /*NULL*/,
-                   "" /*NULL*/},
-                  null_at({1, 4, 7, 10, 11, 12})},
-      StrListsCol{{"Banana",
-                   "" /*NULL*/,
-                   "Kiwi",
-                   "Cherry",
-                   "" /*NULL*/,
-                   "Coconut",
-                   "Orange",
-                   "" /*NULL*/,
-                   "" /*NULL*/,
-                   "", /*NULL*/
-                   "Lemon",
-                   "Peach"},
-                  null_at({1, 4, 7, 8, 9})},
-      StrListsCol{
-        {
-          "Coconut",
-          "Orange",
-          "" /*NULL*/,
-          "" /*NULL*/,
-          "", /*NULL*/
-          "Lemon",
-          "Peach",
-        },
-        null_at({2, 3, 4})}}.release();
+    auto const expected = StrListsCol{StrListsCol{{"Tomato",
+                                                   "" /*NULL*/,
+                                                   "Apple",
+                                                   "Banana",
+                                                   "" /*NULL*/,
+                                                   "Kiwi",
+                                                   "Cherry",
+                                                   "" /*NULL*/,
+                                                   "Coconut",
+                                                   "Orange",
+                                                   "" /*NULL*/,
+                                                   "" /*NULL*/,
+                                                   "" /*NULL*/},
+                                                  nulls_at({1, 4, 7, 10, 11, 12})},
+                                      StrListsCol{{"Banana",
+                                                   "" /*NULL*/,
+                                                   "Kiwi",
+                                                   "Cherry",
+                                                   "" /*NULL*/,
+                                                   "Coconut",
+                                                   "Orange",
+                                                   "" /*NULL*/,
+                                                   "" /*NULL*/,
+                                                   "", /*NULL*/
+                                                   "Lemon",
+                                                   "Peach"},
+                                                  nulls_at({1, 4, 7, 8, 9})},
+                                      StrListsCol{{
+                                                    "Coconut",
+                                                    "Orange",
+                                                    "" /*NULL*/,
+                                                    "" /*NULL*/,
+                                                    "", /*NULL*/
+                                                    "Lemon",
+                                                    "Peach",
+                                                  },
+                                                  nulls_at({2, 3, 4})}}
+                            .release();
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, print_all);
   }
 
@@ -443,7 +446,7 @@ TEST_F(ListConcatenateRowsTest, SlicedStringsColumnsInputWithNulls)
                                                     "" /*NULL*/,
                                                     "" /*NULL*/,
                                                     "" /*NULL*/},
-                                                   null_at({1, 4, 7, 10, 11, 12})},
+                                                   nulls_at({1, 4, 7, 10, 11, 12})},
                                        StrListsCol{{"Banana",
                                                     "" /*NULL*/,
                                                     "Kiwi",
@@ -456,7 +459,7 @@ TEST_F(ListConcatenateRowsTest, SlicedStringsColumnsInputWithNulls)
                                                     "", /*NULL*/
                                                     "Lemon",
                                                     "Peach"},
-                                                   null_at({1, 4, 7, 8, 9})},
+                                                   nulls_at({1, 4, 7, 8, 9})},
                                        StrListsCol{} /*NULL*/},
                                       null_at(2)}
                             .release();

--- a/cpp/tests/lists/combine/concatenate_rows_tests.cpp
+++ b/cpp/tests/lists/combine/concatenate_rows_tests.cpp
@@ -21,6 +21,8 @@
 
 #include <cudf/lists/combine.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace {
 using StrListsCol = cudf::test::lists_column_wrapper<cudf::string_view>;
 using IntListsCol = cudf::test::lists_column_wrapper<int32_t>;
@@ -29,16 +31,6 @@ using TView       = cudf::table_view;
 
 constexpr bool print_all{false};  // For debugging
 constexpr int32_t null{0};
-
-auto all_nulls() { return cudf::test::iterator_all_nulls(); }
-
-auto null_at(cudf::size_type idx) { return cudf::test::iterator_with_null_at(idx); }
-
-auto null_at(std::vector<cudf::size_type> const& indices)
-{
-  return cudf::test::iterator_with_null_at(cudf::host_span<cudf::size_type const>{indices});
-}
-
 }  // namespace
 
 struct ListConcatenateRowsTest : public cudf::test::BaseFixture {

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -34,6 +34,8 @@
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+using namespace cudf::test::iterators;
+
 struct ReplaceErrorTest : public cudf::test::BaseFixture {
 };
 
@@ -192,7 +194,7 @@ TEST_F(ReplaceNullsPolicyStringTest, PrecedingFill)
                                            {1, 0, 0, 1, 1, 0, 1});
 
   cudf::test::strings_column_wrapper expected({"head", "head", "head", "mid", "mid", "mid", "tail"},
-                                              cudf::test::iterator_no_null());
+                                              no_null());
 
   auto result = cudf::replace_nulls(input, cudf::replace_policy::PRECEDING);
 
@@ -205,7 +207,7 @@ TEST_F(ReplaceNullsPolicyStringTest, FollowingFill)
                                            {1, 0, 0, 1, 1, 0, 1});
 
   cudf::test::strings_column_wrapper expected({"head", "mid", "mid", "mid", "mid", "tail", "tail"},
-                                              cudf::test::iterator_no_null());
+                                              no_null());
 
   auto result = cudf::replace_nulls(input, cudf::replace_policy::FOLLOWING);
 
@@ -389,7 +391,7 @@ TYPED_TEST(ReplaceNullsPolicyTest, PrecedingFill)
   TestReplaceNullsWithPolicy(
     cudf::test::fixed_width_column_wrapper<TypeParam>(col.begin(), col.end(), mask.begin()),
     cudf::test::fixed_width_column_wrapper<TypeParam>(
-      expect_col.begin(), expect_col.end(), cudf::test::iterator_no_null()),
+      expect_col.begin(), expect_col.end(), no_null()),
     cudf::replace_policy::PRECEDING);
 }
 
@@ -403,7 +405,7 @@ TYPED_TEST(ReplaceNullsPolicyTest, FollowingFill)
   TestReplaceNullsWithPolicy(
     cudf::test::fixed_width_column_wrapper<TypeParam>(col.begin(), col.end(), mask.begin()),
     cudf::test::fixed_width_column_wrapper<TypeParam>(
-      expect_col.begin(), expect_col.end(), cudf::test::iterator_no_null()),
+      expect_col.begin(), expect_col.end(), no_null()),
     cudf::replace_policy::FOLLOWING);
 }
 
@@ -660,8 +662,7 @@ TEST_F(ReplaceNullsPolicyDictionaryTest, PrecedingFill)
   auto input = cudf::dictionary::encode(input_w);
 
   cudf::test::strings_column_wrapper expected_w(
-    {"head", "head", "head", "mid1", "mid2", "tail", "tail", "tail"},
-    cudf::test::iterator_no_null());
+    {"head", "head", "head", "mid1", "mid2", "tail", "tail", "tail"}, no_null());
   auto expected = cudf::dictionary::encode(expected_w);
 
   auto result = cudf::replace_nulls(*input, cudf::replace_policy::PRECEDING);
@@ -676,8 +677,7 @@ TEST_F(ReplaceNullsPolicyDictionaryTest, FollowingFill)
   auto input = cudf::dictionary::encode(input_w);
 
   cudf::test::strings_column_wrapper expected_w(
-    {"head", "mid1", "mid1", "mid1", "mid2", "tail", "tail", "tail"},
-    cudf::test::iterator_no_null());
+    {"head", "mid1", "mid1", "mid1", "mid2", "tail", "tail", "tail"}, no_null());
   auto expected = cudf::dictionary::encode(expected_w);
 
   auto result = cudf::replace_nulls(*input, cudf::replace_policy::FOLLOWING);

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -194,7 +194,7 @@ TEST_F(ReplaceNullsPolicyStringTest, PrecedingFill)
                                            {1, 0, 0, 1, 1, 0, 1});
 
   cudf::test::strings_column_wrapper expected({"head", "head", "head", "mid", "mid", "mid", "tail"},
-                                              no_null());
+                                              no_nulls());
 
   auto result = cudf::replace_nulls(input, cudf::replace_policy::PRECEDING);
 
@@ -207,7 +207,7 @@ TEST_F(ReplaceNullsPolicyStringTest, FollowingFill)
                                            {1, 0, 0, 1, 1, 0, 1});
 
   cudf::test::strings_column_wrapper expected({"head", "mid", "mid", "mid", "mid", "tail", "tail"},
-                                              no_null());
+                                              no_nulls());
 
   auto result = cudf::replace_nulls(input, cudf::replace_policy::FOLLOWING);
 
@@ -391,7 +391,7 @@ TYPED_TEST(ReplaceNullsPolicyTest, PrecedingFill)
   TestReplaceNullsWithPolicy(
     cudf::test::fixed_width_column_wrapper<TypeParam>(col.begin(), col.end(), mask.begin()),
     cudf::test::fixed_width_column_wrapper<TypeParam>(
-      expect_col.begin(), expect_col.end(), no_null()),
+      expect_col.begin(), expect_col.end(), no_nulls()),
     cudf::replace_policy::PRECEDING);
 }
 
@@ -405,7 +405,7 @@ TYPED_TEST(ReplaceNullsPolicyTest, FollowingFill)
   TestReplaceNullsWithPolicy(
     cudf::test::fixed_width_column_wrapper<TypeParam>(col.begin(), col.end(), mask.begin()),
     cudf::test::fixed_width_column_wrapper<TypeParam>(
-      expect_col.begin(), expect_col.end(), no_null()),
+      expect_col.begin(), expect_col.end(), no_nulls()),
     cudf::replace_policy::FOLLOWING);
 }
 
@@ -662,7 +662,7 @@ TEST_F(ReplaceNullsPolicyDictionaryTest, PrecedingFill)
   auto input = cudf::dictionary::encode(input_w);
 
   cudf::test::strings_column_wrapper expected_w(
-    {"head", "head", "head", "mid1", "mid2", "tail", "tail", "tail"}, no_null());
+    {"head", "head", "head", "mid1", "mid2", "tail", "tail", "tail"}, no_nulls());
   auto expected = cudf::dictionary::encode(expected_w);
 
   auto result = cudf::replace_nulls(*input, cudf::replace_policy::PRECEDING);
@@ -677,7 +677,7 @@ TEST_F(ReplaceNullsPolicyDictionaryTest, FollowingFill)
   auto input = cudf::dictionary::encode(input_w);
 
   cudf::test::strings_column_wrapper expected_w(
-    {"head", "mid1", "mid1", "mid1", "mid2", "tail", "tail", "tail"}, no_null());
+    {"head", "mid1", "mid1", "mid1", "mid2", "tail", "tail", "tail"}, no_nulls());
   auto expected = cudf::dictionary::encode(expected_w);
 
   auto result = cudf::replace_nulls(*input, cudf::replace_policy::FOLLOWING);

--- a/cpp/tests/reshape/interleave_columns_tests.cpp
+++ b/cpp/tests/reshape/interleave_columns_tests.cpp
@@ -500,7 +500,7 @@ TYPED_TEST(ListsColumnsInterleaveTypedTest, SimpleInputWithNulls)
                       .release();
   auto const col3 = ListsCol{{ListsCol{} /*NULL*/,
                               ListsCol{{20, null}, null_at(1)},
-                              ListsCol{{null, 21, null, null}, null_at({0, 2, 3})},
+                              ListsCol{{null, 21, null, null}, nulls_at({0, 2, 3})},
                               ListsCol{},
                               ListsCol{22, 23, 24, 25},
                               ListsCol{{null, null, null, null, null}, all_nulls()}},
@@ -514,7 +514,7 @@ TYPED_TEST(ListsColumnsInterleaveTypedTest, SimpleInputWithNulls)
                                   ListsCol{{20, null}, null_at(1)},
                                   ListsCol{{null, 2, 3, 4}, null_at(0)},
                                   ListsCol{} /*NULL*/,
-                                  ListsCol{{null, 21, null, null}, null_at({0, 2, 3})},
+                                  ListsCol{{null, 21, null, null}, nulls_at({0, 2, 3})},
                                   ListsCol{} /*NULL*/,
                                   ListsCol{{null, 18}, null_at(0)},
                                   ListsCol{},
@@ -524,7 +524,7 @@ TYPED_TEST(ListsColumnsInterleaveTypedTest, SimpleInputWithNulls)
                                   ListsCol{{1, 2, 3, null}, null_at(3)},
                                   ListsCol{{null}, null_at(0)},
                                   ListsCol{{null, null, null, null, null}, all_nulls()}},
-                                 null_at({2, 7, 9})}
+                                 nulls_at({2, 7, 9})}
                           .release();
   auto const results = cudf::interleave_columns(TView{{col1->view(), col2->view(), col3->view()}});
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, print_all);
@@ -547,12 +547,13 @@ TEST_F(ListsColumnsInterleaveTest, SimpleInputStringsColumnsWithNulls)
 {
   auto const col1 = StrListsCol{
     StrListsCol{{"Tomato", "Bear" /*NULL*/, "Apple"}, null_at(1)},
-    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, null_at({1, 4})},
+    StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, nulls_at({1, 4})},
     StrListsCol{
       "Coconut"}}.release();
   auto const col2 =
     StrListsCol{
-      {StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, null_at({1, 2, 3})},
+      {StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/},
+                   nulls_at({1, 2, 3})},
        StrListsCol{"Lemon", "Peach"},
        StrListsCol{{"Deer" /*NULL*/, "Snake" /*NULL*/, "Horse" /*NULL*/}, all_nulls()}}, /*NULL*/
       null_at(2)}
@@ -561,8 +562,8 @@ TEST_F(ListsColumnsInterleaveTest, SimpleInputStringsColumnsWithNulls)
   auto const expected =
     StrListsCol{
       {StrListsCol{{"Tomato", "" /*NULL*/, "Apple"}, null_at(1)},
-       StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, null_at({1, 2, 3})},
-       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/}, null_at({1, 4})},
+       StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, nulls_at({1, 2, 3})},
+       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/}, nulls_at({1, 4})},
        StrListsCol{"Lemon", "Peach"},
        StrListsCol{"Coconut"},
        StrListsCol{}}, /*NULL*/
@@ -580,7 +581,7 @@ TEST_F(ListsColumnsInterleaveTest, SimpleInputStringsColumnsWithNullableChild)
     StrListsCol{
       "Coconut"}}.release();
   auto const col2 = StrListsCol{
-    StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, null_at({1, 2, 3})},
+    StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, nulls_at({1, 2, 3})},
     StrListsCol{"Lemon", "Peach"},
     StrListsCol{
       {"Deer" /*NULL*/, "Snake" /*NULL*/, "Horse" /*NULL*/},
@@ -588,7 +589,7 @@ TEST_F(ListsColumnsInterleaveTest, SimpleInputStringsColumnsWithNullableChild)
 
   auto const expected = StrListsCol{
     StrListsCol{"Tomato", "Bear", "Apple"},
-    StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, null_at({1, 2, 3})},
+    StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, nulls_at({1, 2, 3})},
     StrListsCol{"Banana", "Pig", "Kiwi", "Cherry", "Whale"},
     StrListsCol{"Lemon", "Peach"},
     StrListsCol{"Coconut"},
@@ -636,7 +637,7 @@ TYPED_TEST(ListsColumnsInterleaveTypedTest, SlicedColumnsInputWithNulls)
                              ListsCol{},     /*NULL*/
                              ListsCol{7},
                              ListsCol{8, 9, 10}},
-                            null_at({1, 3, 4})}
+                            nulls_at({1, 3, 4})}
                      .release();
   auto const col1     = cudf::slice(col->view(), {0, 3})[0];
   auto const col2     = cudf::slice(col->view(), {1, 4})[0];
@@ -658,7 +659,7 @@ TYPED_TEST(ListsColumnsInterleaveTypedTest, SlicedColumnsInputWithNulls)
                                   ListsCol{}, /*NULL*/
                                   ListsCol{7},
                                   ListsCol{8, 9, 10}},
-                                 null_at({1, 3, 4, 5, 7, 8, 11, 12})}
+                                 nulls_at({1, 3, 4, 5, 7, 8, 11, 12})}
                           .release();
   auto const results = cudf::interleave_columns(TView{{col1, col2, col3, col4, col5}});
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, print_all);
@@ -696,9 +697,11 @@ TEST_F(ListsColumnsInterleaveTest, SlicedStringsColumnsInputWithNulls)
   auto const col =
     StrListsCol{
       {StrListsCol{{"Tomato", "Bear" /*NULL*/, "Apple"}, null_at(1)},
-       StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/}, null_at({1, 4})},
+       StrListsCol{{"Banana", "Pig" /*NULL*/, "Kiwi", "Cherry", "Whale" /*NULL*/},
+                   nulls_at({1, 4})},
        StrListsCol{"Coconut"},
-       StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/}, null_at({1, 2, 3})},
+       StrListsCol{{"Orange", "Dog" /*NULL*/, "Fox" /*NULL*/, "Duck" /*NULL*/},
+                   nulls_at({1, 2, 3})},
        StrListsCol{"Lemon", "Peach"},
        StrListsCol{{"Deer" /*NULL*/, "Snake" /*NULL*/, "Horse" /*NULL*/}, all_nulls()}}, /*NULL*/
       null_at(5)}
@@ -710,15 +713,15 @@ TEST_F(ListsColumnsInterleaveTest, SlicedStringsColumnsInputWithNulls)
   auto const expected =
     StrListsCol{
       {StrListsCol{{"Tomato", "" /*NULL*/, "Apple"}, null_at(1)},
-       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/}, null_at({1, 4})},
+       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/}, nulls_at({1, 4})},
        StrListsCol{"Coconut"},
-       StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, null_at({1, 2, 3})},
-       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/}, null_at({1, 4})},
+       StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, nulls_at({1, 2, 3})},
+       StrListsCol{{"Banana", "" /*NULL*/, "Kiwi", "Cherry", "" /*NULL*/}, nulls_at({1, 4})},
        StrListsCol{"Coconut"},
-       StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, null_at({1, 2, 3})},
+       StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, nulls_at({1, 2, 3})},
        StrListsCol{"Lemon", "Peach"},
        StrListsCol{"Coconut"},
-       StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, null_at({1, 2, 3})},
+       StrListsCol{{"Orange", "" /*NULL*/, "" /*NULL*/, "" /*NULL*/}, nulls_at({1, 2, 3})},
        StrListsCol{"Lemon", "Peach"},
        StrListsCol{}}, /*NULL*/
       null_at(11)}

--- a/cpp/tests/reshape/interleave_columns_tests.cpp
+++ b/cpp/tests/reshape/interleave_columns_tests.cpp
@@ -22,10 +22,10 @@
 
 #include <cudf/reshape.hpp>
 
-using namespace cudf::test;
+using namespace cudf::test::iterators;
 
 template <typename T>
-struct InterleaveColumnsTest : public BaseFixture {
+struct InterleaveColumnsTest : public cudf::test::BaseFixture {
 };
 
 TYPED_TEST_CASE(InterleaveColumnsTest, cudf::test::FixedWidthTypes);
@@ -41,11 +41,11 @@ TYPED_TEST(InterleaveColumnsTest, OneColumn)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T, int32_t> a({-1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<T, int32_t> a({-1, 0, 1});
 
   cudf::table_view in(std::vector<cudf::column_view>{a});
 
-  auto expected = fixed_width_column_wrapper<T, int32_t>({-1, 0, 1});
+  auto expected = cudf::test::fixed_width_column_wrapper<T, int32_t>({-1, 0, 1});
   auto actual   = cudf::interleave_columns(in);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, actual->view());
@@ -55,12 +55,12 @@ TYPED_TEST(InterleaveColumnsTest, TwoColumns)
 {
   using T = TypeParam;
 
-  auto a = fixed_width_column_wrapper<T, int32_t>({0, 2});
-  auto b = fixed_width_column_wrapper<T, int32_t>({1, 3});
+  auto a = cudf::test::fixed_width_column_wrapper<T, int32_t>({0, 2});
+  auto b = cudf::test::fixed_width_column_wrapper<T, int32_t>({1, 3});
 
   cudf::table_view in(std::vector<cudf::column_view>{a, b});
 
-  auto expected = fixed_width_column_wrapper<T, int32_t>({0, 1, 2, 3});
+  auto expected = cudf::test::fixed_width_column_wrapper<T, int32_t>({0, 1, 2, 3});
   auto actual   = cudf::interleave_columns(in);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, actual->view());
@@ -70,13 +70,13 @@ TYPED_TEST(InterleaveColumnsTest, ThreeColumns)
 {
   using T = TypeParam;
 
-  auto a = fixed_width_column_wrapper<T, int32_t>({0, 3, 6});
-  auto b = fixed_width_column_wrapper<T, int32_t>({1, 4, 7});
-  auto c = fixed_width_column_wrapper<T, int32_t>({2, 5, 8});
+  auto a = cudf::test::fixed_width_column_wrapper<T, int32_t>({0, 3, 6});
+  auto b = cudf::test::fixed_width_column_wrapper<T, int32_t>({1, 4, 7});
+  auto c = cudf::test::fixed_width_column_wrapper<T, int32_t>({2, 5, 8});
 
   cudf::table_view in(std::vector<cudf::column_view>{a, b, c});
 
-  auto expected = fixed_width_column_wrapper<T, int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  auto expected = cudf::test::fixed_width_column_wrapper<T, int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8});
   auto actual   = cudf::interleave_columns(in);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, actual->view());
@@ -86,11 +86,11 @@ TYPED_TEST(InterleaveColumnsTest, OneColumnEmpty)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T> a({});
+  cudf::test::fixed_width_column_wrapper<T> a({});
 
   cudf::table_view in(std::vector<cudf::column_view>{a});
 
-  auto expected = fixed_width_column_wrapper<T>({});
+  auto expected = cudf::test::fixed_width_column_wrapper<T>({});
   auto actual   = cudf::interleave_columns(in);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, actual->view());
@@ -100,13 +100,13 @@ TYPED_TEST(InterleaveColumnsTest, ThreeColumnsEmpty)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T> a({});
-  fixed_width_column_wrapper<T> b({});
-  fixed_width_column_wrapper<T> c({});
+  cudf::test::fixed_width_column_wrapper<T> a({});
+  cudf::test::fixed_width_column_wrapper<T> b({});
+  cudf::test::fixed_width_column_wrapper<T> c({});
 
   cudf::table_view in(std::vector<cudf::column_view>{a, b, c});
 
-  auto expected = fixed_width_column_wrapper<T>({});
+  auto expected = cudf::test::fixed_width_column_wrapper<T>({});
   auto actual   = cudf::interleave_columns(in);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, actual->view());
@@ -116,11 +116,11 @@ TYPED_TEST(InterleaveColumnsTest, OneColumnNullable)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T, int32_t> a({1, 2, 3}, {0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<T, int32_t> a({1, 2, 3}, {0, 1, 0});
 
   cudf::table_view in(std::vector<cudf::column_view>{a});
 
-  auto expected = fixed_width_column_wrapper<T, int32_t>({0, 2, 0}, {0, 1, 0});
+  auto expected = cudf::test::fixed_width_column_wrapper<T, int32_t>({0, 2, 0}, {0, 1, 0});
   auto actual   = cudf::interleave_columns(in);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, actual->view());
@@ -130,13 +130,14 @@ TYPED_TEST(InterleaveColumnsTest, TwoColumnNullable)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T, int32_t> a({1, 2, 3}, {0, 1, 0});
-  fixed_width_column_wrapper<T, int32_t> b({4, 5, 6}, {1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<T, int32_t> a({1, 2, 3}, {0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<T, int32_t> b({4, 5, 6}, {1, 0, 1});
 
   cudf::table_view in(std::vector<cudf::column_view>{a, b});
 
-  auto expected = fixed_width_column_wrapper<T, int32_t>({0, 4, 2, 0, 0, 6}, {0, 1, 1, 0, 0, 1});
-  auto actual   = cudf::interleave_columns(in);
+  auto expected =
+    cudf::test::fixed_width_column_wrapper<T, int32_t>({0, 4, 2, 0, 0, 6}, {0, 1, 1, 0, 0, 1});
+  auto actual = cudf::interleave_columns(in);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, actual->view());
 }
@@ -145,14 +146,14 @@ TYPED_TEST(InterleaveColumnsTest, ThreeColumnsNullable)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T, int32_t> a({1, 4, 7}, {1, 0, 1});
-  fixed_width_column_wrapper<T, int32_t> b({2, 5, 8}, {0, 1, 0});
-  fixed_width_column_wrapper<T, int32_t> c({3, 6, 9}, {1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<T, int32_t> a({1, 4, 7}, {1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<T, int32_t> b({2, 5, 8}, {0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<T, int32_t> c({3, 6, 9}, {1, 0, 1});
 
   cudf::table_view in(std::vector<cudf::column_view>{a, b, c});
 
-  auto expected = fixed_width_column_wrapper<T, int32_t>({1, 0, 3, 0, 5, 0, 7, 0, 9},
-                                                         {1, 0, 1, 0, 1, 0, 1, 0, 1});
+  auto expected = cudf::test::fixed_width_column_wrapper<T, int32_t>({1, 0, 3, 0, 5, 0, 7, 0, 9},
+                                                                     {1, 0, 1, 0, 1, 0, 1, 0, 1});
   auto actual   = cudf::interleave_columns(in);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, actual->view());
@@ -163,8 +164,8 @@ TYPED_TEST(InterleaveColumnsTest, MismatchedDtypes)
   using T = TypeParam;
 
   if (not std::is_same<int, T>::value and not cudf::is_fixed_point<T>()) {
-    fixed_width_column_wrapper<int32_t> input_a({1, 4, 7}, {1, 0, 1});
-    fixed_width_column_wrapper<T, int32_t> input_b({2, 5, 8}, {0, 1, 0});
+    cudf::test::fixed_width_column_wrapper<int32_t> input_a({1, 4, 7}, {1, 0, 1});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> input_b({2, 5, 8}, {0, 1, 0});
 
     cudf::table_view input(std::vector<cudf::column_view>{input_a, input_b});
 
@@ -172,7 +173,7 @@ TYPED_TEST(InterleaveColumnsTest, MismatchedDtypes)
   }
 }
 
-struct InterleaveStringsColumnsTest : public BaseFixture {
+struct InterleaveStringsColumnsTest : public cudf::test::BaseFixture {
 };
 
 TEST_F(InterleaveStringsColumnsTest, ZeroSizedColumns)
@@ -377,16 +378,6 @@ using TView       = cudf::table_view;
 
 constexpr bool print_all{false};  // For debugging
 constexpr int32_t null{0};
-
-auto all_nulls() { return cudf::test::iterator_all_nulls(); }
-
-auto null_at(cudf::size_type idx) { return cudf::test::iterator_with_null_at(idx); }
-
-auto null_at(std::vector<cudf::size_type> const& indices)
-{
-  return cudf::test::iterator_with_null_at(cudf::host_span<cudf::size_type const>{indices});
-}
-
 }  // namespace
 
 struct ListsColumnsInterleaveTest : public cudf::test::BaseFixture {

--- a/cpp/tests/rolling/collect_ops_test.cpp
+++ b/cpp/tests/rolling/collect_ops_test.cpp
@@ -34,6 +34,8 @@
 #include <algorithm>
 #include <vector>
 
+using namespace cudf::test::iterators;
+
 struct CollectListTest : public cudf::test::BaseFixture {
 };
 
@@ -731,8 +733,8 @@ TYPED_TEST(TypedCollectListTest, GroupedTimeRangeRollingWindowWithNulls)
                                       min_periods,
                                       *make_collect_list_aggregation<rolling_aggregation>());
 
-  auto null_at_0 = iterator_with_null_at(0);
-  auto null_at_1 = iterator_with_null_at(1);
+  auto null_at_0 = null_at(0);
+  auto null_at_1 = null_at(1);
 
   // In the results, `11` and `21` should be nulls.
   auto const expected_result = lists_column_wrapper<T, int32_t>{
@@ -846,8 +848,8 @@ TEST_F(CollectListTest, GroupedTimeRangeRollingWindowOnStringsWithNulls)
                                       min_periods,
                                       *make_collect_list_aggregation<rolling_aggregation>());
 
-  auto null_at_0 = iterator_with_null_at(0);
-  auto null_at_1 = iterator_with_null_at(1);
+  auto null_at_0 = null_at(0);
+  auto null_at_1 = null_at(1);
 
   // In the results, `11` and `21` should be nulls.
   auto const expected_result = lists_column_wrapper<cudf::string_view>{
@@ -1037,7 +1039,7 @@ TYPED_TEST(TypedCollectListTest, GroupedTimeRangeRollingWindowWithNullsAndMinPer
                                       min_periods,
                                       *make_collect_list_aggregation<rolling_aggregation>());
 
-  auto null_at_1 = iterator_with_null_at(1);
+  auto null_at_1 = null_at(1);
 
   // In the results, `11` and `21` should be nulls.
   auto const expected_result = lists_column_wrapper<T, int32_t>{
@@ -1163,7 +1165,7 @@ TEST_F(CollectListTest, GroupedTimeRangeRollingWindowOnStringsWithNullsAndMinPer
                                       min_periods,
                                       *make_collect_list_aggregation<rolling_aggregation>());
 
-  auto null_at_1 = iterator_with_null_at(1);
+  auto null_at_1 = null_at(1);
 
   // In the results, `11` and `21` should be nulls.
   auto const expected_result = lists_column_wrapper<cudf::string_view>{
@@ -1874,10 +1876,10 @@ TYPED_TEST(TypedCollectSetTest, GroupedTimeRangeRollingWindowWithNulls)
                                       min_periods,
                                       *make_collect_set_aggregation<rolling_aggregation>());
 
-  auto null_at_1 = iterator_with_null_at(1);
-  auto null_at_2 = iterator_with_null_at(2);
-  auto null_at_3 = iterator_with_null_at(3);
-  auto null_at_4 = iterator_with_null_at(4);
+  auto null_at_1 = null_at(1);
+  auto null_at_2 = null_at(2);
+  auto null_at_3 = null_at(3);
+  auto null_at_4 = null_at(4);
 
   // In the results, `11` and `21` should be nulls.
   auto const expected_result = lists_column_wrapper<T, int32_t>{

--- a/cpp/tests/rolling/collect_ops_test.cpp
+++ b/cpp/tests/rolling/collect_ops_test.cpp
@@ -1877,7 +1877,6 @@ TYPED_TEST(TypedCollectSetTest, GroupedTimeRangeRollingWindowWithNulls)
                                       *make_collect_set_aggregation<rolling_aggregation>());
 
   auto null_at_1 = null_at(1);
-  auto null_at_2 = null_at(2);
   auto null_at_3 = null_at(3);
   auto null_at_4 = null_at(4);
 

--- a/cpp/tests/rolling/lead_lag_test.cpp
+++ b/cpp/tests/rolling/lead_lag_test.cpp
@@ -45,6 +45,7 @@
 
 using cudf::size_type;
 using namespace cudf::test;
+using namespace cudf::test::iterators;
 
 struct LeadLagWindowTest : public cudf::test::BaseFixture {
 };
@@ -542,7 +543,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithNullsAllOver)
   using T   = TypeParam;
   using lcw = lists_column_wrapper<T, int32_t>;
 
-  auto null_at_2       = cudf::test::iterator_with_null_at(2);
+  auto null_at_2       = null_at(2);
   auto const input_col = lcw{{{0, 0},
                               {1, 1},
                               {2, 2},
@@ -573,23 +574,22 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithNullsAllOver)
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(3));
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-    lead_3_output_col->view(),
-    lcw{{{3, 3, 3},
-         {{4, 4, 4, 4}, null_at_2},
-         {5, 5, 5, 5, 5},
-         {},
-         {},
-         {},
-         {30, 30, 30},
-         {40, 40, 40, 40},
-         {{50, 50, 50, 50, 50}, null_at_2},
-         {},
-         {},
-         {}},
-        iterator_with_null_at(std::vector<size_type>{3, 4, 5, 9, 10, 11})}
-      .release()
-      ->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lead_3_output_col->view(),
+                                      lcw{{{3, 3, 3},
+                                           {{4, 4, 4, 4}, null_at_2},
+                                           {5, 5, 5, 5, 5},
+                                           {},
+                                           {},
+                                           {},
+                                           {30, 30, 30},
+                                           {40, 40, 40, 40},
+                                           {{50, 50, 50, 50, 50}, null_at_2},
+                                           {},
+                                           {},
+                                           {}},
+                                          null_at({3, 4, 5, 9, 10, 11})}
+                                        .release()
+                                        ->view());
 
   auto lag_1_output_col =
     cudf::grouped_rolling_window(grouping_keys,
@@ -612,7 +612,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithNullsAllOver)
                                  {20, 20},
                                  {30, 30, 30},
                                  {40, 40, 40, 40}},
-                                iterator_with_null_at(std::vector<size_type>{0, 3, 6})}
+                                null_at({0, 3, 6})}
                               .release()
                               ->view());
 }
@@ -622,7 +622,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithDefaults)
   using T   = TypeParam;
   using lcw = lists_column_wrapper<T, int32_t>;
 
-  auto null_at_2       = cudf::test::iterator_with_null_at(2);
+  auto null_at_2       = null_at(2);
   auto const input_col = lcw{{{0, 0},
                               {1, 1},
                               {2, 2},
@@ -672,23 +672,22 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithDefaults)
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(3));
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-    lead_3_output_col->view(),
-    lcw{{{3, 3, 3},
-         {{4, 4, 4, 4}, null_at_2},
-         {5, 5, 5, 5, 5},
-         {},
-         {},
-         {},
-         {30, 30, 30},
-         {40, 40, 40, 40},
-         {{50, 50, 50, 50, 50}, null_at_2},
-         {},
-         {},
-         {}},
-        iterator_with_null_at(std::vector<size_type>{3, 4, 5, 9, 10, 11})}
-      .release()
-      ->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lead_3_output_col->view(),
+                                      lcw{{{3, 3, 3},
+                                           {{4, 4, 4, 4}, null_at_2},
+                                           {5, 5, 5, 5, 5},
+                                           {},
+                                           {},
+                                           {},
+                                           {30, 30, 30},
+                                           {40, 40, 40, 40},
+                                           {{50, 50, 50, 50, 50}, null_at_2},
+                                           {},
+                                           {},
+                                           {}},
+                                          null_at({3, 4, 5, 9, 10, 11})}
+                                        .release()
+                                        ->view());
 
   auto lag_1_output_col =
     cudf::grouped_rolling_window(grouping_keys,
@@ -711,7 +710,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithDefaults)
                                  {20, 20},
                                  {30, 30, 30},
                                  {40, 40, 40, 40}},
-                                iterator_with_null_at(std::vector<size_type>{0, 3, 6})}
+                                null_at({0, 3, 6})}
                               .release()
                               ->view());
 }
@@ -721,7 +720,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, Structs)
   using T   = TypeParam;
   using lcw = lists_column_wrapper<T, int32_t>;
 
-  auto null_at_2 = cudf::test::iterator_with_null_at(2);
+  auto null_at_2 = null_at(2);
   auto lists_col = lcw{{{0, 0},
                         {1, 1},
                         {2, 2},
@@ -748,7 +747,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, Structs)
                                              "303030",
                                              "40404040",
                                              "5050505050"},
-                                            iterator_with_null_at(9)};
+                                            null_at(9)};
 
   auto structs_col = structs_column_wrapper{lists_col, strings_col}.release();
 
@@ -768,28 +767,26 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, Structs)
                                    following,
                                    min_periods,
                                    *cudf::make_lead_aggregation<cudf::rolling_aggregation>(3));
-    auto expected_lists_col =
-      lcw{{{3, 3, 3},
-           {{4, 4, 4, 4}, null_at_2},
-           {5, 5, 5, 5, 5},
-           {},
-           {},
-           {},
-           {30, 30, 30},
-           {40, 40, 40, 40},
-           {{50, 50, 50, 50, 50}, null_at_2},
-           {},
-           {},
-           {}},
-          iterator_with_null_at(std::vector<size_type>{3, 4, 5, 9, 10, 11})};
+    auto expected_lists_col   = lcw{{{3, 3, 3},
+                                   {{4, 4, 4, 4}, null_at_2},
+                                   {5, 5, 5, 5, 5},
+                                   {},
+                                   {},
+                                   {},
+                                   {30, 30, 30},
+                                   {40, 40, 40, 40},
+                                   {{50, 50, 50, 50, 50}, null_at_2},
+                                   {},
+                                   {},
+                                   {}},
+                                  null_at({3, 4, 5, 9, 10, 11})};
     auto expected_strings_col = strings_column_wrapper{
       {"333", "4444", "55555", "", "", "", "", "40404040", "5050505050", "", "", ""},
-      iterator_with_null_at(std::vector<size_type>{3, 4, 5, 6, 9, 10, 11})};
+      null_at({3, 4, 5, 6, 9, 10, 11})};
 
-    auto expected_structs_col =
-      structs_column_wrapper{{expected_lists_col, expected_strings_col},
-                             iterator_with_null_at(std::vector<size_type>{3, 4, 5, 9, 10, 11})}
-        .release();
+    auto expected_structs_col = structs_column_wrapper{{expected_lists_col, expected_strings_col},
+                                                       null_at({3, 4, 5, 9, 10, 11})}
+                                  .release();
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lead_3_output_col->view(), expected_structs_col->view());
   }
@@ -803,7 +800,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, Structs)
                                    following,
                                    min_periods,
                                    *cudf::make_lag_aggregation<cudf::rolling_aggregation>(1));
-    auto expected_lists_col = lcw{{{},  // null.
+    auto expected_lists_col   = lcw{{{},  // null.
                                    {0, 0},
                                    {1, 1},
                                    {},  // null.
@@ -815,26 +812,23 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, Structs)
                                    {20, 20},
                                    {30, 30, 30},
                                    {40, 40, 40, 40}},
-                                  iterator_with_null_at(std::vector<size_type>{0, 3, 6})};
-    auto expected_strings_col =
-      strings_column_wrapper{{"",  // null.
-                              "00",
-                              "11",
-                              "22",
-                              "333",
-                              "4444",
-                              "",  // null.
-                              "00",
-                              "1010",
-                              "2020",
-                              "",  // null.
-                              "40404040"},
-                             iterator_with_null_at(std::vector<size_type>{0, 6, 10})};
+                                  null_at({0, 3, 6})};
+    auto expected_strings_col = strings_column_wrapper{{"",  // null.
+                                                        "00",
+                                                        "11",
+                                                        "22",
+                                                        "333",
+                                                        "4444",
+                                                        "",  // null.
+                                                        "00",
+                                                        "1010",
+                                                        "2020",
+                                                        "",  // null.
+                                                        "40404040"},
+                                                       null_at({0, 6, 10})};
 
     auto expected_structs_col =
-      structs_column_wrapper{{expected_lists_col, expected_strings_col},
-                             iterator_with_null_at(std::vector<size_type>{0, 6})}
-        .release();
+      structs_column_wrapper{{expected_lists_col, expected_strings_col}, null_at({0, 6})}.release();
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lag_1_output_col->view(), expected_structs_col->view());
   }
@@ -860,7 +854,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsNoDefaults)
                                            "B_333",
                                            "B_4444",
                                            "B_55555"},
-                                          iterator_with_null_at(std::vector{0, 7})}
+                                          null_at(std::vector{0, 7})}
                      .release();
 
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
@@ -880,7 +874,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsNoDefaults)
     lead_2->view(),
     strings_column_wrapper{
       {"A_22", "A_333", "A_4444", "A_55555", "", "", "B_22", "B_333", "B_4444", "B_55555", "", ""},
-      iterator_with_null_at(std::vector{4, 5, 10, 11})});
+      null_at(std::vector{4, 5, 10, 11})});
 
   auto lag_1 = grouped_rolling_window(grouping_keys,
                                       input_col->view(),
@@ -893,7 +887,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsNoDefaults)
     lag_1->view(),
     strings_column_wrapper{
       {"", "", "A_1", "A_22", "A_333", "A_4444", "", "B_0", "", "B_22", "B_333", "B_4444"},
-      iterator_with_null_at(std::vector{0, 1, 6, 8})});
+      null_at(std::vector{0, 1, 6, 8})});
 }
 
 TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaults)
@@ -913,7 +907,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaults)
                                            "B_333",
                                            "B_4444",
                                            "B_55555"},
-                                          iterator_with_null_at(std::vector{0, 7})}
+                                          null_at(std::vector{0, 7})}
                      .release();
 
   auto defaults_col = strings_column_wrapper{"9999",
@@ -970,7 +964,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaults)
     lag_1->view(),
     strings_column_wrapper{
       {"9999", "", "A_1", "A_22", "A_333", "A_4444", "9999", "B_0", "", "B_22", "B_333", "B_4444"},
-      iterator_with_null_at(std::vector{1, 8})});
+      null_at(std::vector{1, 8})});
 }
 
 TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaultsNoGroups)
@@ -990,7 +984,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaultsNoGroups)
                                            "B_333",
                                            "B_4444",
                                            "B_55555"},
-                                          iterator_with_null_at(std::vector{0, 7})}
+                                          null_at(std::vector{0, 7})}
                      .release();
 
   auto defaults_col = strings_column_wrapper{"9999",
@@ -1034,7 +1028,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaultsNoGroups)
                                                               "B_55555",
                                                               "9999",
                                                               "9999"},
-                                                             iterator_with_null_at(5)});
+                                                             null_at(5)});
 
   auto lag_1 = grouped_rolling_window(grouping_keys,
                                       input_col->view(),
@@ -1044,21 +1038,20 @@ TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaultsNoGroups)
                                       min_periods,
                                       *cudf::make_lag_aggregation<cudf::rolling_aggregation>(1));
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-    lag_1->view(),
-    strings_column_wrapper{{"9999",
-                            "",
-                            "A_1",
-                            "A_22",
-                            "A_333",
-                            "A_4444",
-                            "A_55555",
-                            "B_0",
-                            "",
-                            "B_22",
-                            "B_333",
-                            "B_4444"},
-                           iterator_with_null_at(std::vector{1, 8})});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lag_1->view(),
+                                      strings_column_wrapper{{"9999",
+                                                              "",
+                                                              "A_1",
+                                                              "A_22",
+                                                              "A_333",
+                                                              "A_4444",
+                                                              "A_55555",
+                                                              "B_0",
+                                                              "",
+                                                              "B_22",
+                                                              "B_333",
+                                                              "B_4444"},
+                                                             null_at(std::vector{1, 8})});
 }
 
 TEST_F(LeadLagNonFixedWidthTest, Dictionary)
@@ -1101,7 +1094,7 @@ TEST_F(LeadLagNonFixedWidthTest, Dictionary)
     auto expected_keys = strings_column_wrapper{input_strings}.release();
     auto expected_values =
       fixed_width_column_wrapper<uint32_t>{{2, 3, 4, 5, 0, 0, 7, 8, 9, 10, 0, 0},
-                                           iterator_with_null_at(std::vector{4, 5, 10, 11})}
+                                           null_at(std::vector{4, 5, 10, 11})}
         .release();
     auto expected_output =
       make_dictionary_column(expected_keys->view(), expected_values->view()).release();
@@ -1120,7 +1113,7 @@ TEST_F(LeadLagNonFixedWidthTest, Dictionary)
     auto expected_keys = strings_column_wrapper{input_strings}.release();
     auto expected_values =
       fixed_width_column_wrapper<uint32_t>{{0, 0, 1, 2, 3, 4, 0, 6, 0, 7, 8, 9},
-                                           iterator_with_null_at(std::vector{0, 6})}
+                                           null_at(std::vector{0, 6})}
         .release();
     auto expected_output =
       make_dictionary_column(expected_keys->view(), expected_values->view()).release();

--- a/cpp/tests/rolling/lead_lag_test.cpp
+++ b/cpp/tests/rolling/lead_lag_test.cpp
@@ -587,7 +587,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithNullsAllOver)
                                            {},
                                            {},
                                            {}},
-                                          null_at({3, 4, 5, 9, 10, 11})}
+                                          nulls_at({3, 4, 5, 9, 10, 11})}
                                         .release()
                                         ->view());
 
@@ -612,7 +612,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithNullsAllOver)
                                  {20, 20},
                                  {30, 30, 30},
                                  {40, 40, 40, 40}},
-                                null_at({0, 3, 6})}
+                                nulls_at({0, 3, 6})}
                               .release()
                               ->view());
 }
@@ -685,7 +685,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithDefaults)
                                            {},
                                            {},
                                            {}},
-                                          null_at({3, 4, 5, 9, 10, 11})}
+                                          nulls_at({3, 4, 5, 9, 10, 11})}
                                         .release()
                                         ->view());
 
@@ -710,7 +710,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithDefaults)
                                  {20, 20},
                                  {30, 30, 30},
                                  {40, 40, 40, 40}},
-                                null_at({0, 3, 6})}
+                                nulls_at({0, 3, 6})}
                               .release()
                               ->view());
 }
@@ -779,13 +779,13 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, Structs)
                                    {},
                                    {},
                                    {}},
-                                  null_at({3, 4, 5, 9, 10, 11})};
+                                  nulls_at({3, 4, 5, 9, 10, 11})};
     auto expected_strings_col = strings_column_wrapper{
       {"333", "4444", "55555", "", "", "", "", "40404040", "5050505050", "", "", ""},
-      null_at({3, 4, 5, 6, 9, 10, 11})};
+      nulls_at({3, 4, 5, 6, 9, 10, 11})};
 
     auto expected_structs_col = structs_column_wrapper{{expected_lists_col, expected_strings_col},
-                                                       null_at({3, 4, 5, 9, 10, 11})}
+                                                       nulls_at({3, 4, 5, 9, 10, 11})}
                                   .release();
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lead_3_output_col->view(), expected_structs_col->view());
@@ -812,7 +812,7 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, Structs)
                                    {20, 20},
                                    {30, 30, 30},
                                    {40, 40, 40, 40}},
-                                  null_at({0, 3, 6})};
+                                  nulls_at({0, 3, 6})};
     auto expected_strings_col = strings_column_wrapper{{"",  // null.
                                                         "00",
                                                         "11",
@@ -825,10 +825,11 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, Structs)
                                                         "2020",
                                                         "",  // null.
                                                         "40404040"},
-                                                       null_at({0, 6, 10})};
+                                                       nulls_at({0, 6, 10})};
 
     auto expected_structs_col =
-      structs_column_wrapper{{expected_lists_col, expected_strings_col}, null_at({0, 6})}.release();
+      structs_column_wrapper{{expected_lists_col, expected_strings_col}, nulls_at({0, 6})}
+        .release();
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lag_1_output_col->view(), expected_structs_col->view());
   }
@@ -854,7 +855,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsNoDefaults)
                                            "B_333",
                                            "B_4444",
                                            "B_55555"},
-                                          null_at(std::vector{0, 7})}
+                                          nulls_at(std::vector{0, 7})}
                      .release();
 
   auto const grouping_key = fixed_width_column_wrapper<int32_t>{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
@@ -874,7 +875,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsNoDefaults)
     lead_2->view(),
     strings_column_wrapper{
       {"A_22", "A_333", "A_4444", "A_55555", "", "", "B_22", "B_333", "B_4444", "B_55555", "", ""},
-      null_at(std::vector{4, 5, 10, 11})});
+      nulls_at(std::vector{4, 5, 10, 11})});
 
   auto lag_1 = grouped_rolling_window(grouping_keys,
                                       input_col->view(),
@@ -887,7 +888,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsNoDefaults)
     lag_1->view(),
     strings_column_wrapper{
       {"", "", "A_1", "A_22", "A_333", "A_4444", "", "B_0", "", "B_22", "B_333", "B_4444"},
-      null_at(std::vector{0, 1, 6, 8})});
+      nulls_at(std::vector{0, 1, 6, 8})});
 }
 
 TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaults)
@@ -907,7 +908,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaults)
                                            "B_333",
                                            "B_4444",
                                            "B_55555"},
-                                          null_at(std::vector{0, 7})}
+                                          nulls_at(std::vector{0, 7})}
                      .release();
 
   auto defaults_col = strings_column_wrapper{"9999",
@@ -964,7 +965,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaults)
     lag_1->view(),
     strings_column_wrapper{
       {"9999", "", "A_1", "A_22", "A_333", "A_4444", "9999", "B_0", "", "B_22", "B_333", "B_4444"},
-      null_at(std::vector{1, 8})});
+      nulls_at(std::vector{1, 8})});
 }
 
 TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaultsNoGroups)
@@ -984,7 +985,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaultsNoGroups)
                                            "B_333",
                                            "B_4444",
                                            "B_55555"},
-                                          null_at(std::vector{0, 7})}
+                                          nulls_at(std::vector{0, 7})}
                      .release();
 
   auto defaults_col = strings_column_wrapper{"9999",
@@ -1051,7 +1052,7 @@ TEST_F(LeadLagNonFixedWidthTest, StringsWithDefaultsNoGroups)
                                                               "B_22",
                                                               "B_333",
                                                               "B_4444"},
-                                                             null_at(std::vector{1, 8})});
+                                                             nulls_at(std::vector{1, 8})});
 }
 
 TEST_F(LeadLagNonFixedWidthTest, Dictionary)
@@ -1094,7 +1095,7 @@ TEST_F(LeadLagNonFixedWidthTest, Dictionary)
     auto expected_keys = strings_column_wrapper{input_strings}.release();
     auto expected_values =
       fixed_width_column_wrapper<uint32_t>{{2, 3, 4, 5, 0, 0, 7, 8, 9, 10, 0, 0},
-                                           null_at(std::vector{4, 5, 10, 11})}
+                                           nulls_at(std::vector{4, 5, 10, 11})}
         .release();
     auto expected_output =
       make_dictionary_column(expected_keys->view(), expected_values->view()).release();
@@ -1113,7 +1114,7 @@ TEST_F(LeadLagNonFixedWidthTest, Dictionary)
     auto expected_keys = strings_column_wrapper{input_strings}.release();
     auto expected_values =
       fixed_width_column_wrapper<uint32_t>{{0, 0, 1, 2, 3, 4, 0, 6, 0, 7, 8, 9},
-                                           null_at(std::vector{0, 6})}
+                                           nulls_at(std::vector{0, 6})}
         .release();
     auto expected_output =
       make_dictionary_column(expected_keys->view(), expected_values->view()).release();

--- a/cpp/tests/search/search_struct_test.cpp
+++ b/cpp/tests/search/search_struct_test.cpp
@@ -24,6 +24,8 @@
 #include <cudf/search.hpp>
 #include <cudf/table/table_view.hpp>
 
+using namespace cudf::test::iterators;
+
 using bools_col   = cudf::test::fixed_width_column_wrapper<bool>;
 using int32s_col  = cudf::test::fixed_width_column_wrapper<int32_t>;
 using structs_col = cudf::test::structs_column_wrapper;
@@ -66,8 +68,6 @@ auto search_bounds(std::unique_ptr<cudf::column> const& t_col,
 {
   return search_bounds(t_col->view(), values_col, column_orders, null_precedence);
 }
-
-auto null_at(cudf::size_type idx) { return cudf::test::iterator_with_null_at(idx); }
 
 }  // namespace
 
@@ -298,8 +298,8 @@ TYPED_TEST(TypedStructSearchTest, OneColumnHasNullMaskButNoNullElementTest)
   auto const structs_col2 = structs_col{child_col2}.release();
 
   // structs_col3 (and its child column) will have a null mask but no null element
-  auto child_col3         = col_wrapper{{0, 10, 10}, cudf::test::iterator_no_null()};
-  auto const structs_col3 = structs_col{{child_col3}, cudf::test::iterator_no_null()}.release();
+  auto child_col3         = col_wrapper{{0, 10, 10}, no_null()};
+  auto const structs_col3 = structs_col{{child_col3}, no_null()}.release();
 
   // Search struct elements of structs_col2 and structs_col3 in the column structs_col1
   {

--- a/cpp/tests/search/search_struct_test.cpp
+++ b/cpp/tests/search/search_struct_test.cpp
@@ -298,8 +298,8 @@ TYPED_TEST(TypedStructSearchTest, OneColumnHasNullMaskButNoNullElementTest)
   auto const structs_col2 = structs_col{child_col2}.release();
 
   // structs_col3 (and its child column) will have a null mask but no null element
-  auto child_col3         = col_wrapper{{0, 10, 10}, no_null()};
-  auto const structs_col3 = structs_col{{child_col3}, no_null()}.release();
+  auto child_col3         = col_wrapper{{0, 10, 10}, no_nulls()};
+  auto const structs_col3 = structs_col{{child_col3}, no_nulls()}.release();
 
   // Search struct elements of structs_col2 and structs_col3 in the column structs_col1
   {

--- a/cpp/tests/strings/combine/join_list_elements_tests.cpp
+++ b/cpp/tests/strings/combine/join_list_elements_tests.cpp
@@ -141,7 +141,7 @@ TEST_F(StringsListsConcatenateTest, ColumnHasEmptyListAndNullListInput)
 
   // Empty list results in null
   {
-    auto const expected = STR_COL{{"abc-def-", "" /*NULL*/, "" /*NULL*/, "gh"}, null_at({1, 2})};
+    auto const expected = STR_COL{{"abc-def-", "" /*NULL*/, "" /*NULL*/, "gh"}, nulls_at({1, 2})};
     auto results =
       cudf::strings::join_list_elements(string_lv,
                                         cudf::string_scalar("-"),
@@ -185,7 +185,7 @@ TEST_F(StringsListsConcatenateTest, ScalarSeparator)
                                        STR_LISTS{}, /*NULL*/
                                        STR_LISTS{{"ddd" /*NULL*/, "efgh", "ijk"}, null_at(0)},
                                        STR_LISTS{"zzz", "xxxxx"},
-                                       STR_LISTS{{"v", "", "", "w"}, null_at({1, 2})}},
+                                       STR_LISTS{{"v", "", "", "w"}, nulls_at({1, 2})}},
                                       null_at(1)}
                               .release();
   auto const string_lv = cudf::lists_column_view(string_lists->view());
@@ -195,7 +195,7 @@ TEST_F(StringsListsConcatenateTest, ScalarSeparator)
     auto const results = cudf::strings::join_list_elements(string_lv, cudf::string_scalar("+++"));
     std::vector<char const*> h_expected{nullptr, nullptr, nullptr, "zzz+++xxxxx", nullptr};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -206,7 +206,7 @@ TEST_F(StringsListsConcatenateTest, ScalarSeparator)
     std::vector<char const*> h_expected{
       "a+++___+++ccc", nullptr, "___+++efgh+++ijk", "zzz+++xxxxx", "v+++___+++___+++w"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -218,7 +218,7 @@ TEST_F(StringsListsConcatenateTest, ScalarSeparator)
                                                            cudf::strings::separator_on_nulls::NO);
     std::vector<char const*> h_expected{"a+++ccc", nullptr, "efgh+++ijk", "zzz+++xxxxx", "v+++w"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 }
@@ -257,7 +257,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
                                         "ééé+++12345abcdef",
                                         "aaaééébbbéééccc+++12345"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -278,7 +278,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
                                         "ééé+++12345abcdef",
                                         "aaaééébbbéééccc+++12345"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -288,7 +288,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
     auto const results   = cudf::strings::join_list_elements(string_lv, cudf::string_scalar("+++"));
     std::vector<char const*> h_expected{nullptr, nullptr, nullptr, "zzz+++xxxxx"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -300,7 +300,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
     std::vector<char const*> h_expected{
       "a+++___+++ccc", nullptr, "___+++efgh+++ijk", "zzz+++xxxxx"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -311,7 +311,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
     std::vector<char const*> h_expected{
       nullptr, nullptr, "0a0b0c+++5x5y5z", nullptr, "ééé+++12345abcdef", "aaaééébbbéééccc+++12345"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -327,7 +327,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
                                         "ééé+++12345abcdef",
                                         "aaaééébbbéééccc+++12345"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -338,7 +338,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
     std::vector<char const*> h_expected{
       "zzz+++xxxxx", nullptr, nullptr, nullptr, "0a0b0c+++5x5y5z"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -353,7 +353,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
                                         "___+++11111+++00000",
                                         "0a0b0c+++5x5y5z"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 }
@@ -380,7 +380,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
     auto const results = cudf::strings::join_list_elements(string_lv, separators->view());
     std::vector<char const*> h_expected{nullptr, nullptr, nullptr, nullptr, nullptr, "zzz^^^xxxxx"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -391,7 +391,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
     std::vector<char const*> h_expected{
       nullptr, nullptr, "0a0b0c|||xyzééé", nullptr, nullptr, "zzz^^^xxxxx"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -402,7 +402,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
     std::vector<char const*> h_expected{
       "a+++XXXXX+++ccc", nullptr, nullptr, nullptr, "XXXXX%%%ááá%%%ííí", "zzz^^^xxxxx"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -417,7 +417,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
                                         "XXXXX%%%ááá%%%ííí",
                                         "zzz^^^xxxxx"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -431,7 +431,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
     std::vector<char const*> h_expected{
       "a+++ccc", nullptr, "0a0b0c+++xyzééé", "efgh+++ijk", "ááá%%%ííí", "zzz^^^xxxxx"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 }
@@ -476,7 +476,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
                                         "ééé-+-12345abcdef",
                                         "aaaééébbbéééccc=+=12345"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -498,7 +498,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
                                         "ééé-+-12345abcdef",
                                         "aaaééébbbéééccc=+=12345"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -509,7 +509,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const results   = cudf::strings::join_list_elements(string_lv, sep_col);
     std::vector<char const*> h_expected{nullptr, nullptr, nullptr, nullptr};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -522,7 +522,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     std::vector<char const*> h_expected{
       "a+++___+++ccc", nullptr, "___|||efgh|||ijk", "zzz|||xxxxx"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -534,7 +534,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     std::vector<char const*> h_expected{
       nullptr, nullptr, "0a0b0c###5x5y5z", nullptr, "ééé-+-12345abcdef", "aaaééébbbéééccc=+=12345"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -551,7 +551,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
                                         "ééé-+-12345abcdef",
                                         "aaaééébbbéééccc=+=12345"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -562,7 +562,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const results   = cudf::strings::join_list_elements(string_lv, sep_col);
     std::vector<char const*> h_expected{nullptr, nullptr, nullptr, nullptr, "0a0b0c###5x5y5z"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 
@@ -578,7 +578,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
                                         "___~!~11111~!~00000",
                                         "0a0b0c###5x5y5z"};
     auto const expected =
-      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
+      STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptrs(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
   }
 }

--- a/cpp/tests/strings/combine/join_list_elements_tests.cpp
+++ b/cpp/tests/strings/combine/join_list_elements_tests.cpp
@@ -24,6 +24,8 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 
+using namespace cudf::test::iterators;
+
 struct StringsListsConcatenateTest : public cudf::test::BaseFixture {
 };
 
@@ -33,21 +35,6 @@ using STR_COL   = cudf::test::strings_column_wrapper;
 using INT_LISTS = cudf::test::lists_column_wrapper<int32_t>;
 
 constexpr bool print_all{false};
-
-auto all_nulls() { return cudf::test::iterator_all_nulls(); }
-
-auto null_at(cudf::size_type idx) { return cudf::test::iterator_with_null_at(idx); }
-
-auto null_at(std::vector<cudf::size_type> const& indices)
-{
-  return cudf::test::iterator_with_null_at(cudf::host_span<cudf::size_type const>{indices});
-}
-
-auto nulls_from_nullptr(std::vector<const char*> const& strs)
-{
-  return thrust::make_transform_iterator(strs.begin(), [](auto ptr) { return ptr != nullptr; });
-}
-
 }  // namespace
 
 TEST_F(StringsListsConcatenateTest, InvalidInput)
@@ -206,7 +193,7 @@ TEST_F(StringsListsConcatenateTest, ScalarSeparator)
   // No null replacement
   {
     auto const results = cudf::strings::join_list_elements(string_lv, cudf::string_scalar("+++"));
-    std::vector<const char*> h_expected{nullptr, nullptr, nullptr, "zzz+++xxxxx", nullptr};
+    std::vector<char const*> h_expected{nullptr, nullptr, nullptr, "zzz+++xxxxx", nullptr};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
@@ -216,7 +203,7 @@ TEST_F(StringsListsConcatenateTest, ScalarSeparator)
   {
     auto const results = cudf::strings::join_list_elements(
       string_lv, cudf::string_scalar("+++"), cudf::string_scalar("___"));
-    std::vector<const char*> h_expected{
+    std::vector<char const*> h_expected{
       "a+++___+++ccc", nullptr, "___+++efgh+++ijk", "zzz+++xxxxx", "v+++___+++___+++w"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
@@ -229,7 +216,7 @@ TEST_F(StringsListsConcatenateTest, ScalarSeparator)
                                                            cudf::string_scalar("+++"),
                                                            cudf::string_scalar(""),
                                                            cudf::strings::separator_on_nulls::NO);
-    std::vector<const char*> h_expected{"a+++ccc", nullptr, "efgh+++ijk", "zzz+++xxxxx", "v+++w"};
+    std::vector<char const*> h_expected{"a+++ccc", nullptr, "efgh+++ijk", "zzz+++xxxxx", "v+++w"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
@@ -258,7 +245,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
   {
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {0, 11})[0]);
     auto const results   = cudf::strings::join_list_elements(string_lv, cudf::string_scalar("+++"));
-    std::vector<const char*> h_expected{nullptr,
+    std::vector<char const*> h_expected{nullptr,
                                         nullptr,
                                         nullptr,
                                         "zzz+++xxxxx",
@@ -279,7 +266,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {0, 11})[0]);
     auto const results   = cudf::strings::join_list_elements(
       string_lv, cudf::string_scalar("+++"), cudf::string_scalar("___"));
-    std::vector<const char*> h_expected{"a+++___+++ccc",
+    std::vector<char const*> h_expected{"a+++___+++ccc",
                                         nullptr,
                                         "___+++efgh+++ijk",
                                         "zzz+++xxxxx",
@@ -299,7 +286,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
   {
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {0, 4})[0]);
     auto const results   = cudf::strings::join_list_elements(string_lv, cudf::string_scalar("+++"));
-    std::vector<const char*> h_expected{nullptr, nullptr, nullptr, "zzz+++xxxxx"};
+    std::vector<char const*> h_expected{nullptr, nullptr, nullptr, "zzz+++xxxxx"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
@@ -310,7 +297,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {0, 4})[0]);
     auto const results   = cudf::strings::join_list_elements(
       string_lv, cudf::string_scalar("+++"), cudf::string_scalar("___"));
-    std::vector<const char*> h_expected{
+    std::vector<char const*> h_expected{
       "a+++___+++ccc", nullptr, "___+++efgh+++ijk", "zzz+++xxxxx"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
@@ -321,7 +308,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
   {
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {5, 11})[0]);
     auto const results   = cudf::strings::join_list_elements(string_lv, cudf::string_scalar("+++"));
-    std::vector<const char*> h_expected{
+    std::vector<char const*> h_expected{
       nullptr, nullptr, "0a0b0c+++5x5y5z", nullptr, "ééé+++12345abcdef", "aaaééébbbéééccc+++12345"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
@@ -333,7 +320,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {5, 11})[0]);
     auto const results   = cudf::strings::join_list_elements(
       string_lv, cudf::string_scalar("+++"), cudf::string_scalar("___"));
-    std::vector<const char*> h_expected{"abcdef+++012345+++___+++xxx000",
+    std::vector<char const*> h_expected{"abcdef+++012345+++___+++xxx000",
                                         "___+++11111+++00000",
                                         "0a0b0c+++5x5y5z",
                                         nullptr,
@@ -348,7 +335,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
   {
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {3, 8})[0]);
     auto const results   = cudf::strings::join_list_elements(string_lv, cudf::string_scalar("+++"));
-    std::vector<const char*> h_expected{
+    std::vector<char const*> h_expected{
       "zzz+++xxxxx", nullptr, nullptr, nullptr, "0a0b0c+++5x5y5z"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
@@ -360,7 +347,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithScalarSeparator)
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {3, 8})[0]);
     auto const results   = cudf::strings::join_list_elements(
       string_lv, cudf::string_scalar("+++"), cudf::string_scalar("___"));
-    std::vector<const char*> h_expected{"zzz+++xxxxx",
+    std::vector<char const*> h_expected{"zzz+++xxxxx",
                                         nullptr,
                                         "abcdef+++012345+++___+++xxx000",
                                         "___+++11111+++00000",
@@ -391,7 +378,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
   // No null replacement
   {
     auto const results = cudf::strings::join_list_elements(string_lv, separators->view());
-    std::vector<const char*> h_expected{nullptr, nullptr, nullptr, nullptr, nullptr, "zzz^^^xxxxx"};
+    std::vector<char const*> h_expected{nullptr, nullptr, nullptr, nullptr, nullptr, "zzz^^^xxxxx"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
@@ -401,7 +388,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
   {
     auto const results =
       cudf::strings::join_list_elements(string_lv, separators->view(), cudf::string_scalar("|||"));
-    std::vector<const char*> h_expected{
+    std::vector<char const*> h_expected{
       nullptr, nullptr, "0a0b0c|||xyzééé", nullptr, nullptr, "zzz^^^xxxxx"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
@@ -412,7 +399,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
   {
     auto const results = cudf::strings::join_list_elements(
       string_lv, separators->view(), cudf::string_scalar("", false), cudf::string_scalar("XXXXX"));
-    std::vector<const char*> h_expected{
+    std::vector<char const*> h_expected{
       "a+++XXXXX+++ccc", nullptr, nullptr, nullptr, "XXXXX%%%ááá%%%ííí", "zzz^^^xxxxx"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
@@ -423,7 +410,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
   {
     auto const results = cudf::strings::join_list_elements(
       string_lv, separators->view(), cudf::string_scalar("|||"), cudf::string_scalar("XXXXX"));
-    std::vector<const char*> h_expected{"a+++XXXXX+++ccc",
+    std::vector<char const*> h_expected{"a+++XXXXX+++ccc",
                                         nullptr,
                                         "0a0b0c|||xyzééé",
                                         "XXXXX|||efgh|||ijk",
@@ -441,7 +428,7 @@ TEST_F(StringsListsConcatenateTest, ColumnSeparators)
                                                            cudf::string_scalar("+++"),
                                                            cudf::string_scalar(""),
                                                            cudf::strings::separator_on_nulls::NO);
-    std::vector<const char*> h_expected{
+    std::vector<char const*> h_expected{
       "a+++ccc", nullptr, "0a0b0c+++xyzééé", "efgh+++ijk", "ááá%%%ííí", "zzz^^^xxxxx"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
@@ -477,7 +464,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {0, 11})[0]);
     auto const sep_col   = cudf::strings_column_view(cudf::slice(separators->view(), {0, 11})[0]);
     auto const results   = cudf::strings::join_list_elements(string_lv, sep_col);
-    std::vector<const char*> h_expected{nullptr,
+    std::vector<char const*> h_expected{nullptr,
                                         nullptr,
                                         nullptr,
                                         nullptr,
@@ -499,7 +486,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const sep_col   = cudf::strings_column_view(cudf::slice(separators->view(), {0, 11})[0]);
     auto const results   = cudf::strings::join_list_elements(
       string_lv, sep_col, cudf::string_scalar("|||"), cudf::string_scalar("___"));
-    std::vector<const char*> h_expected{"a+++___+++ccc",
+    std::vector<char const*> h_expected{"a+++___+++ccc",
                                         nullptr,
                                         "___|||efgh|||ijk",
                                         "zzz|||xxxxx",
@@ -520,7 +507,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {0, 4})[0]);
     auto const sep_col   = cudf::strings_column_view(cudf::slice(separators->view(), {0, 4})[0]);
     auto const results   = cudf::strings::join_list_elements(string_lv, sep_col);
-    std::vector<const char*> h_expected{nullptr, nullptr, nullptr, nullptr};
+    std::vector<char const*> h_expected{nullptr, nullptr, nullptr, nullptr};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
@@ -532,7 +519,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const sep_col   = cudf::strings_column_view(cudf::slice(separators->view(), {0, 4})[0]);
     auto const results   = cudf::strings::join_list_elements(
       string_lv, sep_col, cudf::string_scalar("|||"), cudf::string_scalar("___"));
-    std::vector<const char*> h_expected{
+    std::vector<char const*> h_expected{
       "a+++___+++ccc", nullptr, "___|||efgh|||ijk", "zzz|||xxxxx"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
@@ -544,7 +531,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {5, 11})[0]);
     auto const sep_col   = cudf::strings_column_view(cudf::slice(separators->view(), {5, 11})[0]);
     auto const results   = cudf::strings::join_list_elements(string_lv, sep_col);
-    std::vector<const char*> h_expected{
+    std::vector<char const*> h_expected{
       nullptr, nullptr, "0a0b0c###5x5y5z", nullptr, "ééé-+-12345abcdef", "aaaééébbbéééccc=+=12345"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
@@ -557,7 +544,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const sep_col   = cudf::strings_column_view(cudf::slice(separators->view(), {5, 11})[0]);
     auto const results   = cudf::strings::join_list_elements(
       string_lv, sep_col, cudf::string_scalar("|||"), cudf::string_scalar("___"));
-    std::vector<const char*> h_expected{"abcdef^^^012345^^^___^^^xxx000",
+    std::vector<char const*> h_expected{"abcdef^^^012345^^^___^^^xxx000",
                                         "___~!~11111~!~00000",
                                         "0a0b0c###5x5y5z",
                                         nullptr,
@@ -573,7 +560,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const string_lv = cudf::lists_column_view(cudf::slice(string_lists->view(), {3, 8})[0]);
     auto const sep_col   = cudf::strings_column_view(cudf::slice(separators->view(), {3, 8})[0]);
     auto const results   = cudf::strings::join_list_elements(string_lv, sep_col);
-    std::vector<const char*> h_expected{nullptr, nullptr, nullptr, nullptr, "0a0b0c###5x5y5z"};
+    std::vector<char const*> h_expected{nullptr, nullptr, nullptr, nullptr, "0a0b0c###5x5y5z"};
     auto const expected =
       STR_COL{h_expected.begin(), h_expected.end(), nulls_from_nullptr(h_expected)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected, print_all);
@@ -585,7 +572,7 @@ TEST_F(StringsListsConcatenateTest, SlicedListsWithColumnSeparators)
     auto const sep_col   = cudf::strings_column_view(cudf::slice(separators->view(), {3, 8})[0]);
     auto const results   = cudf::strings::join_list_elements(
       string_lv, sep_col, cudf::string_scalar("|||"), cudf::string_scalar("___"));
-    std::vector<const char*> h_expected{"zzz|||xxxxx",
+    std::vector<char const*> h_expected{"zzz|||xxxxx",
                                         nullptr,
                                         "abcdef^^^012345^^^___^^^xxx000",
                                         "___~!~11111~!~00000",

--- a/cpp/tests/strings/repeat_strings_tests.cpp
+++ b/cpp/tests/strings/repeat_strings_tests.cpp
@@ -22,20 +22,12 @@
 #include <cudf/strings/repeat_strings.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 
+using namespace cudf::test::iterators;
+
 namespace {
 using STR_COL = cudf::test::strings_column_wrapper;
 
 constexpr bool print_all{false};
-
-auto all_nulls() { return cudf::test::iterator_all_nulls(); }
-
-auto null_at(cudf::size_type idx) { return cudf::test::iterator_with_null_at(idx); }
-
-auto null_at(std::vector<cudf::size_type> const& indices)
-{
-  return cudf::test::iterator_with_null_at(cudf::host_span<cudf::size_type const>{indices});
-}
-
 }  // namespace
 
 struct RepeatJoinStringTest : public cudf::test::BaseFixture {

--- a/cpp/tests/strings/repeat_strings_tests.cpp
+++ b/cpp/tests/strings/repeat_strings_tests.cpp
@@ -109,7 +109,7 @@ TEST_F(RepeatJoinStringTest, AllNullStringsColumn)
 TEST_F(RepeatJoinStringTest, ZeroSizeAndNullStringsColumn)
 {
   auto const strs =
-    STR_COL{{"" /*NULL*/, "", "" /*NULL*/, "", "", "" /*NULL*/}, null_at({0, 2, 5})};
+    STR_COL{{"" /*NULL*/, "", "" /*NULL*/, "", "", "" /*NULL*/}, nulls_at({0, 2, 5})};
   auto const results = cudf::strings::repeat_strings(cudf::strings_column_view(strs), 10);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(strs, *results, print_all);
 }
@@ -178,7 +178,7 @@ TEST_F(RepeatJoinStringTest, StringsColumnWithNulls)
                              "íí",
                              "",
                              "Hello World"},
-                            null_at({1, 3, 5})};
+                            nulls_at({1, 3, 5})};
 
   {
     auto const results  = cudf::strings::repeat_strings(cudf::strings_column_view(strs), 2);
@@ -192,7 +192,7 @@ TEST_F(RepeatJoinStringTest, StringsColumnWithNulls)
                                    "íííí",
                                    "",
                                    "Hello WorldHello World"},
-                                  null_at({1, 3, 5})};
+                                  nulls_at({1, 3, 5})};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
   }
 
@@ -205,7 +205,7 @@ TEST_F(RepeatJoinStringTest, StringsColumnWithNulls)
   // Non-positive repeat times.
   {
     auto const expected = STR_COL{
-      {"", "" /*NULL*/, "", "" /*NULL*/, "", "" /*NULL*/, "", "", "", ""}, null_at({1, 3, 5})};
+      {"", "" /*NULL*/, "", "" /*NULL*/, "", "" /*NULL*/, "", "", "", ""}, nulls_at({1, 3, 5})};
 
     auto results = cudf::strings::repeat_strings(cudf::strings_column_view(strs), 0);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
@@ -227,7 +227,7 @@ TEST_F(RepeatJoinStringTest, StringsColumnWithNulls)
     auto const sliced_strs = cudf::slice(strs, {2, 7})[0];
     auto const results  = cudf::strings::repeat_strings(cudf::strings_column_view(sliced_strs), 2);
     auto const expected = STR_COL{
-      {"abcxyzabcxyz", "" /*NULL*/, "xyzéééxyzééé", "" /*NULL*/, "áááááá"}, null_at({1, 3})};
+      {"abcxyzabcxyz", "" /*NULL*/, "xyzéééxyzééé", "" /*NULL*/, "áááááá"}, nulls_at({1, 3})};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, print_all);
   }
 


### PR DESCRIPTION
This PR refactors the functions in `tests/iterator_utilities.hpp`. In particular:
 * Put the functions into a namespace `iterators`
 * Remove the prefix `iterator_with_` from the function names. As such, instead of having `cudf::test::iterators_with_null_at` (and similar `cudf::test::iterators_with_*`), we will have `cudf::test::iterators::null_at` (and similar). Upon usage, we can import the namespace `cudf::test::iterators` and use just `null_at()`.

This refactor will make the test code look significantly cleaner. The subnamespace `iterators` makes sure that there will be no name conflict.