### PR TITLE
Only install thrust when using a non 'system' version

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -471,8 +471,8 @@ target_include_directories(cudf
                        "$<BUILD_INTERFACE:${CUDF_GENERATED_INCLUDE_DIR}/include>"
            PRIVATE     "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/src>"
            INTERFACE   "$<INSTALL_INTERFACE:include>"
-                       "$<INSTALL_INTERFACE:include/libcudf/libcudacxx>"
-                       "$<INSTALL_INTERFACE:include/libcudf/Thrust>")
+                       "$<INSTALL_INTERFACE:include/libcudf/libcudacxx>")
+
 
 target_compile_definitions(cudf
             PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_DEFINITIONS}>"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -471,8 +471,8 @@ target_include_directories(cudf
                        "$<BUILD_INTERFACE:${CUDF_GENERATED_INCLUDE_DIR}/include>"
            PRIVATE     "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/src>"
            INTERFACE   "$<INSTALL_INTERFACE:include>"
-                       "$<INSTALL_INTERFACE:include/libcudf/libcudacxx>")
-
+                       "$<INSTALL_INTERFACE:include/libcudf/libcudacxx>"
+                       "$<INSTALL_INTERFACE:include/libcudf/Thrust>")
 
 target_compile_definitions(cudf
             PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_DEFINITIONS}>"

--- a/cpp/cmake/thirdparty/get_thrust.cmake
+++ b/cpp/cmake/thirdparty/get_thrust.cmake
@@ -40,26 +40,28 @@ function(find_and_configure_thrust VERSION)
         thrust_create_target(cudf::Thrust FROM_OPTIONS)
     endif()
 
-    include(GNUInstallDirs)
-    install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust/"
-        FILES_MATCHING
-            PATTERN "*.h"
-            PATTERN "*.inl")
-    install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust/dependencies/"
-        FILES_MATCHING
-            PATTERN "*.cuh")
+    if(Thrust_SOURCE_DIR) # only install thrust when we have an in-source version
+        include(GNUInstallDirs)
+        install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust/"
+            FILES_MATCHING
+                PATTERN "*.h"
+                PATTERN "*.inl")
+        install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust/dependencies/"
+            FILES_MATCHING
+                PATTERN "*.cuh")
 
-    install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust/cmake"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust/thrust/")
-    install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub/cmake"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust/dependencies/cub/")
+        install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust/cmake"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust/thrust/")
+        install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub/cmake"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/Thrust/dependencies/cub/")
 
 
-    # Store where CMake can find our custom Thrust install
-    include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(INSTALL Thrust [=[${CMAKE_CURRENT_LIST_DIR}/../../../include/libcudf/Thrust/]=] cudf-exports)
+        # Store where CMake can find our custom Thrust install
+        include("${rapids-cmake-dir}/export/find_package_root.cmake")
+        rapids_export_find_package_root(INSTALL Thrust [=[${CMAKE_CURRENT_LIST_DIR}/../../../include/libcudf/Thrust/]=] cudf-exports)
+    endif()
 endfunction()
 
 set(CUDF_MIN_VERSION_Thrust 1.12.0)

--- a/cpp/cmake/thirdparty/get_thrust.cmake
+++ b/cpp/cmake/thirdparty/get_thrust.cmake
@@ -24,6 +24,13 @@ function(find_and_configure_thrust VERSION)
         set(cpm_thrust_disconnect_update "")
     endif()
 
+    # We currently require cuDF to always build with a custom
+    # version of thrust. This is needed so that build times of
+    # of cudf are kept reasonable, without this CI builds
+    # of cudf will be killed as some source file can take
+    # over 45 minutes to build
+    #
+    set(CPM_DOWNLOAD_ALL TRUE)
     rapids_cpm_find(
         Thrust ${VERSION}
         BUILD_EXPORT_SET cudf-exports


### PR DESCRIPTION
Previously cudf presumed that no system version of Thrust matched the version cudf required, but with the merger
of https://github.com/rapidsai/rmm/pull/854 this isn't true.
