### PR TITLE
Fix debug compile error in gather_struct_tests.cpp

### DIFF
--- a/cpp/tests/copying/gather_struct_tests.cpp
+++ b/cpp/tests/copying/gather_struct_tests.cpp
@@ -84,7 +84,9 @@ auto get_expected_column(std::vector<SourceElementT> const& input_values,
 {
   auto is_valid =  // Validity predicate.
     [&input_values, &input_validity, &struct_validity, &gather_map](auto gather_index) {
-      assert(gather_index >= 0 && gather_index < gather_map.size() || "Gather-index out of range.");
+      assert(
+        gather_index >= 0 && gather_index < static_cast<cudf::size_type>(gather_map.size())) ||
+        "Gather-index out of range.");
 
       auto i{gather_map[gather_index]};  // Index into input_values.
 

--- a/cpp/tests/copying/gather_struct_tests.cpp
+++ b/cpp/tests/copying/gather_struct_tests.cpp
@@ -85,7 +85,7 @@ auto get_expected_column(std::vector<SourceElementT> const& input_values,
   auto is_valid =  // Validity predicate.
     [&input_values, &input_validity, &struct_validity, &gather_map](auto gather_index) {
       assert(
-        gather_index >= 0 && gather_index < static_cast<cudf::size_type>(gather_map.size())) ||
+        (gather_index >= 0 && gather_index < static_cast<cudf::size_type>(gather_map.size())) ||
         "Gather-index out of range.");
 
       auto i{gather_map[gather_index]};  // Index into input_values.


### PR DESCRIPTION
Building libcudf in debug resulted in a compile error introduced by #8527 

```
../tests/copying/gather_struct_tests.cpp:87:32: error: suggest parentheses around ‘&&’ within ‘||’ [-Werror=parentheses]
   87 |       assert(gather_index >= 0 && gather_index < gather_map.size() ||
      |              ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This error only shows in a debug build. This PR fixes the this code by applying the parentheses as the error suggests.