### PR TITLE
Update cudf java bindings to 21.10.0-SNAPSHOT

### DIFF
--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -14,10 +14,8 @@ In the root path of cuDF repo, run below command to build the docker image.
 docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.2.2 -t cudf-build:11.2.2-devel-centos7 .
 ```
 
-The following CUDA versions are supported:
-* CUDA 11.0
-* CUDA 11.1
-* CUDA 11.2
+The following CUDA versions are supported w/ CUDA Enhanced Compatibility:
+* CUDA 11.0+
 
 Change the --build-arg CUDA_VERSION to what you need.
 You can replace the tag "cudf-build:11.2.2-devel-centos7" with another name you like.
@@ -36,7 +34,7 @@ nvidia-docker run -it cudf-build:11.2.2-devel-centos7 bash
 You can download the cuDF repo in the docker container or you can mount it into the container.
 Here I choose to download again in the container.
 ```bash
-git clone --recursive https://github.com/rapidsai/cudf.git -b branch-21.08
+git clone --recursive https://github.com/rapidsai/cudf.git -b branch-21.10
 ```
 
 ### Build cuDF jar with devtoolset
@@ -49,5 +47,5 @@ scl enable devtoolset-9 "java/ci/build-in-docker.sh"
 
 ### The output
 
-You can find the cuDF jar in java/target/ like cudf-21.08.0-SNAPSHOT-cuda11.jar.
+You can find the cuDF jar in java/target/ like cudf-21.10.0-SNAPSHOT-cuda11.jar.
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ai.rapids</groupId>
     <artifactId>cudf</artifactId>
-    <version>21.08.0-SNAPSHOT</version>
+    <version>21.10.0-SNAPSHOT</version>
 
     <name>cudfjni</name>
     <description>


### PR DESCRIPTION
update cudf JNI version to 21.10.0, and preparing nightly artifact build