### PR TITLE
remove deprecated Rmm.initialize method

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -122,36 +122,6 @@ public class Rmm {
   }
 
   /**
-   * Initialize memory manager state and storage. This will always initialize
-   * the CUDA context for the calling thread if it is not already set. The
-   * caller is responsible for setting the desired CUDA device prior to this
-   * call if a specific device is already set.
-   * <p>NOTE: All cudf methods will set the chosen CUDA device in the CUDA
-   * context of the calling thread after this returns.
-   * @param allocationMode Allocation strategy to use. Bit set using
-   *                       {@link RmmAllocationMode#CUDA_DEFAULT},
-   *                       {@link RmmAllocationMode#POOL},
-   *                       {@link RmmAllocationMode#ARENA},
-   *                       {@link RmmAllocationMode#CUDA_ASYNC} and
-   *                       {@link RmmAllocationMode#CUDA_MANAGED_MEMORY}
-   * @param logConf        How to do logging or null if you don't want to
-   * @param poolSize       The initial pool size in bytes
-   * @param maxPoolSize    The maximum size the pool is allowed to grow. If the specified value
-   *                       is <= 0 then the pool size will not be artificially limited.
-   * @throws IllegalStateException if RMM has already been initialized
-   * @throws IllegalArgumentException if a max pool size is specified but the allocation mode
-   *                                  is not {@link RmmAllocationMode#POOL} or
-   *                                  {@link RmmAllocationMode#ARENA} or
-   *                                  {@link RmmAllocationMode#CUDA_ASYNC}, or the maximum pool
-   *                                  size is below the initial size.
-   * @deprecated Use the version without the maxPoolSize parameter instead.
-   */
-  public static synchronized void initialize(int allocationMode, LogConf logConf, long poolSize,
-      long maxPoolSize) throws RmmException {
-    initialize(allocationMode, logConf, poolSize);
-  }
-
-  /**
    * Check if RMM has been initialized already or not.
    */
   public static boolean isInitialized() throws RmmException {


### PR DESCRIPTION
Depends on https://github.com/NVIDIA/spark-rapids/pull/4019.