### PR TITLE
Ensure JNI native libraries load when CompiledExpression loads

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ast/CompiledExpression.java
+++ b/java/src/main/java/ai/rapids/cudf/ast/CompiledExpression.java
@@ -18,12 +18,17 @@ package ai.rapids.cudf.ast;
 
 import ai.rapids.cudf.ColumnVector;
 import ai.rapids.cudf.MemoryCleaner;
+import ai.rapids.cudf.NativeDepsLoader;
 import ai.rapids.cudf.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** This class wraps a native compiled AST and must be closed to avoid native memory leaks. */
 public class CompiledExpression implements AutoCloseable {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
   private static final Logger log = LoggerFactory.getLogger(CompiledExpression.class);
 
   private static class CompiledExpressionCleaner extends MemoryCleaner.Cleaner {


### PR DESCRIPTION
`CompiledExpression` was missing a static block to ensure the native libraries were loaded before the class becomes available for use. This could result in exceptions like the following if no other cudf class with native dependencies is used first in an application:
```
java.lang.UnsatisfiedLinkError: ai.rapids.cudf.ast.CompiledExpression.compile([B)J
  at ai.rapids.cudf.ast.CompiledExpression.compile(Native Method)
  at ai.rapids.cudf.ast.CompiledExpression.<init>(CompiledExpression.java:65)
  at ai.rapids.cudf.ast.Expression.compile(Expression.java:29)
```