### PR TITLE
replace auto with auto& ref for cast<&>

### DIFF
--- a/cpp/include/cudf/detail/indexalator.cuh
+++ b/cpp/include/cudf/detail/indexalator.cuh
@@ -157,8 +157,7 @@ struct base_indexalator {
    */
   CUDA_HOST_DEVICE_CALLABLE difference_type operator-(T const& rhs) const
   {
-    auto& derived = static_cast<T const&>(*this);
-    return (derived.p_ - rhs.p_) / width_;
+    return (static_cast<T const&>(*this).p_ - rhs.p_) / width_;
   }
 
   /**

--- a/cpp/include/cudf/detail/indexalator.cuh
+++ b/cpp/include/cudf/detail/indexalator.cuh
@@ -157,7 +157,7 @@ struct base_indexalator {
    */
   CUDA_HOST_DEVICE_CALLABLE difference_type operator-(T const& rhs) const
   {
-    auto derived = static_cast<T const&>(*this);
+    auto& derived = static_cast<T const&>(*this);
     return (derived.p_ - rhs.p_) / width_;
   }
 

--- a/cpp/src/binaryop/compiled/binary_ops.cu
+++ b/cpp/src/binaryop/compiled/binary_ops.cu
@@ -45,7 +45,7 @@ struct scalar_as_column_device_view {
                          rmm::cuda_stream_view stream,
                          rmm::mr::device_memory_resource* mr)
   {
-    auto h_scalar_type_view = static_cast<cudf::scalar_type_t<T>&>(const_cast<scalar&>(s));
+    auto& h_scalar_type_view = static_cast<cudf::scalar_type_t<T>&>(const_cast<scalar&>(s));
     auto col_v =
       column_view(s.type(), 1, h_scalar_type_view.data(), (bitmask_type const*)s.validity_data());
     return std::pair{column_device_view::create(col_v, stream), std::unique_ptr<column>(nullptr)};
@@ -63,8 +63,8 @@ scalar_as_column_device_view::operator()<cudf::string_view>(scalar const& s,
                                                             rmm::cuda_stream_view stream,
                                                             rmm::mr::device_memory_resource* mr)
 {
-  using T                 = cudf::string_view;
-  auto h_scalar_type_view = static_cast<cudf::scalar_type_t<T>&>(const_cast<scalar&>(s));
+  using T                  = cudf::string_view;
+  auto& h_scalar_type_view = static_cast<cudf::scalar_type_t<T>&>(const_cast<scalar&>(s));
 
   // build offsets column from the string size
   auto offsets_transformer_itr =

--- a/cpp/src/column/column_factories.cu
+++ b/cpp/src/column/column_factories.cu
@@ -63,7 +63,7 @@ std::unique_ptr<cudf::column> column_from_scalar_dispatch::operator()<cudf::stri
   // any of the children in the strings column which would otherwise cause an exception.
   column_view sc{
     data_type{type_id::STRING}, size, nullptr, static_cast<bitmask_type*>(null_mask.data()), size};
-  auto sv = static_cast<scalar_type_t<cudf::string_view> const&>(value);
+  auto& sv = static_cast<scalar_type_t<cudf::string_view> const&>(value);
   // fill the column with the scalar
   auto output = strings::detail::fill(strings_column_view(sc), 0, size, sv, stream, mr);
   output->set_null_mask(rmm::device_buffer{}, 0);  // should be no nulls
@@ -96,7 +96,7 @@ std::unique_ptr<cudf::column> column_from_scalar_dispatch::operator()<cudf::stru
   rmm::mr::device_memory_resource* mr) const
 {
   if (size == 0) CUDF_FAIL("0-length struct column is unsupported.");
-  auto ss   = static_cast<scalar_type_t<cudf::struct_view> const&>(value);
+  auto& ss  = static_cast<scalar_type_t<cudf::struct_view> const&>(value);
   auto iter = thrust::make_constant_iterator(0);
 
   auto children =

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -258,7 +258,7 @@ void aggregate_result_functor::operator()<aggregation::VARIANCE>(aggregation con
 {
   if (cache.has_result(col_idx, agg)) return;
 
-  auto var_agg   = dynamic_cast<cudf::detail::var_aggregation const&>(agg);
+  auto& var_agg  = dynamic_cast<cudf::detail::var_aggregation const&>(agg);
   auto mean_agg  = make_mean_aggregation();
   auto count_agg = make_count_aggregation();
   operator()<aggregation::MEAN>(*mean_agg);
@@ -281,8 +281,8 @@ void aggregate_result_functor::operator()<aggregation::STD>(aggregation const& a
 {
   if (cache.has_result(col_idx, agg)) return;
 
-  auto std_agg = dynamic_cast<cudf::detail::std_aggregation const&>(agg);
-  auto var_agg = make_variance_aggregation(std_agg._ddof);
+  auto& std_agg = dynamic_cast<cudf::detail::std_aggregation const&>(agg);
+  auto var_agg  = make_variance_aggregation(std_agg._ddof);
   operator()<aggregation::VARIANCE>(*var_agg);
   column_view var_result = cache.get_result(col_idx, *var_agg);
 
@@ -298,7 +298,7 @@ void aggregate_result_functor::operator()<aggregation::QUANTILE>(aggregation con
   auto count_agg = make_count_aggregation();
   operator()<aggregation::COUNT_VALID>(*count_agg);
   column_view group_sizes = cache.get_result(col_idx, *count_agg);
-  auto quantile_agg       = dynamic_cast<cudf::detail::quantile_aggregation const&>(agg);
+  auto& quantile_agg      = dynamic_cast<cudf::detail::quantile_aggregation const&>(agg);
 
   auto result = detail::group_quantiles(get_sorted_values(),
                                         group_sizes,
@@ -336,7 +336,7 @@ void aggregate_result_functor::operator()<aggregation::NUNIQUE>(aggregation cons
 {
   if (cache.has_result(col_idx, agg)) return;
 
-  auto nunique_agg = dynamic_cast<cudf::detail::nunique_aggregation const&>(agg);
+  auto& nunique_agg = dynamic_cast<cudf::detail::nunique_aggregation const&>(agg);
 
   auto result = detail::group_nunique(get_sorted_values(),
                                       helper.group_labels(stream),
@@ -353,7 +353,7 @@ void aggregate_result_functor::operator()<aggregation::NTH_ELEMENT>(aggregation 
 {
   if (cache.has_result(col_idx, agg)) return;
 
-  auto nth_element_agg = dynamic_cast<cudf::detail::nth_element_aggregation const&>(agg);
+  auto& nth_element_agg = dynamic_cast<cudf::detail::nth_element_aggregation const&>(agg);
 
   auto count_agg = make_count_aggregation(nth_element_agg._null_handling);
   if (count_agg->kind == aggregation::COUNT_VALID) {
@@ -474,12 +474,12 @@ void aggregate_result_functor::operator()<aggregation::MERGE_SETS>(aggregation c
 {
   if (cache.has_result(col_idx, agg)) { return; }
 
-  auto const merged_result  = detail::group_merge_lists(get_grouped_values(),
+  auto const merged_result   = detail::group_merge_lists(get_grouped_values(),
                                                        helper.group_offsets(stream),
                                                        helper.num_groups(stream),
                                                        stream,
                                                        rmm::mr::get_current_device_resource());
-  auto const merge_sets_agg = dynamic_cast<cudf::detail::merge_sets_aggregation const&>(agg);
+  auto const& merge_sets_agg = dynamic_cast<cudf::detail::merge_sets_aggregation const&>(agg);
   cache.add_result(col_idx,
                    agg,
                    lists::detail::drop_list_duplicates(lists_column_view(merged_result->view()),

--- a/cpp/src/reductions/simple.cuh
+++ b/cpp/src/reductions/simple.cuh
@@ -263,7 +263,7 @@ struct same_element_type_dispatcher {
                                       rmm::cuda_stream_view stream,
                                       rmm::mr::device_memory_resource* mr)
   {
-    auto index = static_cast<numeric_scalar<IndexType> const&>(keys_index);
+    auto& index = static_cast<numeric_scalar<IndexType> const&>(keys_index);
     return cudf::detail::get_element(keys, index.value(stream), stream, mr);
   }
 

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -312,7 +312,7 @@ struct replace_nulls_scalar_kernel_forwarder {
     auto output_view = output->mutable_view();
 
     using ScalarType = cudf::scalar_type_t<col_type>;
-    auto s1          = static_cast<ScalarType const&>(replacement);
+    auto& s1         = static_cast<ScalarType const&>(replacement);
     auto device_in   = cudf::column_device_view::create(input);
 
     auto func = replace_nulls_functor<col_type>{s1.data()};

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -289,8 +289,8 @@ std::unique_ptr<cudf::column> replace_nulls_column_kernel_forwarder::operator()<
 
 template <typename T>
 struct replace_nulls_functor {
-  T* value_it;
-  replace_nulls_functor(T* _value_it) : value_it(_value_it) {}
+  T const* value_it;
+  replace_nulls_functor(T const* _value_it) : value_it(_value_it) {}
   __device__ T operator()(T input, bool is_valid) { return is_valid ? input : *value_it; }
 };
 

--- a/cpp/src/rolling/rolling_detail.cuh
+++ b/cpp/src/rolling/rolling_detail.cuh
@@ -1050,7 +1050,7 @@ std::unique_ptr<column> rolling_window_udf(column_view const& input,
 
   min_periods = std::max(min_periods, 0);
 
-  auto udf_agg = dynamic_cast<udf_aggregation const&>(agg);
+  auto& udf_agg = dynamic_cast<udf_aggregation const&>(agg);
 
   std::string hash = "prog_rolling." + std::to_string(std::hash<std::string>{}(udf_agg._source));
 


### PR DESCRIPTION
While debugging a 'scalar out of bounds memory issue' in compiled binary ops, found that `auto` is used instead of `auto&` for `dynamic/static_cast<&>`.
Using `auto`, causes to create a copy. (calls copy constructor).
But the intention of `cast<&>` is to create a ref variable.

This PR addresses several use cases in libcudf code of `auto` for `dynamic/static_cast<&>`.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
