### PR TITLE
Document that struct support in `read_orc` is experimental

### DIFF
--- a/cpp/include/cudf/io/orc.hpp
+++ b/cpp/include/cudf/io/orc.hpp
@@ -354,6 +354,9 @@ class orc_reader_options_builder {
  *  auto result = cudf::read_orc(options);
  * @endcode
  *
+ * Note: Support for reading files with struct columns is currently experimental, the output may not
+ * be correct in all cases.
+ *
  * @param options Settings for controlling reading behavior.
  * @param mr Device memory resource used to allocate device memory of the table in the returned
  * table_with_metadata.

--- a/cpp/include/cudf/io/orc.hpp
+++ b/cpp/include/cudf/io/orc.hpp
@@ -355,7 +355,7 @@ class orc_reader_options_builder {
  * @endcode
  *
  * Note: Support for reading files with struct columns is currently experimental, the output may not
- * be correct in all cases.
+ * be as reliable as reading for other datatypes.
  *
  * @param options Settings for controlling reading behavior.
  * @param mr Device memory resource used to allocate device memory of the table in the returned

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -256,6 +256,12 @@ Total number of rows
 Number of stripes
 List of column names
 
+Notes
+-----
+Support for reading files with struct columns is currently experimental,
+the output may not be as reliable as reading for other datatypes.
+{remote_data_sources}
+
 Examples
 --------
 >>> import cudf
@@ -373,9 +379,6 @@ doc_read_orc = docfmt_partial(docstring=_docstring_read_orc)
 
 _docstring_to_orc = """
 Write a DataFrame to the ORC format.
-
-Note: Support for reading files with struct columns is currently experimental,
-the output may not be correct in all cases.
 
 Parameters
 ----------

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -374,6 +374,9 @@ doc_read_orc = docfmt_partial(docstring=_docstring_read_orc)
 _docstring_to_orc = """
 Write a DataFrame to the ORC format.
 
+Note: Support for reading files with struct columns is currently experimental,
+the output may not be correct in all cases.
+
 Parameters
 ----------
 fname : str


### PR DESCRIPTION
There are a few open issues related to struct columns in ORC reader:
https://github.com/rapidsai/cudf/issues/8878
https://github.com/rapidsai/cudf/issues/8910
Marking the struct support as experimental.