### PR TITLE
Handle sliced struct/list columns properly in concatenate() bounds checking.

### DIFF
--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -335,13 +335,12 @@ void bounds_and_type_check(host_span<column_view const> cols, rmm::cuda_stream_v
 /**
  * @brief Functor for traversing child columns and recursively verifying concatenation
  * bounds and types.
- *
  */
 class traverse_children {
  public:
   // nothing to do for simple types.
   template <typename T>
-  void operator()(host_span<column_view const> cols, rmm::cuda_stream_view stream)
+  void operator()(host_span<column_view const>, rmm::cuda_stream_view)
   {
   }
 

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -358,9 +358,8 @@ class traverse_children {
                       [](size_t a, auto const& b) -> size_t { return a + b.size(); }) +
       1;
     // note:  output text must include "exceeds size_type range" for python error handling
-    CUDF_EXPECTS(
-      total_offset_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
-      "Total number of concatenated offsets exceeds size_type range");
+    CUDF_EXPECTS(total_offset_count <= static_cast<size_t>(std::numeric_limits<size_type>::max()),
+                 "Total number of concatenated offsets exceeds size_type range");
   }
 };
 
@@ -382,7 +381,7 @@ void traverse_children::operator()<cudf::string_view>(host_span<column_view cons
                         cudf::detail::get_value<offset_type>(scv.offsets(), scv.offset(), stream));
     });
   // note:  output text must include "exceeds size_type range" for python error handling
-  CUDF_EXPECTS(total_char_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+  CUDF_EXPECTS(total_char_count <= static_cast<size_t>(std::numeric_limits<size_type>::max()),
                "Total number of concatenated chars exceeds size_type range");
 }
 
@@ -453,7 +452,7 @@ void bounds_and_type_check(host_span<column_view const> cols, rmm::cuda_stream_v
       return a + static_cast<size_t>(b.size());
     });
   // note:  output text must include "exceeds size_type range" for python error handling
-  CUDF_EXPECTS(total_row_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+  CUDF_EXPECTS(total_row_count <= static_cast<size_t>(std::numeric_limits<size_type>::max()),
                "Total number of concatenated rows exceeds size_type range");
 
   // traverse children

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -358,6 +358,7 @@ class traverse_children {
                       std::size_t{},
                       [](size_t a, auto const& b) -> size_t { return a + b.size(); }) +
       1;
+    // note:  output text must include "exceeds size_type range" for python error handling
     CUDF_EXPECTS(
       total_offset_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
       "Total number of concatenated offsets exceeds size_type range");
@@ -381,6 +382,7 @@ void traverse_children::operator()<cudf::string_view>(host_span<column_view cons
                         scv.offsets(), scv.offset() + b.size(), stream) -
                         cudf::detail::get_value<offset_type>(scv.offsets(), scv.offset(), stream));
     });
+  // note:  output text must include "exceeds size_type range" for python error handling
   CUDF_EXPECTS(total_char_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "Total number of concatenated chars exceeds size_type range");
 }
