### PR TITLE
Use HostColumnVectorCore for child columns in JCudfSerialization.unpackHostColumnVectors

### DIFF
--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -3340,6 +3340,10 @@ public class TableTest extends CudfTestBase {
         }
       } finally {
         for (HostColumnVector c: hostColumns) {
+          // close child columns for multiple times should NOT throw exceptions
+          for (int i = 0; i < c.getNumChildren(); i++) {
+            c.getChildColumnView(i).close();
+          }
           c.close();
         }
       }


### PR DESCRIPTION
Fixes #9595 

 Currently, JCudfSerialization.unpackHostColumnVectors build child columns as HostColumnVector. This may lead to "Close called too many times" on HostColumnVector if the close method of child columns and parent one are both called. 

This PR attempts to replace HostColumnVector with HostColumnVectorCore for child (non-top level) columns, in case of the potential problem described above.