### PR TITLE
Fix concatenate empty structs

### DIFF
--- a/cpp/src/structs/copying/concatenate.cu
+++ b/cpp/src/structs/copying/concatenate.cu
@@ -55,8 +55,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
                  });
 
   // get total length from concatenated children; if no child exists, we would compute it
-  auto const total_length = children[0]->size();
-  auto accSizeFn          = [](size_type s, column_view const& c) { return s + c.size(); };
+  auto const accSizeFn          = [](size_type s, column_view const& c) { return s + c.size(); };
   auto const total_length =
     !children.empty() ? children[0]->size()
                       : std::accumulate(columns.begin(), columns.end(), size_type{0}, accSizeFn);

--- a/cpp/src/structs/copying/concatenate.cu
+++ b/cpp/src/structs/copying/concatenate.cu
@@ -55,10 +55,10 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
                  });
 
   // get total length from concatenated children; if no child exists, we would compute it
-  auto const accSizeFn    = [](size_type s, column_view const& c) { return s + c.size(); };
+  auto const acc_size_fn = [](size_type s, column_view const& c) { return s + c.size(); };
   auto const total_length =
     !children.empty() ? children[0]->size()
-                      : std::accumulate(columns.begin(), columns.end(), size_type{0}, accSizeFn);
+                      : std::accumulate(columns.begin(), columns.end(), size_type{0}, acc_size_fn);
 
   // if any of the input columns have nulls, construct the output mask
   bool const has_nulls =

--- a/cpp/src/structs/copying/concatenate.cu
+++ b/cpp/src/structs/copying/concatenate.cu
@@ -55,7 +55,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
                  });
 
   // get total length from concatenated children; if no child exists, we would compute it
-  auto const accSizeFn          = [](size_type s, column_view const& c) { return s + c.size(); };
+  auto const accSizeFn    = [](size_type s, column_view const& c) { return s + c.size(); };
   auto const total_length =
     !children.empty() ? children[0]->size()
                       : std::accumulate(columns.begin(), columns.end(), size_type{0}, accSizeFn);

--- a/cpp/src/structs/copying/concatenate.cu
+++ b/cpp/src/structs/copying/concatenate.cu
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <numeric>
 
 namespace cudf {
 namespace structs {
@@ -54,9 +55,11 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
                  });
 
   // get total length from concatenated children; if no child exists, we would compute it
-  auto const total_length = !children.empty() ? 
-children[0]->size() : std::accumulate(columns.begin(), columns.end(), size_type{0});
-  }
+  auto const total_length = children[0]->size();
+  auto accSizeFn          = [](size_type s, const column_view& c) { return s + c.size(); };
+  auto const total_length =
+    !children.empty() ? children[0]->size()
+                      : std::accumulate(columns.begin(), columns.end(), size_type{0}, accSizeFn);
 
   // if any of the input columns have nulls, construct the output mask
   bool const has_nulls =

--- a/cpp/src/structs/copying/concatenate.cu
+++ b/cpp/src/structs/copying/concatenate.cu
@@ -53,7 +53,16 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
                    return cudf::detail::concatenate(cols, stream, mr);
                  });
 
-  size_type const total_length = children[0]->size();
+  // get total length from concatenated children; if no child exists, we would compute it
+  size_type total_length;
+  if (!children.empty()) {
+    total_length = children[0]->size();
+  } else {
+    total_length = 0;
+    for (const auto& column : columns) {
+      total_length += column.size();
+    }
+  }
 
   // if any of the input columns have nulls, construct the output mask
   bool const has_nulls =

--- a/cpp/src/structs/copying/concatenate.cu
+++ b/cpp/src/structs/copying/concatenate.cu
@@ -54,14 +54,8 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
                  });
 
   // get total length from concatenated children; if no child exists, we would compute it
-  size_type total_length;
-  if (!children.empty()) {
-    total_length = children[0]->size();
-  } else {
-    total_length = 0;
-    for (const auto& column : columns) {
-      total_length += column.size();
-    }
+  auto const total_length = !children.empty() ? 
+children[0]->size() : std::accumulate(columns.begin(), columns.end(), size_type{0});
   }
 
   // if any of the input columns have nulls, construct the output mask

--- a/cpp/src/structs/copying/concatenate.cu
+++ b/cpp/src/structs/copying/concatenate.cu
@@ -56,7 +56,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
 
   // get total length from concatenated children; if no child exists, we would compute it
   auto const total_length = children[0]->size();
-  auto accSizeFn          = [](size_type s, const column_view& c) { return s + c.size(); };
+  auto accSizeFn          = [](size_type s, column_view const& c) { return s + c.size(); };
   auto const total_length =
     !children.empty() ? children[0]->size()
                       : std::accumulate(columns.begin(), columns.end(), size_type{0}, accSizeFn);

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -826,6 +826,19 @@ TEST_F(StructsColumnTest, ConcatenateStructs)
   cudf::test::expect_columns_equivalent(*result, *expected);
 }
 
+TEST_F(StructsColumnTest, ConcatenateEmptyStructs)
+{
+  using namespace cudf::test;
+
+  auto expected = cudf::make_structs_column(10, {}, 0, rmm::device_buffer());
+  auto first = cudf::make_structs_column(5, {}, 0, rmm::device_buffer());
+  auto second = cudf::make_structs_column(5, {}, 0, rmm::device_buffer());
+
+  // concatenate
+  auto result = cudf::concatenate(std::vector<column_view>({*first, *second}));
+  cudf::test::expect_columns_equivalent(*result, *expected);
+}
+
 TEST_F(StructsColumnTest, ConcatenateSplitStructs)
 {
   using namespace cudf::test;

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -832,10 +832,13 @@ TEST_F(StructsColumnTest, ConcatenateEmptyStructs)
 
   auto expected = cudf::make_structs_column(10, {}, 0, rmm::device_buffer());
   auto first    = cudf::make_structs_column(5, {}, 0, rmm::device_buffer());
-  auto second   = cudf::make_structs_column(5, {}, 0, rmm::device_buffer());
+  auto second   = cudf::make_structs_column(2, {}, 0, rmm::device_buffer());
+  auto third    = cudf::make_structs_column(0, {}, 0, rmm::device_buffer());
+  auto fourth   = cudf::make_structs_column(3, {}, 0, rmm::device_buffer());
 
   // concatenate
-  auto result = cudf::concatenate(std::vector<column_view>({*first, *second}));
+  auto result = cudf::concatenate(std::vector<column_view>({*first, *second, *third, *fourth}));
+  CUDF_EXPECTS(result->size() == expected->size(), "column size changed after concat");
   cudf::test::expect_columns_equivalent(*result, *expected);
 }
 

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -831,8 +831,8 @@ TEST_F(StructsColumnTest, ConcatenateEmptyStructs)
   using namespace cudf::test;
 
   auto expected = cudf::make_structs_column(10, {}, 0, rmm::device_buffer());
-  auto first = cudf::make_structs_column(5, {}, 0, rmm::device_buffer());
-  auto second = cudf::make_structs_column(5, {}, 0, rmm::device_buffer());
+  auto first    = cudf::make_structs_column(5, {}, 0, rmm::device_buffer());
+  auto second   = cudf::make_structs_column(5, {}, 0, rmm::device_buffer());
 
   // concatenate
   auto result = cudf::concatenate(std::vector<column_view>({*first, *second}));


### PR DESCRIPTION
Closes #8929

Current PR is to fix the illegal memory access problem occurred when concatenating structs with empty children. 