### PR TITLE
Fix a crash in pack() when being handed tables with no columns.

### DIFF
--- a/cpp/include/cudf/copying.hpp
+++ b/cpp/include/cudf/copying.hpp
@@ -529,6 +529,7 @@ struct packed_columns {
    * @ingroup copy_split
    */
   struct metadata {
+    metadata() = default;
     metadata(std::vector<uint8_t>&& v) : data_(std::move(v)) {}
     uint8_t const* data() const { return data_.data(); }
     size_t size() const { return data_.size(); }
@@ -536,6 +537,15 @@ struct packed_columns {
    private:
     std::vector<uint8_t> data_;
   };
+
+  packed_columns()
+    : metadata_(std::make_unique<metadata>()), gpu_data(std::make_unique<rmm::device_buffer>())
+  {
+  }
+  packed_columns(std::unique_ptr<metadata>&& md, std::unique_ptr<rmm::device_buffer>&& gd)
+    : metadata_(std::move(md)), gpu_data(std::move(gd))
+  {
+  }
 
   std::unique_ptr<metadata> metadata_;
   std::unique_ptr<rmm::device_buffer> gpu_data;

--- a/cpp/src/copying/pack.cpp
+++ b/cpp/src/copying/pack.cpp
@@ -145,7 +145,7 @@ packed_columns pack(cudf::table_view const& input,
   // do a contiguous_split with no splits to get the memory for the table
   // arranged as we want it
   auto contig_split_result = cudf::detail::contiguous_split(input, {}, stream, mr);
-  return std::move(contig_split_result[0].data);
+  return contig_split_result.empty() ? packed_columns{} : std::move(contig_split_result[0].data);
 }
 
 template <typename ColumnIter>
@@ -229,7 +229,9 @@ packed_columns::metadata pack_metadata(table_view const& table,
                                        size_t buffer_size)
 {
   CUDF_FUNC_RANGE();
-  return detail::pack_metadata(table.begin(), table.end(), contiguous_buffer, buffer_size);
+  return table.is_empty()
+           ? packed_columns::metadata{}
+           : detail::pack_metadata(table.begin(), table.end(), contiguous_buffer, buffer_size);
 }
 
 /**
@@ -238,8 +240,10 @@ packed_columns::metadata pack_metadata(table_view const& table,
 table_view unpack(packed_columns const& input)
 {
   CUDF_FUNC_RANGE();
-  return detail::unpack(input.metadata_->data(),
-                        reinterpret_cast<uint8_t const*>(input.gpu_data->data()));
+  return input.metadata_->size() == 0
+           ? table_view{}
+           : detail::unpack(input.metadata_->data(),
+                            reinterpret_cast<uint8_t const*>(input.gpu_data->data()));
 }
 
 /**

--- a/cpp/tests/copying/pack_tests.cpp
+++ b/cpp/tests/copying/pack_tests.cpp
@@ -472,6 +472,24 @@ TEST_F(PackUnpackTest, NestedSliced)
   this->run_test(t);
 }
 
+TEST_F(PackUnpackTest, EmptyTable)
+{
+  // no columns
+  {
+    cudf::table_view t;
+    this->run_test(t);
+  }
+
+  // no rows
+  {
+    cudf::test::fixed_width_column_wrapper<int> a;
+    cudf::test::strings_column_wrapper b;
+    cudf::test::lists_column_wrapper<float> c;
+    cudf::table_view t({a, b, c});
+    this->run_test(t);
+  }
+}
+
 // clang-format on
 
 }  // namespace test


### PR DESCRIPTION
Also changes the behavior of pack() such that when returning empty data, the `metadata_` and `gpu_data` unique_ptrs are not null, but instead point to empty `metadata` and `rmm::device_buffer` objects, respectively.  Very mild breakage of the interface.