### PR TITLE
Java bindings for cudf::hash_join

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/HashJoin.java
+++ b/java/src/main/java/ai/rapids/cudf/HashJoin.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class represents a hash table built from the join keys of the right-side table for a
+ * join operation. This hash table can then be reused across a series of left probe tables
+ * to compute gather maps for joins more efficiently when the right-side table is not changing.
+ * It can also be used to query the output row count of a join and then pass that result to the
+ * operation that generates the join gather maps to avoid redundant computation when the output
+ * row count must be checked before manifesting the join gather maps.
+ */
+public class HashJoin implements AutoCloseable {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+  private static final Logger log = LoggerFactory.getLogger(HashJoin.class);
+
+  private static class HashJoinCleaner extends MemoryCleaner.Cleaner {
+    private Table buildKeys;
+    private long nativeHandle;
+
+    HashJoinCleaner(Table buildKeys, long nativeHandle) {
+      this.buildKeys = buildKeys;
+      this.nativeHandle = nativeHandle;
+      addRef();
+    }
+
+    @Override
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
+      long origAddress = nativeHandle;
+      boolean neededCleanup = nativeHandle != 0;
+      if (neededCleanup) {
+        try {
+          destroy(nativeHandle);
+          buildKeys.close();
+          buildKeys = null;
+        } finally {
+          nativeHandle = 0;
+        }
+        if (logErrorIfNotClean) {
+          log.error("A HASH TABLE WAS LEAKED (ID: " + id + " " + Long.toHexString(origAddress));
+        }
+      }
+      return neededCleanup;
+    }
+
+    @Override
+    public boolean isClean() {
+      return nativeHandle == 0;
+    }
+  }
+
+  private final HashJoinCleaner cleaner;
+  private final boolean compareNulls;
+  private boolean isClosed = false;
+
+  /**
+   * Construct a hash table for a join from a table representing the join key columns from the
+   * right-side table in the join. The resulting instance must be closed to release the
+   * GPU resources associated with the instance.
+   * @param buildKeys table view containing the join keys for the right-side join table
+   * @param compareNulls true if null key values should match otherwise false
+   */
+  public HashJoin(Table buildKeys, boolean compareNulls) {
+    this.compareNulls = compareNulls;
+    Table buildTable = new Table(buildKeys.getColumns());
+    try {
+      long handle = create(buildTable.getNativeView(), compareNulls);
+      this.cleaner = new HashJoinCleaner(buildTable, handle);
+      MemoryCleaner.register(this, cleaner);
+    } catch (Throwable t) {
+      try {
+        buildTable.close();
+      } catch (Throwable t2) {
+        t.addSuppressed(t2);
+      }
+      throw t;
+    }
+  }
+
+  @Override
+  public synchronized void close() {
+    cleaner.delRef();
+    if (isClosed) {
+      cleaner.logRefCountDebug("double free " + this);
+      throw new IllegalStateException("Close called too many times " + this);
+    }
+    cleaner.clean(false);
+    isClosed = true;
+  }
+
+  long getNativeView() {
+    return cleaner.nativeHandle;
+  }
+
+  /** Get the number of join key columns for the table that was used to generate the has table. */
+  public long getNumberOfColumns() {
+    return cleaner.buildKeys.getNumberOfColumns();
+  }
+
+  /** Returns true if the hash table was built to match on nulls otherwise false. */
+  public boolean getCompareNulls() {
+    return compareNulls;
+  }
+
+  private static native long create(long tableView, boolean nullEqual);
+  private static native void destroy(long handle);
+}

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -277,6 +277,10 @@ public final class MemoryCleaner {
     all.add(new CleanerWeakReference(expr, cleaner, collected, false));
   }
 
+  static void register(HashJoin hashJoin, Cleaner cleaner) {
+    all.add(new CleanerWeakReference(hashJoin, cleaner, collected, true));
+  }
+
   /**
    * This is not 100% perfect and we can still run into situations where RMM buffers were not
    * collected and this returns false because of thread race conditions. This is just a best effort.

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -264,6 +264,7 @@ set(SOURCE_FILES
     "src/ColumnViewJni.cpp"
     "src/CompiledExpression.cpp"
     "src/ContiguousTableJni.cpp"
+    "src/HashJoinJni.cpp"
     "src/HostMemoryBufferNativeUtilsJni.cpp"
     "src/NvcompJni.cpp"
     "src/NvtxRangeJni.cpp"

--- a/java/src/main/native/src/HashJoinJni.cpp
+++ b/java/src/main/native/src/HashJoinJni.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/join.hpp>
+
+#include "cudf_jni_apis.hpp"
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_HashJoin_create(JNIEnv *env, jclass, jlong j_table,
+                                                            jboolean j_nulls_equal) {
+  JNI_NULL_CHECK(env, j_table, "table handle is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    auto tview = reinterpret_cast<cudf::table_view const *>(j_table);
+    auto nulleq = j_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
+    auto hash_join_ptr = new cudf::hash_join(*tview, nulleq);
+    return reinterpret_cast<jlong>(hash_join_ptr);
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_HashJoin_destroy(JNIEnv *env, jclass, jlong j_handle) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto hash_join_ptr = reinterpret_cast<cudf::hash_join *>(j_handle);
+    delete hash_join_ptr;
+  }
+  CATCH_STD(env, );
+}
+
+} // extern "C"

--- a/java/src/test/java/ai/rapids/cudf/HashJoinTest.java
+++ b/java/src/test/java/ai/rapids/cudf/HashJoinTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.rapids.cudf;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HashJoinTest {
+  @Test
+  void testGetNumberOfColumns() {
+    try (Table t = new Table.TestBuilder().column(1, 2).column(3, 4).column(5, 6).build();
+         HashJoin hashJoin = new HashJoin(t, false)) {
+      assertEquals(3, hashJoin.getNumberOfColumns());
+    }
+  }
+
+  @Test
+  void testGetCompareNulls() {
+    try (Table t = new Table.TestBuilder().column(1, 2, 3, 4).column(5, 6, 7, 8).build()) {
+      try (HashJoin hashJoin = new HashJoin(t, false)) {
+        assertFalse(hashJoin.getCompareNulls());
+      }
+      try (HashJoin hashJoin = new HashJoin(t, true)) {
+        assertTrue(hashJoin.getCompareNulls());
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds Java APIs to build a hash table for the right side table in a join and re-use it to join against a series of left probe tables.  It also exposes the ability to compute the join output row count and pass that count to a subsequent call to produce the join gather maps to avoid redundant computation when the output row count must be examined before manifesting the gather maps.