### PR TITLE
Added pct_change to Series

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1295,10 +1295,12 @@ class Frame(libcudf.table.Table):
 
         if value is not None and method is not None:
             raise ValueError("Cannot specify both 'value' and 'method'.")
-        
+
         if method:
             if method not in {"ffill", "bfill", "pad", "backfill"}:
-                raise NotImplementedError(f"Fill method {method} is not supported")
+                raise NotImplementedError(
+                    f"Fill method {method} is not supported"
+                )
             if method == "pad":
                 method = "ffill"
             elif method == "backfill":

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1295,9 +1295,14 @@ class Frame(libcudf.table.Table):
 
         if value is not None and method is not None:
             raise ValueError("Cannot specify both 'value' and 'method'.")
-
-        if method and method not in {"ffill", "bfill"}:
-            raise NotImplementedError(f"Fill method {method} is not supported")
+        
+        if method:
+            if method not in {"ffill", "bfill", "pad", "backfill"}:
+                raise NotImplementedError(f"Fill method {method} is not supported")
+            if method == "pad":
+                method = "ffill"
+            elif method == "backfill":
+                method = "bfill"
 
         if isinstance(value, cudf.Series):
             value = value.reindex(self._data.names)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -6050,13 +6050,9 @@ class Series(SingleColumnFrame, Serializable):
             raise NotImplementedError("limit parameter not supported yet.")
         if freq is not None:
             raise NotImplementedError("freq parameter not supported yet.")
-        if fill_method == "pad":
-            fill_method = "ffill"
-        elif fill_method == "backfill":
-            fill_method = "bfill"
-        elif fill_method not in ["ffill", "bfill"]:
+        elif fill_method not in {"ffill", "pad", "bfill", "backfill"}:
             raise ValueError(
-                "fill_method must be either 'ffill', 'pad', "
+                "fill_method must be one of 'ffill', 'pad', "
                 "'bfill', or 'backfill'."
             )
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -6050,8 +6050,15 @@ class Series(SingleColumnFrame, Serializable):
             raise NotImplementedError("limit parameter not supported yet.")
         if freq is not None:
             raise NotImplementedError("freq parameter not supported yet.")
-        if fill_method not in ["ffill", "bfill"]:
-            raise ValueError("fill_method must be either 'ffill' or 'bfill'.")
+        if fill_method == "pad":
+            fill_method = "ffill"
+        elif fill_method == "backfill":
+            fill_method = "bfill"
+        elif fill_method not in ["ffill", "bfill"]:
+            raise ValueError(
+                "fill_method must be either 'ffill', 'pad', "
+                "'bfill', or 'backfill'."
+            )
 
         data = self.fillna(method=fill_method, limit=limit)
         diff = data.diff(periods=periods)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -6022,6 +6022,42 @@ class Series(SingleColumnFrame, Serializable):
 
         return super()._explode(self._column_names[0], ignore_index)
 
+    def pct_change(
+        self, periods=1, fill_method="ffill", limit=None, freq=None
+    ):
+        """
+        Calculates the percent change between sequential elements
+        in the Series.
+
+        Parameters
+        ----------
+        periods : int, default 1
+            Periods to shift for forming percent change.
+        fill_method : str, default 'ffill'
+            How to handle NAs before computing percent changes.
+        limit : int, optional
+            The number of consecutive NAs to fill before stopping.
+            Not yet implemented.
+        freq : str, optional
+            Increment to use from time series API.
+            Not yet implemented.
+
+        Returns
+        -------
+        Series
+        """
+        if limit is not None:
+            raise NotImplementedError("limit parameter not supported yet.")
+        if freq is not None:
+            raise NotImplementedError("freq parameter not supported yet.")
+        if fill_method not in ["ffill", "bfill"]:
+            raise ValueError("fill_method must be either 'ffill' or 'bfill'.")
+
+        data = self.fillna(method=fill_method, limit=limit)
+        diff = data.diff(periods=periods)
+        change = diff / data.shift(periods=periods, freq=freq)
+        return change
+
 
 class DatetimeProperties(object):
     """

--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -329,7 +329,7 @@ def test_series_median(dtype, num_na):
     ],
 )
 @pytest.mark.parametrize("periods", range(-5, 5))
-@pytest.mark.parametrize("fill_method", ["ffill", "bfill"])
+@pytest.mark.parametrize("fill_method", ["ffill", "bfill", "pad", "backfill"])
 def test_series_pct_change(data, periods, fill_method):
     cs = cudf.Series(data)
     ps = cs.to_pandas()

--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -317,6 +317,32 @@ def test_series_median(dtype, num_na):
 
 
 @pytest.mark.parametrize(
+    "data",
+    [
+        np.random.normal(-100, 100, 1000),
+        np.random.randint(-50, 50, 1000),
+        np.zeros(100),
+        np.array([1.123, 2.343, np.nan, 0.0]),
+        np.array([-2, 3.75, 6, None, None, None, -8.5, None, 4.2]),
+        cudf.Series([]),
+        cudf.Series([-3]),
+    ],
+)
+@pytest.mark.parametrize("periods", range(-5, 5))
+@pytest.mark.parametrize("fill_method", ["ffill", "bfill"])
+def test_series_pct_change(data, periods, fill_method):
+    cs = cudf.Series(data)
+    ps = cs.to_pandas()
+
+    if np.abs(periods) <= len(cs):
+        got = cs.pct_change(periods=periods, fill_method=fill_method)
+        expected = ps.pct_change(periods=periods, fill_method=fill_method)
+        np.testing.assert_array_almost_equal(
+            got.to_array(fillna="pandas"), expected
+        )
+
+
+@pytest.mark.parametrize(
     "data1",
     [
         np.random.normal(-100, 100, 1000),


### PR DESCRIPTION
closes #6133
closes #8727
unit test in test_stats.py: test_series_pct_change

Added pct_change function for Series. The limit and freq arguments could not be fully implemented due to lack of implementation in Series.fillna() and Series.shift() functions respectively.