### PR TITLE
Added deprecation warning for `.label_encoding()`

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -3636,10 +3636,10 @@ class Series(SingleColumnFrame, Serializable):
         4   -1
         dtype: int8
         """
-        
+
         warnings.warn(
-            "Series.label_encoding is deprecated and will be removed "
-            "in the future.",
+            "Series.label_encoding is deprecated and will be removed in the future.\
+                 Consider using cuML's LabelEncoder instead",
             DeprecationWarning,
         )
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -3636,6 +3636,12 @@ class Series(SingleColumnFrame, Serializable):
         4   -1
         dtype: int8
         """
+        
+        warnings.warn(
+            "Series.label_encoding is deprecated and will be removed "
+            "in the future.",
+            DeprecationWarning,
+        )
 
         def _return_sentinel_series():
             return Series(


### PR DESCRIPTION
This PR addresses issue #8608 by adding a deprecation warning before we remove the functionality entirely.