### PR TITLE
[DOC] Update Python UDFs notebook

### DIFF
--- a/docs/cudf/source/guide-to-udfs.ipynb
+++ b/docs/cudf/source/guide-to-udfs.ipynb
@@ -22,7 +22,7 @@
     "- CuPy NDArrays\n",
     "- Numba DeviceNDArrays\n",
     "\n",
-    "It also demonstrates cuDF's default null handling behavior, and how to write UDFs that can interact with null values in a limited fashion. Starting with version 21.08, cuDF provides experimental support for more general null handling, which is covered in the last section of this guide."
+    "It also demonstrates cuDF's default null handling behavior, and how to write UDFs that can interact with null values in a limited fashion. Finally, it demonstrates some newer more general null handling via the `DataFrame.apply` API."
    ]
   },
   {
@@ -1231,7 +1231,7 @@
     "\n",
     "Above, we covered most basic usage of UDFs with cuDF.\n",
     "\n",
-    "The remainder of the guide focuses on considerations for executing UDFs on DataFrames containing null values. If your UDFs will read or write any column containing nulls, **you should read this section carefully**. From 21.08 forward, see the section below labeled `Generalized NA Support` which supercedes this section.\n",
+    "The remainder of the guide focuses on considerations for executing UDFs on DataFrames containing null values. If your UDFs will read or write any column containing nulls, **you should read this section carefully**. \n",
     "\n",
     "Writing UDFs that can handle null values is complicated by the fact that a separate bitmask is used to identify when a value is valid and when it's null. By default, DataFrame methods for applying UDFs like `apply_rows` will handle nulls pessimistically (all rows with a null value will be removed from the output if they are used in the kernel). Exploring how not handling not pessimistically can lead to undefined behavior is outside the scope of this guide. Suffice it to say, pessimistic null handling is the safe and consistent approach. You can see an example below."
    ]
@@ -1447,7 +1447,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In cuDF versions 21.08 and newer, more general support for `NA` handling is provided on an experimental basis. While the details of the way this works are out of scope of this guide, the broad strokes of the pipeline are similar to those of `Series.applymap`: Numba is used to translate a standard python function into an operation on the data columns and their masks, and then the reduced and optimized version of this function is runtime compiled and called using the data. \n",
+    "More general support for `NA` handling is provided on an experimental basis. While the details of the way this works are out of scope of this guide, the broad strokes of the pipeline are similar to those of `Series.applymap`: Numba is used to translate a standard python function into an operation on the data columns and their masks, and then the reduced and optimized version of this function is runtime compiled and called using the data. \n",
     "\n",
     "One advantage of this approach apart from the ability to handle nulls generally in an intuitive manner is it results in a very familiar API to Pandas users. Let's see how this works with an example.\n",
     "\n",
@@ -1456,7 +1456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1472,9 +1472,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>A</th>\n",
+       "      <th>B</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   A     B\n",
+       "0  1     4\n",
+       "1  2  <NA>\n",
+       "2  3     6"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df = cudf.DataFrame({\n",
     "    'A': [1,2,3],\n",
@@ -1492,7 +1549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1510,9 +1567,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0       5\n",
+       "1    <NA>\n",
+       "2       9\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.apply(\n",
     "    lambda row: f(\n",
@@ -1532,9 +1603,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0       5\n",
+       "1    <NA>\n",
+       "2       9\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def g(x, y):\n",
     "    return x + y\n",
@@ -1564,9 +1649,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      a\n",
+       "0     1\n",
+       "1  <NA>\n",
+       "2     3"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@nulludf\n",
     "def f(x):\n",
@@ -1581,9 +1719,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    2\n",
+       "1    0\n",
+       "2    4\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.apply(lambda row: f(row['a']))"
    ]
@@ -1597,9 +1749,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   a  b\n",
+       "0  1  2\n",
+       "1  2  1\n",
+       "2  3  1"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@nulludf\n",
     "def f(x, y):\n",
@@ -1617,9 +1826,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0       3\n",
+       "1       3\n",
+       "2    <NA>\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.apply(lambda row: f(row['a'], row['b']))"
    ]
