### PR TITLE
Fix `gather` for sliced input structs column

### DIFF
--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -453,7 +453,8 @@ struct column_gatherer_impl<struct_view> {
     auto const gather_map_size = std::distance(gather_map_begin, gather_map_end);
     if (gather_map_size == 0) { return empty_like(column); }
 
-    // Gathering needs to operate on the sliced children to properly handle the column offset.
+    // Gathering needs to operate on the sliced children since they need to take into account the
+    // offset of the parent structs column.
     std::vector<cudf::column_view> sliced_children;
     std::transform(thrust::make_counting_iterator(0),
                    thrust::make_counting_iterator(column.num_children()),

--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -450,16 +450,23 @@ struct column_gatherer_impl<struct_view> {
                                      rmm::cuda_stream_view stream,
                                      rmm::mr::device_memory_resource* mr)
   {
-    structs_column_view structs_column(column);
-    auto gather_map_size{std::distance(gather_map_begin, gather_map_end)};
+    auto const gather_map_size = std::distance(gather_map_begin, gather_map_end);
     if (gather_map_size == 0) { return empty_like(column); }
 
+    // Gathering needs to operate on the sliced children to properly handle the column offset.
+    std::vector<cudf::column_view> sliced_children;
+    std::transform(thrust::make_counting_iterator(0),
+                   thrust::make_counting_iterator(column.num_children()),
+                   std::back_inserter(sliced_children),
+                   [structs_view = structs_column_view{column}](auto const idx) {
+                     return structs_view.get_sliced_child(idx);
+                   });
+
     std::vector<std::unique_ptr<cudf::column>> output_struct_members;
-    std::transform(structs_column.child_begin(),
-                   structs_column.child_end(),
+    std::transform(sliced_children.begin(),
+                   sliced_children.end(),
                    std::back_inserter(output_struct_members),
-                   [&gather_map_begin, &gather_map_end, nullify_out_of_bounds, stream, mr](
-                     cudf::column_view const& col) {
+                   [&](auto const& col) {
                      return cudf::type_dispatcher<dispatch_storage_type>(col.type(),
                                                                          column_gatherer{},
                                                                          col,
@@ -470,14 +477,14 @@ struct column_gatherer_impl<struct_view> {
                                                                          mr);
                    });
 
-    auto const nullable = std::any_of(structs_column.child_begin(),
-                                      structs_column.child_end(),
+    auto const nullable = std::any_of(sliced_children.begin(),
+                                      sliced_children.end(),
                                       [](auto const& col) { return col.nullable(); });
     if (nullable) {
       gather_bitmask(
         // Table view of struct column.
         cudf::table_view{
-          std::vector<cudf::column_view>{structs_column.child_begin(), structs_column.child_end()}},
+          std::vector<cudf::column_view>{sliced_children.begin(), sliced_children.end()}},
         gather_map_begin,
         output_struct_members,
         nullify_out_of_bounds ? gather_bitmask_op::NULLIFY : gather_bitmask_op::DONT_CHECK,

--- a/cpp/tests/copying/gather_struct_tests.cpp
+++ b/cpp/tests/copying/gather_struct_tests.cpp
@@ -200,7 +200,6 @@ TYPED_TEST(TypedStructGatherTest, TestSlicedStructsColumnGatherNoNulls)
   auto const structs    = cudf::slice(structs_original, {4, 10})[0];
   auto const gather_map = cudf::test::fixed_width_column_wrapper<int32_t>{1, 5, 3};
   auto const result     = cudf::gather(cudf::table_view{{structs}}, gather_map)->get_column(0);
-
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.view(), expected);
 }
 


### PR DESCRIPTION
This PR fixes the `gather` API for structs columns when the input is a sliced column. Previously, `gather` calls `child_begin()` and `child_end()` to access the children column so if the input structs column is sliced then the output is incorrect.

This closes #9213, and is blocked by https://github.com/rapidsai/cudf/pull/9194 due to conflict work.