@@ -451,6 +453,7 @@ void bounds_and_type_check(host_span<column_view const> cols, rmm::cuda_stream_v
     std::accumulate(cols.begin(), cols.end(), std::size_t{}, [](size_t a, auto const& b) {
       return a + static_cast<size_t>(b.size());
     });
+  // note:  output text must include "exceeds size_type range" for python error handling
   CUDF_EXPECTS(total_row_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "Total number of concatenated rows exceeds size_type range");
 

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/detail/copy.hpp>
+#include <cudf/detail/get_value.cuh>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
@@ -329,58 +330,132 @@ std::unique_ptr<column> concatenate_dispatch::operator()<cudf::struct_view>()
 
 namespace {
 
+void bounds_and_type_check(host_span<column_view const> cols, rmm::cuda_stream_view stream);
+
+/**
+ * @brief Functor for traversing child columns and recursively verifying concatenation
+ * bounds and types.
+ *
+ */
+class traverse_children {
+ public:
+  // nothing to do for simple types.
+  template <typename T>
+  void operator()(host_span<column_view const> cols, rmm::cuda_stream_view stream)
+  {
+  }
+
+ private:
+  // verify length of concatenated offsets.
+  void check_offsets_size(host_span<column_view const> cols)
+  {
+    // offsets.  we can't just add up the total sizes of all offset child columns because each one
+    // has an extra value, regardless of the # of parent rows.  So we have to add up the total # of
+    // rows in the base column and add 1 at the end
+    size_t const total_offset_count =
+      std::accumulate(cols.begin(),
+                      cols.end(),
+                      std::size_t{},
+                      [](size_t a, auto const& b) -> size_t { return a + b.size(); }) +
+      1;
+    CUDF_EXPECTS(
+      total_offset_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+      "Total number of concatenated offsets exceeds size_type range");
+  }
+};
+
+template <>
+void traverse_children::operator()<cudf::string_view>(host_span<column_view const> cols,
+                                                      rmm::cuda_stream_view stream)
+{
+  // verify offsets
+  check_offsets_size(cols);
+
+  // chars
+  size_t const total_char_count = std::accumulate(
+    cols.begin(), cols.end(), std::size_t{}, [stream](size_t a, auto const& b) -> size_t {
+      strings_column_view scv(b);
+      return a + (b.is_empty()
+                    ? 0
+                    : cudf::detail::get_value<offset_type>(
+                        scv.offsets(), scv.offset() + b.size(), stream) -
+                        cudf::detail::get_value<offset_type>(scv.offsets(), scv.offset(), stream));
+    });
+  CUDF_EXPECTS(total_char_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+               "Total number of concatenated chars exceeds size_type range");
+}
+
+template <>
+void traverse_children::operator()<cudf::struct_view>(host_span<column_view const> cols,
+                                                      rmm::cuda_stream_view stream)
+{
+  // march each child
+  auto child_iter         = thrust::make_counting_iterator(0);
+  auto const num_children = cols.front().num_children();
+  std::vector<column_view> nth_children;
+  nth_children.reserve(cols.size());
+  std::for_each(child_iter, child_iter + num_children, [&](auto child_index) {
+    std::transform(cols.begin(),
+                   cols.end(),
+                   std::back_inserter(nth_children),
+                   [child_index, stream](column_view const& col) {
+                     structs_column_view scv(col);
+                     return scv.get_sliced_child(child_index);
+                   });
+
+    bounds_and_type_check(nth_children, stream);
+    nth_children.clear();
+  });
+}
+
+template <>
+void traverse_children::operator()<cudf::list_view>(host_span<column_view const> cols,
+                                                    rmm::cuda_stream_view stream)
+{
+  // verify offsets
+  check_offsets_size(cols);
+
+  // recurse into the child columns
+  std::vector<column_view> nth_children;
+  nth_children.reserve(cols.size());
+  std::transform(
+    cols.begin(), cols.end(), std::back_inserter(nth_children), [stream](column_view const& col) {
+      lists_column_view lcv(col);
+      return lcv.get_sliced_child(stream);
+    });
+  bounds_and_type_check(nth_children, stream);
+}
+
 /**
  * @brief Verifies that the sum of the sizes of all the columns to be concatenated
  * will not exceed the max value of size_type, and verifies all column types match
  *
- * @param begin Beginning of range of columns to check
- * @param end End of range of columns to check
+ * @param columns_to_concat Span of columns to check
  *
  * @throws cudf::logic_error if the total length of the concatenated columns would
  * exceed the max value of size_type
  *
  * @throws cudf::logic_error if all of the input column types don't match
  */
-template <typename ColIter>
-void bounds_and_type_check(ColIter begin, ColIter end)
+void bounds_and_type_check(host_span<column_view const> cols, rmm::cuda_stream_view stream)
 {
-  CUDF_EXPECTS(std::all_of(begin,
-                           end,
-                           [expected_type = (*begin).type()](auto const& c) {
+  CUDF_EXPECTS(std::all_of(cols.begin(),
+                           cols.end(),
+                           [expected_type = cols.front().type()](auto const& c) {
                              return c.type() == expected_type;
                            }),
                "Type mismatch in columns to concatenate.");
 
   // total size of all concatenated rows
   size_t const total_row_count =
-    std::accumulate(begin, end, std::size_t{}, [](size_t a, auto const& b) {
+    std::accumulate(cols.begin(), cols.end(), std::size_t{}, [](size_t a, auto const& b) {
       return a + static_cast<size_t>(b.size());
     });
   CUDF_EXPECTS(total_row_count <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "Total number of concatenated rows exceeds size_type range");
 
-  // march each child
-  auto child_iter         = thrust::make_counting_iterator(0);
-  auto const num_children = (*begin).num_children();
-  std::for_each(child_iter, child_iter + num_children, [&](auto child_index) {
-    std::vector<column_view> nth_children;
-    nth_children.reserve(std::distance(begin, end));
-
-    // we cannot do this via a transform iterator + std::copy_if because some columns
-    // can have no children if they are empty.  so if we had 3 input string columns
-    // and 1 of them was empty, 2 of them would have 2 children, and 1 of them would have
-    // 0 children. so it is not safe to index col.child() directly.
-    std::for_each(begin, end, [child_index, &nth_children](column_view const& col) {
-      if (col.num_children() <= child_index) {
-        CUDF_EXPECTS(col.num_children() == 0,
-                     "Encountered a child column with an unexpected # of children");
-      } else {
-        nth_children.push_back(col.child(child_index));
-      }
-    });
-
-    bounds_and_type_check(nth_children.begin(), nth_children.end());
-  });
+  // traverse children
+  cudf::type_dispatcher(cols.front().type(), traverse_children{}, cols, stream);
 }
 
 }  // anonymous namespace
@@ -393,7 +468,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns_to_conc
   CUDF_EXPECTS(not columns_to_concat.empty(), "Unexpected empty list of columns to concatenate.");
 
   // verify all types match and that we won't overflow size_type in output size
-  bounds_and_type_check(columns_to_concat.begin(), columns_to_concat.end());
+  bounds_and_type_check(columns_to_concat, stream);
 
   if (std::all_of(columns_to_concat.begin(), columns_to_concat.end(), [](column_view const& c) {
         return c.is_empty();
@@ -428,7 +503,7 @@ std::unique_ptr<table> concatenate(host_span<table_view const> tables_to_concat,
                    [i](auto const& t) { return t.column(i); });
 
     // verify all types match and that we won't overflow size_type in output size
-    bounds_and_type_check(cols.begin(), cols.end());
+    bounds_and_type_check(cols, stream);
     concat_columns.emplace_back(detail::concatenate(cols, stream, mr));
   }
   return std::make_unique<table>(std::move(concat_columns));

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -208,7 +208,7 @@ ConfigureTest(SORT_TEST
 ###################################################################################################
 # - copying tests ---------------------------------------------------------------------------------
 ConfigureTest(COPYING_TEST
-    copying/concatenate_tests.cpp
+    copying/concatenate_tests.cu
     copying/copy_if_else_nested_tests.cpp
     copying/copy_range_tests.cpp
     copying/copy_tests.cu

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -433,7 +433,7 @@ TEST_F(OverflowTest, OverflowTest)
   }
 }
 
-TEST_F(OverflowTest, SizeOverflowTestPresliced)
+TEST_F(OverflowTest, Presliced)
 {
   using namespace cudf;
 
@@ -648,7 +648,7 @@ TEST_F(OverflowTest, SizeOverflowTestPresliced)
   }
 }
 
-TEST_F(OverflowTest, SizeOverflowTestBigColumnsSmallSlices)
+TEST_F(OverflowTest, BigColumnsSmallSlices)
 {
   // test : many small slices of large columns. the idea is to make sure
   // that we are respecting the offset/sizes of the slices and not attempting to

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-#include <cudf_test/base_fixture.hpp>
-#include <cudf_test/column_utilities.hpp>
-#include <cudf_test/column_wrapper.hpp>
-#include <cudf_test/table_utilities.hpp>
-#include <cudf_test/type_lists.hpp>
-
 #include <cudf/column/column.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
@@ -28,6 +22,13 @@
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/table_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 
@@ -335,100 +336,427 @@ TEST_F(TableTest, ConcatenateTablesWithOffsetsAndNulls)
   }
 }
 
-TEST_F(TableTest, SizeOverflowTest)
+struct OverflowTest : public cudf::test::BaseFixture {
+};
+
+TEST_F(OverflowTest, OverflowTest)
 {
+  using namespace cudf;
+
   // primitive column
   {
-    constexpr cudf::size_type size =
-      static_cast<cudf::size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+    constexpr size_type size = static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
 
     // try and concatenate 6 char columns of size 1 billion each
-    auto many_chars = cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT8}, size);
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, size);
 
-    cudf::table_view tbl({*many_chars});
-    EXPECT_THROW(cudf::concatenate(std::vector<TView>({tbl, tbl, tbl, tbl, tbl, tbl})),
+    table_view tbl({*many_chars});
+    EXPECT_THROW(cudf::concatenate(std::vector<table_view>({tbl, tbl, tbl, tbl, tbl, tbl})),
                  cudf::logic_error);
   }
 
   // string column, overflow on chars
   {
-    constexpr cudf::size_type size =
-      static_cast<cudf::size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+    constexpr size_type size = static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
 
     // try and concatenate 6 string columns of with 1 billion chars in each
-    auto offsets    = cudf::test::fixed_width_column_wrapper<int>{0, size};
-    auto many_chars = cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT8}, size);
+    auto offsets    = cudf::test::fixed_width_column_wrapper<offset_type>{0, size};
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, size);
     auto col        = cudf::make_strings_column(
       1, offsets.release(), std::move(many_chars), 0, rmm::device_buffer{});
 
-    cudf::table_view tbl({*col});
-    EXPECT_THROW(cudf::concatenate(std::vector<TView>({tbl, tbl, tbl, tbl, tbl, tbl})),
+    table_view tbl({*col});
+    EXPECT_THROW(cudf::concatenate(std::vector<table_view>({tbl, tbl, tbl, tbl, tbl, tbl})),
                  cudf::logic_error);
   }
 
   // string column, overflow on offsets (rows)
   {
-    constexpr cudf::size_type size =
-      static_cast<cudf::size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+    constexpr size_type size = static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
 
     // try and concatenate 6 string columns 1 billion rows each
-    auto many_offsets =
-      cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT32}, size + 1);
-    auto chars = cudf::test::fixed_width_column_wrapper<int8_t>{0, 1, 2};
-    auto col   = cudf::make_strings_column(
+    auto many_offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, size + 1);
+    auto chars        = cudf::test::fixed_width_column_wrapper<int8_t>{0, 1, 2};
+    auto col          = cudf::make_strings_column(
       size, std::move(many_offsets), chars.release(), 0, rmm::device_buffer{});
 
-    cudf::table_view tbl({*col});
-    EXPECT_THROW(cudf::concatenate(std::vector<TView>({tbl, tbl, tbl, tbl, tbl, tbl})),
+    table_view tbl({*col});
+    EXPECT_THROW(cudf::concatenate(std::vector<table_view>({tbl, tbl, tbl, tbl, tbl, tbl})),
                  cudf::logic_error);
   }
 
   // list<struct>, structs too long
   {
-    constexpr cudf::size_type inner_size =
-      static_cast<cudf::size_type>(static_cast<uint32_t>(512) * 1024 * 1024);
+    constexpr size_type inner_size =
+      static_cast<size_type>(static_cast<uint32_t>(512) * 1024 * 1024);
 
     // struct
     std::vector<std::unique_ptr<column>> children;
-    children.push_back(
-      cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT8}, inner_size));
-    children.push_back(
-      cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT8}, inner_size));
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size));
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size));
     auto struct_col =
       cudf::make_structs_column(inner_size, std::move(children), 0, rmm::device_buffer{});
 
     // list
