### PR TITLE
Fix orc_reader_benchmark.cpp compile error

### DIFF
--- a/cpp/benchmarks/io/orc/orc_reader_benchmark.cpp
+++ b/cpp/benchmarks/io/orc/orc_reader_benchmark.cpp
@@ -124,7 +124,7 @@ void BM_orc_read_varying_options(benchmark::State& state)
             // Need to assume that an additional "overflow" stripe is present
             stripes_to_read.push_back(num_stripes);
           }
-          read_options.set_stripes(stripes_to_read);
+          read_options.set_stripes({stripes_to_read});
         } break;
         case row_selection::NROWS:
           read_options.set_skip_rows(chunk * chunk_row_cnt);


### PR DESCRIPTION
Recent changes in #8142 causes the `cpp/benchmarks/io/orc/orc_reader_benchmark.cpp` compile to fail

```
Building CXX object benchmarks/CMakeFiles/ORC_READER_BENCH.dir/io/orc/orc_reader_benchmark.cpp.o
FAILED: benchmarks/CMakeFiles/ORC_READER_BENCH.dir/io/orc/orc_reader_benchmark.cpp.o 
/usr/local/bin/g++ -DCUDF_VERSION=21.08.00 -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -DJITIFY_USE_CACHE -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../benchmarks -I../ -I../src -I_deps/benchmark-src/src/../include -I_deps/jitify-src -I_deps/libcudacxx-src/include -I../include -Iinclude -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem /conda/envs/rapids/include -isystem /usr/local/cuda/include -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-unknown-pragmas -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -std=gnu++1z -MD -MT benchmarks/CMakeFiles/ORC_READER_BENCH.dir/io/orc/orc_reader_benchmark.cpp.o -MF benchmarks/CMakeFiles/ORC_READER_BENCH.dir/io/orc/orc_reader_benchmark.cpp.o.d -o benchmarks/CMakeFiles/ORC_READER_BENCH.dir/io/orc/orc_reader_benchmark.cpp.o -c ../benchmarks/io/orc/orc_reader_benchmark.cpp
../benchmarks/io/orc/orc_reader_benchmark.cpp: In function ‘void BM_orc_read_varying_options(benchmark::State&)’:
../benchmarks/io/orc/orc_reader_benchmark.cpp:127:36: error: cannot convert ‘vector<int>’ to ‘vector<std::vector<int>>’
  127 |           read_options.set_stripes(stripes_to_read);
      |                                    ^~~~~~~~~~~~~~~
      |                                    |
      |                                    vector<int>
In file included from ../benchmarks/io/orc/orc_reader_benchmark.cpp:24:
../include/cudf/io/orc.hpp:145:56: note:   initializing argument 1 of ‘void cudf::io::orc_reader_options::set_stripes(std::vector<std::vector<int> >)’
  145 |   void set_stripes(std::vector<std::vector<size_type>> stripes)
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~

```

This PR fixes the call to `read_options.set_stripes` in the source file.
