### PR TITLE
CUDF installed CMake files use the same destination as libcudf

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -629,7 +629,7 @@ endif()
 
 include(GNUInstallDirs)
 
-set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/cudf)
+set(INSTALL_CONFIGDIR lib/cmake/cudf)
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME cudf)
 
 # install target for cudf_base and the proxy libcudf.so


### PR DESCRIPTION
Previously on CentOS machines the CMake files would be placed into `lib64`, and `libcudf` would be in `lib` breaking everything. Since Conda only supports packages in `lib` ensure everything is placed there no matter the distro.