### PR TITLE
Expose varying stripe granularity from Dask

### DIFF
--- a/python/dask_cudf/dask_cudf/io/orc.py
+++ b/python/dask_cudf/dask_cudf/io/orc.py
@@ -115,14 +115,28 @@ def read_orc(path, columns=None, filters=None, storage_options=None, **kwargs):
     return dd.core.new_dd_object(dsk, name, meta, divisions)
 
 
-def write_orc_partition(df, path, fs, filename, compression, stripe_size_bytes,
-                        stripe_size_rows, row_index_stride):
+def write_orc_partition(
+    df,
+    path,
+    fs,
+    filename,
+    compression,
+    stripe_size_bytes,
+    stripe_size_rows,
+    row_index_stride,
+):
     full_path = fs.sep.join([path, filename])
     with fs.open(full_path, mode="wb") as out_file:
         if not isinstance(out_file, IOBase):
             out_file = BufferedWriter(out_file)
-        cudf.io.to_orc(df, out_file, compression=compression, stripe_size_bytes=stripe_size_bytes,
-                       stripe_size_rows=stripe_size_rows, row_index_stride=row_index_stride)
+        cudf.io.to_orc(
+            df,
+            out_file,
+            compression=compression,
+            stripe_size_bytes=stripe_size_bytes,
+            stripe_size_rows=stripe_size_rows,
+            row_index_stride=row_index_stride,
+        )
     return full_path
 
 
@@ -192,8 +206,16 @@ def to_orc(
     # write parts
     dwrite = delayed(write_orc_partition)
     parts = [
-        dwrite(d, path, fs, filename, compression, stripe_size_bytes,
-               stripe_size_rows, row_index_stride)
+        dwrite(
+            d,
+            path,
+            fs,
+            filename,
+            compression,
+            stripe_size_bytes,
+            stripe_size_rows,
+            row_index_stride,
+        )
         for d, filename in zip(df.to_delayed(), filenames)
     ]
 

--- a/python/dask_cudf/dask_cudf/io/orc.py
+++ b/python/dask_cudf/dask_cudf/io/orc.py
@@ -168,10 +168,10 @@ def to_orc(
     stripe_size_bytes: integer or None, default None
         Maximum size of each stripe of the output.
         If None, 67108864 (64MB) will be used.
-    stripe_size_rows: integer or None, default None 1000000
+    stripe_size_rows: integer or None, default None
         Maximum number of rows of each stripe of the output.
         If None, 1000000 will be used.
-    row_index_stride: integer or None, default None 10000
+    row_index_stride: integer or None, default None
         Row index stride (maximum number of rows in each row group).
         If None, 10000 will be used.
     compute : bool, optional


### PR DESCRIPTION
This exposes `stripe_size_bytes`, `stripe_size_rows`, and `row_index_stride` (these are parameters that were added to `cudf.to_orc` by https://github.com/rapidsai/cudf/pull/9310/) to `dask_cudf.to_orc`.