### PR TITLE
Make AST operators nullable

### DIFF
--- a/cpp/benchmarks/join/conditional_join_benchmark.cu
+++ b/cpp/benchmarks/join/conditional_join_benchmark.cu
@@ -20,6 +20,10 @@ template <typename key_type, typename payload_type>
 class ConditionalJoin : public cudf::benchmark {
 };
 
+// For compatibility with the shared logic for equality (hash) joins, all of
+// the join lambdas defined by these macros accept a null_equality parameter
+// but ignore it (don't forward it to the underlying join implementation)
+// because conditional joins do not use this parameter.
 #define CONDITIONAL_INNER_JOIN_BENCHMARK_DEFINE(name, key_type, payload_type, nullable) \
   BENCHMARK_TEMPLATE_DEFINE_F(ConditionalJoin, name, key_type, payload_type)            \
   (::benchmark::State & st)                                                             \
@@ -28,7 +32,7 @@ class ConditionalJoin : public cudf::benchmark {
                    cudf::table_view const& right,                                       \
                    cudf::ast::operation binary_pred,                                    \
                    cudf::null_equality compare_nulls) {                                 \
-      return cudf::conditional_inner_join(left, right, binary_pred, compare_nulls);     \
+      return cudf::conditional_inner_join(left, right, binary_pred);                    \
     };                                                                                  \
     constexpr bool is_conditional = true;                                               \
     BM_join<key_type, payload_type, nullable, is_conditional>(st, join);                \
@@ -47,7 +51,7 @@ CONDITIONAL_INNER_JOIN_BENCHMARK_DEFINE(conditional_inner_join_64bit_nulls, int6
                    cudf::table_view const& right,                                      \
                    cudf::ast::operation binary_pred,                                   \
                    cudf::null_equality compare_nulls) {                                \
-      return cudf::conditional_left_join(left, right, binary_pred, compare_nulls);     \
+      return cudf::conditional_left_join(left, right, binary_pred);                    \
     };                                                                                 \
     constexpr bool is_conditional = true;                                              \
     BM_join<key_type, payload_type, nullable, is_conditional>(st, join);               \
@@ -66,7 +70,7 @@ CONDITIONAL_LEFT_JOIN_BENCHMARK_DEFINE(conditional_left_join_64bit_nulls, int64_
                    cudf::table_view const& right,                                      \
                    cudf::ast::operation binary_pred,                                   \
                    cudf::null_equality compare_nulls) {                                \
-      return cudf::conditional_inner_join(left, right, binary_pred, compare_nulls);    \
+      return cudf::conditional_inner_join(left, right, binary_pred);                   \
     };                                                                                 \
     constexpr bool is_conditional = true;                                              \
     BM_join<key_type, payload_type, nullable, is_conditional>(st, join);               \
@@ -85,7 +89,7 @@ CONDITIONAL_FULL_JOIN_BENCHMARK_DEFINE(conditional_full_join_64bit_nulls, int64_
                    cudf::table_view const& right,                                           \
                    cudf::ast::operation binary_pred,                                        \
                    cudf::null_equality compare_nulls) {                                     \
-      return cudf::conditional_left_anti_join(left, right, binary_pred, compare_nulls);     \
+      return cudf::conditional_left_anti_join(left, right, binary_pred);                    \
     };                                                                                      \
     constexpr bool is_conditional = true;                                                   \
     BM_join<key_type, payload_type, nullable, is_conditional>(st, join);                    \
@@ -116,7 +120,7 @@ CONDITIONAL_LEFT_ANTI_JOIN_BENCHMARK_DEFINE(conditional_left_anti_join_64bit_nul
                    cudf::table_view const& right,                                           \
                    cudf::ast::operation binary_pred,                                        \
                    cudf::null_equality compare_nulls) {                                     \
-      return cudf::conditional_left_semi_join(left, right, binary_pred, compare_nulls);     \
+      return cudf::conditional_left_semi_join(left, right, binary_pred);                    \
     };                                                                                      \
     constexpr bool is_conditional = true;                                                   \
     BM_join<key_type, payload_type, nullable, is_conditional>(st, join);                    \

--- a/cpp/include/cudf/ast/detail/expression_evaluator.cuh
+++ b/cpp/include/cudf/ast/detail/expression_evaluator.cuh
@@ -235,19 +235,13 @@ struct expression_evaluator {
    * @param plan The collection of device references representing the expression to evaluate.
    * @param thread_intermediate_storage Pointer to this thread's portion of shared memory for
    * storing intermediates.
-   * @param compare_nulls Whether the equality operator returns true or false for two nulls.
 
    */
   __device__ expression_evaluator(table_device_view const& left,
                                   table_device_view const& right,
                                   expression_device_view const& plan,
-                                  IntermediateDataType<has_nulls>* thread_intermediate_storage,
-                                  null_equality compare_nulls = null_equality::EQUAL)
-    : left(left),
-      right(right),
-      plan(plan),
-      thread_intermediate_storage(thread_intermediate_storage),
-      compare_nulls(compare_nulls)
+                                  IntermediateDataType<has_nulls>* thread_intermediate_storage)
+    : left(left), right(right), plan(plan), thread_intermediate_storage(thread_intermediate_storage)
   {
   }
 
@@ -258,17 +252,14 @@ struct expression_evaluator {
    * @param plan The collection of device references representing the expression to evaluate.
    * @param thread_intermediate_storage Pointer to this thread's portion of shared memory for
    * storing intermediates.
-   * @param compare_nulls Whether the equality operator returns true or false for two nulls.
    */
   __device__ expression_evaluator(table_device_view const& table,
                                   expression_device_view const& plan,
-                                  IntermediateDataType<has_nulls>* thread_intermediate_storage,
-                                  null_equality compare_nulls = null_equality::EQUAL)
+                                  IntermediateDataType<has_nulls>* thread_intermediate_storage)
     : left(table),
       right(table),
       plan(plan),
-      thread_intermediate_storage(thread_intermediate_storage),
-      compare_nulls(compare_nulls)
+      thread_intermediate_storage(thread_intermediate_storage)
   {
   }
 
