### PR TITLE
Support multi-char case conversion in capitalize function

### DIFF
--- a/cpp/tests/strings/case_tests.cpp
+++ b/cpp/tests/strings/case_tests.cpp
@@ -151,13 +151,18 @@ TEST_F(StringsCaseTest, Title)
 
 TEST_F(StringsCaseTest, MultiCharUpper)
 {
-  cudf::test::strings_column_wrapper strings{"\u1f52", "\u1f83", "\u1e98", "\ufb05", "\u0149"};
+  cudf::test::strings_column_wrapper strings{"\u1f52 \u1f83", "\u1e98 \ufb05", "\u0149"};
   cudf::test::strings_column_wrapper expected{
-    "\u03a5\u0313\u0300", "\u1f0b\u0399", "\u0057\u030a", "\u0053\u0054", "\u02bc\u004e"};
+    "\u03a5\u0313\u0300 \u1f0b\u0399", "\u0057\u030a \u0053\u0054", "\u02bc\u004e"};
   auto strings_view = cudf::strings_column_view(strings);
 
   auto results = cudf::strings::to_upper(strings_view);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
+  results = cudf::strings::capitalize(strings_view, std::string(" "));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+
+  results = cudf::strings::title(strings_view);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
 


### PR DESCRIPTION
Closes #8644 

Multi-character case conversion support added for strings `to_upper` and `to_lower` is reused for `capitalize` and `title` functions. For example, converting from a single character `ŉ` to its upper-case equivalent is actually two distinct characters `'N` (apostrophe and capital-N). This is different than conversion of a single multi-byte character to another single multi-byte character with different byte lengths. Here a single character is converted into two characters.