### PR TITLE
Only run imports tests on x86_64

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -51,11 +51,11 @@ requirements:
     - packaging
     - cachetools
 
-test:
-  requires:
-    - cudatoolkit {{ cuda_version }}.*
-  imports:
-    - cudf
+test:                                   # [linux64]
+  requires:                             # [linux64]
+    - cudatoolkit {{ cuda_version }}.*  # [linux64]
+  imports:                              # [linux64]
+    - cudf                              # [linux64]
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -36,11 +36,11 @@ requirements:
     - python-confluent-kafka
     - cudf {{ version }}
 
-test:
-  requires:
-    - cudatoolkit {{ cuda_version }}.*
-  imports:
-    - cudf_kafka
+test:                                   # [linux64]
+  requires:                             # [linux64]
+    - cudatoolkit {{ cuda_version }}.*  # [linux64]
+  imports:                              # [linux64]
+    - cudf_kafka                        # [linux64]
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -36,11 +36,11 @@ requirements:
     - python-confluent-kafka
     - cudf_kafka {{ version }}
 
-test:
-  requires:
-    - cudatoolkit {{ cuda_version }}.*
-  imports:
-    - custreamz
+test:                                   # [linux64]
+  requires:                             # [linux64]
+    - cudatoolkit {{ cuda_version }}.*  # [linux64]
+  imports:                              # [linux64]
+    - custreamz                         # [linux64]
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -33,10 +33,10 @@ requirements:
     - cudf {{ version }}
     - dask>=2021.6.0
     - distributed>=2021.6.0
-  
-test:
-  requires:
-    - cudatoolkit {{ cuda_version }}.*
+
+test:                                   # [linux64]
+  requires:                             # [linux64]
+    - cudatoolkit {{ cuda_version }}.*  # [linux64]
 
 
 about:


### PR DESCRIPTION
Temporary workaround for `arm64` as `imports` tests are not working currently