-    auto offsets = cudf::test::fixed_width_column_wrapper<int>{0, inner_size};
+    auto offsets = cudf::test::fixed_width_column_wrapper<offset_type>{0, inner_size};
     auto col =
       cudf::make_lists_column(1, offsets.release(), std::move(struct_col), 0, rmm::device_buffer{});
 
-    cudf::table_view tbl({*col});
-    auto tables = std::vector<TView>({tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl});
+    table_view tbl({*col});
+    auto tables =
+      std::vector<table_view>({tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl});
     EXPECT_THROW(cudf::concatenate(tables), cudf::logic_error);
   }
 
   // struct<int, list>, list child too long
   {
-    constexpr cudf::size_type inner_size =
-      static_cast<cudf::size_type>(static_cast<uint32_t>(512) * 1024 * 1024);
-    constexpr cudf::size_type size = 3;
+    constexpr size_type inner_size =
+      static_cast<size_type>(static_cast<uint32_t>(512) * 1024 * 1024);
+    constexpr size_type size = 3;
 
     // list
-    auto offsets = cudf::test::fixed_width_column_wrapper<int>{0, 0, 0, inner_size};
-    auto many_chars =
-      cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT8}, inner_size);
+    auto offsets    = cudf::test::fixed_width_column_wrapper<offset_type>{0, 0, 0, inner_size};
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size);
     auto list_col =
       cudf::make_lists_column(3, offsets.release(), std::move(many_chars), 0, rmm::device_buffer{});
 
     // struct
     std::vector<std::unique_ptr<column>> children;