@@ -672,8 +663,7 @@ struct expression_evaluator {
         possibly_null_value_t<Out, has_nulls> result;
         if (!lhs.has_value() && !rhs.has_value()) {
           // Case 1: Both null, so the output is based on compare_nulls.
-          result = possibly_null_value_t<Out, has_nulls>(this->evaluator.compare_nulls ==
-                                                         null_equality::EQUAL);
+          result = possibly_null_value_t<Out, has_nulls>(false);
         } else if (lhs.has_value() && rhs.has_value()) {
           // Case 2: Neither is null, so the output is given by the operation.
           result = possibly_null_value_t<Out, has_nulls>(OperatorFunctor{}(*lhs, *rhs));
@@ -716,8 +706,6 @@ struct expression_evaluator {
   IntermediateDataType<has_nulls>*
     thread_intermediate_storage;  ///< The shared memory store of intermediates produced during
                                   ///< evaluation.
-  null_equality
-    compare_nulls;  ///< Whether the equality operator returns true or false for two nulls.
 };
 
 }  // namespace detail

--- a/cpp/include/cudf/ast/detail/expression_evaluator.cuh
+++ b/cpp/include/cudf/ast/detail/expression_evaluator.cuh
@@ -598,8 +598,9 @@ struct expression_evaluator {
      */
     template <ast_operator op,
               typename OutputType,
-              std::enable_if_t<detail::is_valid_unary_op<detail::operator_functor<op, has_nulls>,
-                                                         Input>>* = nullptr>
+              std::enable_if_t<
+                detail::is_valid_unary_op<detail::operator_functor<op, has_nulls>,
+                                          possibly_null_value_t<Input, has_nulls>>>* = nullptr>
     __device__ void operator()(OutputType& output_object,
                                cudf::size_type const output_row_index,
                                possibly_null_value_t<Input, has_nulls> const input,
@@ -614,8 +615,9 @@ struct expression_evaluator {
 
     template <ast_operator op,
               typename OutputType,
-              std::enable_if_t<!detail::is_valid_unary_op<detail::operator_functor<op, has_nulls>,
-                                                          Input>>* = nullptr>
+              std::enable_if_t<
+                !detail::is_valid_unary_op<detail::operator_functor<op, has_nulls>,
+                                           possibly_null_value_t<Input, has_nulls>>>* = nullptr>
     __device__ void operator()(OutputType& output_object,
                                cudf::size_type const output_row_index,
                                possibly_null_value_t<Input, has_nulls> const input,
@@ -650,11 +652,12 @@ struct expression_evaluator {
      * @param rhs Right input to the operation.
      * @param output Output data reference.
      */
-    template <
-      ast_operator op,
-      typename OutputType,
-      std::enable_if_t<
-        detail::is_valid_binary_op<detail::operator_functor<op, has_nulls>, LHS, RHS>>* = nullptr>
+    template <ast_operator op,
+              typename OutputType,
+              std::enable_if_t<detail::is_valid_binary_op<detail::operator_functor<op, has_nulls>,
+                                                          possibly_null_value_t<LHS, has_nulls>,
+                                                          possibly_null_value_t<RHS, has_nulls>>>* =
+                nullptr>
     __device__ void operator()(OutputType& output_object,
                                cudf::size_type const output_row_index,
                                possibly_null_value_t<LHS, has_nulls> const lhs,
@@ -688,11 +691,12 @@ struct expression_evaluator {
       }
     }
 
-    template <
-      ast_operator op,
-      typename OutputType,
-      std::enable_if_t<
-        !detail::is_valid_binary_op<detail::operator_functor<op, has_nulls>, LHS, RHS>>* = nullptr>
+    template <ast_operator op,
+              typename OutputType,
+              std::enable_if_t<
+                !detail::is_valid_binary_op<detail::operator_functor<op, has_nulls>,
+                                            possibly_null_value_t<LHS, has_nulls>,
+                                            possibly_null_value_t<RHS, has_nulls>>>* = nullptr>
     __device__ void operator()(OutputType& output_object,
                                cudf::size_type const output_row_index,
                                possibly_null_value_t<LHS, has_nulls> const lhs,

--- a/cpp/include/cudf/ast/detail/operators.hpp
+++ b/cpp/include/cudf/ast/detail/operators.hpp
@@ -207,12 +207,12 @@ CUDA_HOST_DEVICE_CALLABLE constexpr void ast_operator_dispatcher(ast_operator op
  *
  * @tparam op AST operator.
  */
-template <ast_operator op>
+template <ast_operator op, bool has_nulls>
 struct operator_functor {
 };
 
 template <>
-struct operator_functor<ast_operator::ADD> {
+struct operator_functor<ast_operator::ADD, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -223,7 +223,7 @@ struct operator_functor<ast_operator::ADD> {
 };
 
 template <>
-struct operator_functor<ast_operator::SUB> {
+struct operator_functor<ast_operator::SUB, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -234,7 +234,7 @@ struct operator_functor<ast_operator::SUB> {
 };
 
 template <>
-struct operator_functor<ast_operator::MUL> {
+struct operator_functor<ast_operator::MUL, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -245,7 +245,7 @@ struct operator_functor<ast_operator::MUL> {
 };
 
 template <>
-struct operator_functor<ast_operator::DIV> {
+struct operator_functor<ast_operator::DIV, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -256,7 +256,7 @@ struct operator_functor<ast_operator::DIV> {
 };
 
 template <>
-struct operator_functor<ast_operator::TRUE_DIV> {
+struct operator_functor<ast_operator::TRUE_DIV, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -268,7 +268,7 @@ struct operator_functor<ast_operator::TRUE_DIV> {
 };
 
 template <>
-struct operator_functor<ast_operator::FLOOR_DIV> {
+struct operator_functor<ast_operator::FLOOR_DIV, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -280,7 +280,7 @@ struct operator_functor<ast_operator::FLOOR_DIV> {
 };
 
 template <>
-struct operator_functor<ast_operator::MOD> {
+struct operator_functor<ast_operator::MOD, false> {
   static constexpr auto arity{2};
 
   template <typename LHS,
@@ -315,7 +315,7 @@ struct operator_functor<ast_operator::MOD> {
 };
 
 template <>
-struct operator_functor<ast_operator::PYMOD> {
+struct operator_functor<ast_operator::PYMOD, false> {
   static constexpr auto arity{2};
 
   template <typename LHS,
@@ -362,7 +362,7 @@ struct operator_functor<ast_operator::PYMOD> {
 };
 
 template <>
-struct operator_functor<ast_operator::POW> {
+struct operator_functor<ast_operator::POW, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -373,7 +373,7 @@ struct operator_functor<ast_operator::POW> {
 };
 
 template <>
-struct operator_functor<ast_operator::EQUAL> {
+struct operator_functor<ast_operator::EQUAL, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -384,7 +384,7 @@ struct operator_functor<ast_operator::EQUAL> {
 };
 
 template <>
-struct operator_functor<ast_operator::NOT_EQUAL> {
+struct operator_functor<ast_operator::NOT_EQUAL, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -395,7 +395,7 @@ struct operator_functor<ast_operator::NOT_EQUAL> {
 };
 
 template <>
-struct operator_functor<ast_operator::LESS> {
+struct operator_functor<ast_operator::LESS, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -406,7 +406,7 @@ struct operator_functor<ast_operator::LESS> {
 };
 
 template <>
-struct operator_functor<ast_operator::GREATER> {
+struct operator_functor<ast_operator::GREATER, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -417,7 +417,7 @@ struct operator_functor<ast_operator::GREATER> {
 };
 
 template <>
-struct operator_functor<ast_operator::LESS_EQUAL> {
+struct operator_functor<ast_operator::LESS_EQUAL, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -428,7 +428,7 @@ struct operator_functor<ast_operator::LESS_EQUAL> {
 };
 
 template <>
-struct operator_functor<ast_operator::GREATER_EQUAL> {
+struct operator_functor<ast_operator::GREATER_EQUAL, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -439,7 +439,7 @@ struct operator_functor<ast_operator::GREATER_EQUAL> {
 };
 
 template <>
-struct operator_functor<ast_operator::BITWISE_AND> {
+struct operator_functor<ast_operator::BITWISE_AND, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -450,7 +450,7 @@ struct operator_functor<ast_operator::BITWISE_AND> {
 };
 
 template <>
-struct operator_functor<ast_operator::BITWISE_OR> {
+struct operator_functor<ast_operator::BITWISE_OR, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -461,7 +461,7 @@ struct operator_functor<ast_operator::BITWISE_OR> {
 };
 
 template <>
-struct operator_functor<ast_operator::BITWISE_XOR> {
+struct operator_functor<ast_operator::BITWISE_XOR, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -472,7 +472,7 @@ struct operator_functor<ast_operator::BITWISE_XOR> {
 };
 
 template <>
-struct operator_functor<ast_operator::LOGICAL_AND> {
+struct operator_functor<ast_operator::LOGICAL_AND, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -483,7 +483,7 @@ struct operator_functor<ast_operator::LOGICAL_AND> {
 };
 
 template <>
-struct operator_functor<ast_operator::LOGICAL_OR> {
+struct operator_functor<ast_operator::LOGICAL_OR, false> {
   static constexpr auto arity{2};
 
   template <typename LHS, typename RHS>
@@ -494,7 +494,7 @@ struct operator_functor<ast_operator::LOGICAL_OR> {
 };
 
 template <>
-struct operator_functor<ast_operator::IDENTITY> {
+struct operator_functor<ast_operator::IDENTITY, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -505,7 +505,7 @@ struct operator_functor<ast_operator::IDENTITY> {
 };
 
 template <>
-struct operator_functor<ast_operator::SIN> {
+struct operator_functor<ast_operator::SIN, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -516,7 +516,7 @@ struct operator_functor<ast_operator::SIN> {
 };
 
 template <>
-struct operator_functor<ast_operator::COS> {
+struct operator_functor<ast_operator::COS, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -527,7 +527,7 @@ struct operator_functor<ast_operator::COS> {
 };
 
 template <>
-struct operator_functor<ast_operator::TAN> {
+struct operator_functor<ast_operator::TAN, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -538,7 +538,7 @@ struct operator_functor<ast_operator::TAN> {
 };
 
 template <>
-struct operator_functor<ast_operator::ARCSIN> {
+struct operator_functor<ast_operator::ARCSIN, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -549,7 +549,7 @@ struct operator_functor<ast_operator::ARCSIN> {
 };
 
 template <>
-struct operator_functor<ast_operator::ARCCOS> {
+struct operator_functor<ast_operator::ARCCOS, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -560,7 +560,7 @@ struct operator_functor<ast_operator::ARCCOS> {
 };
 
 template <>
-struct operator_functor<ast_operator::ARCTAN> {
+struct operator_functor<ast_operator::ARCTAN, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -571,7 +571,7 @@ struct operator_functor<ast_operator::ARCTAN> {
 };
 
 template <>
-struct operator_functor<ast_operator::SINH> {
+struct operator_functor<ast_operator::SINH, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -582,7 +582,7 @@ struct operator_functor<ast_operator::SINH> {
 };
 
 template <>
-struct operator_functor<ast_operator::COSH> {
+struct operator_functor<ast_operator::COSH, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -593,7 +593,7 @@ struct operator_functor<ast_operator::COSH> {
 };
 
 template <>
-struct operator_functor<ast_operator::TANH> {
+struct operator_functor<ast_operator::TANH, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -604,7 +604,7 @@ struct operator_functor<ast_operator::TANH> {
 };
 
 template <>
-struct operator_functor<ast_operator::ARCSINH> {
+struct operator_functor<ast_operator::ARCSINH, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -615,7 +615,7 @@ struct operator_functor<ast_operator::ARCSINH> {
 };
 
 template <>
-struct operator_functor<ast_operator::ARCCOSH> {
+struct operator_functor<ast_operator::ARCCOSH, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -626,7 +626,7 @@ struct operator_functor<ast_operator::ARCCOSH> {
 };
 
 template <>
-struct operator_functor<ast_operator::ARCTANH> {
+struct operator_functor<ast_operator::ARCTANH, false> {
   static constexpr auto arity{1};
 
   template <typename InputT, std::enable_if_t<std::is_floating_point<InputT>::value>* = nullptr>
@@ -637,7 +637,7 @@ struct operator_functor<ast_operator::ARCTANH> {
 };
 
 template <>
-struct operator_functor<ast_operator::EXP> {
+struct operator_functor<ast_operator::EXP, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -648,7 +648,7 @@ struct operator_functor<ast_operator::EXP> {
 };
 
 template <>
-struct operator_functor<ast_operator::LOG> {
+struct operator_functor<ast_operator::LOG, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -659,7 +659,7 @@ struct operator_functor<ast_operator::LOG> {
 };
 
 template <>
-struct operator_functor<ast_operator::SQRT> {
+struct operator_functor<ast_operator::SQRT, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -670,7 +670,7 @@ struct operator_functor<ast_operator::SQRT> {
 };
 
 template <>
-struct operator_functor<ast_operator::CBRT> {
+struct operator_functor<ast_operator::CBRT, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -681,7 +681,7 @@ struct operator_functor<ast_operator::CBRT> {
 };
 
 template <>
-struct operator_functor<ast_operator::CEIL> {
+struct operator_functor<ast_operator::CEIL, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -692,7 +692,7 @@ struct operator_functor<ast_operator::CEIL> {
 };
 
 template <>
-struct operator_functor<ast_operator::FLOOR> {
+struct operator_functor<ast_operator::FLOOR, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -703,7 +703,7 @@ struct operator_functor<ast_operator::FLOOR> {
 };
 
 template <>
-struct operator_functor<ast_operator::ABS> {
+struct operator_functor<ast_operator::ABS, false> {
   static constexpr auto arity{1};
 
   // Only accept signed or unsigned types (both require is_arithmetic<T> to be true)
@@ -721,7 +721,7 @@ struct operator_functor<ast_operator::ABS> {
 };
 
 template <>
-struct operator_functor<ast_operator::RINT> {
+struct operator_functor<ast_operator::RINT, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -732,7 +732,7 @@ struct operator_functor<ast_operator::RINT> {
 };
 
 template <>
-struct operator_functor<ast_operator::BIT_INVERT> {
+struct operator_functor<ast_operator::BIT_INVERT, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -743,7 +743,7 @@ struct operator_functor<ast_operator::BIT_INVERT> {
 };
 
 template <>
-struct operator_functor<ast_operator::NOT> {
+struct operator_functor<ast_operator::NOT, false> {
   static constexpr auto arity{1};
 
   template <typename InputT>
@@ -751,6 +751,12 @@ struct operator_functor<ast_operator::NOT> {
   {
     return !input;
   }
+};
+
+template <ast_operator op>
+struct operator_functor<op, true> : operator_functor<op, false> {
+  using operator_functor<op, false>::arity;
+  using operator_functor<op, false>::operator();
 };
 
 /**
@@ -793,6 +799,7 @@ struct single_dispatch_binary_operator_types {
  * This functor performs single dispatch, which assumes lhs_type == rhs_type. This may not be true
  * for all binary operators but holds for all currently implemented operators.
  */
+template <bool has_nulls>
 struct type_dispatch_binary_op {
   /**
    * @brief Performs type dispatch for a binary operator.
@@ -812,10 +819,11 @@ struct type_dispatch_binary_op {
                                             Ts&&... args)
   {
     // Single dispatch (assume lhs_type == rhs_type)
-    type_dispatcher(lhs_type,
-                    detail::single_dispatch_binary_operator_types<operator_functor<op>>{},
-                    std::forward<F>(f),
-                    std::forward<Ts>(args)...);
+    type_dispatcher(
+      lhs_type,
+      detail::single_dispatch_binary_operator_types<operator_functor<op, has_nulls>>{},
+      std::forward<F>(f),
+      std::forward<Ts>(args)...);
   }
 };
 
@@ -829,12 +837,12 @@ struct type_dispatch_binary_op {
  * @param f Forwarded functor to be called.
  * @param args Forwarded arguments to `operator()` of `f`.
  */
-template <typename F, typename... Ts>
+template <bool has_nulls, typename F, typename... Ts>
 CUDA_HOST_DEVICE_CALLABLE constexpr void binary_operator_dispatcher(
   ast_operator op, cudf::data_type lhs_type, cudf::data_type rhs_type, F&& f, Ts&&... args)
 {
   ast_operator_dispatcher(op,
-                          detail::type_dispatch_binary_op{},
+                          detail::type_dispatch_binary_op<has_nulls>{},
                           lhs_type,
                           rhs_type,
                           std::forward<F>(f),
@@ -877,12 +885,13 @@ struct dispatch_unary_operator_types {
 /**
  * @brief Functor performing a type dispatch for a unary operator.
  */
+template <bool has_nulls>
 struct type_dispatch_unary_op {
   template <ast_operator op, typename F, typename... Ts>
   CUDA_HOST_DEVICE_CALLABLE void operator()(cudf::data_type input_type, F&& f, Ts&&... args)
   {
     type_dispatcher(input_type,
-                    detail::dispatch_unary_operator_types<operator_functor<op>>{},
+                    detail::dispatch_unary_operator_types<operator_functor<op, has_nulls>>{},
                     std::forward<F>(f),
                     std::forward<Ts>(args)...);
   }
@@ -897,14 +906,14 @@ struct type_dispatch_unary_op {
  * @param f Forwarded functor to be called.
  * @param args Forwarded arguments to `operator()` of `f`.
  */
-template <typename F, typename... Ts>
+template <bool has_nulls, typename F, typename... Ts>
 CUDA_HOST_DEVICE_CALLABLE constexpr void unary_operator_dispatcher(ast_operator op,
                                                                    cudf::data_type input_type,
                                                                    F&& f,
                                                                    Ts&&... args)
 {
   ast_operator_dispatcher(op,
-                          detail::type_dispatch_unary_op{},
+                          detail::type_dispatch_unary_op<has_nulls>{},
                           input_type,
                           std::forward<F>(f),
                           std::forward<Ts>(args)...);
@@ -981,16 +990,18 @@ struct return_type_functor {
  * @param operand_types Vector of input types to the operator.
  * @return cudf::data_type Return type of the operator.
  */
+template <bool has_nulls>
 inline cudf::data_type ast_operator_return_type(ast_operator op,
                                                 std::vector<cudf::data_type> const& operand_types)
 {
   auto result = cudf::data_type(cudf::type_id::EMPTY);
   switch (operand_types.size()) {
     case 1:
-      unary_operator_dispatcher(op, operand_types[0], detail::return_type_functor{}, result);
+      unary_operator_dispatcher<has_nulls>(
+        op, operand_types[0], detail::return_type_functor{}, result);
       break;
     case 2:
-      binary_operator_dispatcher(
+      binary_operator_dispatcher<has_nulls>(
         op, operand_types[0], operand_types[1], detail::return_type_functor{}, result);
       break;
     default: CUDF_FAIL("Unsupported operator return type."); break;
@@ -1005,7 +1016,8 @@ struct arity_functor {
   template <ast_operator op>
   CUDA_HOST_DEVICE_CALLABLE void operator()(cudf::size_type& result)
   {
-    result = operator_functor<op>::arity;
+    // Arity is not dependent on null handling, so just use the false implementation here.
+    result = operator_functor<op, false>::arity;
   }
 };
 

--- a/cpp/include/cudf/ast/detail/operators.hpp
+++ b/cpp/include/cudf/ast/detail/operators.hpp
@@ -822,10 +822,10 @@ struct operator_functor<ast_operator::NULL_EQUAL, true> {
   CUDA_DEVICE_CALLABLE auto operator()(LHS const lhs, RHS const rhs)
     -> possibly_null_value_t<decltype(NonNullOperator{}(*lhs, *rhs)), true>
   {
-    // Case 1: Two nulls compare equal.
-    if (!lhs.has_value() && !rhs.has_value()) { return {true}; }
-    // Case 2: Neither is null, so the output is given by the operation.
+    // Case 1: Neither is null, so the output is given by the operation.
     if (lhs.has_value() && rhs.has_value()) { return {NonNullOperator{}(*lhs, *rhs)}; }
+    // Case 2: Two nulls compare equal.
+    if (!lhs.has_value() && !rhs.has_value()) { return {true}; }
     // Case 3: One value is null, while the other is not, so we return false.
     return {false};
   }
@@ -843,10 +843,10 @@ struct operator_functor<ast_operator::NULL_LOGICAL_AND, true> {
   CUDA_DEVICE_CALLABLE auto operator()(LHS const lhs, RHS const rhs)
     -> possibly_null_value_t<decltype(NonNullOperator{}(*lhs, *rhs)), true>
   {
-    // Case 1: Two nulls return null.
-    if (!lhs.has_value() && !rhs.has_value()) { return {}; }
-    // Case 2: Neither is null, so the output is given by the operation.
+    // Case 1: Neither is null, so the output is given by the operation.
     if (lhs.has_value() && rhs.has_value()) { return {NonNullOperator{}(*lhs, *rhs)}; }
+    // Case 2: Two nulls return null.
+    if (!lhs.has_value() && !rhs.has_value()) { return {}; }
     // Case 3: One value is null, while the other is not. If it's true we return null, otherwise we
     // return false.
     auto const& valid_element = lhs.has_value() ? lhs : rhs;
@@ -866,10 +866,10 @@ struct operator_functor<ast_operator::NULL_LOGICAL_OR, true> {
   CUDA_DEVICE_CALLABLE auto operator()(LHS const lhs, RHS const rhs)
     -> possibly_null_value_t<decltype(NonNullOperator{}(*lhs, *rhs)), true>
   {
-    // Case 1: Two nulls return null.
-    if (!lhs.has_value() && !rhs.has_value()) { return {}; }
-    // Case 2: Neither is null, so the output is given by the operation.
+    // Case 1: Neither is null, so the output is given by the operation.
     if (lhs.has_value() && rhs.has_value()) { return {NonNullOperator{}(*lhs, *rhs)}; }
+    // Case 2: Two nulls return null.
+    if (!lhs.has_value() && !rhs.has_value()) { return {}; }
     // Case 3: One value is null, while the other is not. If it's true we return true, otherwise we
     // return null.
     auto const& valid_element = lhs.has_value() ? lhs : rhs;
@@ -939,7 +939,7 @@ struct type_dispatch_binary_op {
     // Single dispatch (assume lhs_type == rhs_type)
     type_dispatcher(
       lhs_type,
-      // Always non-null operator since this is just for the purpose of type determination.
+      // Always dispatch to the non-null operator for the purpose of type determination.
       detail::single_dispatch_binary_operator_types<operator_functor<op, false>>{},
       std::forward<F>(f),
       std::forward<Ts>(args)...);
@@ -1010,7 +1010,7 @@ struct type_dispatch_unary_op {
   {
     type_dispatcher(
       input_type,
-      // Always non-null operator since this is just for the purpose of type determination.
+      // Always dispatch to the non-null operator for the purpose of type determination.
       detail::dispatch_unary_operator_types<operator_functor<op, false>>{},
       std::forward<F>(f),
       std::forward<Ts>(args)...);

--- a/cpp/include/cudf/ast/detail/operators.hpp
+++ b/cpp/include/cudf/ast/detail/operators.hpp
@@ -771,19 +771,25 @@ struct operator_functor<op, true> : operator_functor<op, false> {
             typename RHS,
             std::size_t arity_placeholder             = arity,
             std::enable_if_t<arity_placeholder == 2>* = nullptr>
-  CUDA_DEVICE_CALLABLE auto operator()(LHS lhs, RHS rhs)
-    -> decltype(operator_functor<op, false>::operator()(lhs, rhs))
+  CUDA_DEVICE_CALLABLE auto operator()(LHS const lhs, RHS const rhs)
+    -> possibly_null_value_t<decltype(operator_functor<op, false>::operator()(*lhs, *rhs)), true>
   {
-    return operator_functor<op, false>::operator()(lhs, rhs);
+    using Out =
+      possibly_null_value_t<decltype(operator_functor<op, false>::operator()(*lhs, *rhs)), true>;
+    return (lhs.has_value() && rhs.has_value())
+             ? Out(operator_functor<op, false>::operator()(*lhs, *rhs))
+             : Out();
   }
 
   template <typename Input,
             std::size_t arity_placeholder             = arity,
             std::enable_if_t<arity_placeholder == 1>* = nullptr>
-  CUDA_DEVICE_CALLABLE auto operator()(Input input)
-    -> decltype(operator_functor<op, false>::operator()(input))
+  CUDA_DEVICE_CALLABLE auto operator()(Input const input)
+    -> possibly_null_value_t<decltype(operator_functor<op, false>::operator()(*input)), true>
   {
-    return operator_functor<op, false>::operator()(input);
+    using Out =
+      possibly_null_value_t<decltype(operator_functor<op, false>::operator()(*input)), true>;
+    return input.has_value() ? Out(operator_functor<op, false>::operator()(*input)) : Out();
   }
 };
 

--- a/cpp/include/cudf/ast/detail/operators.hpp
+++ b/cpp/include/cudf/ast/detail/operators.hpp
@@ -19,12 +19,6 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
-// TODO: Figure out why these are necessary; I think it's because the type
-// dispatcher combined with thrust::optional for list and struct views leads to
-// introspection that is not possible without the definitions of these classes
-// available, but that is unfortunate and should be avoidable.
-#include <cudf/lists/list_view.cuh>
-#include <cudf/structs/struct_view.hpp>
 
 #include <cuda/std/type_traits>
 

--- a/cpp/include/cudf/ast/detail/operators.hpp
+++ b/cpp/include/cudf/ast/detail/operators.hpp
@@ -386,16 +386,10 @@ struct operator_functor<ast_operator::EQUAL, false> {
   }
 };
 
-// TODO: Try to alias this if possible.
+// Alias NULL_EQUAL = EQUAL in the non-nullable case.
 template <>
-struct operator_functor<ast_operator::NULL_EQUAL, false> {
-  static constexpr auto arity{2};
-
-  template <typename LHS, typename RHS>
-  CUDA_DEVICE_CALLABLE auto operator()(LHS lhs, RHS rhs) -> decltype(lhs == rhs)
-  {
-    return lhs == rhs;
-  }
+struct operator_functor<ast_operator::NULL_EQUAL, false>
+  : public operator_functor<ast_operator::EQUAL, false> {
 };
 
 template <>

--- a/cpp/include/cudf/ast/detail/operators.hpp
+++ b/cpp/include/cudf/ast/detail/operators.hpp
@@ -807,8 +807,8 @@ struct operator_functor<ast_operator::NULL_EQUAL, true> {
     if (!lhs.has_value() && !rhs.has_value()) { return {true}; }
     // Case 2: Neither is null, so the output is given by the operation.
     if (lhs.has_value() && rhs.has_value()) { return {NonNullOperator{}(*lhs, *rhs)}; }
-    // Case 3: One value is null, while the other is not, so we propagate nulls.
-    return {};
+    // Case 3: One value is null, while the other is not, so we return false.
+    return {false};
   }
 };
 

--- a/cpp/include/cudf/ast/detail/operators.hpp
+++ b/cpp/include/cudf/ast/detail/operators.hpp
@@ -779,9 +779,7 @@ struct single_dispatch_binary_operator_types {
   template <typename LHS,
             typename F,
             typename... Ts,
-            std::enable_if_t<is_valid_binary_op<OperatorFunctor,
-                                                possibly_null_value_t<LHS, has_nulls>,
-                                                possibly_null_value_t<LHS, has_nulls>>>* = nullptr>
+            std::enable_if_t<is_valid_binary_op<OperatorFunctor, LHS, LHS>>* = nullptr>
   CUDA_HOST_DEVICE_CALLABLE void operator()(F&& f, Ts&&... args)
   {
     f.template operator()<OperatorFunctor,
@@ -792,9 +790,7 @@ struct single_dispatch_binary_operator_types {
   template <typename LHS,
             typename F,
             typename... Ts,
-            std::enable_if_t<!is_valid_binary_op<OperatorFunctor,
-                                                 possibly_null_value_t<LHS, has_nulls>,
-                                                 possibly_null_value_t<LHS, has_nulls>>>* = nullptr>
+            std::enable_if_t<!is_valid_binary_op<OperatorFunctor, LHS, LHS>>* = nullptr>
   CUDA_HOST_DEVICE_CALLABLE void operator()(F&& f, Ts&&... args)
   {
 #ifndef __CUDA_ARCH__

--- a/cpp/include/cudf/ast/expressions.hpp
+++ b/cpp/include/cudf/ast/expressions.hpp
@@ -46,28 +46,35 @@ struct expression {
  */
 enum class ast_operator {
   // Binary operators
-  ADD,            ///< operator +
-  SUB,            ///< operator -
-  MUL,            ///< operator *
-  DIV,            ///< operator / using common type of lhs and rhs
-  TRUE_DIV,       ///< operator / after promoting type to floating point
-  FLOOR_DIV,      ///< operator / after promoting to 64 bit floating point and then
-                  ///< flooring the result
-  MOD,            ///< operator %
-  PYMOD,          ///< operator % but following python's sign rules for negatives
-  POW,            ///< lhs ^ rhs
-  EQUAL,          ///< operator ==
-  NULL_EQUAL,     ///< operator ==, but nulls compare equal
-  NOT_EQUAL,      ///< operator !=
-  LESS,           ///< operator <
-  GREATER,        ///< operator >
-  LESS_EQUAL,     ///< operator <=
-  GREATER_EQUAL,  ///< operator >=
-  BITWISE_AND,    ///< operator &
-  BITWISE_OR,     ///< operator |
-  BITWISE_XOR,    ///< operator ^
-  LOGICAL_AND,    ///< operator &&
-  LOGICAL_OR,     ///< operator ||
+  ADD,               ///< operator +
+  SUB,               ///< operator -
+  MUL,               ///< operator *
+  DIV,               ///< operator / using common type of lhs and rhs
+  TRUE_DIV,          ///< operator / after promoting type to floating point
+  FLOOR_DIV,         ///< operator / after promoting to 64 bit floating point and then
+                     ///< flooring the result
+  MOD,               ///< operator %
+  PYMOD,             ///< operator % but following python's sign rules for negatives
+  POW,               ///< lhs ^ rhs
+  EQUAL,             ///< operator ==
+  NULL_EQUAL,        ///< NULL_EQUAL(null, null) is true, NULL_EQUAL(null, valid) is false, and
+                     ///< NULL_EQUAL(valid, valid) == EQUAL(valid, valid)
+  NOT_EQUAL,         ///< operator !=
+  LESS,              ///< operator <
+  GREATER,           ///< operator >
+  LESS_EQUAL,        ///< operator <=
+  GREATER_EQUAL,     ///< operator >=
+  BITWISE_AND,       ///< operator &
+  BITWISE_OR,        ///< operator |
+  BITWISE_XOR,       ///< operator ^
+  LOGICAL_AND,       ///< operator &&
+  NULL_LOGICAL_AND,  ///< NULL_LOGICAL_AND(null, null) is null, NULL_LOGICAL_AND(null, true) is
+                     ///< null, NULL_LOGICAL_AND(null, false) is false, and NULL_LOGICAL_AND(valid,
+                     ///< valid) == LOGICAL_AND(valid, valid)
+  LOGICAL_OR,        ///< operator ||
+  NULL_LOGICAL_OR,   ///< NULL_LOGICAL_OR(null, null) is null, NULL_LOGICAL_OR(null, true) is true,
+                     ///< NULL_LOGICAL_OR(null, false) is null, and NULL_LOGICAL_OR(valid, valid) ==
+                     ///< LOGICAL_OR(valid, valid)
   // Unary operators
   IDENTITY,    ///< Identity function
   SIN,         ///< Trigonometric sine

--- a/cpp/include/cudf/ast/expressions.hpp
+++ b/cpp/include/cudf/ast/expressions.hpp
@@ -46,33 +46,36 @@ struct expression {
  */
 enum class ast_operator {
   // Binary operators
-  ADD,               ///< operator +
-  SUB,               ///< operator -
-  MUL,               ///< operator *
-  DIV,               ///< operator / using common type of lhs and rhs
-  TRUE_DIV,          ///< operator / after promoting type to floating point
-  FLOOR_DIV,         ///< operator / after promoting to 64 bit floating point and then
-                     ///< flooring the result
-  MOD,               ///< operator %
-  PYMOD,             ///< operator % but following python's sign rules for negatives
-  POW,               ///< lhs ^ rhs
-  EQUAL,             ///< operator ==
-  NULL_EQUAL,        ///< NULL_EQUAL(null, null) is true, NULL_EQUAL(null, valid) is false, and
-                     ///< NULL_EQUAL(valid, valid) == EQUAL(valid, valid)
-  NOT_EQUAL,         ///< operator !=
-  LESS,              ///< operator <
-  GREATER,           ///< operator >
-  LESS_EQUAL,        ///< operator <=
+  ADD,         ///< operator +
+  SUB,         ///< operator -
+  MUL,         ///< operator *
+  DIV,         ///< operator / using common type of lhs and rhs
+  TRUE_DIV,    ///< operator / after promoting type to floating point
+  FLOOR_DIV,   ///< operator / after promoting to 64 bit floating point and then
+               ///< flooring the result
+  MOD,         ///< operator %
+  PYMOD,       ///< operator % using Python's sign rules for negatives
+  POW,         ///< lhs ^ rhs
+  EQUAL,       ///< operator ==
+  NULL_EQUAL,  ///< operator == with Spark rules: NULL_EQUAL(null, null) is true, NULL_EQUAL(null,
+               ///< valid) is false, and
+               ///< NULL_EQUAL(valid, valid) == EQUAL(valid, valid)
+  NOT_EQUAL,   ///< operator !=
+  LESS,        ///< operator <
+  GREATER,     ///< operator >
+  LESS_EQUAL,  ///< operator <=
   GREATER_EQUAL,     ///< operator >=
   BITWISE_AND,       ///< operator &
   BITWISE_OR,        ///< operator |
   BITWISE_XOR,       ///< operator ^
   LOGICAL_AND,       ///< operator &&
-  NULL_LOGICAL_AND,  ///< NULL_LOGICAL_AND(null, null) is null, NULL_LOGICAL_AND(null, true) is
+  NULL_LOGICAL_AND,  ///< operator && with Spark rules: NULL_LOGICAL_AND(null, null) is null,
+                     ///< NULL_LOGICAL_AND(null, true) is
                      ///< null, NULL_LOGICAL_AND(null, false) is false, and NULL_LOGICAL_AND(valid,
                      ///< valid) == LOGICAL_AND(valid, valid)
   LOGICAL_OR,        ///< operator ||
-  NULL_LOGICAL_OR,   ///< NULL_LOGICAL_OR(null, null) is null, NULL_LOGICAL_OR(null, true) is true,
+  NULL_LOGICAL_OR,   ///< operator || with Spark rules: NULL_LOGICAL_OR(null, null) is null,
+                     ///< NULL_LOGICAL_OR(null, true) is true,
                      ///< NULL_LOGICAL_OR(null, false) is null, and NULL_LOGICAL_OR(valid, valid) ==
                      ///< LOGICAL_OR(valid, valid)
   // Unary operators

--- a/cpp/include/cudf/ast/expressions.hpp
+++ b/cpp/include/cudf/ast/expressions.hpp
@@ -57,6 +57,7 @@ enum class ast_operator {
   PYMOD,          ///< operator % but following python's sign rules for negatives
   POW,            ///< lhs ^ rhs
   EQUAL,          ///< operator ==
+  NULL_EQUAL,     ///< operator ==, but nulls compare equal
   NOT_EQUAL,      ///< operator !=
   LESS,           ///< operator <
   GREATER,        ///< operator >

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -678,7 +678,6 @@ class hash_join {
  * @param left The left table
  * @param right The right table
  * @param binary_predicate The condition on which to join.
- * @param compare_nulls Whether the equality operator returns true or false for two nulls.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return A pair of vectors [`left_indices`, `right_indices`] that can be used to construct
@@ -690,7 +689,6 @@ conditional_inner_join(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  null_equality compare_nulls            = null_equality::EQUAL,
   std::optional<std::size_t> output_size = {},
   rmm::mr::device_memory_resource* mr    = rmm::mr::get_current_device_resource());
 
@@ -725,7 +723,6 @@ conditional_inner_join(
  * @param left The left table
  * @param right The right table
  * @param binary_predicate The condition on which to join.
- * @param compare_nulls Whether the equality operator returns true or false for two nulls.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return A pair of vectors [`left_indices`, `right_indices`] that can be used to construct
@@ -736,7 +733,6 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 conditional_left_join(table_view const& left,
                       table_view const& right,
                       ast::expression const& binary_predicate,
-                      null_equality compare_nulls            = null_equality::EQUAL,
                       std::optional<std::size_t> output_size = {},
                       rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
@@ -770,7 +766,6 @@ conditional_left_join(table_view const& left,
  * @param left The left table
  * @param right The right table
  * @param binary_predicate The condition on which to join.
- * @param compare_nulls Whether the equality operator returns true or false for two nulls.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return A pair of vectors [`left_indices`, `right_indices`] that can be used to construct
@@ -781,7 +776,6 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 conditional_full_join(table_view const& left,
                       table_view const& right,
                       ast::expression const& binary_predicate,
-                      null_equality compare_nulls         = null_equality::EQUAL,
                       rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -809,7 +803,6 @@ conditional_full_join(table_view const& left,
  * @param left The left table
  * @param right The right table
  * @param binary_predicate The condition on which to join.
- * @param compare_nulls Whether the equality operator returns true or false for two nulls.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return A vector `left_indices` that can be used to construct the result of
@@ -820,7 +813,6 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_semi_join(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  null_equality compare_nulls            = null_equality::EQUAL,
   std::optional<std::size_t> output_size = {},
   rmm::mr::device_memory_resource* mr    = rmm::mr::get_current_device_resource());
 
@@ -849,7 +841,6 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_semi_join(
  * @param left The left table
  * @param right The right table
  * @param binary_predicate The condition on which to join.
- * @param compare_nulls Whether the equality operator returns true or false for two nulls.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return A vector `left_indices` that can be used to construct the result of
@@ -860,7 +851,6 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_anti_join(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  null_equality compare_nulls            = null_equality::EQUAL,
   std::optional<std::size_t> output_size = {},
   rmm::mr::device_memory_resource* mr    = rmm::mr::get_current_device_resource());
 
@@ -877,7 +867,6 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_anti_join(
  * @param left The left table
  * @param right The right table
  * @param binary_predicate The condition on which to join.
- * @param compare_nulls Whether the equality operator returns true or false for two nulls.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return The size that would result from performing the requested join.
@@ -886,7 +875,6 @@ std::size_t conditional_inner_join_size(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  null_equality compare_nulls         = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -902,7 +890,6 @@ std::size_t conditional_inner_join_size(
  * @param left The left table
  * @param right The right table
  * @param binary_predicate The condition on which to join.
- * @param compare_nulls Whether the equality operator returns true or false for two nulls.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return The size that would result from performing the requested join.
@@ -911,7 +898,6 @@ std::size_t conditional_left_join_size(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  null_equality compare_nulls         = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -927,7 +913,6 @@ std::size_t conditional_left_join_size(
  * @param left The left table
  * @param right The right table
  * @param binary_predicate The condition on which to join.
- * @param compare_nulls Whether the equality operator returns true or false for two nulls.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return The size that would result from performing the requested join.
@@ -936,7 +921,6 @@ std::size_t conditional_left_semi_join_size(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  null_equality compare_nulls         = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -952,7 +936,6 @@ std::size_t conditional_left_semi_join_size(
  * @param left The left table
  * @param right The right table
  * @param binary_predicate The condition on which to join.
- * @param compare_nulls Whether the equality operator returns true or false for two nulls.
  * @param mr Device memory resource used to allocate the returned table and columns' device memory
  *
  * @return The size that would result from performing the requested join.
@@ -961,7 +944,6 @@ std::size_t conditional_left_anti_join_size(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  null_equality compare_nulls         = null_equality::EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 /** @} */  // end of group
 }  // namespace cudf

--- a/cpp/src/ast/expression_parser.cpp
+++ b/cpp/src/ast/expression_parser.cpp
@@ -162,7 +162,9 @@ cudf::size_type expression_parser::visit(operation const& expr)
     });
   // Resolve expression type
   auto const op        = expr.get_operator();
-  auto const data_type = cudf::ast::detail::ast_operator_return_type(op, operand_types);
+  auto const data_type = has_nulls
+                           ? cudf::ast::detail::ast_operator_return_type<true>(op, operand_types)
+                           : cudf::ast::detail::ast_operator_return_type<false>(op, operand_types);
   _operators.push_back(op);
   // Push data reference
   auto const output = [&]() {

--- a/cpp/src/ast/expression_parser.cpp
+++ b/cpp/src/ast/expression_parser.cpp
@@ -162,9 +162,7 @@ cudf::size_type expression_parser::visit(operation const& expr)
     });
   // Resolve expression type
   auto const op        = expr.get_operator();
-  auto const data_type = _has_nulls
-                           ? cudf::ast::detail::ast_operator_return_type<true>(op, operand_types)
-                           : cudf::ast::detail::ast_operator_return_type<false>(op, operand_types);
+  auto const data_type = cudf::ast::detail::ast_operator_return_type(op, operand_types);
   _operators.push_back(op);
   // Push data reference
   auto const output = [&]() {

--- a/cpp/src/ast/expression_parser.cpp
+++ b/cpp/src/ast/expression_parser.cpp
@@ -162,7 +162,7 @@ cudf::size_type expression_parser::visit(operation const& expr)
     });
   // Resolve expression type
   auto const op        = expr.get_operator();
-  auto const data_type = has_nulls
+  auto const data_type = _has_nulls
                            ? cudf::ast::detail::ast_operator_return_type<true>(op, operand_types)
                            : cudf::ast::detail::ast_operator_return_type<false>(op, operand_types);
   _operators.push_back(op);

--- a/cpp/src/join/conditional_join.hpp
+++ b/cpp/src/join/conditional_join.hpp
@@ -36,7 +36,6 @@ namespace detail {
  * @param right Table of right  columns to join
  * tables have been flipped, meaning the output indices should also be flipped
  * @param JoinKind The type of join to be performed
- * @param compare_nulls Controls whether null join-key values should match or not.
  * @param stream CUDA stream used for device memory operations and kernel launches
  *
  * @return Join output indices vector pair
@@ -46,7 +45,6 @@ std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
 conditional_join(table_view const& left,
                  table_view const& right,
                  ast::expression const& binary_predicate,
-                 null_equality compare_nulls,
                  join_kind JoinKind,
                  std::optional<std::size_t> output_size = {},
                  rmm::cuda_stream_view stream           = rmm::cuda_stream_default,
@@ -60,7 +58,6 @@ conditional_join(table_view const& left,
  * @param right Table of right  columns to join
  * tables have been flipped, meaning the output indices should also be flipped
  * @param JoinKind The type of join to be performed
- * @param compare_nulls Controls whether null join-key values should match or not.
  * @param stream CUDA stream used for device memory operations and kernel launches
  *
  * @return Join output indices vector pair
@@ -69,7 +66,6 @@ std::size_t compute_conditional_join_output_size(
   table_view const& left,
   table_view const& right,
   ast::expression const& binary_predicate,
-  null_equality compare_nulls,
   join_kind JoinKind,
   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -459,6 +459,22 @@ TEST_F(TransformTest, PyMod)
   cudf::test::expect_columns_equal(expected, result->view(), verbosity);
 }
 
+TEST_F(TransformTest, BasicEqualityNullEqualNoNulls)
+{
+  auto c_0   = column_wrapper<int32_t>{3, 20, 1, 50};
+  auto c_1   = column_wrapper<int32_t>{3, 7, 1, 0};
+  auto table = cudf::table_view{{c_0, c_1}};
+
+  auto col_ref_0  = cudf::ast::column_reference(0);
+  auto col_ref_1  = cudf::ast::column_reference(1);
+  auto expression = cudf::ast::operation(cudf::ast::ast_operator::NULL_EQUAL, col_ref_0, col_ref_1);
+
+  auto expected = column_wrapper<bool>{true, false, true, false};
+  auto result   = cudf::compute_column(table, expression);
+
+  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+}
+
 TEST_F(TransformTest, BasicEqualityNulls)
 {
   auto c_0   = column_wrapper<int32_t>{{3, 20, 1, 50}, {1, 1, 1, 0}};

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -493,15 +493,15 @@ TEST_F(TransformTest, BasicEqualityNormalEqualWithNulls)
 
 TEST_F(TransformTest, BasicEqualityNulls)
 {
-  auto c_0   = column_wrapper<int32_t>{{3, 20, 1, 50}, {1, 1, 1, 0}};
-  auto c_1   = column_wrapper<int32_t>{{3, 7, 1, 0}, {1, 1, 1, 0}};
+  auto c_0   = column_wrapper<int32_t>{{3, 20, 1, 2, 50}, {1, 1, 0, 1, 0}};
+  auto c_1   = column_wrapper<int32_t>{{3, 7, 1, 2, 0}, {1, 1, 1, 0, 0}};
   auto table = cudf::table_view{{c_0, c_1}};
 
   auto col_ref_0  = cudf::ast::column_reference(0);
   auto col_ref_1  = cudf::ast::column_reference(1);
   auto expression = cudf::ast::operation(cudf::ast::ast_operator::NULL_EQUAL, col_ref_0, col_ref_1);
 
-  auto expected = column_wrapper<bool>{{true, false, true, true}, {1, 1, 1, 1}};
+  auto expected = column_wrapper<bool>{{true, false, false, false, true}, {1, 1, 1, 1, 1}};
   auto result   = cudf::compute_column(table, expression);
 
   cudf::test::expect_columns_equal(expected, result->view(), verbosity);

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -308,9 +308,9 @@ TEST_F(TransformTest, UnaryNotNulls)
   auto expression = cudf::ast::operation(cudf::ast::ast_operator::NOT, col_ref_0);
 
   auto result   = cudf::compute_column(table, expression);
-  auto expected = column_wrapper<bool>{{false, true, false, false}, {0, 0, 1, 1}};
+  auto expected = column_wrapper<bool>{{false, true, true, false}, {0, 0, 1, 1}};
 
-  // cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, UnaryTrigonometry)

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -298,6 +298,21 @@ TEST_F(TransformTest, UnaryNot)
   cudf::test::expect_columns_equal(expected, result->view(), verbosity);
 }
 
+TEST_F(TransformTest, UnaryNotNulls)
+{
+  auto c_0   = column_wrapper<int32_t>{{3, 0, 0, 50}, {0, 0, 1, 1}};
+  auto table = cudf::table_view{{c_0}};
+
+  auto col_ref_0 = cudf::ast::column_reference(0);
+
+  auto expression = cudf::ast::operation(cudf::ast::ast_operator::NOT, col_ref_0);
+
+  auto result   = cudf::compute_column(table, expression);
+  auto expected = column_wrapper<bool>{{false, true, false, false}, {0, 0, 1, 1}};
+
+  // cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+}
+
 TEST_F(TransformTest, UnaryTrigonometry)
 {
   auto c_0   = column_wrapper<double>{0.0, M_PI / 4, M_PI / 3};

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -548,4 +548,44 @@ TEST_F(TransformTest, BasicAdditionLargeNulls)
   cudf::test::expect_columns_equal(expected, result->view(), verbosity);
 }
 
+TEST_F(TransformTest, NullLogicalAnd)
+{
+  auto c_0   = column_wrapper<bool>{{false, false, true, true, false, false, true, true},
+                                  {1, 1, 1, 1, 1, 0, 0, 0}};
+  auto c_1   = column_wrapper<bool>{{false, true, false, true, true, true, false, true},
+                                  {1, 1, 1, 1, 0, 1, 1, 0}};
+  auto table = cudf::table_view{{c_0, c_1}};
+
+  auto col_ref_0 = cudf::ast::column_reference(0);
+  auto col_ref_1 = cudf::ast::column_reference(1);
+  auto expression =
+    cudf::ast::operation(cudf::ast::ast_operator::NULL_LOGICAL_AND, col_ref_0, col_ref_1);
+
+  auto expected = column_wrapper<bool>{{false, false, false, true, false, false, false, true},
+                                       {1, 1, 1, 1, 1, 0, 1, 0}};
+  auto result   = cudf::compute_column(table, expression);
+
+  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+}
+
+TEST_F(TransformTest, NullLogicalOr)
+{
+  auto c_0   = column_wrapper<bool>{{false, false, true, true, false, false, true, true},
+                                  {1, 1, 1, 1, 1, 0, 1, 0}};
+  auto c_1   = column_wrapper<bool>{{false, true, false, true, true, true, false, true},
+                                  {1, 1, 1, 1, 0, 1, 0, 0}};
+  auto table = cudf::table_view{{c_0, c_1}};
+
+  auto col_ref_0 = cudf::ast::column_reference(0);
+  auto col_ref_1 = cudf::ast::column_reference(1);
+  auto expression =
+    cudf::ast::operation(cudf::ast::ast_operator::NULL_LOGICAL_OR, col_ref_0, col_ref_1);
+
+  auto expected = column_wrapper<bool>{{false, true, true, true, false, true, true, true},
+                                       {1, 1, 1, 1, 0, 1, 1, 0}};
+  auto result   = cudf::compute_column(table, expression);
+
+  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+}
+
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -475,6 +475,22 @@ TEST_F(TransformTest, BasicEqualityNullEqualNoNulls)
   cudf::test::expect_columns_equal(expected, result->view(), verbosity);
 }
 
+TEST_F(TransformTest, BasicEqualityNormalEqualWithNulls)
+{
+  auto c_0   = column_wrapper<int32_t>{{3, 20, 1, 50}, {1, 1, 0, 0}};
+  auto c_1   = column_wrapper<int32_t>{{3, 7, 1, 0}, {1, 1, 0, 0}};
+  auto table = cudf::table_view{{c_0, c_1}};
+
+  auto col_ref_0  = cudf::ast::column_reference(0);
+  auto col_ref_1  = cudf::ast::column_reference(1);
+  auto expression = cudf::ast::operation(cudf::ast::ast_operator::EQUAL, col_ref_0, col_ref_1);
+
+  auto expected = column_wrapper<bool>{{true, false, true, true}, {1, 1, 0, 0}};
+  auto result   = cudf::compute_column(table, expression);
+
+  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+}
+
 TEST_F(TransformTest, BasicEqualityNulls)
 {
   auto c_0   = column_wrapper<int32_t>{{3, 20, 1, 50}, {1, 1, 1, 0}};

--- a/cpp/tests/join/conditional_join_tests.cu
+++ b/cpp/tests/join/conditional_join_tests.cu
@@ -36,8 +36,6 @@
 #include <utility>
 #include <vector>
 
-// Defining expressions for AST evaluation is currently a bit tedious, so we
-// define some standard nodes here that can be easily reused elsewhere.
 namespace {
 using PairJoinReturn   = std::pair<std::unique_ptr<rmm::device_uvector<cudf::size_type>>,
                                  std::unique_ptr<rmm::device_uvector<cudf::size_type>>>;

--- a/cpp/tests/join/conditional_join_tests.cu
+++ b/cpp/tests/join/conditional_join_tests.cu
@@ -71,38 +71,31 @@ struct ConditionalJoinTest : public cudf::test::BaseFixture {
              cudf::table_view>
   parse_input(std::vector<U> left_data, std::vector<U> right_data)
   {
+    auto wrapper_generator = [](U& v) {
+      if constexpr (std::is_same_v<U, std::vector<T>>) {
+        return cudf::test::fixed_width_column_wrapper<T>(v.begin(), v.end());
+      } else if constexpr (std::is_same_v<U, std::pair<std::vector<T>, std::vector<bool>>>) {
+        return cudf::test::fixed_width_column_wrapper<T>(
+          v.first.begin(), v.first.end(), v.second.begin());
+      }
+      throw std::runtime_error("Invalid input to parse_input.");
+      return cudf::test::fixed_width_column_wrapper<T>();
+    };
+
     // Note that we need to maintain the column wrappers otherwise the
     // resulting column views will be referencing potentially invalid memory.
     std::vector<cudf::test::fixed_width_column_wrapper<T>> left_wrappers;
-    std::vector<cudf::test::fixed_width_column_wrapper<T>> right_wrappers;
-
     std::vector<cudf::column_view> left_columns;
+    for (auto v : left_data) {
+      left_wrappers.push_back(wrapper_generator(v));
+      left_columns.push_back(left_wrappers.back());
+    }
+
+    std::vector<cudf::test::fixed_width_column_wrapper<T>> right_wrappers;
     std::vector<cudf::column_view> right_columns;
-
-    if constexpr (std::is_same_v<U, std::vector<T>>) {
-      for (auto v : left_data) {
-        left_wrappers.push_back(cudf::test::fixed_width_column_wrapper<T>(v.begin(), v.end()));
-        left_columns.push_back(left_wrappers.back());
-      }
-
-      for (auto v : right_data) {
-        right_wrappers.push_back(cudf::test::fixed_width_column_wrapper<T>(v.begin(), v.end()));
-        right_columns.push_back(right_wrappers.back());
-      }
-    } else if constexpr (std::is_same_v<U, std::pair<std::vector<T>, std::vector<bool>>>) {
-      for (auto v : left_data) {
-        left_wrappers.push_back(cudf::test::fixed_width_column_wrapper<T>(
-          v.first.begin(), v.first.end(), v.second.begin()));
-        left_columns.push_back(left_wrappers.back());
-      }
-
-      for (auto v : right_data) {
-        right_wrappers.push_back(cudf::test::fixed_width_column_wrapper<T>(
-          v.first.begin(), v.first.end(), v.second.begin()));
-        right_columns.push_back(right_wrappers.back());
-      }
-    } else {
-      throw std::runtime_error("Invalid input to parse_input.");
+    for (auto v : right_data) {
+      right_wrappers.push_back(wrapper_generator(v));
+      right_columns.push_back(right_wrappers.back());
     }
 
     return std::make_tuple(std::move(left_wrappers),

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -569,64 +569,50 @@ public final class Table implements AutoCloseable {
                                                      boolean compareNullsEqual) throws CudfException;
 
   private static native long conditionalLeftJoinRowCount(long leftTable, long rightTable,
-                                                         long condition,
-                                                         boolean compareNullsEqual) throws CudfException;
+                                                         long condition) throws CudfException;
 
   private static native long[] conditionalLeftJoinGatherMaps(long leftTable, long rightTable,
-                                                             long condition,
-                                                             boolean compareNullsEqual) throws CudfException;
+                                                             long condition) throws CudfException;
 
   private static native long[] conditionalLeftJoinGatherMapsWithCount(long leftTable, long rightTable,
                                                                       long condition,
-                                                                      boolean compareNullsEqual,
                                                                       long rowCount) throws CudfException;
 
   private static native long conditionalInnerJoinRowCount(long leftTable, long rightTable,
-                                                          long condition,
-                                                          boolean compareNullsEqual) throws CudfException;
+                                                          long condition) throws CudfException;
 
   private static native long[] conditionalInnerJoinGatherMaps(long leftTable, long rightTable,
-                                                              long condition,
-                                                              boolean compareNullsEqual) throws CudfException;
+                                                              long condition) throws CudfException;
 
   private static native long[] conditionalInnerJoinGatherMapsWithCount(long leftTable, long rightTable,
                                                                        long condition,
-                                                                       boolean compareNullsEqual,
                                                                        long rowCount) throws CudfException;
 
   private static native long[] conditionalFullJoinGatherMaps(long leftTable, long rightTable,
-                                                             long condition,
-                                                             boolean compareNullsEqual) throws CudfException;
+                                                             long condition) throws CudfException;
 
   private static native long[] conditionalFullJoinGatherMapsWithCount(long leftTable, long rightTable,
                                                                       long condition,
-                                                                      boolean compareNullsEqual,
                                                                       long rowCount) throws CudfException;
 
   private static native long conditionalLeftSemiJoinRowCount(long leftTable, long rightTable,
-                                                             long condition,
-                                                             boolean compareNullsEqual) throws CudfException;
+                                                             long condition) throws CudfException;
 
   private static native long[] conditionalLeftSemiJoinGatherMap(long leftTable, long rightTable,
-                                                                long condition,
-                                                                boolean compareNullsEqual) throws CudfException;
+                                                                long condition) throws CudfException;
 
   private static native long[] conditionalLeftSemiJoinGatherMapWithCount(long leftTable, long rightTable,
                                                                          long condition,
-                                                                         boolean compareNullsEqual,
                                                                          long rowCount) throws CudfException;
 
   private static native long conditionalLeftAntiJoinRowCount(long leftTable, long rightTable,
-                                                             long condition,
-                                                             boolean compareNullsEqual) throws CudfException;
+                                                             long condition) throws CudfException;
 
   private static native long[] conditionalLeftAntiJoinGatherMap(long leftTable, long rightTable,
-                                                                long condition,
-                                                                boolean compareNullsEqual) throws CudfException;
+                                                                long condition) throws CudfException;
 
   private static native long[] conditionalLeftAntiJoinGatherMapWithCount(long leftTable, long rightTable,
                                                                          long condition,
-                                                                         boolean compareNullsEqual,
                                                                          long rowCount) throws CudfException;
 
   private static native long[] crossJoin(long leftTable, long rightTable) throws CudfException;
@@ -2148,13 +2134,11 @@ public final class Table implements AutoCloseable {
    * the left table, and the table argument represents the columns from the right table.
    * @param rightTable the right side table of the join in the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @return row count for the join result
    */
-  public long conditionalLeftJoinRowCount(Table rightTable, CompiledExpression condition,
-                                          boolean compareNullsEqual) {
+  public long conditionalLeftJoinRowCount(Table rightTable, CompiledExpression condition) {
     return conditionalLeftJoinRowCount(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual);
+            condition.getNativeHandle());
   }
 
   /**
@@ -2166,15 +2150,13 @@ public final class Table implements AutoCloseable {
    * It is the responsibility of the caller to close the resulting gather map instances.
    * @param rightTable the right side table of the join in the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @return left and right table gather maps
    */
   public GatherMap[] conditionalLeftJoinGatherMaps(Table rightTable,
-                                                   CompiledExpression condition,
-                                                   boolean compareNullsEqual) {
+                                                   CompiledExpression condition) {
     long[] gatherMapData =
         conditionalLeftJoinGatherMaps(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual);
+            condition.getNativeHandle());
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2191,17 +2173,15 @@ public final class Table implements AutoCloseable {
    * in undefined behavior.
    * @param rightTable the right side table of the join in the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @param outputRowCount number of output rows in the join result
    * @return left and right table gather maps
    */
   public GatherMap[] conditionalLeftJoinGatherMaps(Table rightTable,
                                                    CompiledExpression condition,
-                                                   boolean compareNullsEqual,
                                                    long outputRowCount) {
     long[] gatherMapData =
         conditionalLeftJoinGatherMapsWithCount(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual, outputRowCount);
+            condition.getNativeHandle(), outputRowCount);
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2293,14 +2273,12 @@ public final class Table implements AutoCloseable {
    * the left table, and the table argument represents the columns from the right table.
    * @param rightTable the right side table of the join in the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @return row count for the join result
    */
   public long conditionalInnerJoinRowCount(Table rightTable,
-                                           CompiledExpression condition,
-                                           boolean compareNullsEqual) {
+                                           CompiledExpression condition) {
     return conditionalInnerJoinRowCount(getNativeView(), rightTable.getNativeView(),
-        condition.getNativeHandle(), compareNullsEqual);
+        condition.getNativeHandle());
   }
 
   /**
@@ -2312,15 +2290,13 @@ public final class Table implements AutoCloseable {
    * It is the responsibility of the caller to close the resulting gather map instances.
    * @param rightTable the right side table of the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @return left and right table gather maps
    */
   public GatherMap[] conditionalInnerJoinGatherMaps(Table rightTable,
-                                                    CompiledExpression condition,
-                                                    boolean compareNullsEqual) {
+                                                    CompiledExpression condition) {
     long[] gatherMapData =
         conditionalInnerJoinGatherMaps(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual);
+            condition.getNativeHandle());
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2337,17 +2313,15 @@ public final class Table implements AutoCloseable {
    * in undefined behavior.
    * @param rightTable the right side table of the join in the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @param outputRowCount number of output rows in the join result
    * @return left and right table gather maps
    */
   public GatherMap[] conditionalInnerJoinGatherMaps(Table rightTable,
                                                     CompiledExpression condition,
-                                                    boolean compareNullsEqual,
                                                     long outputRowCount) {
     long[] gatherMapData =
         conditionalInnerJoinGatherMapsWithCount(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual, outputRowCount);
+            condition.getNativeHandle(), outputRowCount);
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2447,15 +2421,13 @@ public final class Table implements AutoCloseable {
    * It is the responsibility of the caller to close the resulting gather map instances.
    * @param rightTable the right side table of the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @return left and right table gather maps
    */
   public GatherMap[] conditionalFullJoinGatherMaps(Table rightTable,
-                                                   CompiledExpression condition,
-                                                   boolean compareNullsEqual) {
+                                                   CompiledExpression condition) {
     long[] gatherMapData =
         conditionalFullJoinGatherMaps(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual);
+            condition.getNativeHandle());
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2493,14 +2465,12 @@ public final class Table implements AutoCloseable {
    * the left table, and the table argument represents the columns from the right table.
    * @param rightTable the right side table of the join in the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @return row count for the join result
    */
   public long conditionalLeftSemiJoinRowCount(Table rightTable,
-                                              CompiledExpression condition,
-                                              boolean compareNullsEqual) {
+                                              CompiledExpression condition) {
     return conditionalLeftSemiJoinRowCount(getNativeView(), rightTable.getNativeView(),
-        condition.getNativeHandle(), compareNullsEqual);
+        condition.getNativeHandle());
   }
 
   /**
@@ -2512,15 +2482,13 @@ public final class Table implements AutoCloseable {
    * It is the responsibility of the caller to close the resulting gather map instance.
    * @param rightTable the right side table of the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @return left table gather map
    */
   public GatherMap conditionalLeftSemiJoinGatherMap(Table rightTable,
-                                                    CompiledExpression condition,
-                                                    boolean compareNullsEqual) {
+                                                    CompiledExpression condition) {
     long[] gatherMapData =
         conditionalLeftSemiJoinGatherMap(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual);
+            condition.getNativeHandle());
     return buildSemiJoinGatherMap(gatherMapData);
   }
 
@@ -2537,17 +2505,15 @@ public final class Table implements AutoCloseable {
    * in undefined behavior.
    * @param rightTable the right side table of the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @param outputRowCount number of output rows in the join result
    * @return left table gather map
    */
   public GatherMap conditionalLeftSemiJoinGatherMap(Table rightTable,
                                                     CompiledExpression condition,
-                                                    boolean compareNullsEqual,
                                                     long outputRowCount) {
     long[] gatherMapData =
         conditionalLeftSemiJoinGatherMapWithCount(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual, outputRowCount);
+            condition.getNativeHandle(), outputRowCount);
     return buildSemiJoinGatherMap(gatherMapData);
   }
 
@@ -2578,14 +2544,12 @@ public final class Table implements AutoCloseable {
    * the left table, and the table argument represents the columns from the right table.
    * @param rightTable the right side table of the join in the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @return row count for the join result
    */
   public long conditionalLeftAntiJoinRowCount(Table rightTable,
-                                              CompiledExpression condition,
-                                              boolean compareNullsEqual) {
+                                              CompiledExpression condition) {
     return conditionalLeftAntiJoinRowCount(getNativeView(), rightTable.getNativeView(),
-        condition.getNativeHandle(), compareNullsEqual);
+        condition.getNativeHandle());
   }
 
   /**
@@ -2597,15 +2561,13 @@ public final class Table implements AutoCloseable {
    * It is the responsibility of the caller to close the resulting gather map instance.
    * @param rightTable the right side table of the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @return left table gather map
    */
   public GatherMap conditionalLeftAntiJoinGatherMap(Table rightTable,
-                                                    CompiledExpression condition,
-                                                    boolean compareNullsEqual) {
+                                                    CompiledExpression condition) {
     long[] gatherMapData =
         conditionalLeftAntiJoinGatherMap(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual);
+            condition.getNativeHandle());
     return buildSemiJoinGatherMap(gatherMapData);
   }
 
@@ -2622,17 +2584,15 @@ public final class Table implements AutoCloseable {
    * in undefined behavior.
    * @param rightTable the right side table of the join
    * @param condition conditional expression to evaluate during the join
-   * @param compareNullsEqual true if null key values should match otherwise false
    * @param outputRowCount number of output rows in the join result
    * @return left table gather map
    */
   public GatherMap conditionalLeftAntiJoinGatherMap(Table rightTable,
                                                     CompiledExpression condition,
-                                                    boolean compareNullsEqual,
                                                     long outputRowCount) {
     long[] gatherMapData =
         conditionalLeftAntiJoinGatherMapWithCount(getNativeView(), rightTable.getNativeView(),
-            condition.getNativeHandle(), compareNullsEqual, outputRowCount);
+            condition.getNativeHandle(), outputRowCount);
     return buildSemiJoinGatherMap(gatherMapData);
   }
 

--- a/java/src/main/java/ai/rapids/cudf/ast/BinaryOperator.java
+++ b/java/src/main/java/ai/rapids/cudf/ast/BinaryOperator.java
@@ -30,7 +30,7 @@ public enum BinaryOperator {
   TRUE_DIV(4),            // operator / after promoting type to floating point
   FLOOR_DIV(5),           // operator / after promoting to 64 bit floating point and then flooring the result
   MOD(6),                 // operator %
-  PYMOD(7),               // operator % using python's sign rules for negatives
+  PYMOD(7),               // operator % using Python's sign rules for negatives
   POW(8),                 // lhs ^ rhs
   EQUAL(9),               // operator ==
   NULL_EQUAL(10),         // operator == using Spark rules for null inputs

--- a/java/src/main/java/ai/rapids/cudf/ast/BinaryOperator.java
+++ b/java/src/main/java/ai/rapids/cudf/ast/BinaryOperator.java
@@ -23,26 +23,29 @@ import java.nio.ByteBuffer;
  * NOTE: This must be kept in sync with `jni_to_binary_operator` in CompiledExpression.cpp!
  */
 public enum BinaryOperator {
-  ADD(0),            // operator +
-  SUB(1),            // operator -
-  MUL(2),            // operator *
-  DIV(3),            // operator / using common type of lhs and rhs
-  TRUE_DIV(4),       // operator / after promoting type to floating point
-  FLOOR_DIV(5),      // operator / after promoting to 64 bit floating point and then flooring the result
-  MOD(6),            // operator %
-  PYMOD(7),          // operator % but following python's sign rules for negatives
-  POW(8),            // lhs ^ rhs
-  EQUAL(9),          // operator ==
-  NOT_EQUAL(10),     // operator !=
-  LESS(11),          // operator <
-  GREATER(12),       // operator >
-  LESS_EQUAL(13),    // operator <=
-  GREATER_EQUAL(14), // operator >=
-  BITWISE_AND(15),   // operator &
-  BITWISE_OR(16),    // operator |
-  BITWISE_XOR(17),   // operator ^
-  LOGICAL_AND(18),   // operator &&
-  LOGICAL_OR(19);    // operator ||
+  ADD(0),                 // operator +
+  SUB(1),                 // operator -
+  MUL(2),                 // operator *
+  DIV(3),                 // operator / using common type of lhs and rhs
+  TRUE_DIV(4),            // operator / after promoting type to floating point
+  FLOOR_DIV(5),           // operator / after promoting to 64 bit floating point and then flooring the result
+  MOD(6),                 // operator %
+  PYMOD(7),               // operator % but following python's sign rules for negatives
+  POW(8),                 // lhs ^ rhs
+  EQUAL(9),               // operator ==
+  NULL_EQUAL(10),         // operator == but supporting Spark rules for null inputs
+  NOT_EQUAL(11),          // operator !=
+  LESS(12),               // operator <
+  GREATER(13),            // operator >
+  LESS_EQUAL(14),         // operator <=
+  GREATER_EQUAL(15),      // operator >=
+  BITWISE_AND(16),        // operator &
+  BITWISE_OR(17),         // operator |
+  BITWISE_XOR(18),        // operator ^
+  LOGICAL_AND(19),        // operator &&
+  NULL_LOGICAL_AND(20),   // operator && but supporting Spark rules for null inputs
+  LOGICAL_OR(21),         // operator ||
+  NULL_LOGICAL_OR(22);    // operator || but supporting Spark rules for null inputs
 
   private final byte nativeId;
 

--- a/java/src/main/java/ai/rapids/cudf/ast/BinaryOperator.java
+++ b/java/src/main/java/ai/rapids/cudf/ast/BinaryOperator.java
@@ -30,10 +30,10 @@ public enum BinaryOperator {
   TRUE_DIV(4),            // operator / after promoting type to floating point
   FLOOR_DIV(5),           // operator / after promoting to 64 bit floating point and then flooring the result
   MOD(6),                 // operator %
-  PYMOD(7),               // operator % but following python's sign rules for negatives
+  PYMOD(7),               // operator % using python's sign rules for negatives
   POW(8),                 // lhs ^ rhs
   EQUAL(9),               // operator ==
-  NULL_EQUAL(10),         // operator == but supporting Spark rules for null inputs
+  NULL_EQUAL(10),         // operator == using Spark rules for null inputs
   NOT_EQUAL(11),          // operator !=
   LESS(12),               // operator <
   GREATER(13),            // operator >
@@ -43,9 +43,9 @@ public enum BinaryOperator {
   BITWISE_OR(17),         // operator |
   BITWISE_XOR(18),        // operator ^
   LOGICAL_AND(19),        // operator &&
-  NULL_LOGICAL_AND(20),   // operator && but supporting Spark rules for null inputs
+  NULL_LOGICAL_AND(20),   // operator && using Spark rules for null inputs
   LOGICAL_OR(21),         // operator ||
-  NULL_LOGICAL_OR(22);    // operator || but supporting Spark rules for null inputs
+  NULL_LOGICAL_OR(22);    // operator || using Spark rules for null inputs
 
   private final byte nativeId;
 

--- a/java/src/main/native/src/CompiledExpression.cpp
+++ b/java/src/main/native/src/CompiledExpression.cpp
@@ -165,16 +165,19 @@ cudf::ast::ast_operator jni_to_binary_operator(jbyte jni_op_value) {
     case 7: return cudf::ast::ast_operator::PYMOD;
     case 8: return cudf::ast::ast_operator::POW;
     case 9: return cudf::ast::ast_operator::EQUAL;
-    case 10: return cudf::ast::ast_operator::NOT_EQUAL;
-    case 11: return cudf::ast::ast_operator::LESS;
-    case 12: return cudf::ast::ast_operator::GREATER;
-    case 13: return cudf::ast::ast_operator::LESS_EQUAL;
-    case 14: return cudf::ast::ast_operator::GREATER_EQUAL;
-    case 15: return cudf::ast::ast_operator::BITWISE_AND;
-    case 16: return cudf::ast::ast_operator::BITWISE_OR;
-    case 17: return cudf::ast::ast_operator::BITWISE_XOR;
-    case 18: return cudf::ast::ast_operator::LOGICAL_AND;
-    case 19: return cudf::ast::ast_operator::LOGICAL_OR;
+    case 10: return cudf::ast::ast_operator::NULL_EQUAL;
+    case 11: return cudf::ast::ast_operator::NOT_EQUAL;
+    case 12: return cudf::ast::ast_operator::LESS;
+    case 13: return cudf::ast::ast_operator::GREATER;
+    case 14: return cudf::ast::ast_operator::LESS_EQUAL;
+    case 15: return cudf::ast::ast_operator::GREATER_EQUAL;
+    case 16: return cudf::ast::ast_operator::BITWISE_AND;
+    case 17: return cudf::ast::ast_operator::BITWISE_OR;
+    case 18: return cudf::ast::ast_operator::BITWISE_XOR;
+    case 19: return cudf::ast::ast_operator::LOGICAL_AND;
+    case 20: return cudf::ast::ast_operator::NULL_LOGICAL_AND;
+    case 21: return cudf::ast::ast_operator::LOGICAL_OR;
+    case 22: return cudf::ast::ast_operator::NULL_LOGICAL_OR;
     default: throw std::invalid_argument("unexpected JNI AST binary operator value");
   }
 }

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -1608,7 +1608,7 @@ public class TableTest extends CudfTestBase {
              .column(inv, inv, 0, 1, 3, inv, inv, 0, 1, inv, 1, inv, 0, 1)
              .build();
          CompiledExpression condition = expr.compile()) {
-      GatherMap[] maps = left.conditionalLeftJoinGatherMaps(right, condition, false);
+      GatherMap[] maps = left.conditionalLeftJoinGatherMaps(right, condition);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -1622,7 +1622,7 @@ public class TableTest extends CudfTestBase {
   @Test
   void testConditionalLeftJoinGatherMapsNulls() {
     final int inv = Integer.MIN_VALUE;
-    BinaryOperation expr = new BinaryOperation(BinaryOperator.EQUAL,
+    BinaryOperation expr = new BinaryOperation(BinaryOperator.NULL_EQUAL,
         new ColumnReference(0, TableReference.LEFT),
         new ColumnReference(0, TableReference.RIGHT));
     try (Table left = new Table.TestBuilder()
@@ -1636,7 +1636,7 @@ public class TableTest extends CudfTestBase {
              .column(inv, inv, 2, inv, inv, inv, inv, 0, 1, 0, 1, 3) // right
              .build();
          CompiledExpression condition = expr.compile()) {
-      GatherMap[] maps = left.conditionalLeftJoinGatherMaps(right, condition, true);
+      GatherMap[] maps = left.conditionalLeftJoinGatherMaps(right, condition);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -1662,9 +1662,9 @@ public class TableTest extends CudfTestBase {
              .column(inv, inv, 0, 1, 3, inv, inv, 0, 1, inv, 1, inv, 0, 1)
              .build();
          CompiledExpression condition = expr.compile()) {
-      long rowCount = left.conditionalLeftJoinRowCount(right, condition, false);
+      long rowCount = left.conditionalLeftJoinRowCount(right, condition);
       assertEquals(expected.getRowCount(), rowCount);
-      GatherMap[] maps = left.conditionalLeftJoinGatherMaps(right, condition, false, rowCount);
+      GatherMap[] maps = left.conditionalLeftJoinGatherMaps(right, condition, rowCount);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -1678,7 +1678,7 @@ public class TableTest extends CudfTestBase {
   @Test
   void testConditionalLeftJoinGatherMapsNullsWithCount() {
     final int inv = Integer.MIN_VALUE;
-    BinaryOperation expr = new BinaryOperation(BinaryOperator.EQUAL,
+    BinaryOperation expr = new BinaryOperation(BinaryOperator.NULL_EQUAL,
         new ColumnReference(0, TableReference.LEFT),
         new ColumnReference(0, TableReference.RIGHT));
     try (Table left = new Table.TestBuilder()
@@ -1692,9 +1692,9 @@ public class TableTest extends CudfTestBase {
              .column(inv, inv, 2, inv, inv, inv, inv, 0, 1, 0, 1, 3) // right
              .build();
          CompiledExpression condition = expr.compile()) {
-      long rowCount = left.conditionalLeftJoinRowCount(right, condition, true);
+      long rowCount = left.conditionalLeftJoinRowCount(right, condition);
       assertEquals(expected.getRowCount(), rowCount);
-      GatherMap[] maps = left.conditionalLeftJoinGatherMaps(right, condition, true, rowCount);
+      GatherMap[] maps = left.conditionalLeftJoinGatherMaps(right, condition, rowCount);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -1853,7 +1853,7 @@ public class TableTest extends CudfTestBase {
              .column(0, 1, 3, 0, 1, 1, 0, 1)
              .build();
          CompiledExpression condition = expr.compile()) {
-      GatherMap[] maps = left.conditionalInnerJoinGatherMaps(right, condition, false);
+      GatherMap[] maps = left.conditionalInnerJoinGatherMaps(right, condition);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -1866,7 +1866,7 @@ public class TableTest extends CudfTestBase {
 
   @Test
   void testConditionalInnerJoinGatherMapsNulls() {
-    BinaryOperation expr = new BinaryOperation(BinaryOperator.EQUAL,
+    BinaryOperation expr = new BinaryOperation(BinaryOperator.NULL_EQUAL,
         new ColumnReference(0, TableReference.LEFT),
         new ColumnReference(0, TableReference.RIGHT));
     try (Table left = new Table.TestBuilder()
@@ -1880,7 +1880,7 @@ public class TableTest extends CudfTestBase {
              .column(2, 0, 1, 0, 1, 3) // right
              .build();
          CompiledExpression condition = expr.compile()) {
-      GatherMap[] maps = left.conditionalInnerJoinGatherMaps(right, condition, true);
+      GatherMap[] maps = left.conditionalInnerJoinGatherMaps(right, condition);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -1905,9 +1905,9 @@ public class TableTest extends CudfTestBase {
              .column(0, 1, 3, 0, 1, 1, 0, 1)
              .build();
          CompiledExpression condition = expr.compile()) {
-      long rowCount = left.conditionalInnerJoinRowCount(right, condition, false);
+      long rowCount = left.conditionalInnerJoinRowCount(right, condition);
       assertEquals(expected.getRowCount(), rowCount);
-      GatherMap[] maps = left.conditionalInnerJoinGatherMaps(right, condition, false, rowCount);
+      GatherMap[] maps = left.conditionalInnerJoinGatherMaps(right, condition, rowCount);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -1920,7 +1920,7 @@ public class TableTest extends CudfTestBase {
 
   @Test
   void testConditionalInnerJoinGatherMapsNullsWithCount() {
-    BinaryOperation expr = new BinaryOperation(BinaryOperator.EQUAL,
+    BinaryOperation expr = new BinaryOperation(BinaryOperator.NULL_EQUAL,
         new ColumnReference(0, TableReference.LEFT),
         new ColumnReference(0, TableReference.RIGHT));
     try (Table left = new Table.TestBuilder()
@@ -1934,9 +1934,9 @@ public class TableTest extends CudfTestBase {
              .column(2, 0, 1, 0, 1, 3) // right
              .build();
          CompiledExpression condition = expr.compile()) {
-      long rowCount = left.conditionalInnerJoinRowCount(right, condition, true);
+      long rowCount = left.conditionalInnerJoinRowCount(right, condition);
       assertEquals(expected.getRowCount(), rowCount);
-      GatherMap[] maps = left.conditionalInnerJoinGatherMaps(right, condition, true, rowCount);
+      GatherMap[] maps = left.conditionalInnerJoinGatherMaps(right, condition, rowCount);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -2102,7 +2102,7 @@ public class TableTest extends CudfTestBase {
              .column(  2,   4,   5, inv, inv, 0, 1, 3, inv, inv, 0, 1, inv, 1, inv, 0, 1)
              .build();
          CompiledExpression condition = expr.compile()) {
-      GatherMap[] maps = left.conditionalFullJoinGatherMaps(right, condition, false);
+      GatherMap[] maps = left.conditionalFullJoinGatherMaps(right, condition);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -2116,7 +2116,7 @@ public class TableTest extends CudfTestBase {
   @Test
   void testConditionalFullJoinGatherMapsNulls() {
     final int inv = Integer.MIN_VALUE;
-    BinaryOperation expr = new BinaryOperation(BinaryOperator.EQUAL,
+    BinaryOperation expr = new BinaryOperation(BinaryOperator.NULL_EQUAL,
         new ColumnReference(0, TableReference.LEFT),
         new ColumnReference(0, TableReference.RIGHT));
     try (Table left = new Table.TestBuilder()
@@ -2130,7 +2130,7 @@ public class TableTest extends CudfTestBase {
              .column(  4,   5, inv, inv, 2, inv, inv, inv, inv, 0, 1, 0, 1, 3) // right
              .build();
          CompiledExpression condition = expr.compile()) {
-      GatherMap[] maps = left.conditionalFullJoinGatherMaps(right, condition, true);
+      GatherMap[] maps = left.conditionalFullJoinGatherMaps(right, condition);
       try {
         verifyJoinGatherMaps(maps, expected);
       } finally {
@@ -2182,14 +2182,14 @@ public class TableTest extends CudfTestBase {
              .column(2, 5, 7, 9) // left
              .build();
          CompiledExpression condition = expr.compile();
-         GatherMap map = left.conditionalLeftSemiJoinGatherMap(right, condition, false)) {
+         GatherMap map = left.conditionalLeftSemiJoinGatherMap(right, condition)) {
       verifySemiJoinGatherMap(map, expected);
     }
   }
 
   @Test
   void testConditionalLeftSemiJoinGatherMapNulls() {
-    BinaryOperation expr = new BinaryOperation(BinaryOperator.EQUAL,
+    BinaryOperation expr = new BinaryOperation(BinaryOperator.NULL_EQUAL,
         new ColumnReference(0, TableReference.LEFT),
         new ColumnReference(0, TableReference.RIGHT));
     try (Table left = new Table.TestBuilder()
@@ -2202,7 +2202,7 @@ public class TableTest extends CudfTestBase {
              .column(2, 7, 8, 9) // left
              .build();
          CompiledExpression condition = expr.compile();
-         GatherMap map = left.conditionalLeftSemiJoinGatherMap(right, condition, true)) {
+         GatherMap map = left.conditionalLeftSemiJoinGatherMap(right, condition)) {
       verifySemiJoinGatherMap(map, expected);
     }
   }
@@ -2220,10 +2220,10 @@ public class TableTest extends CudfTestBase {
              .column(2, 5, 7, 9) // left
              .build();
          CompiledExpression condition = expr.compile()) {
-      long rowCount = left.conditionalLeftSemiJoinRowCount(right, condition, false);
+      long rowCount = left.conditionalLeftSemiJoinRowCount(right, condition);
       assertEquals(expected.getRowCount(), rowCount);
       try (GatherMap map =
-               left.conditionalLeftSemiJoinGatherMap(right, condition, false, rowCount)) {
+               left.conditionalLeftSemiJoinGatherMap(right, condition, rowCount)) {
         verifySemiJoinGatherMap(map, expected);
       }
     }
@@ -2231,7 +2231,7 @@ public class TableTest extends CudfTestBase {
 
   @Test
   void testConditionalLeftSemiJoinGatherMapNullsWithCount() {
-    BinaryOperation expr = new BinaryOperation(BinaryOperator.EQUAL,
+    BinaryOperation expr = new BinaryOperation(BinaryOperator.NULL_EQUAL,
         new ColumnReference(0, TableReference.LEFT),
         new ColumnReference(0, TableReference.RIGHT));
     try (Table left = new Table.TestBuilder()
@@ -2244,10 +2244,10 @@ public class TableTest extends CudfTestBase {
              .column(2, 7, 8, 9) // left
              .build();
          CompiledExpression condition = expr.compile()) {
-      long rowCount = left.conditionalLeftSemiJoinRowCount(right, condition, true);
+      long rowCount = left.conditionalLeftSemiJoinRowCount(right, condition);
       assertEquals(expected.getRowCount(), rowCount);
       try (GatherMap map =
-               left.conditionalLeftSemiJoinGatherMap(right, condition, true, rowCount)) {
+               left.conditionalLeftSemiJoinGatherMap(right, condition, rowCount)) {
         verifySemiJoinGatherMap(map, expected);
       }
     }
@@ -2294,14 +2294,14 @@ public class TableTest extends CudfTestBase {
              .column(0, 1, 3, 4, 6, 8) // left
              .build();
          CompiledExpression condition = expr.compile();
-         GatherMap map = left.conditionalLeftAntiJoinGatherMap(right, condition, false)) {
+         GatherMap map = left.conditionalLeftAntiJoinGatherMap(right, condition)) {
       verifySemiJoinGatherMap(map, expected);
     }
   }
 
   @Test
   void testConditionalAntiSemiJoinGatherMapNulls() {
-    BinaryOperation expr = new BinaryOperation(BinaryOperator.EQUAL,
+    BinaryOperation expr = new BinaryOperation(BinaryOperator.NULL_EQUAL,
         new ColumnReference(0, TableReference.LEFT),
         new ColumnReference(0, TableReference.RIGHT));
     try (Table left = new Table.TestBuilder()
@@ -2314,7 +2314,7 @@ public class TableTest extends CudfTestBase {
              .column(0, 1, 3, 4, 5, 6) // left
              .build();
          CompiledExpression condition = expr.compile();
-         GatherMap map = left.conditionalLeftAntiJoinGatherMap(right, condition, true)) {
+         GatherMap map = left.conditionalLeftAntiJoinGatherMap(right, condition)) {
       verifySemiJoinGatherMap(map, expected);
     }
   }
@@ -2332,10 +2332,10 @@ public class TableTest extends CudfTestBase {
              .column(0, 1, 3, 4, 6, 8) // left
              .build();
          CompiledExpression condition = expr.compile()) {
-      long rowCount = left.conditionalLeftAntiJoinRowCount(right, condition, false);
+      long rowCount = left.conditionalLeftAntiJoinRowCount(right, condition);
       assertEquals(expected.getRowCount(), rowCount);
       try (GatherMap map =
-               left.conditionalLeftAntiJoinGatherMap(right, condition, false, rowCount)) {
+               left.conditionalLeftAntiJoinGatherMap(right, condition, rowCount)) {
         verifySemiJoinGatherMap(map, expected);
       }
     }
@@ -2343,7 +2343,7 @@ public class TableTest extends CudfTestBase {
 
   @Test
   void testConditionalAntiSemiJoinGatherMapNullsWithCount() {
-    BinaryOperation expr = new BinaryOperation(BinaryOperator.EQUAL,
+    BinaryOperation expr = new BinaryOperation(BinaryOperator.NULL_EQUAL,
         new ColumnReference(0, TableReference.LEFT),
         new ColumnReference(0, TableReference.RIGHT));
     try (Table left = new Table.TestBuilder()
@@ -2356,10 +2356,10 @@ public class TableTest extends CudfTestBase {
              .column(0, 1, 3, 4, 5, 6) // left
              .build();
          CompiledExpression condition = expr.compile()) {
-      long rowCount = left.conditionalLeftAntiJoinRowCount(right, condition, true);
+      long rowCount = left.conditionalLeftAntiJoinRowCount(right, condition);
       assertEquals(expected.getRowCount(), rowCount);
       try (GatherMap map =
-               left.conditionalLeftAntiJoinGatherMap(right, condition, true, rowCount)) {
+               left.conditionalLeftAntiJoinGatherMap(right, condition, rowCount)) {
         verifySemiJoinGatherMap(map, expected);
       }
     }

--- a/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
@@ -468,7 +468,7 @@ public class CompiledExpressionTest extends CudfTestBase {
     Integer[] in2 = new Integer[] { 123, -456, null, 0, -3 };
     return Stream.of(
         // nulls compare as equal by default
-        Arguments.of(BinaryOperator.EQUAL, in1, in2, Arrays.asList(false, false, true, false, true)),
+        Arguments.of(BinaryOperator.NULL_EQUAL, in1, in2, Arrays.asList(false, false, true, false, true)),
         Arguments.of(BinaryOperator.NOT_EQUAL, in1, in2, mapArray(in1, in2, (a, b) -> !a.equals(b))),
         Arguments.of(BinaryOperator.LESS, in1, in2, mapArray(in1, in2, (a, b) -> a < b)),
         Arguments.of(BinaryOperator.GREATER, in1, in2, mapArray(in1, in2, (a, b) -> a > b)),

--- a/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
@@ -518,11 +518,13 @@ public class CompiledExpressionTest extends CudfTestBase {
   }
 
   private static Stream<Arguments> createBinaryBooleanOperationParams() {
-    Boolean[] in1 = new Boolean[] { false, true, null, true, false };
-    Boolean[] in2 = new Boolean[] { true, null, null, true, false };
+    Boolean[] in1 = new Boolean[] { false, true, false, null, true, false };
+    Boolean[] in2 = new Boolean[] { true, null, null, null, true, false };
     return Stream.of(
         Arguments.of(BinaryOperator.LOGICAL_AND, in1, in2, mapArray(in1, in2, (a, b) -> a && b)),
-        Arguments.of(BinaryOperator.LOGICAL_OR, in1, in2, mapArray(in1, in2, (a, b) -> a || b)));
+        Arguments.of(BinaryOperator.LOGICAL_OR, in1, in2, mapArray(in1, in2, (a, b) -> a || b)),
+        Arguments.of(BinaryOperator.NULL_LOGICAL_AND, in1, in2, Arrays.asList(false, null, false, null, true, false)),
+        Arguments.of(BinaryOperator.NULL_LOGICAL_OR, in1, in2, Arrays.asList(true, true, null, null, true, false)));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
Contributes to #8980 and #8145.

This PR makes all `operator_functors` templated on the potential nullability of the inputs, allowing per-operator customization of null handling with minimal performance penalties. The default specialization in the nullable case is a null-propagating fall-through to the non-nullable case, which matches standard libcudf semantics, but any specific operator's null handling behavior can be customized by explicit specialization of the `operator_functor` template corresponding to that operator.

This PR implements `NULL_EQUAL`, `NULL_LOGICAL_AND`, and `NULL_LOGICAL_OR` operators that behave like their non-nullable counterparts when no nulls are present but can return non-null results from null inputs. The `NULL_EQUAL` operator replaces the `compare_nulls` parameter for conditional joins.