### PR TITLE
remove alignment options for RMM jni

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -178,38 +178,6 @@ public class Rmm {
    */
   public static synchronized void initialize(int allocationMode, LogConf logConf, long poolSize,
       long maxPoolSize) throws RmmException {
-    initialize(allocationMode, logConf, poolSize, maxPoolSize, 0, 0);
-  }
-
-  /**
-   * Initialize memory manager state and storage. This will always initialize
-   * the CUDA context for the calling thread if it is not already set. The
-   * caller is responsible for setting the desired CUDA device prior to this
-   * call if a specific device is already set.
-   * <p>NOTE: All cudf methods will set the chosen CUDA device in the CUDA
-   * context of the calling thread after this returns.
-   * @param allocationMode Allocation strategy to use. Bit set using
-   *                       {@link RmmAllocationMode#CUDA_DEFAULT},
-   *                       {@link RmmAllocationMode#POOL},
-   *                       {@link RmmAllocationMode#ARENA},
-   *                       {@link RmmAllocationMode#CUDA_ASYNC} and
-   *                       {@link RmmAllocationMode#CUDA_MANAGED_MEMORY}
-   * @param logConf        How to do logging or null if you don't want to
-   * @param poolSize       The initial pool size in bytes
-   * @param maxPoolSize    The maximum size the pool is allowed to grow. If the specified value
-   *                       is <= 0 then the pool size will not be artificially limited.
-   * @param allocationAlignment The size to which allocations are aligned.
-   * @param alignmentThreshold  Only allocations with size larger than or equal to this threshold
-   *                            are aligned with `allocationAlignment`.
-   * @throws IllegalStateException if RMM has already been initialized
-   * @throws IllegalArgumentException if a max pool size is specified but the allocation mode
-   *                                  is not {@link RmmAllocationMode#POOL} or
-   *                                  {@link RmmAllocationMode#ARENA} or
-   *                                  {@link RmmAllocationMode#CUDA_ASYNC}, or the maximum pool
-   *                                  size is below the initial size.
-   */
-  public static synchronized void initialize(int allocationMode, LogConf logConf, long poolSize,
-      long maxPoolSize, long allocationAlignment, long alignmentThreshold) throws RmmException {
     if (initialized) {
       throw new IllegalStateException("RMM is already initialized");
     }
@@ -242,8 +210,7 @@ public class Rmm {
       loc = logConf.loc;
     }
 
-    initializeInternal(allocationMode, loc.internalId, path, poolSize, maxPoolSize,
-        allocationAlignment, alignmentThreshold);
+    initializeInternal(allocationMode, loc.internalId, path, poolSize, maxPoolSize);
     MemoryCleaner.setDefaultGpu(Cuda.getDevice());
     initialized = true;
   }
@@ -289,8 +256,7 @@ public class Rmm {
   }
 
   private static native void initializeInternal(int allocationMode, int logTo, String path,
-      long poolSize, long maxPoolSize, long allocationAlignment, long alignmentThreshold)
-      throws RmmException;
+      long poolSize, long maxPoolSize) throws RmmException;
 
   /**
    * Shut down any initialized RMM instance.  This should be used very rarely.  It does not need to

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -322,9 +322,10 @@ std::unique_ptr<rmm::mr::cuda_memory_resource> Cuda_memory_resource{};
 
 extern "C" {
 
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(
-    JNIEnv *env, jclass clazz, jint allocation_mode, jint log_to, jstring jpath, jlong pool_size,
-    jlong max_pool_size) {
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(JNIEnv *env, jclass clazz,
+                                                                  jint allocation_mode, jint log_to,
+                                                                  jstring jpath, jlong pool_size,
+                                                                  jlong max_pool_size) {
   try {
     // make sure the CUDA device is setup in the context
     cudaError_t cuda_status = cudaFree(0);
@@ -375,7 +376,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(
       Initialized_resource = std::make_shared<rmm::mr::cuda_memory_resource>();
     }
 
-    auto wrapped = make_tracking_adaptor( Initialized_resource.get(), RMM_ALLOC_SIZE_ALIGNMENT);
+    auto wrapped = make_tracking_adaptor(Initialized_resource.get(), RMM_ALLOC_SIZE_ALIGNMENT);
     Tracking_memory_resource.reset(wrapped);
 
     auto resource = Tracking_memory_resource.get();

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -324,7 +324,7 @@ extern "C" {
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(
     JNIEnv *env, jclass clazz, jint allocation_mode, jint log_to, jstring jpath, jlong pool_size,
-    jlong max_pool_size, jlong allocation_alignment, jlong alignment_threshold) {
+    jlong max_pool_size) {
   try {
     // make sure the CUDA device is setup in the context
     cudaError_t cuda_status = cudaFree(0);
@@ -375,14 +375,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(
       Initialized_resource = std::make_shared<rmm::mr::cuda_memory_resource>();
     }
 
-    if (allocation_alignment != 0) {
-      Initialized_resource = rmm::mr::make_owning_wrapper<rmm::mr::aligned_resource_adaptor>(
-          Initialized_resource, allocation_alignment, alignment_threshold);
-    }
-
-    auto wrapped = make_tracking_adaptor(
-        Initialized_resource.get(),
-        std::max(RMM_ALLOC_SIZE_ALIGNMENT, static_cast<std::size_t>(allocation_alignment)));
+    auto wrapped = make_tracking_adaptor( Initialized_resource.get(), RMM_ALLOC_SIZE_ALIGNMENT);
     Tracking_memory_resource.reset(wrapped);
 
     auto resource = Tracking_memory_resource.get();


### PR DESCRIPTION
GDS IO alignment turns out to be not very useful. Removed in preparation for further cleanup of the RMM initialization code. Followup of https://github.com/NVIDIA/spark-rapids/pull/3938. 