### PR TITLE
Implement JNI for groupby aggregations `M2` and `MERGE_M2`

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Aggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/Aggregation.java
@@ -45,24 +45,24 @@ public abstract class Aggregation {
         ALL(6),
         SUM_OF_SQUARES(7),
         MEAN(8),
-        M2(9),
-        VARIANCE(10), // This can take a delta degrees of freedom
-        STD(11), // This can take a delta degrees of freedom
-        MEDIAN(12),
-        QUANTILE(13),
-        ARGMAX(14),
-        ARGMIN(15),
-        NUNIQUE(16),
-        NTH_ELEMENT(17),
-        ROW_NUMBER(18),
-        COLLECT_LIST(19),
-        COLLECT_SET(20),
-        LEAD(21),
-        LAG(22),
-        PTX(23),
-        CUDA(24),
-        MERGE_LISTS(25),
-        MERGE_SETS(26),
+        VARIANCE(9), // This can take a delta degrees of freedom
+        STD(10), // This can take a delta degrees of freedom
+        MEDIAN(11),
+        QUANTILE(12),
+        ARGMAX(13),
+        ARGMIN(14),
+        NUNIQUE(15),
+        NTH_ELEMENT(16),
+        ROW_NUMBER(17),
+        COLLECT_LIST(18),
+        COLLECT_SET(19),
+        MERGE_LISTS(20),
+        MERGE_SETS(21),
+        LEAD(22),
+        LAG(23),
+        PTX(24),
+        CUDA(25),
+        M2(26),
         MERGE_M2(27);
 
         final int nativeId;

--- a/java/src/main/java/ai/rapids/cudf/Aggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/Aggregation.java
@@ -45,23 +45,25 @@ public abstract class Aggregation {
         ALL(6),
         SUM_OF_SQUARES(7),
         MEAN(8),
-        VARIANCE(9), // This can take a delta degrees of freedom
-        STD(10), // This can take a delta degrees of freedom
-        MEDIAN(11),
-        QUANTILE(12),
-        ARGMAX(13),
-        ARGMIN(14),
-        NUNIQUE(15),
-        NTH_ELEMENT(16),
-        ROW_NUMBER(17),
-        COLLECT_LIST(18),
-        COLLECT_SET(19),
-        MERGE_LISTS(20),
-        MERGE_SETS(21),
-        LEAD(22),
-        LAG(23),
-        PTX(24),
-        CUDA(25);
+        M2(9),
+        VARIANCE(10), // This can take a delta degrees of freedom
+        STD(11), // This can take a delta degrees of freedom
+        MEDIAN(12),
+        QUANTILE(13),
+        ARGMAX(14),
+        ARGMIN(15),
+        NUNIQUE(16),
+        NTH_ELEMENT(17),
+        ROW_NUMBER(18),
+        COLLECT_LIST(19),
+        COLLECT_SET(20),
+        LEAD(21),
+        LAG(22),
+        PTX(23),
+        CUDA(24),
+        MERGE_LISTS(25),
+        MERGE_SETS(26),
+        MERGE_M2(27);
 
         final int nativeId;
 
@@ -565,6 +567,19 @@ public abstract class Aggregation {
         return new MeanAggregation();
     }
 
+    public static class M2Aggregation extends NoParamAggregation {
+        private M2Aggregation() {
+            super(Kind.M2);
+        }
+    }
+
+    /**
+     * Sum of square of differences from mean.
+     */
+    public static M2Aggregation M2() {
+        return new M2Aggregation();
+    }
+
     public static class VarianceAggregation extends DdofAggregation {
         private VarianceAggregation(int ddof) {
             super(Kind.VARIANCE, ddof);
@@ -844,6 +859,19 @@ public abstract class Aggregation {
      */
     public static LagAggregation lag(int offset, ColumnVector defaultOutput) {
         return new LagAggregation(offset, defaultOutput);
+    }
+
+    public static final class MergeM2Aggregation extends NoParamAggregation {
+        private MergeM2Aggregation() {
+            super(Kind.MERGE_M2);
+        }
+    }
+
+    /**
+     * Merge the partial M2 values produced by multiple instances of M2Aggregation.
+     */
+    public static MergeM2Aggregation mergeM2() {
+        return new MergeM2Aggregation();
     }
 
     /**

--- a/java/src/main/native/src/AggregationJni.cpp
+++ b/java/src/main/native/src/AggregationJni.cpp
@@ -55,30 +55,31 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNoParamAgg(JNIEnv 
           return cudf::make_sum_of_squares_aggregation();
         case 8: // MEAN
           return cudf::make_mean_aggregation();
-        case 9: // M2
-          return cudf::make_m2_aggregation();
-        // case 10: VARIANCE
-        // case 11: STD
-        case 12: // MEDIAN
+        // case 9: VARIANCE
+        // case 10: STD
+        case 11: // MEDIAN
           return cudf::make_median_aggregation();
-        // case 13: QUANTILE
-        case 14: // ARGMAX
+        // case 12: QUANTILE
+        case 13: // ARGMAX
           return cudf::make_argmax_aggregation();
-        case 15: // ARGMIN
+        case 14: // ARGMIN
           return cudf::make_argmin_aggregation();
-        // case 16: NUNIQUE
-        // case 17: NTH_ELEMENT
-        case 18: // ROW_NUMBER
+        // case 15: NUNIQUE
+        // case 16: NTH_ELEMENT
+        case 17: // ROW_NUMBER
           return cudf::make_row_number_aggregation();
-        // case 19: COLLECT_LIST
-        // case 20: COLLECT_SET
-        // case 21: LEAD
-        // case 22: LAG
-        // case 23: PTX
-        // case 24: CUDA
-        case 25: // MERGE_LISTS
+        // case 18: COLLECT_LIST
+        // case 19: COLLECT_SET
+        // case 20: MERGE_LISTS
+        case 20:
           return cudf::make_merge_lists_aggregation();
-          // case 26: MERGE_SETS
+          // case 21: MERGE_SETS
+          // case 22: LEAD
+          // case 23: LAG
+          // case 24: PTX
+          // case 25: CUDA
+        case 26: // M2
+          return cudf::make_m2_aggregation();
         case 27: // MERGE_M2
           return cudf::make_merge_m2_aggregation();
 
@@ -114,10 +115,10 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createDdofAgg(JNIEnv *en
     std::unique_ptr<cudf::aggregation> ret;
     // These numbers come from Aggregation.java and must stay in sync
     switch (kind) {
-      case 10: // VARIANCE
+      case 9: // VARIANCE
         ret = cudf::make_variance_aggregation(ddof);
         break;
-      case 11: // STD
+      case 10: // STD
         ret = cudf::make_std_aggregation(ddof);
         break;
       default: throw std::logic_error("Unsupported DDOF Aggregation Operation");
@@ -142,7 +143,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCountLikeAgg(JNIEn
       case 4: // COUNT
         ret = cudf::make_count_aggregation(policy);
         break;
-      case 16: // NUNIQUE
+      case 15: // NUNIQUE
         ret = cudf::make_nunique_aggregation(policy);
         break;
       default: throw std::logic_error("Unsupported Count Like Aggregation Operation");
@@ -180,10 +181,10 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createLeadLagAgg(JNIEnv 
     std::unique_ptr<cudf::aggregation> ret;
     // These numbers come from Aggregation.java and must stay in sync
     switch (kind) {
-      case 21: // LEAD
+      case 22: // LEAD
         ret = cudf::make_lead_aggregation(offset);
         break;
-      case 22: // LAG
+      case 23: // LAG
         ret = cudf::make_lag_aggregation(offset);
         break;
       default: throw std::logic_error("Unsupported Lead/Lag Aggregation Operation");

--- a/java/src/main/native/src/AggregationJni.cpp
+++ b/java/src/main/native/src/AggregationJni.cpp
@@ -20,8 +20,7 @@
 
 extern "C" {
 
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Aggregation_close(JNIEnv *env,
-                                                             jclass class_object,
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Aggregation_close(JNIEnv *env, jclass class_object,
                                                              jlong ptr) {
   try {
     cudf::jni::auto_set_device(env);
@@ -36,64 +35,56 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNoParamAgg(JNIEnv 
                                                                          jint kind) {
   try {
     cudf::jni::auto_set_device(env);
-    std::unique_ptr<cudf::aggregation> ret;
-    // These numbers come from Aggregation.java and must stay in sync
-    switch (kind) {
-      case 0: // SUM
-        ret = cudf::make_sum_aggregation();
-        break;
-      case 1: // PRODUCT
-        ret = cudf::make_product_aggregation();
-        break;
-      case 2: // MIN
-        ret = cudf::make_min_aggregation();
-        break;
-      case 3: // MAX
-        ret = cudf::make_max_aggregation();
-        break;
-      //case 4 COUNT
-      case 5: // ANY
-        ret = cudf::make_any_aggregation();
-        break;
-      case 6: // ALL
-        ret = cudf::make_all_aggregation();
-        break;
-      case 7: // SUM_OF_SQUARES
-        ret = cudf::make_sum_of_squares_aggregation();
-        break;
-      case 8: // MEAN
-        ret = cudf::make_mean_aggregation();
-        break;
-      // case 9: VARIANCE
-      // case 10: STD
-      case 11: // MEDIAN
-        ret = cudf::make_median_aggregation();
-        break;
-      // case 12: QUANTILE
-      case 13: // ARGMAX
-        ret = cudf::make_argmax_aggregation();
-        break;
-      case 14: // ARGMIN
-        ret = cudf::make_argmin_aggregation();
-        break;
-      // case 15: NUNIQUE
-      // case 16: NTH_ELEMENT
-      case 17: // ROW_NUMBER
-        ret = cudf::make_row_number_aggregation();
-        break;
-      // case 18: COLLECT_LIST
-      // case 19: COLLECT_SET
-      // case 20: MERGE_LISTS
-      case 20:
-        ret = cudf::make_merge_lists_aggregation();
-        break;
-      // case 21: MERGE_SETS
-      // case 22: LEAD
-      // case 23: LAG
-      // case 24: PTX
-      // case 25: CUDA
-      default: throw std::logic_error("Unsupported No Parameter Aggregation Operation");
-    }
+    auto ret = [&] {
+      // These numbers come from Aggregation.java and must stay in sync
+      switch (kind) {
+        case 0: // SUM
+          return cudf::make_sum_aggregation();
+        case 1: // PRODUCT
+          return cudf::make_product_aggregation();
+        case 2: // MIN
+          return cudf::make_min_aggregation();
+        case 3: // MAX
+          return cudf::make_max_aggregation();
+        // case 4 COUNT
+        case 5: // ANY
+          return cudf::make_any_aggregation();
+        case 6: // ALL
+          return cudf::make_all_aggregation();
+        case 7: // SUM_OF_SQUARES
+          return cudf::make_sum_of_squares_aggregation();
+        case 8: // MEAN
+          return cudf::make_mean_aggregation();
+        case 9: // M2
+          return cudf::make_m2_aggregation();
+        // case 10: VARIANCE
+        // case 11: STD
+        case 12: // MEDIAN
+          return cudf::make_median_aggregation();
+        // case 13: QUANTILE
+        case 14: // ARGMAX
+          return cudf::make_argmax_aggregation();
+        case 15: // ARGMIN
+          return cudf::make_argmin_aggregation();
+        // case 16: NUNIQUE
+        // case 17: NTH_ELEMENT
+        case 18: // ROW_NUMBER
+          return cudf::make_row_number_aggregation();
+        // case 19: COLLECT_LIST
+        // case 20: COLLECT_SET
+        // case 21: LEAD
+        // case 22: LAG
+        // case 23: PTX
+        // case 24: CUDA
+        case 25: // MERGE_LISTS
+          return cudf::make_merge_lists_aggregation();
+          // case 26: MERGE_SETS
+        case 27: // MERGE_M2
+          return cudf::make_merge_m2_aggregation();
+
+        default: throw std::logic_error("Unsupported No Parameter Aggregation Operation");
+      }
+    }();
 
     return reinterpret_cast<jlong>(ret.release());
   }
@@ -107,9 +98,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNthAgg(JNIEnv *env
   try {
     cudf::jni::auto_set_device(env);
 
-    std::unique_ptr<cudf::aggregation> ret = 
-        cudf::make_nth_element_aggregation(offset,
-                include_nulls ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+    std::unique_ptr<cudf::aggregation> ret = cudf::make_nth_element_aggregation(
+        offset, include_nulls ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
     return reinterpret_cast<jlong>(ret.release());
   }
   CATCH_STD(env, 0);
@@ -117,18 +107,17 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNthAgg(JNIEnv *env
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createDdofAgg(JNIEnv *env,
                                                                       jclass class_object,
-                                                                      jint kind,
-                                                                      jint ddof) {
+                                                                      jint kind, jint ddof) {
   try {
     cudf::jni::auto_set_device(env);
 
     std::unique_ptr<cudf::aggregation> ret;
     // These numbers come from Aggregation.java and must stay in sync
     switch (kind) {
-      case 9: // VARIANCE
+      case 10: // VARIANCE
         ret = cudf::make_variance_aggregation(ddof);
         break;
-      case 10: // STD
+      case 11: // STD
         ret = cudf::make_std_aggregation(ddof);
         break;
       default: throw std::logic_error("Unsupported DDOF Aggregation Operation");
@@ -153,7 +142,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCountLikeAgg(JNIEn
       case 4: // COUNT
         ret = cudf::make_count_aggregation(policy);
         break;
-      case 15: // NUNIQUE
+      case 16: // NUNIQUE
         ret = cudf::make_nunique_aggregation(policy);
         break;
       default: throw std::logic_error("Unsupported Count Like Aggregation Operation");
@@ -184,18 +173,17 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createQuantAgg(JNIEnv *e
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createLeadLagAgg(JNIEnv *env,
                                                                          jclass class_object,
-                                                                         jint kind,
-                                                                         jint offset) {
+                                                                         jint kind, jint offset) {
   try {
     cudf::jni::auto_set_device(env);
 
     std::unique_ptr<cudf::aggregation> ret;
     // These numbers come from Aggregation.java and must stay in sync
     switch (kind) {
-      case 22: // LEAD
+      case 21: // LEAD
         ret = cudf::make_lead_aggregation(offset);
         break;
-      case 23: // LAG
+      case 22: // LAG
         ret = cudf::make_lag_aggregation(offset);
         break;
       default: throw std::logic_error("Unsupported Lead/Lag Aggregation Operation");
@@ -205,9 +193,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createLeadLagAgg(JNIEnv 
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCollectListAgg(JNIEnv *env,
-                                                                             jclass class_object,
-                                                                             jboolean include_nulls) {
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCollectListAgg(
+    JNIEnv *env, jclass class_object, jboolean include_nulls) {
   try {
     cudf::jni::auto_set_device(env);
     cudf::null_policy policy =
@@ -231,9 +218,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCollectSetAgg(JNIE
         nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
     cudf::nan_equality nan_equality =
         nans_equal ? cudf::nan_equality::ALL_EQUAL : cudf::nan_equality::UNEQUAL;
-    std::unique_ptr<cudf::aggregation> ret = cudf::make_collect_set_aggregation(null_policy,
-                                                                                null_equality,
-                                                                                nan_equality);
+    std::unique_ptr<cudf::aggregation> ret =
+        cudf::make_collect_set_aggregation(null_policy, null_equality, nan_equality);
     return reinterpret_cast<jlong>(ret.release());
   }
   CATCH_STD(env, 0);
@@ -249,8 +235,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createMergeSetsAgg(JNIEn
         nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
     cudf::nan_equality nan_equality =
         nans_equal ? cudf::nan_equality::ALL_EQUAL : cudf::nan_equality::UNEQUAL;
-    std::unique_ptr<cudf::aggregation> ret = cudf::make_merge_sets_aggregation(null_equality,
-                                                                               nan_equality);
+    std::unique_ptr<cudf::aggregation> ret =
+        cudf::make_merge_sets_aggregation(null_equality, nan_equality);
     return reinterpret_cast<jlong>(ret.release());
   }
   CATCH_STD(env, 0);

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -18,22 +18,45 @@
 
 package ai.rapids.cudf;
 
-import ai.rapids.cudf.HostColumnVector.*;
+import ai.rapids.cudf.HostColumnVector.BasicType;
+import ai.rapids.cudf.HostColumnVector.Builder;
+import ai.rapids.cudf.HostColumnVector.DataType;
+import ai.rapids.cudf.HostColumnVector.ListType;
+import ai.rapids.cudf.HostColumnVector.StructData;
+import ai.rapids.cudf.HostColumnVector.StructType;
+
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static ai.rapids.cudf.ParquetWriterOptions.listBuilder;
 import static ai.rapids.cudf.ParquetWriterOptions.structBuilder;
 import static ai.rapids.cudf.Table.TestBuilder;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TableTest extends CudfTestBase {
   private static final File TEST_PARQUET_FILE = new File("src/test/resources/acq.parquet");


### PR DESCRIPTION
This PR adds JNI for the new groupby aggregations `M2` and `MERGE_M2`.