### PR TITLE
Address debug build errors

### DIFF
--- a/cpp/tests/copying/gather_struct_tests.cpp
+++ b/cpp/tests/copying/gather_struct_tests.cpp
@@ -84,7 +84,9 @@ auto get_expected_column(std::vector<SourceElementT> const& input_values,
 {
   auto is_valid =  // Validity predicate.
     [&input_values, &input_validity, &struct_validity, &gather_map](auto gather_index) {
-      assert(gather_index >= 0 && gather_index < gather_map.size() || "Gather-index out of range.");
+      assert((gather_index >= static_cast<size_type>(0) &&
+              gather_index < static_cast<size_type>(gather_map.size())) ||
+             "Gather-index out of range.");
 
       auto i{gather_map[gather_index]};  // Index into input_values.
 


### PR DESCRIPTION
Fixes #8564 

```
../tests/copying/gather_struct_tests.cpp:87:48: error: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Werror=sign-compare]
   87 |       assert(gather_index >= 0 && gather_index < gather_map.size() || "Gather-index out of range.");
      |                                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
../tests/copying/gather_struct_tests.cpp:87:32: error: suggest parentheses around ‘&&’ within ‘||’ [-Werror=parentheses]
   87 |       assert(gather_index >= 0 && gather_index < gather_map.size() || "Gather-index out of range.");
      |              ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```