### PR TITLE
Support Arrow NativeFile and PythonFile for remote ORC storage

### DIFF
--- a/python/cudf/cudf/_lib/orc.pyx
+++ b/python/cudf/cudf/_lib/orc.pyx
@@ -66,6 +66,10 @@ cpdef read_raw_orc_statistics(filepath_or_buffer):
     cudf.io.orc.read_orc_statistics
     """
 
+    # Hanlde NativeFile input
+    if isinstance(filepath_or_buffer, NativeFile):
+        filepath_or_buffer = NativeFileDatasource(filepath_or_buffer)
+
     cdef raw_orc_statistics raw = (
         libcudf_read_raw_orc_statistics(make_source_info([filepath_or_buffer]))
     )

--- a/python/cudf/cudf/_lib/orc.pyx
+++ b/python/cudf/cudf/_lib/orc.pyx
@@ -41,7 +41,6 @@ from cudf._lib.io.utils cimport (
     update_column_struct_field_names,
     update_struct_field_names,
 )
-from cudf._lib.table cimport Table, table_view_from_table
 
 from cudf._lib.types import SUPPORTED_NUMPY_TO_LIBCUDF_TYPES
 
@@ -49,7 +48,11 @@ from cudf._lib.types cimport underlying_type_t_type_id
 
 import numpy as np
 
-from cudf._lib.utils cimport data_from_unique_ptr, get_column_names
+from cudf._lib.utils cimport (
+    data_from_unique_ptr,
+    get_column_names,
+    table_view_from_table,
+)
 
 from pyarrow.lib import NativeFile
 
@@ -140,7 +143,7 @@ cdef compression_type _get_comp_type(object compression):
         raise ValueError(f"Unsupported `compression` type {compression}")
 
 
-cpdef write_orc(Table table,
+cpdef write_orc(table,
                 object path_or_buf,
                 object compression=None,
                 bool enable_statistics=True):
@@ -268,7 +271,7 @@ cdef class ORCWriter:
         self.index = index
         self.initialized = False
 
-    def write_table(self, Table table):
+    def write_table(self, table):
         """ Writes a single table to the file """
         if not self.initialized:
             self._initialize_chunked_state(table)
@@ -292,7 +295,7 @@ cdef class ORCWriter:
     def __dealloc__(self):
         self.close()
 
-    def _initialize_chunked_state(self, Table table):
+    def _initialize_chunked_state(self, table):
         """
         Prepare all the values required to build the
         chunked_orc_writer_options anb creates a writer"""

--- a/python/cudf/cudf/_lib/orc.pyx
+++ b/python/cudf/cudf/_lib/orc.pyx
@@ -34,12 +34,14 @@ from cudf._lib.cpp.io.types cimport (
 )
 from cudf._lib.cpp.table.table_view cimport table_view
 from cudf._lib.cpp.types cimport data_type, size_type, type_id
+from cudf._lib.io.datasource cimport NativeFileDatasource
 from cudf._lib.io.utils cimport (
     make_sink_info,
     make_source_info,
     update_column_struct_field_names,
     update_struct_field_names,
 )
+from cudf._lib.table cimport Table, table_view_from_table
 
 from cudf._lib.types import SUPPORTED_NUMPY_TO_LIBCUDF_TYPES
 
@@ -47,11 +49,9 @@ from cudf._lib.types cimport underlying_type_t_type_id
 
 import numpy as np
 
-from cudf._lib.utils cimport (
-    data_from_unique_ptr,
-    get_column_names,
-    table_view_from_table,
-)
+from cudf._lib.utils cimport data_from_unique_ptr, get_column_names
+
+from pyarrow.lib import NativeFile
 
 from cudf._lib.utils import _index_level_name, generate_pandas_metadata
 from cudf.api.types import is_list_dtype, is_struct_dtype
@@ -136,7 +136,7 @@ cdef compression_type _get_comp_type(object compression):
         raise ValueError(f"Unsupported `compression` type {compression}")
 
 
-cpdef write_orc(table,
+cpdef write_orc(Table table,
                 object path_or_buf,
                 object compression=None,
                 bool enable_statistics=True):
@@ -209,6 +209,9 @@ cdef orc_reader_options make_orc_reader_options(
     object decimal_cols_as_float
 ) except*:
 
+    for i, datasource in enumerate(filepaths_or_buffers):
+        if isinstance(datasource, NativeFile):
+            filepaths_or_buffers[i] = NativeFileDatasource(datasource)
     cdef vector[string] c_column_names
     cdef vector[vector[size_type]] strps = stripes
     c_column_names.reserve(len(column_names))
@@ -261,7 +264,7 @@ cdef class ORCWriter:
         self.index = index
         self.initialized = False
 
-    def write_table(self, table):
+    def write_table(self, Table table):
         """ Writes a single table to the file """
         if not self.initialized:
             self._initialize_chunked_state(table)
@@ -285,7 +288,7 @@ cdef class ORCWriter:
     def __dealloc__(self):
         self.close()
 
-    def _initialize_chunked_state(self, table):
+    def _initialize_chunked_state(self, Table table):
         """
         Prepare all the values required to build the
         chunked_orc_writer_options anb creates a writer"""

--- a/python/cudf/cudf/io/orc.py
+++ b/python/cudf/cudf/io/orc.py
@@ -287,7 +287,7 @@ def read_orc(
     use_index=True,
     decimal_cols_as_float=None,
     timestamp_type=None,
-    use_python_file_object=None,
+    use_python_file_object=True,
     **kwargs,
 ):
     """{docstring}"""
@@ -311,14 +311,6 @@ def read_orc(
             raise ValueError(
                 "A list of stripes must be provided for each input source"
             )
-
-    # Set `use_python_file_object`.
-    # By default, we will use an Arrow-backed PythonFile object
-    # whenever we are performing partial IO, and are not filtering.
-    if use_python_file_object is None:
-        use_python_file_object = bool(
-            (stripes or columns or num_rows) and not filters
-        )
 
     filepaths_or_buffers = []
     for source in filepath_or_buffer:

--- a/python/cudf/cudf/tests/test_s3.py
+++ b/python/cudf/cudf/tests/test_s3.py
@@ -308,7 +308,9 @@ def test_read_json(s3_base, s3so):
     assert_eq(expect, got)
 
 
-def test_read_orc(s3_base, s3so, datadir):
+@pytest.mark.parametrize("use_python_file_object", [False, True])
+@pytest.mark.parametrize("columns", [None, ["string1"]])
+def test_read_orc(s3_base, s3so, datadir, use_python_file_object, columns):
     source_file = str(datadir / "orc" / "TestOrcFile.testSnappy.orc")
     fname = "test_orc_reader.orc"
     bname = "orc"
@@ -319,9 +321,14 @@ def test_read_orc(s3_base, s3so, datadir):
 
     with s3_context(s3_base=s3_base, bucket=bname, files={fname: buffer}):
         got = cudf.read_orc(
-            "s3://{}/{}".format(bname, fname), storage_options=s3so
+            "s3://{}/{}".format(bname, fname),
+            columns=columns,
+            storage_options=s3so,
+            use_python_file_object=use_python_file_object,
         )
 
+    if columns:
+        expect = expect[columns]
     assert_eq(expect, got)
 
 

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -357,6 +357,10 @@ use_index : bool, default True
 decimal_cols_as_float: list, default None
     If specified, names of the columns that should be converted from
     Decimal to Float64 in the resulting dataframe.
+use_python_file_object : boolean, default True
+    If True, Arrow-backed PythonFile objects will be used in place of fsspec
+    AbstractBufferedFile objects at IO time. This option is likely to improve
+    performance when making small reads from larger ORC files.
 kwargs are passed to the engine
 
 Returns


### PR DESCRIPTION
This is a follow-up to #9304, and is more-or-less the ORC version of #9376

These changes will enable partial IO to behave "correctly" for `cudf.read_orc` from remote storage. Simpe multi-stripe file example:

```python
# After this PR
%time gdf = cudf.read_orc(orc_path, stripes=[0], storage_options=storage_options)
CPU times: user 579 ms, sys: 166 ms, total: 744 ms
Wall time: 2.38 s

# Before this PR
%time gdf = cudf.read_orc(orc_path, stripes=[0], storage_options=storage_options)
CPU times: user 3.9 s, sys: 1.47 s, total: 5.37 s
Wall time: 8.5 s
```

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