@@ -1633,9 +1856,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>3.14</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   a     b\n",
+       "0  1   0.5\n",
+       "1  2  <NA>\n",
+       "2  3  3.14"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@nulludf\n",
     "def f(x, y):\n",
@@ -1650,9 +1930,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0     1.5\n",
+       "1    <NA>\n",
+       "2    6.14\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.apply(lambda row: f(row['a'], row['b']))"
    ]
@@ -1679,9 +1973,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   a\n",
+       "0  1\n",
+       "1  3\n",
+       "2  5"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@nulludf\n",
     "def f(x):\n",
@@ -1698,9 +2045,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    1.5\n",
+       "1    1.5\n",
+       "2    5.0\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.apply(lambda row: f(row['a']))"
    ]
@@ -1714,9 +2075,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "      <th>c</th>\n",
+       "      <th>d</th>\n",
+       "      <th>e</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>4</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>8</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>5</td>\n",
+       "      <td>4</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "      <td>4</td>\n",
+       "      <td>8</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   a  b     c  d  e\n",
+       "0  1  4  <NA>  8  7\n",
+       "1  2  5     4  7  1\n",
+       "2  3  6     4  8  6"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\n",
     "@nulludf\n",
@@ -1735,9 +2165,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    <NA>\n",
+       "1     4.8\n",
+       "2     5.0\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.apply(\n",
     "    lambda row: f(\n",

--- a/docs/cudf/source/guide-to-udfs.ipynb
+++ b/docs/cudf/source/guide-to-udfs.ipynb
@@ -22,7 +22,7 @@
     "- CuPy NDArrays\n",
     "- Numba DeviceNDArrays\n",
     "\n",
