### PR TITLE
Modernize libcudf basic example CMakeFile; updates CI build tests

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -196,13 +196,6 @@ fi
 
 # Both regular and Project Flash proceed here
 
-# set environment variable for numpy 1.16
-# will be enabled for later versions by default
-np_ver=$(python -c "import numpy; print('.'.join(numpy.__version__.split('.')[:-1]))")
-if [ "$np_ver" == "1.16" ];then
-    export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
-fi
-
 ################################################################################
 # BUILD - Build libcudf examples
 ################################################################################
@@ -210,6 +203,13 @@ fi
 # If examples grows too large to build, should move to cpu side
 gpuci_logger "Building libcudf examples"
 $WORKSPACE/cpp/examples/build.sh
+
+# set environment variable for numpy 1.16
+# will be enabled for later versions by default
+np_ver=$(python -c "import numpy; print('.'.join(numpy.__version__.split('.')[:-1]))")
+if [ "$np_ver" == "1.16" ];then
+    export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
+fi
 
 ################################################################################
 # TEST - Run py.test, notebooks

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -192,9 +192,6 @@ else
         "$WORKSPACE/build.sh" cudf dask_cudf cudf_kafka -l --ptds
     fi
 
-    # If examples grows too large to build, should move to cpu side
-    gpuci_logger "Building libcudf examples"
-    $WORKSPACE/cpp/examples/build.sh
 fi
 
 # Both regular and Project Flash proceed here
@@ -206,6 +203,13 @@ if [ "$np_ver" == "1.16" ];then
     export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 fi
 
+################################################################################
+# BUILD - Build libcudf examples
+################################################################################
+
+# If examples grows too large to build, should move to cpu side
+gpuci_logger "Building libcudf examples"
+$WORKSPACE/cpp/examples/build.sh
 
 ################################################################################
 # TEST - Run py.test, notebooks

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -58,4 +58,4 @@ sed_runner "s/version == ${CURRENT_SHORT_TAG}/version == ${NEXT_SHORT_TAG}/g" RE
 sed_runner "s/cudf=${CURRENT_SHORT_TAG}/cudf=${NEXT_SHORT_TAG}/g" README.md
 
 # Libcudf examples update
-sed_runner "s/CUDF_TAG \"branch-${CURRENT_SHORT_TAG}\"/CUDF_TAG \"branch-${NEXT_SHORT_TAG}\"/" cpp/examples/basic/CMakeLists.txt
+sed_runner "s/CUDF_TAG branch-${CURRENT_SHORT_TAG}/CUDF_TAG branch-${NEXT_SHORT_TAG}/" cpp/examples/basic/CMakeLists.txt

--- a/cpp/examples/basic/CMakeLists.txt
+++ b/cpp/examples/basic/CMakeLists.txt
@@ -1,23 +1,12 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(basic_example VERSION 0.0.1 LANGUAGES C CXX CUDA)
+project(basic_example VERSION 0.0.1 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CUDA_ARCHITECTURES "")
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CPM_DOWNLOAD_VERSION v0.32.2)
+file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/${CPM_DOWNLOAD_VERSION}/get_cpm.cmake ${CMAKE_BINARY_DIR}/cmake/get_cpm.cmake)
+include(${CMAKE_BINARY_DIR}/cmake/get_cpm.cmake)
 
-set(CPM_DOWNLOAD_VERSION 0.27.2) 
-set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
-
-set(CUDF_TAG "branch-21.08")
-
-if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
-    message(STATUS "Downloading CPM.cmake")
-    file(DOWNLOAD https://github.com/TheLartians/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake ${CPM_DOWNLOAD_LOCATION})
-endif()
-
-include(${CPM_DOWNLOAD_LOCATION})
-
+set(CUDF_TAG branch-21.08)
 CPMFindPackage(NAME  cudf
     GIT_REPOSITORY  https://github.com/rapidsai/cudf
     GIT_TAG         ${CUDF_TAG}
@@ -25,6 +14,8 @@ CPMFindPackage(NAME  cudf
     SOURCE_SUBDIR   cpp
 )
 
+
 # Configure your project here
-add_executable(${PROJECT_NAME} "src/process_csv.cpp")
-target_link_libraries(${PROJECT_NAME} cudf::cudf)
+add_executable(basic_example src/process_csv.cpp)
+target_link_libraries(basic_example PRIVATE cudf::cudf)
+target_compile_features(basic_example PRIVATE cxx_std_17)


### PR DESCRIPTION
Follow up of #7671 

This PR addresses review comments from https://github.com/rapidsai/cudf/pull/7671#issuecomment-864072535, modernizing the CMakeFile in libcudf basic example.

This PR also updates build tests for examples to make sure they are tested after both regular/project flash code path.