### PR TITLE
Set pass_filenames: false in mypy pre-commit configuration.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
         hooks:
               - id: mypy
                 args: ["--config-file=python/cudf/setup.cfg", "python/cudf/cudf"]
+                pass_filenames: false
       - repo: https://github.com/pycqa/pydocstyle
         rev: 6.0.0
         hooks:


### PR DESCRIPTION
I made a small mistake in PR #9300. I missed the setting `pass_filenames: false`, which causes mypy to fail with an error about duplicate module names. This PR adds that setting back and fixes the error.
