### PR TITLE
Fix test failure with cuda 11.5 in row_bit_count tests.

### DIFF
--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -87,14 +87,21 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> build_list_column()
   using LCW                     = cudf::test::lists_column_wrapper<T, int>;
   constexpr size_type type_size = sizeof(device_storage_type_t<T>) * CHAR_BIT;
 
-  // clang-format off
-  cudf::test::lists_column_wrapper<T, int> col{ {{1, 2}, {3, 4, 5}}, 
-                                                LCW{LCW{}}, 
-                                                {LCW{10}},
-                                                {{6, 7, 8}, {9}},
-                                                {{-1, -2}, {-3, -4}},
-                                                {{-5, -6, -7}, {-8, -9}} };
-  // clang-format on
+  // {
+  //  {{1, 2}, {3, 4, 5}},
+  //  {{}},
+  //  {LCW{10}},
+  //  {{6, 7, 8}, {9}},
+  //  {{-1, -2}, {-3, -4}},
+  //  {{-5, -6, -7}, {-8, -9}}
+  // }
+  cudf::test::fixed_width_column_wrapper<T> values{
+    1, 2, 3, 4, 5, 10, 6, 7, 8, 9, -1, -2, -3, -4, -5, -6, -7, -8, -9};
+  cudf::test::fixed_width_column_wrapper<offset_type> inner_offsets{
+    0, 2, 5, 6, 9, 10, 12, 14, 17, 19};
+  auto inner_list = cudf::make_lists_column(9, inner_offsets.release(), values.release(), 0, {});
+  cudf::test::fixed_width_column_wrapper<offset_type> outer_offsets{0, 2, 2, 3, 5, 7, 9};
+  auto list = cudf::make_lists_column(6, outer_offsets.release(), std::move(inner_list), 0, {});
 
   // expected size = (num rows at level 1 + num_rows at level 2) + # values in the leaf
   cudf::test::fixed_width_column_wrapper<size_type> expected{
@@ -105,7 +112,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> build_list_column()
     ((4 + 8) * CHAR_BIT) + (type_size * 4),
     ((4 + 8) * CHAR_BIT) + (type_size * 5)};
 
-  return {col.release(), expected.release()};
+  return {std::move(list), expected.release()};
 }
 
 TYPED_TEST(RowBitCountTyped, Lists)
@@ -128,18 +135,26 @@ TYPED_TEST(RowBitCountTyped, ListsWithNulls)
   using LCW                     = cudf::test::lists_column_wrapper<T, int>;
   constexpr size_type type_size = sizeof(device_storage_type_t<T>) * CHAR_BIT;
 
-  std::vector<bool> valids{true, false, true};
-  std::vector<bool> valids2{false, true, false};
-  std::vector<bool> valids3{true, false};
+  // {
+  //  {{1, 2}, {3, null, 5}},
+  //  {{}},
+  //  {LCW{10}},
+  //  {{null, 7, null}, null},
+  // }
+  cudf::test::fixed_width_column_wrapper<T> values{{1, 2, 3, 4, 5, 10, 6, 7, 8},
+                                                   {1, 1, 1, 0, 1, 1, 0, 1, 0}};
+  cudf::test::fixed_width_column_wrapper<offset_type> inner_offsets{0, 2, 5, 6, 9, 9};
+  std::vector<bool> inner_list_validity{1, 1, 1, 1, 0};
+  auto inner_list = cudf::make_lists_column(
+    5,
+    inner_offsets.release(),
+    values.release(),
+    1,
+    cudf::test::detail::make_null_mask(inner_list_validity.begin(), inner_list_validity.end()));
+  cudf::test::fixed_width_column_wrapper<offset_type> outer_offsets{0, 2, 2, 3, 5};
+  auto list = cudf::make_lists_column(4, outer_offsets.release(), std::move(inner_list), 0, {});
 
-  // clang-format off
-  cudf::test::lists_column_wrapper<T, int> col{ {{1, 2}, {{3, 4, 5}, valids.begin()}}, 
-                                                LCW{LCW{}}, 
-                                                {LCW{10}}, 
-                                                {{{{6, 7, 8}, valids2.begin()}, {9}}, valids3.begin()} };
-  // clang-format on
-
-  table_view t({col});
+  table_view t({*list});
   auto result = cudf::row_bit_count(t);
 
   // expected size = (num rows at level 1 + num_rows at level 2) + # values in the leaf + validity


### PR DESCRIPTION
Test code was relying on a quirky (and probably incorrect) compiler behavior where 
```
using LCW   = cudf::test::lists_column_wrapper<T, int>;
lists_column_wrapper<int> col{ LCW{LCW{}} };
```
would produce a `List<List<int>>` column with no rows at the top.  With cuda 11.5 the order of constructors causes this to create a `List<List<int>>` column with 1 row at the top.  This leaves `lists_column_wrapper` with no way to currently express "an entirely empty list column nested more than 1 level deep" so the fix for now is just to construct these tests manually.