### PR TITLE
`extract_list_element()` with `column_view` indices

### DIFF
--- a/cpp/include/cudf/lists/extract.hpp
+++ b/cpp/include/cudf/lists/extract.hpp
@@ -65,6 +65,11 @@ std::unique_ptr<column> extract_list_element(
   size_type index,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+std::unique_ptr<column> extract_list_element(
+  lists_column_view const& lists_column,
+  column_view const& indices,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 /** @} */  // end of group
 }  // namespace lists
 }  // namespace cudf

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -32,11 +32,12 @@ namespace {
 /**
  * @brief Convert index value for each sublist into a gather index for
  * the lists column's child column.
+ * This specialization is for when the index is a fixed size_type value.
  */
-template <bool PositiveIndex = true>
+template <bool PositiveIndex = true, typename IndexType = size_type>
 struct map_index_fn {
   column_device_view const d_offsets;  // offsets to each sublist (including validity mask)
-  size_type const index;               // index of element within each sublist
+  IndexType const index;               // index of element within each sublist
   size_type const out_of_bounds;       // value to use to indicate out-of-bounds
 
   __device__ int32_t operator()(size_type idx)
@@ -44,24 +45,57 @@ struct map_index_fn {
     if (d_offsets.is_null(idx)) return out_of_bounds;
     auto const offset = d_offsets.element<int32_t>(idx);
     auto const length = d_offsets.element<int32_t>(idx + 1) - offset;
-    if (PositiveIndex)
-      return index < length ? index + offset : out_of_bounds;
-    else
-      return index >= -length ? length + index + offset : out_of_bounds;
+    if constexpr (PositiveIndex) { return index < length ? index + offset : out_of_bounds; }
+    return index >= -length ? length + index + offset : out_of_bounds;
   }
 };
 
+/**
+ * @brief Convert index value for each sublist into a gather index for
+ * the lists column's child column.
+ * This specialization works on a column_device_view of indices.
+ */
+template <bool ignored>
+struct map_index_fn<ignored, column_view> {
+  column_device_view const d_offsets;  // offsets to each sublist (including validity mask)
+  column_device_view const d_indices;  // column of indices for each element within a sublist
+  size_type const out_of_bounds;       // value to use to indicate out-of-bounds
+
+  __device__ int32_t operator()(size_type idx)
+  {
+    if (d_offsets.is_null(idx) || d_indices.is_null(idx)) return out_of_bounds;
+    auto const offset = d_offsets.element<int32_t>(idx);
+    auto const length = d_offsets.element<int32_t>(idx + 1) - offset;
+    auto const index  = d_indices.element<int32_t>(idx);
+
+    if (index >= 0) {
+      return index < length ? index + offset : out_of_bounds;
+    } else {
+      return index >= -length ? length + index + offset : out_of_bounds;
+    }
+  }
+};
+
+template <typename IndexType = size_type>
+auto get_device_accessible_index(IndexType const& index, rmm::cuda_stream_view)
+{
+  return &index;  // size_type is accessible in __device__.
+}
+
+template <>
+auto get_device_accessible_index<column_view>(column_view const& index_column,
+                                              rmm::cuda_stream_view stream)
+{
+  return column_device_view::create(index_column, stream);
+}
+
 }  // namespace
 
-/**
- * @copydoc cudf::lists::extract_list_element
- *
- * @param stream CUDA stream used for device memory operations and kernel launches.
- */
-std::unique_ptr<column> extract_list_element(lists_column_view lists_column,
-                                             size_type index,
-                                             rmm::cuda_stream_view stream,
-                                             rmm::mr::device_memory_resource* mr)
+template <bool PositiveIndex, typename IndexType = size_type>
+std::unique_ptr<column> extract_list_element_impl(lists_column_view lists_column,
+                                                  IndexType index,
+                                                  rmm::cuda_stream_view stream,
+                                                  rmm::mr::device_memory_resource* mr)
 {
   if (lists_column.is_empty()) return empty_like(lists_column.child());
   auto const offsets_column = lists_column.offsets();
@@ -82,18 +116,13 @@ std::unique_ptr<column> extract_list_element(lists_column_view lists_column,
 
   // build the gather map using the offsets and the provided index
   auto const d_column = column_device_view::create(annotated_offsets, stream);
-  if (index < 0)
-    thrust::transform(rmm::exec_policy(stream),
-                      thrust::make_counting_iterator<size_type>(0),
-                      thrust::make_counting_iterator<size_type>(gather_map->size()),
-                      d_gather_map,
-                      map_index_fn<false>{*d_column, index, child_column.size()});
-  else
-    thrust::transform(rmm::exec_policy(stream),
-                      thrust::make_counting_iterator<size_type>(0),
-                      thrust::make_counting_iterator<size_type>(gather_map->size()),
-                      d_gather_map,
-                      map_index_fn<true>{*d_column, index, child_column.size()});
+  auto const d_index  = get_device_accessible_index(index, stream);
+  thrust::transform(
+    rmm::exec_policy(stream),
+    thrust::make_counting_iterator<size_type>(0),
+    thrust::make_counting_iterator<size_type>(gather_map->size()),
+    d_gather_map,
+    map_index_fn<PositiveIndex, IndexType>{*d_column, *d_index, child_column.size()});
 
   // call gather on the child column
   auto result = cudf::detail::gather(table_view({child_column}),
@@ -108,6 +137,30 @@ std::unique_ptr<column> extract_list_element(lists_column_view lists_column,
   return std::unique_ptr<column>(std::move(result.front()));
 }
 
+/**
+ * @copydoc cudf::lists::extract_list_element
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::unique_ptr<column> extract_list_element(lists_column_view lists_column,
+                                             size_type index,
+                                             rmm::cuda_stream_view stream,
+                                             rmm::mr::device_memory_resource* mr)
+{
+  return index < 0 ? extract_list_element_impl<false>(lists_column, index, stream, mr)
+                   : extract_list_element_impl<true>(lists_column, index, stream, mr);
+}
+
+std::unique_ptr<column> extract_list_element(lists_column_view lists_column,
+                                             column_view const& indices,
+                                             rmm::cuda_stream_view stream,
+                                             rmm::mr::device_memory_resource* mr)
+{
+  CUDF_EXPECTS(lists_column.size() == indices.size(),
+               "Index column must have as many elements as lists column.");
+  return extract_list_element_impl<false, column_view>(lists_column, indices, stream, mr);
+}
+
 }  // namespace detail
 
 /**
@@ -118,6 +171,13 @@ std::unique_ptr<column> extract_list_element(lists_column_view const& lists_colu
                                              rmm::mr::device_memory_resource* mr)
 {
   return detail::extract_list_element(lists_column, index, rmm::cuda_stream_default, mr);
+}
+
+std::unique_ptr<column> extract_list_element(lists_column_view const& lists_column,
+                                             column_view const& indices,
+                                             rmm::mr::device_memory_resource* mr)
+{
+  return detail::extract_list_element(lists_column, indices, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace lists


### PR DESCRIPTION
Fixes #9172.

Adds an overload of `extract_list_element()` where the indices
may be specified as a column_view.

This function returns a list element from a potentially different index,
for each list row. The semantics of the scalar-index version of the function
are retained. i.e.:

0. The index is 0-based.
1. if (list_row == null) return null;
2. if (index > list_row.size()) return null;
3. if (index == null) return null;
4. if (index < 0 || -index <= length) return list_row[length + index];

Currently a work in progress. The following still needs addressing:
- [ ] Tests for nested list elements
- [ ] Doxygen docs for the header
- [ ] Polish