-    "It also demonstrates cuDF's default null handling behavior, and how to write UDFs that can interact with null values in a limited fashion."
+    "It also demonstrates cuDF's default null handling behavior, and how to write UDFs that can interact with null values in a limited fashion. Starting with version 21.08, cuDF provides experimental support for more general null handling, which is covered in the last section of this guide."
    ]
   },
   {
@@ -592,8 +592,8 @@
     {
      "data": {
       "text/plain": [
-       "0     null\n",
-       "1     null\n",
+       "0     <NA>\n",
+       "1     <NA>\n",
        "2      6.0\n",
        "3      7.0\n",
        "4    100.0\n",
@@ -731,13 +731,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>null</td>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>null</td>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -785,8 +785,8 @@
       ],
       "text/plain": [
        "             a            b\n",
-       "0         null         null\n",
-       "1         null         null\n",
+       "0         <NA>         <NA>\n",
+       "1         <NA>         <NA>\n",
        "2  7.549834435  7.549834435\n",
        "3  7.615773106  7.615773106\n",
        "4  7.681145748  7.681145748\n",
@@ -918,18 +918,9 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/rapids/lib/python3.7/site-packages/cudf/core/dataframe.py:2559: UserWarning: as_index==True not supported due to the lack of multi-index with legacy groupby function. Use hash method for multi-index\n",
-      "  \"as_index==True not supported due to the lack of \"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "grouped = df.groupby(['b'], method=\"cudf\")"
+    "grouped = df.groupby(['b'])"
    ]
   },
   {
@@ -1002,7 +993,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
+       "      <th>1</th>\n",
        "      <td>0.480099</td>\n",
        "      <td>False</td>\n",
        "      <td>Bob</td>\n",
@@ -1011,7 +1002,7 @@
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>4</th>\n",
        "      <td>-0.970850</td>\n",
        "      <td>False</td>\n",
        "      <td>Sarah</td>\n",
@@ -1020,7 +1011,7 @@
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>6</th>\n",
        "      <td>0.801430</td>\n",
        "      <td>False</td>\n",
        "      <td>Sarah</td>\n",
@@ -1029,7 +1020,7 @@
        "      <td>1.035597</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>7</th>\n",
        "      <td>-0.933157</td>\n",
        "      <td>False</td>\n",
        "      <td>Quinn</td>\n",
@@ -1038,7 +1029,7 @@
        "      <td>-3.675258</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>0</th>\n",
        "      <td>-0.691674</td>\n",
        "      <td>True</td>\n",
        "      <td>Dan</td>\n",
@@ -1047,7 +1038,7 @@
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
+       "      <th>2</th>\n",
        "      <td>-0.473370</td>\n",
        "      <td>True</td>\n",
        "      <td>Xavier</td>\n",
@@ -1056,7 +1047,7 @@
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6</th>\n",
+       "      <th>3</th>\n",
        "      <td>0.067479</td>\n",
        "      <td>True</td>\n",
        "      <td>Alice</td>\n",
@@ -1065,7 +1056,7 @@
        "      <td>-3.658552</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>7</th>\n",
+       "      <th>5</th>\n",
        "      <td>0.837494</td>\n",
        "      <td>True</td>\n",
        "      <td>Wendy</td>\n",
@@ -1097,14 +1088,14 @@
       ],
       "text/plain": [
        "          a      b       c         e        out  rolling_avg_e\n",
-       "0  0.480099  False     Bob  4.800994   5.281093            NaN\n",
-       "1 -0.970850  False   Sarah -9.708501  -0.970850            NaN\n",
-       "2  0.801430  False   Sarah  8.014297   8.815727       1.035597\n",
-       "3 -0.933157  False   Quinn -9.331571  -0.933157      -3.675258\n",
-       "4 -0.691674   True     Dan -6.916743  -0.691674            NaN\n",
-       "5 -0.473370   True  Xavier -4.733700  -0.473370            NaN\n",
-       "6  0.067479   True   Alice  0.674788   0.742267      -3.658552\n",
-       "7  0.837494   True   Wendy  8.374940   9.212434       1.438676\n",
+       "1  0.480099  False     Bob  4.800994   5.281093            NaN\n",
+       "4 -0.970850  False   Sarah -9.708501  -0.970850            NaN\n",
+       "6  0.801430  False   Sarah  8.014297   8.815727       1.035597\n",
+       "7 -0.933157  False   Quinn -9.331571  -0.933157      -3.675258\n",
+       "0 -0.691674   True     Dan -6.916743  -0.691674            NaN\n",
+       "2 -0.473370   True  Xavier -4.733700  -0.473370            NaN\n",
+       "3  0.067479   True   Alice  0.674788   0.742267      -3.658552\n",
+       "5  0.837494   True   Wendy  8.374940   9.212434       1.438676\n",
        "8  0.913899   True  Ursula  9.138987  10.052885       6.062905\n",
        "9 -0.725581   True  George -7.255814  -0.725581       3.419371"
       ]
@@ -1198,7 +1189,7 @@
     "    if i < x.size:\n",
     "        out[i] = x[i] * 5\n",
     "        \n",
-    "out = cudf.Series(cudautils.zeros(len(s), dtype='int32'))\n",
+    "out = cudf.Series(cp.zeros(len(s), dtype='int32'))\n",
     "multiply_by_5.forall(s.shape[0])(s, out)\n",
     "out"
    ]
@@ -1240,7 +1231,7 @@
     "\n",
     "Above, we covered most basic usage of UDFs with cuDF.\n",
     "\n",
-    "The remainder of the guide focuses on considerations for executing UDFs on DataFrames containing null values. If your UDFs will read or write any column containing nulls, **you should read this section carefully**.\n",
+    "The remainder of the guide focuses on considerations for executing UDFs on DataFrames containing null values. If your UDFs will read or write any column containing nulls, **you should read this section carefully**. From 21.08 forward, see the section below labeled `Generalized NA Support` which supercedes this section.\n",
     "\n",
     "Writing UDFs that can handle null values is complicated by the fact that a separate bitmask is used to identify when a value is valid and when it's null. By default, DataFrame methods for applying UDFs like `apply_rows` will handle nulls pessimistically (all rows with a null value will be removed from the output if they are used in the kernel). Exploring how not handling not pessimistically can lead to undefined behavior is outside the scope of this guide. Suffice it to say, pessimistic null handling is the safe and consistent approach. You can see an example below."
    ]
@@ -1287,18 +1278,18 @@
        "      <th>1</th>\n",
        "      <td>977</td>\n",
        "      <td>1026</td>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>1026</td>\n",
        "      <td>1019</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>1078</td>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>985</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1314,9 +1305,9 @@
       "text/plain": [
        "      a     b     c\n",
        "0   963  1005   997\n",
-       "1   977  1026  null\n",
-       "2  null  1026  1019\n",
-       "3  1078  null   985\n",
+       "1   977  1026  <NA>\n",
+       "2  <NA>  1026  1019\n",
+       "3  1078  <NA>   985\n",
        "4   979   982  1011"
       ]
      },
