### PR TITLE
Enable casting to pandas nullable dtypes

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -67,10 +67,10 @@ from cudf.utils import ioutils, utils
 from cudf.utils.dtypes import (
     check_cast_unsupported_dtype,
     cudf_dtype_from_pa_type,
-    cudf_dtypes_to_pandas_dtypes,
     get_time_unit,
     min_unsigned_type,
     np_to_pa_dtype,
+    pandas_dtypes_to_cudf_dtypes,
 )
 from cudf.utils.utils import mask_dtype
 
@@ -878,9 +878,7 @@ class ColumnBase(Column, Serializable):
         raise NotImplementedError()
 
     def astype(self, dtype: Dtype, **kwargs) -> ColumnBase:
-        if dtype in cudf_dtypes_to_pandas_dtypes.values():
-            # pandas nullable dtypes
-            dtype = np.dtype(dtype.type)
+        dtype = pandas_dtypes_to_cudf_dtypes.get(dtype, dtype)
         if _is_non_decimal_numeric_dtype(dtype):
             return self.as_numerical_column(dtype, **kwargs)
         elif is_categorical_dtype(dtype):

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -67,6 +67,7 @@ from cudf.utils import ioutils, utils
 from cudf.utils.dtypes import (
     check_cast_unsupported_dtype,
     cudf_dtype_from_pa_type,
+    cudf_dtypes_to_pandas_dtypes,
     get_time_unit,
     min_unsigned_type,
     np_to_pa_dtype,
@@ -877,6 +878,9 @@ class ColumnBase(Column, Serializable):
         raise NotImplementedError()
 
     def astype(self, dtype: Dtype, **kwargs) -> ColumnBase:
+        if dtype in cudf_dtypes_to_pandas_dtypes.values():
+            # pandas nullable dtypes
+            dtype = np.dtype(dtype.type)
         if _is_non_decimal_numeric_dtype(dtype):
             return self.as_numerical_column(dtype, **kwargs)
         elif is_categorical_dtype(dtype):

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -878,6 +878,9 @@ class ColumnBase(Column, Serializable):
         raise NotImplementedError()
 
     def astype(self, dtype: Dtype, **kwargs) -> ColumnBase:
+        if is_categorical_dtype(dtype):
+            return self.as_categorical_column(dtype, **kwargs)
+
         dtype = pandas_dtypes_to_cudf_dtypes.get(dtype, dtype)
         if _is_non_decimal_numeric_dtype(dtype):
             return self.as_numerical_column(dtype, **kwargs)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -3633,6 +3633,23 @@ def test_one_row_head():
     assert_eq(head_pdf, head_gdf)
 
 
+@pytest.mark.parametrize("dtype", ALL_TYPES)
+@pytest.mark.parametrize(
+    "np_dtype,pd_dtype",
+    [
+        tuple(item)
+        for item in cudf.utils.dtypes.cudf_dtypes_to_pandas_dtypes.items()
+    ],
+)
+def test_series_astype_pandas_nullable(dtype, np_dtype, pd_dtype):
+    source = cudf.Series([0, 1, None], dtype=dtype)
+
+    expect = source.astype(np_dtype)
+    got = source.astype(pd_dtype)
+
+    assert_eq(expect, got)
+
+
 @pytest.mark.parametrize("dtype", NUMERIC_TYPES)
 @pytest.mark.parametrize("as_dtype", NUMERIC_TYPES)
 def test_series_astype_numeric_to_numeric(dtype, as_dtype):

--- a/python/cudf/cudf/tests/test_joining.py
+++ b/python/cudf/cudf/tests/test_joining.py
@@ -1529,7 +1529,7 @@ def test_categorical_typecast_inner_one_cat(dtype):
     data = np.array([1, 2, 3], dtype=dtype)
 
     left = make_categorical_dataframe(data)
-    right = left.astype(left["key"].dtype.categories)
+    right = left.astype(left["key"].dtype.categories.dtype)
 
     result = left.merge(right, on="key", how="inner")
     assert result["key"].dtype == left["key"].dtype.categories.dtype
@@ -1541,7 +1541,7 @@ def test_categorical_typecast_left_one_cat(dtype):
     data = np.array([1, 2, 3], dtype=dtype)
 
     left = make_categorical_dataframe(data)
-    right = left.astype(left["key"].dtype.categories)
+    right = left.astype(left["key"].dtype.categories.dtype)
 
     result = left.merge(right, on="key", how="left")
     assert result["key"].dtype == left["key"].dtype
@@ -1553,7 +1553,7 @@ def test_categorical_typecast_outer_one_cat(dtype):
     data = np.array([1, 2, 3], dtype=dtype)
 
     left = make_categorical_dataframe(data)
-    right = left.astype(left["key"].dtype.categories)
+    right = left.astype(left["key"].dtype.categories.dtype)
 
     result = left.merge(right, on="key", how="outer")
     assert result["key"].dtype == left["key"].dtype.categories.dtype

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -62,8 +62,6 @@ cudf_dtypes_to_pandas_dtypes = {
     np.dtype("int16"): pd.Int16Dtype(),
     np.dtype("int32"): pd.Int32Dtype(),
     np.dtype("int64"): pd.Int64Dtype(),
-    np.dtype("float32"): pd.Float32Dtype(),
-    np.dtype("float64"): pd.Float64Dtype(),
     np.dtype("bool_"): pd.BooleanDtype(),
     np.dtype("object"): pd.StringDtype(),
 }

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -62,6 +62,8 @@ cudf_dtypes_to_pandas_dtypes = {
     np.dtype("int16"): pd.Int16Dtype(),
     np.dtype("int32"): pd.Int32Dtype(),
     np.dtype("int64"): pd.Int64Dtype(),
+    np.dtype("float32"): pd.Float32Dtype(),
+    np.dtype("float64"): pd.Float64Dtype(),
     np.dtype("bool_"): pd.BooleanDtype(),
     np.dtype("object"): pd.StringDtype(),
 }


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/8885

Defer to the closest corresponding NumPy dtype. 