### PR TITLE
Add example to docstrings in `rolling.apply`

### DIFF
--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -288,6 +288,10 @@ class Rolling(GetAttrGetItemMixin):
         ----------
         func : function
             A user defined function that takes an 1D array as input
+        args : tuple
+            unsupported.
+        kwargs
+            unsupported
 
         See also
         --------
@@ -308,7 +312,7 @@ class Rolling(GetAttrGetItemMixin):
         ...             if i > 3:
         ...                     count += 1
         ...     return count
-        ... 
+        ...
         >>> s = cudf.Series([0, 1.1, 5.8, 3.1, 6.2, 2.0, 1.5])
         >>> s.rolling(3, min_periods=1).apply(count_if_gt_3)
         0    0


### PR DESCRIPTION
Partially address #7850

Currently docstrings of `rolling.apply` has no example to show case the usage of the API. This PR adds that and also points out that currently `args` and `kwargs` is unsupported.