@@ -1388,22 +1379,22 @@
        "      <th>1</th>\n",
        "      <td>977</td>\n",
        "      <td>1026</td>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>2003.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>1026</td>\n",
        "      <td>1019</td>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>1078</td>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>985</td>\n",
-       "      <td>null</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1419,9 +1410,9 @@
       "text/plain": [
        "      a     b     c     out\n",
        "0   963  1005   997  1968.0\n",
-       "1   977  1026  null  2003.0\n",
-       "2  null  1026  1019    null\n",
-       "3  1078  null   985    null\n",
+       "1   977  1026  <NA>  2003.0\n",
+       "2  <NA>  1026  1019    <NA>\n",
+       "3  1078  <NA>   985    <NA>\n",
        "4   979   982  1011  1961.0"
       ]
      },
@@ -1449,227 +1440,338 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Operating on Null Values\n",
-    "\n",
-    "If you don't need to conditionally handle null values in your UDFs, feel free to skip these final two sections.\n",
-    "\n",
-    "As a developer or data scientist, you may sometimes need to write UDFs that operate on null values. This means you need to think about the null bitmask array when writing your UDF. As a note, cuDF allows you to turn off pessimistic null handling in `apply_rows`. Instead of doing this, if you need to operate on null values we recommend writing standard `Numba.cuda` kernels. To help you interact with null bitmasks from Python, cuDF provides the `mask_get` utility function. The following example illustrates how you can use `mask_get` in Numba kernels like we used earlier in this guide."
+    "## Generalized NA Support"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Standard Numba Kernels\n",
+    "In cuDF versions 21.08 and newer, more general support for `NA` handling is provided on an experimental basis. While the details of the way this works are out of scope of this guide, the broad strokes of the pipeline are similar to those of `Series.applymap`: Numba is used to translate a standard python function into an operation on the data columns and their masks, and then the reduced and optimized version of this function is runtime compiled and called using the data. \n",
     "\n",
