### PR TITLE
Revert "Remove cudf unneeded build time requirement of the cuda driver"

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -526,12 +526,12 @@ if(CUDA_STATIC_RUNTIME)
     # Tell CMake what CUDA language runtime to use
     set_target_properties(cudf PROPERTIES CUDA_RUNTIME_LIBRARY Static)
     # Make sure to export to consumers what runtime we used
-    target_link_libraries(cudf PUBLIC CUDA::cudart_static)
+    target_link_libraries(cudf PUBLIC CUDA::cudart_static CUDA::cuda_driver)
 else()
     # Tell CMake what CUDA language runtime to use
     set_target_properties(cudf PROPERTIES CUDA_RUNTIME_LIBRARY Shared)
     # Make sure to export to consumers what runtime we used
-    target_link_libraries(cudf PUBLIC CUDA::cudart)
+    target_link_libraries(cudf PUBLIC CUDA::cudart CUDA::cuda_driver)
 endif()
 
 # Add cuFile interface if available


### PR DESCRIPTION
This reverts the relaxation of linking to the CUDA driver (libcuda.so), as developers would get linking issues like:
```
../libcudf.so: undefined reference to `cuLaunchKernel'
../libcudf.so: undefined reference to `cuLinkComplete'
../libcudf.so: undefined reference to `cuModuleGetFunction'
../libcudf.so: undefined reference to `cuGetErrorString'
../libcudf.so: undefined reference to `cuOccupancyMaxPotentialBlockSizeWithFlags'
../libcudf.so: undefined reference to `cuLinkAddData_v2'
../libcudf.so: undefined reference to `cuDeviceGetAttribute'
../libcudf.so: undefined reference to `cuModuleUnload'
../libcudf.so: undefined reference to `cuLinkDestroy'
../libcudf.so: undefined reference to `cuModuleLoadData'
../libcudf.so: undefined reference to `cuCtxGetDevice'
../libcudf.so: undefined reference to `cuLinkCreate_v2'
../libcudf.so: undefined reference to `cuLinkAddFile_v2'
../libcudf.so: undefined reference to `cuCtxGetCurrent'
```