### PR TITLE
Remove unneeded stream/mr from a cudf::make_strings_column

### DIFF
--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -420,27 +420,21 @@ std::unique_ptr<column> make_strings_column(
  *
  * The columns and mask are moved into the resulting strings column.
  *
- * @param[in] num_strings The number of strings the column represents.
- * @param[in] offsets_column The column of offset values for this column. The number of elements is
+ * @param num_strings The number of strings the column represents.
+ * @param offsets_column The column of offset values for this column. The number of elements is
  *  one more than the total number of strings so the `offset[last] - offset[0]` is the total number
  *  of bytes in the strings vector.
- * @param[in] chars_column The column of char bytes for all the strings for this column. Individual
+ * @param chars_column The column of char bytes for all the strings for this column. Individual
  *  strings are identified by the offsets and the nullmask.
- * @param[in] null_count The number of null string entries.
- * @param[in] null_mask The bits specifying the null strings in device memory. Arrow format for
+ * @param null_count The number of null string entries.
+ * @param null_mask The bits specifying the null strings in device memory. Arrow format for
  *  nulls is used for interpreting this bitmask.
- * @param[in] stream CUDA stream used for device memory operations and kernel launches.
- * @param[in] mr Device memory resource used for allocation of the column's `null_mask` and children
- * columns' device memory.
  */
-std::unique_ptr<column> make_strings_column(
-  size_type num_strings,
-  std::unique_ptr<column> offsets_column,
-  std::unique_ptr<column> chars_column,
-  size_type null_count,
-  rmm::device_buffer&& null_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> make_strings_column(size_type num_strings,
+                                            std::unique_ptr<column> offsets_column,
+                                            std::unique_ptr<column> chars_column,
+                                            size_type null_count,
+                                            rmm::device_buffer&& null_mask);
 
 /**
  * @brief Construct a STRING type column given offsets, columns, and optional null count and null

--- a/cpp/include/cudf/strings/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/strings/detail/copy_if_else.cuh
@@ -111,9 +111,7 @@ std::unique_ptr<cudf::column> copy_if_else(
                              std::move(offsets_column),
                              std::move(chars_column),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/include/cudf/strings/detail/copy_range.cuh
+++ b/cpp/include/cudf/strings/detail/copy_range.cuh
@@ -210,9 +210,7 @@ std::unique_ptr<column> copy_range(
                                std::move(p_offsets_column),
                                std::move(p_chars_column),
                                null_count,
-                               std::move(null_mask),
-                               stream,
-                               mr);
+                               std::move(null_mask));
   }
 }
 

--- a/cpp/include/cudf/strings/detail/gather.cuh
+++ b/cpp/include/cudf/strings/detail/gather.cuh
@@ -339,9 +339,7 @@ std::unique_ptr<cudf::column> gather(
                              std::move(out_offsets_column),
                              std::move(out_chars_column),
                              0,
-                             rmm::device_buffer{0, stream, mr},
-                             stream,
-                             mr);
+                             rmm::device_buffer{});
 }
 
 /**

--- a/cpp/include/cudf/strings/detail/merge.cuh
+++ b/cpp/include/cudf/strings/detail/merge.cuh
@@ -103,9 +103,7 @@ std::unique_ptr<column> merge(strings_column_view const& lhs,
                              std::move(offsets_column),
                              std::move(chars_column),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/include/cudf/strings/detail/scatter.cuh
+++ b/cpp/include/cudf/strings/detail/scatter.cuh
@@ -79,9 +79,7 @@ std::unique_ptr<column> scatter(
                              std::move(offsets_column),
                              std::move(chars_column),
                              UNKNOWN_NULL_COUNT,
-                             cudf::detail::copy_bitmask(target.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(target.parent(), stream, mr));
 }
 
 }  // namespace detail

--- a/cpp/include/cudf/strings/detail/strings_column_factories.cuh
+++ b/cpp/include/cudf/strings/detail/strings_column_factories.cuh
@@ -131,9 +131,7 @@ std::unique_ptr<column> make_strings_column(IndexPairIterator begin,
                              std::move(offsets_column),
                              std::move(chars_column),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 /**
@@ -189,9 +187,7 @@ std::unique_ptr<column> make_strings_column(CharIterator chars_begin,
                              std::move(offsets_column),
                              std::move(chars_column),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/hash/md5_hash.cu
+++ b/cpp/src/hash/md5_hash.cu
@@ -92,13 +92,8 @@ std::unique_ptr<column> md5_hash(table_view const& input,
                      hasher.finalize(&hash_state, d_chars + (row_index * 32));
                    });
 
-  return make_strings_column(input.num_rows(),
-                             std::move(offsets_column),
-                             std::move(chars_column),
-                             0,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+  return make_strings_column(
+    input.num_rows(), std::move(offsets_column), std::move(chars_column), 0, std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/interop/from_arrow.cu
+++ b/cpp/src/interop/from_arrow.cu
@@ -285,9 +285,7 @@ std::unique_ptr<column> dispatch_to_cudf_column::operator()<cudf::string_view>(
                                      std::move(offsets_column),
                                      std::move(chars_column),
                                      UNKNOWN_NULL_COUNT,
-                                     std::move(*get_mask_buffer(array, stream, mr)),
-                                     stream,
-                                     mr);
+                                     std::move(*get_mask_buffer(array, stream, mr)));
 
   return num_rows == array.length() ? std::move(out_col)
                                     : std::make_unique<column>(cudf::detail::slice(

--- a/cpp/src/io/csv/durations.cu
+++ b/cpp/src/io/csv/durations.cu
@@ -204,9 +204,7 @@ struct dispatch_from_durations_fn {
                                std::move(offsets_column),
                                std::move(chars_column),
                                durations.null_count(),
-                               std::move(null_mask),
-                               stream,
-                               mr);
+                               std::move(null_mask));
   }
 
   // non-duration types throw an exception

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -166,9 +166,7 @@ struct column_to_strings_fn {
                                std::move(children.first),
                                std::move(children.second),
                                column_v.null_count(),
-                               cudf::detail::copy_bitmask(column_v, stream_, mr_),
-                               stream_,
-                               mr_);
+                               cudf::detail::copy_bitmask(column_v, stream_, mr_));
   }
 
   // ints:

--- a/cpp/src/lists/copying/scatter_helper.cu
+++ b/cpp/src/lists/copying/scatter_helper.cu
@@ -279,10 +279,8 @@ struct list_child_constructor {
     return cudf::make_strings_column(num_child_rows,
                                      std::move(string_offsets),
                                      std::move(string_chars),
-                                     child_null_mask.second,            // Null count.
-                                     std::move(child_null_mask.first),  // Null mask.
-                                     stream,
-                                     mr);
+                                     child_null_mask.second,  // Null count.
+                                     std::move(child_null_mask.first));
   }
 
   /**

--- a/cpp/src/lists/interleave_columns.cu
+++ b/cpp/src/lists/interleave_columns.cu
@@ -189,9 +189,7 @@ struct interleave_list_entries_fn {
                                std::move(offsets_column),
                                std::move(chars_column),
                                null_count,
-                               std::move(null_mask),
-                               stream,
-                               mr);
+                               std::move(null_mask));
   }
 
   template <class T>

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -140,9 +140,7 @@ std::unique_ptr<cudf::column> clamp_string_column(strings_column_view const& inp
                              std::move(offsets_column),
                              std::move(chars_column),
                              input.null_count(),
-                             std::move(copy_bitmask(input.parent())),
-                             stream,
-                             mr);
+                             std::move(copy_bitmask(input.parent())));
 }
 
 template <typename T, typename OptionalScalarIterator, typename ReplaceScalarIterator>

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -270,9 +270,7 @@ std::unique_ptr<cudf::column> replace_nulls_column_kernel_forwarder::operator()<
                                    std::move(offsets),
                                    std::move(output_chars),
                                    input.size() - valid_counter.value(stream),
-                                   std::move(valid_bits),
-                                   stream,
-                                   mr);
+                                   std::move(valid_bits));
 }
 
 template <>

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -431,9 +431,7 @@ std::unique_ptr<cudf::column> replace_kernel_forwarder::operator()<cudf::string_
                                    std::move(offsets),
                                    std::move(output_chars),
                                    null_count,
-                                   std::move(valid_bits),
-                                   stream,
-                                   mr);
+                                   std::move(valid_bits));
 }
 
 template <>

--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -207,9 +207,7 @@ struct interleave_columns_impl<T, typename std::enable_if_t<std::is_same_v<T, cu
                                std::move(offsets_column),
                                std::move(chars_column),
                                null_count,
-                               std::move(valid_mask.first),
-                               stream,
-                               mr);
+                               std::move(valid_mask.first));
   }
 };
 

--- a/cpp/src/strings/capitalize.cu
+++ b/cpp/src/strings/capitalize.cu
@@ -199,9 +199,7 @@ std::unique_ptr<column> capitalizer(CapitalFn cfn,
                              std::move(children.first),
                              std::move(children.second),
                              input.null_count(),
-                             cudf::detail::copy_bitmask(input.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(input.parent(), stream, mr));
 }
 
 }  // namespace

--- a/cpp/src/strings/case.cu
+++ b/cpp/src/strings/case.cu
@@ -144,9 +144,7 @@ std::unique_ptr<column> convert_case(strings_column_view const& strings,
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 }  // namespace

--- a/cpp/src/strings/char_types/char_types.cu
+++ b/cpp/src/strings/char_types/char_types.cu
@@ -182,9 +182,7 @@ std::unique_ptr<column> filter_characters_of_type(strings_column_view const& str
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/combine/concatenate.cu
+++ b/cpp/src/strings/combine/concatenate.cu
@@ -156,9 +156,7 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
                              std::move(children.first),
                              std::move(children.second),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 namespace {
@@ -254,9 +252,7 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
                              std::move(children.first),
                              std::move(children.second),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/combine/join.cu
+++ b/cpp/src/strings/combine/join.cu
@@ -117,13 +117,8 @@ std::unique_ptr<column> join_strings(strings_column_view const& strings,
       if ((idx + 1) < d_strings.size()) d_buffer = detail::copy_string(d_buffer, d_separator);
     });
 
-  return make_strings_column(1,
-                             std::move(offsets_column),
-                             std::move(chars_column),
-                             null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+  return make_strings_column(
+    1, std::move(offsets_column), std::move(chars_column), null_count, std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/combine/join_list_elements.cu
+++ b/cpp/src/strings/combine/join_list_elements.cu
@@ -208,13 +208,8 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
                            stream,
                            mr);
 
-  return make_strings_column(num_rows,
-                             std::move(offsets_column),
-                             std::move(chars_column),
-                             null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+  return make_strings_column(
+    num_rows, std::move(offsets_column), std::move(chars_column), null_count, std::move(null_mask));
 }
 
 namespace {
@@ -288,13 +283,8 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
                            stream,
                            mr);
 
-  return make_strings_column(num_rows,
-                             std::move(offsets_column),
-                             std::move(chars_column),
-                             null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+  return make_strings_column(
+    num_rows, std::move(offsets_column), std::move(chars_column), null_count, std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -140,9 +140,7 @@ std::unique_ptr<column> from_booleans(column_view const& booleans,
                              std::move(offsets_column),
                              std::move(chars_column),
                              booleans.null_count(),
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -977,9 +977,7 @@ std::unique_ptr<column> from_timestamps(column_view const& timestamps,
                              std::move(offsets_column),
                              std::move(chars_column),
                              timestamps.null_count(),
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -441,9 +441,7 @@ struct dispatch_from_durations_fn {
                                std::move(offsets_column),
                                std::move(chars_column),
                                durations.null_count(),
-                               std::move(null_mask),
-                               stream,
-                               mr);
+                               std::move(null_mask));
   }
 
   // non-duration types throw an exception

--- a/cpp/src/strings/convert/convert_fixed_point.cu
+++ b/cpp/src/strings/convert/convert_fixed_point.cu
@@ -296,9 +296,7 @@ struct dispatch_from_fixed_point_fn {
                                std::move(offsets_column),
                                std::move(chars_column),
                                input.null_count(),
-                               cudf::detail::copy_bitmask(input, stream, mr),
-                               stream,
-                               mr);
+                               cudf::detail::copy_bitmask(input, stream, mr));
   }
 
   template <typename T, std::enable_if_t<not cudf::is_fixed_point<T>()>* = nullptr>

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -505,9 +505,7 @@ struct dispatch_from_floats_fn {
                                std::move(offsets_column),
                                std::move(chars_column),
                                floats.null_count(),
-                               std::move(null_mask),
-                               stream,
-                               mr);
+                               std::move(null_mask));
   }
 
   // non-float types throw an exception

--- a/cpp/src/strings/convert/convert_hex.cu
+++ b/cpp/src/strings/convert/convert_hex.cu
@@ -188,9 +188,7 @@ struct dispatch_integers_to_hex_fn {
                                std::move(children.first),
                                std::move(children.second),
                                input.null_count(),
-                               cudf::detail::copy_bitmask(input, stream, mr),
-                               stream,
-                               mr);
+                               cudf::detail::copy_bitmask(input, stream, mr));
   }
   // non-integral types throw an exception
   template <typename T, typename... Args>

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -362,9 +362,7 @@ struct dispatch_from_integers_fn {
                                std::move(offsets_column),
                                std::move(chars_column),
                                integers.null_count(),
-                               std::move(null_mask),
-                               stream,
-                               mr);
+                               std::move(null_mask));
   }
 
   // non-integral types throw an exception

--- a/cpp/src/strings/convert/convert_ipv4.cu
+++ b/cpp/src/strings/convert/convert_ipv4.cu
@@ -204,9 +204,7 @@ std::unique_ptr<column> integers_to_ipv4(
                              std::move(offsets_column),
                              std::move(chars_column),
                              integers.null_count(),
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 std::unique_ptr<column> is_ipv4(strings_column_view const& strings,

--- a/cpp/src/strings/convert/convert_urls.cu
+++ b/cpp/src/strings/convert/convert_urls.cu
@@ -153,9 +153,7 @@ std::unique_ptr<column> url_encode(
                              std::move(offsets_column),
                              std::move(chars_column),
                              strings.null_count(),
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail
@@ -412,9 +410,7 @@ std::unique_ptr<column> url_decode(
                              std::move(offsets_column),
                              std::move(chars_column),
                              strings.null_count(),
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -307,9 +307,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
                              std::move(offsets_column),
                              std::move(chars_column),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -71,9 +71,7 @@ std::unique_ptr<cudf::column> copy_slice(strings_column_view const& strings,
                              std::move(offsets_column),
                              std::move(chars_column),
                              UNKNOWN_NULL_COUNT,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/copying/shift.cu
+++ b/cpp/src/strings/copying/shift.cu
@@ -132,13 +132,8 @@ std::unique_ptr<column> shift(strings_column_view const& input,
                     shift_chars_fn{*d_input_chars, d_fill_str, shift_offset});
 
   // caller sets the null-mask
-  return make_strings_column(input.size(),
-                             std::move(offsets_column),
-                             std::move(chars_column),
-                             0,
-                             rmm::device_buffer{},
-                             stream,
-                             mr);
+  return make_strings_column(
+    input.size(), std::move(offsets_column), std::move(chars_column), 0, rmm::device_buffer{});
 }
 
 }  // namespace cudf::strings::detail

--- a/cpp/src/strings/filling/fill.cu
+++ b/cpp/src/strings/filling/fill.cu
@@ -98,9 +98,7 @@ std::unique_ptr<column> fill(
                              std::move(offsets_column),
                              std::move(chars_column),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/filter_chars.cu
+++ b/cpp/src/strings/filter_chars.cu
@@ -143,9 +143,7 @@ std::unique_ptr<column> filter_characters(
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -1038,9 +1038,7 @@ std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& c
                              std::move(offsets),
                              std::move(chars),
                              col.size() - d_valid_count.value(stream),
-                             std::move(validity),
-                             stream,
-                             mr);
+                             std::move(validity));
 }
 
 }  // namespace

--- a/cpp/src/strings/padding.cu
+++ b/cpp/src/strings/padding.cu
@@ -138,9 +138,7 @@ std::unique_ptr<column> pad(
                              std::move(offsets_column),
                              std::move(chars_column),
                              strings.null_count(),
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 //
@@ -194,9 +192,7 @@ std::unique_ptr<column> zfill(
                              std::move(offsets_column),
                              std::move(chars_column),
                              strings.null_count(),
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -87,9 +87,7 @@ auto generate_empty_output(strings_column_view const& input,
                              std::move(offsets_column),
                              std::move(chars_column),
                              input.null_count(),
-                             cudf::detail::copy_bitmask(input.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(input.parent(), stream, mr));
 }
 
 /**
@@ -163,9 +161,7 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
                              std::move(offsets_column),
                              std::move(chars_column),
                              input.null_count(),
-                             cudf::detail::copy_bitmask(input.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(input.parent(), stream, mr));
 }
 
 namespace {
@@ -330,9 +326,7 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
                              std::move(offsets_column),
                              std::move(chars_column),
                              UNKNOWN_NULL_COUNT,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 std::pair<std::unique_ptr<column>, int64_t> repeat_strings_output_sizes(

--- a/cpp/src/strings/replace/backref_re.cu
+++ b/cpp/src/strings/replace/backref_re.cu
@@ -164,9 +164,7 @@ std::unique_ptr<column> replace_with_backrefs(
                              std::move(offsets),
                              std::move(chars),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/replace/multi_re.cu
+++ b/cpp/src/strings/replace/multi_re.cu
@@ -206,9 +206,7 @@ std::unique_ptr<column> replace_re(
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/replace/replace.cu
+++ b/cpp/src/strings/replace/replace.cu
@@ -494,9 +494,7 @@ std::unique_ptr<column> replace_char_parallel(strings_column_view const& strings
                              std::move(offsets_column),
                              std::move(chars_column),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 /**
@@ -532,9 +530,7 @@ std::unique_ptr<column> replace_row_parallel(strings_column_view const& strings,
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 }  // namespace
@@ -699,9 +695,7 @@ std::unique_ptr<column> replace_slice(strings_column_view const& strings,
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 namespace {
@@ -787,9 +781,7 @@ std::unique_ptr<column> replace(strings_column_view const& strings,
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 std::unique_ptr<column> replace_nulls(strings_column_view const& strings,
@@ -830,13 +822,8 @@ std::unique_ptr<column> replace_nulls(strings_column_view const& strings,
                        memcpy(d_chars + d_offsets[idx], d_str.data(), d_str.size_bytes());
                      });
 
-  return make_strings_column(strings_count,
-                             std::move(offsets_column),
-                             std::move(chars_column),
-                             0,
-                             rmm::device_buffer{0, stream, mr},
-                             stream,
-                             mr);
+  return make_strings_column(
+    strings_count, std::move(offsets_column), std::move(chars_column), 0, rmm::device_buffer{});
 }
 
 }  // namespace detail

--- a/cpp/src/strings/replace/replace_re.cu
+++ b/cpp/src/strings/replace/replace_re.cu
@@ -158,9 +158,7 @@ std::unique_ptr<column> replace_re(
                              std::move(children.first),
                              std::move(children.second),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -114,9 +114,7 @@ std::unique_ptr<column> make_strings_column(size_type num_strings,
                                             std::unique_ptr<column> offsets_column,
                                             std::unique_ptr<column> chars_column,
                                             size_type null_count,
-                                            rmm::device_buffer&& null_mask,
-                                            rmm::cuda_stream_view stream,
-                                            rmm::mr::device_memory_resource* mr)
+                                            rmm::device_buffer&& null_mask)
 {
   CUDF_FUNC_RANGE();
 

--- a/cpp/src/strings/strip.cu
+++ b/cpp/src/strings/strip.cu
@@ -115,9 +115,7 @@ std::unique_ptr<column> strip(
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/substring.cu
+++ b/cpp/src/strings/substring.cu
@@ -125,9 +125,7 @@ std::unique_ptr<column> slice_strings(
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 }  // namespace detail
@@ -220,9 +218,7 @@ std::unique_ptr<column> compute_substrings_from_fn(column_device_view const& d_c
                              std::move(children.first),
                              std::move(children.second),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 /**

--- a/cpp/src/strings/translate.cu
+++ b/cpp/src/strings/translate.cu
@@ -117,9 +117,7 @@ std::unique_ptr<column> translate(
                              std::move(children.first),
                              std::move(children.second),
                              strings.null_count(),
-                             cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                             stream,
-                             mr);
+                             cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 }  // namespace detail

--- a/cpp/src/strings/wrap.cu
+++ b/cpp/src/strings/wrap.cu
@@ -125,9 +125,7 @@ std::unique_ptr<column> wrap(
                              std::move(offsets_column),
                              std::move(chars_column),
                              null_count,
-                             std::move(null_mask),
-                             stream,
-                             mr);
+                             std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/text/detokenize.cu
+++ b/cpp/src/text/detokenize.cu
@@ -185,13 +185,8 @@ std::unique_ptr<cudf::column> detokenize(cudf::strings_column_view const& string
   chars_column->set_null_count(0);
 
   // make the output strings column from the offsets and chars column
-  return cudf::make_strings_column(output_count,
-                                   std::move(offsets_column),
-                                   std::move(chars_column),
-                                   0,
-                                   rmm::device_buffer{0, stream, mr},
-                                   stream,
-                                   mr);
+  return cudf::make_strings_column(
+    output_count, std::move(offsets_column), std::move(chars_column), 0, rmm::device_buffer{});
 }
 
 }  // namespace detail

--- a/cpp/src/text/generate_ngrams.cu
+++ b/cpp/src/text/generate_ngrams.cu
@@ -134,13 +134,8 @@ std::unique_ptr<cudf::column> generate_ngrams(
     ngram_generator_fn{d_strings, ngrams, d_separator}, ngrams_count, stream, mr);
 
   // make the output strings column from the offsets and chars column
-  return cudf::make_strings_column(ngrams_count,
-                                   std::move(children.first),
-                                   std::move(children.second),
-                                   0,
-                                   rmm::device_buffer{0, stream, mr},
-                                   stream,
-                                   mr);
+  return cudf::make_strings_column(
+    ngrams_count, std::move(children.first), std::move(children.second), 0, rmm::device_buffer{});
 }
 
 }  // namespace detail
@@ -250,13 +245,8 @@ std::unique_ptr<cudf::column> generate_character_ngrams(cudf::strings_column_vie
                      strings_count,
                      generator);
 
-  return cudf::make_strings_column(total_ngrams,
-                                   std::move(offsets_column),
-                                   std::move(chars_column),
-                                   0,  // no nulls in the result
-                                   rmm::device_buffer{0, stream, mr},
-                                   stream,
-                                   mr);
+  return cudf::make_strings_column(
+    total_ngrams, std::move(offsets_column), std::move(chars_column), 0, rmm::device_buffer{});
 }
 
 }  // namespace detail

--- a/cpp/src/text/ngrams_tokenize.cu
+++ b/cpp/src/text/ngrams_tokenize.cu
@@ -243,13 +243,8 @@ std::unique_ptr<cudf::column> ngrams_tokenize(
   chars_column->set_null_count(0);
   offsets_column->set_null_count(0);
   // create the output strings column
-  return make_strings_column(total_ngrams,
-                             std::move(offsets_column),
-                             std::move(chars_column),
-                             0,
-                             rmm::device_buffer{0, stream, mr},
-                             stream,
-                             mr);
+  return make_strings_column(
+    total_ngrams, std::move(offsets_column), std::move(chars_column), 0, rmm::device_buffer{});
 }
 
 }  // namespace detail

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -185,9 +185,7 @@ std::unique_ptr<cudf::column> normalize_spaces(
                                    std::move(children.first),
                                    std::move(children.second),
                                    strings.null_count(),
-                                   cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                                   stream,
-                                   mr);
+                                   cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 /**
@@ -230,9 +228,7 @@ std::unique_ptr<cudf::column> normalize_characters(cudf::strings_column_view con
                                    std::move(children.first),
                                    std::move(children.second),
                                    strings.null_count(),
-                                   cudf::detail::copy_bitmask(strings.parent(), stream, mr),
-                                   stream,
-                                   mr);
+                                   cudf::detail::copy_bitmask(strings.parent(), stream, mr));
 }
 
 }  // namespace detail

--- a/cpp/src/text/replace.cu
+++ b/cpp/src/text/replace.cu
@@ -229,9 +229,7 @@ std::unique_ptr<cudf::column> replace_tokens(cudf::strings_column_view const& st
                                    std::move(children.first),
                                    std::move(children.second),
                                    strings.null_count(),
-                                   std::move(null_mask),
-                                   stream,
-                                   mr);
+                                   std::move(null_mask));
 }
 
 std::unique_ptr<cudf::column> filter_tokens(cudf::strings_column_view const& strings,
@@ -263,9 +261,7 @@ std::unique_ptr<cudf::column> filter_tokens(cudf::strings_column_view const& str
                                    std::move(children.first),
                                    std::move(children.second),
                                    strings.null_count(),
-                                   std::move(null_mask),
-                                   stream,
-                                   mr);
+                                   std::move(null_mask));
 }
 
 }  // namespace detail

--- a/cpp/src/text/tokenize.cu
+++ b/cpp/src/text/tokenize.cu
@@ -214,13 +214,8 @@ std::unique_ptr<cudf::column> character_tokenize(cudf::strings_column_view const
   auto chars_column = std::make_unique<cudf::column>(chars_view, stream, mr);
 
   // return new strings column
-  return cudf::make_strings_column(num_characters,
-                                   std::move(offsets_column),
-                                   std::move(chars_column),
-                                   0,
-                                   rmm::device_buffer{},
-                                   stream,
-                                   mr);
+  return cudf::make_strings_column(
+    num_characters, std::move(offsets_column), std::move(chars_column), 0, rmm::device_buffer{});
 }
 
 }  // namespace detail


### PR DESCRIPTION
During development of the text parser, we found a factory function that accepted a `stream` and `mr` parameters but did not actually need them. This PR removes the parameters and fixes any of the callers that passed these.
