### PR TITLE
Add detail interface for `split` and `slice(table_view)`

### DIFF
--- a/cpp/include/cudf/detail/copy.hpp
+++ b/cpp/include/cudf/detail/copy.hpp
@@ -76,6 +76,33 @@ std::vector<column_view> slice(column_view const& input,
                                rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 /**
+ * @copydoc cudf::slice(table_view const&,std::vector<size_type> const&)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::vector<table_view> slice(table_view const& input,
+                              std::vector<size_type> const& indices,
+                              rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+/**
+ * @copydoc cudf::split(column_view const&,std::vector<size_type> const&)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::vector<column_view> split(column_view const& input,
+                               std::vector<size_type> const& splits,
+                               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+/**
+ * @copydoc cudf::split(table_view const&,std::vector<size_type> const&)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::vector<table_view> split(table_view const& input,
+                              std::vector<size_type> const& splits,
+                              rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+/**
  * @copydoc cudf::shift(column_view const&,size_type,scalar const&,
  * rmm::mr::device_memory_resource*)
  *

--- a/cpp/src/copying/slice.cu
+++ b/cpp/src/copying/slice.cu
@@ -63,25 +63,16 @@ std::vector<column_view> slice(column_view const& input,
   return std::vector<column_view>{begin, begin + indices.size() / 2};
 }
 
-}  // namespace detail
-
-std::vector<cudf::column_view> slice(cudf::column_view const& input,
-                                     std::vector<size_type> const& indices)
-{
-  CUDF_FUNC_RANGE();
-  return detail::slice(input, indices, rmm::cuda_stream_default);
-}
-
 std::vector<cudf::table_view> slice(cudf::table_view const& input,
-                                    std::vector<size_type> const& indices)
+                                    std::vector<size_type> const& indices,
+                                    rmm::cuda_stream_view stream)
 {
-  CUDF_FUNC_RANGE();
   CUDF_EXPECTS(indices.size() % 2 == 0, "indices size must be even");
   if (indices.empty()) { return {}; }
 
   // 2d arrangement of column_views that represent the outgoing table_views sliced_table[i][j]
   // where i is the i'th column of the j'th table_view
-  auto op = [&indices](auto const& c) { return cudf::slice(c, indices); };
+  auto op = [&indices, &stream](auto const& c) { return slice(c, indices, stream); };
   auto f  = thrust::make_transform_iterator(input.begin(), op);
 
   auto sliced_table = std::vector<std::vector<cudf::column_view>>(f, f + input.num_columns());
@@ -99,6 +90,22 @@ std::vector<cudf::table_view> slice(cudf::table_view const& input,
   }
 
   return result;
+};
+
+}  // namespace detail
+
+std::vector<cudf::column_view> slice(cudf::column_view const& input,
+                                     std::vector<size_type> const& indices)
+{
+  CUDF_FUNC_RANGE();
+  return detail::slice(input, indices, rmm::cuda_stream_default);
+}
+
+std::vector<cudf::table_view> slice(cudf::table_view const& input,
+                                    std::vector<size_type> const& indices)
+{
+  CUDF_FUNC_RANGE();
+  return detail::slice(input, indices, rmm::cuda_stream_default);
 };
 
 }  // namespace cudf

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -22,7 +22,7 @@
 #include "writer_impl.hpp"
 
 #include <cudf/column/column_device_view.cuh>
-#include <cudf/copying.hpp>
+#include <cudf/detail/copy.hpp>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/scalar/scalar.hpp>
@@ -423,7 +423,7 @@ void writer::impl::write(table_view const& table,
       });
 
       // split table_view into chunks:
-      vector_views = cudf::split(table, splits);
+      vector_views = cudf::detail::split(table, splits, stream);
     }
 
     // convert each chunk to CSV:

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -68,7 +68,8 @@ struct reduce_dispatch_functor {
       } break;
       case aggregation::MEDIAN: {
         auto sorted_indices = sorted_order(table_view{{col}}, {}, {null_order::AFTER}, stream, mr);
-        auto valid_sorted_indices = split(*sorted_indices, {col.size() - col.null_count()})[0];
+        auto valid_sorted_indices =
+          split(*sorted_indices, {col.size() - col.null_count()}, stream)[0];
         auto col_ptr =
           quantile(col, {0.5}, interpolation::LINEAR, valid_sorted_indices, true, stream, mr);
         return get_element(*col_ptr, 0, stream, mr);
@@ -78,7 +79,8 @@ struct reduce_dispatch_functor {
         CUDF_EXPECTS(quantile_agg->_quantiles.size() == 1,
                      "Reduction quantile accepts only one quantile value");
         auto sorted_indices = sorted_order(table_view{{col}}, {}, {null_order::AFTER}, stream, mr);
-        auto valid_sorted_indices = split(*sorted_indices, {col.size() - col.null_count()})[0];
+        auto valid_sorted_indices =
+          split(*sorted_indices, {col.size() - col.null_count()}, stream)[0];
 
         auto col_ptr = quantile(col,
                                 quantile_agg->_quantiles,

--- a/cpp/src/transpose/transpose.cu
+++ b/cpp/src/transpose/transpose.cu
@@ -49,7 +49,7 @@ std::pair<std::unique_ptr<column>, table_view> transpose(table_view const& input
   auto splits_iter   = thrust::make_transform_iterator(
     one_iter, [width = input.num_columns()](size_type idx) { return idx * width; });
   auto splits = std::vector<size_type>(splits_iter, splits_iter + input.num_rows() - 1);
-  auto output_column_views = cudf::split(output_column->view(), splits);
+  auto output_column_views = split(output_column->view(), splits, stream);
 
   return std::make_pair(std::move(output_column), table_view(output_column_views));
 }


### PR DESCRIPTION
`cudf::detail::slice` performs a `segmented_count_unset_bits` that requires stream ordering. The depending `split` interface does not have an internal version that accepts a `stream` argument. Similarly for `slice(table_view)`. This PR fixes that.