### PR TITLE
Implement `interleave_columns` for lists with arbitrary nested type

### DIFF
--- a/cpp/src/lists/interleave_columns.cu
+++ b/cpp/src/lists/interleave_columns.cu
@@ -89,16 +89,6 @@ generate_list_offsets_and_validities(table_view const& input,
   return {std::move(list_offsets), std::move(validities)};
 }
 
-// Error case when no other overload or specialization is available
-template <typename T, typename Enable = void>
-struct interleave_list_entries_impl {
-  template <typename... Args>
-  std::unique_ptr<column> operator()(Args&&...)
-  {
-    CUDF_FAIL("Called `interleave_list_entries_fn()` on non-supported types.");
-  }
-};
-
 /**
  * @brief Concatenate all input columns into one column and gather its rows to generate an output
  * column that is the result of interleaving the input columns.
@@ -200,6 +190,16 @@ struct compute_string_sizes_and_interleave_lists_fn {
         thrust::copy(thrust::seq, input_ptr, input_ptr + end_byte - start_byte, output_ptr);
       }
     }
+  }
+};
+
+// Error case when no other overload or specialization is available
+template <typename T, typename Enable = void>
+struct interleave_list_entries_impl {
+  template <typename... Args>
+  std::unique_ptr<column> operator()(Args&&...)
+  {
+    CUDF_FAIL("Called `interleave_list_entries_fn()` on non-supported types.");
   }
 };
 

--- a/cpp/tests/reshape/interleave_columns_tests.cpp
+++ b/cpp/tests/reshape/interleave_columns_tests.cpp
@@ -27,8 +27,15 @@ using namespace cudf::test::iterators;
 
 namespace {
 constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::FIRST_ERROR};
-using StructsCol = cudf::test::structs_column_wrapper;
-using StringsCol = cudf::test::strings_column_wrapper;
+using TView       = cudf::table_view;
+using IntCol      = cudf::test::fixed_width_column_wrapper<int32_t>;
+using StructsCol  = cudf::test::structs_column_wrapper;
+using StringsCol  = cudf::test::strings_column_wrapper;
+using StrListsCol = cudf::test::lists_column_wrapper<cudf::string_view>;
+using IntListsCol = cudf::test::lists_column_wrapper<int32_t>;
+
+constexpr int32_t null{0};      // mark for null elements
+constexpr int32_t NOT_USE{-1};  // mark for elements that we don't care
 }  // namespace
 
 template <typename T>
@@ -377,15 +384,6 @@ TYPED_TEST(FixedPointTestBothReps, FixedPointInterleave)
   }
 }
 
-namespace {
-using StrListsCol = cudf::test::lists_column_wrapper<cudf::string_view>;
-using IntListsCol = cudf::test::lists_column_wrapper<int32_t>;
-using IntCol      = cudf::test::fixed_width_column_wrapper<int32_t>;
-using TView       = cudf::table_view;
-
-constexpr int32_t null{0};  // mark for null elements
-}  // namespace
-
 struct ListsColumnsInterleaveTest : public cudf::test::BaseFixture {
 };
 
@@ -692,7 +690,7 @@ TYPED_TEST(ListsColumnsInterleaveTypedTest, SlicedColumnsInputNullableChild)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, verbosity);
 }
 
-TYPED_TEST(ListsColumnsInterleaveTypedTest, InputListsofListsColumnNoNull)
+TYPED_TEST(ListsColumnsInterleaveTypedTest, InputListsOfListsNoNull)
 {
   using ListsCol = cudf::test::lists_column_wrapper<TypeParam>;
 
@@ -715,7 +713,125 @@ TYPED_TEST(ListsColumnsInterleaveTypedTest, InputListsofListsColumnNoNull)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, verbosity);
 }
 
-TYPED_TEST(ListsColumnsInterleaveTypedTest, InputListsofStructsColumnNoNull)
+TYPED_TEST(ListsColumnsInterleaveTypedTest, InputListsOfListsWithNulls)
+{
+  using ListsCol = cudf::test::lists_column_wrapper<TypeParam>;
+
+  auto const col1 = ListsCol{
+    ListsCol{ListsCol{{null, 2, 3}, null_at(0)}, ListsCol{{4, null, null}, nulls_at({1, 2})}},
+    ListsCol{{ListsCol{7, 8}, ListsCol{9, 10}, ListsCol{null, null, null} /*NULL*/}, null_at(2)},
+    ListsCol{ListsCol{11, 12, 13}, ListsCol{{14, null}, null_at(1)}, ListsCol{16, 17}}};
+  auto const col2 =
+    ListsCol{ListsCol{{ListsCol{11, 12, 13}, ListsCol{null, null} /*NULL*/}, null_at(1)},
+             ListsCol{ListsCol{17, 18}, ListsCol{{19, 110, null}, null_at(2)}},
+             ListsCol{ListsCol{111, 112, 13}, ListsCol{114, 115}, ListsCol{116, 117}}};
+  auto const expected = ListsCol{
+    ListsCol{ListsCol{{null, 2, 3}, null_at(0)}, ListsCol{{4, null, null}, nulls_at({1, 2})}},
+    ListsCol{{ListsCol{11, 12, 13}, ListsCol{null, null} /*NULL*/}, null_at(1)},
+    ListsCol{{ListsCol{7, 8}, ListsCol{9, 10}, ListsCol{null, null, null} /*NULL*/}, null_at(2)},
+    ListsCol{ListsCol{17, 18}, ListsCol{{19, 110, null}, null_at(2)}},
+    ListsCol{ListsCol{11, 12, 13}, ListsCol{{14, null}, null_at(1)}, ListsCol{16, 17}},
+    ListsCol{
+      ListsCol{111, 112, 13},
+      ListsCol{114, 115},
+      ListsCol{116, 117}}}.release();
+  auto const results = cudf::interleave_columns(TView{{col1, col2}});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, verbosity);
+}
+
+TYPED_TEST(ListsColumnsInterleaveTypedTest, SlicedInputListsOfListsNoNull)
+{
+  using ListsCol = cudf::test::lists_column_wrapper<TypeParam>;
+
+  auto const col1_original = ListsCol{
+    ListsCol{ListsCol{11, 11, 11}, ListsCol{22}, ListsCol{33, 33, 33}},  // don't care
+    ListsCol{ListsCol{11, 11, 11}, ListsCol{22}, ListsCol{33, 33, 33}},  // don't care
+    //
+    ListsCol{ListsCol{1, 2, 3}, ListsCol{4, 5, 6}},
+    ListsCol{ListsCol{7, 8}, ListsCol{9, 10}},
+    ListsCol{ListsCol{11, 12, 13}, ListsCol{14, 15}, ListsCol{16, 17}},
+    //
+    ListsCol{ListsCol{11, 11, 11}, ListsCol{22}, ListsCol{33, 33, 33}},  // don't care
+    ListsCol{ListsCol{11, 11, 11}, ListsCol{22}, ListsCol{33, 33, 33}}   // don't care
+  };
+  auto const col2_original = ListsCol{
+    ListsCol{ListsCol{11, 12, 13}, ListsCol{14, 15, 16}},
+    ListsCol{ListsCol{17, 18}, ListsCol{19, 110}},
+    ListsCol{ListsCol{111, 112, 13}, ListsCol{114, 115}, ListsCol{116, 117}},
+    //
+    ListsCol{ListsCol{11, 11, 11}, ListsCol{22}, ListsCol{33, 33, 33}}  // don't care
+  };
+
+  auto const col1 = cudf::slice(col1_original, {2, 5})[0];
+  auto const col2 = cudf::slice(col2_original, {0, 3})[0];
+  auto const expected =
+    ListsCol{ListsCol{ListsCol{1, 2, 3}, ListsCol{4, 5, 6}},
+             ListsCol{ListsCol{11, 12, 13}, ListsCol{14, 15, 16}},
+             ListsCol{ListsCol{7, 8}, ListsCol{9, 10}},
+             ListsCol{ListsCol{17, 18}, ListsCol{19, 110}},
+             ListsCol{ListsCol{11, 12, 13}, ListsCol{14, 15}, ListsCol{16, 17}},
+             ListsCol{ListsCol{111, 112, 13}, ListsCol{114, 115}, ListsCol{116, 117}}}
+      .release();
+  auto const results = cudf::interleave_columns(TView{{col1, col2}});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, verbosity);
+}
+
+TYPED_TEST(ListsColumnsInterleaveTypedTest, SlicedInputListsOfListsWithNulls)
+{
+  using ListsCol = cudf::test::lists_column_wrapper<TypeParam>;
+
+  auto const col1_original = ListsCol{
+    {
+      ListsCol{ListsCol{{null, 11}, null_at(0)},
+               ListsCol{{22, null, null}, nulls_at({1, 2})}},  // don't care
+      ListsCol{ListsCol{{null, 11}, null_at(0)},
+               ListsCol{{22, null, null}, nulls_at({1, 2})}},  // don't care
+      ListsCol{ListsCol{{null, 11}, null_at(0)},
+               ListsCol{{22, null, null}, nulls_at({1, 2})}},  // don't care
+      //
+      ListsCol{ListsCol{{null, 2, 3}, null_at(0)}, ListsCol{{4, null, null}, nulls_at({1, 2})}},
+      ListsCol{{ListsCol{7, 8}, ListsCol{9, 10}, ListsCol{null, null, null} /*NULL*/}, null_at(2)},
+      ListsCol{ListsCol{11, 12, 13}, ListsCol{{14, null}, null_at(1)}, ListsCol{16, 17}},
+      //
+      ListsCol{ListsCol{{null, 11}, null_at(0)},
+               ListsCol{{22, null, null}, nulls_at({1, 2})}}  // don't care
+    },
+    nulls_at({0, 2, 3})};
+  auto const col2_original = ListsCol{
+    ListsCol{ListsCol{{null, 11}, null_at(0)},
+             ListsCol{{22, null, null}, nulls_at({1, 2})}},  // don't care
+    ListsCol{ListsCol{{null, 11}, null_at(0)},
+             ListsCol{{22, null, null}, nulls_at({1, 2})}},  // don't care
+                                                             //
+    ListsCol{{ListsCol{11, 12, 13}, ListsCol{null, null} /*NULL*/}, null_at(1)},
+    ListsCol{ListsCol{17, 18}, ListsCol{{19, 110, null}, null_at(2)}},
+    ListsCol{ListsCol{111, 112, 13}, ListsCol{114, 115}, ListsCol{116, 117}},
+    ListsCol{ListsCol{{null, 11}, null_at(0)},
+             //
+             ListsCol{{22, null, null}, nulls_at({1, 2})}},  // don't care
+    ListsCol{ListsCol{{null, 11}, null_at(0)},
+             ListsCol{{22, null, null}, nulls_at({1, 2})}},  // don't care
+    ListsCol{ListsCol{{null, 11}, null_at(0)},
+             ListsCol{{22, null, null}, nulls_at({1, 2})}}  // don't care
+  };
+
+  auto const col1 = cudf::slice(col1_original, {3, 6})[0];
+  auto const col2 = cudf::slice(col2_original, {2, 5})[0];
+  auto const expected =
+    ListsCol{
+      {ListsCol{ListsCol{{null, 2, 3}, null_at(0)}, ListsCol{{4, null, null}, nulls_at({1, 2})}},
+       ListsCol{{ListsCol{11, 12, 13}, ListsCol{null, null} /*NULL*/}, null_at(1)},
+       ListsCol{{ListsCol{7, 8}, ListsCol{9, 10}, ListsCol{null, null, null} /*NULL*/}, null_at(2)},
+       ListsCol{ListsCol{17, 18}, ListsCol{{19, 110, null}, null_at(2)}},
+       ListsCol{ListsCol{11, 12, 13}, ListsCol{{14, null}, null_at(1)}, ListsCol{16, 17}},
+       ListsCol{ListsCol{111, 112, 13}, ListsCol{114, 115}, ListsCol{116, 117}}},
+      null_at(0)}
+      .release();
+  auto const results = cudf::interleave_columns(TView{{col1, col2}});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, verbosity);
+}
+
+TYPED_TEST(ListsColumnsInterleaveTypedTest, InputListsOfStructsNoNull)
 {
   using ColWrapper = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
 
@@ -748,6 +864,140 @@ TYPED_TEST(ListsColumnsInterleaveTypedTest, InputListsofStructsColumnNoNull)
   auto const expected = cudf::make_lists_column(
     6, IntCol{0, 1, 4, 6, 7, 9, 10}.release(), structs_expected.release(), 0, {});
   auto const results = cudf::interleave_columns(TView{{col1->view(), col2->view()}});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, verbosity);
