### PR TITLE
Expose APIs to wrap CUDA or RMM allocations with a Java device buffer instance

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/CudaMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/CudaMemoryBuffer.java
@@ -72,7 +72,15 @@ public class CudaMemoryBuffer extends BaseDeviceMemoryBuffer {
     }
   }
 
-  CudaMemoryBuffer(long address, long lengthInBytes, Cuda.Stream stream) {
+  /**
+   * Wrap an existing CUDA allocation in a device memory buffer. The CUDA allocation will be freed
+   * when the resulting device memory buffer instance frees its memory resource (i.e.: when its
+   * reference count goes to zero).
+   * @param address device address of the CUDA memory allocation
+   * @param lengthInBytes length of the CUDA allocation in bytes
+   * @param stream CUDA stream to use for synchronization when freeing the allocation
+   */
+  public CudaMemoryBuffer(long address, long lengthInBytes, Cuda.Stream stream) {
     super(address, lengthInBytes, new CudaBufferCleaner(address, lengthInBytes, stream));
   }
 

--- a/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
+++ b/java/src/main/java/ai/rapids/cudf/DeviceMemoryBuffer.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -99,8 +99,16 @@ public class DeviceMemoryBuffer extends BaseDeviceMemoryBuffer {
     }
   }
 
-  // Static factory method to make this a little simpler from JNI
-  static DeviceMemoryBuffer fromRmm(long address, long lengthInBytes, long rmmBufferAddress) {
+  /**
+   * Wrap an existing RMM allocation in a device memory buffer. The RMM allocation will be freed
+   * when the resulting device memory buffer instance frees its memory resource (i.e.: when its
+   * reference count goes to zero).
+   * @param address device address of the RMM allocation
+   * @param lengthInBytes length of the RMM allocation in bytes
+   * @param rmmBufferAddress host address of the rmm::device_buffer that owns the device memory
+   * @return new device memory buffer instance that wraps the existing RMM allocation
+   */
+  public static DeviceMemoryBuffer fromRmm(long address, long lengthInBytes, long rmmBufferAddress) {
     return new DeviceMemoryBuffer(address, lengthInBytes, rmmBufferAddress);
   }
 


### PR DESCRIPTION
Closes #9531.

Publicizes the existing Java APIs to wrap an `rmm::device_buffer` or a CUDA memory allocation as a Java device buffer instance.  This can be useful when interfacing with native code that has separately allocated memory via RMM or CUDA and is passing ownership of the buffer to a cudf object.