### PR TITLE
MD5 Python hash API

### DIFF
--- a/python/cudf/cudf/_lib/hash.pyx
+++ b/python/cudf/cudf/_lib/hash.pyx
@@ -63,6 +63,8 @@ def hash(source_table, str method, object initial_hash_values=None,
     cdef libcudf_types.hash_id c_hash_id
     if method == "murmur3":
         c_hash_function = libcudf_types.hash_id.HASH_MURMUR3
+    elif method == "md5":
+        c_hash_function = libcudf_types.hash_id.HASH_MD5
     else:
         raise ValueError(f"Unsupported hash function: {method}")
     with nogil:

--- a/python/cudf/cudf/_lib/hash.pyx
+++ b/python/cudf/cudf/_lib/hash.pyx
@@ -54,17 +54,22 @@ def hash_partition(source_table, object columns_to_hash,
     )
 
 
-def hash(source_table, object initial_hash_values=None, int seed=0):
+def hash(source_table, str method, object initial_hash_values=None,
+         int seed=0):
     cdef vector[uint32_t] c_initial_hash = initial_hash_values or []
     cdef table_view c_source_view = table_view_from_table(
         source_table, ignore_index=True)
-
     cdef unique_ptr[column] c_result
+    cdef libcudf_types.hash_id c_hash_id
+    if method == "murmur3":
+        c_hash_function = libcudf_types.hash_id.HASH_MURMUR3
+    else:
+        raise ValueError(f"Unsupported hash function: {method}")
     with nogil:
         c_result = move(
             cpp_hash(
                 c_source_view,
-                libcudf_types.hash_id.HASH_MURMUR3,
+                c_hash_function,
                 c_initial_hash,
                 seed
             )

--- a/python/cudf/cudf/_lib/hash.pyx
+++ b/python/cudf/cudf/_lib/hash.pyx
@@ -60,7 +60,7 @@ def hash(source_table, str method, object initial_hash=None,
     cdef table_view c_source_view = table_view_from_table(
         source_table, ignore_index=True)
     cdef unique_ptr[column] c_result
-    cdef libcudf_types.hash_id c_hash_id
+    cdef libcudf_types.hash_id c_hash_function
     if method == "murmur3":
         c_hash_function = libcudf_types.hash_id.HASH_MURMUR3
     elif method == "md5":

--- a/python/cudf/cudf/_lib/hash.pyx
+++ b/python/cudf/cudf/_lib/hash.pyx
@@ -54,9 +54,9 @@ def hash_partition(source_table, object columns_to_hash,
     )
 
 
-def hash(source_table, str method, object initial_hash_values=None,
+def hash(source_table, str method, object initial_hash=None,
          int seed=0):
-    cdef vector[uint32_t] c_initial_hash = initial_hash_values or []
+    cdef vector[uint32_t] c_initial_hash = initial_hash or []
     cdef table_view c_source_view = table_view_from_table(
         source_table, ignore_index=True)
     cdef unique_ptr[column] c_result

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5021,16 +5021,13 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
         Series
             Hash values for each row.
         """
-        if method not in {"murmur3", "md5"}:
-            raise ValueError(f"Unsupported hash function: {method}")
-
         if columns is None:
             table_to_hash = self
         else:
             cols = [self[k]._column for k in columns]
             table_to_hash = Frame(data=dict(zip(columns, cols)))
 
-        return Series(table_to_hash._hash())
+        return Series(table_to_hash._hash(method=method))
 
     def partition_by_hash(self, columns, nparts, keep_index=True):
         """Partition the dataframe by the hashed value of data in *columns*.

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5030,7 +5030,7 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
             cols = [self[k]._column for k in columns]
             table_to_hash = Frame(data=dict(zip(columns, cols)))
 
-        return Series(table_to_hash._hash()).values
+        return Series(table_to_hash._hash())
 
     def partition_by_hash(self, columns, nparts, keep_index=True):
         """Partition the dataframe by the hashed value of data in *columns*.

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5003,7 +5003,7 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
             tpb=tpb,
         )
 
-    def hash_columns(self, columns=None):
+    def hash_columns(self, columns=None, method="murmur3"):
         """Hash the given *columns* and return a new device array
 
         Parameters
@@ -5011,7 +5011,19 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
         columns : sequence of str; optional
             Sequence of column names. If columns is *None* (unspecified),
             all columns in the frame are used.
+        method : {'murmur3', 'md5'}, default 'murmur3'
+            Hash function to use:
+            * murmur3: MurmurHash3 hash function.
+            * md5: MD5 hash function.
+
+        Returns
+        -------
+        Series
+            Hash values for each row.
         """
+        if method not in {"murmur3", "md5"}:
+            raise ValueError(f"Unsupported hash function: {method}")
+
         if columns is None:
             table_to_hash = self
         else:

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -623,8 +623,8 @@ class Frame:
             result._index.names = self._index.names
         return result
 
-    def _hash(self, method, initial_hash_values=None):
-        return libcudf.hash.hash(self, method, initial_hash_values)
+    def _hash(self, method, initial_hash=None):
+        return libcudf.hash.hash(self, method, initial_hash)
 
     def _hash_partition(
         self, columns_to_hash, num_partitions, keep_index=True

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -623,8 +623,8 @@ class Frame:
             result._index.names = self._index.names
         return result
 
-    def _hash(self, initial_hash_values=None):
-        return libcudf.hash.hash(self, initial_hash_values)
+    def _hash(self, method, initial_hash_values=None):
+        return libcudf.hash.hash(self, method, initial_hash_values)
 
     def _hash_partition(
         self, columns_to_hash, num_partitions, keep_index=True

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -4165,7 +4165,9 @@ class Series(SingleColumnFrame, Serializable):
             raise ValueError("stop must be a positive integer.")
 
         initial_hash = [hash(self.name) & 0xFFFFFFFF] if use_name else None
-        hashed_values = Series(self._hash(initial_hash))
+        hashed_values = Series(
+            self._hash(method="murmur3", initial_hash=initial_hash)
+        )
 
         if hashed_values.has_nulls:
             raise ValueError("Column must have no nulls.")

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -4095,13 +4095,20 @@ class Series(SingleColumnFrame, Serializable):
         """
         return self._unaryop("floor")
 
-    def hash_values(self):
+    def hash_values(self, method="murmur3"):
         """Compute the hash of values in this column.
+
+        Parameters
+        ----------
+        method : {'murmur3', 'md5'}, default 'murmur3'
+            Hash function to use:
+            * murmur3: MurmurHash3 hash function.
+            * md5: MD5 hash function.
 
         Returns
         -------
-        cupy array
-            A cupy array with hash values.
+        Series
+            A Series with hash values.
 
         Examples
         --------
@@ -4112,10 +4119,10 @@ class Series(SingleColumnFrame, Serializable):
         1    120
         2     30
         dtype: int64
-        >>> series.hash_values()
+        >>> series.hash_values(method="murmur3")
         array([-1930516747,   422619251,  -941520876], dtype=int32)
         """
-        return Series(self._hash()).values
+        return Series(self._hash())
 
     def hash_encode(self, stop, use_name=False):
         """Encode column values as ints in [0, stop) using hash function.

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -4122,7 +4122,7 @@ class Series(SingleColumnFrame, Serializable):
         >>> series.hash_values(method="murmur3")
         array([-1930516747,   422619251,  -941520876], dtype=int32)
         """
-        return Series(self._hash())
+        return Series(self._hash(method=method))
 
     def hash_encode(self, stop, use_name=False):
         """Encode column values as ints in [0, stop) using hash function.

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1111,7 +1111,7 @@ def test_dataframe_hash_columns(nrows, method):
     gdf["a"] = data
     gdf["b"] = gdf.a + 100
     out = gdf.hash_columns(["a", "b"])
-    # assert isinstance(out, cupy.ndarray)
+    assert isinstance(out, cudf.Series)
     assert len(out) == nrows
     assert out.dtype == np.int32
 


### PR DESCRIPTION
This PR introduces a public API in cuDF for MD5 hashing, using the parameter `DataFrame.hash_columns(..., method="md5")` or `Series.hash_values(..., method="md5")`. The default hashing method is MurmurHash3. I also changed the return value of `Series.hash_values` to be a `Series`, rather than a cupy array.