### PR TITLE
Preserve the decimal scale when creating a default scalar

### DIFF
--- a/cpp/src/scalar/scalar_factories.cpp
+++ b/cpp/src/scalar/scalar_factories.cpp
@@ -123,25 +123,22 @@ namespace {
 struct default_scalar_functor {
   data_type type;
 
-  template <typename T,
-           typename std::enable_if_t<not is_fixed_point<T>()>* = nullptr>
+  template <typename T, typename std::enable_if_t<not is_fixed_point<T>()>* = nullptr>
   std::unique_ptr<cudf::scalar> operator()(rmm::cuda_stream_view stream,
                                            rmm::mr::device_memory_resource* mr)
   {
     return make_fixed_width_scalar(data_type(type_to_id<T>()), stream, mr);
   }
 
-  template <typename T,
-            typename std::enable_if_t<is_fixed_point<T>()>* = nullptr>
+  template <typename T, typename std::enable_if_t<is_fixed_point<T>()>* = nullptr>
   std::unique_ptr<cudf::scalar> operator()(rmm::cuda_stream_view stream,
                                            rmm::mr::device_memory_resource* mr)
   {
     auto const scale_ = numeric::scale_type{type.scale()};
-    auto s = make_fixed_point_scalar<T>(0, scale_, stream, mr);
+    auto s            = make_fixed_point_scalar<T>(0, scale_, stream, mr);
     s->set_valid_async(false, stream);
     return s;
   }
-
 };
 
 template <>

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -560,14 +560,16 @@ struct ReductionDtypeTest : public cudf::test::BaseFixture {
 
 TEST_F(ReductionDtypeTest, all_null_output)
 {
-  auto sum_agg       = cudf::make_sum_aggregation();
+  auto sum_agg = cudf::make_sum_aggregation();
 
-  auto const col = cudf::test::fixed_point_column_wrapper<int32_t>{{0, 0, 0}, {0, 0, 0}, numeric::scale_type{-2}}.release();
+  auto const col =
+    cudf::test::fixed_point_column_wrapper<int32_t>{{0, 0, 0}, {0, 0, 0}, numeric::scale_type{-2}}
+      .release();
 
   std::unique_ptr<cudf::scalar> result = cudf::reduce(*col, sum_agg, col->type());
-  ASSERT_EQ(result->is_valid(), false);
-  ASSERT_EQ(result->type().id(), col->type().id());
-  ASSERT_EQ(result->type().scale(), col->type().scale());
+  EXPECT_EQ(result->is_valid(), false);
+  EXPECT_EQ(result->type().id(), col->type().id());
+  EXPECT_EQ(result->type().scale(), col->type().scale());
 }
 
 // test case for different output precision


### PR DESCRIPTION
this fixes #9431

I am no C++ expert so I am happy to get any advice on a better way to fix this issue.