### PR TITLE
Add `datetime::is_leap_year`

### DIFF
--- a/cpp/include/cudf/datetime.hpp
+++ b/cpp/include/cudf/datetime.hpp
@@ -189,6 +189,23 @@ std::unique_ptr<cudf::column> add_calendrical_months(
   cudf::column_view const& timestamps,
   cudf::column_view const& months,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/**
+ * @brief  Check if the year of the given date is a leap year
+ *
+ * `output[i] == true` if year of `column[i]` is a leap year
+ * `output[i] == false` if year of `column[i]` is not a leap year
+ * `output[i] is null` if year of `column[i]` is null
+ *
+ * @param[in] cudf::column_view of the input datetime values
+ *
+ * @returns cudf::column of datatype BOOL8 truth value of the corresponding date
+ * @throw cudf::logic_error if input column datatype is not a TIMESTAMP
+ */
+std::unique_ptr<cudf::column> is_leap_year(
+  cudf::column_view const& column,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 /** @} */  // end of group
 }  // namespace datetime
 }  // namespace cudf

--- a/cpp/include/cudf/datetime.hpp
+++ b/cpp/include/cudf/datetime.hpp
@@ -195,7 +195,7 @@ std::unique_ptr<cudf::column> add_calendrical_months(
  *
  * `output[i] == true` if year of `column[i]` is a leap year
  * `output[i] == false` if year of `column[i]` is not a leap year
- * `output[i] is null` if year of `column[i]` is null
+ * `output[i] is null` if `column[i]` is null
  *
  * @param[in] cudf::column_view of the input datetime values
  *

--- a/cpp/include/cudf/detail/datetime.hpp
+++ b/cpp/include/cudf/detail/datetime.hpp
@@ -132,6 +132,7 @@ std::unique_ptr<cudf::column> add_calendrical_months(
  */
 std::unique_ptr<cudf::column> is_leap_year(
   cudf::column_view const& column,
+  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/datetime.hpp
+++ b/cpp/include/cudf/detail/datetime.hpp
@@ -124,6 +124,16 @@ std::unique_ptr<cudf::column> add_calendrical_months(
   cudf::column_view const& months,
   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/**
+ * @copydoc cudf::is_leap_year(cudf::column_view const&, rmm::mr::device_memory_resource *)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::unique_ptr<cudf::column> is_leap_year(
+  cudf::column_view const& column,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 }  // namespace detail
 }  // namespace datetime
 }  // namespace cudf

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -22,7 +22,6 @@
 #include <cudf/detail/datetime.hpp>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
-#include <cudf/null_mask.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/traits.hpp>

--- a/cpp/tests/datetime/datetime_ops_test.cpp
+++ b/cpp/tests/datetime/datetime_ops_test.cpp
@@ -26,7 +26,7 @@
 #include <cudf/types.hpp>
 #include <cudf/wrappers/timestamps.hpp>
 
-#define XXX false // stub for null values
+#define XXX false  // stub for null values
 
 template <typename T>
 struct NonTimestampTest : public cudf::test::BaseFixture {
@@ -543,39 +543,28 @@ TEST_F(BasicDatetimeOpsTest, TestIsLeapYear)
   // Time in seconds since epoch
   // Dates converted using epochconverter.com
   auto timestamps_s =
-    cudf::test::fixed_width_column_wrapper<cudf::timestamp_s, cudf::timestamp_s::rep>{{
-      1594332839L,   // 2020-07-09 10:13:59 GMT - leap year
-      0L,           // null
-      915148800L,   // 1999-01-01 00:00:00 GMT - non leap year
-      -11663029161L, // 1600-5-31 05:40:39 GMT - leap year
-      707904541L, // 1992-06-07 08:09:01 GMT - leap year
-      2181048447L, // 1900-11-20 09:12:33 GMT - non leap year
-      0L, // UNIX EPOCH 1970-01-01 00:00:00 GMT - non leap year
-      -12212553600L, // First full year of Gregorian Calandar 1583-01-01 00:00:00 - non-leap-year
-      0L,           // null
-      13591632822L, // 2400-09-13 13:33:42 GMT - leap year
-      4539564243L, // 2113-11-08 06:04:03 GMT - non leap year
-      0L            // null
-    },
-    {true, false, true, true, true, true, true, true, false, true, true, false}};
-  
+    cudf::test::fixed_width_column_wrapper<cudf::timestamp_s, cudf::timestamp_s::rep>{
+      {
+        1594332839L,    // 2020-07-09 10:13:59 GMT - leap year
+        0L,             // null
+        915148800L,     // 1999-01-01 00:00:00 GMT - non leap year
+        -11663029161L,  // 1600-5-31 05:40:39 GMT - leap year
+        707904541L,     // 1992-06-07 08:09:01 GMT - leap year
+        2181048447L,    // 1900-11-20 09:12:33 GMT - non leap year
+        0L,             // UNIX EPOCH 1970-01-01 00:00:00 GMT - non leap year
+        -12212553600L,  // First full year of Gregorian Calandar 1583-01-01 00:00:00 - non-leap-year
+        0L,             // null
+        13591632822L,   // 2400-09-13 13:33:42 GMT - leap year
+        4539564243L,    // 2113-11-08 06:04:03 GMT - non leap year
+        0L              // null
+      },
+      {true, false, true, true, true, true, true, true, false, true, true, false}};
+
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(
     *is_leap_year(timestamps_s),
-    cudf::test::fixed_width_column_wrapper<bool>{{
-      true,
-      XXX,
-      false,
-      true,
-      true,
-      false,
-      false,
-      false,
-      XXX,
-      true,
-      false,
-      XXX
-    },
-    {true, false, true, true, true, true, true, true, false, true, true, false}});
+    cudf::test::fixed_width_column_wrapper<bool>{
+      {true, XXX, false, true, true, false, false, false, XXX, true, false, XXX},
+      {true, false, true, true, true, true, true, true, false, true, true, false}});
 }
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/datetime/datetime_ops_test.cpp
+++ b/cpp/tests/datetime/datetime_ops_test.cpp
@@ -26,6 +26,8 @@
 #include <cudf/types.hpp>
 #include <cudf/wrappers/timestamps.hpp>
 
+#define XXX false // stub for null values
+
 template <typename T>
 struct NonTimestampTest : public cudf::test::BaseFixture {
   cudf::data_type type() { return cudf::data_type{cudf::type_to_id<T>()}; }
@@ -530,6 +532,50 @@ TEST_F(BasicDatetimeOpsTest, TestAddMonthsWithSecondsAndNullValues)
       },
       {false, false, true, false, true, false, true, false, true, true, true, true}},
     true);
+}
+
+TEST_F(BasicDatetimeOpsTest, TestIsLeapYear)
+{
+  using namespace cudf::test;
+  using namespace cudf::datetime;
+  using namespace cuda::std::chrono;
+
+  // Time in seconds since epoch
+  // Dates converted using epochconverter.com
+  auto timestamps_s =
+    cudf::test::fixed_width_column_wrapper<cudf::timestamp_s, cudf::timestamp_s::rep>{{
+      1594332839L,   // 2020-07-09 10:13:59 GMT - leap year
+      0L,           // null
+      915148800L,   // 1999-01-01 00:00:00 GMT - non leap year
+      -11663029161L, // 1600-5-31 05:40:39 GMT - leap year
+      707904541L, // 1992-06-07 08:09:01 GMT - leap year
+      2181048447L, // 1900-11-20 09:12:33 GMT - non leap year
+      0L, // UNIX EPOCH 1970-01-01 00:00:00 GMT - non leap year
+      -12212553600L, // First full year of Gregorian Calandar 1583-01-01 00:00:00 - non-leap-year
+      0L,           // null
+      13591632822L, // 2400-09-13 13:33:42 GMT - leap year
+      4539564243L, // 2113-11-08 06:04:03 GMT - non leap year
+      0L            // null
+    },
+    {true, false, true, true, true, true, true, true, false, true, true, false}};
+  
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    *is_leap_year(timestamps_s),
+    cudf::test::fixed_width_column_wrapper<bool>{{
+      true,
+      XXX,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      XXX,
+      true,
+      false,
+      XXX
+    },
+    {true, false, true, true, true, true, true, true, false, true, true, false}});
 }
 
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
Part 1 of #8677 

This PR adds `datetime::is_leap_year`. The function returns `true` for datetime column rows with leap year; `false` for rows with non leap years, and `null` for null rows.