### PR TITLE
Fix cudf::hash_join output size for struct joins

### DIFF
--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -394,11 +394,11 @@ std::size_t hash_join::hash_join_impl::full_join_size(cudf::table_view const& pr
     probe, {}, {}, structs::detail::column_nullability::FORCE);
   auto const flattened_probe_table = std::get<0>(flattened_probe);
 
-  auto build_table             = cudf::table_device_view::create(_build, stream);
-  auto d_flattened_probe_table = cudf::table_device_view::create(flattened_probe_table, stream);
+  auto build_table_ptr           = cudf::table_device_view::create(_build, stream);
+  auto flattened_probe_table_ptr = cudf::table_device_view::create(flattened_probe_table, stream);
 
   return get_full_join_size(
-    *build_table, *d_flattened_probe_table, *_hash_table, compare_nulls, stream, mr);
+    *build_table_ptr, *flattened_probe_table_ptr, *_hash_table, compare_nulls, stream, mr);
 }
 
 template <cudf::detail::join_kind JoinKind>

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -353,11 +353,11 @@ std::size_t hash_join::hash_join_impl::inner_join_size(cudf::table_view const& p
     probe, {}, {}, structs::detail::column_nullability::FORCE);
   auto const flattened_probe_table = std::get<0>(flattened_probe);
 
-  auto build_table             = cudf::table_device_view::create(_build, stream);
-  auto d_flattened_probe_table = cudf::table_device_view::create(flattened_probe_table, stream);
+  auto build_table_ptr           = cudf::table_device_view::create(_build, stream);
+  auto flattened_probe_table_ptr = cudf::table_device_view::create(flattened_probe_table, stream);
 
   return cudf::detail::compute_join_output_size<cudf::detail::join_kind::INNER_JOIN>(
-    *build_table, *d_flattened_probe_table, *_hash_table, compare_nulls, stream);
+    *build_table_ptr, *flattened_probe_table_ptr, *_hash_table, compare_nulls, stream);
 }
 
 std::size_t hash_join::hash_join_impl::left_join_size(cudf::table_view const& probe,
@@ -373,11 +373,11 @@ std::size_t hash_join::hash_join_impl::left_join_size(cudf::table_view const& pr
     probe, {}, {}, structs::detail::column_nullability::FORCE);
   auto const flattened_probe_table = std::get<0>(flattened_probe);
 
-  auto build_table             = cudf::table_device_view::create(_build, stream);
-  auto d_flattened_probe_table = cudf::table_device_view::create(flattened_probe_table, stream);
+  auto build_table_ptr           = cudf::table_device_view::create(_build, stream);
+  auto flattened_probe_table_ptr = cudf::table_device_view::create(flattened_probe_table, stream);
 
   return cudf::detail::compute_join_output_size<cudf::detail::join_kind::LEFT_JOIN>(
-    *build_table, *d_flattened_probe_table, *_hash_table, compare_nulls, stream);
+    *build_table_ptr, *flattened_probe_table_ptr, *_hash_table, compare_nulls, stream);
 }
 
 std::size_t hash_join::hash_join_impl::full_join_size(cudf::table_view const& probe,

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -349,11 +349,15 @@ std::size_t hash_join::hash_join_impl::inner_join_size(cudf::table_view const& p
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(_hash_table, "Hash table of hash join is null.");
 
-  auto build_table = cudf::table_device_view::create(_build, stream);
-  auto probe_table = cudf::table_device_view::create(probe, stream);
+  auto flattened_probe = structs::detail::flatten_nested_columns(
+    probe, {}, {}, structs::detail::column_nullability::FORCE);
+  auto const flattened_probe_table = std::get<0>(flattened_probe);
+
+  auto build_table             = cudf::table_device_view::create(_build, stream);
+  auto d_flattened_probe_table = cudf::table_device_view::create(flattened_probe_table, stream);
 
   return cudf::detail::compute_join_output_size<cudf::detail::join_kind::INNER_JOIN>(
-    *build_table, *probe_table, *_hash_table, compare_nulls, stream);
+    *build_table, *d_flattened_probe_table, *_hash_table, compare_nulls, stream);
 }
 
 std::size_t hash_join::hash_join_impl::left_join_size(cudf::table_view const& probe,
@@ -365,11 +369,15 @@ std::size_t hash_join::hash_join_impl::left_join_size(cudf::table_view const& pr
   // Trivial left join case - exit early
   if (!_hash_table) { return probe.num_rows(); }
 
-  auto build_table = cudf::table_device_view::create(_build, stream);
-  auto probe_table = cudf::table_device_view::create(probe, stream);
+  auto flattened_probe = structs::detail::flatten_nested_columns(
+    probe, {}, {}, structs::detail::column_nullability::FORCE);
+  auto const flattened_probe_table = std::get<0>(flattened_probe);
+
+  auto build_table             = cudf::table_device_view::create(_build, stream);
+  auto d_flattened_probe_table = cudf::table_device_view::create(flattened_probe_table, stream);
 
   return cudf::detail::compute_join_output_size<cudf::detail::join_kind::LEFT_JOIN>(
-    *build_table, *probe_table, *_hash_table, compare_nulls, stream);
+    *build_table, *d_flattened_probe_table, *_hash_table, compare_nulls, stream);
 }
 
 std::size_t hash_join::hash_join_impl::full_join_size(cudf::table_view const& probe,
@@ -382,10 +390,15 @@ std::size_t hash_join::hash_join_impl::full_join_size(cudf::table_view const& pr
   // Trivial left join case - exit early
   if (!_hash_table) { return probe.num_rows(); }
 
-  auto build_table = cudf::table_device_view::create(_build, stream);
-  auto probe_table = cudf::table_device_view::create(probe, stream);
+  auto flattened_probe = structs::detail::flatten_nested_columns(
+    probe, {}, {}, structs::detail::column_nullability::FORCE);
+  auto const flattened_probe_table = std::get<0>(flattened_probe);
 
-  return get_full_join_size(*build_table, *probe_table, *_hash_table, compare_nulls, stream, mr);
+  auto build_table             = cudf::table_device_view::create(_build, stream);
+  auto d_flattened_probe_table = cudf::table_device_view::create(flattened_probe_table, stream);
+
+  return get_full_join_size(
+    *build_table, *d_flattened_probe_table, *_hash_table, compare_nulls, stream, mr);
 }
 
 template <cudf::detail::join_kind JoinKind>

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -1256,9 +1256,8 @@ TEST_F(JoinTest, HashJoinSequentialProbes)
     auto result = hash_join.full_join(t0, cudf::null_equality::EQUAL, optional_size);
     column_wrapper<int32_t> col_gold_0{{NoneValue, NoneValue, NoneValue, NoneValue, 4, 0, 1, 2, 3}};
     column_wrapper<int32_t> col_gold_1{{0, 1, 2, 3, 4, NoneValue, NoneValue, NoneValue, NoneValue}};
-
-    auto table_ptrs = gather_maps_as_tables(col_gold_0, col_gold_1, result);
-    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*table_ptrs.first, *table_ptrs.second);
+    auto const [sorted_gold, sorted_result] = gather_maps_as_tables(col_gold_0, col_gold_1, result);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*sorted_gold, *sorted_result);
   }
 
   {
@@ -1277,8 +1276,8 @@ TEST_F(JoinTest, HashJoinSequentialProbes)
     auto result = hash_join.left_join(t0, cudf::null_equality::EQUAL, optional_size);
     column_wrapper<int32_t> col_gold_0{{0, 1, 2, 3, 4}};
     column_wrapper<int32_t> col_gold_1{{NoneValue, NoneValue, NoneValue, NoneValue, 4}};
-    auto table_ptrs = gather_maps_as_tables(col_gold_0, col_gold_1, result);
-    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*table_ptrs.first, *table_ptrs.second);
+    auto const [sorted_gold, sorted_result] = gather_maps_as_tables(col_gold_0, col_gold_1, result);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*sorted_gold, *sorted_result);
   }
 
   {
@@ -1297,8 +1296,8 @@ TEST_F(JoinTest, HashJoinSequentialProbes)
     auto result = hash_join.inner_join(t0, cudf::null_equality::EQUAL, optional_size);
     column_wrapper<int32_t> col_gold_0{{2, 4, 0}};
     column_wrapper<int32_t> col_gold_1{{1, 1, 4}};
-    auto table_ptrs = gather_maps_as_tables(col_gold_0, col_gold_1, result);
-    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*table_ptrs.first, *table_ptrs.second);
+    auto const [sorted_gold, sorted_result] = gather_maps_as_tables(col_gold_0, col_gold_1, result);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*sorted_gold, *sorted_result);
   }
 }
 
