### PR TITLE
Improve Python docstring formatting.

### DIFF
--- a/python/cudf/cudf/comm/gpuarrow.py
+++ b/python/cudf/cudf/comm/gpuarrow.py
@@ -129,13 +129,11 @@ class GpuArrowNodeReader(object):
         return self._series._column.mask_array_view
 
     def make_series(self):
-        """Make a Series object out of this node
-        """
+        """Make a Series object out of this node"""
         return self._series.copy(deep=False)
 
     def _make_dictionary_series(self):
-        """Make a dictionary-encoded series from this node
-        """
+        """Make a dictionary-encoded series from this node"""
         assert self.is_dictionary
         return self._series.copy(deep=False)
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -400,8 +400,7 @@ class ColumnBase(Column, Serializable):
 
     @property
     def nullmask(self) -> Buffer:
-        """The gpu buffer for the null-mask
-        """
+        """The gpu buffer for the null-mask"""
         if not self.nullable:
             raise ValueError("Column has no null mask")
         return self.mask_array_view
@@ -630,8 +629,7 @@ class ColumnBase(Column, Serializable):
         )
 
     def isnull(self) -> ColumnBase:
-        """Identify missing values in a Column.
-        """
+        """Identify missing values in a Column."""
         result = libcudf.unary.is_null(self)
 
         if self.dtype.kind == "f":
@@ -642,8 +640,7 @@ class ColumnBase(Column, Serializable):
         return result
 
     def notnull(self) -> ColumnBase:
-        """Identify non-missing values in a Column.
-        """
+        """Identify non-missing values in a Column."""
         result = libcudf.unary.is_valid(self)
 
         if self.dtype.kind == "f":
@@ -697,8 +694,7 @@ class ColumnBase(Column, Serializable):
         keep_index: bool = True,
         nullify: bool = False,
     ) -> T:
-        """Return Column by taking values from the corresponding *indices*.
-        """
+        """Return Column by taking values from the corresponding *indices*."""
         # Handle zero size
         if indices.size == 0:
             return cast(T, column_empty_like(self, newsize=0))
@@ -1254,8 +1250,7 @@ def column_empty_like(
     masked: bool = False,
     newsize: int = None,
 ) -> ColumnBase:
-    """Allocate a new column like the given *column*
-    """
+    """Allocate a new column like the given *column*"""
     if dtype is None:
         dtype = column.dtype
     row_count = len(column) if newsize is None else newsize
@@ -1297,8 +1292,7 @@ def column_empty_like_same_mask(
 def column_empty(
     row_count: int, dtype: Dtype = "object", masked: bool = False
 ) -> ColumnBase:
-    """Allocate a new column like the given row_count and dtype.
-    """
+    """Allocate a new column like the given row_count and dtype."""
     dtype = cudf.dtype(dtype)
     children = ()  # type: Tuple[ColumnBase, ...]
 

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -347,8 +347,7 @@ class DatetimeColumn(column.ColumnBase):
             )
 
     def _default_na_value(self) -> DatetimeLikeScalar:
-        """Returns the default NA value for this column
-        """
+        """Returns the default NA value for this column"""
         return np.datetime64("nat", self.time_unit)
 
     def mean(self, skipna=None, dtype=np.float64) -> ScalarLike:

--- a/python/cudf/cudf/core/column/decimal.py
+++ b/python/cudf/cudf/core/column/decimal.py
@@ -25,8 +25,7 @@ from .numerical_base import NumericalBaseColumn
 
 
 class DecimalBaseColumn(NumericalBaseColumn):
-    """Base column for decimal64 and decimal32 columns
-    """
+    """Base column for decimal64 and decimal32 columns"""
 
     dtype: Union[Decimal32Dtype, Decimal64Dtype]
 

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -291,8 +291,7 @@ class NumericalColumn(NumericalBaseColumn):
         return lhs, rhs
 
     def _default_na_value(self) -> ScalarLike:
-        """Returns the default NA value for this column
-        """
+        """Returns the default NA value for this column"""
         dkind = self.dtype.kind
         if dkind == "f":
             return self.dtype.type(np.nan)

--- a/python/cudf/cudf/core/column/numerical_base.py
+++ b/python/cudf/cudf/core/column/numerical_base.py
@@ -194,8 +194,7 @@ class NumericalBaseColumn(ColumnBase):
     def round(
         self, decimals: int = 0, how: str = "half_even"
     ) -> NumericalBaseColumn:
-        """Round the values in the Column to the given number of decimals.
-        """
+        """Round the values in the Column to the given number of decimals."""
         return libcudf.round.round(self, decimal_places=decimals, how=how)
 
     def _apply_scan_op(self, op: str) -> ColumnBase:

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -42,7 +42,7 @@ from cudf.utils.dtypes import can_convert_to_column
 
 
 def str_to_boolean(column: StringColumn):
-    """Takes in string column and returns boolean column """
+    """Takes in string column and returns boolean column"""
     return (
         libstrings.count_characters(column) > cudf.Scalar(0, dtype="int8")
     ).fillna(False)
@@ -4767,7 +4767,7 @@ class StringMethods(ColumnMethods):
         0     True
         1    False
         dtype: bool
-         """
+        """
         ltype = libstrings.LetterType.CONSONANT
 
         if can_convert_to_column(position):

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -305,8 +305,7 @@ class TimeDeltaColumn(column.ColumnBase):
         )
 
     def _default_na_value(self) -> ScalarLike:
-        """Returns the default NA value for this column
-        """
+        """Returns the default NA value for this column"""
         return np.timedelta64("nat", self.time_unit)
 
     @property

--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -244,9 +244,7 @@ class ColumnAccessor(MutableMapping):
             del self._column_length
 
     def to_pandas_index(self) -> pd.Index:
-        """"
-        Convert the keys of the ColumnAccessor to a Pandas Index object.
-        """
+        """Convert the keys of the ColumnAccessor to a Pandas Index object."""
         if self.multiindex and len(self.level_names) > 0:
             # Using `from_frame()` instead of `from_tuples`
             # prevents coercion of values to a different type

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -923,8 +923,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     @property
     def ndim(self):
-        """Dimension of the data. DataFrame ndim is always 2.
-        """
+        """Dimension of the data. DataFrame ndim is always 2."""
         return 2
 
     def __dir__(self):
@@ -1023,8 +1022,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     @annotate("DATAFRAME_SETITEM", color="blue", domain="cudf_python")
     def __setitem__(self, arg, value):
-        """Add/set column by *arg or DataFrame*
-        """
+        """Add/set column by *arg or DataFrame*"""
         if isinstance(arg, DataFrame):
             # not handling set_item where arg = df & value = df
             if isinstance(value, DataFrame):
@@ -1143,13 +1141,13 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     def _slice(self: T, arg: slice) -> T:
         """
-       _slice : slice the frame as per the arg
+        _slice : slice the frame as per the arg
 
-       Parameters
-       ----------
-       arg : should always be of type slice
+        Parameters
+        ----------
+        arg : should always be of type slice
 
-       """
+        """
         from cudf.core.index import RangeIndex
 
         num_rows = len(self)
@@ -1306,7 +1304,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             return NotImplemented
 
     def _get_numeric_data(self):
-        """ Return a dataframe with only numeric data types """
+        """Return a dataframe with only numeric data types"""
         columns = [
             c
             for c, dt in self.dtypes.items()
@@ -2057,7 +2055,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         return iter(self.columns)
 
     def iteritems(self):
-        """ Iterate over column names and series pairs """
+        """Iterate over column names and series pairs"""
         for k in self:
             yield (k, self[k])
 
@@ -2078,8 +2076,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
     @property  # type: ignore
     @annotate("DATAFRAME_COLUMNS_GETTER", color="yellow", domain="cudf_python")
     def columns(self):
-        """Returns a tuple of columns
-        """
+        """Returns a tuple of columns"""
         return self._data.to_pandas_index()
 
     @columns.setter  # type: ignore
@@ -2128,8 +2125,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     @property
     def index(self):
-        """Returns the index of the DataFrame
-        """
+        """Returns the index of the DataFrame"""
         return self._index
 
     @index.setter
@@ -2618,7 +2614,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     @annotate("INSERT", color="green", domain="cudf_python")
     def insert(self, loc, name, value):
-        """ Add a column to DataFrame at the index specified by loc.
+        """Add a column to DataFrame at the index specified by loc.
 
         Parameters
         ----------
@@ -2842,8 +2838,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             return out
 
     def _drop_column(self, name):
-        """Drop a column by *name*
-        """
+        """Drop a column by *name*"""
         if name not in self._data:
             raise KeyError(f"column '{name}' does not exist")
         del self._data[name]
@@ -2926,8 +2921,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         return self._mimic_inplace(outdf, inplace=inplace)
 
     def pop(self, item):
-        """Return a column and drop it from the DataFrame.
-        """
+        """Return a column and drop it from the DataFrame."""
         popped = self[item]
         del self[item]
         return popped
@@ -5612,8 +5606,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
     # Stats
     #
     def _prepare_for_rowwise_op(self, method, skipna):
-        """Prepare a DataFrame for CuPy-based row-wise operations.
-        """
+        """Prepare a DataFrame for CuPy-based row-wise operations."""
 
         if method not in _cupy_nan_methods_map and any(
             col.nullable for col in self._columns
@@ -6239,8 +6232,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         return df
 
     def corr(self):
-        """Compute the correlation matrix of a DataFrame.
-        """
+        """Compute the correlation matrix of a DataFrame."""
         corr = cupy.corrcoef(self.values, rowvar=False)
         df = DataFrame(cupy.asfortranarray(corr)).set_index(self.columns)
         df.columns = self.columns
@@ -6766,11 +6758,11 @@ def _setitem_with_dataframe(
     mask: Optional[cudf.core.column.ColumnBase] = None,
 ):
     """