+}
+
+TYPED_TEST(ListsColumnsInterleaveTypedTest, InputListsOfStructsWithNulls)
+{
+  using ColWrapper = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
+
+  auto structs1 = [] {
+    auto child1 = ColWrapper{{1, 2, null, 4, 5}, null_at(2)};
+    auto child2 = ColWrapper{{6, 7, 8, 9, null}, null_at(4)};
+    auto child3 = StringsCol{"Banana", "Mango", "Apple", "Cherry", "Kiwi"};
+    return StructsCol{{child1, child2, child3}, null_at(0)};
+  }();
+
+  auto structs2 = [] {
+    auto child1 = ColWrapper{11, 12, 13, 14, 15};
+    auto child2 = ColWrapper{{null, 17, 18, 19, 110}, null_at(0)};
+    auto child3 = StringsCol{{"" /*NULL*/, "Duck", "Cat", "Dog", "" /*NULL*/}, nulls_at({0, 4})};
+    return StructsCol{{child1, child2, child3}};
+  }();
+
+  auto structs_expected = [] {
+    auto child1 = ColWrapper{{1, 11, 12, 13, 2, null, 14, 4, 5, 15}, null_at(5)};
+    auto child2 = ColWrapper{{6, null, 17, 18, 7, 8, 19, 9, null, 110}, nulls_at({1, 8})};
+    auto child3 = StringsCol{{"Banana",
+                              "" /*NULL*/,
+                              "Duck",
+                              "Cat",
+                              "Mango",
+                              "Apple",
+                              "Dog",
+                              "Cherry",
+                              "Kiwi",
+                              "" /*NULL*/},
+                             nulls_at({1, 9})};
+    return StructsCol{{child1, child2, child3}, null_at(0)};
+  }();
+
+  auto const col1 =
+    cudf::make_lists_column(3, IntCol{0, 1, 3, 5}.release(), structs1.release(), 0, {});
+  auto const col2 =
+    cudf::make_lists_column(3, IntCol{0, 3, 4, 5}.release(), structs2.release(), 0, {});
+  auto const expected = cudf::make_lists_column(
+    6, IntCol{0, 1, 4, 6, 7, 9, 10}.release(), structs_expected.release(), 0, {});
+  auto const results = cudf::interleave_columns(TView{{col1->view(), col2->view()}});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, verbosity);
+}
+
+TYPED_TEST(ListsColumnsInterleaveTypedTest, SlicedInputListsOfStructsNoNull)
+{
+  using ColWrapper = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
+
+  auto structs1 = [] {
+    auto child1 = ColWrapper{NOT_USE, NOT_USE, 1, 2, 3, 4, 5, NOT_USE};
+    auto child2 = ColWrapper{NOT_USE, NOT_USE, 6, 7, 8, 9, 10, NOT_USE};
+    auto child3 =
+      StringsCol{"NOT_USE", "NOT_USE", "Banana", "Mango", "Apple", "Cherry", "Kiwi", "NOT_USE"};
+    return StructsCol{{child1, child2, child3}};
+  }();
+
+  auto structs2 = [] {
+    auto child1 = ColWrapper{11, 12, 13, 14, 15, NOT_USE, NOT_USE};
+    auto child2 = ColWrapper{16, 17, 18, 19, 110, NOT_USE, NOT_USE};
+    auto child3 = StringsCol{"Bear", "Duck", "Cat", "Dog", "Panda", "NOT_USE", "NOT_USE"};
+    return StructsCol{{child1, child2, child3}};
+  }();
+
+  auto structs_expected = [] {
+    auto child1 = ColWrapper{1, 11, 12, 13, 2, 3, 14, 4, 5, 15};
+    auto child2 = ColWrapper{6, 16, 17, 18, 7, 8, 19, 9, 10, 110};
+    auto child3 = StringsCol{
+      "Banana", "Bear", "Duck", "Cat", "Mango", "Apple", "Dog", "Cherry", "Kiwi", "Panda"};
+    return StructsCol{{child1, child2, child3}};
+  }();
+
+  auto const col1_original =
+    cudf::make_lists_column(5, IntCol{0, 2, 3, 5, 7, 8}.release(), structs1.release(), 0, {});
+  auto const col2_original =
+    cudf::make_lists_column(4, IntCol{0, 3, 4, 5, 7}.release(), structs2.release(), 0, {});
+  auto const expected = cudf::make_lists_column(
+    6, IntCol{0, 1, 4, 6, 7, 9, 10}.release(), structs_expected.release(), 0, {});
+
+  auto const col1    = cudf::slice(col1_original->view(), {1, 4})[0];
+  auto const col2    = cudf::slice(col2_original->view(), {0, 3})[0];
+  auto const results = cudf::interleave_columns(TView{{col1, col2}});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, verbosity);
+}
+
+TYPED_TEST(ListsColumnsInterleaveTypedTest, SlicedInputListsOfStructsWithNulls)
+{
+  using ColWrapper = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
+
+  auto structs1 = [] {
+    auto child1 = ColWrapper{{NOT_USE, 1, 2, null, 4, 5, NOT_USE}, nulls_at({0, 3})};
+    auto child2 = ColWrapper{{NOT_USE, 6, 7, 8, 9, null, NOT_USE}, null_at(5)};
+    auto child3 = StringsCol{"NOT_USE", "Banana", "Mango", "Apple", "Cherry", "Kiwi", "NOT_USE"};
+    return StructsCol{{child1, child2, child3}, nulls_at({1, 6})};
+  }();
+
+  auto structs2 = [] {
+    auto child1 = ColWrapper{{NOT_USE, 11, 12, 13, 14, 15}, null_at(0)};
+    auto child2 = ColWrapper{{NOT_USE, null, 17, 18, 19, 110}, null_at(1)};
+    auto child3 =
+      StringsCol{{"NOT_USE", "" /*NULL*/, "Duck", "Cat", "Dog", "" /*NULL*/}, nulls_at({0, 1, 5})};
+    return StructsCol{{child1, child2, child3}};
+  }();
+
+  auto structs_expected = [] {
+    auto child1 = ColWrapper{{1, 11, 12, 13, 2, null, 14, 4, 5, 15}, null_at(5)};
+    auto child2 = ColWrapper{{6, null, 17, 18, 7, 8, 19, 9, null, 110}, nulls_at({1, 8})};
+    auto child3 = StringsCol{{"Banana",
+                              "" /*NULL*/,
+                              "Duck",
+                              "Cat",
+                              "Mango",
+                              "Apple",
+                              "Dog",
+                              "Cherry",
+                              "Kiwi",
+                              "" /*NULL*/},
+                             nulls_at({1, 9})};
+    return StructsCol{{child1, child2, child3}, null_at(0)};
+  }();
+
+  auto const col1_original =
+    cudf::make_lists_column(5, IntCol{0, 1, 2, 4, 6, 7}.release(), structs1.release(), 0, {});
+  auto const col2_original =
+    cudf::make_lists_column(4, IntCol{0, 1, 4, 5, 6}.release(), structs2.release(), 0, {});
+
+  auto const col1     = cudf::slice(col1_original->view(), {1, 4})[0];
+  auto const col2     = cudf::slice(col2_original->view(), {1, 4})[0];
+  auto const expected = cudf::make_lists_column(
+    6, IntCol{0, 1, 4, 6, 7, 9, 10}.release(), structs_expected.release(), 0, {});
+  auto const results = cudf::interleave_columns(TView{{col1, col2}});
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results, verbosity);
 }
 
@@ -1031,7 +1281,6 @@ TYPED_TEST(StructsColumnsInterleaveTypedTest, NestedInputStructsColumns)
 TYPED_TEST(StructsColumnsInterleaveTypedTest, SlicedColumnsInputNoNull)
 {
   using ColWrapper = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
-  constexpr int32_t NOT_USE{-1};  // mark for elements that we don't care
 
   auto const structs1_original = [] {
     auto child1 = ColWrapper{NOT_USE, NOT_USE, 1, 2, 3, NOT_USE};


### PR DESCRIPTION
This PR adds more support for lists column in the `interleave_column` API. In particular, it adds nested types support for the list entries. As such, now we can call `interleave_column` on a lists column of any type such as lists of structs, lists of lists, lists of lists of lists and so on. In addition, this PR also does a simple refactor of the existing overload functions with a new style of SFINAE implementation.

Closes #9106.