### PR TITLE
Change all DeprecationWarnings to FutureWarning.

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -3697,7 +3697,7 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
         warnings.warn(
             "The as_gpu_matrix method will be removed in a future cuDF "
             "release. Consider using `to_cupy` instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         if columns is None:
             columns = self._data.names
@@ -3745,7 +3745,7 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
         warnings.warn(
             "The as_matrix method will be removed in a future cuDF "
             "release. Consider using `to_numpy` instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.as_gpu_matrix(columns=columns).copy_to_host()
 

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -5372,7 +5372,7 @@ class SingleColumnFrame(Frame):
         warnings.warn(
             "The to_gpu_array method will be removed in a future cuDF "
             "release. Consider using `to_cupy` instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self._column.to_gpu_array(fillna=fillna)
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2484,7 +2484,7 @@ class Series(SingleColumnFrame, Serializable):
         warnings.warn(
             "The to_array method will be removed in a future cuDF "
             "release. Consider using `to_numpy` instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self._column.to_array(fillna=fillna)
 


### PR DESCRIPTION
Following up with some extra replacements of `DeprecationWarning` with `FutureWarning` that were missed in #9347 (these were added after I started that PR). From here forward, all PRs introducing deprecations of user APIs should use `FutureWarning`.