-    children.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT32}, size));
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT32}, size));
     children.push_back(std::move(list_col));
     auto col = cudf::make_structs_column(size, std::move(children), 0, rmm::device_buffer{});
 
-    cudf::table_view tbl({*col});
-    auto tables = std::vector<TView>({tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl});
+    table_view tbl({*col});
+    auto tables =
+      std::vector<table_view>({tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl, tbl});
     EXPECT_THROW(cudf::concatenate(tables), cudf::logic_error);
+  }
+}
+
+TEST_F(OverflowTest, SizeOverflowTestPresliced)
+{
+  using namespace cudf;
+
+  // primitive column
+  {
+    constexpr size_type size = static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+
+    // try and concatenate 4 char columns of size ~1/2 billion each
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, size);
+    auto sliced     = cudf::split(*many_chars, {511 * 1024 * 1024});
+
+    // 511 * 1024 * 1024, should succeed
+    table_view a({sliced[0]});
+    cudf::concatenate(std::vector<table_view>({a, a, a, a}));
+
+    // 513 * 1024 * 1024, should fail
+    table_view b({sliced[1]});
+    EXPECT_THROW(cudf::concatenate(std::vector<table_view>({b, b, b, b})), cudf::logic_error);
+  }
+
+  // struct<int8> column
+  {
+    constexpr size_type size = static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+
+    // try and concatenate 4 char columns of size ~1/2 billion each
+    std::vector<std::unique_ptr<column>> children;
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT8}, size));
+    auto struct_col = cudf::make_structs_column(size, std::move(children), 0, rmm::device_buffer{});
+
+    auto sliced = cudf::split(*struct_col, {511 * 1024 * 1024});
+
+    // 511 * 1024 * 1024, should succeed
+    table_view a({sliced[0]});
+    cudf::concatenate(std::vector<table_view>({a, a, a, a}));
+
+    // 513 * 1024 * 1024, should fail
+    table_view b({sliced[1]});
+    EXPECT_THROW(cudf::concatenate(std::vector<table_view>({b, b, b, b})), cudf::logic_error);
+  }
+
+  // strings, overflow on chars
+  {
+    constexpr size_type total_chars_size = 1024 * 1024 * 1024;
+    constexpr size_type string_size      = 64;
+    constexpr size_type num_rows         = total_chars_size / string_size;
+
+    // try and concatenate 4 string columns of with ~1/2 billion chars in each
+    auto offset_gen = cudf::detail::make_counting_transform_iterator(
+      0, [string_size](size_type index) { return index * string_size; });
+    cudf::test::fixed_width_column_wrapper<int> offsets(offset_gen, offset_gen + num_rows + 1);
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, num_rows);
+    auto col        = cudf::make_strings_column(
+      num_rows, offsets.release(), std::move(many_chars), 0, rmm::device_buffer{});
+
+    auto sliced = cudf::split(*col, {(num_rows / 2) - 1});
+
+    // (num_rows / 2) - 1 should succeed
+    table_view a({sliced[0]});
+    cudf::concatenate(std::vector<table_view>({a, a, a, a}));
+
+    // (num_rows / 2) + 1 should fail
+    table_view b({sliced[1]});
+    EXPECT_THROW(cudf::concatenate(std::vector<table_view>({b, b, b, b})), cudf::logic_error);
+  }
+
+  // strings, overflow on offsets
+  {
+    constexpr size_type total_chars_size = 1024 * 1024 * 1024;
+    constexpr size_type string_size      = 1;
+    constexpr size_type num_rows         = total_chars_size / string_size;
+
+    // try and concatenate 4 string columns of with ~1/2 billion chars in each
+    auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
+    thrust::fill(rmm::exec_policy(),
+                 offsets->mutable_view().begin<offset_type>(),
+                 offsets->mutable_view().end<offset_type>(),
+                 string_size);
+    thrust::exclusive_scan(rmm::exec_policy(),
+                           offsets->view().begin<offset_type>(),
+                           offsets->view().end<offset_type>(),
+                           offsets->mutable_view().begin<offset_type>());
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, num_rows);
+    auto col        = cudf::make_strings_column(
+      num_rows, std::move(offsets), std::move(many_chars), 0, rmm::device_buffer{});
+
+    // should pass (with 2 rows to spare)
+    // leaving this disabled as it typically runs out of memory on a T4
+    /*
+    {
+      auto sliced = cudf::split(*col, {(num_rows / 2) + 1});
+      table_view b({sliced[1]});
+      cudf::concatenate(std::vector<table_view>({b, b, b, b}));
+    }
+    */
+
+    // should fail by 1 row (2,147,483,647 rows which is fine, but that requires 2,147,483,648
+    // offsets, which is not)
+    {
+      auto a = cudf::split(*col, {(num_rows / 2)});
+      table_view ta({a[1]});
+
+      auto b = cudf::split(*col, {(num_rows / 2) + 1});
+      table_view tb({b[1]});
+
+      EXPECT_THROW(cudf::concatenate(std::vector<table_view>({ta, ta, ta, tb})), cudf::logic_error);
+    }
+  }
+
+  // list<struct>, structs too long
+  {
+    constexpr size_type inner_size =
+      static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+
+    // struct
+    std::vector<std::unique_ptr<column>> children;
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size));
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size));
+    auto struct_col =
+      cudf::make_structs_column(inner_size, std::move(children), 0, rmm::device_buffer{});
+
+    // list
+    constexpr size_type list_size = inner_size / 4;
+    auto offsets                  = cudf::test::fixed_width_column_wrapper<int>{
+      0, list_size, list_size * 2, list_size * 3, inner_size};
+    auto col =
+      cudf::make_lists_column(4, offsets.release(), std::move(struct_col), 0, rmm::device_buffer{});
+
+    auto sliced = cudf::split(*col, {2});
+    table_view tbl({sliced[1]});
+    auto tables = std::vector<table_view>({tbl, tbl, tbl, tbl});
+    EXPECT_THROW(cudf::concatenate(tables), cudf::logic_error);
+  }
+
+  // list<struct>, overflow on offsets
+  {
+    constexpr size_type inner_size = 1024 * 1024 * 1024;
+    constexpr size_type list_size  = 1;
+    constexpr size_type num_rows   = inner_size / list_size;
+
+    // struct
+    std::vector<std::unique_ptr<column>> children;
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size));
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size));
+    auto struct_col =
+      cudf::make_structs_column(inner_size, std::move(children), 0, rmm::device_buffer{});
+
+    // try and concatenate 4 struct columns of with ~1/2 billion elements in each
+    auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
+    thrust::fill(rmm::exec_policy(),
+                 offsets->mutable_view().begin<offset_type>(),
+                 offsets->mutable_view().end<offset_type>(),
+                 list_size);
+    thrust::exclusive_scan(rmm::exec_policy(),
+                           offsets->view().begin<offset_type>(),
+                           offsets->view().end<offset_type>(),
+                           offsets->mutable_view().begin<offset_type>());
+    auto col = cudf::make_strings_column(
+      num_rows, std::move(offsets), std::move(struct_col), 0, rmm::device_buffer{});
+
+    // should pass (with 2 rows to spare)
+    // leaving this disabled as it typically runs out of memory on a T4
+    /*
+    {
+      auto sliced = cudf::split(*col, {(num_rows / 2) + 1});
+      table_view b({sliced[1]});
+      cudf::concatenate(std::vector<table_view>({b, b, b, b}));
+    }
+    */
+
+    // should fail by 1 row (2,147,483,647 rows which is fine, but that requires 2,147,483,648
+    // offsets, which is not)
+    {
+      auto a = cudf::split(*col, {(num_rows / 2)});
+      table_view ta({a[1]});
+
+      auto b = cudf::split(*col, {(num_rows / 2) + 1});
+      table_view tb({b[1]});
+
+      EXPECT_THROW(cudf::concatenate(std::vector<table_view>({ta, ta, ta, tb})), cudf::logic_error);
+    }
+  }
+
+  // struct<int8, list>, list child elements too long
+  {
+    constexpr size_type inner_size =
+      static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+    constexpr size_type num_rows  = 4;
+    constexpr size_type list_size = inner_size / num_rows;
+
+    // list
+    auto offsets = cudf::test::fixed_width_column_wrapper<offset_type>{
+      0, list_size, (list_size * 2) - 1, list_size * 3, inner_size};
+    auto many_chars =
+      cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT8}, inner_size);
+    auto list_col = cudf::make_lists_column(
+      num_rows, offsets.release(), std::move(many_chars), 0, rmm::device_buffer{});
+
+    // struct
+    std::vector<std::unique_ptr<column>> children;
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT8}, num_rows));
+    children.push_back(std::move(list_col));
+    auto struct_col =
+      cudf::make_structs_column(num_rows, std::move(children), 0, rmm::device_buffer{});
+
+    auto sliced = cudf::split(*struct_col, {2});
+
+    table_view a({sliced[0]});
+    cudf::concatenate(std::vector<table_view>({a, a, a, a}));
+
+    table_view b({sliced[1]});
+    EXPECT_THROW(cudf::concatenate(std::vector<table_view>({b, b, b, b})), cudf::logic_error);
+  }
+}
+
+TEST_F(OverflowTest, SizeOverflowTestBigColumnsSmallSlices)
+{
+  // test : many small slices of large columns. the idea is to make sure
+  // that we are respecting the offset/sizes of the slices and not attempting to
+  // concatenate the entire large initial columns
+
+  using namespace cudf;
+
+  // primitive column
+  {
+    constexpr size_type size = static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, size);
+    auto sliced     = cudf::slice(*many_chars, {16, 32});
+
+    // 192 total rows
+    table_view a({sliced[0]});
+    cudf::concatenate(std::vector<table_view>({a, a, a, a, a, a, a, a, a, a, a, a}));
+  }
+
+  // strings column
+  {
+    constexpr size_type inner_size =
+      static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+    constexpr size_type num_rows    = 1024;
+    constexpr size_type string_size = inner_size / num_rows;
+
+    auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
+    thrust::fill(rmm::exec_policy(),
+                 offsets->mutable_view().begin<offset_type>(),
+                 offsets->mutable_view().end<offset_type>(),
+                 string_size);
+    thrust::exclusive_scan(rmm::exec_policy(),
+                           offsets->view().begin<offset_type>(),
+                           offsets->view().end<offset_type>(),
+                           offsets->mutable_view().begin<offset_type>());
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size);
+    auto col        = cudf::make_strings_column(
+      num_rows, std::move(offsets), std::move(many_chars), 0, rmm::device_buffer{});
+
+    auto sliced = cudf::slice(*col, {16, 32});
+
+    // 192 outer rows
+    // 201,326,592 inner rows
+    table_view a({sliced[0]});
+    cudf::concatenate(std::vector<table_view>({a, a, a, a, a, a, a, a, a, a, a, a}));
+  }
+
+  // list<int8> column
+  {
+    constexpr size_type inner_size =
+      static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+    constexpr size_type num_rows  = 1024;
+    constexpr size_type list_size = inner_size / num_rows;
+
+    auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
+    thrust::fill(rmm::exec_policy(),
+                 offsets->mutable_view().begin<offset_type>(),
+                 offsets->mutable_view().end<offset_type>(),
+                 list_size);
+    thrust::exclusive_scan(rmm::exec_policy(),
+                           offsets->view().begin<offset_type>(),
+                           offsets->view().end<offset_type>(),
+                           offsets->mutable_view().begin<offset_type>());
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size);
+    auto col        = cudf::make_lists_column(
+      num_rows, std::move(offsets), std::move(many_chars), 0, rmm::device_buffer{});
+
+    auto sliced = cudf::slice(*col, {16, 32});
+
+    // 192 outer rows
+    // 201,326,592 inner rows
+    table_view a({sliced[0]});
+    cudf::concatenate(std::vector<table_view>({a, a, a, a, a, a, a, a, a, a, a, a}));
+  }
+
+  // struct<int8, list>
+  {
+    constexpr size_type inner_size =
+      static_cast<size_type>(static_cast<uint32_t>(1024) * 1024 * 1024);
+    constexpr size_type num_rows  = 1024;
+    constexpr size_type list_size = inner_size / num_rows;
+
+    auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
+    thrust::fill(rmm::exec_policy(),
+                 offsets->mutable_view().begin<offset_type>(),
+                 offsets->mutable_view().end<offset_type>(),
+                 list_size);
+    thrust::exclusive_scan(rmm::exec_policy(),
+                           offsets->view().begin<offset_type>(),
+                           offsets->view().end<offset_type>(),
+                           offsets->mutable_view().begin<offset_type>());
+    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, inner_size);
+    auto list_col   = cudf::make_lists_column(
+      num_rows, std::move(offsets), std::move(many_chars), 0, rmm::device_buffer{});
+
+    // struct
+    std::vector<std::unique_ptr<column>> children;
+    children.push_back(cudf::make_fixed_width_column(data_type{type_id::INT8}, num_rows));
+    children.push_back(std::move(list_col));
+    auto struct_col =
+      cudf::make_structs_column(num_rows, std::move(children), 0, rmm::device_buffer{});
+
+    auto sliced = cudf::slice(*struct_col, {16, 32});
+
+    // 192 outer rows
+    // 201,326,592 inner rows
+    table_view a({sliced[0]});
+    cudf::concatenate(std::vector<table_view>({a, a, a, a, a, a, a, a, a, a, a, a}));
   }
 }
 
