### PR TITLE
[Experimental] Optimize cudf/dask-cudf read_parquet for s3/remote filesystems

### DIFF
--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -340,6 +340,10 @@ class arrow_io_source : public datasource {
    *
    * @param Apache Arrow Filesystem URI
    */
+
+  arrow_io_source()  = default;
+  ~arrow_io_source() = default;
+
   explicit arrow_io_source(std::string_view arrow_uri)
   {
     const std::string uri_start_delimiter = "//";

--- a/python/cudf/cudf/_lib/cpp/io/types.pxd
+++ b/python/cudf/cudf/_lib/cpp/io/types.pxd
@@ -102,3 +102,8 @@ cdef extern from "cudf/io/datasource.hpp" \
 
     cdef cppclass datasource:
         pass
+
+    cdef cppclass arrow_io_source(datasource):
+        arrow_io_source() except +
+        arrow_io_source(string arrow_uri) except +
+        arrow_io_source(shared_ptr[CRandomAccessFile]) except +

--- a/python/cudf/cudf/_lib/io/datasource.pxd
+++ b/python/cudf/cudf/_lib/io/datasource.pxd
@@ -1,10 +1,11 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
-from libcpp.memory cimport unique_ptr
-
-from cudf._lib.cpp.io.types cimport datasource
+from cudf._lib.cpp.io.types cimport arrow_io_source, datasource
 
 
 cdef class Datasource:
-
     cdef datasource* get_datasource(self) nogil except *
+
+cdef class NativeFileDatasource(Datasource):
+    cdef arrow_io_source c_datasource
+    cdef datasource* get_datasource(self) nogil

--- a/python/cudf/cudf/_lib/io/datasource.pyx
+++ b/python/cudf/cudf/_lib/io/datasource.pyx
@@ -1,8 +1,11 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
-from libcpp.memory cimport unique_ptr
+from libcpp.memory cimport shared_ptr
+from libcpp.utility cimport move
+from pyarrow.includes.libarrow cimport CRandomAccessFile
+from pyarrow.lib cimport NativeFile
 
-from cudf._lib.cpp.io.types cimport datasource
+from cudf._lib.cpp.io.types cimport arrow_io_source, datasource, source_info
 
 
 cdef class Datasource:
@@ -10,3 +13,16 @@ cdef class Datasource:
         with gil:
             raise NotImplementedError("get_datasource() should not "
                                       + "be directly invoked here")
+
+cdef class NativeFileDatasource(Datasource):
+
+    def __cinit__(self, NativeFile native_file,):
+
+        cdef shared_ptr[CRandomAccessFile] ra_src
+        cdef arrow_io_source arrow_src
+
+        ra_src = native_file.get_random_access_file()
+        self.c_datasource = arrow_io_source(ra_src)
+
+    cdef datasource* get_datasource(self) nogil:
+        return <datasource *> &(self.c_datasource)

--- a/python/cudf/cudf/_lib/io/utils.pyx
+++ b/python/cudf/cudf/_lib/io/utils.pyx
@@ -8,9 +8,12 @@ from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.utility cimport move
 from libcpp.vector cimport vector
+from pyarrow.includes.libarrow cimport CRandomAccessFile
+from pyarrow.lib cimport NativeFile
 
 from cudf._lib.column cimport Column
 from cudf._lib.cpp.io.types cimport (
+    arrow_io_source,
     column_name_info,
     data_sink,
     datasource,
@@ -19,12 +22,14 @@ from cudf._lib.cpp.io.types cimport (
     sink_info,
     source_info,
 )
-from cudf._lib.io.datasource cimport Datasource
+from cudf._lib.io.datasource cimport Datasource, NativeFileDatasource
 
 import codecs
 import errno
 import io
 import os
+
+from pyarrow.lib import NativeFile
 
 import cudf
 from cudf.utils.dtypes import is_struct_dtype
@@ -35,7 +40,6 @@ from cudf.utils.dtypes import is_struct_dtype
 cdef source_info make_source_info(list src) except*:
     if not src:
         raise ValueError("Need to pass at least one source")
-
     cdef const unsigned char[::1] c_buffer
     cdef vector[host_buffer] c_host_buffers
     cdef vector[string] c_files
@@ -59,6 +63,9 @@ cdef source_info make_source_info(list src) except*:
     #                 change when UCX and/or cuStreamz support is added.
     elif isinstance(src[0], Datasource):
         csrc = src[0]
+        return source_info(csrc.get_datasource())
+    elif isinstance(src[0], NativeFile):
+        csrc = NativeFileDatasource(src[0])
         return source_info(csrc.get_datasource())
     elif isinstance(src[0], (int, float, complex, basestring, os.PathLike)):
         # If source is a file, return source_info where type=FILEPATH

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -207,7 +207,7 @@ def _get_byte_ranges(file_list, row_groups, columns, fs):
 
     if row_groups is None:
         if columns is None:
-            return None, None  # No reason to construct this
+            return None, None, None  # No reason to construct this
         row_groups = [None for path in file_list]
 
     # Construct a list of required byte-ranges for every file

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -170,7 +170,7 @@ def _filter_row_groups(paths, fs, filters=None, row_groups=None):
         paths = ioutils.stringify_pathlike(paths[0])
 
     # Convert filters to ds.Expression
-    if filters:
+    if filters is not None:
         filters = pq._filters_to_expression(filters)
 
     # Initialize ds.FilesystemDataset
@@ -179,7 +179,7 @@ def _filter_row_groups(paths, fs, filters=None, row_groups=None):
     )
     file_list = dataset.files
 
-    if filters:
+    if filters is not None:
         # Load IDs of filtered row groups for each file in dataset
         filtered_rg_ids = defaultdict(list)
         for fragment in dataset.get_fragments(filter=filters):
@@ -278,6 +278,7 @@ def read_parquet(
     num_rows=None,
     strings_to_categorical=False,
     use_pandas_metadata=True,
+    legacy_transfer=False,
     *args,
     **kwargs,
 ):
@@ -329,6 +330,7 @@ def read_parquet(
         and isinstance(
             filepath_or_buffer[0], fsspec.spec.AbstractBufferedFile,
         )
+        and not legacy_transfer
     ):
         byte_ranges, footers, file_sizes = _get_byte_ranges(
             filepath_or_buffer, row_groups, columns, fs,
@@ -352,6 +354,7 @@ def read_parquet(
             footer=footers[i] if footers else None,
             file_size=file_sizes[i] if file_sizes else None,
             add_par1_magic=True,
+            legacy_transfer=legacy_transfer,
             **kwargs,
         )
         if compression is not None:

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -5,9 +5,12 @@ import os
 import urllib
 import warnings
 from io import BufferedWriter, BytesIO, IOBase, TextIOWrapper
+from queue import Queue
+from threading import Thread
 
 import fsspec
 import fsspec.implementations.local
+import numpy as np
 import pandas as pd
 import pyarrow.fs as pa_fs
 from fsspec.core import get_fs_token_paths
@@ -1238,7 +1241,8 @@ def get_filepath_or_buffer(
                 path_or_data = [fs.open_input_file(fpath) for fpath in paths]
             else:
                 path_or_data = [
-                    BytesIO(fs.open(fpath).read()) for fpath in paths
+                    BytesIO(_fsspec_data_transfer(fpath, fs=fs, **kwargs))
+                    for fpath in paths
                 ]
             if len(path_or_data) == 1:
                 path_or_data = path_or_data[0]
@@ -1246,7 +1250,10 @@ def get_filepath_or_buffer(
     elif not isinstance(path_or_data, iotypes) and is_file_like(path_or_data):
         if isinstance(path_or_data, TextIOWrapper):
             path_or_data = path_or_data.buffer
-        path_or_data = BytesIO(path_or_data.read())
+        path_or_data = BytesIO(
+            # path_or_data.read()
+            _fsspec_data_transfer(path_or_data, **kwargs)
+        )
 
     return path_or_data, compression
 
@@ -1468,3 +1475,122 @@ def _ensure_filesystem(passed_filesystem, path):
             0
         ]
     return passed_filesystem
+
+
+#
+# Fsspec Data-transfer Optimization Code
+#
+
+
+def _fsspec_data_transfer(
+    path_or_fob,
+    fs=None,
+    byte_ranges=None,
+    footer=None,
+    file_size=None,
+    add_par1_magic=None,
+    bytes_per_thread=128_000_000,
+    **kwargs,
+):
+
+    if is_file_like(path_or_fob):
+        file_size = path_or_fob.size
+
+    # Start with empty buffer
+    file_size = file_size or fs.size(path_or_fob)
+    buf = np.zeros(file_size, dtype="b")
+
+    if byte_ranges:
+
+        # Call multi-threaded data transfer of
+        # remote byte-ranges to local buffer
+        _read_byte_ranges(
+            path_or_fob, byte_ranges, buf, fs=fs, num_threads=len(byte_ranges)
+        )
+
+        # Add Header & Footer bytes
+        if footer is not None:
+            footer_size = len(footer)
+            buf[-footer_size:] = np.frombuffer(
+                footer[-footer_size:], dtype="b"
+            )
+
+        # Add parquet magic bytes (optional)
+        if add_par1_magic:
+            buf[:4] = np.frombuffer(b"PAR1", dtype="b")
+            if footer is None:
+                buf[-4:] = np.frombuffer(b"PAR1", dtype="b")
+
+    else:
+        # return fs.open(path_or_fob).read()
+        byte_ranges = [
+            (b, min(bytes_per_thread, file_size - b))
+            for b in range(0, file_size, bytes_per_thread)
+        ]
+        _read_byte_ranges(
+            path_or_fob, byte_ranges, buf, fs=fs, num_threads=len(byte_ranges)
+        )
+
+    return buf.tobytes()
+
+
+def _assign_block(fs, path_or_fob, local_buffer, offset, nbytes):
+    if fs is None:
+        # We have an open fsspec file object
+        path_or_fob.seek(offset)
+        local_buffer[offset : offset + nbytes] = np.frombuffer(
+            path_or_fob.read(nbytes), dtype="b",
+        )
+    else:
+        # We have an fsspec filesystem and a path
+        local_buffer[offset : offset + nbytes] = np.frombuffer(
+            fs.read_block(path_or_fob, offset, nbytes), dtype="b",
+        )
+
+
+class ReadBlockWorker(Thread):
+    def __init__(self, queue, fs, path_or_fob, local_buffer):
+        Thread.__init__(self)
+        self.queue = queue
+        self.fs = fs
+        self.path_or_fob = path_or_fob
+        self.local_buffer = local_buffer
+
+    def run(self):
+        while True:
+            # Get the work from the queue and expand the tuple
+            offset, nbytes = self.queue.get()
+            try:
+                _assign_block(
+                    self.fs,
+                    self.path_or_fob,
+                    self.local_buffer,
+                    offset,
+                    nbytes,
+                )
+            finally:
+                self.queue.task_done()
+
+
+def _read_byte_ranges(
+    path_or_fob, ranges, local_buffer, fs=None, num_threads=1
+):
+
+    # No reason to generate more threads than byte-ranges
+    num_threads = min(num_threads, len(ranges))
+
+    if num_threads > 1:
+        queue = Queue()
+        for x in range(num_threads):
+            worker = ReadBlockWorker(queue, fs, path_or_fob, local_buffer)
+            worker.daemon = True
+            worker.start()
+
+    for (offset, nbytes) in ranges:
+        if num_threads > 1:
+            queue.put((offset, nbytes))
+        else:
+            _assign_block(fs, path_or_fob, local_buffer, offset, nbytes)
+
+    if num_threads > 1:
+        queue.join()

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1492,7 +1492,7 @@ def _fsspec_data_transfer(
     bytes_per_thread=128_000_000,
     **kwargs,
 ):
-
+    # return fs.open(path_or_fob).read()
     if is_file_like(path_or_fob):
         file_size = path_or_fob.size
 
@@ -1522,7 +1522,6 @@ def _fsspec_data_transfer(
                 buf[-4:] = np.frombuffer(b"PAR1", dtype="b")
 
     else:
-        # return fs.open(path_or_fob).read()
         byte_ranges = [
             (b, min(bytes_per_thread, file_size - b))
             for b in range(0, file_size, bytes_per_thread)

--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2019-2020, NVIDIA CORPORATION.
 import warnings
+from contextlib import ExitStack
 from functools import partial
 from io import BufferedWriter, BytesIO, IOBase
 
@@ -73,30 +74,38 @@ class CudfEngine(ArrowDatasetEngine):
         if row_groups == [None for path in paths]:
             row_groups = None
 
-        # Non-local filesystem handling
-        paths_or_fobs = paths
-        if not cudf.utils.ioutils._is_local_filesystem(fs):
-            # Convert paths to file objects for remote data
-            if arrow_filesystem:
-                paths_or_fobs = [
-                    arrow_filesystem.open_input_file(path) for path in paths
-                ]
-            else:
-                cache_type = "none" if columns or row_groups else "bytes"
-                paths_or_fobs = [
-                    fs.open(path, mode="rb", cache_type=cache_type)
-                    for path in paths
-                ]
+        with ExitStack() as stack:
 
-        # Use cudf to read in data
-        df = cudf.read_parquet(
-            paths_or_fobs,
-            engine="cudf",
-            columns=columns,
-            row_groups=row_groups if row_groups else None,
-            strings_to_categorical=strings_to_categorical,
-            **kwargs,
-        )
+            # Non-local filesystem handling
+            paths_or_fobs = paths
+            if not cudf.utils.ioutils._is_local_filesystem(fs):
+
+                # Convert paths to file objects for remote data
+                if arrow_filesystem:
+                    paths_or_fobs = [
+                        stack.enter_context(
+                            arrow_filesystem.open_input_file(path)
+                        )
+                        for path in paths
+                    ]
+                else:
+                    cache_type = "none" if columns or row_groups else "bytes"
+                    paths_or_fobs = [
+                        stack.enter_context(
+                            fs.open(path, mode="rb", cache_type=cache_type)
+                        )
+                        for path in paths
+                    ]
+
+            # Use cudf to read in data
+            df = cudf.read_parquet(
+                paths_or_fobs,
+                engine="cudf",
+                columns=columns,
+                row_groups=row_groups if row_groups else None,
+                strings_to_categorical=strings_to_categorical,
+                **kwargs,
+            )
 
         if partitions and partition_keys is None:
 
@@ -155,12 +164,21 @@ class CudfEngine(ArrowDatasetEngine):
         categories=(),
         partitions=(),
         partitioning=None,
+        schema=None,
         **kwargs,
     ):
+
         if columns is not None:
             columns = [c for c in columns]
         if isinstance(index, list):
             columns += index
+
+        # Check if we are actually selecting any columns
+        read_columns = columns
+        if schema and columns:
+            ignored = set(schema.names) - set(columns)
+            if not ignored:
+                read_columns = None
 
         if not isinstance(pieces, list):
             pieces = [pieces]
@@ -183,7 +201,7 @@ class CudfEngine(ArrowDatasetEngine):
                     cls._read_paths(
                         paths,
                         fs,
-                        columns=columns,
+                        columns=read_columns,
                         row_groups=rgs if rgs else None,
                         strings_to_categorical=strings_to_cats,
                         partitions=partitions,
@@ -206,7 +224,7 @@ class CudfEngine(ArrowDatasetEngine):
             cls._read_paths(
                 paths,
                 fs,
-                columns=columns,
+                columns=read_columns,
                 row_groups=rgs if rgs else None,
                 strings_to_categorical=strings_to_cats,
                 partitions=partitions,
@@ -336,8 +354,9 @@ def read_parquet(
     columns=None,
     split_row_groups=None,
     row_groups_per_part=None,
+    arrow_filesystem=False,
+    legacy_transfer=False,
     read=None,
-    arrow_filesystem=None,
     **kwargs,
 ):
     """ Read parquet files into a Dask DataFrame
@@ -370,20 +389,25 @@ def read_parquet(
 
     # Check if we should use an arrow-backed filesystem
     # on the workers (at IO time)
-    if arrow_filesystem is not False:
+    read_kwargs = (read or {}).copy()
+    if arrow_filesystem:
         arrow_filesystem = cudf.utils.ioutils._try_pyarrow_filesystem(
             path, kwargs.get("storage_options", {}),
         )[0]
-    if arrow_filesystem:
-        read_kwargs = (read or {}).copy()
-        read_kwargs["arrow_filesystem"] = arrow_filesystem
-        kwargs["read"] = read_kwargs
+        if arrow_filesystem:
+            read_kwargs["arrow_filesystem"] = arrow_filesystem
+
+    # Check if we are using legacy approach to remote
+    # data transfer (single `read` call into host memory)
+    if legacy_transfer:
+        read_kwargs["legacy_transfer"] = legacy_transfer
 
     return dd.read_parquet(
         path,
         columns=columns,
         split_row_groups=split_row_groups,
         engine=CudfEngine,
+        read=read_kwargs,
         **kwargs,
     )
 


### PR DESCRIPTION
### Background

The current versions of `cudf.read_parquet` and `dask_cudf.read_parquet` are poorly optimized for remote storage (e.g. s3 and gcs).  As discussed in #7475, this is because cudf and dask-cudf use fsspec as a universal file-system adapter, and libcudf's parquet logic cannot call into a python-based fsspec file-system object to seek/read specific byte ranges from the remote file. For this reason, cudf/dask-cudf currently call `read` to copy all contents of each parquet file into a local memory buffer before passing that buffer to libcudf.  This is okay if the process calling `read_parquet` intends to read the entire file, and the file is reasonably small.  However, there are other common cases:

- **CASE 1 - The process is selecting only a subset of parquet column-chunks**: If the user has specified a specific set of columns and/or row-groups in the `read_parquet` call, then it is clearly inefficient to copy the entire file to host memory. 
- **CASE 2 - The parquet file is large**:  If the file is large, a concurrent gather operation will most-likely outperform a vanilla `read` operation.

### Changes in This PR

This PR builds upon the cpp/cython changes in #8961 to enable the creation and/or processing of Arrow `NativeFile` objects in `cudf.read_parquet`.  Since Arrow-backed FileSystem definitions do not exist for all remote file-systems (e.g. GCS), this PR also optimizes the transfer of data from remote storage to host memory with Fsspec (taking advantage of the same optimization targeted in [fsspec#744](https://github.com/intake/filesystem_spec/pull/744).  More specifically, we use a local "dummy buffer", and avoid transferring any data that is not actually required by the underlying libcudf parquet read. We also use a concurrent read operation to transfer the bytes of the file in parallel.

Although the fsspec optimization was originally intended as a "temporary" solution for GCS, it is actually more performant (and stable) than the Arrow-`NativeFile` approach. The only disadvantage of using fsspec is that we still need enough host memory to store the entire parquet file (even if we do not actually populate most of the buffer with remote data).

#### Experimental API

We introduce the `arrow_filesystem=` option to both the cudf and dask-cudf `read_parquet` APIs.  This argument is a boolean, with a default value of `False`. It determines whether a url-based path input should be used to infer an Arrow-based filesystem object.  If url-based file-sytem inference fails, both cudf and dask-cudf will fall back to fsspec for file-system handling.  We also introduce a `legacy_transfer=` option (default `False`) to allow the user to avoid the optimized data-transfer logic in the case that fsspec is used.

#### Default APIs

`df = cudf.read_parquet(<path-or-handle>, arrow_filesystem=False, legacy_transfer=False)`
`ddf = dask_cudf.read_parquet(<path-or-handle>, arrow_filesystem=False, legacy_transfer=False)`

#### API Notes

- `arrow_filesystem`: Setting this value to `True` tells cudf/dask-cudf to **try** to infer an arrow-based filesystem object that will enable random access in libcudf.  When the underlying parquet file can be opened as an arrow `NativeFile`, cudf no longer needs to copy the data into a local host buffer before calling down to libcudf (because libcudf can seek/read from the arrow file object directly).
    - Using `arrow_filesystem=True` currently works in most cases, but does not perform as well as the optimized fsspec data transfer, and still fails in some cases (especially in Dask).
- `legacy_transfer`: Setting this value to `True` will avoid the new fsspec data-transfer optimization.  The option is only included for debugging and comparison, and may be removed before this PR is ready to merge.