### PR TITLE
Import rapids-cmake modules using the correct cmake variable.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -618,7 +618,7 @@ if(CUDF_BUILD_BENCHMARKS)
                         "BENCHMARK_ENABLE_INSTALL OFF")
 
     # Find or install NVBench
-    include(${rapids-cmake}/cpm/nvbench.cmake)
+    include(${rapids-cmake-dir}/cpm/nvbench.cmake)
     rapids_cpm_nvbench()
     add_subdirectory(benchmarks)
 endif()


### PR DESCRIPTION
Use `rapids-cmake-dir` when computing the location of rapids-cmake modules.

Corrects build errors that occur when `CUDF_BUILD_BENCHMARKS` is enabled.