### PR TITLE
Handle empty child columns in row_bit_count()

### DIFF
--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -453,6 +453,67 @@ TEST_F(RowBitCount, NestedTypes)
   }
 }
 
+TEST_F(RowBitCount, ListOfStrings)
+{
+  using namespace cudf;
+  using namespace cudf::test;
+  using offsets_wrapper = fixed_width_column_wrapper<offset_type>;
+
+  // clang-format off
+  auto strings = std::vector<std::string>{ "daïs", "def", "", "z", "bananas", "warp", "", "zing" };
+  auto valids  = std::vector<bool>{            1,     0,   0,  1,         0,      1,   1,     1 };
+  // clang-format on
+
+  cudf::test::strings_column_wrapper col(strings.begin(), strings.end(), valids.begin());
+
+  auto offsets   = cudf::test::fixed_width_column_wrapper<int>{0, 2, 4, 6, 8};
+  auto lists_col = cudf::make_lists_column(
+    4,
+    offsets_wrapper{0, 2, 4, 6, 8}.release(),
+    strings_column_wrapper{strings.begin(), strings.end(), valids.begin()}.release(),
+    0,
+    {});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(row_bit_count(table_view{{lists_col->view()}})->view(),
+                                      fixed_width_column_wrapper<offset_type>{138, 106, 130, 130});
+}
+
+TEST_F(RowBitCount, NullsInStringList)
+{
+  using namespace cudf;
+  using namespace cudf::test;
+
+  // Test with a list<string> column with 4 empty list rows.
+  // Note: Since there are no strings in any of the lists,
+  //       the lists column's child can be empty.
+  auto offsets = fixed_width_column_wrapper<offset_type>{0, 0, 0, 0, 0};
+  auto lists_col =
+    make_lists_column(4, offsets.release(), make_empty_column(data_type{type_id::STRING}), 0, {});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(row_bit_count(table_view{{lists_col->view()}})->view(),
+                                      fixed_width_column_wrapper<offset_type>{32, 32, 32, 32});
+}
+
+TEST_F(RowBitCount, NullsInListOfLists)
+{
+  using namespace cudf;
+  using namespace cudf::test;
+
+  // Test with a list<list> column with 4 empty list rows.
+  // Note: Since there are no elements in any of the lists,
+  //       the lists column's child can be empty.
+  auto empty_child_lists_column = [] {
+    auto exemplar = lists_column_wrapper<int32_t>{{0, 1, 2}, {3, 4, 5}};
+    return empty_like(exemplar);
+  };
+
+  auto offsets   = fixed_width_column_wrapper<offset_type>{0, 0, 0, 0, 0};
+  auto lists_col = make_lists_column(4, offsets.release(), empty_child_lists_column(), 0, {});
+  auto constexpr offset_nbits = sizeof(offset_type) * CHAR_BIT;
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(row_bit_count(table_view{{lists_col->view()}})->view(),
+                                      fixed_width_column_wrapper<offset_type>{32, 32, 32, 32});
+}
+
 struct sum_functor {
   size_type const* s0;
   size_type const* s1;

--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -453,7 +453,7 @@ TEST_F(RowBitCount, NestedTypes)
   }
 }
 
-TEST_F(RowBitCount, ListOfStrings)
+TEST_F(RowBitCount, NullsInStringsList)
 {
   using namespace cudf;
   using namespace cudf::test;
@@ -477,7 +477,7 @@ TEST_F(RowBitCount, ListOfStrings)
                                       fixed_width_column_wrapper<offset_type>{138, 106, 130, 130});
 }
 
-TEST_F(RowBitCount, NullsInStringList)
+TEST_F(RowBitCount, EmptyChildColumnInListOfStrings)
 {
   using namespace cudf;
   using namespace cudf::test;
@@ -493,7 +493,7 @@ TEST_F(RowBitCount, NullsInStringList)
                                       fixed_width_column_wrapper<offset_type>{32, 32, 32, 32});
 }
 