@@ -1337,8 +1336,8 @@ TEST_F(JoinTest, HashJoinWithStructsAndNulls)
     auto result = hash_join.left_join(t0, cudf::null_equality::EQUAL, output_size);
     column_wrapper<int32_t> col_gold_0{{0, 1, 2, 3, 4}};
     column_wrapper<int32_t> col_gold_1{{0, NoneValue, 2, NoneValue, NoneValue}};
-    auto table_ptrs = gather_maps_as_tables(col_gold_0, col_gold_1, result);
-    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*table_ptrs.first, *table_ptrs.second);
+    auto const [sorted_gold, sorted_result] = gather_maps_as_tables(col_gold_0, col_gold_1, result);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*sorted_gold, *sorted_result);
   }
 
   {
@@ -1347,8 +1346,8 @@ TEST_F(JoinTest, HashJoinWithStructsAndNulls)
     auto result = hash_join.inner_join(t0, cudf::null_equality::EQUAL, output_size);
     column_wrapper<int32_t> col_gold_0{{0, 2}};
     column_wrapper<int32_t> col_gold_1{{0, 2}};
-    auto table_ptrs = gather_maps_as_tables(col_gold_0, col_gold_1, result);
-    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*table_ptrs.first, *table_ptrs.second);
+    auto const [sorted_gold, sorted_result] = gather_maps_as_tables(col_gold_0, col_gold_1, result);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*sorted_gold, *sorted_result);
   }
 
   {
@@ -1357,8 +1356,8 @@ TEST_F(JoinTest, HashJoinWithStructsAndNulls)
     auto result = hash_join.full_join(t0, cudf::null_equality::EQUAL, output_size);
     column_wrapper<int32_t> col_gold_0{{NoneValue, NoneValue, NoneValue, 0, 1, 2, 3, 4}};
     column_wrapper<int32_t> col_gold_1{{1, 3, 4, 0, NoneValue, 2, NoneValue, NoneValue}};
-    auto table_ptrs = gather_maps_as_tables(col_gold_0, col_gold_1, result);
-    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*table_ptrs.first, *table_ptrs.second);
+    auto const [sorted_gold, sorted_result] = gather_maps_as_tables(col_gold_0, col_gold_1, result);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*sorted_gold, *sorted_result);
   }
 }
 


### PR DESCRIPTION
Fixes #9095.

This adds calls to `flatten_nested_columns` in the `cudf::hash_join` join output size APIs along with tests for joins on struct columns using `cudf::hash_join`.