### PR TITLE
Use Arrow PythonFile for remote CSV storage

### DIFF
--- a/python/cudf/cudf/io/csv.py
+++ b/python/cudf/cudf/io/csv.py
@@ -46,6 +46,7 @@ def read_csv(
     na_filter=True,
     prefix=None,
     index_col=None,
+    use_python_file_object=True,
     **kwargs,
 ):
     """{docstring}"""
@@ -58,20 +59,20 @@ def read_csv(
             "`read_csv` does not yet support reading multiple files"
         )
 
+    # Only need to pass byte_ranges to get_filepath_or_buffer
+    # if `use_python_file_object=False`
+    byte_ranges = None
+    if not use_python_file_object and byte_range:
+        byte_ranges = [byte_range]
+
     filepath_or_buffer, compression = ioutils.get_filepath_or_buffer(
         path_or_data=filepath_or_buffer,
         compression=compression,
         iotypes=(BytesIO, StringIO, NativeFile),
-        byte_ranges=[byte_range] if byte_range else None,
-        clip_local_buffer=True if byte_range else False,
+        byte_ranges=byte_ranges,
+        use_python_file_object=use_python_file_object,
         **kwargs,
     )
-
-    # Adjust byte_range for clipped local buffers
-    use_byte_range = byte_range
-    if byte_range and isinstance(filepath_or_buffer, BytesIO):
-        if byte_range[1] == filepath_or_buffer.getbuffer().nbytes:
-            use_byte_range = (0, byte_range[1])
 
     if na_values is not None and is_scalar(na_values):
         na_values = [na_values]
@@ -100,7 +101,7 @@ def read_csv(
         true_values=true_values,
         false_values=false_values,
         nrows=nrows,
-        byte_range=use_byte_range,
+        byte_range=byte_range,
         skip_blank_lines=skip_blank_lines,
         parse_dates=parse_dates,
         comment=comment,

--- a/python/cudf/cudf/tests/test_gcs.py
+++ b/python/cudf/cudf/tests/test_gcs.py
@@ -29,7 +29,7 @@ def pdf(scope="module"):
     return df
 
 
-def test_read_csv(pdf, monkeypatch):
+def test_read_csv(pdf, monkeypatch, tmpdir):
     # Write to buffer
     fpath = TEST_BUCKET + "test_csv_reader.csv"
     buffer = pdf.to_csv(index=False)
@@ -42,8 +42,21 @@ def test_read_csv(pdf, monkeypatch):
 
     monkeypatch.setattr(gcsfs.core.GCSFileSystem, "open", mock_open)
     monkeypatch.setattr(gcsfs.core.GCSFileSystem, "size", mock_size)
-    got = cudf.read_csv("gcs://{}".format(fpath))
 
+    # Test read from explicit path.
+    # Since we are monkey-patching, we cannot use
+    # use_python_file_object=True, because the pyarrow
+    # `open_input_file` command will fail (since it doesn't
+    # use the monkey-pathced `open` definition)
+    got = cudf.read_csv("gcs://{}".format(fpath), use_python_file_object=False)
+    assert_eq(pdf, got)
+
+    # AbstractBufferedFile -> PythonFile conversion
+    # will work fine with the monkey-patched FS if we
+    # pass in an fsspec file object
+    fs = gcsfs.core.GCSFileSystem()
+    with fs.open("gcs://{}".format(fpath)) as f:
+        got = cudf.read_csv(f)
     assert_eq(pdf, got)
 
 

--- a/python/cudf/cudf/tests/test_gcs.py
+++ b/python/cudf/cudf/tests/test_gcs.py
@@ -47,7 +47,7 @@ def test_read_csv(pdf, monkeypatch, tmpdir):
     # Since we are monkey-patching, we cannot use
     # use_python_file_object=True, because the pyarrow
     # `open_input_file` command will fail (since it doesn't
-    # use the monkey-pathced `open` definition)
+    # use the monkey-patched `open` definition)
     got = cudf.read_csv("gcs://{}".format(fpath), use_python_file_object=False)
     assert_eq(pdf, got)
 

--- a/python/cudf/cudf/tests/test_s3.py
+++ b/python/cudf/cudf/tests/test_s3.py
@@ -130,13 +130,25 @@ def test_read_csv(s3_base, s3so, pdf, bytes_per_thread):
     fname = "test_csv_reader.csv"
     bname = "csv"
     buffer = pdf.to_csv(index=False)
+
+    # Use fsspec file object
     with s3_context(s3_base=s3_base, bucket=bname, files={fname: buffer}):
         got = cudf.read_csv(
             "s3://{}/{}".format(bname, fname),
             storage_options=s3so,
             bytes_per_thread=bytes_per_thread,
+            use_python_file_object=False,
         )
+    assert_eq(pdf, got)
 
+    # Use Arrow PythonFile object
+    with s3_context(s3_base=s3_base, bucket=bname, files={fname: buffer}):
+        got = cudf.read_csv(
+            "s3://{}/{}".format(bname, fname),
+            storage_options=s3so,
+            bytes_per_thread=bytes_per_thread,
+            use_python_file_object=True,
+        )
     assert_eq(pdf, got)
 
 
@@ -161,17 +173,33 @@ def test_read_csv_byte_range(s3_base, s3so, pdf, bytes_per_thread):
     fname = "test_csv_reader_byte_range.csv"
     bname = "csv"
     buffer = pdf.to_csv(index=False)
+    expect = pdf.iloc[-2:].reset_index(drop=True)
+
+    # Use fsspec file object
     with s3_context(s3_base=s3_base, bucket=bname, files={fname: buffer}):
         got = cudf.read_csv(
             "s3://{}/{}".format(bname, fname),
             storage_options=s3so,
             byte_range=(74, 73),
             bytes_per_thread=bytes_per_thread,
-            header=False,
+            header=None,
             names=["Integer", "Float", "Integer2", "String", "Boolean"],
+            use_python_file_object=False,
         )
+    assert_eq(expect, got)
 
-    assert_eq(pdf.iloc[-2:].reset_index(drop=True), got)
+    # Use Arrow PythonFile object
+    with s3_context(s3_base=s3_base, bucket=bname, files={fname: buffer}):
+        got = cudf.read_csv(
+            "s3://{}/{}".format(bname, fname),
+            storage_options=s3so,
+            byte_range=(74, 73),
+            bytes_per_thread=bytes_per_thread,
+            header=None,
+            names=["Integer", "Float", "Integer2", "String", "Boolean"],
+            use_python_file_object=True,
+        )
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize("chunksize", [None, 3])

--- a/python/cudf/cudf/tests/test_s3.py
+++ b/python/cudf/cudf/tests/test_s3.py
@@ -168,12 +168,14 @@ def test_read_csv_arrow_nativefile(s3_base, s3so, pdf):
 
 
 @pytest.mark.parametrize("bytes_per_thread", [32, 1024])
-def test_read_csv_byte_range(s3_base, s3so, pdf, bytes_per_thread):
+@pytest.mark.parametrize("use_python_file_object", [True, False])
+def test_read_csv_byte_range(
+    s3_base, s3so, pdf, bytes_per_thread, use_python_file_object
+):
     # Write to buffer
     fname = "test_csv_reader_byte_range.csv"
     bname = "csv"
     buffer = pdf.to_csv(index=False)
-    expect = pdf.iloc[-2:].reset_index(drop=True)
 
     # Use fsspec file object
     with s3_context(s3_base=s3_base, bucket=bname, files={fname: buffer}):
@@ -184,22 +186,10 @@ def test_read_csv_byte_range(s3_base, s3so, pdf, bytes_per_thread):
             bytes_per_thread=bytes_per_thread,
             header=None,
             names=["Integer", "Float", "Integer2", "String", "Boolean"],
-            use_python_file_object=False,
+            use_python_file_object=use_python_file_object,
         )
