### PR TITLE
Fix for strings containing special JSON characters in get_json_object().

### DIFF
--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -108,8 +108,8 @@ class parser {
   /**
    * @brief Parse an escape sequence.
    *
-   * Parse an escape sequence.  Must be a valid sequence as specified
-   * by the JSON format  https://www.json.org/json-en.html
+   * Must be a valid sequence as specified by the JSON format
+   * https://www.json.org/json-en.html
    *
    * @returns True on success or false on fail.
    */

--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -98,6 +98,44 @@ class parser {
     return false;
   }
 
+  CUDA_HOST_DEVICE_CALLABLE bool is_hex_digit(char c)
+  {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+  }
+
+  CUDA_HOST_DEVICE_CALLABLE int64_t chars_left() { return input_len - ((pos - input) + 1); }
+
+  /**
+   * @brief Parse an escape sequence.
+   *
+   * Parse an escape sequence.  Must be a valid sequence as specified
+   * by the JSON format  https://www.json.org/json-en.html
+   *
+   * @returns True on success or false on fail.
+   */
+  CUDA_HOST_DEVICE_CALLABLE bool parse_escape_seq()
+  {
+    if (*pos != '\\') { return false; }
+    char c = *++pos;
+
+    // simple case
+    if (c == '\"' || c == '\\' || c == '/' || c == 'b' || c == 'f' || c == 'n' || c == 'r' ||
+        c == 't') {
+      pos++;
+      return true;
+    }
+
+    // hex digits: must be of the form uXXXX  where each X is a valid hex digit
+    if (c == 'u' && chars_left() >= 4 && is_hex_digit(pos[1]) && is_hex_digit(pos[2]) &&
+        is_hex_digit(pos[3]) && is_hex_digit(pos[4])) {
+      pos += 5;
+      return true;
+    }
+
+    // an illegal escape sequence.
+    return false;
+  }
+
   /**
    * @brief Parse a quote-enclosed JSON string.
    *
@@ -122,12 +160,16 @@ class parser {
 
         const char* start = ++pos;
         while (!eof()) {
-          if (*pos == quote) {
+          // handle escaped characters
+          if (*pos == '\\') {
+            if (!parse_escape_seq()) { return parse_result::ERROR; }
+          } else if (*pos == quote) {
             str = string_view(start, pos - start);
             pos++;
             return parse_result::SUCCESS;
+          } else {
+            pos++;
           }
-          pos++;
         }
       }
     }
@@ -229,15 +271,22 @@ class json_state : private parser {
       int arr_count = 0;
 
       while (!eof(end)) {
-        // could do some additional checks here. we know our current
-        // element type, so we could be more strict on what kinds of
-        // characters we expect to see.
-        switch (*end++) {
-          case '{': obj_count++; break;
-          case '}': obj_count--; break;
-          case '[': arr_count++; break;
-          case ']': arr_count--; break;
-          default: break;
+        // parse strings explicitly so we handle all interesting corner cases (such as strings
+        // containing {, }, [ or ]
+        if (is_quote(*end)) {
+          string_view str;
+          pos = end;
+          if (parse_string(str, false, *end) == parse_result::ERROR) { return parse_result::ERROR; }
+          end = pos;
+        } else {
+          char const c = *end++;
+          switch (c) {
+            case '{': obj_count++; break;
+            case '}': obj_count--; break;
+            case '[': arr_count++; break;
+            case ']': arr_count--; break;
+            default: break;
+          }
         }
         if (obj_count == 0 && arr_count == 0) { break; }
       }


### PR DESCRIPTION

Fixes  https://github.com/rapidsai/cudf/issues/8387

Also adds proper handling for valid JSON escape sequences in strings.