-    "First, we import `mask_get` and create a DataFrame with some null values."
+    "One advantage of this approach apart from the ability to handle nulls generally in an intuitive manner is it results in a very familiar API to Pandas users. Let's see how this works with an example.\n",
+    "\n",
+    "The key to accessing this API is a decorator: `cudf.core.udf.pipeline.nulludf`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>-0.691674315</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.480099393</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>null</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0.067478787</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>null</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "              a      b\n",
-       "0  -0.691674315   True\n",
-       "1   0.480099393  False\n",
-       "2          null   True\n",
-       "3   0.067478787   True\n",
-       "4          null  False"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from cudf.utils.cudautils import mask_get\n",
-    "\n",
-    "df = randomdata(nrows=10, dtypes={'a':float, 'b':bool}, seed=12)\n",
-    "df.loc[[2,4], 'a'] = None\n",
-    "df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we'll define a simple kernel like before, with a couple of differences. This kernel needs access to the null bitmask, so we include a `validity_mask` argument. We also wrap our logic in a conditional based on the results of `mask_get`:\n",
-    "- If the result of `mask_get` for that index **is** valid (there is a value), do the multiplication\n",
-    "- If the result of `mask_get` for that index **is not** valid (it's null), set the output -999999"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@cuda.jit\n",
-    "def gpu_kernel_masked(in_col, validity_mask, out_col, multiplier):\n",
-    "    i = cuda.grid(1)\n",
-    "    if i < in_col.size:\n",
-    "        valid = mask_get(validity_mask, i)\n",
-    "        if valid:\n",
-    "            out_col[i] = in_col[i] * multiplier\n",
-    "        else:\n",
-    "            out_col[i] = -999999"
+    "from cudf.core.udf.pipeline import nulludf"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now grab the underlying DeviceArrays and execute our kernel like we did previously, except that this time we also pass in the DeviceArray of our column's null mask. Because Numba doesn't yet handle masked GPU arrays, we can't directly pass our `Series` here."
+    "Let's create a simple example DataFrame for demonstrational purposes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "      <th>result</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>-0.691674315</td>\n",
-       "      <td>True</td>\n",
-       "      <td>-6.916743</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.480099393</td>\n",
-       "      <td>False</td>\n",
-       "      <td>4.800994</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>null</td>\n",
-       "      <td>True</td>\n",
-       "      <td>-999999.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0.067478787</td>\n",
-       "      <td>True</td>\n",
-       "      <td>0.674788</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>null</td>\n",
-       "      <td>False</td>\n",
-       "      <td>-999999.000000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "              a      b         result\n",
-       "0  -0.691674315   True      -6.916743\n",
-       "1   0.480099393  False       4.800994\n",
-       "2          null   True -999999.000000\n",
-       "3   0.067478787   True       0.674788\n",
-       "4          null  False -999999.000000"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import rmm # RAPIDS Memory Manager\n",
+    "df = cudf.DataFrame({\n",
+    "    'A': [1,2,3],\n",
+    "    'B': [4,cudf.NA,6]\n",
+    "})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The entrypoint for UDFs used in this manner is `cudf.DataFrame.apply`. To use it, start by defining a completely standard python function decorated with the decorator `nulludf`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@nulludf\n",
+    "def f(x, y):\n",
+    "    return x + y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally call the function as you would in pandas - by using a lambda function to map the UDF onto \"rows\" of the DataFrame: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.apply(\n",
+    "    lambda row: f(\n",
+    "        row['A'],\n",
+    "        row['B']\n",
+    "    ),\n",
+    "    axis=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Advanced users might recognize that cuDF does not actually have a `row` object (a special type of Pandas series that behaves like a dict). The `nulludf` decorator is the key to making this work - it really just rearranges things nicely such that the API works in this way. The same function works the same way in pandas, except without the decorator of course:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def g(x, y):\n",
+    "    return x + y\n",
     "\n",
-    "a_dary = df.a._column.data.mem\n",
-    "a_mask = df.a.nullmask.mem\n",
-    "output_dary = rmm.device_array_like(a_dary)\n",
+    "df.to_pandas(nullable=True).apply(\n",
+    "    lambda row: g(\n",
+    "        row['A'],\n",
+    "        row['B']\n",
+    "    ),\n",
+    "    axis=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that Pandas returns `object` dtype - see notes on this in the caveats section."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This API supports UDFs that interact with nulls in more complex ways, and leverages the `cudf.NA` singleton object much in the same manner as Pandas, allowing for more flexible functions. As a basic example this function conditions on wether or not a value is `NA` and returns a scalar in that case:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@nulludf\n",
+    "def f(x):\n",
+    "    if x is cudf.NA:\n",
+    "        return 0\n",
+    "    else:\n",
+    "        return x + 1\n",
     "\n",
