### PR TITLE
Frame copy to use __class__ instead of type()

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -385,7 +385,7 @@ class Frame:
         b    2
         dtype: int64
         """
-        new_frame = self.__class__.__new__(type(self))
+        new_frame = self.__class__.__new__(self.__class__)
         new_frame._data = self._data.copy(deep=deep)
 
         if self._index is not None:


### PR DESCRIPTION
This PR address the asymmetry in the following line in `Frame.copy()`:
```python
new_frame = self.__class__.__new__(type(self))
```
The problem is that `self.__class__` might not equal `type(self)`, which is the case for proxy objects like the one used in Dask-CUDA.
Related Dask-CUDA PR: https://github.com/rapidsai/dask-cuda/pull/751

cc. @randerzander 