### PR TITLE
Fix stream compaction's `drop_duplicates` API to use stable sort

### DIFF
--- a/cpp/include/cudf/stream_compaction.hpp
+++ b/cpp/include/cudf/stream_compaction.hpp
@@ -210,7 +210,6 @@ std::unique_ptr<table> apply_boolean_mask(
 enum class duplicate_keep_option {
   KEEP_FIRST = 0,  ///< Keeps first duplicate element and unique elements
   KEEP_LAST,       ///< Keeps last duplicate element and unique elements
-  KEEP_ANY,        ///< Keeps one duplicate element at any position and unique elements
   KEEP_NONE        ///< Keeps only unique elements
 };
 


### PR DESCRIPTION
Currently, stream compaction API `drop_duplicates` uses unstable sort for all of its internal sorting. This is wrong since we may want to have stable sorting results so we can choose to keep the first or the last duplicate element from the repeated sequences. 

This PR does two things:
 * Fixes the issue mentioned above by using stable sort if the input option is to keep the first or last duplicate element, and
 * Adds a new keep option into the enum class `duplicate_keep_option`:  `KEEP_ANY`. This option allows the user to choose to keep one element from the repeated sequence at any position.

Note that the issue did not show up by any failed test because thrust default (unstable) sort, which is called internally in `drop_duplicate`, still produces the same results as thrust stable sort most of the time (but this is not guaranteed). As such, the current `drop_duplicate` still produces correct results in its tests.

This PR blocks https://github.com/rapidsai/cudf/pull/9345.