### PR TITLE
Fix branch_stack calculation in `row_bit_count()`

### DIFF
--- a/cpp/src/transform/row_bit_count.cu
+++ b/cpp/src/transform/row_bit_count.cu
@@ -408,7 +408,7 @@ __global__ void compute_row_sizes(device_span<column_device_view const> cols,
   if (tid >= num_rows) { return; }
 
   // branch stack. points to the last list prior to branching.
-  row_span* my_branch_stack = thread_branch_stacks + (tid * max_branch_depth);
+  row_span* my_branch_stack = thread_branch_stacks + (threadIdx.x * max_branch_depth);
   size_type branch_depth{0};
 
   // current row span - always starts at 1 row.

--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -220,7 +220,7 @@ TEST_F(RowBitCount, StructsWithLists_RowsExceedingASingleBlock)
   //   [ struct({0,1}), struct({2,3}), struct({4,5}), ... ]
 
   using namespace cudf;
-  auto constexpr num_rows = 256 * 2;  // Exceeding a block size.
+  auto constexpr num_rows = 1024 * 2;  // Exceeding a block size.
 
   // List child column = {0, 1, 2, 3, 4, ..., 2*num_rows};
   auto ints      = make_numeric_column(data_type{type_id::INT32}, num_rows * 2);


### PR DESCRIPTION
Fixes #8938.

For input with a number of rows exceeding  `max_block_size`, `row_bit_count()` currently
reaches past the bounds of its shared-memory allocation, causing illegal memory access
errors like in [cudf/issues/8938](https://github.com/rapidsai/cudf/issues/8938).

This commit corrects the calculation of the branch stack's base address, and adds a
test for this case.