### PR TITLE
Fix usage of deprecated arrow ipc API [skip ci]

### DIFF
--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -237,7 +237,7 @@ public:
       }
 
       // There is an option to have a file writer too, with metadata
-      auto tmp_writer = arrow::ipc::NewStreamWriter(sink.get(), arrow_tab->schema());
+      auto tmp_writer = arrow::ipc::MakeStreamWriter(sink, arrow_tab->schema());
       if (!tmp_writer.ok()) {
         throw std::runtime_error(tmp_writer.status().message());
       }


### PR DESCRIPTION
After cudf upgraded to a new version of arrow one of the APIs we were using was deprecated. This updates the JNI code to use the new version of the API.