### PR TITLE
Column-at-a-time filtered reading for ORC

### DIFF
--- a/python/dask_cudf/dask_cudf/io/orc.py
+++ b/python/dask_cudf/dask_cudf/io/orc.py
@@ -144,9 +144,9 @@ def read_orc(
         # Determine which columns are filtering vs. remaining
         filters = _prepare_filters(filters)
         query_string, local_dict = _filters_to_query(filters)
-        columns_in_predicate = [
-            col for conjunction in filters for (col, op, val) in conjunction
-        ]
+        columns_in_predicate = list(
+            {col for conjunction in filters for (col, _, _) in conjunction}
+        )
         columns = [c for c in columns if c not in columns_in_predicate]
 
         # Read in only the columns relevant to the filtering
@@ -172,7 +172,6 @@ def read_orc(
             lambda df: len(df)
         ).compute()
         is_filtered_partition_empty = filtered_partition_lens == 0
-        print(f"{list(is_filtered_partition_empty)=}")
 
         # Cull empty partitions
         filtered_df_partitions = [
@@ -213,7 +212,6 @@ def read_orc(
                 )
                 N += 1
             partition_idx += 1
-    print(f"Filtered {partition_idx} partitions to {N} partitions")
 
     divisions = [None] * (len(dsk) + 1)
     res = dd.core.new_dd_object(dsk, name, meta, divisions)

--- a/python/dask_cudf/dask_cudf/io/orc.py
+++ b/python/dask_cudf/dask_cudf/io/orc.py
@@ -156,7 +156,7 @@ def read_orc(
 
         # Read in only the columns relevant to the filtering
         filtered_df = read_orc(
-            path,
+            paths,
             columns=columns_in_predicate,
             filters=None,
             storage_options=None,

--- a/python/dask_cudf/dask_cudf/io/tests/test_orc.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_orc.py
@@ -68,8 +68,16 @@ def test_read_orc_cols(engine, columns):
         ),
     ],
 )
-def test_read_orc_filtered(tmpdir, engine, predicate, expected_len):
-    df = dask_cudf.read_orc(sample_orc, engine=engine, filters=predicate)
+@pytest.mark.parametrize("filtering_columns_first", [False, True])
+def test_read_orc_filtered(
+    tmpdir, engine, predicate, expected_len, filtering_columns_first
+):
+    df = dask_cudf.read_orc(
+        sample_orc,
+        engine=engine,
+        filters=predicate,
+        filtering_columns_first=filtering_columns_first,
+    )
 
     dd.assert_eq(len(df), expected_len)
 

--- a/python/dask_cudf/dask_cudf/io/tests/test_orc.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_orc.py
@@ -80,6 +80,7 @@ def test_read_orc_filtered(
     )
 
     dd.assert_eq(len(df), expected_len)
+    dd.assert_eq(df.columns, dask_cudf.read_orc(sample_orc).columns)
 
 
 def test_read_orc_first_file_empty(tmpdir):


### PR DESCRIPTION
This PR introduces a `filtering_columns_first` parameter flag for `read_orc` in Dask cuDF. If set to true, the columns relevant to the `filters` will be read in first and used to read in only the relevant stripes for the remaining columns.

This is currently working but still needs some tests, benchmarking, and also ensuring that returned data frames have divisions if needed.

- [x] Working implementation
- [x] Explore creating Dask graph using dictionary instead of Dask Delayed API - decided not to
- [x] Benchmark time and memory usage, make figures
- [ ] See if we can reduce overhead by horizontally concatenating and reordering columns without copying
- [ ] See if this should/can be made generic across Parquet/ORC/etc.
- [x] Add tests

Example + benchmark results:
```python
df = dask_cudf.read_orc(
    "datasets/gpu-bdb/sf100/orc-split-row-group/web_sales/*.orc"
).query("ws_item_sk == 7947 and ws_bill_customer_sk == 854575").compute()
# Wall time: 27 s
```
```python
df = dask_cudf.read_orc(
    "datasets/gpu-bdb/sf100/orc-split-row-group/web_sales/*.orc"
    filters=[("ws_item_sk", "==", 7947), ("ws_bill_customer_sk", "==", 854575)]
).query("ws_item_sk == 7947 and ws_bill_customer_sk == 854575").compute()
# Wall time: 9.04 s
```
```python
df = dask_cudf.read_orc(
    "datasets/gpu-bdb/sf100/orc-split-row-group/web_sales/*.orc"
    filters=[("ws_item_sk", "==", 7947), ("ws_bill_customer_sk", "==", 854575)],
    filtering_columns_first=True
).query("ws_item_sk == 7947 and ws_bill_customer_sk == 854575").compute()
# Wall time: 1.73 s
```