### PR TITLE
Fix struct and list dtype logic in dask_cudf.read_parquet

### DIFF
--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -256,6 +256,9 @@ def set_object_dtypes_from_pa_schema(df, schema):
     # Simple utility to modify cudf DataFrame
     # "object" dtypes to agree with a specific
     # pyarrow schema.
+    #
+    # Note that this utility will NOT allow dtype
+    # casting for cudf-specific list or struct columns
     if schema:
         for name in df.columns:
             if name in schema.names and df[name].dtype == "O":

--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -259,9 +259,11 @@ def set_object_dtypes_from_pa_schema(df, schema):
     if schema:
         for name in df.columns:
             if name in schema.names and df[name].dtype == "O":
-                df[name] = df[name].astype(
-                    cudf_dtype_from_pa_type(schema.field(name).type)
-                )
+                typ = cudf_dtype_from_pa_type(schema.field(name).type)
+                if typ not in ("list", "struct"):
+                    df[name] = df[name].astype(
+                        cudf_dtype_from_pa_type(schema.field(name).type)
+                    )
 
 
 def read_parquet(

--- a/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
@@ -476,3 +476,21 @@ def test_create_metadata_file_inconsistent_schema(tmpdir):
     # before computing, and "int" after
     dd.assert_eq(ddf1.compute(), ddf2)
     dd.assert_eq(ddf1.compute(), ddf2.compute())
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [[0], [1, 2], [3]],
+        [None, [1, 2], [3]],
+        [{"f1": 1}, {"f1": 0, "f2": "dog"}, {"f2": "cat"}],
+        [None, {"f1": 0, "f2": "dog"}, {"f2": "cat"}],
+    ],
+)
+def test_cudf_dtypes_from_pandas(tmpdir, data):
+    # Simple test that we can read in list and struct types
+    fn = str(tmpdir.join("test.parquet"))
+    dfp = pd.DataFrame({"data": data})
+    dfp.to_parquet(fn, engine="pyarrow", index=True)
+    ddf2 = dask_cudf.read_parquet(fn)
+    dd.assert_eq(cudf.from_pandas(dfp), ddf2)


### PR DESCRIPTION
The `dask_cudf.read_parquet` logic currently uses a utility called `set_object_dtypes_from_pa_schema` to cast dtypes into proper cudf/pyarrow dtypes.  The same utility is used to both (1) "reset" `pandas.DataFrame` metadata to agree with the pyarrow schema, and (2) to cast `cudf.DataFrame` partitions to the "correct" dtypes at IO time.  In both cases, the `pd/cudf.DataFrame` columns cannot be cast to cudf list and/or struct columns.  Therefore, this PR simply adds a simpole check to avoid casting for list/struct dtypes.  We also add a new test (`test_cudf_dtypes_from_pandas`) to add test coverage for the original bug.
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
