### PR TITLE
Add axis parameter passthrough to `DataFrame` and `Series` take for pandas API compatibility

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -2553,7 +2553,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         if not inplace:
             return result
 
-    def take(self, positions, keep_index=True):
+    def take(self, positions, axis=0, keep_index=True):
         """
         Return a new DataFrame containing the rows specified by *positions*
 
@@ -2584,6 +2584,8 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         0  1.0  a
         2  3.0  c
         """
+        if axis != 0:
+            raise NotImplementedError("Only axis=0 is supported.")
         positions = as_column(positions)
         if is_bool_dtype(positions):
             return self._apply_boolean_mask(positions)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1170,7 +1170,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         else:
             self.loc[key] = value
 
-    def take(self, indices, keep_index=True):
+    def take(self, indices, axis=0, keep_index=True):
         """
         Return Series by taking values from the corresponding *indices*.
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1208,6 +1208,8 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         1    14
         dtype: int64
         """
+        if axis != 0:
+            raise ValueError("Only axis=0 is valid for Series objects.")
         if keep_index is True or is_scalar(indices):
             return self.iloc[indices]
         else:

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1208,8 +1208,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         1    14
         dtype: int64
         """
-        if axis != 0:
-            raise ValueError("Only axis=0 is valid for Series objects.")
+        axis = self._get_axis_from_axis_arg(axis)
         if keep_index is True or is_scalar(indices):
             return self.iloc[indices]
         else:


### PR DESCRIPTION
DataFrames and Series in Pandas support an axis parameter that cuDF does not: 

- https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.take.html
- https://pandas.pydata.org/docs/reference/api/pandas.Series.take.html

This PR adds the parameter (with appropriate `NotImplemented` Error). 

Note: This is a blocker for cuML upgrading to Scikit-learn 1.0 integration (blocks using sklearn search with cuML models). 

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
