### PR TITLE
support cupy array inputs for series.quantile

### DIFF
--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -162,7 +162,7 @@ def is_list_like(obj):
         Return True if given object is list-like.
     """
     return isinstance(
-        obj, (Sequence, np.ndarray, cp.ndarray)
+        obj, (Sequence, np.ndarray)
     ) and not isinstance(obj, (str, bytes))
 
 

--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -161,7 +161,7 @@ def is_list_like(obj):
     bool
         Return True if given object is list-like.
     """
-    return isinstance(obj, (Sequence, np.ndarray)) and not isinstance(
+    return isinstance(obj, (Sequence, np.ndarray, cp.ndarray)) and not isinstance(
         obj, (str, bytes)
     )
 

--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -161,9 +161,9 @@ def is_list_like(obj):
     bool
         Return True if given object is list-like.
     """
-    return isinstance(obj, (Sequence, np.ndarray, cp.ndarray)) and not isinstance(
-        obj, (str, bytes)
-    )
+    return isinstance(
+        obj, (Sequence, np.ndarray, cp.ndarray)
+    ) and not isinstance(obj, (str, bytes))
 
 
 # These methods are aliased directly into this namespace, but can be modified

--- a/python/cudf/cudf/core/column/numerical_base.py
+++ b/python/cudf/cudf/core/column/numerical_base.py
@@ -9,6 +9,7 @@ from typing import Sequence, Union
 import numpy as np
 
 import cudf
+import cupy as cp
 from cudf import _lib as libcudf
 from cudf._typing import Dtype, ScalarLike
 from cudf.core.column import ColumnBase
@@ -128,6 +129,8 @@ class NumericalBaseColumn(ColumnBase):
     def quantile(
         self, q: Union[float, Sequence[float]], interpolation: str, exact: bool
     ) -> NumericalBaseColumn:
+        if isinstance(q, cp.ndarray):
+           q = q.get()
         if isinstance(q, Number) or cudf.utils.dtypes.is_list_like(q):
             np_array_q = np.asarray(q)
             if np.logical_or(np_array_q < 0, np_array_q > 1).any():

--- a/python/cudf/cudf/core/column/numerical_base.py
+++ b/python/cudf/cudf/core/column/numerical_base.py
@@ -130,7 +130,7 @@ class NumericalBaseColumn(ColumnBase):
         self, q: Union[float, Sequence[float]], interpolation: str, exact: bool
     ) -> NumericalBaseColumn:
         if isinstance(q, cp.ndarray):
-           q = q.get()
+            q = q.get()
         if isinstance(q, Number) or cudf.utils.dtypes.is_list_like(q):
             np_array_q = np.asarray(q)
             if np.logical_or(np_array_q < 0, np_array_q > 1).any():

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -5456,8 +5456,11 @@ class Series(SingleColumnFrame, Serializable):
         if isinstance(q, Number):
             return result
 
-        if quant_index and not isinstance(q, cp.ndarray): #if cupy skip over index
-            index = np.asarray(q)
+        if quant_index:
+            if isinstance(q, cp.ndarray):
+                index = cp.asarray(q)
+            else:
+                index = np.asarray(q)
             if len(self) == 0:
                 result = column_empty_like(
                     index, dtype=self.dtype, masked=True, newsize=len(index),

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -334,7 +334,6 @@ class Series(SingleColumnFrame, Serializable):
         3     NaN
         dtype: float64
         """
-        print("hello")
         return cls(s, nan_as_null=nan_as_null)
 
     def serialize(self):

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -10,7 +10,7 @@ from shutil import get_terminal_size
 from typing import Any, Optional
 from uuid import uuid4
 
-import cupy
+import cupy as cp
 import numpy as np
 import pandas as pd
 from pandas._config import get_option
@@ -334,6 +334,7 @@ class Series(SingleColumnFrame, Serializable):
         3     NaN
         dtype: float64
         """
+        print("hello")
         return cls(s, nan_as_null=nan_as_null)
 
     def serialize(self):
@@ -5450,13 +5451,12 @@ class Series(SingleColumnFrame, Serializable):
         0.75    3.25
         dtype: float64
         """
-
         result = self._column.quantile(q, interpolation, exact)
 
         if isinstance(q, Number):
             return result
 
-        if quant_index:
+        if quant_index and not isinstance(q, cp.ndarray): #if cupy skip over index
             index = np.asarray(q)
             if len(self) == 0:
                 result = column_empty_like(

--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import pandas as pd
+import cupy as cp
 import pytest
 
 import cudf
@@ -142,6 +143,7 @@ def test_exact_quantiles(int_method):
 
     df = pd.DataFrame(arr)
     gdf_series = cudf.Series(arr)
+    cupy_quant = cp.asarray(quant_values)
 
     q1 = gdf_series.quantile(
         quant_values, interpolation=int_method, exact=True
@@ -177,12 +179,15 @@ def test_approx_quantiles():
 
     arr = np.asarray([6.8, 0.15, 3.4, 4.17, 2.13, 1.11, -1.01, 0.8, 5.7])
     quant_values = [0.0, 0.25, 0.33, 0.5, 1.0]
+    cp_quant = cp.asarray(quant_values)
 
     gdf_series = cudf.Series(arr)
     pdf_series = pd.Series(arr)
 
     q1 = gdf_series.quantile(quant_values, exact=False)
     q2 = pdf_series.quantile(quant_values)
+    q3 = gdf_series.quantile(cp_quant)
+    q4 = gdf_series.quantile(cp_quant, quant_index=False)
 
     assert_eq(q1, q2)
 

--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -187,9 +187,9 @@ def test_approx_quantiles():
     q1 = gdf_series.quantile(quant_values, exact=False)
     q2 = pdf_series.quantile(quant_values)
     q3 = gdf_series.quantile(cp_quant)
-    q4 = gdf_series.quantile(cp_quant, quant_index=False)
 
     assert_eq(q1, q2)
+    assert_eq(q1, q3)
 
 
 def test_approx_quantiles_int():


### PR DESCRIPTION
This update ensures that cp arrays can be used as parameters for the quantile function (closes https://github.com/rapidsai/cudf/issues/8288)