### PR TITLE
Bug fix: `replace_nulls_policy` functor not returning correct indices for gathermap

### DIFF
--- a/cpp/include/cudf/detail/replace/nulls.cuh
+++ b/cpp/include/cudf/detail/replace/nulls.cuh
@@ -35,8 +35,7 @@ using idx_valid_pair_t = thrust::tuple<cudf::size_type, bool>;
 struct replace_policy_functor {
   __device__ idx_valid_pair_t operator()(idx_valid_pair_t const& lhs, idx_valid_pair_t const& rhs)
   {
-    return thrust::get<1>(rhs) ? thrust::make_tuple(thrust::get<0>(rhs), true)
-                               : thrust::make_tuple(thrust::get<0>(lhs), true);
+    return thrust::get<1>(rhs) ? rhs : lhs;
   }
 };
 

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -33,7 +33,8 @@
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
-#include "thrust/iterator/counting_iterator.h"
+
+#include <thrust/iterator/counting_iterator.h>
 
 using namespace cudf::test::iterators;
 

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -33,6 +33,7 @@
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
+#include "thrust/iterator/counting_iterator.h"
 
 using namespace cudf::test::iterators;
 
@@ -440,6 +441,48 @@ TYPED_TEST(ReplaceNullsPolicyTest, FollowingFillTrailingNulls)
     cudf::test::fixed_width_column_wrapper<TypeParam>(col.begin(), col.end(), mask.begin()),
     cudf::test::fixed_width_column_wrapper<TypeParam>(
       expect_col.begin(), expect_col.end(), expect_mask.begin()),
+    cudf::replace_policy::FOLLOWING);
+}
+
+TYPED_TEST(ReplaceNullsPolicyTest, PrecedingFillLargeArray)
+{
+  cudf::size_type const sz = 1000;
+
+  // Source: 0, null, null...
+  auto src_begin       = thrust::make_counting_iterator(0);
+  auto src_end         = src_begin + sz;
+  auto nulls_idx_begin = thrust::make_counting_iterator(1);
+  auto nulls_idx_end   = nulls_idx_begin + sz - 1;
+
+  // Expected: 0, 0, 0, ...
+  auto expected_begin = thrust::make_constant_iterator(0);
+  auto expected_end   = expected_begin + sz;
+
+  TestReplaceNullsWithPolicy(
+    cudf::test::fixed_width_column_wrapper<TypeParam>(
+      src_begin, src_end, nulls_at(nulls_idx_begin, nulls_idx_end)),
+    cudf::test::fixed_width_column_wrapper<TypeParam>(expected_begin, expected_end, no_nulls()),
+    cudf::replace_policy::PRECEDING);
+}
+
+TYPED_TEST(ReplaceNullsPolicyTest, FollowingFillLargeArray)
+{
+  cudf::size_type const sz = 1000;
+
+  // Source: null, ... null, 999
+  auto src_begin       = thrust::make_counting_iterator(0);
+  auto src_end         = src_begin + sz;
+  auto nulls_idx_begin = thrust::make_counting_iterator(0);
+  auto nulls_idx_end   = nulls_idx_begin + sz - 1;
+
+  // Expected: 999, 999, 999, ...
+  auto expected_begin = thrust::make_constant_iterator(sz - 1);
+  auto expected_end   = expected_begin + sz;
+
+  TestReplaceNullsWithPolicy(
+    cudf::test::fixed_width_column_wrapper<TypeParam>(
+      src_begin, src_end, nulls_at(nulls_idx_begin, nulls_idx_end)),
+    cudf::test::fixed_width_column_wrapper<TypeParam>(expected_begin, expected_end, no_nulls()),
     cudf::replace_policy::FOLLOWING);
 }
 

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -303,6 +303,8 @@ def test_series_fillna_numerical(psr, data_dtype, fill_value, inplace):
         [1, None, None, 2, 3, 4],
         [None, None, 1, 2, None, 3, 4],
         [1, 2, None, 3, 4, None, None],
+        [0] + [None] * 14,
+        [None] * 14 + [0],
     ],
 )
 @pytest.mark.parametrize("container", [pd.Series, pd.DataFrame])


### PR DESCRIPTION
Closes #8673 

This PR fixes a bug in the functor for `replace_nulls(replace_policy)`. The current functor assumes that the second element of the pair is discarded and is arbitrarily returned true. This breaks the associative constraints for `inclusive_scan` functors.