### PR TITLE
Depend on `cudatoolkit` in `dask-cudf`

### DIFF
--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -25,19 +25,16 @@ build:
 requirements:
   host:
     - python
+    - cudatoolkit {{ cuda_version }}.*
     - cudf {{ version }}
     - dask>=2021.6.0
     - distributed>=2021.6.0
   run:
     - python
+    - {{ pin_compatible("cudatoolkit", max_pin="x.x") }}
     - cudf {{ version }}
     - dask>=2021.6.0
     - distributed>=2021.6.0
-  
-test:
-  requires:
-    - cudatoolkit {{ cuda_version }}.*
-
 
 about:
   home: http://rapids.ai/


### PR DESCRIPTION
When building Conda packages in a CI job where every other constraint (like Python version) are the same except for CUDA version, we can end up producing a package with the same hash twice (in two different CUDA versioned jobs). If these both get uploaded around the same time, we can run into issues downloading the package. To fix this, depend on `cudatoolkit` in `dask-cudf` as well. This will create a different hash for each package based on CUDA version. Thus we won't end up uploading a package with the same name twice.