### PR TITLE
Fix Cython compilation warnings.

### DIFF
--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -163,6 +163,7 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
     cdef map[string, string] user_data = c_out_table.metadata.user_data
     json_str = user_data[b'pandas'].decode('utf-8')
     meta = None
+    is_range_index = False
     if json_str != "":
         meta = json.loads(json_str)
         if 'index_columns' in meta and len(meta['index_columns']) > 0:
@@ -171,7 +172,6 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
                     index_col[0]['kind'] == 'range':
                 is_range_index = True
             else:
-                is_range_index = False
                 index_col_names = OrderedDict()
                 for idx_col in index_col:
                     for c in meta['columns']:

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -160,10 +160,10 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
 
     # Access the Parquet user_data json to find the index
     index_col = None
+    is_range_index = False
     cdef map[string, string] user_data = c_out_table.metadata.user_data
     json_str = user_data[b'pandas'].decode('utf-8')
     meta = None
-    is_range_index = False
     if json_str != "":
         meta = json.loads(json_str)
         if 'index_columns' in meta and len(meta['index_columns']) > 0:

--- a/python/cudf/cudf/_lib/reduce.pyx
+++ b/python/cudf/cudf/_lib/reduce.pyx
@@ -100,11 +100,7 @@ def scan(scan_op, Column incol, inclusive, **kwargs):
     cdef unique_ptr[column] c_result
     cdef Aggregation cython_agg = make_aggregation(scan_op, kwargs)
 
-    cdef scan_type c_inclusive
-    if inclusive is True:
-        c_inclusive = scan_type.INCLUSIVE
-    elif inclusive is False:
-        c_inclusive = scan_type.EXCLUSIVE
+    cdef scan_type c_inclusive = scan_type.INCLUSIVE if inclusive else scan_type.EXCLUSIVE
 
     with nogil:
         c_result = move(cpp_scan(

--- a/python/cudf/cudf/_lib/reduce.pyx
+++ b/python/cudf/cudf/_lib/reduce.pyx
@@ -100,7 +100,8 @@ def scan(scan_op, Column incol, inclusive, **kwargs):
     cdef unique_ptr[column] c_result
     cdef Aggregation cython_agg = make_aggregation(scan_op, kwargs)
 
-    cdef scan_type c_inclusive = scan_type.INCLUSIVE if inclusive else scan_type.EXCLUSIVE
+    cdef scan_type c_inclusive = \
+        scan_type.INCLUSIVE if inclusive else scan_type.EXCLUSIVE
 
     with nogil:
         c_result = move(cpp_scan(

--- a/python/cudf/cudf/_lib/utils.pyx
+++ b/python/cudf/cudf/_lib/utils.pyx
@@ -234,7 +234,7 @@ cdef data_from_unique_ptr(
     cdef vector[unique_ptr[column]] c_columns = move(c_tbl.get().release())
     cdef vector[unique_ptr[column]].iterator it = c_columns.begin()
 
-    cdef size_type i
+    cdef size_t i
 
     columns = [Column.from_unique_ptr(move(dereference(it+i)))
                for i in range(c_columns.size())]

--- a/python/cudf/cudf/_lib/utils.pyx
+++ b/python/cudf/cudf/_lib/utils.pyx
@@ -234,7 +234,7 @@ cdef data_from_unique_ptr(
     cdef vector[unique_ptr[column]] c_columns = move(c_tbl.get().release())
     cdef vector[unique_ptr[column]].iterator it = c_columns.begin()
 
-    cdef int i
+    cdef size_type i
 
     columns = [Column.from_unique_ptr(move(dereference(it+i)))
                for i in range(c_columns.size())]


### PR DESCRIPTION
This PR fixes three small issues relating to uninitialized variables in Cython code. This removes warnings from the build log and fixes potential bugs.

- Parquet code had a boolean variable `is_range_index` that was not initialized if `json_str != ""`.
- Reduction scan type wasn't correctly initialized (`if True:` / `elif False:` pattern)
- Undesired comparison of a signed int and an unsigned value in a utility function.