### PR TITLE
Fix `interleave_columns` when the input string lists column having empty child column

### DIFF
--- a/cpp/src/lists/interleave_columns.cu
+++ b/cpp/src/lists/interleave_columns.cu
@@ -169,6 +169,10 @@ struct compute_string_sizes_and_interleave_lists_fn {
     auto const start_str_idx = list_offsets[list_id];
     auto const end_str_idx   = list_offsets[list_id + 1];
 
+    // In case of empty list (i.e. it doesn't contain any string element), we just ignore it because
+    // there will not be anything to store for that list in the child column.
+    if (start_str_idx == end_str_idx) { return; }
+
     // read_idx and write_idx are indices of string elements.
     size_type write_idx = dst_list_offsets[idx];
 


### PR DESCRIPTION
This closes #9290. In particular, when the input lists column (of strings) contain all empty lists, the internal function still tries to access the first element of the child column (which is empty) causes a seg-fault.