### PR TITLE
Optionally nullify out-of-bounds indices in segmented_gather().

### DIFF
--- a/cpp/include/cudf/lists/detail/gather.cuh
+++ b/cpp/include/cudf/lists/detail/gather.cuh
@@ -288,6 +288,7 @@ std::unique_ptr<column> gather_list_leaf(
 /**
  * @copydoc cudf::lists::segmented_gather(lists_column_view const& source_column,
  *                                        lists_column_view const& gather_map_list,
+ *                                        out_of_bounds_policy bounds_policy,
  *                                        rmm::mr::device_memory_resource* mr)
  *
  * @param stream CUDA stream on which to execute kernels
@@ -295,6 +296,7 @@ std::unique_ptr<column> gather_list_leaf(
 std::unique_ptr<column> segmented_gather(
   lists_column_view const& source_column,
   lists_column_view const& gather_map_list,
+  out_of_bounds_policy bounds_policy  = out_of_bounds_policy::DONT_CHECK,
   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 

--- a/cpp/include/cudf/lists/gather.hpp
+++ b/cpp/include/cudf/lists/gather.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 
 namespace cudf {
@@ -32,7 +33,7 @@ namespace lists {
  *
  * `source_column` with any depth and `gather_map_list` with depth 1 are only supported.
  *
- * * @code{.pseudo}
+ * @code{.pseudo}
  * source_column   : [{"a", "b", "c", "d"}, {"1", "2", "3", "4"}, {"x", "y", "z"}]
  * gather_map_list : [{0, 1, 3, 2}, {1, 3, 2}, {}]
  *
@@ -44,11 +45,24 @@ namespace lists {
  * @throws cudf::logic_error if gather_map is not list column of an index type.
  *
  * If indices in `gather_map_list` are outside the range `[-n, n)`, where `n` is the number of
- * elements in corresponding row of the source column, the behavior is undefined.
+ * elements in corresponding row of the source column, the behaviour is as follows:
+ *   1. If `bounds_policy` is set to `DONT_CHECK`, the behaviour is undefined.
+ *   2. If `bounds_policy` is set to `NULLIFY`, the corresponding element in the list row
+ *      is set to null in the output column.
+ *
+ * @code{.pseudo}
+ * source_column       : [{"a", "b", "c", "d"}, {"1", "2", "3", "4"}, {"x", "y", "z"}]
+ * gather_map_list     : [{0, -1, 4, -5}, {1, 3, 5}, {}]
+ *
+ * result_with_nullify : [{"a", "d", null, null}, {"2", "4", null}, {}]
+ * @endcode
  *
  * @param source_column View into the list column to gather from
  * @param gather_map_list View into a non-nullable list column of integral indices that maps the
  * element in list of each row in the source columns to rows of lists in the destination columns.
+ * @param bounds_policy Can be `DONT_CHECK` or `NULLIFY`. Selects whether or not to nullify the
+ * output list row's element, when the gather index falls outside the range `[-n, n)`,
+ * where `n` is the number of elements in list row corresponding to the gather-map row.
  * @param mr Device memory resource to allocate any returned objects
  * @return column with elements in list of rows gathered based on `gather_map_list`
  *
@@ -56,6 +70,7 @@ namespace lists {
 std::unique_ptr<column> segmented_gather(
   lists_column_view const& source_column,
   lists_column_view const& gather_map_list,
+  out_of_bounds_policy bounds_policy  = out_of_bounds_policy::DONT_CHECK,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -42,9 +42,9 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
 
   auto const gather_map_sliced_child = gather_map.get_sliced_child(stream);
   auto const gather_map_size         = gather_map_sliced_child.size();
-  auto const gather_index_begin = gather_map.offsets().begin<size_type>() + 1 + gather_map.offset();
-  auto const gather_index_end   = gather_index_begin + gather_map.size();
-  auto const value_offsets      = value_column.offsets().begin<size_type>() + value_column.offset();
+  auto const gather_index_begin      = gather_map.offsets_begin() + 1;
+  auto const gather_index_end        = gather_map.offsets_end();
+  auto const value_offsets           = value_column.offsets_begin();
   auto const map_begin =
     cudf::detail::indexalator_factory::make_input_iterator(gather_map_sliced_child);
   auto const out_of_bounds = [] __device__(auto const index, auto const list_size) {

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -64,8 +64,8 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
         thrust::seq, gather_index_begin, gather_index_end, gather_index_begin[-1] + index) -
       gather_index_begin;
     // Get each sub_index in list in each row of gather_map.
-    auto sub_index = map_begin[index];
-    auto list_size = value_offsets[offset_idx + 1] - value_offsets[offset_idx];
+    auto sub_index          = map_begin[index];
+    auto list_size          = value_offsets[offset_idx + 1] - value_offsets[offset_idx];
     auto wrapped_sub_index  = sub_index < 0 ? sub_index + list_size : sub_index;
     auto constexpr null_idx = cuda::std::numeric_limits<cudf::size_type>::max();
     // Add sub_index to value_column offsets, to get gather indices of child of value_column

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -21,7 +21,9 @@
 #include <cudf/lists/detail/gather.cuh>
 
 #include <thrust/binary_search.h>
+#include <limits>
 #include <rmm/cuda_stream_view.hpp>
+#include "cudf/types.hpp"
 
 namespace cudf {
 namespace lists {
@@ -29,6 +31,7 @@ namespace detail {
 
 std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
                                          lists_column_view const& gather_map,
+                                         out_of_bounds_policy bounds_policy,
                                          rmm::cuda_stream_view stream,
                                          rmm::mr::device_memory_resource* mr)
 {
@@ -38,27 +41,38 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
   CUDF_EXPECTS(value_column.size() == gather_map.size(),
                "Gather map and list column should be same size");
 
-  auto gather_map_sliced_child = gather_map.get_sliced_child(stream);
-  auto const gather_map_size   = gather_map_sliced_child.size();
-  auto gather_index_begin      = gather_map.offsets().begin<size_type>() + 1 + gather_map.offset();
-  auto gather_index_end        = gather_index_begin + gather_map.size();
-  auto value_offsets           = value_column.offsets().begin<size_type>() + value_column.offset();
-  auto map_begin = cudf::detail::indexalator_factory::make_input_iterator(gather_map_sliced_child);
+  auto const gather_map_sliced_child = gather_map.get_sliced_child(stream);
+  auto const gather_map_size         = gather_map_sliced_child.size();
+  auto const gather_index_begin = gather_map.offsets().begin<size_type>() + 1 + gather_map.offset();
+  auto const gather_index_end   = gather_index_begin + gather_map.size();
+  auto const value_offsets      = value_column.offsets().begin<size_type>() + value_column.offset();
+  auto const map_begin =
+    cudf::detail::indexalator_factory::make_input_iterator(gather_map_sliced_child);
+  auto const out_of_bounds = [] __device__(auto const index, auto const list_size) {
+    return index >= list_size || (index < 0 && -index > list_size);
+  };
 
   // Calculate Flattened gather indices  (value_offset[row]+sub_index
-  auto transformer = [value_offsets, map_begin, gather_index_begin, gather_index_end] __device__(
-                       size_type index) -> size_type {
+  auto transformer = [value_offsets,
+                      map_begin,
+                      gather_index_begin,
+                      gather_index_end,
+                      bounds_policy,
+                      out_of_bounds] __device__(size_type index) -> size_type {
     // Get each row's offset. (Each row is a list).
     auto offset_idx =
       thrust::upper_bound(
         thrust::seq, gather_index_begin, gather_index_end, gather_index_begin[-1] + index) -
       gather_index_begin;
     // Get each sub_index in list in each row of gather_map.
-    auto sub_index         = map_begin[index];
-    auto list_size         = value_offsets[offset_idx + 1] - value_offsets[offset_idx];
-    auto wrapped_sub_index = (sub_index % list_size + list_size) % list_size;
+    auto sub_index          = map_begin[index];
+    auto list_size          = value_offsets[offset_idx + 1] - value_offsets[offset_idx];
+    auto wrapped_sub_index  = (sub_index % list_size + list_size) % list_size;
+    auto constexpr null_idx = cuda::std::numeric_limits<cudf::size_type>::max();
     // Add sub_index to value_column offsets, to get gather indices of child of value_column
-    return value_offsets[offset_idx] + wrapped_sub_index - value_offsets[0];
+    return (bounds_policy == out_of_bounds_policy::NULLIFY && out_of_bounds(sub_index, list_size))
+             ? null_idx
+             : value_offsets[offset_idx] + wrapped_sub_index - value_offsets[0];
   };
   auto child_gather_index_begin = cudf::detail::make_counting_transform_iterator(0, transformer);
 
@@ -66,7 +80,7 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
   auto child_table = cudf::detail::gather(table_view({value_column.get_sliced_child(stream)}),
                                           child_gather_index_begin,
                                           child_gather_index_begin + gather_map_size,
-                                          out_of_bounds_policy::DONT_CHECK,
+                                          bounds_policy,
                                           stream,
                                           mr);
   auto child       = std::move(child_table->release().front());
@@ -94,9 +108,11 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
 
 std::unique_ptr<column> segmented_gather(lists_column_view const& source_column,
                                          lists_column_view const& gather_map_list,
+                                         out_of_bounds_policy bounds_policy,
                                          rmm::mr::device_memory_resource* mr)
 {
-  return detail::segmented_gather(source_column, gather_map_list, rmm::cuda_stream_default, mr);
+  return detail::segmented_gather(
+    source_column, gather_map_list, bounds_policy, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -21,9 +21,8 @@
 #include <cudf/lists/detail/gather.cuh>
 
 #include <thrust/binary_search.h>
-#include <limits>
+
 #include <rmm/cuda_stream_view.hpp>
-#include "cudf/types.hpp"
 
 namespace cudf {
 namespace lists {
@@ -65,9 +64,9 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
         thrust::seq, gather_index_begin, gather_index_end, gather_index_begin[-1] + index) -
       gather_index_begin;
     // Get each sub_index in list in each row of gather_map.
-    auto sub_index          = map_begin[index];
-    auto list_size          = value_offsets[offset_idx + 1] - value_offsets[offset_idx];
-    auto wrapped_sub_index  = (sub_index % list_size + list_size) % list_size;
+    auto sub_index = map_begin[index];
+    auto list_size = value_offsets[offset_idx + 1] - value_offsets[offset_idx];
+    auto wrapped_sub_index  = sub_index < 0 ? sub_index + list_size : sub_index;
     auto constexpr null_idx = cuda::std::numeric_limits<cudf::size_type>::max();
     // Add sub_index to value_column offsets, to get gather indices of child of value_column
     return (bounds_policy == out_of_bounds_policy::NULLIFY && out_of_bounds(sub_index, list_size))

--- a/cpp/tests/copying/segmented_gather_list_tests.cpp
+++ b/cpp/tests/copying/segmented_gather_list_tests.cpp
@@ -176,7 +176,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNested)
     LCW<T> list{{{2, 3}, {4, 5}},
                 {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
                 {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {-17, -18}}};
-    LCW<int> gather_map{{0, 2, -2}, {1}, {1, 0, -1, 5}};
+    LCW<int> gather_map{{0, -2, -2}, {1}, {1, 0, -1, -5}};
 
     auto results =
       cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
@@ -256,14 +256,14 @@ TYPED_TEST(SegmentedGatherTest, GatherOutOfOrder)
     LCW<T> list{{{2, 3}, {4, 5}},
                 {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
                 {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
-    LCW<int> gather_map{{1, 0}, {1, 2, 0}, {5, 4, 3, 2, 1, 0}};
+    LCW<int> gather_map{{1, 0}, {1, 2, 0}, {4, 3, 2, 1, 0}};
 
     auto results =
       cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
 
     LCW<T> expected{{{4, 5}, {2, 3}},
                     {{9, 10, 11}, {12, 13, 14}, {6, 7, 8}},
-                    {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}};
+                    {{17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}};
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
   }

--- a/cpp/tests/copying/segmented_gather_list_tests.cpp
+++ b/cpp/tests/copying/segmented_gather_list_tests.cpp
@@ -25,9 +25,6 @@
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-using cudf::test::iterators::null_at;
-using cudf::test::iterators::nulls_at;
-
 template <typename T>
 class SegmentedGatherTest : public cudf::test::BaseFixture {
 };
@@ -35,7 +32,7 @@ using FixedWidthTypesNotBool = cudf::test::Concat<cudf::test::IntegralTypesNotBo
                                                   cudf::test::FloatingPointTypes,
                                                   cudf::test::DurationTypes,
                                                   cudf::test::TimestampTypes>;
-TYPED_TEST_CASE(SegmentedGatherTest, FixedWidthTypesNotBool);
+TYPED_TEST_SUITE(SegmentedGatherTest, FixedWidthTypesNotBool);
 
 class SegmentedGatherTestList : public cudf::test::BaseFixture {
 };
@@ -46,6 +43,11 @@ class SegmentedGatherTestList : public cudf::test::BaseFixture {
 template <typename T>
 using LCW = cudf::test::lists_column_wrapper<T, int32_t>;
 using cudf::lists_column_view;
+using cudf::lists::detail::segmented_gather;
+using cudf::test::iterators::no_nulls;
+using cudf::test::iterators::null_at;
+using cudf::test::iterators::nulls_at;
+auto constexpr NULLIFY = cudf::out_of_bounds_policy::NULLIFY;
 
 TYPED_TEST(SegmentedGatherTest, Gather)
 {
@@ -56,23 +58,18 @@ TYPED_TEST(SegmentedGatherTest, Gather)
 
   {
     // Straight-line case.
-    LCW<int> gather_map{{3, 2, 1, 0}, {0}, {0, 1}, {0, 2, 1}};
-    LCW<T> expected{{4, 3, 2, 1}, {5}, {6, 7}, {8, 10, 9}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
+    auto const gather_map = LCW<int>{{3, 2, 1, 0}, {0}, {0, 1}, {0, 2, 1}};
+    auto const expected   = LCW<T>{{4, 3, 2, 1}, {5}, {6, 7}, {8, 10, 9}};
+    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
   }
 
   {
     // Nullify out-of-bounds values.
-    LCW<int> gather_map{{3, 2, 4, 0}, {0}, {0, -3}, {0, 2, 1}};
-    LCW<T> expected{{{4, 3, 2, 1}, null_at(2)}, {5}, {{6, 7}, null_at(1)}, {8, 10, 9}};
-
-    auto results = cudf::lists::detail::segmented_gather(
-      lists_column_view{list}, lists_column_view{gather_map}, cudf::out_of_bounds_policy::NULLIFY);
-
+    auto const gather_map = LCW<int>{{3, 2, 4, 0}, {0}, {0, -3}, {0, 2, 1}};
+    auto const expected = LCW<T>{{{4, 3, 2, 1}, null_at(2)}, {5}, {{6, 7}, null_at(1)}, {8, 10, 9}};
+    auto const results =
+      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
   }
 }
@@ -84,41 +81,31 @@ TYPED_TEST(SegmentedGatherTest, GatherNothing)
 
   // List<T>
   {
-    LCW<T> list{{1, 2, 3, 4}, {5}, {6, 7}, {8, 9, 10}};
-    LCW<int> gather_map{LCW<int>{}, LCW<int>{}, LCW<int>{}, LCW<int>{}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-    LCW<T> expected{LCW<T>{}, LCW<T>{}, LCW<T>{}, LCW<T>{}};
+    auto const list       = LCW<T>{{1, 2, 3, 4}, {5}, {6, 7}, {8, 9, 10}};
+    auto const gather_map = LCW<int>{LCW<int>{}, LCW<int>{}, LCW<int>{}, LCW<int>{}};
+    auto const results  = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const expected = LCW<T>{LCW<T>{}, LCW<T>{}, LCW<T>{}, LCW<T>{}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
   }
   // List<List<T>>
   {
-    LCW<T> list{{{1, 2, 3, 4}, {5}}, {{6, 7}}, {{}, {8, 9, 10}}};
-    LCW<int> gather_map{LCW<int>{}, LCW<int>{}, LCW<int>{}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const list       = LCW<T>{{{1, 2, 3, 4}, {5}}, {{6, 7}}, {{}, {8, 9, 10}}};
+    auto const gather_map = LCW<int>{LCW<int>{}, LCW<int>{}, LCW<int>{}};
+    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
 
     // hack to get column of empty list of list
-    LCW<T> expected_dummy{{{1, 2, 3, 4}, {5}}, LCW<T>{}, LCW<T>{}, LCW<T>{}};
-    auto expected = cudf::split(expected_dummy, {1})[1];
+    auto const expected_dummy = LCW<T>{{{1, 2, 3, 4}, {5}}, LCW<T>{}, LCW<T>{}, LCW<T>{}};
+    auto const expected       = cudf::split(expected_dummy, {1})[1];
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
   }
-
   // List<List<List<T>>>
   {
-    LCW<T> list{{{{1, 2, 3, 4}, {5}}}, {{{6, 7}, {8, 9, 10}}}};
-    LCW<int> gather_map{LCW<int>{}, LCW<int>{}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-    LCW<T> expected_dummy{{{{1, 2, 3, 4}}},  // hack to get column of empty list of list of list
-                          LCW<T>{},
-                          LCW<T>{}};
-    auto expected = cudf::split(expected_dummy, {1})[1];
+    auto const list       = LCW<T>{{{{1, 2, 3, 4}, {5}}}, {{{6, 7}, {8, 9, 10}}}};
+    auto const gather_map = LCW<int>{LCW<int>{}, LCW<int>{}};
+    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    // hack to get column of empty list of list of list
+    auto const expected_dummy = LCW<T>{{{{1, 2, 3, 4}}}, LCW<T>{}, LCW<T>{}};
+    auto const expected       = cudf::split(expected_dummy, {1})[1];
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
     // the result should preserve the full List<List<List<int>>> hierarchy
@@ -143,26 +130,23 @@ TYPED_TEST(SegmentedGatherTest, GatherNulls)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
 
   // List<T>
-  LCW<T> list{{{1, 2, 3, 4}, valids}, {5}, {{6, 7}, valids}, {{8, 9, 10}, valids}};
+  auto const list = LCW<T>{{{1, 2, 3, 4}, valids}, {5}, {{6, 7}, valids}, {{8, 9, 10}, valids}};
+
   {
     // Test gathering on lists that contain nulls.
-    LCW<int> gather_map{{0, 1}, LCW<int>{}, {1}, {2, 1, 0}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-    LCW<T> expected{{{1, 2}, valids}, LCW<T>{}, {{7}, valids + 1}, {{10, 9, 8}, valids}};
+    auto const gather_map = LCW<int>{{0, 1}, LCW<int>{}, {1}, {2, 1, 0}};
+    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const expected =
+      LCW<T>{{{1, 2}, valids}, LCW<T>{}, {{7}, valids + 1}, {{10, 9, 8}, valids}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
   }
   {
     // Test gathering on lists that contain nulls, with out-of-bounds indices.
-    LCW<int> gather_map{{10, -10}, LCW<int>{}, {1}, {2, -10, 0}};
-
-    auto results = cudf::lists::detail::segmented_gather(
-      lists_column_view{list}, lists_column_view{gather_map}, cudf::out_of_bounds_policy::NULLIFY);
-
-    LCW<T> expected{
-      {{0, 0}, nulls_at({0, 1})}, LCW<T>{}, {{7}, valids + 1}, {{10, 0, 8}, null_at(1)}};
+    auto const gather_map = LCW<int>{{10, -10}, LCW<int>{}, {1}, {2, -10, 0}};
+    auto const results =
+      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto const expected =
+      LCW<T>{{{0, 0}, nulls_at({0, 1})}, LCW<T>{}, {{7}, valids + 1}, {{10, 0, 8}, null_at(1)}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
   }
 }
@@ -173,77 +157,76 @@ TYPED_TEST(SegmentedGatherTest, GatherNested)
 
   // List<List<T>>
   {
-    LCW<T> list{{{2, 3}, {4, 5}},
-                {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
-                {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {-17, -18}}};
-    LCW<int> gather_map{{0, -2, -2}, {1}, {1, 0, -1, -5}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-    LCW<T> expected{
-      {{2, 3}, {2, 3}, {2, 3}}, {{9, 10, 11}}, {{17, 18}, {15, 16}, {-17, -18}, {15, 16}}};
+    // clang-format off
+    auto const list       = LCW<T>{{{2, 3}, {4, 5}},
+                                   {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
+                                   {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {-17, -18}}};
+    auto const gather_map = LCW<int>{{0, -2, -2}, {1}, {1, 0, -1, -5}};
+    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const expected   = LCW<T>{{{2, 3}, {2, 3}, {2, 3}}, 
+                                   {{9, 10, 11}}, 
+                                   {{17, 18}, {15, 16}, {-17, -18}, {15, 16}}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on 
   }
 
   // List<List<T>>, with out-of-bounds gather indices.
   {
-    LCW<T> list{{{2, 3}, {4, 5}},
-                {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
-                {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {-17, -18}}};
-    LCW<int> gather_map{{0, 2, -2}, {1}, {1, 0, -1, -6}};
-
-    auto results = cudf::lists::detail::segmented_gather(
-      lists_column_view{list}, lists_column_view{gather_map}, cudf::out_of_bounds_policy::NULLIFY);
-
-    LCW<T> expected{{{{2, 3}, LCW<T>{}, {2, 3}}, null_at(1)},
-                    {{9, 10, 11}},
-                    {{{17, 18}, {15, 16}, {-17, -18}, LCW<T>{}}, null_at(3)}};
+    // clang-format off
+    auto const list       = LCW<T>{{{2, 3}, {4, 5}},
+                                   {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
+                                   {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {-17, -18}}};
+    auto const gather_map = LCW<int>{{0, 2, -2}, {1}, {1, 0, -1, -6}};
+    auto const results =
+      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto const expected = LCW<T>{{{{2, 3}, LCW<T>{}, {2, 3}}, null_at(1)},
+                                 {{9, 10, 11}},
+                                 {{{17, 18}, {15, 16}, {-17, -18}, LCW<T>{}}, null_at(3)}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on
   }
 
   // List<List<List<T>>>
   {
-    LCW<T> list{{{{2, 3}, {4, 5}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
-                {{{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}},
-                {{LCW<T>{0}}},
-                {{{10}, {20, 30, 40, 50}, {60, 70, 80}},
-                 {{0, 1, 3}, {5}},
-                 {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
-                {{{10, 20}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}};
-    LCW<int> gather_map{{1}, LCW<int>{}, {0}, {1}, {0, -1, 1}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-    LCW<T> expected{{{{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
-                    LCW<T>{},
-                    {{LCW<T>{0}}},
-                    {{{0, 1, 3}, {5}}},
-                    {{{10, 20}}, {{40, 50}, {60, 70, 80}}, {LCW<T>{30}}}};
+    // clang-format off
+    auto const list = LCW<T>{{{{2, 3}, {4, 5}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
+                             {{{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}},
+                             {{LCW<T>{0}}},
+                             {{{10}, {20, 30, 40, 50}, {60, 70, 80}},
+                              {{0, 1, 3}, {5}},
+                              {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
+                             {{{10, 20}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}};
+    auto const gather_map = LCW<int>{{1}, LCW<int>{}, {0}, {1}, {0, -1, 1}};
+    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const expected = LCW<T>{{{{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
+                                 LCW<T>{},
+                                 {{LCW<T>{0}}},
+                                 {{{0, 1, 3}, {5}}},
+                                 {{{10, 20}}, {{40, 50}, {60, 70, 80}}, {LCW<T>{30}}}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on
   }
 
   // List<List<List<T>>>, with out-of-bounds gather indices.
   {
-    LCW<T> list{{{{2, 3}, {4, 5}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
-                {{{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}},
-                {{LCW<T>{0}}},
-                {{{10}, {20, 30, 40, 50}, {60, 70, 80}},
-                 {{0, 1, 3}, {5}},
-                 {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
-                {{{10, 20}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}};
-    LCW<int> gather_map{{1}, LCW<int>{}, {0}, {1}, {0, -1, 3, -4}};
-
-    auto results = cudf::lists::detail::segmented_gather(
-      lists_column_view{list}, lists_column_view{gather_map}, cudf::out_of_bounds_policy::NULLIFY);
-
-    LCW<T> expected{{{{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
-                    LCW<T>{},
-                    {{LCW<T>{0}}},
-                    {{{0, 1, 3}, {5}}},
-                    {{{{10, 20}}, {{40, 50}, {60, 70, 80}}, LCW<T>{}, LCW<T>{}}, nulls_at({2, 3})}};
+    auto const list       = LCW<T>{{{{2, 3}, {4, 5}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
+                             {{{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}},
+                             {{LCW<T>{0}}},
+                             {{{10}, {20, 30, 40, 50}, {60, 70, 80}},
+                              {{0, 1, 3}, {5}},
+                              {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
+                             {{{10, 20}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}};
+    auto const gather_map = LCW<int>{{1}, LCW<int>{}, {0}, {1}, {0, -1, 3, -4}};
+    auto const results =
+      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto const expected =
+      LCW<T>{{{{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
+             LCW<T>{},
+             {{LCW<T>{0}}},
+             {{{0, 1, 3}, {5}}},
+             {{{{10, 20}}, {{40, 50}, {60, 70, 80}}, LCW<T>{}, LCW<T>{}}, nulls_at({2, 3})}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on
   }
 }
 
@@ -253,36 +236,32 @@ TYPED_TEST(SegmentedGatherTest, GatherOutOfOrder)
 
   // List<List<T>>
   {
-    LCW<T> list{{{2, 3}, {4, 5}},
-                {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
-                {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
-    LCW<int> gather_map{{1, 0}, {1, 2, 0}, {4, 3, 2, 1, 0}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-    LCW<T> expected{{{4, 5}, {2, 3}},
-                    {{9, 10, 11}, {12, 13, 14}, {6, 7, 8}},
-                    {{17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}};
-
+    // clang-format off
+    auto const list       = LCW<T>{{{2, 3}, {4, 5}},
+                                   {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
+                                   {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
+    auto const gather_map = LCW<int>{{1, 0}, {1, 2, 0}, {4, 3, 2, 1, 0}};
+    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const expected   = LCW<T>{{{4, 5}, {2, 3}},
+                                   {{9, 10, 11}, {12, 13, 14}, {6, 7, 8}},
+                                   {{17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on
   }
 
   // List<List<T>>, with out-of-bounds gather indices.
   {
-    LCW<T> list{{{2, 3}, {4, 5}},
-                {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
-                {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
-    LCW<int> gather_map{{1, 0}, {3, -1, -4}, {5, 4, 3, 2, 1, 0}};
-
-    auto results = cudf::lists::detail::segmented_gather(
-      lists_column_view{list}, lists_column_view{gather_map}, cudf::out_of_bounds_policy::NULLIFY);
-
-    LCW<T> expected{{{4, 5}, {2, 3}},
-                    {{LCW<T>{}, {12, 13, 14}, LCW<T>{}}, nulls_at({0, 2})},
-                    {{LCW<T>{}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}, null_at(0)}};
-
+    // clang-format off
+    auto const list       = LCW<T>{{{2, 3}, {4, 5}},
+                                   {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
+                                   {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
+    auto const gather_map = LCW<int>{{1, 0}, {3, -1, -4}, {5, 4, 3, 2, 1, 0}};
+    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto const expected   = LCW<T>{{{4, 5}, {2, 3}},
+                                   {{LCW<T>{}, {12, 13, 14}, LCW<T>{}}, nulls_at({0, 2})},
+                                   {{LCW<T>{}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}, null_at(0)}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on
   }
 }
 
@@ -292,35 +271,32 @@ TYPED_TEST(SegmentedGatherTest, GatherNegatives)
 
   // List<List<T>>
   {
-    LCW<T> list{{{2, 3}, {4, 5}},
-                {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
-                {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
-    LCW<int> gather_map{{-1, 0}, {-2, -1, 0}, {-5, -4, -3, -2, -1, 0}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-    LCW<T> expected{{{4, 5}, {2, 3}},
-                    {{9, 10, 11}, {12, 13, 14}, {6, 7, 8}},
-                    {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}};
-
+    // clang-format off
+    auto const list       = LCW<T>{{{2, 3}, {4, 5}},
+                                   {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
+                                   {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
+    auto const gather_map = LCW<int>{{-1, 0}, {-2, -1, 0}, {-5, -4, -3, -2, -1, 0}};
+    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const expected   = LCW<T>{{{4, 5}, {2, 3}},
+                                   {{9, 10, 11}, {12, 13, 14}, {6, 7, 8}},
+                                   {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on
   }
   // List<List<T>>, with out-of-bounds gather indices.
   {
-    LCW<T> list{{{2, 3}, {4, 5}},
-                {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
-                {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
-    LCW<int> gather_map{{-1, 0}, {-2, -1, -4}, {-6, -4, -3, -2, -1, 0}};
-
-    auto results = cudf::lists::detail::segmented_gather(
-      lists_column_view{list}, lists_column_view{gather_map}, cudf::out_of_bounds_policy::NULLIFY);
-
-    LCW<T> expected{{{4, 5}, {2, 3}},
-                    {{{9, 10, 11}, {12, 13, 14}, LCW<T>{}}, null_at(2)},
-                    {{LCW<T>{}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}, null_at(0)}};
-
+    // clang-format off
+    auto const list       = LCW<T>{{{2, 3}, {4, 5}},
+                                   {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
+                                   {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
+    auto const gather_map = LCW<int>{{-1, 0}, {-2, -1, -4}, {-6, -4, -3, -2, -1, 0}};
+    auto const results    = 
+      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto const expected   = LCW<T>{{{4, 5}, {2, 3}},
+                                   {{{9, 10, 11}, {12, 13, 14}, LCW<T>{}}, null_at(2)},
+                                   {{LCW<T>{}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}, null_at(0)}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on
   }
 }
 
@@ -333,46 +309,38 @@ TYPED_TEST(SegmentedGatherTest, GatherNestedNulls)
 
   // List<List<T>>
   {
-    LCW<T> list{{{{2, 3}, valids}, {4, 5}},
-                {{{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}, valids},
-                {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}},
-                {{{{25, 26}, valids}, {27, 28}, {{29, 30}, valids}, {31, 32}, {33, 34}}, valids}};
-
-    LCW<int> gather_map{{0, 1}, {0, 2}, LCW<int>{}, {0, 1, 4}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-    auto trues = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
-
-    LCW<T> expected{{{{2, 3}, valids}, {4, 5}},
-                    {{{6, 7, 8}, {12, 13, 14}}, trues},
-                    LCW<T>{},
-                    {{{{25, 26}, valids}, {27, 28}, {33, 34}}, valids}};
-
+    // clang-format off
+    auto const list = LCW<T>{{{{2, 3}, valids}, {4, 5}},
+                             {{{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}, valids},
+                             {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}},
+                             {{{{25, 26}, valids}, {27, 28}, {{29, 30}, valids}, {31, 32}, {33, 34}}, valids}};
+    auto const gather_map = LCW<int>{{0, 1}, {0, 2}, LCW<int>{}, {0, 1, 4}};
+    auto const results  = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const expected = LCW<T>{{{{2, 3}, valids}, {4, 5}},
+                                 {{{6, 7, 8}, {12, 13, 14}}, no_nulls()},
+                                 LCW<T>{},
+                                 {{{{25, 26}, valids}, {27, 28}, {33, 34}}, valids}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on
   }
 
   // List<List<List<List<T>>>>
   {
-    LCW<T> list{{{{{2, 3}, {4, 5}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
-                 {{{15, 16}, {{27, 28}, valids}, {{37, 38}, valids}, {47, 48}, {57, 58}}},
-                 {{LCW<T>{0}}},
-                 {{{10}, {20, 30, 40, 50}, {60, 70, 80}},
-                  {{0, 1, 3}, {5}},
-                  {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
-                 {{{{{10, 20}, valids}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}, valids}}};
-
-    LCW<int> gather_map{{1, 2, 4}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-    LCW<T> expected{{{{{15, 16}, {{27, 28}, valids}, {{37, 38}, valids}, {47, 48}, {57, 58}}},
-                     {{LCW<T>{0}}},
-                     {{{{{10, 20}, valids}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}, valids}}};
-
+    // clang-format off
+    auto const list = LCW<T>{{{{{2, 3}, {4, 5}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
+                              {{{15, 16}, {{27, 28}, valids}, {{37, 38}, valids}, {47, 48}, {57, 58}}},
+                              {{LCW<T>{0}}},
+                              {{{10}, {20, 30, 40, 50}, {60, 70, 80}},
+                                {{0, 1, 3}, {5}},
+                                {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
+                              {{{{{10, 20}, valids}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}, valids}}};
+    auto const gather_map = LCW<int>{{1, 2, 4}};
+    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const expected   = LCW<T>{{{{{15, 16}, {{27, 28}, valids}, {{37, 38}, valids}, {47, 48}, {57, 58}}},
+                                    {{LCW<T>{0}}},
+                                    {{{{{10, 20}, valids}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}, valids}}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    // clang-format on
   }
 }
 
@@ -380,15 +348,11 @@ TYPED_TEST(SegmentedGatherTest, GatherNestedWithEmpties)
 {
   using T = TypeParam;
 
-  LCW<T> list{{{2, 3}, LCW<T>{}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}, {LCW<T>{}}};
-  LCW<int> gather_map{LCW<int>{0}, LCW<int>{0}, LCW<int>{0}};
-
-  auto results =
-    cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
-  // skip one null, gather one null.
-  LCW<T> expected{{{2, 3}}, {{6, 7, 8}}, {LCW<T>{}}};
-
+  auto const list = LCW<T>{{{2, 3}, LCW<T>{}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}, {LCW<T>{}}};
+  auto const gather_map = LCW<int>{LCW<int>{0}, LCW<int>{0}, LCW<int>{0}};
+  auto results          = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+  auto const expected =
+    LCW<T>{{{2, 3}}, {{6, 7, 8}}, {LCW<T>{}}};  // skip one null, gather one null.
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
 }
 
@@ -396,7 +360,7 @@ TYPED_TEST(SegmentedGatherTest, GatherSliced)
 {
   using T = TypeParam;
   {
-    LCW<T> a{
+    auto const a = LCW<T>{
       {{1, 1, 1}, {2, 2}, {3, 3}},
       {{4, 4, 4}, {5, 5}, {6, 6}},
       {{7, 7, 7}, {8, 8}, {9, 9}},
@@ -406,23 +370,27 @@ TYPED_TEST(SegmentedGatherTest, GatherSliced)
       {{50, 50, 50, 50}, {6, 13}},
       {{70, 70, 70, 70}, {80}},
     };
-    auto split_a = cudf::split(a, {3});
+    auto const split_a = cudf::split(a, {3});
 
-    auto result0 = cudf::lists::detail::segmented_gather(
-      lists_column_view{split_a[0]}, lists_column_view{LCW<int>{{1, 2}, {0, 2}, {0, 1}}});
-    LCW<T> expected0{
-      {{2, 2}, {3, 3}},
-      {{4, 4, 4}, {6, 6}},
-      {{7, 7, 7}, {8, 8}},
-    };
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected0, result0->view());
+    {
+      auto const gather_map = lists_column_view{LCW<int>{{1, 2}, {0, 2}, {0, 1}}};
+      auto const result     = segmented_gather(lists_column_view{split_a[0]}, gather_map);
+      auto const expected   = LCW<T>{
+        {{2, 2}, {3, 3}},
+        {{4, 4, 4}, {6, 6}},
+        {{7, 7, 7}, {8, 8}},
+      };
+      CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+    }
 
-    auto result1 = cudf::lists::detail::segmented_gather(
-      lists_column_view{split_a[1]},
-      lists_column_view{LCW<int>{{0, 1}, LCW<int>{}, LCW<int>{}, {0, 1}, LCW<int>{}}});
-    LCW<T> expected1{
-      {{10, 10, 10}, {11, 11}}, LCW<T>{}, LCW<T>{}, {{50, 50, 50, 50}, {6, 13}}, LCW<T>{}};
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, result1->view());
+    {
+      auto const gather_map =
+        lists_column_view{LCW<int>{{0, 1}, LCW<int>{}, LCW<int>{}, {0, 1}, LCW<int>{}}};
+      auto const result = segmented_gather(lists_column_view{split_a[1]}, gather_map);
+      auto const expected =
+        LCW<T>{{{10, 10, 10}, {11, 11}}, LCW<T>{}, LCW<T>{}, {{50, 50, 50, 50}, {6, 13}}, LCW<T>{}};
+      CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+    }
   }
 
   auto valids =
@@ -509,25 +477,21 @@ TEST_F(SegmentedGatherTestString, StringGather)
   using T = cudf::string_view;
   // List<T>
   {
-    LCW<T> list{{"a", "b", "c", "d"}, {"1", "22", "333", "4"}, {"x", "y", "z"}};
-    LCW<int8_t> gather_map{{0, 1, 3, 2}, {1, 0, 3, 2}, LCW<int8_t>{}};
-    LCW<T> expected{{"a", "b", "d", "c"}, {"22", "1", "4", "333"}, LCW<T>{}};
-
-    auto result =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const list       = LCW<T>{{"a", "b", "c", "d"}, {"1", "22", "333", "4"}, {"x", "y", "z"}};
+    auto const gather_map = LCW<int8_t>{{0, 1, 3, 2}, {1, 0, 3, 2}, LCW<int8_t>{}};
+    auto const expected   = LCW<T>{{"a", "b", "d", "c"}, {"22", "1", "4", "333"}, LCW<T>{}};
+    auto const result = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
   }
 
   // List<T>, with out-of-order gather indices.
   {
-    LCW<T> list{{"a", "b", "c", "d"}, {"1", "22", "333", "4"}, {"x", "y", "z"}};
-    LCW<int8_t> gather_map{{0, 1, 3, 4}, {1, -5, 3, 2}, LCW<int8_t>{}};
-    LCW<T> expected{{{"a", "b", "d", "c"}, cudf::test::iterators::null_at(3)},
-                    {{"22", "1", "4", "333"}, cudf::test::iterators::null_at(1)},
-                    LCW<T>{}};
-
-    auto result = cudf::lists::detail::segmented_gather(
-      lists_column_view{list}, lists_column_view{gather_map}, cudf::out_of_bounds_policy::NULLIFY);
+    auto const list       = LCW<T>{{"a", "b", "c", "d"}, {"1", "22", "333", "4"}, {"x", "y", "z"}};
+    auto const gather_map = LCW<int8_t>{{0, 1, 3, 4}, {1, -5, 3, 2}, LCW<int8_t>{}};
+    auto const expected   = LCW<T>{{{"a", "b", "d", "c"}, cudf::test::iterators::null_at(3)},
+                                 {{"22", "1", "4", "333"}, cudf::test::iterators::null_at(1)},
+                                 LCW<T>{}};
+    auto result = segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
   }
 }
@@ -539,56 +503,48 @@ TEST_F(SegmentedGatherTestFloat, GatherMapSliced)
 
   // List<T>
   {
-    LCW<T> list{{1, 2, 3, 4}, {5}, {6, 7}, {8, 9, 10}, {11, 12}, {13, 14, 15, 16}};
-    LCW<int> gather_map{{3, 2, 1, 0}, {0}, {0, 1}, {0, 2, 1}, {0}, {1}};
+    auto const list = LCW<T>{{1, 2, 3, 4}, {5}, {6, 7}, {8, 9, 10}, {11, 12}, {13, 14, 15, 16}};
+    auto const gather_map = LCW<int>{{3, 2, 1, 0}, {0}, {0, 1}, {0, 2, 1}, {0}, {1}};
     // gather_map.offset: 0, 4, 5, 7, 10, 11, 12
-    LCW<T> expected{{4, 3, 2, 1}, {5}, {6, 7}, {8, 10, 9}, {11}, {14}};
-
-    auto results =
-      cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-
+    auto const expected = LCW<T>{{4, 3, 2, 1}, {5}, {6, 7}, {8, 10, 9}, {11}, {14}};
+    auto const results  = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
-    auto sliced  = cudf::split(list, {1, 4});
-    auto split_m = cudf::split(gather_map, {1, 4});
-    auto split_e = cudf::split(expected, {1, 4});
 
-    auto result0 = cudf::lists::detail::segmented_gather(lists_column_view{sliced[0]},
-                                                         lists_column_view{split_m[0]});
+    auto const sliced  = cudf::split(list, {1, 4});
+    auto const split_m = cudf::split(gather_map, {1, 4});
+    auto const split_e = cudf::split(expected, {1, 4});
+
+    auto result0 = segmented_gather(lists_column_view{sliced[0]}, lists_column_view{split_m[0]});
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[0], result0->view());
-    auto result1 = cudf::lists::detail::segmented_gather(lists_column_view{sliced[1]},
-                                                         lists_column_view{split_m[1]});
+    auto result1 = segmented_gather(lists_column_view{sliced[1]}, lists_column_view{split_m[1]});
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[1], result1->view());
-    auto result2 = cudf::lists::detail::segmented_gather(lists_column_view{sliced[2]},
-                                                         lists_column_view{split_m[2]});
+    auto result2 = segmented_gather(lists_column_view{sliced[2]}, lists_column_view{split_m[2]});
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[2], result2->view());
   }
 
   // List<T>, with out-of-bounds gather indices.
   {
-    LCW<T> list{{1, 2, 3, 4}, {5}, {6, 7}, {8, 9, 10}, {11, 12}, {13, 14, 15, 16}};
-    LCW<int> gather_map{{3, -5, 1, 0}, {0}, {0, 1}, {0, 2, 3}, {0}, {1}};
+    auto const list = LCW<T>{{1, 2, 3, 4}, {5}, {6, 7}, {8, 9, 10}, {11, 12}, {13, 14, 15, 16}};
+    auto const gather_map = LCW<int>{{3, -5, 1, 0}, {0}, {0, 1}, {0, 2, 3}, {0}, {1}};
     // gather_map.offset: 0, 4, 5, 7, 10, 11, 12
-    LCW<T> expected{{{4, 0, 2, 1}, null_at(1)}, {5}, {6, 7}, {{8, 10, 9}, null_at(2)}, {11}, {14}};
-
-    auto results = cudf::lists::detail::segmented_gather(
-      lists_column_view{list}, lists_column_view{gather_map}, cudf::out_of_bounds_policy::NULLIFY);
-
+    auto const expected =
+      LCW<T>{{{4, 0, 2, 1}, null_at(1)}, {5}, {6, 7}, {{8, 10, 9}, null_at(2)}, {11}, {14}};
+    auto results =
+      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
-    auto sliced  = cudf::split(list, {1, 4});
-    auto split_m = cudf::split(gather_map, {1, 4});
-    auto split_e = cudf::split(expected, {1, 4});
 
-    auto result0 = cudf::lists::detail::segmented_gather(lists_column_view{sliced[0]},
-                                                         lists_column_view{split_m[0]},
-                                                         cudf::out_of_bounds_policy::NULLIFY);
+    auto const sliced  = cudf::split(list, {1, 4});
+    auto const split_m = cudf::split(gather_map, {1, 4});
+    auto const split_e = cudf::split(expected, {1, 4});
+
+    auto const result0 =
+      segmented_gather(lists_column_view{sliced[0]}, lists_column_view{split_m[0]}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[0], result0->view());
-    auto result1 = cudf::lists::detail::segmented_gather(lists_column_view{sliced[1]},
-                                                         lists_column_view{split_m[1]},
-                                                         cudf::out_of_bounds_policy::NULLIFY);
+    auto const result1 =
+      segmented_gather(lists_column_view{sliced[1]}, lists_column_view{split_m[1]}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[1], result1->view());
-    auto result2 = cudf::lists::detail::segmented_gather(lists_column_view{sliced[2]},
-                                                         lists_column_view{split_m[2]},
-                                                         cudf::out_of_bounds_policy::NULLIFY);
+    auto const result2 =
+      segmented_gather(lists_column_view{sliced[2]}, lists_column_view{split_m[2]}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[2], result2->view());
   }
 }


### PR DESCRIPTION
The behaviour of `cudf::lists::segmented_gather()` is currently undefined for any
index value `i` that falls outside the range `[-n, n)`, where `n` is the number of
elements in the list row.

This commit adds support to explicitly specify an `out_of_bounds_policy`, like in
`cudf::gather()`. The erstwhile behaviour is retained when the bounds policy is set
to `DONT_CHECK`. If the bounds policy is specified as `NULLIFY`, then for any
index falling outside the range `[-n, n)`, the list element is set to `null`.

E.g.
```c++
auto source_column = [{"a", "b", "c", "d"}, {"1", "2", "3", "4"}, {"x", "y", "z"}];
auto gather_map    = [{0, -1, 4, -5}, {1, 3, 5}, {}];
auto result = segmented_gather(source_column, gather_map, NULLIFY);
result == [{"a", "d", null, null}, {"2", "4", null}, {}];
```
