### PR TITLE
Fix libcudf compile warnings on debug 11.4 build

### DIFF
--- a/cpp/src/copying/gather.cu
+++ b/cpp/src/copying/gather.cu
@@ -61,7 +61,7 @@ std::unique_ptr<table> gather(table_view const& source_table,
                               rmm::cuda_stream_view stream,
                               rmm::mr::device_memory_resource* mr)
 {
-  CUDF_EXPECTS(gather_map.size() <= std::numeric_limits<size_type>::max(),
+  CUDF_EXPECTS(gather_map.size() <= static_cast<size_t>(std::numeric_limits<size_type>::max()),
                "invalid gather map size");
   auto map_col = column_view(data_type{type_to_id<size_type>()},
                              static_cast<size_type>(gather_map.size()),

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -310,7 +310,7 @@ std::unique_ptr<table> scatter(table_view const& source,
                                rmm::cuda_stream_view stream,
                                rmm::mr::device_memory_resource* mr)
 {
-  CUDF_EXPECTS(scatter_map.size() <= std::numeric_limits<size_type>::max(),
+  CUDF_EXPECTS(scatter_map.size() <= static_cast<size_t>(std::numeric_limits<size_type>::max()),
                "invalid scatter map size");
   auto map_col = column_view(data_type{type_to_id<size_type>()},
                              static_cast<size_type>(scatter_map.size()),

--- a/cpp/src/io/json/json_gpu.cu
+++ b/cpp/src/io/json/json_gpu.cu
@@ -142,9 +142,7 @@ __inline__ __device__ T decode_value(char const* begin,
 }
 
 template <typename T, std::enable_if_t<cudf::is_duration<T>()>* = nullptr>
-__inline__ __device__ T decode_value(char const* begin,
-                                     char const* end,
-                                     parse_options_view const& opts)
+__inline__ __device__ T decode_value(char const* begin, char const* end, parse_options_view const&)
 {
   return to_duration<T>(begin, end);
 }


### PR DESCRIPTION
This fixes some compile warnings recently added in #9299 and #9278. These warnings are turned into errors on a libcudf Debug build.