### PR TITLE
[REVIEW] Fix `replace` to handle null values correctly

### DIFF
--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -1091,8 +1091,8 @@ class CategoricalColumn(column.ColumnBase):
                 replaced = replaced._set_categories(new_categories)
                 replaced = replaced.fillna(fill_value)
             df = df.dropna(subset=["old"])
-            to_replace_col = df["old"]._column
-            replacement_col = df["new"]._column
+            to_replace_col = df._data["old"]
+            replacement_col = df._data["new"]
         else:
             replaced = self
         if df._data["new"].null_count > 0:
@@ -1103,8 +1103,8 @@ class CategoricalColumn(column.ColumnBase):
             ]
             replaced = replaced._set_categories(new_categories)
             df = df.dropna(subset=["new"])
-            to_replace_col = df["old"]._column
-            replacement_col = df["new"]._column
+            to_replace_col = df._data["old"]
+            replacement_col = df._data["new"]
 
         # create a dataframe containing the pre-replacement categories
         # and a copy of them to work with. The index of this dataframe
@@ -1132,9 +1132,9 @@ class CategoricalColumn(column.ColumnBase):
         # those categories don't exist anymore
         # Resetting the index creates a column 'index' that associates
         # the original integers to the new labels
-        bmask = new_cats["cats"]._column.notna()
+        bmask = new_cats._data["cats"].notna()
         new_cats = cudf.DataFrame(
-            {"cats": new_cats["cats"]._column.apply_boolean_mask(bmask)}
+            {"cats": new_cats._data["cats"].apply_boolean_mask(bmask)}
         ).reset_index()
 
         # old_cats contains replaced categories and the ints that
@@ -1150,7 +1150,7 @@ class CategoricalColumn(column.ColumnBase):
         to_replace_col = column.as_column(catmap.index).astype(
             replaced.codes.dtype
         )
