### PR TITLE
Temporarily disable libcudf example build tests

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -201,8 +201,8 @@ fi
 ################################################################################
 
 # If examples grows too large to build, should move to cpu side
-gpuci_logger "Building libcudf examples"
-$WORKSPACE/cpp/examples/build.sh
+# gpuci_logger "Building libcudf examples"
+# $WORKSPACE/cpp/examples/build.sh
 
 # set environment variable for numpy 1.16
 # will be enabled for later versions by default


### PR DESCRIPTION
Currently when CI build libcudf examples, it rebuilds the entire libcudf library. Until we figure out how to reuse the built libcudf artifacts in CI, we should disable the build to save CI build times.

Looking to be re-enabled by #8638