### PR TITLE
Support nulls in timeseries generator

### DIFF
--- a/python/cudf/cudf/tests/test_datasets.py
+++ b/python/cudf/cudf/tests/test_datasets.py
@@ -6,10 +6,10 @@ from cudf.testing._utils import assert_eq
 
 def test_dataset_timeseries():
     gdf1 = gd.datasets.timeseries(
-        dtypes={"x": int, "y": float}, freq="120s", seed=1
+        dtypes={"x": int, "y": float}, freq="120s", nulls_frequency=0.3, seed=1
     )
     gdf2 = gd.datasets.timeseries(
-        dtypes={"x": int, "y": float}, freq="120s", seed=1
+        dtypes={"x": int, "y": float}, freq="120s", nulls_frequency=0.3, seed=1
     )
 
     assert_eq(gdf1, gdf2)
@@ -23,6 +23,7 @@ def test_dataset_timeseries():
         "2010",
         freq="2H",
         dtypes={"value": float, "name": "category", "id": int},
+        nulls_frequency=0.7,
         seed=1,
     )
 


### PR DESCRIPTION
This PR adds `nulls_frequency` argument to timeseries generator. It is worth nothing that the random mask generator under the hood is also tied to `seed` parameter, in that if two generation process uses the same seed, they will have the same mask distribution.

Verifying nulls distribution:
```python
>>> import cudf
>>> gdf = cudf.datasets.timeseries(start='2020-02-01', end='2021-02-01', freq='1D', dtypes={"name": "category", "id": int, "x": float, "y": float}, nulls_frequency=0.7, seed=1)
>>> for col in gdf:
...    print(gdf[col].isna().sum() / len(gdf[col]))
0.6920980926430518
0.7111716621253406
0.7138964577656676
0.7029972752043597
```