-        This function sets item dataframes relevant columns with replacement df
-        :param input_df: Dataframe to be modified inplace
-        :param replace_df: Replacement DataFrame to replace values with
-        :param input_cols: columns to replace in the input dataframe
-        :param mask: boolean mask in case of masked replacing
+    This function sets item dataframes relevant columns with replacement df
+    :param input_df: Dataframe to be modified inplace
+    :param replace_df: Replacement DataFrame to replace values with
+    :param input_cols: columns to replace in the input dataframe
+    :param mask: boolean mask in case of masked replacing
     """
 
     if input_cols is None:

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1765,8 +1765,7 @@ class Frame:
         return self
 
     def shift(self, periods=1, freq=None, axis=0, fill_value=None):
-        """Shift values by `periods` positions.
-        """
+        """Shift values by `periods` positions."""
         assert axis in (None, 0) and freq is None
         return self._shift(periods)
 
@@ -5505,7 +5504,7 @@ class Frame:
 
     def rmul(self, other, axis, level=None, fill_value=None):
         """
-        Get Multiplication of dataframe or series and other, element-wise 
+        Get Multiplication of dataframe or series and other, element-wise
         (binary operator `rmul`).
 
         Equivalent to ``other * frame``, but with support to substitute a

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -820,7 +820,7 @@ class GroupBy(Serializable):
         interpolation : {"linear", "lower", "higher", "midpoint", "nearest"}
             The interpolation method to use when the desired quantile lies
             between two data points. Defaults to "linear".
-       """
+        """
 
         def func(x):
             return getattr(x, "quantile")(q=q, interpolation=interpolation)
@@ -893,8 +893,7 @@ class GroupBy(Serializable):
         return result._copy_type_metadata(value_columns)
 
     def _scan_fill(self, method: str, limit: int) -> DataFrameOrSeries:
