### PR TITLE
Fix some unused variable warnings in libcudf

### DIFF
--- a/cpp/src/groupby/sort/group_tdigest.cu
+++ b/cpp/src/groupby/sort/group_tdigest.cu
@@ -606,13 +606,7 @@ struct typed_group_tdigest {
     typename T,
     typename... Args,
     typename std::enable_if_t<!cudf::is_numeric<T>() && !cudf::is_fixed_point<T>()>* = nullptr>
-  std::unique_ptr<column> operator()(Args&&...)  // column_view const&,
-                                                 // cudf::device_span<size_type const>
-                                                 // group_offsets, cudf::device_span<size_type const>
-                                                 // group_labels, cudf::device_span<size_type const>
-                                                 // group_valid_counts, size_type num_groups, int
-                                                 // delta, rmm::cuda_stream_view stream,
-                                                 // rmm::mr::device_memory_resource* mr)
+  std::unique_ptr<column> operator()(Args&&...)
   {
     CUDF_FAIL("Non-numeric type in group_tdigest");
   }

--- a/cpp/src/groupby/sort/group_tdigest.cu
+++ b/cpp/src/groupby/sort/group_tdigest.cu
@@ -299,6 +299,8 @@ __global__ void generate_cluster_limits_kernel(int delta_,
         nearest_w_index       = last_inserted_index + 1;
         auto [r, i, adjusted] = cumulative_weight(nearest_w_index);
         adjusted_next_limit   = max(next_limit, adjusted);
+        (void)r;
+        (void)i;
       }
       cluster_wl[group_num_clusters[group_index]] = adjusted_next_limit;
       last_inserted_index                         = nearest_w_index;
@@ -469,6 +471,7 @@ std::unique_ptr<column> compute_tdigests(int delta,
      group_cumulative_weight] __device__(size_type value_index) -> size_type {
       auto [group_index, relative_value_index, cumulative_weight] =
         group_cumulative_weight(value_index);
+      (void)relative_value_index;
 
       // compute start of cluster weight limits for this group
       double const* weight_limits = group_cluster_wl + group_cluster_offsets[group_index];
@@ -601,15 +604,15 @@ struct typed_group_tdigest {
 
   template <
     typename T,
+    typename... Args,
     typename std::enable_if_t<!cudf::is_numeric<T>() && !cudf::is_fixed_point<T>()>* = nullptr>
-  std::unique_ptr<column> operator()(column_view const& col,
-                                     cudf::device_span<size_type const> group_offsets,
-                                     cudf::device_span<size_type const> group_labels,
-                                     cudf::device_span<size_type const> group_valid_counts,
-                                     size_type num_groups,
-                                     int delta,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::mr::device_memory_resource* mr)
+  std::unique_ptr<column> operator()(Args&&...)  // column_view const&,
+                                                 // cudf::device_span<size_type const>
+                                                 // group_offsets, cudf::device_span<size_type const>
+                                                 // group_labels, cudf::device_span<size_type const>
+                                                 // group_valid_counts, size_type num_groups, int
+                                                 // delta, rmm::cuda_stream_view stream,
+                                                 // rmm::mr::device_memory_resource* mr)
   {
     CUDF_FAIL("Non-numeric type in group_tdigest");
   }

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -376,10 +376,10 @@ struct column_row_comparator_dispatch {
   }
 
   template <class Type, std::enable_if_t<!cudf::is_equality_comparable<Type, Type>()>* = nullptr>
-  bool operator()(size_type i, size_type j) const
+  bool operator()(size_type, size_type) const
   {
     CUDF_FAIL(
-      "`column_row_comparator_dispatch` cannot operate on types that are not equally comparable.");
+      "column_row_comparator_dispatch cannot operate on types that are not equally comparable.");
   }
 };
 


### PR DESCRIPTION
Some unused variable warnings are appearing in 11.4 builds from recent PR merges.