### PR TITLE
Build CUDA version agnostic packages for dask-cudf

### DIFF
--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda_{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - VERSION_SUFFIX
     - PARALLEL_LEVEL
@@ -28,11 +28,13 @@ requirements:
     - cudf {{ version }}
     - dask>=2021.09.1
     - distributed>=2021.09.1
+    - cudatoolkit {{ cuda_version }}
   run:
     - python
     - cudf {{ version }}
     - dask>=2021.09.1
     - distributed>=2021.09.1
+    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 test:                                   # [linux64]
   requires:                             # [linux64]


### PR DESCRIPTION
- Add CUDA version to `dask-cudf` build string
- Add `cudatoolkit` as build and runtime dependency for `dask-cudf`