### PR TITLE
Add handling for nulls in `dask_cudf.sorting.quantile_divisions`

### DIFF
--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -186,14 +186,9 @@ def quantile_divisions(df, by, npartitions):
         dtype = df[columns[0]].dtype
         divisions = divisions[columns[0]].astype("int64")
         divisions.iloc[-1] += 1
-        divisions = (
-            sorted(
-                divisions.dropna()
-                .drop_duplicates()
-                .astype(dtype)
-                .values.tolist()
-            )
-            + [None] * divisions.null_count
+        divisions = sorted(
+            divisions.drop_duplicates().astype(dtype).to_arrow().tolist(),
+            key=lambda x: (x is None, x),
         )
     else:
         for col in columns:

--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -186,8 +186,14 @@ def quantile_divisions(df, by, npartitions):
         dtype = df[columns[0]].dtype
         divisions = divisions[columns[0]].astype("int64")
         divisions.iloc[-1] += 1
-        divisions = sorted(
-            divisions.drop_duplicates().astype(dtype).values.tolist()
+        divisions = (
+            sorted(
+                divisions.dropna()
+                .drop_duplicates()
+                .astype(dtype)
+                .values.tolist()
+            )
+            + [None] * divisions.null_count
         )
     else:
         for col in columns:

--- a/python/dask_cudf/dask_cudf/tests/test_sort.py
+++ b/python/dask_cudf/dask_cudf/tests/test_sort.py
@@ -67,8 +67,7 @@ def test_sort_values_with_nulls(by):
     if isinstance(divisions, list):
         assert None in divisions
     else:
-        for col in by:
-            assert divisions[col].has_nulls
+        assert all([divisions[col].has_nulls for col in by])
 
     got = ddf.sort_values(by=by)
     expect = df.sort_values(by=by)

--- a/python/dask_cudf/dask_cudf/tests/test_sort.py
+++ b/python/dask_cudf/dask_cudf/tests/test_sort.py
@@ -7,6 +7,7 @@ from dask import dataframe as dd
 import cudf
 
 import dask_cudf
+from dask_cudf.sorting import quantile_divisions
 
 
 @pytest.mark.parametrize("by", ["a", "b", "c", "d", ["a", "b"], ["c", "d"]])
@@ -60,6 +61,14 @@ def test_sort_values_with_nulls(by):
         }
     )
     ddf = dd.from_pandas(df, npartitions=10)
+
+    # assert that quantile divisions of dataframe contains nulls
+    divisions = quantile_divisions(ddf, by, ddf.npartitions)
+    if isinstance(divisions, list):
+        assert None in divisions
+    else:
+        for col in by:
+            assert divisions[col].has_nulls
 
     got = ddf.sort_values(by=by)
     expect = df.sort_values(by=by)

--- a/python/dask_cudf/dask_cudf/tests/test_sort.py
+++ b/python/dask_cudf/dask_cudf/tests/test_sort.py
@@ -49,3 +49,19 @@ def test_sort_repartition():
     new_ddf = ddf.shuffle(on="a", ignore_index=True, npartitions=3)
 
     dd.assert_eq(len(new_ddf), len(ddf))
+
+
+@pytest.mark.parametrize("by", ["a", "b", ["a", "b"]])
+def test_sort_values_with_nulls(by):
+    df = cudf.DataFrame(
+        {
+            "a": list(range(50)) + [None] * 50 + list(range(50, 100)),
+            "b": [None] * 100 + list(range(100, 150)),
+        }
+    )
+    ddf = dd.from_pandas(df, npartitions=10)
+
+    got = ddf.sort_values(by=by)
+    expect = df.sort_values(by=by)
+
+    dd.assert_eq(got, expect)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

Closes #9157

Originally, `dask_cudf.DataFrame.sort_values` would fail if the DataFrame had enough null values that `divisions` contained nulls here:

https://github.com/rapidsai/cudf/blob/1935a8a9de87152e70b7930c911e0a44da0560cc/python/dask_cudf/dask_cudf/sorting.py#L189-L191

As you cannot get the `values` of a Series containing nulls; this PR drops the nulls from `divisions` before calling `values`, appending the correct amount to the resulting list afterwards to avoid this failure.