### PR TITLE
cudf_kafka explicitly search for a matching patch version of cudf

### DIFF
--- a/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
+++ b/cpp/libcudf_kafka/cmake/thirdparty/CUDF_KAFKA_GetCUDF.cmake
@@ -28,7 +28,7 @@ function(find_and_configure_cudf VERSION)
     endif()
 endfunction()
 
-set(CUDA_KAFKA_MIN_VERSION_cudf "${CUDA_KAFKA_VERSION_MAJOR}.${CUDA_KAFKA_VERSION_MINOR}.00")
+set(CUDA_KAFKA_MIN_VERSION_cudf "${CUDA_KAFKA_VERSION_MAJOR}.${CUDA_KAFKA_VERSION_MINOR}.${CUDA_KAFKA_VERSION_PATCH}")
 find_and_configure_cudf(${CUDA_KAFKA_MIN_VERSION_cudf})
 
 if(cudf_ADDED)


### PR DESCRIPTION
This fixes issues where cudf_kafka tries to search for/build an older cudf patch version. ( 21.06.01 searching for 21.06.00 )