### PR TITLE
Fix memcheck error in groupby-tdigest get_scalar_minmax

### DIFF
--- a/cpp/src/groupby/sort/group_tdigest.cu
+++ b/cpp/src/groupby/sort/group_tdigest.cu
@@ -532,10 +532,12 @@ struct get_scalar_minmax {
 
   __device__ thrust::tuple<double, double> operator()(size_type group_index)
   {
-    // note: .element<T>() is taking care of fixed-point conversions for us.
-    return {static_cast<double>(col.element<T>(group_offsets[group_index])),
-            static_cast<double>(
-              col.element<T>(group_offsets[group_index] + (group_valid_counts[group_index] - 1)))};
+    auto const valid_count = group_valid_counts[group_index];
+    return valid_count > 0
+             ? thrust::make_tuple(
+                 static_cast<double>(col.element<T>(group_offsets[group_index])),
+                 static_cast<double>(col.element<T>(group_offsets[group_index] + valid_count - 1)))
+             : thrust::make_tuple(0.0, 0.0);
   }
 };
 


### PR DESCRIPTION
The groupby tdigest logic in the `get_scalar_minmax` would access incorrect device memory when encountering an empty group. The index value calculated for a column element in an empty group would be off by -1. This was found running a cuda-memcheck (compute-sanitizer) with the `AllNulls` gtest. Here the first group is empty resulting an out-of-bounds read at `col.element<T>(-1)`.

This PR adds a check for the empty group (`valid_count==0`) to prevent reading the incorrect column row.