### PR TITLE
JNI build no longer looks for Arrow in conda environment

### DIFF
--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -173,8 +173,8 @@ message(STATUS "RMM: RMM_INCLUDE set to ${RMM_INCLUDE}")
 
 find_path(ARROW_INCLUDE "arrow"
           HINTS "$ENV{ARROW_ROOT}/include"
-                "$ENV{CONDA_PREFIX}/include"
-                "${CUDF_CPP_BUILD_DIR}/_deps/arrow-src/cpp/src")
+                "${CUDF_CPP_BUILD_DIR}/_deps/arrow-src/cpp/src"
+                "$ENV{CONDA_PREFIX}/include")
 
 message(STATUS "ARROW: ARROW_INCLUDE set to ${ARROW_INCLUDE}")
 
@@ -187,8 +187,8 @@ endif(CUDF_JNI_ARROW_STATIC)
 
 find_library(ARROW_LIBRARY ${CUDF_JNI_ARROW_LIBNAME} REQUIRED
   HINTS "$ENV{ARROW_ROOT}/lib"
-        "$ENV{CONDA_PREFIX}/lib"
-        "${CUDF_CPP_BUILD_DIR}/_deps/arrow-build/release")
+        "${CUDF_CPP_BUILD_DIR}/_deps/arrow-build/release"
+        "$ENV{CONDA_PREFIX}/lib")
 
 if(NOT ARROW_LIBRARY)
   if(CUDF_JNI_ARROW_STATIC)

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -173,8 +173,7 @@ message(STATUS "RMM: RMM_INCLUDE set to ${RMM_INCLUDE}")
 
 find_path(ARROW_INCLUDE "arrow"
           HINTS "$ENV{ARROW_ROOT}/include"
-                "${CUDF_CPP_BUILD_DIR}/_deps/arrow-src/cpp/src"
-                "$ENV{CONDA_PREFIX}/include")
+                "${CUDF_CPP_BUILD_DIR}/_deps/arrow-src/cpp/src")
 
 message(STATUS "ARROW: ARROW_INCLUDE set to ${ARROW_INCLUDE}")
 
@@ -187,8 +186,7 @@ endif(CUDF_JNI_ARROW_STATIC)
 
 find_library(ARROW_LIBRARY ${CUDF_JNI_ARROW_LIBNAME} REQUIRED
   HINTS "$ENV{ARROW_ROOT}/lib"
-        "${CUDF_CPP_BUILD_DIR}/_deps/arrow-build/release"
-        "$ENV{CONDA_PREFIX}/lib")
+        "${CUDF_CPP_BUILD_DIR}/_deps/arrow-build/release")
 
 if(NOT ARROW_LIBRARY)
   if(CUDF_JNI_ARROW_STATIC)


### PR DESCRIPTION
Updates the Java bindings native build to no longer look for the Arrow dependency in the conda environment.  It now expects to find it in the libcudf build area or under the `ARROW_ROOT` environment variable if the user has specified it.