### PR TITLE
Fix cudf doc test instructions [skip-ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,7 +221,7 @@ $ ./build.sh dask_cudf
 - To run Python tests (Optional):
 ```bash
 $ cd $CUDF_HOME/python
-$ py.test -v cudf                           # run cudf test suite
+$ py.test -v cudf/cudf/tests                # run cudf test suite
 $ py.test -v dask_cudf                      # run dask_cudf test suite
 ```
 


### PR DESCRIPTION
In the [contributing doc](https://github.com/rapidsai/cudf/blob/branch-21.08/CONTRIBUTING.md#contributing-to-cudf), the line:

`py.test -v cudf` raises an error:

`ImportError while importing test module '/media/ikone/Win10/github/cudf/python/cudf/cudf/benchmarks/bench_cudf_io.py'.`

`Hint: make sure your test modules/packages have valid Python names.`
                                                                         
`Traceback:                                                                                                                                                    
/home/ikone/utils/miniconda3/envs/cudf_dev/lib/python3.8/importlib/__init__.py:127: in import_module                                                          
    return _bootstrap._gcd_import(name[level:], package, level)                                                                                               
cudf/cudf/benchmarks/bench_cudf_io.py:7: in <module>                                                                                                          
    from conftest import option                                                                                                                               
E   ImportError: cannot import name 'option' from 'conftest' (/media/ikone/Win10/github/cudf/python/cudf/cudf/tests/conftest.py  `

In fact it runs also benchmark tests  which must be ran separately not with cudf unit tests located at `cudf/cudf/tests`. This creates a conflict between `conftest.py` from benchmark and unit tests where the latter overrides the former.
Information about benchmark tests are mentioned in [README.md](https://github.com/rapidsai/cudf/blob/branch-21.08/python/cudf/cudf/benchmarks/README.md):  
`py.test -v cudf/benchmarks/`