-    "gpu_kernel_masked.forall(output_dary.size)(a_dary, a_mask, output_dary, 10)\n",
-    "df['result'] = output_dary\n",
-    "df.head()"
+    "df = cudf.DataFrame({'a': [1, cudf.NA, 3]})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.apply(lambda row: f(row['a']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`cudf.NA` can also be directly returned from a function resulting in data that has the the correct nulls in the end, just as if it were run in Pandas. For the following data, the last row fulfills the condition that `1 + 3 > 3` and returns `NA` for that row:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@nulludf\n",
+    "def f(x, y):\n",
+    "    if x + y > 3:\n",
+    "        return cudf.NA\n",
+    "    else:\n",
+    "        return x + y\n",
+    "\n",
+    "df = cudf.DataFrame({\n",
+    "    'a': [1, 2, 3], \n",
+    "    'b': [2, 1, 1]\n",
+    "})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.apply(lambda row: f(row['a'], row['b']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mixed types are allowed, but will return the common type, rather than object as in Pandas. Here's a null aware op between an int and a float column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@nulludf\n",
+    "def f(x, y):\n",
+    "     return x + y\n",
+    "\n",
+    "df = cudf.DataFrame({\n",
+    "    'a': [1, 2, 3], \n",
+    "    'b': [0.5, cudf.NA, 3.14]\n",
+    "})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.apply(lambda row: f(row['a'], row['b']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Functions may also return scalar values, however the result will be promoted to a safe type regardless of the data. This means even if you have a function like:\n",
+    "\n",
+    "```python\n",
+    "def f(x):\n",
+    "    if x > 1000:\n",
+    "        return 1.5\n",
+    "    else:\n",
+    "        return 2\n",
+    "```\n",
+    "And your data is:\n",
+    "```python\n",
+    "[1,2,3,4,5]\n",
+    "```\n",
+    "You will get floats in the final data even though a float is never returned. This is because Numba ultimately needs to produce one function that can handle any data, which means if there's any possibility a float could result, you must always assume it will happen. Here's an example of a function that returns a scalar in some cases:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@nulludf\n",
+    "def f(x):\n",
+    "    if x > 3:\n",
+    "            return x\n",
+    "    else:\n",
+    "            return 1.5\n",
+    "\n",
+    "df = cudf.DataFrame({\n",
+    "    'a': [1, 3, 5]\n",
+    "})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.apply(lambda row: f(row['a']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Any number of columns and many arithmetic operators are supported, allowing for complex UDFs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "@nulludf\n",
+    "def f(v, w, x, y, z):\n",
+    "    return x + (y - (z / w)) % v\n",
+    "\n",
+    "df = cudf.DataFrame({\n",
+    "    'a': [1, 2, 3],\n",
+    "    'b': [4, 5, 6],\n",
+    "    'c': [cudf.NA, 4, 4],\n",
+    "    'd': [8, 7, 8],\n",
+    "    'e': [7, 1, 6]\n",
+    "})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.apply(\n",
+    "    lambda row: f(\n",
+    "            row['a'],\n",
+    "            row['b'],\n",
+    "            row['c'],\n",
+    "            row['d'],\n",
+    "            row['e']\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Caveats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Only numeric nondecimal scalar types are currently supported as of yet, but strings and structured types are in planning. Attempting to use this API with those types will throw a `TypeError`.\n",
+    "- Due to some more recent CUDA features being leveraged in the pipeline, support for CUDA 11.0 is currently unavailable. In particular, the 11.1+ toolkit will be needed, else the API will raise.\n",
+    "- We do not yet fully support all arithmetic operators. Certain ops like bitwise operations are not currently implemented, but planned in future releases. If an operator is needed, a github issue should be raised so that it can be properly prioritized and implemented.\n",
+    "- Due to limitations in the Numba's output is currently runtime compiled, we can't yet support certain functions:\n",
+    "    - `pow`\n",
+    "    - `sin`\n",
+    "    - `cos`\n",
+    "    - `tan`\n",
+    "  \n",
+    "  Attempting to use these functions inside a UDF will result in an NVRTC error.\n",
+    "  "
    ]
   },
   {
@@ -1686,6 +1788,7 @@
     "- GroupBy DataFrames\n",
     "- CuPy NDArrays\n",
     "- Numba DeviceNDArrays\n",
+    "- Generalized NA UDFs\n",
     "\n",
     "\n",
     "For more information please see the [cuDF](https://docs.rapids.ai/api/cudf/nightly/), [Numba.cuda](https://numba.pydata.org/numba-doc/dev/cuda/index.html), and [CuPy](https://docs-cupy.chainer.org/en/stable/) documentation."
@@ -1694,7 +1797,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1708,7 +1811,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updates a rather outdated IPython notebook describing the UDF frameworks in cuDF python.

- Fixes up outdated API calls that don't work with this branch.
- Removes the old section about null handling, which leverages functions we have removed at this point.
- Adds a new section about null handling through our new framework. 