### PR TITLE
Fix the crash in stats code

### DIFF
--- a/cpp/src/io/statistics/typed_statistics_chunk.cuh
+++ b/cpp/src/io/statistics/typed_statistics_chunk.cuh
@@ -238,7 +238,7 @@ __inline__ __device__ statistics_chunk
 get_untyped_chunk(const typed_statistics_chunk<T, include_aggregate>& chunk)
 {
   using E = typename detail::extrema_type<T>::type;
-  statistics_chunk stat;
+  statistics_chunk stat{};
   stat.non_nulls  = chunk.non_nulls;
   stat.null_count = chunk.num_rows - chunk.non_nulls;
   stat.has_minmax = chunk.has_minmax;

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -2036,8 +2036,6 @@ def test_parquet_writer_nulls_pandas_read(tmpdir, pdf):
     gdf = cudf.from_pandas(pdf)
 
     num_rows = len(gdf)
-    if num_rows == 1:
-        pytest.skip("Skipping due a bug in parquet writer with all null df")
 
     if num_rows > 0:
         for col in gdf.columns:


### PR DESCRIPTION
`stat.(min/max)_value.str_val.length` is used in calculating allocation size for page/stripe headers. Not zero initializing stat caused these values to be garbage.
Also re-enabled the pytest that was disabled in #9230

Fixes #9231 
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