-        replacement_col = catmap["index"]._column.astype(replaced.codes.dtype)
+        replacement_col = catmap._data["index"].astype(replaced.codes.dtype)
 
         replaced = column.as_column(replaced.codes)
         output = libcudf.replace.replace(

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -300,6 +300,8 @@ class NumericalColumn(NumericalBaseColumn):
         """
         to_replace_col = as_column(to_replace)
         replacement_col = as_column(replacement)
+        print(to_replace_col)
+        print(replacement_col)
 
         if type(to_replace_col) != type(replacement_col):
             raise TypeError(
@@ -334,8 +336,17 @@ class NumericalColumn(NumericalBaseColumn):
         to_replace_col, replacement_col, replaced = numeric_normalize_types(
             to_replace_col, replacement_col, replaced
         )
+        df = cudf.DataFrame({"old": to_replace_col, "new": replacement_col})
+        df = df.drop_duplicates(subset=["old"], keep="last", ignore_index=True)
+        if df._data["old"].null_count == 1:
+            # import pdb;pdb.set_trace()
+            replaced = replaced.fillna(
+                df._data["new"][df._data["old"].isna()][0]
+            )
+            df = df.dropna(subset=["old"])
+
         return libcudf.replace.replace(
-            replaced, to_replace_col, replacement_col
+            replaced, df["old"]._column, df["new"]._column
         )
 
     def fillna(
@@ -607,6 +618,7 @@ def _safe_cast_to_int(col: ColumnBase, dtype: DtypeObj) -> ColumnBase:
 def _normalize_find_and_replace_input(
     input_column_dtype: DtypeObj, col_to_normalize: Union[ColumnBase, list]
 ) -> ColumnBase:
+    # import pdb;pdb.set_trace()
     normalized_column = column.as_column(
         col_to_normalize,
         dtype=input_column_dtype if len(col_to_normalize) <= 0 else None,
@@ -618,9 +630,12 @@ def _normalize_find_and_replace_input(
         )
         # Scalar case
         if len(col_to_normalize) == 1:
-            col_to_normalize_casted = input_column_dtype.type(
-                col_to_normalize[0]
-            )
+            if cudf._lib.scalar._is_null_host_scalar(col_to_normalize[0]):
+                return normalized_column.astype(input_column_dtype)
+            else:
+                col_to_normalize_casted = input_column_dtype.type(
+                    col_to_normalize[0]
+                )
             if not np.isnan(col_to_normalize_casted) and (
                 col_to_normalize_casted != col_to_normalize[0]
             ):

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -298,8 +298,8 @@ class NumericalColumn(NumericalBaseColumn):
         """
         Return col with *to_replace* replaced with *value*.
         """
-        to_replace_col = as_column(to_replace)
-        replacement_col = as_column(replacement)
+        to_replace_col = column.as_column(to_replace)
+        replacement_col = column.as_column(replacement)
 
         if type(to_replace_col) != type(replacement_col):
             raise TypeError(

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -300,8 +300,6 @@ class NumericalColumn(NumericalBaseColumn):
         """
         to_replace_col = as_column(to_replace)
         replacement_col = as_column(replacement)
-        print(to_replace_col)
-        print(replacement_col)
 
         if type(to_replace_col) != type(replacement_col):
             raise TypeError(
@@ -339,7 +337,6 @@ class NumericalColumn(NumericalBaseColumn):
         df = cudf.DataFrame({"old": to_replace_col, "new": replacement_col})
         df = df.drop_duplicates(subset=["old"], keep="last", ignore_index=True)
         if df._data["old"].null_count == 1:
-            # import pdb;pdb.set_trace()
             replaced = replaced.fillna(
                 df._data["new"][df._data["old"].isna()][0]
             )
@@ -618,7 +615,6 @@ def _safe_cast_to_int(col: ColumnBase, dtype: DtypeObj) -> ColumnBase:
 def _normalize_find_and_replace_input(
     input_column_dtype: DtypeObj, col_to_normalize: Union[ColumnBase, list]
 ) -> ColumnBase:
-    # import pdb;pdb.set_trace()
     normalized_column = column.as_column(
         col_to_normalize,
         dtype=input_column_dtype if len(col_to_normalize) <= 0 else None,

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5360,8 +5360,19 @@ class StringColumn(column.ColumnBase):
             and replacement_col.dtype != self.dtype
         ):
             return self.copy()
+        df = cudf.DataFrame({"old": to_replace_col, "new": replacement_col})
+        df = df.drop_duplicates(subset=["old"], keep="last", ignore_index=True)
+        if df._data["old"].null_count == 1:
+            import pdb
 
-        return libcudf.replace.replace(self, to_replace_col, replacement_col)
+            pdb.set_trace()
+            res = self.fillna(df._data["new"][df._data["old"].isna()][0])
+            df = df.dropna(subset=["old"])
+        else:
+            res = self
+        return libcudf.replace.replace(
+            res, df["old"]._column, df["new"]._column
+        )
 
     def fillna(
         self,
@@ -5372,6 +5383,9 @@ class StringColumn(column.ColumnBase):
         if fill_value is not None:
             if not is_scalar(fill_value):
                 fill_value = column.as_column(fill_value, dtype=self.dtype)
+            elif cudf._lib.scalar._is_null_host_scalar(fill_value):
+                # Trying to fill <NA> with <NA> value? Return copy.
+                return self.copy(deep=True)
             return super().fillna(value=fill_value, dtype="object")
         else:
             return super().fillna(method=method)

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5284,9 +5284,7 @@ class StringColumn(column.ColumnBase):
             df = df.dropna(subset=["old"])
         else:
             res = self
-        return libcudf.replace.replace(
-            res, df["old"]._column, df["new"]._column
-        )
+        return libcudf.replace.replace(res, df._data["old"], df._data["new"])
 
     def fillna(
         self,

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5307,8 +5307,8 @@ class StringColumn(column.ColumnBase):
     def _find_first_and_last(self, value: ScalarLike) -> Tuple[int, int]:
         found_indices = libstrings.contains_re(self, f"^{value}$")
         found_indices = libcudf.unary.cast(found_indices, dtype=np.int32)
-        first = column.as_column(found_indices).find_first_value(1)
-        last = column.as_column(found_indices).find_last_value(1)
+        first = column.as_column(found_indices).find_first_value(np.int32(1))
+        last = column.as_column(found_indices).find_last_value(np.int32(1))
         return first, last
 
     def find_first_value(

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5280,9 +5280,6 @@ class StringColumn(column.ColumnBase):
         df = cudf.DataFrame({"old": to_replace_col, "new": replacement_col})
         df = df.drop_duplicates(subset=["old"], keep="last", ignore_index=True)
         if df._data["old"].null_count == 1:
-            import pdb
-
-            pdb.set_trace()
             res = self.fillna(df._data["new"][df._data["old"].isna()][0])
             df = df.dropna(subset=["old"])
         else:

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -1275,3 +1275,69 @@ def test_series_replace_errors():
         lfunc_args_and_kwargs=([{"a": 1}, object()],),
         rfunc_args_and_kwargs=([{"a": 1}, object()],),
     )
+
+
+@pytest.mark.parametrize(
+    "gsr,old,new,expected",
+    [
+        (
+            cudf.Series(["a", "b", "c", None]),
+            None,
+            "a",
+            cudf.Series(["a", "b", "c", "a"]),
+        ),
+        (
+            cudf.Series(["a", "b", "c", None]),
+            [None, "a", "a"],
+            ["c", "b", "d"],
+            cudf.Series(["d", "b", "c", "c"]),
+        ),
+        (
+            cudf.Series(["a", "b", "c", None]),
+            [None, "a"],
+            ["b", None],
+            cudf.Series([None, "b", "c", "b"]),
+        ),
+        (
+            cudf.Series(["a", "b", "c", None]),
+            [None, None],
+            [None, None],
+            cudf.Series(["a", "b", "c", None]),
+        ),
+        (cudf.Series([1, 2, None, 3]), None, 10, cudf.Series([1, 2, 10, 3])),
+        (
+            cudf.Series([1, 2, None, 3]),
+            [None, 1, 1],
+            [3, 2, 4],
+            cudf.Series([4, 2, 3, 3]),
+        ),
+        (
+            cudf.Series([1, 2, None, 3]),
+            [None, 1],
+            [2, None],
+            cudf.Series([None, 2, 2, 3]),
+        ),
+        (
+            cudf.Series(["a", "q", "t", None], dtype="category"),
+            None,
+            "z",
+            cudf.Series(["a", "q", "t", "z"], dtype="category"),
+        ),
+        (
+            cudf.Series(["a", "q", "t", None], dtype="category"),
+            [None, "a", "q"],
+            ["z", None, None],
+            cudf.Series([None, None, "t", "z"], dtype="category"),
+        ),
+        (
+            cudf.Series(["a", None, "t", None], dtype="category"),
+            [None, "t"],
+            ["p", None],
+            cudf.Series(["a", "p", None, "p"], dtype="category"),
+        ),
+    ],
+)
+def test_replace_nulls(gsr, old, new, expected):
+
+    actual = gsr.replace(old, new)
+    assert_eq(expected, actual)


### PR DESCRIPTION
Fixes: #7293 

This PR introduces fixes to `replace` and it's internal APIs which error/fault when there is a `None`/`<NA>` value on either `lhs` or `rhs` and certain combinations of each. Introduced tests where there were failures previously that are covered by new changes in this PR.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
