### PR TITLE
Update pre-commit hook URLs.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
               - id: black
                 files: python/.*
       - repo: https://github.com/PyCQA/flake8
-        rev: 3.8.3
+        rev: 4.0.1
         hooks:
               - id: flake8
                 alias: flake8


### PR DESCRIPTION
Following up on #9412, this PR updates some pre-commit hook URLs that have moved. This now uses the canonical URLs instead of a redirect.

Note: As of PR #9412, the pre-commit configuration is used for style checks on CI. The versions used by pre-commit are in a separate virtual environment from any linters/formatters in the user's local/conda environment.

I also updated the pinned versions of `flake8`, `pydocstyle`, and `isort`, which are more than a year old. The updates to these hooks do not require any changes to the code for compliance, and I do not anticipate any PR conflicts. Users of pre-commit will be automatically upgraded next time pre-commit runs. I did not upgrade `black` or `mypy`:
- Upgrading `black` to the latest version introduces a relatively large number of small formatting changes and should be handled in a separate PR.
- Upgrading `mypy` to the latest version introduces an issue I reported in #9300 and should be handled in a separate PR.