### PR TITLE
fix cufilejni build w/ c++17

### DIFF
--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -293,6 +293,14 @@ target_compile_definitions(cudfjni
 
 if(USE_GDS)
     add_library(cufilejni SHARED "src/CuFileJni.cpp")
+    SET_TARGET_PROPERTIES(cufilejni
+        PROPERTIES BUILD_RPATH "\$ORIGIN"
+                   # set target compile options
+                   CXX_STANDARD                        17
+                   CXX_STANDARD_REQUIRED               ON
+                   CUDA_STANDARD                       17
+                   CUDA_STANDARD_REQUIRED              ON
+    )
     target_include_directories(cufilejni PRIVATE "${cuFile_INCLUDE_DIRS}")
     target_link_libraries(cufilejni PRIVATE cudfjni "${cuFile_LIBRARIES}")
 endif(USE_GDS)


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

cufilejni was not specified CXX standard, so if `ENABLE_GDS=ON`, it will fail w/ 
```
error: 'is_same_v' is not a member of 'std'; did you mean 'is_same'
```