### PR TITLE
Move libcudacxx to use `rapids_cpm` and use newer versions

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -478,12 +478,10 @@ target_compile_options(cudf
 target_include_directories(cudf
            PUBLIC      "$<BUILD_INTERFACE:${DLPACK_INCLUDE_DIR}>"
                        "$<BUILD_INTERFACE:${JITIFY_INCLUDE_DIR}>"
-                       "$<BUILD_INTERFACE:${LIBCUDACXX_INCLUDE_DIR}>"
                        "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/include>"
                        "$<BUILD_INTERFACE:${CUDF_GENERATED_INCLUDE_DIR}/include>"
            PRIVATE     "$<BUILD_INTERFACE:${CUDF_SOURCE_DIR}/src>"
-           INTERFACE   "$<INSTALL_INTERFACE:include>"
-                       "$<INSTALL_INTERFACE:include/libcudf/libcudacxx>")
+           INTERFACE   "$<INSTALL_INTERFACE:include>")
 
 target_compile_definitions(cudf
             PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_DEFINITIONS}>"
@@ -517,6 +515,7 @@ add_dependencies(cudf jitify_preprocess_run)
 # Specify the target module library dependencies
 target_link_libraries(cudf
            PUBLIC ${ARROW_LIBRARIES}
+                  libcudacxx::libcudacxx
                   cudf::Thrust
                   rmm::rmm
            PRIVATE cuco::cuco

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -653,11 +653,6 @@ install(DIRECTORY
             ${CUDF_SOURCE_DIR}/include/cudf_test
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(DIRECTORY
-            ${CUDF_GENERATED_INCLUDE_DIR}/include/libcxx
-            ${CUDF_GENERATED_INCLUDE_DIR}/include/libcudacxx
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libcudf)
-
 install(TARGETS cudftestutil
         DESTINATION ${lib_dir}
         EXPORT cudf-testing-exports)
@@ -705,35 +700,8 @@ set(common_code_string
 if(NOT TARGET cudf::Thrust)
   thrust_create_target(cudf::Thrust FROM_OPTIONS)
 endif()
-
-# nvcc automatically adds the CUDA Toolkit system include paths before any
-# system include paths that CMake adds.
-#
-# CMake implicitly treats all includes on import targets as 'SYSTEM' includes.
-#
-# To get the cudacxx shipped with cudf to be picked up by consumers instead of the
-# version shipped with the CUDA Toolkit we need to make sure it is a non-SYSTEM
-# include on the CMake side.
-#
-# To do this currently, we move the includes from the cudf::cudf target to a
-# non-import target to ensure they are `-I` instead of `-isystem`
-
-add_library(cudf_non_system_includes INTERFACE)
-target_link_libraries(cudf::cudf INTERFACE cudf_non_system_includes)
-
-get_target_property(all_includes cudf::cudf INTERFACE_INCLUDE_DIRECTORIES)
-set(system_includes )
-set(normal_includes )
-foreach(include IN LISTS all_includes)
-  if(include MATCHES "/libcudacxx")
-    list(APPEND normal_includes "${include}")
-  else()
-    list(APPEND system_includes "${include}")
-  endif()
-endforeach()
-set_target_properties(cudf::cudf PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${system_includes}")
-set_target_properties(cudf_non_system_includes PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${normal_includes}")
 ]=])
+
 set(install_code_string
     [=[
 set(ArrowCUDA_DIR "${Arrow_DIR}")

--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -27,6 +27,10 @@ function(jit_preprocess_files)
                           ${ARGN}
                           )
 
+    get_target_property(libcudacxx_raw_includes libcudacxx::libcudacxx INTERFACE_INCLUDE_DIRECTORIES)
+    foreach(inc IN LISTS libcudacxx_raw_includes)
+        list(APPEND libcudacxx_includes "-I${inc}")
+    endforeach()
     foreach(ARG_FILE ${ARG_FILES})
         set(ARG_OUTPUT ${CUDF_GENERATED_INCLUDE_DIR}/include/jit_preprocessed_files/${ARG_FILE}.jit.hpp)
         get_filename_component(jit_output_directory "${ARG_OUTPUT}" DIRECTORY )
@@ -45,7 +49,7 @@ function(jit_preprocess_files)
                                     -D__CUDACC_RTC__
                                     -I${CUDF_SOURCE_DIR}/include
                                     -I${CUDF_SOURCE_DIR}/src
-                                    -I${LIBCUDACXX_INCLUDE_DIR}
+                                    ${libcudacxx_includes}
                                     -I${CUDAToolkit_INCLUDE_DIRS}
                                     --no-preinclude-workarounds
                                     --no-replace-pragma-once
@@ -63,5 +67,3 @@ jit_preprocess_files(SOURCE_DIRECTORY      ${CUDF_SOURCE_DIR}/src
 
 add_custom_target(jitify_preprocess_run DEPENDS ${JIT_PREPROCESSED_FILES})
 
-file(COPY "${LIBCUDACXX_INCLUDE_DIR}/" DESTINATION "${CUDF_GENERATED_INCLUDE_DIR}/include/libcudacxx")
-file(COPY "${LIBCXX_INCLUDE_DIR}"      DESTINATION "${CUDF_GENERATED_INCLUDE_DIR}/include/libcxx")

--- a/cpp/cmake/libcudacxx.patch
+++ b/cpp/cmake/libcudacxx.patch
@@ -1,0 +1,21 @@
+diff --git a/include/cuda/std/detail/__config b/include/cuda/std/detail/__config
+index d55a43688..654142d7e 100644
+--- a/include/cuda/std/detail/__config
++++ b/include/cuda/std/detail/__config
+@@ -23,7 +23,7 @@
+     #define _LIBCUDACXX_CUDACC_VER_MINOR __CUDACC_VER_MINOR__
+     #define _LIBCUDACXX_CUDACC_VER_BUILD __CUDACC_VER_BUILD__
+     #define _LIBCUDACXX_CUDACC_VER                                                  \
+-        _LIBCUDACXX_CUDACC_VER_MAJOR * 10000 + _LIBCUDACXX_CUDACC_VER_MINOR * 100 + \
++        _LIBCUDACXX_CUDACC_VER_MAJOR * 10000 + _LIBCUDACXX_CUDACC_VER_MINOR * 1000 + \
+         _LIBCUDACXX_CUDACC_VER_BUILD
+ 
+     #define _LIBCUDACXX_HAS_NO_LONG_DOUBLE
+@@ -64,7 +64,7 @@
+ #  endif
+ #endif
+ 
+-#if defined(_LIBCUDACXX_COMPILER_MSVC) || (defined(_LIBCUDACXX_CUDACC_VER) && (_LIBCUDACXX_CUDACC_VER < 110500))
++#if defined(_LIBCUDACXX_COMPILER_MSVC) || (defined(_LIBCUDACXX_CUDACC_VER) && (_LIBCUDACXX_CUDACC_VER < 1105000))
+ #  define _LIBCUDACXX_HAS_NO_INT128
+ #endif

--- a/cpp/cmake/thirdparty/get_libcudacxx.cmake
+++ b/cpp/cmake/thirdparty/get_libcudacxx.cmake
@@ -14,18 +14,14 @@
 # limitations under the License.
 #=============================================================================
 
-function(find_and_configure_libcudacxx VERSION)
-    rapids_cpm_find(libcudacxx ${VERSION}
-        GIT_REPOSITORY      https://github.com/NVIDIA/libcudacxx.git
-        GIT_TAG             ${VERSION}
-        GIT_SHALLOW         TRUE
-        DOWNLOAD_ONLY       TRUE
-    )
+function(find_and_configure_libcudacxx)
+    include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
+
+    rapids_cpm_libcudacxx(BUILD_EXPORT_SET cudf-exports
+                          INSTALL_EXPORT_SET cudf-exports)
 
     set(LIBCUDACXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/include" PARENT_SCOPE)
     set(LIBCXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/libcxx/include" PARENT_SCOPE)
 endfunction()
 
-set(CUDF_MIN_VERSION_libcudacxx 1.4.0)
-
-find_and_configure_libcudacxx(${CUDF_MIN_VERSION_libcudacxx})
+find_and_configure_libcudacxx()

--- a/cpp/cmake/thirdparty/get_libcudacxx.cmake
+++ b/cpp/cmake/thirdparty/get_libcudacxx.cmake
@@ -18,7 +18,8 @@ function(find_and_configure_libcudacxx)
     include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
 
     rapids_cpm_libcudacxx(BUILD_EXPORT_SET cudf-exports
-                          INSTALL_EXPORT_SET cudf-exports)
+                          INSTALL_EXPORT_SET cudf-exports
+                          PATCH_COMMAND   patch --reject-file=- -p1 -N < ${CUDF_SOURCE_DIR}/cmake/libcudacxx.patch || true)
 
     set(LIBCUDACXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/include" PARENT_SCOPE)
 endfunction()

--- a/cpp/cmake/thirdparty/get_libcudacxx.cmake
+++ b/cpp/cmake/thirdparty/get_libcudacxx.cmake
@@ -21,7 +21,6 @@ function(find_and_configure_libcudacxx)
                           INSTALL_EXPORT_SET cudf-exports)
 
     set(LIBCUDACXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/include" PARENT_SCOPE)
-    set(LIBCXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/libcxx/include" PARENT_SCOPE)
 endfunction()
 
 find_and_configure_libcudacxx()

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -21,7 +21,7 @@ function(find_and_configure_nvcomp VERSION)
         GLOBAL_TARGETS     nvcomp::nvcomp
         CPM_ARGS
             GITHUB_REPOSITORY  NVIDIA/nvcomp
-            GIT_TAG            aa003db89e052e4ce408910ff17e1054b7c43b7d
+            GIT_TAG            c435afaf4ba8a8d12f379d688effcb185886cec1
             OPTIONS            "BUILD_STATIC ON"
                                "BUILD_TESTS OFF"
                                "BUILD_BENCHMARKS OFF"

--- a/java/src/main/native/src/NvcompJni.cpp
+++ b/java/src/main/native/src/NvcompJni.cpp
@@ -65,7 +65,7 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_isLZ4Data(JNIEnv
     auto in_ptr = reinterpret_cast<void const *>(j_in_ptr);
     auto in_size = static_cast<std::size_t>(j_in_size);
     auto stream = reinterpret_cast<cudaStream_t>(j_stream);
-    return LZ4IsData(in_ptr, in_size, stream);
+    return nvcompLZ4IsData(in_ptr, in_size, stream);
   }
   CATCH_STD(env, 0)
 }
@@ -74,7 +74,7 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_isLZ4Metadata(JN
                                                                               jlong metadata_ptr) {
   try {
     cudf::jni::auto_set_device(env);
-    return LZ4IsMetadata(reinterpret_cast<void *>(metadata_ptr));
+    return nvcompLZ4IsMetadata(reinterpret_cast<void *>(metadata_ptr));
   }
   CATCH_STD(env, 0)
 }

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -209,7 +209,7 @@ extensions = [
             os.path.join(CUDF_ROOT, "_deps/dlpack-src/include"),
             os.path.join(
                 os.path.dirname(sysconfig.get_path("include")),
-                "libcudf/libcudacxx",
+                "rapids/libcudacxx",
             ),
             os.path.dirname(sysconfig.get_path("include")),
             np.get_include(),

--- a/python/cudf_kafka/setup.py
+++ b/python/cudf_kafka/setup.py
@@ -63,7 +63,7 @@ extensions = [
             os.path.join(CUDF_ROOT, "_deps/libcudacxx-src/include"),
             os.path.join(
                 os.path.dirname(sysconfig.get_path("include")),
-                "libcudf/libcudacxx",
+                "rapids/libcudacxx",
             ),
             os.path.dirname(sysconfig.get_path("include")),
             np.get_include(),


### PR DESCRIPTION
Updates cudf to use the newest versions of nvbench and libcudacxx to allow compilation with both CUDA 11.4 and 11.5.