### PR TITLE
Fix joining on indexes with duplicate level names

### DIFF
--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -208,7 +208,7 @@ class Merge(object):
                 left_keys.extend(
                     [
                         _Indexer(name=on, index=True)
-                        for on in self.lhs.index.names
+                        for on in self.lhs.index._data.names
                     ]
                 )
             if self.left_on:
@@ -223,7 +223,7 @@ class Merge(object):
                 right_keys.extend(
                     [
                         _Indexer(name=on, index=True)
-                        for on in self.rhs.index.names
+                        for on in self.rhs.index._data.names
                     ]
                 )
             if self.right_on:

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1524,9 +1524,14 @@ class MultiIndex(BaseIndex):
         if not isinstance(multiindex, pd.MultiIndex):
             raise TypeError("not a pandas.MultiIndex")
 
+        names = multiindex.names
+        if not len(multiindex.names) == len(set(multiindex.names)):
+            # non-unique names
+            names = tuple(range(len(names)))
+
         mi = cls(
             names=multiindex.names,
-            source_data=multiindex.to_frame(),
+            source_data=multiindex.to_frame(name=names),
             nan_as_null=nan_as_null,
         )
 

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1524,10 +1524,13 @@ class MultiIndex(BaseIndex):
         if not isinstance(multiindex, pd.MultiIndex):
             raise TypeError("not a pandas.MultiIndex")
 
-        names = multiindex.names
-        if not len(multiindex.names) == len(set(multiindex.names)):
-            # non-unique names
-            names = tuple(range(len(names)))
+        # if `multiindex` has two or more levels that
+        # have the same name, then `multiindex.to_frame()`
+        # results in a DataFrame containing only one of those
+        # levels. Thus, set `names` to some tuple of unique values
+        # and then call `multiindex.to_frame(name=names)`,
+        # which preserves all levels of `multiindex`.
+        names = tuple(range(len(multiindex.names)))
 
         mi = cls(
             names=multiindex.names,


### PR DESCRIPTION
Previously, joining on indexes with duplicate level names yielded an error:

```python
In [9]: lhs
Out[9]:
     a
x x
1 1  1
  2  2
  3  3

In [10]: rhs
Out[10]:
     b
x x
1 1  1
  4  2
  3  3

In [11]: lhs.join(rhs) # KeyError
```