### PR TITLE
Add `get_element` for struct column

### DIFF
--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -186,8 +186,9 @@ struct get_element_functor {
     bool valid = is_element_valid_sync(input, index, stream);
     auto row_contents =
       std::make_unique<column>(slice(input, index, index + 1), stream, mr)->release();
-    auto scalar_contents = std::make_unique<table>(std::move(row_contents.children));
-    return std::make_unique<struct_scalar>(std::move(*scalar_contents), valid, stream, mr);
+    auto scalar_contents = table(std::move(row_contents.children));
+    auto res = std::make_unique<struct_scalar>(std::move(scalar_contents), valid, stream, mr);
+    return res;
   }
 };
 

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -187,8 +187,7 @@ struct get_element_functor {
     auto row_contents =
       std::make_unique<column>(slice(input, index, index + 1), stream, mr)->release();
     auto scalar_contents = table(std::move(row_contents.children));
-    auto res = std::make_unique<struct_scalar>(std::move(scalar_contents), valid, stream, mr);
-    return res;
+    return std::make_unique<struct_scalar>(std::move(scalar_contents), valid, stream, mr);
   }
 };
 

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -26,7 +26,6 @@
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/scalar/scalar_factories.hpp>
 
-#include <memory>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf {

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -16,6 +16,7 @@
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/copying.hpp>
+#include <cudf/detail/copy.hpp>
 #include <cudf/detail/indexalator.cuh>
 #include <cudf/detail/is_element_valid.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
@@ -25,6 +26,7 @@
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/scalar/scalar_factories.hpp>
 
+#include <memory>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf {
@@ -174,11 +176,18 @@ struct get_element_functor {
                                                    mr);
   }
 
-  template <typename T, typename... Args>
-  std::enable_if_t<std::is_same<T, struct_view>::value, std::unique_ptr<scalar>> operator()(
-    Args &&...)
+  template <typename T, std::enable_if_t<std::is_same<T, struct_view>::value> *p = nullptr>
+  std::unique_ptr<scalar> operator()(
+    column_view const &input,
+    size_type index,
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource())
   {
-    CUDF_FAIL("get_element_functor not supported for struct_view");
+    bool valid = is_element_valid_sync(input, index, stream);
+    auto row_contents =
+      std::make_unique<column>(slice(input, index, index + 1), stream, mr)->release();
+    auto scalar_contents = std::make_unique<table>(std::move(row_contents.children));
+    return std::make_unique<struct_scalar>(std::move(*scalar_contents), valid, stream, mr);
   }
 };
 

--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -885,7 +885,6 @@ TYPED_TEST(StructGetValueTestTyped, mixed_types_invalid)
   EXPECT_FALSE(typed_s->is_valid());
 
   // expect to preserve types along column hierarchy.
-  // TODO: use `column_types_equal` after GH 8505 merged
   EXPECT_EQ(typed_s->view().column(0).type().id(), type_to_id<TypeParam>());
   EXPECT_EQ(typed_s->view().column(1).type().id(), type_id::STRING);
   EXPECT_EQ(typed_s->view().column(2).type().id(), type_id::DICTIONARY32);

--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -27,6 +27,7 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/iterator_utilities.hpp>
+#include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -790,6 +791,70 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNull)
 
   EXPECT_FALSE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_data, typed_s->view());
+}
+
+struct StructGetValueTest : public BaseFixture {
+};
+template <typename T>
+struct StructGetValueTestTyped : public BaseFixture {
+};
+
+TYPED_TEST_CASE(StructGetValueTestTyped, FixedWidthTypes);
+
+TYPED_TEST(StructGetValueTestTyped, mixed_types_valid)
+{
+  using LCW = lists_column_wrapper<TypeParam, int32_t>;
+
+  // col fields
+  fixed_width_column_wrapper<TypeParam> f1{1, 2, 3};
+  strings_column_wrapper f2{"aa", "bbb", "c"};
+  dictionary_column_wrapper<TypeParam, uint32_t> f3{42, 42, 24};
+  LCW f4{LCW{8, 8, 8}, LCW{9, 9}, LCW{10}};
+
+  structs_column_wrapper col{f1, f2, f3, f4};
+
+  size_type index = 2;
+  auto s          = get_element(col, index);
+  auto typed_s    = static_cast<struct_scalar const *>(s.get());
+
+  // expect fields
+  fixed_width_column_wrapper<TypeParam> ef1{3};
+  strings_column_wrapper ef2{"c"};
+  dictionary_column_wrapper<int32_t, TypeParam> ef3{24};
+  LCW ef4{LCW{10}};
+
+  table_view expect_data{{ef1, ef2, ef3, ef4}};
+
+  EXPECT_TRUE(typed_s->is_valid());
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expect_data, typed_s->view());
+}
+
+TYPED_TEST(StructGetValueTestTyped, mixed_types_invalid)
+{
+  using LCW             = lists_column_wrapper<TypeParam, int32_t>;
+  using validity_mask_t = std::vector<valid_type>;
+
+  // col fields
+  fixed_width_column_wrapper<TypeParam> f1{1, 2, 3};
+  strings_column_wrapper f2{"aa", "bbb", "c"};
+  dictionary_column_wrapper<TypeParam, uint32_t> f3{42, 42, 24};
+  LCW f4{LCW{8, 8, 8}, LCW{9, 9}, LCW{10}};
+
+  structs_column_wrapper col({f1, f2, f3, f4}, validity_mask_t{false, true, true}.begin());
+
+  size_type index = 0;
+  auto s          = get_element(col, index);
+  auto typed_s    = static_cast<struct_scalar const *>(s.get());
+
+  EXPECT_FALSE(typed_s->is_valid());
+
+  // expect to preserve types along hierarchy.
+  EXPECT_EQ(typed_s->view().column(0).type().id(), type_to_id<TypeParam>());
+  EXPECT_EQ(typed_s->view().column(1).type().id(), type_id::STRING);
+  EXPECT_EQ(typed_s->view().column(2).type().id(), type_id::DICTIONARY32);
+  EXPECT_EQ(typed_s->view().column(2).child(1).type().id(), type_to_id<TypeParam>());
+  EXPECT_EQ(typed_s->view().column(3).type().id(), type_id::LIST);
+  EXPECT_EQ(typed_s->view().column(3).child(1).type().id(), type_to_id<TypeParam>());
 }
 
 }  // namespace test


### PR DESCRIPTION
Partly addresses #8558 

This PR supports retrieving a `struct_scalar` from `STRUCT` type column.