### PR TITLE
Fixing empty input to getMapValue crashing

### DIFF
--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -112,7 +112,6 @@ std::unique_ptr<column>
 get_gather_map_for_map_values(column_view const &input, string_scalar &lookup_key,
                               rmm::cuda_stream_view stream, rmm::mr::device_memory_resource *mr) {
   constexpr size_type block_size{256};
-
   cudf::detail::grid_1d grid{input.size(), block_size};
 
   auto input_device_view = cudf::column_device_view::create(input, stream);

--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -112,6 +112,11 @@ std::unique_ptr<column>
 get_gather_map_for_map_values(column_view const &input, string_scalar &lookup_key,
                               rmm::cuda_stream_view stream, rmm::mr::device_memory_resource *mr) {
   constexpr size_type block_size{256};
+
+  if (input.size() == 0) {
+    return make_empty_column(data_type{cudf::type_to_id<size_type>()});
+  }
+
   cudf::detail::grid_1d grid{input.size(), block_size};
 
   auto input_device_view = cudf::column_device_view::create(input, stream);
@@ -191,6 +196,10 @@ std::unique_ptr<column> map_lookup(column_view const &map_column, string_scalar 
   auto gather_map = has_nulls ?
                         get_gather_map_for_map_values<true>(map_column, lookup_key, stream, mr) :
                         get_gather_map_for_map_values<false>(map_column, lookup_key, stream, mr);
+
+  if (gather_map->size() == 0) {
+    return make_empty_column(cudf::data_type{cudf::type_id::STRING});
+  }
 
   // Gather map is now available.
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -5413,6 +5413,17 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testGetMapValueEmptyInput() {
+    HostColumnVector.StructType structType = new HostColumnVector.StructType(true, Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
+        new HostColumnVector.BasicType(true, DType.STRING)));
+    try (ColumnVector cv = ColumnVector.fromLists(new HostColumnVector.ListType(true, structType));
+         ColumnVector res = cv.getMapValue(Scalar.fromString("a"));
+         ColumnVector expected = ColumnVector.fromStrings()) {
+      assertColumnsAreEqual(expected, res);
+    }
+  }
+
+  @Test
   void testGetMapKeyExistence() {
     List<HostColumnVector.StructData> list1 = Arrays.asList(new HostColumnVector.StructData("a", "b"));
     List<HostColumnVector.StructData> list2 = Arrays.asList(new HostColumnVector.StructData("a", "c"));


### PR DESCRIPTION
This changes the calls in java/cudf to check for an empty input and return an empty result instead of crashing.

Fixes #9253 
