### PR TITLE
Remove usage of deprecated thrust::host_space_tag.

### DIFF
--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -822,8 +822,8 @@ void update_null_mask(cudf::detail::hostdevice_2dvector<gpu::ColumnDesc>& chunks
     }
   }
 
-  thrust::counting_iterator<int, thrust::host_space_tag> col_idx_it(0);
-  thrust::counting_iterator<int, thrust::host_space_tag> stripe_idx_it(0);
+  thrust::counting_iterator<int, thrust::host_system_tag> col_idx_it(0);
+  thrust::counting_iterator<int, thrust::host_system_tag> stripe_idx_it(0);
 
   if (is_mask_updated) {
     // Update chunks with pointers to column data which might have been changed.
@@ -892,8 +892,8 @@ void reader::impl::decode_stream_data(cudf::detail::hostdevice_2dvector<gpu::Col
 {
   const auto num_stripes = chunks.size().first;
   const auto num_columns = chunks.size().second;
-  thrust::counting_iterator<int, thrust::host_space_tag> col_idx_it(0);
-  thrust::counting_iterator<int, thrust::host_space_tag> stripe_idx_it(0);
+  thrust::counting_iterator<int, thrust::host_system_tag> col_idx_it(0);
+  thrust::counting_iterator<int, thrust::host_system_tag> stripe_idx_it(0);
 
   // Update chunks with pointers to column data
   std::for_each(stripe_idx_it, stripe_idx_it + num_stripes, [&](auto stripe_idx) {

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -822,8 +822,8 @@ void update_null_mask(cudf::detail::hostdevice_2dvector<gpu::ColumnDesc>& chunks
     }
   }
 
-  thrust::counting_iterator<int, thrust::host_system_tag> col_idx_it(0);
-  thrust::counting_iterator<int, thrust::host_system_tag> stripe_idx_it(0);
+  thrust::counting_iterator<int> col_idx_it(0);
+  thrust::counting_iterator<int> stripe_idx_it(0);
 
   if (is_mask_updated) {
     // Update chunks with pointers to column data which might have been changed.
@@ -892,8 +892,8 @@ void reader::impl::decode_stream_data(cudf::detail::hostdevice_2dvector<gpu::Col
 {
   const auto num_stripes = chunks.size().first;
   const auto num_columns = chunks.size().second;
-  thrust::counting_iterator<int, thrust::host_system_tag> col_idx_it(0);
-  thrust::counting_iterator<int, thrust::host_system_tag> stripe_idx_it(0);
+  thrust::counting_iterator<int> col_idx_it(0);
+  thrust::counting_iterator<int> stripe_idx_it(0);
 
   // Update chunks with pointers to column data
   std::for_each(stripe_idx_it, stripe_idx_it + num_stripes, [&](auto stripe_idx) {


### PR DESCRIPTION
This PR fixes a deprecation warning from Thrust calls in the ORC reader.

Thrust 1.6.0 replaced `thrust::host_space_tag` with `thrust::host_system_tag` ([changelog](https://github.com/NVIDIA/thrust/blob/main/CHANGELOG.md#thrust-160)). The deprecated name was removed in Thrust 1.13.0 ([changelog](https://github.com/NVIDIA/thrust/blob/main/CHANGELOG.md#thrust-1130-nvidia-hpc-sdk-217)).
