### PR TITLE
Resolve `hash_columns` `FutureWarning` in `dask_cudf`

### DIFF
--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -313,11 +313,7 @@ def union_categoricals_cudf(
 
 
 def safe_hash(frame):
-    index = frame.index
-    if isinstance(frame, cudf.DataFrame):
-        return cudf.Series(frame.hash_columns(), index=index)
-    else:
-        return cudf.Series(frame.hash_values(), index=index)
+    return cudf.Series(frame.hash_values(), index=frame.index)
 
 
 @hash_object_dispatch.register((cudf.DataFrame, cudf.Series))


### PR DESCRIPTION
Resolve the following `FutureWarning` raised in `dask_cudf` when using `safe_hash`:

```python
FutureWarning: The `hash_columns` method will be removed in a future cuDF release. Replace `df.hash_columns(columns, method)` with `df[columns].hash_values(method)`.
```

This blocks Dask-CUDA CI, as we're following a strict policy towards deprecation warnings.