### PR TITLE
Implement customized ColumnAccessor for MultiIndex

### DIFF
--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -152,6 +152,15 @@ class ColumnAccessor(MutableMapping):
     def __iter__(self):
         return self._data.__iter__()
 
+    def keys(self):
+        return self._data.keys()
+
+    def values(self):
+        return self._data.values()
+
+    def items(self):
+        return self._data.items()
+
     def __getitem__(self, key: Any) -> ColumnBase:
         return self._data[key]
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -2256,8 +2256,7 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
                         if isinstance(col, pd.MultiIndex)
                         else col
                     )
-                    cols = [col._data[x] for x in col._data]
-                    columns_to_add.extend(cols)
+                    columns_to_add.extend(col._data.columns)
                     names.extend(col.names)
                 else:
                     if isinstance(col, (pd.RangeIndex, cudf.RangeIndex)):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5959,9 +5959,9 @@ class DataFrame(Frame, Serializable, GetAttrGetItemMixin):
         name_index = Frame({0: self._column_names}).tile(self.shape[0])
         new_index = list(repeated_index._columns) + [name_index._columns[0]]
         if isinstance(self._index, cudf.MultiIndex):
-            index_names = self._index.names + [None]
+            index_names = self._index.names + (None,)
         else:
-            index_names = [None] * len(new_index)
+            index_names = (None,) * len(new_index)
         new_index = cudf.core.multiindex.MultiIndex.from_frame(
             DataFrame(dict(zip(range(0, len(new_index)), new_index))),
             names=index_names,

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1415,10 +1415,9 @@ class Frame:
 
         if isinstance(value, cudf.Series):
             value = value.reindex(self._data.names)
-        elif isinstance(value, cudf.DataFrame) and not self.index.equals(
-            value.index
-        ):
-            value = value.reindex(self.index)
+        elif isinstance(value, cudf.DataFrame):
+            if not self.index.equals(value.index):
+                value = value.reindex(self.index)
         elif not isinstance(value, abc.Mapping):
             value = {name: copy.deepcopy(value) for name in self._data.names}
         elif isinstance(value, abc.Mapping):
@@ -5637,7 +5636,7 @@ class Frame:
 
     def rmul(self, other, axis, level=None, fill_value=None):
         """
-        Get Multiplication of dataframe or series and other, element-wise 
+        Get Multiplication of dataframe or series and other, element-wise
         (binary operator `rmul`).
 
         Equivalent to ``other * frame``, but with support to substitute a

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -69,13 +69,14 @@ class Frame:
         A Frame representing the (optional) index columns.
     """
 
-    _data: "ColumnAccessor"
+    _data: ColumnAccessor
     _index: Optional[cudf.core.index.BaseIndex]
+    _accessor_type = ColumnAccessor
 
     def __init__(self, data=None, index=None):
         if data is None:
             data = {}
-        self._data = cudf.core.column_accessor.ColumnAccessor(data)
+        self._data = self.__class__._accessor_type(data)
         self._index = index
 
     @property
@@ -2116,7 +2117,7 @@ class Frame:
         }
 
         return self.__class__._from_data(
-            data=cudf.core.column_accessor.ColumnAccessor(
+            data=self.__class__._accessor_type(
                 cols,
                 multiindex=self._data.multiindex,
                 level_names=self._data.level_names,

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1415,11 +1415,10 @@ class Frame:
 
         if isinstance(value, cudf.Series):
             value = value.reindex(self._data.names)
-        elif isinstance(value, cudf.DataFrame):
-            if not self.index.equals(value.index):
-                value = value.reindex(self.index)
-            else:
-                value = value
+        elif isinstance(value, cudf.DataFrame) and not self.index.equals(
+            value.index
+        ):
+            value = value.reindex(self.index)
         elif not isinstance(value, abc.Mapping):
             value = {name: copy.deepcopy(value) for name in self._data.names}
         elif isinstance(value, abc.Mapping):

--- a/python/cudf/cudf/core/join/_join_helpers.py
+++ b/python/cudf/cudf/core/join/_join_helpers.py
@@ -44,7 +44,7 @@ class _Indexer:
         raise KeyError()
 
     def set(self, obj: Frame, value: ColumnBase, validate=False):
-        # set the colum in `obj`
+        # set the column in `obj`
         if self.column:
             obj._data.set_by_label(self.name, value, validate=validate)
         else:

--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -205,7 +205,7 @@ class Merge(object):
                 left_keys.extend(
                     [
                         _Indexer(name=on, index=True)
-                        for on in self.lhs.index._data.names
+                        for on in self.lhs.index._data.keys()
                     ]
                 )
             if self.left_on:
@@ -220,7 +220,7 @@ class Merge(object):
                 right_keys.extend(
                     [
                         _Indexer(name=on, index=True)
-                        for on in self.rhs.index._data.names
+                        for on in self.rhs.index._data.keys()
                     ]
                 )
             if self.right_on:

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1726,8 +1726,19 @@ class MultiIndex(Frame, BaseIndex):
         else:
             return index_sorted
 
+    def drop_duplicates(self, keep="first"):
+        # TODO: This override is necessary to properly handle duplicate names.
+        # Once index/name handling is all moved to the Python layer this
+        # override should no longer be necessary.
+        other = self.copy(deep=False)
+        other.names = list(range(other._num_columns))
+        # Call the parent method to avoid infinite recursion.
+        result = super(MultiIndex, other).drop_duplicates(keep=keep)
+        result.names = self.names
+        return result
+
     def unique(self):
-        return self.drop_duplicates(ignore_index=True)
+        return self.drop_duplicates()
 
     def _clean_nulls_from_index(self):
         """

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1710,46 +1710,6 @@ class MultiIndex(Frame, BaseIndex):
         else:
             return index_sorted
 
-    def fillna(self, value):
-        """
-        Fill null values with the specified value.
-
-        Parameters
-        ----------
-        value : scalar
-            Scalar value to use to fill nulls. This value cannot be a
-            list-likes.
-
-        Returns
-        -------
-        filled : MultiIndex
-
-        Examples
-        --------
-        >>> import cudf
-        >>> index = cudf.MultiIndex(
-        ...         levels=[["a", "b", "c", None], ["1", None, "5"]],
-        ...         codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
-        ...         names=["x", "y"],
-        ...       )
-        >>> index
-        MultiIndex([( 'a',  '1'),
-                    ( 'a',  '5'),
-                    ( 'b', <NA>),
-                    ( 'c', <NA>),
-                    (<NA>,  '1')],
-                   names=['x', 'y'])
-        >>> index.fillna('hello')
-        MultiIndex([(    'a',     '1'),
-                    (    'a',     '5'),
-                    (    'b', 'hello'),
-                    (    'c', 'hello'),
-                    ('hello',     '1')],
-                   names=['x', 'y'])
-        """
-
-        return super().fillna(value=value)
-
     def unique(self):
         return self.drop_duplicates(ignore_index=True)
 

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1610,8 +1610,16 @@ class MultiIndex(Frame, BaseIndex):
             return mi
 
     def to_pandas(self, nullable=False, **kwargs):
-        result = self.to_frame(index=False).to_pandas(nullable=nullable)
-        return pd.MultiIndex.from_frame(result, names=self.names)
+        names = self.names
+        if len(set(names)) != len(names):
+            # Duplicate names are present that would be lost on conversion to
+            # frame, so we must instead convert a copied version.
+            midx = self.copy(deep=False)
+            midx.names = range(len(names))
+        else:
+            midx = self
+        result = midx.to_frame(index=False).to_pandas(nullable=nullable)
+        return pd.MultiIndex.from_frame(result, names=names)
 
     @classmethod
     def from_pandas(cls, multiindex, nan_as_null=None):

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -196,7 +196,9 @@ class _MultiIndexColumnAccessor(ColumnAccessor):
         """
         if pd.api.types.is_integer(index):
             index = (index,)
-        data = {k: v for k, v in self._data.items() if k[0] in index}
+        keys = list(self._data.keys())
+        keys = [keys[i] for i in index]
+        data = {key: self._data[key] for key in keys}
         return self.__class__(
             data, multiindex=self.multiindex, level_names=self.level_names,
         )
@@ -242,7 +244,7 @@ class _MultiIndexColumnAccessor(ColumnAccessor):
     def _select_by_label_list_like(self, key: Any) -> ColumnAccessor:
         indices = []
         for k in key:
-            indices.append(self._get_and_validate_unique_index(key))
+            indices.append(self._get_and_validate_unique_index(k))
         return self.select_by_index(indices)
 
     def _select_by_label_slice(self, key: slice) -> ColumnAccessor:

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -720,9 +720,9 @@ class MultiIndex(Frame, BaseIndex):
                         column.timedelta.TimeDeltaColumn,
                     ),
                 ):
-                    preprocess_df[name[1]] = col.astype("str").fillna(
-                        cudf._NA_REP
-                    )
+                    new_col = col.astype("str")
+                    preprocess._data[name] = new_col
+                    preprocess_df[name[1]] = new_col.fillna(cudf._NA_REP)
 
             tuples_list = list(
                 zip(

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -282,9 +282,7 @@ class Series(SingleColumnFrame, Serializable):
         index: Optional[BaseIndex] = None,
         name: Any = None,
     ) -> Series:
-        """
-        Construct the Series from a ColumnAccessor
-        """
+        """Construct the Series from a Mapping."""
         out: Series = super()._from_data(data, index, name)
         if index is None:
             out._index = RangeIndex(out._data.nrows)
@@ -4616,9 +4614,7 @@ class DatetimeProperties(object):
         """
         res = libcudf.datetime.is_leap_year(self.series._column).fillna(False)
         return Series._from_data(
-            ColumnAccessor({None: res}),
-            index=self.series._index,
-            name=self.series.name,
+            {None: res}, index=self.series._index, name=self.series.name,
         )
 
     @property
@@ -4748,9 +4744,7 @@ class DatetimeProperties(object):
         """
         res = libcudf.datetime.days_in_month(self.series._column)
         return Series._from_data(
-            ColumnAccessor({None: res}),
-            index=self.series._index,
-            name=self.series.name,
+            {None: res}, index=self.series._index, name=self.series.name,
         )
 
     @property
@@ -4793,9 +4787,7 @@ class DatetimeProperties(object):
         """  # noqa: E501
         last_day = libcudf.datetime.last_day_of_month(self.series._column)
         last_day = Series._from_data(
-            ColumnAccessor({None: last_day}),
-            index=self.series._index,
-            name=self.series.name,
+            {None: last_day}, index=self.series._index, name=self.series.name,
         )
         return (self.day == last_day.dt.day).fillna(False)
 

--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2020-2021, NVIDIA CORPORATION
 
-import itertools
-
 import numba
 import pandas as pd
 from pandas.api.indexers import BaseIndexer
@@ -434,11 +432,18 @@ class RollingGroupby(Rolling):
         index = cudf.MultiIndex.from_frame(
             cudf.DataFrame(
                 {
-                    key: value
-                    for key, value in itertools.chain(
-                        self._group_keys._data.items(),
-                        self.obj.index._data.items(),
-                    )
+                    **{
+                        (
+                            key[1]
+                            if isinstance(self._group_keys, cudf.MultiIndex)
+                            else key
+                        ): value
+                        for key, value in self._group_keys._data.items()
+                    },
+                    **{
+                        key: value
+                        for key, value in self.obj.index._data.items()
+                    },
                 }
             )
         )

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2973,7 +2973,7 @@ def test_dataframe_sort_index(
 @pytest.mark.parametrize("ignore_index", [True, False])
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize("na_position", ["first", "last"])
-def test_dataframe_mulitindex_sort_index(
+def test_dataframe_multiindex_sort_index(
     axis, level, ascending, inplace, ignore_index, na_position
 ):
     pdf = pd.DataFrame(
@@ -2996,8 +2996,6 @@ def test_dataframe_mulitindex_sort_index(
         inplace=inplace,
         na_position=na_position,
     )
-    if ignore_index is True:
-        expected = expected
     got = gdf.sort_index(
         axis=axis,
         level=level,

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -1914,6 +1914,8 @@ def test_index_from_arrow(data):
 
 
 def test_multiindex_to_arrow():
+    # TODO: Should this work for integer keys? I don't think pyarrow supports
+    # them, should we provide a nicer error?
     pdf = pd.DataFrame(
         {
             "a": [1, 2, 1, 2, 3],

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -1069,54 +1069,6 @@ def test_multiindex_values_host():
 
 
 @pytest.mark.parametrize(
-    "gdi, fill_value, expected",
-    [
-        (
-            cudf.MultiIndex(
-                levels=[[1, 3, 4, None], [1, 2, 5]],
-                codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
-                names=["x", "y"],
-            ),
-            5,
-            cudf.MultiIndex(
-                levels=[[1, 3, 4, 5], [1, 2, 5]],
-                codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
-                names=["x", "y"],
-            ),
-        ),
-        (
-            cudf.MultiIndex(
-                levels=[[1, 3, 4, None], [1, None, 5]],
-                codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
-                names=["x", "y"],
-            ),
-            100,
-            cudf.MultiIndex(
-                levels=[[1, 3, 4, 100], [1, 100, 5]],
-                codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
-                names=["x", "y"],
-            ),
-        ),
-        (
-            cudf.MultiIndex(
-                levels=[["a", "b", "c", None], ["1", None, "5"]],
-                codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
-                names=["x", "y"],
-            ),
-            "100",
-            cudf.MultiIndex(
-                levels=[["a", "b", "c", "100"], ["1", "100", "5"]],
-                codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
-                names=["x", "y"],
-            ),
-        ),
-    ],
-)
-def test_multiIndex_fillna(gdi, fill_value, expected):
-    assert_eq(expected, gdi.fillna(fill_value))
-
-
-@pytest.mark.parametrize(
     "pdi",
     [
         pd.MultiIndex(

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -81,6 +81,7 @@ def test_multiindex_construction():
     assert_eq(pmi, mi)
     pmi = pd.MultiIndex(levels, codes)
     mi = cudf.MultiIndex(levels=levels, codes=codes)
+    mi.to_frame()
     assert_eq(pmi, mi)
 
 

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -682,7 +682,7 @@ def test_multiindex_copy_sem(data, levels, codes, names):
 
     for glv, plv in zip(gmi_copy.levels, pmi_copy.levels):
         assert all(glv.values_host == plv.values)
-    for (_, gval), pval in zip(gmi.codes._data._data.items(), pmi.codes):
+    for (_, gval), pval in zip(gmi.codes._data.items(), pmi.codes):
         assert all(gval.values_host == pval.astype(np.int64))
     assert_eq(gmi_copy.names, pmi_copy.names)
 
@@ -770,8 +770,8 @@ def test_multiindex_copy_deep(data, deep):
         mi2 = mi1.copy(deep=deep)
 
         # Assert ._levels idendity
-        lptrs = [lv._data._data[None].base_data.ptr for lv in mi1._levels]
-        rptrs = [lv._data._data[None].base_data.ptr for lv in mi2._levels]
+        lptrs = [lv._data[None].base_data.ptr for lv in mi1._levels]
+        rptrs = [lv._data[None].base_data.ptr for lv in mi2._levels]
 
         assert all([(x == y) is same_ref for x, y in zip(lptrs, rptrs)])
 

--- a/python/cudf/cudf/tests/test_repr.py
+++ b/python/cudf/cudf/tests/test_repr.py
@@ -210,13 +210,11 @@ def test_MI():
         }
     )
     levels = [["a", "b", "c", "d"], ["w", "x", "y", "z"], ["m", "n"]]
-    codes = cudf.DataFrame(
-        {
-            "a": [0, 0, 0, 0, 1, 1, 2, 2, 3, 3],
-            "b": [0, 1, 2, 3, 0, 1, 2, 3, 0, 1],
-            "c": [0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
-        }
-    )
+    codes = [
+        [0, 0, 0, 0, 1, 1, 2, 2, 3, 3],
+        [0, 1, 2, 3, 0, 1, 2, 3, 0, 1],
+        [0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+    ]
     pd.options.display.max_rows = 999
     pd.options.display.max_columns = 0
     gdf = gdf.set_index(cudf.MultiIndex(levels=levels, codes=codes))

--- a/python/cudf/cudf/tests/test_rolling.py
+++ b/python/cudf/cudf/tests/test_rolling.py
@@ -442,9 +442,9 @@ def test_rolling_groupby_multi(agg):
         expect = getattr(
             pdf.groupby(["a", "b"], sort=True).rolling(window_size), agg
         )().fillna(-1)
-        got = getattr(
-            gdf.groupby(["a", "b"], sort=True).rolling(window_size), agg
-        )().fillna(-1)
+        gby = gdf.groupby(["a", "b"], sort=True)
+        rolling = gby.rolling(window_size)
+        got = getattr(rolling, agg)().fillna(-1)
         assert_eq(expect, got, check_dtype=False)
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
MultiIndex needs support for duplicate column names. We currently handle this in an ad hoc manner by assigning integer column names to the underlying ColumnAccessor (guaranteeing uniqueness) and storing the actual names in a separate list (allowing for duplicates). This approach is very brittle and can easily lead to a MultiIndex in an invalid state. Additionally, there are cases involving methods that work with the ColumnAccessor (e.g. `_from_data`) that make it basically impossible to propagate the true names through, requiring lots of easy-to-forget special handling.

This PR introduces a subclass of ColumnAccessor that is specifically designed to support duplicate column names. Rather than carrying around the names as an extra attribute of MultiIndex, the column names are automatically stored in special tuples as the keys to the new `_MultiIndexColumnAccessor`. This class handles packing and unpacking names into these tuples to abstract that logic away from the MultiIndex and making it easier to transparently pass columns around between classes.

The new solution still has plenty of sharp edges, largely due to the fact that this PR is an intermediate solution designed to move us in the direction of building duplicate name support directly into the class while also working with existing code paths. However, I think it's a distinct improvement on the current approach: it is mostly self-documenting and self-explanatory, it bakes duplicate names directly into the architecture in a way that's much harder to do incorrectly, and it makes it much easier to write code that fails _loudly_ when MultiIndexes with duplicate names exhibit unexpected behavior. As we improve other areas of cudf such as our Python-Cython interfaces, many of the currently problematic cases should vanish. We can reevaluate the way this class works as further refactorings continue.