-    assert_eq(expect, got)
 
-    # Use Arrow PythonFile object
-    with s3_context(s3_base=s3_base, bucket=bname, files={fname: buffer}):
-        got = cudf.read_csv(
-            "s3://{}/{}".format(bname, fname),
-            storage_options=s3so,
-            byte_range=(74, 73),
-            bytes_per_thread=bytes_per_thread,
-            header=None,
-            names=["Integer", "Float", "Integer2", "String", "Boolean"],
-            use_python_file_object=True,
-        )
-    assert_eq(expect, got)
+    assert_eq(pdf.iloc[-2:].reset_index(drop=True), got)
 
 
 @pytest.mark.parametrize("chunksize", [None, 3])

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -887,7 +887,7 @@ index_col : int, string or False, default None
 use_python_file_object : boolean, default True
     If True, Arrow-backed PythonFile objects will be used in place of fsspec
     AbstractBufferedFile objects at IO time. This option is likely to improve
-    performance when making small reads from larger parquet files.
+    performance when making small reads from larger CSV files.
 
 Returns
 -------


### PR DESCRIPTION
This is a simple follow-up to #9304 and #9265 meant to achieve the following:

- After this PR, the default behavior of `cudf.read_csv` will be to convert fsspec-based `AbstractBufferedFile` objects to Arrow `PythonFile` objects for non-local file systems. Since `PythonFile` objects inherit from `NativeFile` objects, libcudf can seek/read distinct byte ranges without requiring the entire file to be read into host memory (i.e. the default behavior enables proper partial IO from remote storage)

- #9265 recently added an fsspec-based optimization for transfering csv byte ranges into local memory. That optimization already allowed us to avoid a full file transfer when a specific `byte_range` is specified to the `cudf.read_csv` call.  However, the simpler approach introduced in this PR is (1) more general, (2) easier to maintain, and (3) demonstrates comparable performance. Therefore, this PR also rolls back one of the less-maintainable optimizations added in #9265 (local buffer clipping).

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
