### PR TITLE
Skip Comparing Uniform Window Results in Var/std Tests

### DIFF
--- a/python/cudf/cudf/tests/test_rolling.py
+++ b/python/cudf/cudf/tests/test_rolling.py
@@ -136,7 +136,7 @@ def test_rolling_with_offset(agg):
 @pytest.mark.parametrize("agg", ["std", "var"])
 @pytest.mark.parametrize("ddof", [0, 1])
 @pytest.mark.parametrize("center", [True, False])
-@pytest.mark.parametrize("seed", [42, 100])
+@pytest.mark.parametrize("seed", [100, 2000])
 @pytest.mark.parametrize("window_size", [2, 10, 100])
 def test_rolling_var_std_large(agg, ddof, center, seed, window_size):
     if PANDAS_GE_110:
@@ -151,27 +151,26 @@ def test_rolling_var_std_large(agg, ddof, center, seed, window_size):
     flower_bound = -math.sqrt(abs(np.finfo(np.float64).min) / window_size)
 
     n_rows = 1_000
-    cardinality = 100
     data = rand_dataframe(
         dtypes_meta=[
             {
                 "dtype": "int64",
                 "null_frequency": 0.4,
-                "cardinality": cardinality,
+                "cardinality": n_rows,
                 "min_bound": ilower_bound,
                 "max_bound": iupper_bound,
             },
             {
                 "dtype": "float64",
                 "null_frequency": 0.4,
-                "cardinality": cardinality,
+                "cardinality": n_rows,
                 "min_bound": flower_bound,
                 "max_bound": fupper_bound,
             },
             {
                 "dtype": "decimal64",
                 "null_frequency": 0.4,
-                "cardinality": cardinality,
+                "cardinality": n_rows,
                 "min_bound": ilower_bound,
                 "max_bound": iupper_bound,
             },
@@ -186,13 +185,18 @@ def test_rolling_var_std_large(agg, ddof, center, seed, window_size):
     expect = getattr(pdf.rolling(window_size, 1, center), agg)(ddof=ddof)
     got = getattr(gdf.rolling(window_size, 1, center), agg)(ddof=ddof)
 
-    # Due to pandas-37051, pandas rolling var/std on uniform window is
-    # not reliable. Skipping these rows when comparing.
-    for col in expect:
-        mask = (got[col].fillna(-1) != 0).to_pandas()
-        expect[col] = expect[col][mask]
-        got[col] = got[col][mask]
-        assert_eq(expect[col], got[col], **kwargs)
+    import platform
+
+    if platform.machine() == "aarch64":
+        # Due to pandas-37051, pandas rolling var/std on uniform window is
+        # not reliable. Skipping these rows when comparing.
+        for col in expect:
+            mask = (got[col].fillna(-1) != 0).to_pandas()
+            expect[col] = expect[col][mask]
+            got[col] = got[col][mask]
+            assert_eq(expect[col], got[col], **kwargs)
+    else:
+        assert_eq(expect, got, **kwargs)
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
Close #9404 

The issue in 9404 results from that pandas computes different rolling std results on x86 compared to `aarch64` on a uniform window. In this specific test case, the window is

```
(Pdb) pdf['1'][574:576]
574    2.064967e+153
575    2.064967e+153
Name: 1, dtype: float64
```

On `aarch64`, pandas computes
```python
(Pdb) mask = np.isclose(expect['1'].fillna(0), got['1'].fillna(0).to_pandas())
(Pdb) expect['1'][~mask]
575    1.149735e+145
```

On `x86`, pandas computes
```python
(Pdb) expect['1'][575]
0.0
```

Since the results computed on uniform windows by pandas is not reliable, this PR drops these rows before comparing the results.