@@ -708,7 +1036,7 @@ TEST_F(ListsColumnTest, ConcatenateEmptyLists)
   }
 
   {
-    cudf::test::lists_column_wrapper<int> a{LCW{}};
+    cudf::test::lists_column_wrapper<int> a{{LCW{}}};
     cudf::test::lists_column_wrapper<int> b{4, 5, 6, 7};
     cudf::test::lists_column_wrapper<int> expected{LCW{}, {4, 5, 6, 7}};
 
@@ -718,7 +1046,7 @@ TEST_F(ListsColumnTest, ConcatenateEmptyLists)
   }
 
   {
-    cudf::test::lists_column_wrapper<int> a{LCW{}}, b{LCW{}}, c{LCW{}};
+    cudf::test::lists_column_wrapper<int> a{{LCW{}}}, b{{LCW{}}}, c{{LCW{}}};
     cudf::test::lists_column_wrapper<int> d{4, 5, 6, 7};
     cudf::test::lists_column_wrapper<int> expected{LCW{}, LCW{}, LCW{}, {4, 5, 6, 7}};
 
@@ -729,7 +1057,7 @@ TEST_F(ListsColumnTest, ConcatenateEmptyLists)
 
   {
     cudf::test::lists_column_wrapper<int> a{1, 2};
-    cudf::test::lists_column_wrapper<int> b{LCW{}}, c{LCW{}};
+    cudf::test::lists_column_wrapper<int> b{{LCW{}}}, c{{LCW{}}};
     cudf::test::lists_column_wrapper<int> d{4, 5, 6, 7};
     cudf::test::lists_column_wrapper<int> expected{{1, 2}, LCW{}, LCW{}, {4, 5, 6, 7}};
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2361,7 +2361,7 @@ def concat_columns(objs: "MutableSequence[ColumnBase]") -> ColumnBase:
         try:
             col = libcudf.concat.concat_columns(objs)
         except RuntimeError as e:
-            if "concatenated rows exceeds size_type range" in str(e):
+            if "exceeds size_type range" in str(e):
                 raise OverflowError(
                     "total size of output is too large for a cudf column"
                 ) from e


### PR DESCRIPTION

Fixes  https://github.com/rapidsai/cudf/issues/8748

Note:  `concatenate_tests.cpp` was renamed to `concatenate_tests.cu` because of the addition of some thrust calls.  

Existing overflow tests moved to `OverflowTest` section.  New tests specific to this PR are:

`Overflowtest.Presliced`
`OverflowTest.BigColumnsSmallSlices`
