### PR TITLE
Fix repeated mangled names in read_csv with duplicate column names 

### DIFF
--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -315,7 +315,9 @@ table_with_metadata reader::impl::read(rmm::cuda_stream_view stream)
         if (opts_.is_enabled_mangle_dupe_cols()) {
           // Rename duplicates of column X as X.1, X.2, ...; First appearance
           // stays as X
-          col_name += "." + std::to_string(col_names_histogram[col_name] - 1);
+          do {
+            col_name += "." + std::to_string(col_names_histogram[col_name] - 1);
+          } while (col_names_histogram[col_name]++);
         } else {
           // All duplicate columns will be ignored; First appearance is parsed
           const auto idx     = &col_name - col_names_.data();

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -1261,6 +1261,17 @@ def test_csv_reader_column_names(names):
         assert list(df) == list(names)
 
 
+def test_csv_reader_repeated_column_name():
+    buffer = """A,A,A.1,A,A.2,A,A.4,A,A
+                1,2,3.1,4,a.2,a,a.4,a,a
+                2,4,6.1,8,b.2,b,b.4,b,b"""
+
+    # pandas and cudf to have same repeated column names
+    pdf = pd.read_csv(StringIO(buffer))
+    gdf = cudf.read_csv(StringIO(buffer))
+    assert_eq(pdf.columns, gdf.columns)
+
+
 def test_csv_reader_bools_false_positives(tmpdir):
     # values that are equal to ["True", "TRUE", "False", "FALSE"]
     # when using ints to detect bool values


### PR DESCRIPTION
Fixes mangled name bug `read_csv` with duplicate columns.
mismatch with pandas behavior.
#### csv file:
```csv
A,A,A.1,A,A.2,A,A.4,A,A
1,2,3,4.0,a,a,a.4,a,a
2,4,6,8.0,b,b,b.4,b,a
3,6,2,6.0,c,c,c.4,c,c
```

|A|	A|		A.1|	A|		A.2|	A|		A.4|	A|		A|
|-|-|-|-|-|-|-|-|-|
|A|	A.1|	A.1.1|	A.2|	A.2.1|	A.3| 	A.4| 	A.4.1|	A.5|


#### Pandas:
```python
In [1]: import pandas as pd
In [2]: pd.read_csv("test.csv")
Out[2]: 
   A  A.1  A.1.1  A.2 A.2.1 A.3  A.4 A.4.1 A.5
0  1    2      3  4.0     a   a  a.4     a   a
1  2    4      6  8.0     b   b  b.4     b   a
2  3    6      2  6.0     c   c  c.4     c   c
```

#### cudf: (21.08 nightly docker)
```python
In [1]: import cudf
In [2]: cudf.__version__
Out[2]: '21.08.00a+238.gfba09e66d8'
In [3]: cudf.read_csv("test.csv")
Out[3]: 
   A  A.1 A.2 A.3 A.4 A.5
0  1    3   a   a   a   a
1  2    6   b   b   b   a
2  3    2   c   c   c   c
```


This PR fixes this issue.
```python
In [2]: cudf.read_csv("test.csv")
Out[2]: 
   A  A.1  A.1.1  A.2 A.2.1 A.3  A.4 A.4.1 A.5
0  1    2      3  4.0     a   a  a.4     a   a
1  2    4      6  8.0     b   b  b.4     b   a
2  3    6      2  6.0     c   c  c.4     c   c
```



Related info (sparks):
Spark duplicate column naming. 
https://issues.apache.org/jira/browse/SPARK-16896
https://github.com/apache/spark/pull/14745
cudf sparks addon doesn't use libcudf names. So, this PR does not affect it.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
