### PR TITLE
[BUG] Use raw strings to avoid SyntaxErrors in parsed docstrings.

### DIFF
--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -552,7 +552,7 @@ class StringMethods(ColumnMethods):
     def extract(
         self, pat: str, flags: int = 0, expand: bool = True
     ) -> SeriesOrIndex:
-        """
+        r"""
         Extract capture groups in the regex `pat` as columns in a DataFrame.
 
         For each subject string in the Series, extract groups from the first
@@ -624,7 +624,7 @@ class StringMethods(ColumnMethods):
         na=np.nan,
         regex: bool = True,
     ) -> SeriesOrIndex:
-        """
+        r"""
         Test if pattern or regex is contained within a string of a Series or
         Index.
 
@@ -3270,7 +3270,7 @@ class StringMethods(ColumnMethods):
         return self._return_or_inplace(libstrings.wrap(self._column, width))
 
     def count(self, pat: str, flags: int = 0) -> SeriesOrIndex:
-        """
+        r"""
         Count occurrences of pattern in each string of the Series/Index.
 
         This function is used to count the number of times a particular


### PR DESCRIPTION
I was looking at running cuDF Python tests with `-Werror` but ran into a few problems. One of those problems is that the docstrings in `string.py` use `\d` in code examples for regular expressions, which causes a SyntaxError if the docstring is parsed during test collection because `\d` is not a valid escape sequence in Python. Using a raw string in those methods' docstrings fixes the problem.

(Eventually I'd like to get our Python tests to fail if warnings are encountered -- with a list of excluded/filtered warnings that are outside our control.)