### PR TITLE
compile libnvcomp with PTDS if requested

### DIFF
--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -32,6 +32,11 @@ function(find_and_configure_nvcomp VERSION)
         add_library(nvcomp::nvcomp ALIAS nvcomp)
     endif()
 
+    # Per-thread default stream
+    if(PER_THREAD_DEFAULT_STREAM)
+        target_compile_definitions(nvcomp PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
+    endif()
+
 endfunction()
 
 set(CUDF_MIN_VERSION_nvCOMP 2.1.0)

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -33,8 +33,8 @@ function(find_and_configure_nvcomp VERSION)
     endif()
 
     # Per-thread default stream
-    if(PER_THREAD_DEFAULT_STREAM)
-        target_compile_definitions(nvcomp PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
+    if(TARGET nvcomp AND PER_THREAD_DEFAULT_STREAM)
+        target_compile_definitions(nvcomp PRIVATE CUDA_API_PER_THREAD_DEFAULT_STREAM)
     endif()
 
 endfunction()


### PR DESCRIPTION
closes #9534 

Change get_nvcomp.cmake to compile with CUDA_API_PER_THREAD_DEFAULT_STREAM is PER_THREAD_DEFAULT_STREAM is defined.

I did not add unit tests for this, but I tested it manually by building CUDF and then running a query to verify that PTDS was being used.
