### PR TITLE
Fix several test and benchmark issues related to bitmask allocations.

### DIFF
--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -809,7 +809,7 @@ void expect_equal_buffers(void const* lhs, void const* rhs, std::size_t size_byt
 std::vector<bitmask_type> bitmask_to_host(cudf::column_view const& c)
 {
   if (c.nullable()) {
-    auto num_bitmasks = bitmask_allocation_size_bytes(c.size()) / sizeof(bitmask_type);
+    auto num_bitmasks = num_bitmask_words(c.size());
     std::vector<bitmask_type> host_bitmask(num_bitmasks);
     if (c.offset() == 0) {
       CUDA_TRY(cudaMemcpy(host_bitmask.data(),

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -133,7 +133,7 @@ TYPED_TEST(ColumnUtilitiesTest, NullableToHostAllValid)
 
   auto masks = cudf::test::detail::make_null_mask_vector(all_valid, all_valid + size);
 
-  EXPECT_TRUE(std::equal(masks.begin(), masks.end(), host_data.second.begin()));
+  EXPECT_TRUE(cudf::test::validate_host_masks(masks, host_data.second, size));
 }
 
 struct ColumnUtilitiesEquivalenceTest : public cudf::test::BaseFixture {


### PR DESCRIPTION

I encountered a crash when trying to use the data coming out of `create_random_table`.  The code was not generating buffers padded to 64 bytes, which was expected by the column utilities code.  I made several changes to address this:

- Fix the core issue itself:  make the bitmask buffers coming out of create_random_table conform to the cudf standard.

- Changed `bitmask_to_host` in column_utilites.cu to only return the number of bitmask words necessary to represent the number of rows in the column. Previously it was returning all the padding words as well, which was meaningless.

- Fixed an issue in test code that wasn't using `cudf::test::validate_host_masks` when it should have been.