### PR TITLE
Provide a better error message when `CUDA::cuda_driver` not found

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -537,8 +537,8 @@ endif()
 # The CUDA::cuda_driver is needed due to JITIFY sources which
 # directly call the cuda driver API
 if(NOT TARGET CUDA::cuda_driver)
-    message(FATAL_ERROR "cudf requires `libcuda.so` to be built.
-        This commonly occurs when trying to build cudf from a container without the NVIDIA runtime loaded.")
+    message(FATAL_ERROR "Building libcudf requires `libcuda.so` to be present.
+        This error often occurs when trying to build libcudf from a container without the NVIDIA runtime loaded.")
 endif()
 target_link_libraries(cudf PRIVATE CUDA::cuda_driver)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -526,13 +526,21 @@ if(CUDA_STATIC_RUNTIME)
     # Tell CMake what CUDA language runtime to use
     set_target_properties(cudf PROPERTIES CUDA_RUNTIME_LIBRARY Static)
     # Make sure to export to consumers what runtime we used
-    target_link_libraries(cudf PUBLIC CUDA::cudart_static CUDA::cuda_driver)
+    target_link_libraries(cudf PUBLIC CUDA::cudart_static)
 else()
     # Tell CMake what CUDA language runtime to use
     set_target_properties(cudf PROPERTIES CUDA_RUNTIME_LIBRARY Shared)
     # Make sure to export to consumers what runtime we used
-    target_link_libraries(cudf PUBLIC CUDA::cudart CUDA::cuda_driver)
+    target_link_libraries(cudf PUBLIC CUDA::cudart)
 endif()
+
+# The CUDA::cuda_driver is needed due to JITIFY sources which
+# directly call the cuda driver API
+if(NOT TARGET CUDA::cuda_driver)
+    message(FATAL_ERROR "cudf requires `libcuda.so` to be built.
+        This commonly occurs when trying to build cudf from a container without the NVIDIA runtime loaded.")
+endif()
+target_link_libraries(cudf PRIVATE CUDA::cuda_driver)
 
 # Add cuFile interface if available
 if(TARGET cuFile::cuFile_interface)


### PR DESCRIPTION
cuDF JITIFY sources require the the CUDA driver ( libcuda.so ) or
stub to exist for correct compilation/linking. If they can't be
found explain why, instead of producing a bad error message
