### PR TITLE
Add access to cuda_async_memory_resource

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -82,11 +82,7 @@ public class Rmm {
    * call if a specific device is already set.
    * <p>NOTE: All cudf methods will set the chosen CUDA device in the CUDA
    * context of the calling thread after this returns.
-   * @param allocationMode Allocation strategy to use. Bit set using
-   *                       {@link RmmAllocationMode#CUDA_DEFAULT},
-   *                       {@link RmmAllocationMode#POOL},
-   *                       {@link RmmAllocationMode#ARENA} and
-   *                       {@link RmmAllocationMode#CUDA_MANAGED_MEMORY}
+   * @param allocationMode Allocation strategy to use. Bit set using {@link RmmAllocationMode}
    * @param enableLogging  Enable logging memory manager events
    * @param poolSize       The initial pool size in bytes
    * @throws IllegalStateException if RMM has already been initialized
@@ -103,11 +99,7 @@ public class Rmm {
    * call if a specific device is already set.
    * <p>NOTE: All cudf methods will set the chosen CUDA device in the CUDA
    * context of the calling thread after this returns.
-   * @param allocationMode Allocation strategy to use. Bit set using
-   *                       {@link RmmAllocationMode#CUDA_DEFAULT},
-   *                       {@link RmmAllocationMode#POOL},
-   *                       {@link RmmAllocationMode#ARENA} and
-   *                       {@link RmmAllocationMode#CUDA_MANAGED_MEMORY}
+   * @param allocationMode Allocation strategy to use. Bit set using {@link RmmAllocationMode}
    * @param enableLogging  Enable logging memory manager events
    * @param poolSize       The initial pool size in bytes
    * @param maxPoolSize    The maximum size the pool is allowed to grow. If the specified value
@@ -135,11 +127,7 @@ public class Rmm {
    * call if a specific device is already set.
    * <p>NOTE: All cudf methods will set the chosen CUDA device in the CUDA
    * context of the calling thread after this returns.
-   * @param allocationMode Allocation strategy to use. Bit set using
-   *                       {@link RmmAllocationMode#CUDA_DEFAULT},
-   *                       {@link RmmAllocationMode#POOL},
-   *                       {@link RmmAllocationMode#ARENA} and
-   *                       {@link RmmAllocationMode#CUDA_MANAGED_MEMORY}
+   * @param allocationMode Allocation strategy to use. Bit set using {@link RmmAllocationMode}
    * @param logConf        How to do logging or null if you don't want to
    * @param poolSize       The initial pool size in bytes
    * @throws IllegalStateException if RMM has already been initialized
@@ -156,19 +144,16 @@ public class Rmm {
    * call if a specific device is already set.
    * <p>NOTE: All cudf methods will set the chosen CUDA device in the CUDA
    * context of the calling thread after this returns.
-   * @param allocationMode Allocation strategy to use. Bit set using
-   *                       {@link RmmAllocationMode#CUDA_DEFAULT},
-   *                       {@link RmmAllocationMode#POOL},
-   *                       {@link RmmAllocationMode#ARENA} and
-   *                       {@link RmmAllocationMode#CUDA_MANAGED_MEMORY}
+   * @param allocationMode Allocation strategy to use. Bit set using {@link RmmAllocationMode}
    * @param logConf        How to do logging or null if you don't want to
    * @param poolSize       The initial pool size in bytes
    * @param maxPoolSize    The maximum size the pool is allowed to grow. If the specified value
    *                       is <= 0 then the pool size will not be artificially limited.
    * @throws IllegalStateException if RMM has already been initialized
    * @throws IllegalArgumentException if a max pool size is specified but the allocation mode
-   *                                  is not {@link RmmAllocationMode#POOL} or
-   *                                  {@link RmmAllocationMode#ARENA}, or the maximum pool size is
+   *                                  is not {@link RmmAllocationMode#POOL}
+   *                                  {@link RmmAllocationMode#ARENA},
+   *                                  {@link RmmAllocationMode#ASYNC} or the maximum pool size is
    *                                  below the initial size.
    */
   public static synchronized void initialize(int allocationMode, LogConf logConf, long poolSize,
@@ -183,11 +168,7 @@ public class Rmm {
    * call if a specific device is already set.
    * <p>NOTE: All cudf methods will set the chosen CUDA device in the CUDA
    * context of the calling thread after this returns.
-   * @param allocationMode Allocation strategy to use. Bit set using
-   *                       {@link RmmAllocationMode#CUDA_DEFAULT},
-   *                       {@link RmmAllocationMode#POOL},
-   *                       {@link RmmAllocationMode#ARENA} and
-   *                       {@link RmmAllocationMode#CUDA_MANAGED_MEMORY}
+   * @param allocationMode Allocation strategy to use. Bit set using {@link RmmAllocationMode}
    * @param logConf        How to do logging or null if you don't want to
    * @param poolSize       The initial pool size in bytes
    * @param maxPoolSize    The maximum size the pool is allowed to grow. If the specified value
@@ -197,8 +178,9 @@ public class Rmm {
    *                            are aligned with `allocationAlignment`.
    * @throws IllegalStateException if RMM has already been initialized
    * @throws IllegalArgumentException if a max pool size is specified but the allocation mode
-   *                                  is not {@link RmmAllocationMode#POOL} or
-   *                                  {@link RmmAllocationMode#ARENA}, or the maximum pool size is
+   *                                  is not {@link RmmAllocationMode#POOL}
+   *                                  {@link RmmAllocationMode#ARENA},
+   *                                  {@link RmmAllocationMode#ASYNC} or the maximum pool size is
    *                                  below the initial size.
    */
   public static synchronized void initialize(int allocationMode, LogConf logConf, long poolSize,
@@ -207,9 +189,11 @@ public class Rmm {
       throw new IllegalStateException("RMM is already initialized");
     }
     if (maxPoolSize > 0) {
-      if (allocationMode != RmmAllocationMode.POOL && allocationMode != RmmAllocationMode.ARENA) {
+      if (allocationMode != RmmAllocationMode.POOL &&
+          allocationMode != RmmAllocationMode.ARENA &&
+          allocationMode != RmmAllocationMode.ASYNC) {
         throw new IllegalArgumentException(
-                "Pool limit only supported in POOL or ARENA allocation mode");
+                "Pool limit only supported in POOL, ARENA, or ASYNC allocation mode");
       }
       if (maxPoolSize < poolSize) {
         throw new IllegalArgumentException("Pool limit of " + maxPoolSize

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -188,10 +188,12 @@ public class Rmm {
     if (initialized) {
       throw new IllegalStateException("RMM is already initialized");
     }
-    bool isPool = allocationMode & RmmAllocationMode.POOL;
-    bool isArena = allocationMode & RmmAllocationMode.ARENA;
-    bool isAsync = allocationMode & RmmAllocationMode.ASYNC;
-    bool isManaged = allocationMode & RmmAllocationMode.CUDA_MANAGED_MEMORY;
+
+    boolean isPool = (allocationMode & RmmAllocationMode.POOL) != 0;
+    boolean isArena = (allocationMode & RmmAllocationMode.ARENA) != 0;
+    boolean isAsync = (allocationMode & RmmAllocationMode.ASYNC) != 0;
+    boolean isManaged = (allocationMode & RmmAllocationMode.CUDA_MANAGED_MEMORY) != 0;
+
     if (maxPoolSize > 0) {
       if (!isPool && !isArena && !isAsync) { 
         throw new IllegalArgumentException(

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -188,10 +188,12 @@ public class Rmm {
     if (initialized) {
       throw new IllegalStateException("RMM is already initialized");
     }
+    bool isPool = allocationMode & RmmAllocationMode.POOL;
+    bool isArena = allocationMode & RmmAllocationMode.ARENA;
+    bool isAsync = allocationMode & RmmAllocationMode.ASYNC;
+    bool isManaged = allocationMode & RmmAllocationMode.CUDA_MANAGED_MEMORY;
     if (maxPoolSize > 0) {
-      if (allocationMode != RmmAllocationMode.POOL &&
-          allocationMode != RmmAllocationMode.ARENA &&
-          allocationMode != RmmAllocationMode.ASYNC) {
+      if (!isPool && !isArena && !isAsync) { 
         throw new IllegalArgumentException(
                 "Pool limit only supported in POOL, ARENA, or ASYNC allocation mode");
       }
@@ -199,6 +201,10 @@ public class Rmm {
         throw new IllegalArgumentException("Pool limit of " + maxPoolSize
             + " is less than initial pool size of " + poolSize);
       }
+    }
+    if (isAsync && isManaged) {
+      throw new IllegalArgumentException(
+            "CUDA Unified Memory is not supported in ASYNC allocation mode");
     }
     LogLoc loc = LogLoc.NONE;
     String path = null;

--- a/java/src/main/java/ai/rapids/cudf/RmmAllocationMode.java
+++ b/java/src/main/java/ai/rapids/cudf/RmmAllocationMode.java
@@ -32,4 +32,8 @@ public class RmmAllocationMode {
    * Use arena suballocation strategy
    */
   public static final int ARENA = 0x00000004;
+  /**
+   * Use cuda async strategy
+   */
+  public static final int ASYNC = 0x00000008;
 }

--- a/java/src/test/java/ai/rapids/cudf/RmmTest.java
+++ b/java/src/test/java/ai/rapids/cudf/RmmTest.java
@@ -404,6 +404,15 @@ public class RmmTest {
         () -> Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, false, 1024, 2048));
   }
 
+  @Test
+  public void testAsyncAllocManagedFails() {
+    assertThrows(IllegalArgumentException.class,
+      () -> Rmm.initialize(
+        RmmAllocationMode.ASYNC | RmmAllocationMode.CUDA_MANAGED_MEMORY, 
+          false, 1024, 2048));
+  }
+
+
   private static class AllocFailException extends RuntimeException {}
   private static class AllocThresholdException extends RuntimeException {}
   private static class DeallocThresholdException extends RuntimeException {}

--- a/java/src/test/java/ai/rapids/cudf/RmmTest.java
+++ b/java/src/test/java/ai/rapids/cudf/RmmTest.java
@@ -376,14 +376,19 @@ public class RmmTest {
 
   @Test
   public void testPoolLimit() {
-    Rmm.initialize(RmmAllocationMode.POOL, false, 1024, 2048);
-    try (DeviceMemoryBuffer ignored1 = Rmm.alloc(512);
-         DeviceMemoryBuffer ignored2 = Rmm.alloc(1024)) {
-      assertThrows(OutOfMemoryError.class,
-          () -> {
-            DeviceMemoryBuffer ignored3 = Rmm.alloc(1024);
-            ignored3.close();
-      });
+    int[] modes = {
+      RmmAllocationMode.POOL, RmmAllocationMode.ASYNC};
+    for (int mode : modes) {
+      Rmm.initialize(mode, false, 1024, 2048);
+      try (DeviceMemoryBuffer ignored1 = Rmm.alloc(512);
+           DeviceMemoryBuffer ignored2 = Rmm.alloc(1024)) {
+        assertThrows(OutOfMemoryError.class,
+            () -> {
+              DeviceMemoryBuffer ignored3 = Rmm.alloc(1024);
+              ignored3.close();
+        });
+      }
+      Rmm.shutdown();
     }
   }
 


### PR DESCRIPTION
This adds access to `cuda_async_memory_resource` (`ASYNC` allocation mode). In RMM's implementation, a cuda memory pool is created for each `cuda_async_memory_resource` instance.

This allocator should not be used in production yet, but we are adding it to cuDF so we can begin testing with it.

The `cuda_async_memory_resource` doesn't have a limit. This is something we need in cases where we must reserve part of the GPU for things like kernel launches, or bounce buffers for networking (note this allocator does not support `nv_peer_mem`). So it is wrapped in a `limiting_resource_adapter` to provide the high ceiling. 

The RMM instantiation here is getting a bit complicated. Filed this (https://github.com/rapidsai/cudf/issues/9209) as a follow up, as we really ought to clean up the api.