### PR TITLE
Fix #9247: Prevent Numba Performance Warnings in cuDF

### DIFF
--- a/python/cudf/cudf/__init__.py
+++ b/python/cudf/cudf/__init__.py
@@ -4,7 +4,7 @@ from cudf.utils.gpu_utils import validate_setup
 validate_setup()
 
 import cupy
-from numba import cuda
+from numba import config as numba_config, cuda
 
 import rmm
 
@@ -103,6 +103,14 @@ from cudf.utils.utils import set_allocator
 
 cuda.set_memory_manager(rmm.RMMNumbaManager)
 cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+
+try:
+    # Numba 0.54: Disable low occupancy warnings
+    numba_config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+except AttributeError:
+    # Numba < 0.54: No occupancy warnings
+    pass
+del numba_config
 
 __version__ = get_versions()["version"]
 del get_versions


### PR DESCRIPTION
Numba 0.54 introduces performance warnings whenever a kernel is launched with low occupancy. Certain operations in cuDF can indirectly cause this warning to be emitted, for example `DataFrame.iloc` (which one would not expect to be particularly efficient anyway). This message could be disconcerting for users and appear in a lot of workflows; therefore, this commit configures Numba 0.54  at cuDF import time to suppress the low occupancy warning.

Fixes #9247.

There has been some discussion about whether this needs to be a hotfix, so I'm opening this PR initially targeted at 21.10 accordingly - cc @quasiben @shwina @JohnZed.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
