### PR TITLE
[REVIEW] FIX Allow consumers of libcudf to use driver link

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -542,7 +542,7 @@ if(NOT TARGET CUDA::cuda_driver)
     message(FATAL_ERROR "Building libcudf requires `libcuda.so` to be present.
         This error often occurs when trying to build libcudf from a container without the NVIDIA runtime loaded.")
 endif()
-target_link_libraries(cudf PRIVATE CUDA::cuda_driver)
+target_link_libraries(cudf PUBLIC CUDA::cuda_driver)
 
 # Add cuFile interface if available
 if(TARGET cuFile::cuFile_interface)


### PR DESCRIPTION
This PR changes the linking step for the cuda driver. Having it set to `PRIVATE` was breaking compilation of consumers of libcudf inside containers, such as GTests.