### PR TITLE
Fix orc timestamp bug

### DIFF
--- a/cpp/src/io/orc/orc_gpu.h
+++ b/cpp/src/io/orc/orc_gpu.h
@@ -112,7 +112,7 @@ struct ColumnDesc {
   TypeKind type_kind;                      // column data type
   uint8_t dtype_len;      // data type length (for types that can be mapped to different sizes)
   int32_t decimal_scale;  // number of fractional decimal digits for decimal type
-  int32_t ts_clock_rate;  // output timestamp clock frequency (0=default, 1000=ms, 1000000000=ns)
+  type_id timestamp_type_id;  // output timestamp type id (type_id::EMPTY by default)
   column_validity_info parent_validity_info;  // consists of parent column valid_map and null count
   uint32_t* parent_null_count_prefix_sums;  // per-stripe prefix sums of parent column's null count
 };

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -1411,7 +1411,7 @@ table_with_metadata reader::impl::read(size_type skip_rows,
                                     : cudf::size_of(column_types[col_idx]);
             chunk.num_rowgroups = stripe_num_rowgroups;
             if (chunk.type_kind == orc::TIMESTAMP) {
-              chunk.ts_clock_rate = to_clockrate(_timestamp_type.id());
+              chunk.timestamp_type_id = _timestamp_type.id();
             }
             if (not is_data_empty) {
               for (int k = 0; k < gpu::CI_NUM_STREAMS; k++) {

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -1807,7 +1807,9 @@ __global__ void __launch_bounds__(block_size)
                   res = cuda::std::chrono::duration_cast<duration_us>(d_ns).count();
                   break;
                 }
-                default: res = d_ns.count();  // nanoseconds if not specified
+                default:
+                  res = d_ns.count();  // nanoseconds as output in case of `type_id::EMPTY` and
+                                       // `type_id::TIMESTAMP_NANOSECONDS`
               }
               static_cast<int64_t*>(data_out)[row] = res;
               break;

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -1103,9 +1103,7 @@ TEST_F(OrcReaderTest, MultipleInputs)
 
 TEST_F(OrcReaderTest, SimpleTimestamps)
 {
-  int64_t num_rows = 100;
-
-  auto int_data = random_values<int64_t>(num_rows);
+  auto int_data = random_values<int64_t>(5);
   auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
 
   column_wrapper<int64_t> const intcol{int_data.begin(), int_data.end(), validity};

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -1101,6 +1101,31 @@ TEST_F(OrcReaderTest, MultipleInputs)
   CUDF_TEST_EXPECT_TABLES_EQUAL(*result.tbl, *full_table);
 }
 
+TEST_F(OrcReaderTest, SimpleTimestamps)
+{
+  int64_t num_rows = 100;
+
+  auto int_data = random_values<int64_t>(num_rows);
+  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+
+  column_wrapper<int64_t> const intcol{int_data.begin(), int_data.end(), validity};
+  auto tscol = cudf::bit_cast(intcol, cudf::data_type{cudf::type_id::TIMESTAMP_NANOSECONDS});
+  table_view expected({tscol});
+
+  auto filepath = temp_env->get_temp_filepath("OrcSimpleTimestamps.orc");
+  cudf_io::orc_writer_options out_opts =
+    cudf_io::orc_writer_options::builder(cudf_io::sink_info{filepath}, expected);
+  cudf_io::write_orc(out_opts);
+
+  cudf_io::orc_reader_options in_opts =
+    cudf_io::orc_reader_options::builder(cudf_io::source_info{filepath})
+      .use_index(false)
+      .timestamp_type(cudf::data_type{cudf::type_id::TIMESTAMP_NANOSECONDS});
+  auto result = cudf_io::read_orc(in_opts);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
+}
+
 struct OrcWriterTestDecimal : public OrcWriterTest,
                               public ::testing::WithParamInterface<std::tuple<int, int>> {
 };


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/9365

This PR fixed an ORC reader bug when reading with a specified timestamp type. It gets rid of the clock rate logic by directly operating over timestamp type id.