### PR TITLE
Fix debug compile error for csv_test.cpp

### DIFF
--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -415,7 +415,7 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnNegativeScale)
   result_strings.reserve(reference_strings.size());
 
   std::ifstream read_result_file(filepath);
-  assert(read_result_file.is_open());
+  ASSERT_TRUE(read_result_file.is_open());
 
   std::copy(std::istream_iterator<std::string>(read_result_file),
             std::istream_iterator<std::string>(),
@@ -461,7 +461,7 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnPositiveScale)
   result_strings.reserve(reference_strings.size());
 
   std::ifstream read_result_file(filepath);
-  assert(read_result_file.is_open());
+  ASSERT_TRUE(read_result_file.is_open());
 
   std::copy(std::istream_iterator<std::string>(read_result_file),
             std::istream_iterator<std::string>(),
@@ -2175,9 +2175,9 @@ TEST_F(CsvReaderTest, DtypesMap)
   auto result = cudf_io::read_csv(in_opts);
 
   const auto result_table = result.tbl->view();
-  assert(result_table.num_columns() == 2);
-  assert(result_table.column(0).type() == data_type{type_id::INT32});
-  assert(result_table.column(1).type() == data_type{type_id::INT16});
+  ASSERT_EQ(result_table.num_columns(), 2);
+  ASSERT_EQ(result_table.column(0).type(), data_type{type_id::INT32});
+  ASSERT_EQ(result_table.column(1).type(), data_type{type_id::INT16});
   expect_column_data_equal(std::vector<int32_t>{12, 34, 56}, result_table.column(0));
   expect_column_data_equal(std::vector<int16_t>{9, 8, 7}, result_table.column(1));
 }

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -2175,7 +2175,7 @@ TEST_F(CsvReaderTest, DtypesMap)
   auto result = cudf_io::read_csv(in_opts);
 
   const auto result_table = result.tbl->view();
-  assert(result_table->num_columns() == 2);
+  assert(result_table.num_columns() == 2);
   assert(result_table.column(0).type() == data_type{type_id::INT32});
   assert(result_table.column(1).type() == data_type{type_id::INT16});
   expect_column_data_equal(std::vector<int32_t>{12, 34, 56}, result_table.column(0));


### PR DESCRIPTION
Found an compile error in `csv_test.cpp` that only occurs with a debug build since it exists in an `assert()` statement.
Looks like this was introduced in PR #8856
