### PR TITLE
[REVIEW] Fix `read_csv` C++ import

### DIFF
--- a/python/cudf/cudf/_lib/cpp/io/csv.pxd
+++ b/python/cudf/cudf/_lib/cpp/io/csv.pxd
@@ -183,7 +183,7 @@ cdef extern from "cudf/io/csv.hpp" \
         csv_reader_options build() except+
 
     cdef cudf_io_types.table_with_metadata read_csv(
-        csv_reader_options &options
+        csv_reader_options options
     ) except +
 
     cdef cppclass csv_writer_options:


### PR DESCRIPTION
Some changes were recently made to the `io` system in #9040. It looks like the signature change of `read_csv` in the C++ code wasn't reported on the Cython layer. This PR should fix the problem.