### PR TITLE
Update cmake to 3.20.5 in the Java Docker image [skip ci]

### DIFF
--- a/java/ci/Dockerfile.centos7
+++ b/java/ci/Dockerfile.centos7
@@ -31,8 +31,10 @@ RUN yum install -y git zlib-devel maven tar wget patch
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir /usr/local/rapids && mkdir /rapids && chmod 777 /usr/local/rapids && chmod 777 /rapids
 
-RUN cd /usr/local/ && wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.tar.gz && \
-   tar zxf cmake-3.19.0-Linux-x86_64.tar.gz
+RUN cd /usr/local/ && wget --quiet https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.tar.gz && \
+   tar zxf cmake-3.20.5-linux-x86_64.tar.gz && \
+   rm cmake-3.20.5-linux-x86_64.tar.gz
+ENV PATH /usr/local/cmake-3.20.5-linux-x86_64/bin:$PATH
 
 # get GDS user-space lib
 RUN cd /tmp/ && wget https://developer.download.nvidia.com/gds/redist/rel-0.95.1/gds-redistrib-0.95.1.tgz && \

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -48,9 +48,6 @@ export GIT_COMMITTER_EMAIL="ci@nvidia.com"
 export CUDACXX=/usr/local/cuda/bin/nvcc
 export LIBCUDF_KERNEL_CACHE_PATH=/rapids
 
-# add cmake 3.19 to PATH
-export PATH=/usr/local/cmake-3.19.0-Linux-x86_64/bin:$PATH
-
 ###### Build libcudf ######
 rm -rf "$WORKSPACE/cpp/build"
 mkdir -p "$WORKSPACE/cpp/build"


### PR DESCRIPTION
cuDF updated the cmake requiring `3.20.1` or higher version with #8586, while cmake version in the java docker image is still `3.19.0`.

Need to update cmake version in the java docker image to meet the requirement.

Signed-off-by: Tim Liu <timl@nvidia.com>
