### PR TITLE
rapids-export correctly reference build code block and doc strings

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -735,7 +735,7 @@ rapids_export(BUILD cudf
     GLOBAL_TARGETS cudf
     NAMESPACE cudf::
     DOCUMENTATION doc_string
-    FINAL_CODE_BLOCK code_string)
+    FINAL_CODE_BLOCK build_code_string)
 
 export(EXPORT cudf-testing-exports
     FILE ${CUDF_BINARY_DIR}/cudf-testing.cmake

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -662,8 +662,6 @@ rapids_export_write_dependencies(INSTALL cudf-testing-exports
 
 set(doc_string
     [=[
-#[=======================================================================[
-
 Provide targets for the cudf library.
 
 Built based on the Apache Arrow columnar memory format, cuDF is a GPU DataFrame
@@ -687,19 +685,6 @@ This module offers an optional testing component which defines the
 following IMPORTED GLOBAL  targets:
 
  cudf::cudftestutil     - The main cudf testing library
-
-Result Variables
-^^^^^^^^^^^^^^^^
-
-This module will set the following variables in your project::
-
-  CUDF_FOUND
-  CUDF_VERSION
-  CUDF_VERSION_MAJOR
-  CUDF_VERSION_MINOR
-  CUDF_VERSION_PATCH
-
-#]=======================================================================]
     ]=])
 
 
@@ -726,6 +711,7 @@ rapids_export(INSTALL cudf
     EXPORT_SET cudf-exports
     GLOBAL_TARGETS cudf
     NAMESPACE cudf::
+    DOCUMENTATION doc_string
     FINAL_CODE_BLOCK install_code_string)
 
 ################################################################################################
@@ -748,6 +734,7 @@ rapids_export(BUILD cudf
     EXPORT_SET cudf-exports
     GLOBAL_TARGETS cudf
     NAMESPACE cudf::
+    DOCUMENTATION doc_string
     FINAL_CODE_BLOCK code_string)
 
 export(EXPORT cudf-testing-exports


### PR DESCRIPTION
The update to rapids-cmake, introduced two regressions that this PR fixes.

1. re-include the a documentation header to the cudf-config.cmake files describing the project
2. The build directory cudf-config.cmake properly recreates testing dependencies and the `cudf::Thrust` target