-TEST_F(RowBitCount, NullsInListOfLists)
+TEST_F(RowBitCount, EmptyChildColumnInListOfLists)
 {
   using namespace cudf;
   using namespace cudf::test;

--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -455,9 +455,7 @@ TEST_F(RowBitCount, NestedTypes)
 
 TEST_F(RowBitCount, NullsInStringsList)
 {
-  using namespace cudf;
-  using namespace cudf::test;
-  using offsets_wrapper = fixed_width_column_wrapper<offset_type>;
+  using offsets_wrapper = cudf::test::fixed_width_column_wrapper<offset_type>;
 
   // clang-format off
   auto strings = std::vector<std::string>{ "daïs", "def", "", "z", "bananas", "warp", "", "zing" };
@@ -470,48 +468,45 @@ TEST_F(RowBitCount, NullsInStringsList)
   auto lists_col = cudf::make_lists_column(
     4,
     offsets_wrapper{0, 2, 4, 6, 8}.release(),
-    strings_column_wrapper{strings.begin(), strings.end(), valids.begin()}.release(),
+    cudf::test::strings_column_wrapper{strings.begin(), strings.end(), valids.begin()}.release(),
     0,
     {});
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(row_bit_count(table_view{{lists_col->view()}})->view(),
-                                      fixed_width_column_wrapper<offset_type>{138, 106, 130, 130});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    cudf::row_bit_count(table_view{{lists_col->view()}})->view(),
+    cudf::test::fixed_width_column_wrapper<offset_type>{138, 106, 130, 130});
 }
 
 TEST_F(RowBitCount, EmptyChildColumnInListOfStrings)
 {
-  using namespace cudf;
-  using namespace cudf::test;
-
   // Test with a list<string> column with 4 empty list rows.
   // Note: Since there are no strings in any of the lists,
   //       the lists column's child can be empty.
-  auto offsets = fixed_width_column_wrapper<offset_type>{0, 0, 0, 0, 0};
-  auto lists_col =
-    make_lists_column(4, offsets.release(), make_empty_column(data_type{type_id::STRING}), 0, {});
+  auto offsets   = cudf::test::fixed_width_column_wrapper<offset_type>{0, 0, 0, 0, 0};
+  auto lists_col = cudf::make_lists_column(
+    4, offsets.release(), cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}), 0, {});
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(row_bit_count(table_view{{lists_col->view()}})->view(),
-                                      fixed_width_column_wrapper<offset_type>{32, 32, 32, 32});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    cudf::row_bit_count(table_view{{lists_col->view()}})->view(),
+    cudf::test::fixed_width_column_wrapper<offset_type>{32, 32, 32, 32});
 }
 
 TEST_F(RowBitCount, EmptyChildColumnInListOfLists)
 {
-  using namespace cudf;
-  using namespace cudf::test;
-
   // Test with a list<list> column with 4 empty list rows.
   // Note: Since there are no elements in any of the lists,
   //       the lists column's child can be empty.
   auto empty_child_lists_column = [] {
-    auto exemplar = lists_column_wrapper<int32_t>{{0, 1, 2}, {3, 4, 5}};
-    return empty_like(exemplar);
+    auto exemplar = cudf::test::lists_column_wrapper<int32_t>{{0, 1, 2}, {3, 4, 5}};
+    return cudf::empty_like(exemplar);
   };
 
-  auto offsets   = fixed_width_column_wrapper<offset_type>{0, 0, 0, 0, 0};
-  auto lists_col = make_lists_column(4, offsets.release(), empty_child_lists_column(), 0, {});
+  auto offsets   = cudf::test::fixed_width_column_wrapper<offset_type>{0, 0, 0, 0, 0};
+  auto lists_col = cudf::make_lists_column(4, offsets.release(), empty_child_lists_column(), 0, {});
   auto constexpr offset_nbits = sizeof(offset_type) * CHAR_BIT;
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(row_bit_count(table_view{{lists_col->view()}})->view(),
-                                      fixed_width_column_wrapper<offset_type>{32, 32, 32, 32});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    cudf::row_bit_count(table_view{{lists_col->view()}})->view(),
+    cudf::test::fixed_width_column_wrapper<offset_type>{32, 32, 32, 32});
 }
 
 struct sum_functor {


### PR DESCRIPTION
Fixes #8775.
Addresses failures seen in NVIDIA/spark-rapids/issues/2723.

`row_bit_count()` handles string and list inputs by computing the sizes of the offsets, and that of the elements in the underlying child column.
For cases where the child column is empty (e.g. where the input string/list column contains only nulls), row_bit_count() erroneously attempts to read the contents of the empty `offsets` and `child.data()`, leading to bad reads and crashes.

This commit allows `row_bit_count()` to identify empty child row spans as having `0` size. It also correctly handles empty child columns.

