### PR TITLE
Remove flatbuffers dependency

### DIFF
--- a/conda/environments/cudf_dev_cuda11.0.yml
+++ b/conda/environments/cudf_dev_cuda11.0.yml
@@ -49,7 +49,6 @@ dependencies:
   - arrow-cpp-proc * cuda
   - double-conversion
   - rapidjson
-  - flatbuffers
   - hypothesis
   - sphinx-markdown-tables
   - sphinx-copybutton

--- a/conda/environments/cudf_dev_cuda11.2.yml
+++ b/conda/environments/cudf_dev_cuda11.2.yml
@@ -49,7 +49,6 @@ dependencies:
   - arrow-cpp-proc * cuda
   - double-conversion
   - rapidjson
-  - flatbuffers
   - hypothesis
   - sphinx-markdown-tables
   - sphinx-copybutton

--- a/python/cudf/requirements/cuda-11.0/dev_requirements.txt
+++ b/python/cudf/requirements/cuda-11.0/dev_requirements.txt
@@ -10,7 +10,6 @@ cmake-setuptools>=0.1.3
 cython>=0.29,<0.30
 dlpack
 fastavro>=0.22.9
-flatbuffers
 fsspec>=0.6.0
 hypothesis
 mimesis

--- a/python/cudf/requirements/cuda-11.2/dev_requirements.txt
+++ b/python/cudf/requirements/cuda-11.2/dev_requirements.txt
@@ -10,7 +10,6 @@ cmake-setuptools>=0.1.3
 cython>=0.29,<0.30
 dlpack
 fastavro>=0.22.9
-flatbuffers
 fsspec>=0.6.0
 hypothesis
 mimesis


### PR DESCRIPTION
As discussed with @jakirkham and @trxcllnt, cudf does not depend directly on `flatbuffers` so we can remove the dependency
