### PR TITLE
Add `is_leap_year` to `DateTimeProperties` and `DatetimeIndex`

### DIFF
--- a/python/cudf/cudf/_lib/cpp/datetime.pxd
+++ b/python/cudf/cudf/_lib/cpp/datetime.pxd
@@ -17,3 +17,4 @@ cdef extern from "cudf/datetime.hpp" namespace "cudf::datetime" nogil:
         const column_view& months
     ) except +
     cdef unique_ptr[column] day_of_year(const column_view& column) except +
+    cdef unique_ptr[column] is_leap_year(const column_view& column) except +

--- a/python/cudf/cudf/_lib/datetime.pyx
+++ b/python/cudf/cudf/_lib/datetime.pyx
@@ -59,3 +59,13 @@ def extract_datetime_component(Column col, object field):
         result = result.binary_operator("sub", result.dtype.type(1))
 
     return result
+
+
+def is_leap_year(Column col):
+    cdef unique_ptr[column] c_result
+    cdef column_view col_view = col.view()
+
+    with nogil:
+        c_result = move(libcudf_datetime.is_leap_year(col_view))
+
+    return Column.from_unique_ptr(move(c_result))

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -13,6 +13,7 @@ from nvtx import annotate
 from pandas._config import get_option
 
 import cudf
+from cudf._lib.datetime import is_leap_year
 from cudf._lib.filling import sequence
 from cudf._lib.search import search_sorted
 from cudf._lib.table import Table
@@ -2342,6 +2343,24 @@ class DatetimeIndex(GenericIndex):
         Int16Index([366, 1, 2, 3, 4, 5, 6, 7, 8], dtype='int16')
         """
         return self._get_dt_field("day_of_year")
+
+    @property
+    def is_leap_year(self):
+        """
+        Boolean indicator if the date belongs to a leap year.
+
+        A leap year is a year, which has 366 days (instead of 365) including
+        29th of February as an intercalary day. Leap years are years which are
+        multiples of four with the exception of years divisible by 100 but not
+        by 400.
+
+        Returns
+        -------
+        ndarray
+        Booleans indicating if dates belong to a leap year.
+        """
+        res = is_leap_year(self._values).fillna(False)
+        return cupy.array(res.to_gpu_array())
 
     def to_pandas(self):
         nanos = self._values.astype("datetime64[ns]")

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2360,7 +2360,7 @@ class DatetimeIndex(GenericIndex):
         Booleans indicating if dates belong to a leap year.
         """
         res = is_leap_year(self._values).fillna(False)
-        return cupy.array(res.to_gpu_array())
+        return cupy.asarray(res)
 
     def to_pandas(self):
         nanos = self._values.astype("datetime64[ns]")

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -6366,6 +6366,28 @@ class DatetimeProperties(object):
         """
         return self._get_dt_field("day_of_year")
 
+    @property
+    def is_leap_year(self):
+        """
+        Boolean indicator if the date belongs to a leap year.
+
+        A leap year is a year, which has 366 days (instead of 365) including
+        29th of February as an intercalary day. Leap years are years which are
+        multiples of four with the exception of years divisible by 100 but not
+        by 400.
+
+        Returns
+        -------
+        Series
+        Booleans indicating if dates belong to a leap year.
+        """
+        res = libcudf.datetime.is_leap_year(self.series._column).fillna(False)
+        return Series._from_data(
+            ColumnAccessor({None: res}),
+            index=self.series._index,
+            name=self.series.name,
+        )
+
     def _get_dt_field(self, field):
         out_column = self.series._column.get_dt_field(field)
         return Series(

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -1264,3 +1264,36 @@ def test_datetime_to_datetime_error():
             "'coerce', 'warn'], found: %d-%B-%Y %H:%M"
         ),
     )
+
+
+def test_is_leap_year():
+    data = [
+        "2020-05-31 08:00:00",
+        None,
+        "1999-12-31 18:40:00",
+        "2000-12-31 04:00:00",
+        None,
+        "1900-02-28 07:00:00",
+        "1800-03-14 07:30:00",
+        "2100-03-14 07:30:00",
+        "1970-01-01 00:00:00",
+        "1969-12-31 12:59:00",
+    ]
+
+    # Series
+    ps = pd.Series(data, dtype="datetime64[s]")
+    gs = cudf.from_pandas(ps)
+
+    expect = ps.dt.is_leap_year
+    got = gs.dt.is_leap_year
+
+    assert_eq(expect, got)
+
+    # DatetimeIndex
+    pIndex = pd.DatetimeIndex(data)
+    gIndex = cudf.from_pandas(pIndex)
+
+    expect2 = pIndex.is_leap_year
+    got2 = gIndex.is_leap_year
+
+    assert_eq(expect2, got2)


### PR DESCRIPTION
Closes #8677 

This PR adds `is_leap_year` for `cudf.Series.dt` and `cudf.DatetimeIndex`. Nulls in time series are treated as `NaT`s in Pandas time series and is mapped to `False` in this operation. E.g.

```python
>>> s = cudf.Series(['2020-01-01 08:00:00', None, '2021-12-31 09:00:00'], dtype='datetime64[ns]')
>>> s.dt.is_leap_year
0     True
1    False
2    False
dtype: bool
```