-        """Internal implementation for `ffill` and `bfill`
-        """
+        """Internal implementation for `ffill` and `bfill`"""
         value_columns = self.grouping.values
         result = self.obj.__class__._from_data(
             self._groupby.replace_nulls(
@@ -1365,8 +1364,7 @@ class _Grouping(Serializable):
 
     @property
     def keys(self):
-        """Return grouping key columns as index
-        """
+        """Return grouping key columns as index"""
         nkeys = len(self._key_columns)
 
         if nkeys == 0:

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -656,8 +656,7 @@ class MultiIndex(Frame, BaseIndex):
         self._codes = cudf.DataFrame._from_data(codes)
 
     def _compute_validity_mask(self, index, row_tuple, max_length):
-        """ Computes the valid set of indices of values in the lookup
-        """
+        """Computes the valid set of indices of values in the lookup"""
         lookup = cudf.DataFrame()
         for name, row in zip(index.names, row_tuple):
             if isinstance(row, slice) and row == slice(None):

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -592,7 +592,7 @@ def get_dummies(
     drop_first=False,
     dtype="uint8",
 ):
-    """ Returns a dataframe whose columns are the one hot encodings of all
+    """Returns a dataframe whose columns are the one hot encodings of all
     columns in `df`
 
     Parameters

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -85,7 +85,7 @@ from cudf.utils.utils import (
 
 def _append_new_row_inplace(col: ColumnLike, value: ScalarLike):
     """Append a scalar `value` to the end of `col` inplace.
-       Cast to common type if possible
+    Cast to common type if possible
     """
     to_type = find_common_type([type(value), col.dtype])
     val_col = as_column(value, dtype=to_type)
@@ -2120,8 +2120,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
 
     @property
     def index(self):
-        """The index object
-        """
+        """The index object"""
         return self._index
 
     @index.setter
@@ -2130,8 +2129,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
 
     @property
     def nullmask(self):
-        """The gpu buffer for the null-mask
-        """
+        """The gpu buffer for the null-mask"""
         return cudf.Series(self._column.nullmask)
 
     def as_mask(self):

--- a/python/cudf/cudf/core/tools/numeric.py
+++ b/python/cudf/cudf/core/tools/numeric.py
@@ -226,8 +226,7 @@ def _convert_str_col(col, errors, _downcast=None):
 
 
 def _proc_inf_empty_strings(col):
-    """Handles empty and infinity strings
-    """
+    """Handles empty and infinity strings"""
     col = libstrings.to_lower(col)
     col = _proc_empty_strings(col)
     col = _proc_inf_strings(col)
@@ -235,8 +234,7 @@ def _proc_inf_empty_strings(col):
 
 
 def _proc_empty_strings(col):
-    """Replaces empty strings with NaN
-    """
+    """Replaces empty strings with NaN"""
     s = cudf.Series(col)
     s = s.where(s != "", "NaN")
     return s._column

--- a/python/cudf/cudf/datasets.py
+++ b/python/cudf/cudf/datasets.py
@@ -18,7 +18,7 @@ def timeseries(
     nulls_frequency=0,
     seed=None,
 ):
-    """ Create timeseries dataframe with random data
+    """Create timeseries dataframe with random data
 
     Parameters
     ----------
@@ -81,7 +81,7 @@ def timeseries(
 
 
 def randomdata(nrows=10, dtypes=None, seed=None):
-    """ Create a dataframe with random data
+    """Create a dataframe with random data
 
     Parameters
     ----------

--- a/python/cudf/cudf/testing/_utils.py
+++ b/python/cudf/cudf/testing/_utils.py
@@ -68,7 +68,7 @@ def count_zero(arr):
 
 
 def assert_eq(left, right, **kwargs):
-    """ Assert that two cudf-like things are equivalent
+    """Assert that two cudf-like things are equivalent
 
     This equality test works for pandas/cudf dataframes/series/indexes/scalars
     in the same way, and so makes it easier to perform parametrized testing

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -92,8 +92,7 @@ def test_index_find_label_range_genericindex():
 
 
 def test_index_find_label_range_rangeindex():
-    """Cudf specific
-    """
+    """Cudf specific"""
     # step > 0
     # 3, 8, 13, 18
     ridx = RangeIndex(3, 20, 5)
@@ -344,8 +343,7 @@ def test_index_copy_string(name, dtype, deep=True):
     NUMERIC_TYPES + ["datetime64[ns]", "timedelta64[ns]"] + OTHER_TYPES,
 )
 def test_index_copy_integer(name, dtype, deep=True):
-    """Test for NumericIndex Copy Casts
-    """
+    """Test for NumericIndex Copy Casts"""
     cidx = cudf.Int64Index([1, 2, 3])
     pidx = cidx.to_pandas()
 
@@ -358,8 +356,7 @@ def test_index_copy_integer(name, dtype, deep=True):
 @pytest.mark.parametrize("name", ["x"])
 @pytest.mark.parametrize("dtype", SIGNED_TYPES)
 def test_index_copy_float(name, dtype, deep=True):
-    """Test for NumericIndex Copy Casts
-    """
+    """Test for NumericIndex Copy Casts"""
     cidx = cudf.Float64Index([1.0, 2.0, 3.0])
     pidx = cidx.to_pandas()
 

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -666,8 +666,7 @@ def test_multiindex_equals():
 )
 @pytest.mark.parametrize("names", [["X", "Y"]])
 def test_multiindex_copy_sem(data, levels, codes, names):
-    """Test semantic equality for MultiIndex.copy
-    """
+    """Test semantic equality for MultiIndex.copy"""
     gdf = cudf.DataFrame(data)
     pdf = gdf.to_pandas()
 
@@ -740,8 +739,8 @@ def test_multiindex_copy_sem(data, levels, codes, names):
 @pytest.mark.parametrize("deep", [True, False])
 def test_multiindex_copy_deep(data, deep):
     """Test memory idendity for deep copy
-        Case1: Constructed from GroupBy, StringColumns
-        Case2: Constrcuted from MultiIndex, NumericColumns
+    Case1: Constructed from GroupBy, StringColumns
+    Case2: Constrcuted from MultiIndex, NumericColumns
     """
     same_ref = not deep
 

--- a/python/cudf/cudf/tests/test_serialize.py
+++ b/python/cudf/cudf/tests/test_serialize.py
@@ -44,7 +44,7 @@ from cudf.testing._utils import assert_eq
 )
 @pytest.mark.parametrize("to_host", [True, False])
 def test_serialize(df, to_host):
-    """ This should hopefully replace all functions below """
+    """This should hopefully replace all functions below"""
     a = df()
     if "cudf" not in type(a).__module__:
         a = cudf.from_pandas(a)

--- a/python/cudf/cudf/tests/test_sorting.py
+++ b/python/cudf/cudf/tests/test_sorting.py
@@ -117,8 +117,7 @@ def test_series_sort_index(nelem, asc):
 @pytest.mark.parametrize("data", [[0, 1, 1, 2, 2, 2, 3, 3], [0], [1, 2, 3]])
 @pytest.mark.parametrize("n", [-100, -50, -12, -2, 0, 1, 2, 3, 4, 7])
 def test_series_nlargest(data, n):
-    """Indirectly tests Series.sort_values()
-    """
+    """Indirectly tests Series.sort_values()"""
     sr = Series(data)
     psr = pd.Series(data)
     assert_eq(sr.nlargest(n), psr.nlargest(n))
@@ -136,8 +135,7 @@ def test_series_nlargest(data, n):
 @pytest.mark.parametrize("data", [[0, 1, 1, 2, 2, 2, 3, 3], [0], [1, 2, 3]])
 @pytest.mark.parametrize("n", [-100, -50, -12, -2, 0, 1, 2, 3, 4, 9])
 def test_series_nsmallest(data, n):
-    """Indirectly tests Series.sort_values()
-    """
+    """Indirectly tests Series.sort_values()"""
     sr = Series(data)
     psr = pd.Series(data)
     assert_eq(sr.nsmallest(n), psr.nsmallest(n))

--- a/python/cudf/cudf/utils/applyutils.py
+++ b/python/cudf/cudf/utils/applyutils.py
@@ -332,8 +332,7 @@ _cache = dict()  # type: Dict[Any, Any]
 
 @functools.wraps(_make_row_wise_kernel)
 def _load_cache_or_make_row_wise_kernel(cache_key, func, *args, **kwargs):
-    """Caching version of ``_make_row_wise_kernel``.
-    """
+    """Caching version of ``_make_row_wise_kernel``."""
     if cache_key is None:
         cache_key = func
     try:
@@ -349,8 +348,7 @@ def _load_cache_or_make_row_wise_kernel(cache_key, func, *args, **kwargs):
 
 @functools.wraps(_make_chunk_wise_kernel)
 def _load_cache_or_make_chunk_wise_kernel(func, *args, **kwargs):
-    """Caching version of ``_make_row_wise_kernel``.
-    """
+    """Caching version of ``_make_row_wise_kernel``."""
     try:
         return _cache[func]
     except KeyError:
@@ -360,6 +358,5 @@ def _load_cache_or_make_chunk_wise_kernel(func, *args, **kwargs):
 
 
 def _mangle_user(name):
-    """Mangle user variable name
-    """
+    """Mangle user variable name"""
     return "__user_{}".format(name)

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -121,8 +121,7 @@ ALL_TYPES = NUMERIC_TYPES | DATETIME_TYPES | TIMEDELTA_TYPES | OTHER_TYPES
 
 
 def np_to_pa_dtype(dtype):
-    """Util to convert numpy dtype to PyArrow dtype.
-    """
+    """Util to convert numpy dtype to PyArrow dtype."""
     # special case when dtype is np.datetime64
     if dtype.kind == "M":
         time_unit, _ = np.datetime_data(dtype)
@@ -153,8 +152,7 @@ def get_numeric_type_info(dtype):
 
 
 def numeric_normalize_types(*args):
-    """Cast all args to a common type using numpy promotion logic
-    """
+    """Cast all args to a common type using numpy promotion logic"""
     dtype = np.result_type(*[a.dtype for a in args])
     return [a.astype(dtype) for a in args]
 
@@ -171,8 +169,8 @@ def _find_common_type_decimal(dtypes):
 
 
 def cudf_dtype_from_pydata_dtype(dtype):
-    """ Given a numpy or pandas dtype, converts it into the equivalent cuDF
-        Python dtype.
+    """Given a numpy or pandas dtype, converts it into the equivalent cuDF
+    Python dtype.
     """
 
     if cudf.api.types.is_categorical_dtype(dtype):
@@ -188,8 +186,8 @@ def cudf_dtype_from_pydata_dtype(dtype):
 
 
 def cudf_dtype_to_pa_type(dtype):
-    """ Given a cudf pandas dtype, converts it into the equivalent cuDF
-        Python dtype.
+    """Given a cudf pandas dtype, converts it into the equivalent cuDF
+    Python dtype.
     """
     if cudf.api.types.is_categorical_dtype(dtype):
         raise NotImplementedError()
@@ -204,8 +202,8 @@ def cudf_dtype_to_pa_type(dtype):
 
 
 def cudf_dtype_from_pa_type(typ):
-    """ Given a cuDF pyarrow dtype, converts it into the equivalent
-        cudf pandas dtype.
+    """Given a cuDF pyarrow dtype, converts it into the equivalent
+    cudf pandas dtype.
     """
     if pa.types.is_list(typ):
         return cudf.core.dtypes.ListDtype.from_arrow(typ)

--- a/python/cudf/cudf/utils/hash_vocab_utils.py
+++ b/python/cudf/cudf/utils/hash_vocab_utils.py
@@ -247,7 +247,7 @@ def hash_vocab(
     sep_token="[SEP]",
 ):
     """
-      Write the vocab vocabulary hashtable to the output_path
+    Write the vocab vocabulary hashtable to the output_path
     """
     np.random.seed(1243342)
     vocab = _load_vocab_dict(vocab_path)

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1115,7 +1115,8 @@ def _is_local_filesystem(fs):
 
 
 def ensure_single_filepath_or_buffer(path_or_data, **kwargs):
-    """Return False if `path_or_data` resolves to multiple filepaths or buffers
+    """Return False if `path_or_data` resolves to multiple filepaths or
+    buffers.
     """
     path_or_data = stringify_pathlike(path_or_data)
     if isinstance(path_or_data, str):
@@ -1140,8 +1141,7 @@ def ensure_single_filepath_or_buffer(path_or_data, **kwargs):
 
 
 def is_directory(path_or_data, **kwargs):
-    """Returns True if the provided filepath is a directory
-    """
+    """Returns True if the provided filepath is a directory"""
     path_or_data = stringify_pathlike(path_or_data)
     if isinstance(path_or_data, str):
         storage_options = kwargs.get("storage_options")

--- a/python/cudf/cudf/utils/queryutils.py
+++ b/python/cudf/cudf/utils/queryutils.py
@@ -157,8 +157,7 @@ def {kernelname}(out, {args}):
 
 
 def _wrap_query_expr(name, fn, args):
-    """Wrap the query expression in a cuda kernel.
-    """
+    """Wrap the query expression in a cuda kernel."""
 
     def _add_idx(arg):
         if arg.startswith(ENVREF_PREFIX):

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -383,8 +383,8 @@ def _cast_to_appropriate_cudf_type(val, index=None):
 
 def _get_cupy_compatible_args_index(args, ser_index=None):
     """
-     This function returns cupy compatible arguments and output index
-     if conversion is not possible it returns None
+    This function returns cupy compatible arguments and output index
+    if conversion is not possible it returns None
     """
 
     casted_ls = []

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -33,7 +33,7 @@ DASK_VERSION = LooseVersion(dask.__version__)
 
 
 class _Frame(dd.core._Frame, OperatorMethodMixin):
-    """ Superclass for DataFrame and Series
+    """Superclass for DataFrame and Series
 
     Parameters
     ----------
@@ -263,13 +263,13 @@ class DataFrame(_Frame, dd.core.DataFrame):
         return df
 
     def to_parquet(self, path, *args, **kwargs):
-        """ Calls dask.dataframe.io.to_parquet with CudfEngine backend """
+        """Calls dask.dataframe.io.to_parquet with CudfEngine backend"""
         from dask_cudf.io import to_parquet
 
         return to_parquet(self, path, *args, **kwargs)
 
     def to_orc(self, path, **kwargs):
-        """ Calls dask_cudf.io.to_orc """
+        """Calls dask_cudf.io.to_orc"""
         from dask_cudf.io import to_orc
 
         return to_orc(self, path, **kwargs)
@@ -326,8 +326,7 @@ class DataFrame(_Frame, dd.core.DataFrame):
         return super().repartition(*args, **kwargs)
 
     def shuffle(self, *args, **kwargs):
-        """ Wraps dask.dataframe DataFrame.shuffle method
-        """
+        """Wraps dask.dataframe DataFrame.shuffle method"""
         shuffle_arg = kwargs.pop("shuffle", None)
         if shuffle_arg and shuffle_arg != "tasks":
             raise ValueError("dask_cudf does not support disk-based shuffle.")

--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -180,24 +180,24 @@ def groupby_agg(
     sort=False,
     as_index=True,
 ):
-    """ Optimized groupby aggregation for Dask-CuDF.
+    """Optimized groupby aggregation for Dask-CuDF.
 
-        This aggregation algorithm only supports the following options:
+    This aggregation algorithm only supports the following options:
 
-        - "count"
-        - "mean"
-        - "std"
-        - "var"
-        - "sum"
-        - "min"
-        - "max"
-        - "collect"
-        - "first"
-        - "last"
+    - "count"
+    - "mean"
+    - "std"
+    - "var"
+    - "sum"
+    - "min"
+    - "max"
+    - "collect"
+    - "first"
+    - "last"
 
-        This "optimized" approach is more performant than the algorithm
-        in `dask.dataframe`, because it allows the cudf backend to
-        perform multiple aggregations at once.
+    This "optimized" approach is more performant than the algorithm
+    in `dask.dataframe`, because it allows the cudf backend to
+    perform multiple aggregations at once.
     """
     # Assert that aggregations are supported
     aggs = _redirect_aggs(aggs_in)
@@ -348,8 +348,7 @@ def groupby_agg(
 
 
 def _redirect_aggs(arg):
-    """ Redirect aggregations to their corresponding name in cuDF
-    """
+    """Redirect aggregations to their corresponding name in cuDF"""
     redirects = {
         sum: "sum",
         max: "max",
@@ -375,8 +374,7 @@ def _redirect_aggs(arg):
 
 
 def _is_supported(arg, supported: set):
-    """ Check that aggregations in `arg` are a subset of `supported`
-    """
+    """Check that aggregations in `arg` are a subset of `supported`"""
     if isinstance(arg, (list, dict)):
         if isinstance(arg, dict):
             _global_set: Set[str] = set()
@@ -395,8 +393,7 @@ def _is_supported(arg, supported: set):
 
 
 def _make_name(*args, sep="_"):
-    """ Combine elements of `args` into a new string
-    """
+    """Combine elements of `args` into a new string"""
     _args = (arg for arg in args if arg != "")
     return sep.join(_args)
 
@@ -404,15 +401,15 @@ def _make_name(*args, sep="_"):
 def _groupby_partition_agg(
     df, gb_cols, aggs, columns, split_out, dropna, sort, sep
 ):
-    """ Initial partition-level aggregation task.
+    """Initial partition-level aggregation task.
 
-        This is the first operation to be executed on each input
-        partition in `groupby_agg`.  Depending on `aggs`, four possible
-        groupby aggregations ("count", "sum", "min", and "max") are
-        performed.  The result is then partitioned (by hashing `gb_cols`)
-        into a number of distinct dictionary elements.  The number of
-        elements in the output dictionary (`split_out`) corresponds to
-        the number of partitions in the final output of `groupby_agg`.
+    This is the first operation to be executed on each input
+    partition in `groupby_agg`.  Depending on `aggs`, four possible
+    groupby aggregations ("count", "sum", "min", and "max") are
+    performed.  The result is then partitioned (by hashing `gb_cols`)
+    into a number of distinct dictionary elements.  The number of
+    elements in the output dictionary (`split_out`) corresponds to
+    the number of partitions in the final output of `groupby_agg`.
     """
 
     # Modify dict for initial (partition-wise) aggregations
@@ -459,15 +456,15 @@ def _groupby_partition_agg(
 
 
 def _tree_node_agg(dfs, gb_cols, split_out, dropna, sort, sep):
-    """ Node in groupby-aggregation reduction tree.
+    """Node in groupby-aggregation reduction tree.
 
-        Following the initial `_groupby_partition_agg` tasks,
-        the `groupby_agg` algorithm will perform a tree reduction
-        to combine the data from the input partitions into
-        `split_out` different output partitions.  For each node in
-        the reduction tree, the input DataFrame objects are
-        concatenated, and "sum", "min" and/or "max" groupby
-        aggregations are used to combine the necessary statistics.
+    Following the initial `_groupby_partition_agg` tasks,
+    the `groupby_agg` algorithm will perform a tree reduction
+    to combine the data from the input partitions into
+    `split_out` different output partitions.  For each node in
+    the reduction tree, the input DataFrame objects are
+    concatenated, and "sum", "min" and/or "max" groupby
+    aggregations are used to combine the necessary statistics.
     """
 
     df = _concat(dfs, ignore_index=True)
@@ -493,8 +490,7 @@ def _tree_node_agg(dfs, gb_cols, split_out, dropna, sort, sep):
 
 
 def _var_agg(df, col, count_name, sum_name, pow2_sum_name, ddof=1):
-    """ Calculate variance (given count, sum, and sum-squared columns).
-    """
+    """Calculate variance (given count, sum, and sum-squared columns)."""
 
     # Select count, sum, and sum-squared
     n = df[count_name]
@@ -526,13 +522,13 @@ def _finalize_gb_agg(
     str_cols_out,
     aggs_renames,
 ):
-    """ Final aggregation task.
+    """Final aggregation task.
 
-        This is the final operation on each output partitions
-        of the `groupby_agg` algorithm.  This function must
-        take care of higher-order aggregations, like "mean",
-        "std" and "var".  We also need to deal with the column
-        index, the row index, and final sorting behavior.
+    This is the final operation on each output partitions
+    of the `groupby_agg` algorithm.  This function must
+    take care of higher-order aggregations, like "mean",
+    "std" and "var".  We also need to deal with the column
+    index, the row index, and final sorting behavior.
     """
 
     # Deal with higher-order aggregations

--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -351,7 +351,7 @@ def read_parquet(
     row_groups_per_part=None,
     **kwargs,
 ):
-    """ Read parquet files into a Dask DataFrame
+    """Read parquet files into a Dask DataFrame
 
     Calls ``dask.dataframe.read_parquet`` to cordinate the execution of
     ``cudf.read_parquet``, and ultimately read multiple partitions into

--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -46,7 +46,7 @@ def _quantile(a, q):
 
 
 def merge_quantiles(finalq, qs, vals):
-    """ Combine several quantile calculations of different data.
+    """Combine several quantile calculations of different data.
     [NOTE: Same logic as dask.array merge_percentiles]
     """
     if isinstance(finalq, Iterator):
@@ -223,8 +223,7 @@ def sort_values(
     ascending=True,
     na_position="last",
 ):
-    """ Sort by the given list/tuple of column names.
-    """
+    """Sort by the given list/tuple of column names."""
     if na_position not in ("first", "last"):
         raise ValueError("na_position must be either 'first' or 'last'")
 


### PR DESCRIPTION
This PR applies black 21.9b0 to fix docstrings, then re-applies the pinned version of black 19.10b0 to undo incompatible formatting changes. The minor fixes to docstrings (mostly improving whitespace consistency and line wrapping) remain and are contained in this PR. Tagging @galipremsagar for review since he already approved the changes in the previous PR #9450 that was closed due to issues with conflicting versions of black in VSCode/rapids-compose and pre-commit.