### PR TITLE
Fix bug that columns only initialized once when specified `columns` and `index` in dataframe ctor

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -239,12 +239,12 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
                 self._index = as_index(index)
             if columns is not None:
                 self._data = ColumnAccessor(
-                    dict.fromkeys(
-                        columns,
-                        column.column_empty(
+                    {
+                        k: column.column_empty(
                             len(self), dtype="object", masked=True
-                        ),
-                    )
+                        )
+                        for k in columns
+                    }
                 )
         elif hasattr(data, "__cuda_array_interface__"):
             arr_interface = data.__cuda_array_interface__

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -8153,6 +8153,16 @@ def test_dataframe_constructor_columns(df, columns, index):
     assert_local_eq(actual, df, expected, host_columns)
 
 
+def test_dataframe_constructor_column_index_only():
+    columns = ["a", "b", "c"]
+    index = ["r1", "r2", "r3"]
+
+    gdf = cudf.DataFrame(index=index, columns=columns)
+    assert not id(gdf["a"]._column) == id(gdf["b"]._column) and not id(
+        gdf["b"]._column
+    ) == id(gdf["c"]._column)
+
+
 @pytest.mark.parametrize(
     "data",
     [


### PR DESCRIPTION
Closes #8621 

This PR fixes a bug when initializing dataframe with `columns` and `index` parameters, the columns are only initialized once. Leading to all columns are pointing to the same object. 