### PR TITLE
JNI: Hotfix on testGetCudaRuntimeInfo [skip ci]

### DIFF
--- a/java/src/test/java/ai/rapids/cudf/CudaTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CudaTest.java
@@ -24,6 +24,9 @@ public class CudaTest {
 
   @Test
   public void testGetCudaRuntimeInfo() {
+    // The driver version is not necessarily larger than runtime version. Drivers of previous
+    // version are also able to support runtime of later version, only if they support same
+    // kinds of computeModes.
     assert Cuda.getDriverVersion() >= 1000;
     assert Cuda.getRuntimeVersion() >= 1000;
     assertEquals(Cuda.getNativeComputeMode(), Cuda.getComputeMode().nativeId);

--- a/java/src/test/java/ai/rapids/cudf/CudaTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CudaTest.java
@@ -24,8 +24,8 @@ public class CudaTest {
 
   @Test
   public void testGetCudaRuntimeInfo() {
-    assert Cuda.getDriverVersion() >= Cuda.getRuntimeVersion();
-    assert Cuda.getRuntimeVersion() > 1000;
+    assert Cuda.getDriverVersion() >= 1000;
+    assert Cuda.getRuntimeVersion() >= 1000;
     assertEquals(Cuda.getNativeComputeMode(), Cuda.getComputeMode().nativeId);
   }
 


### PR DESCRIPTION
A hot fix on the test for Java APIs which are used to get CUDA runtime information