### PR TITLE
Remove unnecessary call to device_uvector::release()

### DIFF
--- a/cpp/include/cudf/lists/detail/gather.cuh
+++ b/cpp/include/cudf/lists/detail/gather.cuh
@@ -117,11 +117,6 @@ gather_data make_gather_data(cudf::lists_column_view const& source_column,
                       return src_offsets[index] - shift;
                     });
 
-  // now that we are done using the gather_map, we can release the underlying prev_base_offsets.
-  // doing this prevents this (potentially large) memory buffer from sitting around unused as the
-  // recursion continues.
-  prev_base_offsets.release();
-
   // Retrieve size of the resulting gather map for level N+1 (the last offset)
   size_type child_gather_map_size =
     cudf::detail::get_value<size_type>(dst_offsets_c->view(), output_count, stream);


### PR DESCRIPTION
There was an unneeded call to `device_uvector::release()` that did not use the return value. rapidsai/rmm#857 marks that function `[[nodiscard]]`, so removing this allows libcudf to compile after the RMM PR is merged.

The `release()` is unnecessary because `prev_base_offsets` is passed by rvalue reference and therefore will be freed when the function exits (the uvector in the calling context it has been moved-from).