### PR TITLE
Pin mypy in .pre-commit-config.yaml to match conda environment pinning.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,18 +54,14 @@ repos:
                 language: system
                 files: \.(cu|cuh|h|hpp|cpp|inl)$
                 args: ['-fallback-style=none']
-      - repo: local
+      - repo: https://github.com/pre-commit/mirrors-mypy
+        rev: 'v0.782'
         hooks:
               - id: mypy
-                name: mypy
-                description: mypy
-                pass_filenames: false
-                entry: mypy --config-file=python/cudf/setup.cfg python/cudf/cudf
-                language: system
-                types: [python]
-      -   repo: https://github.com/pycqa/pydocstyle
-          rev: 6.0.0
-          hooks:
+                args: ["--config-file=python/cudf/setup.cfg", "python/cudf/cudf"]
+      - repo: https://github.com/pycqa/pydocstyle
+        rev: 6.0.0
+        hooks:
               - id: pydocstyle
                 args: ["--config=python/.flake8"]
 


### PR DESCRIPTION
Currently mypy set as is a "local" hook in pre-commit, meaning that it uses `mypy` from the user's environment. I have mypy 0.910 installed (released Jun 22, 2021) locally and it fails with the following error:
```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 2
python/cudf/cudf/tests/conftest.py: error: Duplicate module named "conftest" (also at "python/cudf/cudf/benchmarks/conftest.py")
python/cudf/cudf/tests/conftest.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
Found 1 error in 1 file (errors prevented further checking)
```

The conda environment pinning is [currently 0.782](https://github.com/rapidsai/cudf/blob/ba763105e006494a536c1a2fafc5112ab3dae362/conda/environments/cudf_dev_cuda11.2.yml#L39) (released Jun 23, 2020). Newer versions of mypy (around 0.900) have substantial behavior changes, so my newer version throws errors that are not seen in the older mypy that is pinned for CI checks.

This PR changes the behavior of `.pre-commit-config.yml` to use mypy from a mirror repository, at the same pinning used in the conda environment, instead of the local executable.