### PR TITLE
Add Java API to deserialize a table to host columns

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
+++ b/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
@@ -29,6 +29,8 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Serialize and deserialize CUDF tables and columns using a custom format.  The goal of this is
@@ -1660,6 +1662,51 @@ public class JCudfSerialization {
   // COLUMN AND TABLE READ
   /////////////////////////////////////////////
 
+  private static HostColumnVector buildHostColumn(SerializedColumnHeader column,
+                                                  ArrayDeque<ColumnOffsets> columnOffsets,
+                                                  HostMemoryBuffer buffer) {
+    ColumnOffsets offsetsInfo = columnOffsets.remove();
+    SerializedColumnHeader[] children = column.getChildren();
+    int numChildren = children != null ? children.length : 0;
+    List<HostColumnVectorCore> childColumns = new ArrayList<>(numChildren);
+    try {
+      if (children != null) {
+        for (SerializedColumnHeader child : children) {
+          childColumns.add(buildHostColumn(child, columnOffsets, buffer));
+        }
+      }
+      DType dtype = column.getType();
+      long rowCount = column.getRowCount();
+      long nullCount = column.getNullCount();
+      HostMemoryBuffer dataBuffer = null;
+      HostMemoryBuffer validityBuffer = null;
+      HostMemoryBuffer offsetsBuffer = null;
+      if (!dtype.isNestedType()) {
+        dataBuffer = buffer.slice(offsetsInfo.data, offsetsInfo.dataLen);
+      }
+      if (nullCount > 0) {
+        long validitySize = BitVectorHelper.getValidityLengthInBytes(rowCount);
+        validityBuffer = buffer.slice(offsetsInfo.validity, validitySize);
+      }
+      if (dtype.hasOffsets()) {
+        // one 32-bit integer offset per row plus one additional offset at the end
+        long offsetsSize = rowCount > 0 ? (rowCount + 1) * Integer.BYTES : 0;
+        offsetsBuffer = buffer.slice(offsetsInfo.offsets, offsetsSize);
+      }
+      HostColumnVector result = new HostColumnVector(dtype, column.getRowCount(),
+              Optional.of(column.getNullCount()), dataBuffer, validityBuffer, offsetsBuffer,
+              childColumns);
+      childColumns = null;
+      return result;
+    } finally {
+      if (childColumns != null) {
+        for (HostColumnVectorCore c : childColumns) {
+          c.close();
+        }
+      }
+    }
+  }
+
   private static long buildColumnView(SerializedColumnHeader column,
                                       ArrayDeque<ColumnOffsets> columnOffsets,
                                       DeviceMemoryBuffer combinedBuffer) {
@@ -1767,6 +1814,38 @@ public class JCudfSerialization {
     } finally {
       closeAll(providersPerColumn);
     }
+  }
+
+  /**
+   * Deserialize a serialized contiguous table into an array of host columns.
+   *
+   * @param header     serialized table header
+   * @param hostBuffer buffer containing the data for all columns in the serialized table
+   * @return array of host columns representing the data from the serialized table
+   */
+  public static HostColumnVector[] unpackHostColumnVectors(SerializedTableHeader header,
+                                                           HostMemoryBuffer hostBuffer) {
+    ArrayDeque<ColumnOffsets> columnOffsets = buildIndex(header, hostBuffer);
+    int numColumns = header.getNumColumns();
+    HostColumnVector[] columns = new HostColumnVector[numColumns];
+    boolean succeeded = false;
+    try {
+      for (int i = 0; i < numColumns; i++) {
+        SerializedColumnHeader column = header.getColumnHeader(i);
+        columns[i] = buildHostColumn(column, columnOffsets, hostBuffer);
+      }
+      assert columnOffsets.isEmpty();
+      succeeded = true;
+    } finally {
+      if (!succeeded) {
+        for (HostColumnVector c : columns) {
+          if (c != null) {
+            c.close();
+          }
+        }
+      }
+    }
+    return columns;
   }
 
   /**


### PR DESCRIPTION
Adds a new JCudfSerialization API to deserialize a serialized table to host columns.  This is useful for applications that need to examine data sent over the network from a cudf process without requiring the receiving process to have a GPU bound to that process.