### PR TITLE
Use cmake 3.20.1 as it is now required by rmm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Compiler requirements:
 
 * `gcc`     version 9.3+
 * `nvcc`    version 11.0+
-* `cmake`   version 3.18.0+
+* `cmake`   version 3.20.1+
 
 CUDA/GPU requirements:
 

--- a/conda/environments/cudf_dev_cuda11.0.yml
+++ b/conda/environments/cudf_dev_cuda11.0.yml
@@ -11,7 +11,7 @@ dependencies:
   - clang-tools=8.0.1
   - cupy>7.1.0,<10.0.0a0
   - rmm=21.08.*
-  - cmake>=3.18
+  - cmake>=3.20.1
   - cmake_setuptools>=0.1.3
   - python>=3.7,<3.9
   - numba>=0.53.1

--- a/conda/environments/cudf_dev_cuda11.2.yml
+++ b/conda/environments/cudf_dev_cuda11.2.yml
@@ -11,7 +11,7 @@ dependencies:
   - clang-tools=8.0.1
   - cupy>7.1.0,<10.0.0a0
   - rmm=21.08.*
-  - cmake>=3.18
+  - cmake>=3.20.1
   - cmake_setuptools>=0.1.3
   - python>=3.7,<3.9
   - numba>=0.53.1

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -24,7 +24,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.18
+    - cmake >=3.20.1
   host:
     - python
     - cython >=0.29,<0.30

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -33,7 +33,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.18
+    - cmake >=3.20.1
   host:
     - librmm {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*

--- a/conda/recipes/libcudf_kafka/meta.yaml
+++ b/conda/recipes/libcudf_kafka/meta.yaml
@@ -23,7 +23,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.18
+    - cmake >=3.20.1
   host:
     - libcudf {{ version }}
     - librdkafka >=1.5.0,<1.5.3


### PR DESCRIPTION
Corrects failures when compiling in CI due to the bump in requirements by rmm usage of rapids-cmake