### PR TITLE
[REVIEW] ENH Allow arbitrary CMake config options in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,10 @@ function hasArg {
 
 function cmakeArgs {
     # Check for correctly formatted cmake args option
-    if [[ -n $(echo $ARGS | grep -E "\-\-cmake\-args=\"") ]]; then
+    if [[ $(echo $ARGS | grep -Eo "\-\-cmake\-args=" | wc -l ) -gt 1 ]]; then
+	echo "Multiple --cmake-args options were provided, please provide only one: ${ARGS}"
+        exit 1
+    elif [[ -n $(echo $ARGS | grep -E "\-\-cmake\-args=\"") ]]; then
         # There are possible weird edge cases that may cause this regex filter to output nothing and fail silently
         # the true pipe will catch any weird edge cases that may happen and will cause the program to fall back
         # on the invalid option error

--- a/build.sh
+++ b/build.sh
@@ -19,26 +19,26 @@ REPODIR=$(cd $(dirname $0); pwd)
 
 VALIDARGS="clean libcudf cudf dask_cudf benchmarks tests libcudf_kafka cudf_kafka custreamz -v -g -n -l --allgpuarch --disable_nvtx --show_depr_warn --ptds -h"
 HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [tests] [libcudf_kafka] [cudf_kafka] [custreamz] [-v] [-g] [-n] [-h] [-l] [--cmake-args=\"<args>\"]
-   clean                     - remove all existing build artifacts and configuration (start
-                               over)
-   libcudf                   - build the cudf C++ code only
-   cudf                      - build the cudf Python package
-   dask_cudf                 - build the dask_cudf Python package
-   benchmarks                - build benchmarks
-   tests                     - build tests
-   libcudf_kafka             - build the libcudf_kafka C++ code only
-   cudf_kafka                - build the cudf_kafka Python package
-   custreamz                 - build the custreamz Python package
-   -v                        - verbose build mode
-   -g                        - build for debug
-   -n                        - no install step
-   -l                        - build legacy tests
-   --allgpuarch              - build for all supported GPU architectures
-   --disable_nvtx            - disable inserting NVTX profiling ranges
-   --show_depr_warn          - show cmake deprecation warnings
-   --ptds                    - enable per-thread default stream
-   --cmake-args=\"<args>\"   - pass arbitrary list of CMake configuration options
-   -h | --h[elp]             - print this text
+   clean			 - remove all existing build artifacts and configuration (start
+                                   over)
+   libcudf			 - build the cudf C++ code only
+   cudf				 - build the cudf Python package
+   dask_cudf			 - build the dask_cudf Python package
+   benchmarks			 - build benchmarks
+   tests			 - build tests
+   libcudf_kafka		 - build the libcudf_kafka C++ code only
+   cudf_kafka			 - build the cudf_kafka Python package
+   custreamz			 - build the custreamz Python package
+   -v				 - verbose build mode
+   -g				 - build for debug
+   -n				 - no install step
+   -l				 - build legacy tests
+   --allgpuarch			 - build for all supported GPU architectures
+   --disable_nvtx		 - disable inserting NVTX profiling ranges
+   --show_depr_warn		 - show cmake deprecation warnings
+   --ptds			 - enable per-thread default stream
+   --cmake-args=\\\"<args>\\\"	 - pass arbitrary list of CMake configuration options (escape all quotes in argument)
+   -h | --h[elp]		 - print this text
 
    default action (no args) is to build and install 'libcudf' then 'cudf'
    then 'dask_cudf' targets

--- a/build.sh
+++ b/build.sh
@@ -74,18 +74,18 @@ function hasArg {
 
 function cmakeArgs {
     # Check for correctly formatted cmake args option
-    if [[ $(echo $ARGS | grep -E "\-\-cmake\-args=\"") ]]; then
+    if [[ -n $(echo $ARGS | grep -E "\-\-cmake\-args=\"") ]]; then
         # There are possible weird edge cases that may cause this regex filter to output nothing and fail silently
         # the true pipe will catch any weird edge cases that may happen and will cause the program to fall back
         # on the invalid option error
-        CMAKE_ARGS=$(echo $ARGS | { grep -Eo "\-\-cmake\-args=\".+\" " || true; })
+        CMAKE_ARGS=$(echo $ARGS | { grep -Eo "\-\-cmake\-args=\".+\"" || true; })
         if [[ -n ${CMAKE_ARGS} ]]; then
 	    # Remove the full  CMAKE_ARGS argument from list of args so that it passes validArgs function
 	    ARGS=${ARGS//$CMAKE_ARGS/}
 	    # Filter the full argument down to just the extra string that will be added to cmake call
             CMAKE_ARGS=$(echo $CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
         fi
-    elif [[ $(echo $ARGS | grep -E "\-\-cmake\-args=") ]]; then
+    elif [[ -z $(echo $ARGS | grep -E "\-\-cmake\-args=") ]]; then
 	CMAKE_ARGS="$(echo $ARGS | grep -Eo "\-\-cmake\-args=(.+)? ")"
 	echo "Invalid formatting for --cmake-args, see --help: $CMAKE_ARGS"
         exit 1
@@ -220,7 +220,8 @@ if hasArg libcudf_kafka; then
     cmake -S $REPODIR/cpp/libcudf_kafka -B ${KAFKA_LIB_BUILD_DIR} \
           -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DBUILD_TESTS=${BUILD_TESTS} \
-          -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+	  ${CMAKE_ARGS}
 
 
     cd ${KAFKA_LIB_BUILD_DIR}

--- a/build.sh
+++ b/build.sh
@@ -75,7 +75,10 @@ function hasArg {
 function cmakeArgs {
     # Check for correctly formatted cmake args option
     if [[ $(echo $ARGS | grep -E "\-\-cmake\-args=\"") ]]; then
-        CMAKE_ARGS="$(echo $ARGS | grep -Eo "\-\-cmake\-args=\".+\" ")"
+	# There are possible weird edge cases that may cause this regex filter to output nothing and fail silently
+        # the true pipe will catch any weird edge cases that may happen and will cause the program to fall back
+        # on the invalid option error
+        CMAKE_ARGS=$(echo $ARGS | { grep -Eo "\-\-cmake\-args=\".+\" " || true; })
         if [[ -n ${CMAKE_ARGS} ]]; then
 	    # Remove the full  CMAKE_ARGS argument from list of args so that it passes validArgs function
 	    ARGS=${ARGS//$CMAKE_ARGS/}
@@ -105,7 +108,7 @@ cmakeArgs
 if (( ${NUMARGS} != 0 )); then
     for a in ${ARGS}; do
     if ! (echo " ${VALIDARGS} " | grep -q " ${a} "); then
-        echo "Invalid option: ${a}"
+        echo "Invalid option, check --help: ${a}"
         exit 1
     fi
     done

--- a/build.sh
+++ b/build.sh
@@ -75,7 +75,7 @@ function hasArg {
 function cmakeArgs {
     # Check for correctly formatted cmake args option
     if [[ $(echo $ARGS | grep -Eo "\-\-cmake\-args=" | wc -l ) -gt 1 ]]; then
-	echo "Multiple --cmake-args options were provided, please provide only one: ${ARGS}"
+        echo "Multiple --cmake-args options were provided, please provide only one: ${ARGS}"
         exit 1
     elif [[ -n $(echo $ARGS | grep -E "\-\-cmake\-args=\"") ]]; then
         # There are possible weird edge cases that may cause this regex filter to output nothing and fail silently

--- a/build.sh
+++ b/build.sh
@@ -220,7 +220,7 @@ if hasArg libcudf_kafka; then
           -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DBUILD_TESTS=${BUILD_TESTS} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-	  ${CMAKE_ARGS}
+          ${CMAKE_ARGS}
 
 
     cd ${KAFKA_LIB_BUILD_DIR}

--- a/build.sh
+++ b/build.sh
@@ -80,14 +80,14 @@ function cmakeArgs {
         # on the invalid option error
         CMAKE_ARGS=$(echo $ARGS | { grep -Eo "\-\-cmake\-args=\".+\"" || true; })
         if [[ -n ${CMAKE_ARGS} ]]; then
-	    # Remove the full  CMAKE_ARGS argument from list of args so that it passes validArgs function
-	    ARGS=${ARGS//$CMAKE_ARGS/}
-	    # Filter the full argument down to just the extra string that will be added to cmake call
+            # Remove the full  CMAKE_ARGS argument from list of args so that it passes validArgs function
+            ARGS=${ARGS//$CMAKE_ARGS/}
+            # Filter the full argument down to just the extra string that will be added to cmake call
             CMAKE_ARGS=$(echo $CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
         fi
     elif [[ -z $(echo $ARGS | grep -E "\-\-cmake\-args=") ]]; then
-	CMAKE_ARGS="$(echo $ARGS | grep -Eo "\-\-cmake\-args=(.+)? ")"
-	echo "Invalid formatting for --cmake-args, see --help: $CMAKE_ARGS"
+        CMAKE_ARGS="$(echo $ARGS | grep -Eo "\-\-cmake\-args=(.+)? ")"
+        echo "Invalid formatting for --cmake-args, see --help: $CMAKE_ARGS"
         exit 1
     fi
 }

--- a/build.sh
+++ b/build.sh
@@ -73,11 +73,14 @@ function hasArg {
 }
 
 function cmakeArgs {
-    # Check for correctly formatted cmake args option
-    if [[ $(echo $ARGS | grep -Eo "\-\-cmake\-args=" | wc -l ) -gt 1 ]]; then
+    # Check for multiple cmake args options
+    if [[ $(echo $ARGS | { grep -Eo "\-\-cmake\-args" || true; } | wc -l ) -gt 1 ]]; then
         echo "Multiple --cmake-args options were provided, please provide only one: ${ARGS}"
         exit 1
-    elif [[ -n $(echo $ARGS | grep -E "\-\-cmake\-args=\"") ]]; then
+    fi
+
+    # Check for cmake args option
+    if [[ -n $(echo $ARGS | { grep -E "\-\-cmake\-args" || true; } ) ]]; then
         # There are possible weird edge cases that may cause this regex filter to output nothing and fail silently
         # the true pipe will catch any weird edge cases that may happen and will cause the program to fall back
         # on the invalid option error
@@ -88,10 +91,6 @@ function cmakeArgs {
             # Filter the full argument down to just the extra string that will be added to cmake call
             CMAKE_ARGS=$(echo $CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
         fi
-    elif [[ -z $(echo $ARGS | grep -E "\-\-cmake\-args=") ]]; then
-        CMAKE_ARGS="$(echo $ARGS | grep -Eo "\-\-cmake\-args=(.+)? ")"
-        echo "Invalid formatting for --cmake-args, see --help: $CMAKE_ARGS"
-        exit 1
     fi
 }
 
@@ -110,7 +109,7 @@ if (( ${NUMARGS} != 0 )); then
     cmakeArgs
     for a in ${ARGS}; do
     if ! (echo " ${VALIDARGS} " | grep -q " ${a} "); then
-        echo "Invalid option, check --help: ${a}"
+        echo "Invalid option or formatting, check --help: ${a}"
         exit 1
     fi
     done

--- a/build.sh
+++ b/build.sh
@@ -83,7 +83,7 @@ function cmakeArgs {
             CMAKE_ARGS=$(echo $CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
         fi
     elif [[ $(echo $ARGS | grep -E "\-\-cmake\-args=") ]]; then
-	CMAKE_ARGS="$(echo $ARGS | grep -Eo "\-\-cmake\-args=.+ ")"
+	CMAKE_ARGS="$(echo $ARGS | grep -Eo "\-\-cmake\-args=(.+)? ")"
 	echo "Invalid formatting for --cmake-args, see --help: $CMAKE_ARGS"
         exit 1
     fi

--- a/build.sh
+++ b/build.sh
@@ -101,11 +101,10 @@ if hasArg -h || hasArg --h || hasArg --help; then
     exit 0
 fi
 
-# Check for additional arbitrary cmake options
-cmakeArgs
-
 # Check for valid usage
 if (( ${NUMARGS} != 0 )); then
+    # Check for cmake args
+    cmakeArgs
     for a in ${ARGS}; do
     if ! (echo " ${VALIDARGS} " | grep -q " ${a} "); then
         echo "Invalid option, check --help: ${a}"

--- a/build.sh
+++ b/build.sh
@@ -19,26 +19,26 @@ REPODIR=$(cd $(dirname $0); pwd)
 
 VALIDARGS="clean libcudf cudf dask_cudf benchmarks tests libcudf_kafka cudf_kafka custreamz -v -g -n -l --allgpuarch --disable_nvtx --show_depr_warn --ptds -h"
 HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [tests] [libcudf_kafka] [cudf_kafka] [custreamz] [-v] [-g] [-n] [-h] [-l] [--cmake-args=\"<args>\"]
-   clean			 - remove all existing build artifacts and configuration (start
+   clean                         - remove all existing build artifacts and configuration (start
                                    over)
-   libcudf			 - build the cudf C++ code only
-   cudf				 - build the cudf Python package
-   dask_cudf			 - build the dask_cudf Python package
-   benchmarks			 - build benchmarks
-   tests			 - build tests
-   libcudf_kafka		 - build the libcudf_kafka C++ code only
-   cudf_kafka			 - build the cudf_kafka Python package
-   custreamz			 - build the custreamz Python package
-   -v				 - verbose build mode
-   -g				 - build for debug
-   -n				 - no install step
-   -l				 - build legacy tests
-   --allgpuarch			 - build for all supported GPU architectures
-   --disable_nvtx		 - disable inserting NVTX profiling ranges
-   --show_depr_warn		 - show cmake deprecation warnings
-   --ptds			 - enable per-thread default stream
-   --cmake-args=\\\"<args>\\\"	 - pass arbitrary list of CMake configuration options (escape all quotes in argument)
-   -h | --h[elp]		 - print this text
+   libcudf                       - build the cudf C++ code only
+   cudf                          - build the cudf Python package
+   dask_cudf                     - build the dask_cudf Python package
+   benchmarks                    - build benchmarks
+   tests                         - build tests
+   libcudf_kafka                 - build the libcudf_kafka C++ code only
+   cudf_kafka                    - build the cudf_kafka Python package
+   custreamz                     - build the custreamz Python package
+   -v                            - verbose build mode
+   -g                            - build for debug
+   -n                            - no install step
+   -l                            - build legacy tests
+   --allgpuarch                  - build for all supported GPU architectures
+   --disable_nvtx                - disable inserting NVTX profiling ranges
+   --show_depr_warn              - show cmake deprecation warnings
+   --ptds                        - enable per-thread default stream
+   --cmake-args=\\\"<args>\\\"   - pass arbitrary list of CMake configuration options (escape all quotes in argument)
+   -h | --h[elp]                 - print this text
 
    default action (no args) is to build and install 'libcudf' then 'cudf'
    then 'dask_cudf' targets

--- a/build.sh
+++ b/build.sh
@@ -18,26 +18,27 @@ ARGS=$*
 REPODIR=$(cd $(dirname $0); pwd)
 
 VALIDARGS="clean libcudf cudf dask_cudf benchmarks tests libcudf_kafka cudf_kafka custreamz -v -g -n -l --allgpuarch --disable_nvtx --show_depr_warn --ptds -h"
-HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [tests] [libcudf_kafka] [cudf_kafka] [custreamz] [-v] [-g] [-n] [-h] [-l]
-   clean                - remove all existing build artifacts and configuration (start
-                          over)
-   libcudf              - build the cudf C++ code only
-   cudf                 - build the cudf Python package
-   dask_cudf            - build the dask_cudf Python package
-   benchmarks           - build benchmarks
-   tests                - build tests
-   libcudf_kafka        - build the libcudf_kafka C++ code only
-   cudf_kafka           - build the cudf_kafka Python package
-   custreamz            - build the custreamz Python package
-   -v                   - verbose build mode
-   -g                   - build for debug
-   -n                   - no install step
-   -l                   - build legacy tests
-   --allgpuarch         - build for all supported GPU architectures
-   --disable_nvtx       - disable inserting NVTX profiling ranges
-   --show_depr_warn     - show cmake deprecation warnings
-   --ptds               - enable per-thread default stream
-   -h | --h[elp]        - print this text
+HELP="$0 [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [tests] [libcudf_kafka] [cudf_kafka] [custreamz] [-v] [-g] [-n] [-h] [-l] [--cmake-args=\"<args>\"]
+   clean                     - remove all existing build artifacts and configuration (start
+                               over)
+   libcudf                   - build the cudf C++ code only
+   cudf                      - build the cudf Python package
+   dask_cudf                 - build the dask_cudf Python package
+   benchmarks                - build benchmarks
+   tests                     - build tests
+   libcudf_kafka             - build the libcudf_kafka C++ code only
+   cudf_kafka                - build the cudf_kafka Python package
+   custreamz                 - build the custreamz Python package
+   -v                        - verbose build mode
+   -g                        - build for debug
+   -n                        - no install step
+   -l                        - build legacy tests
+   --allgpuarch              - build for all supported GPU architectures
+   --disable_nvtx            - disable inserting NVTX profiling ranges
+   --show_depr_warn          - show cmake deprecation warnings
+   --ptds                    - enable per-thread default stream
+   --cmake-args=\"<args>\"   - pass arbitrary list of CMake configuration options
+   -h | --h[elp]             - print this text
 
    default action (no args) is to build and install 'libcudf' then 'cudf'
    then 'dask_cudf' targets
@@ -71,6 +72,18 @@ function hasArg {
     (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")
 }
 
+function cmakeArgs {
+    # Check for correctly formatted cmake args option
+    CMAKE_ARGS=$(echo $ARGS | grep -Eo "\-\-cmake\-args=\".+\" ")
+
+    if [[ -n ${CMAKE_ARGS} ]]; then
+	# Remove the full  CMAKE_ARGS argument from list of args so that it passes validArgs function
+	ARGS=${ARGS//$CMAKE_ARGS/}
+	# Filter the full argument down to just the extra string that will be added to cmake call
+        CMAKE_ARGS=$(echo $CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
+    fi
+}
+
 function buildAll {
     ((${NUMARGS} == 0 )) || !(echo " ${ARGS} " | grep -q " [^-]\+ ")
 }
@@ -79,6 +92,9 @@ if hasArg -h || hasArg --h || hasArg --help; then
     echo "${HELP}"
     exit 0
 fi
+
+# Check for additional arbitrary cmake options
+cmakeArgs
 
 # Check for valid usage
 if (( ${NUMARGS} != 0 )); then
@@ -139,7 +155,6 @@ fi
 # Configure, build, and install libcudf
 
 if buildAll || hasArg libcudf; then
-
     if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
         CUDF_CMAKE_CUDA_ARCHITECTURES="-DCMAKE_CUDA_ARCHITECTURES="
         echo "Building for the architecture of the GPU in the system..."
@@ -156,7 +171,8 @@ if buildAll || hasArg libcudf; then
           -DBUILD_BENCHMARKS=${BUILD_BENCHMARKS} \
           -DDISABLE_DEPRECATION_WARNING=${BUILD_DISABLE_DEPRECATION_WARNING} \
           -DPER_THREAD_DEFAULT_STREAM=${BUILD_PER_THREAD_DEFAULT_STREAM} \
-          -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+          ${CMAKE_ARGS}
 
     cd ${LIB_BUILD_DIR}
 

--- a/build.sh
+++ b/build.sh
@@ -74,13 +74,18 @@ function hasArg {
 
 function cmakeArgs {
     # Check for correctly formatted cmake args option
-    CMAKE_ARGS=$(echo $ARGS | grep -Eo "\-\-cmake\-args=\".+\" ")
-
-    if [[ -n ${CMAKE_ARGS} ]]; then
-	# Remove the full  CMAKE_ARGS argument from list of args so that it passes validArgs function
-	ARGS=${ARGS//$CMAKE_ARGS/}
-	# Filter the full argument down to just the extra string that will be added to cmake call
-        CMAKE_ARGS=$(echo $CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
+    if [[ $(echo $ARGS | grep -E "\-\-cmake\-args=\"") ]]; then
+        CMAKE_ARGS="$(echo $ARGS | grep -Eo "\-\-cmake\-args=\".+\" ")"
+        if [[ -n ${CMAKE_ARGS} ]]; then
+	    # Remove the full  CMAKE_ARGS argument from list of args so that it passes validArgs function
+	    ARGS=${ARGS//$CMAKE_ARGS/}
+	    # Filter the full argument down to just the extra string that will be added to cmake call
+            CMAKE_ARGS=$(echo $CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
+        fi
+    elif [[ $(echo $ARGS | grep -E "\-\-cmake\-args=") ]]; then
+	CMAKE_ARGS="$(echo $ARGS | grep -Eo "\-\-cmake\-args=.+ ")"
+	echo "Invalid formatting for --cmake-args, see --help: $CMAKE_ARGS"
+        exit 1
     fi
 }
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -152,6 +152,16 @@ public final class ColumnVector extends ColumnView {
     incRefCountInternal(true);
   }
 
+
+  /**
+   * For a ColumnVector this is really just incrementing the reference count.
+   * @return this
+   */
+  @Override
+  public ColumnVector copyToColumnVector() {
+    return incRefCount();
+  }
+
   /**
    * Retrieves the column_view for a cudf::column and if it fails to do so, the column is deleted
    * and the exception is thrown to the caller.
@@ -803,7 +813,7 @@ public final class ColumnVector extends ColumnView {
   /**
    * Native method to concatenate columns of strings together using a separator specified for each row
    * and returns the result as a string column.
-   * @param columns array of longs holding the native handles of the column_views to combine.
+   * @param columnViews array of longs holding the native handles of the column_views to combine.
    * @param sep_column long holding the native handle of the strings_column_view used as separators.
    * @param separator_narep string scalar indicating null behavior when a separator is null.
    *                        If set to null and the separator is null the resulting string will


### PR DESCRIPTION
This PR adds a feature to the root `build.sh` script which allows it to consume any arbitrary CMake args and add them to the CMake configuration step.

Some local testing:
`--cmake-args`
```
$ bash build.sh -v -g --cmake-args='improper format' libcudf
Invalid formatting for --cmake-args, see --help: --cmake-args=improper format

$ bash build.sh -v -g --cmake-args="improper format" libcudf
Invalid formatting for --cmake-args, see --help: --cmake-args=improper format

$ bash build.sh -v -g --cmake-args= libcudf
Invalid formatting for --cmake-args, see --help: --cmake-args=

# This is just echoing the additional args that will be added to cmake then exiting before build
$ bash build.sh -v -g --cmake-args=\"-DEXAMPLE_ARG -DEXAMPLE_ARG=/path/to/file -DEXAMPLE_ARG=\"string argument\"\" libcudf
-DEXAMPLE_ARG -DEXAMPLE_ARG=/path/to/file -DEXAMPLE_ARG="string argument"
```

New `--help` output
```
$ bash build.sh --help
build.sh [clean] [libcudf] [cudf] [dask_cudf] [benchmarks] [tests] [libcudf_kafka] [cudf_kafka] [custreamz] [-v] [-g] [-n] [-h] [-l] [--cmake-args="<args>"]
   clean			 - remove all existing build artifacts and configuration (start
                                   over)
   libcudf			 - build the cudf C++ code only
   cudf				 - build the cudf Python package
   dask_cudf			 - build the dask_cudf Python package
   benchmarks			 - build benchmarks
   tests			 - build tests
   libcudf_kafka		 - build the libcudf_kafka C++ code only
   cudf_kafka			 - build the cudf_kafka Python package
   custreamz			 - build the custreamz Python package
   -v				 - verbose build mode
   -g				 - build for debug
   -n				 - no install step
   -l				 - build legacy tests
   --allgpuarch			 - build for all supported GPU architectures
   --disable_nvtx		 - disable inserting NVTX profiling ranges
   --show_depr_warn		 - show cmake deprecation warnings
   --ptds			 - enable per-thread default stream
   --cmake-args=\"<args>\"	 - pass arbitrary list of CMake configuration options (escape all quotes in argument)
   -h | --h[elp]		 - print this text

   default action (no args) is to build and install 'libcudf' then 'cudf'
```