### PR TITLE
Update `bitmask_and` and `bitmask_or` to return a pair of resulting mask and count of unset bits

### DIFF
--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -39,7 +39,7 @@ namespace detail {
  * @param source_begin_bits Array of offsets into corresponding @p source masks.
  *                          Must be same size as source array
  * @param source_size_bits Number of bits in each mask in @p source
- * @param count Pointer to valid-bit counter
+ * @param count Pointer to counter of set bits
  */
 template <int block_size, typename Binop>
 __global__ void offset_bitmask_binop(Binop op,
@@ -123,7 +123,7 @@ std::pair<rmm::device_buffer, size_type> bitmask_binop(
 
 /**
  * @brief Performs a merge of the specified bitmasks using the binary operator
- *        provided, writes in place to destination and returns count of valid bits
+ *        provided, writes in place to destination and returns count of set bits
  *
  * @param[in] op The binary operator used to combine the bitmasks
  * @param[out] dest_mask Destination to which the merged result is written
@@ -132,7 +132,7 @@ std::pair<rmm::device_buffer, size_type> bitmask_binop(
  * @param[in] mask_size_bits The number of bits to be ANDed in each mask
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  * @param[in] mr Device memory resource used to allocate the returned device_buffer
- * @return size_type Count of valid bits
+ * @return size_type Count of set bits
  */
 template <typename Binop>
 size_type inplace_bitmask_binop(

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -79,17 +79,17 @@ __global__ void offset_bitmask_binop(Binop op,
     bool const first{tid == 0};
     bool const last{not first};
 
-    auto const first_bit_index = 0;
-    auto const last_bit_index  = source_size_bits - 1;
+    auto constexpr first_bit_index = 0;
+    auto const last_bit_index      = source_size_bits - 1;
 
     size_type bit_index = (first) ? first_bit_index : last_bit_index;
-    size_type word_index =
-      (first) ? cudf::word_index(first_bit_index) : cudf::word_index(last_bit_index);
 
     size_type num_slack_bits = bit_index % word_size;
     if (last) { num_slack_bits = word_size - num_slack_bits - 1; }
 
     if (num_slack_bits > 0) {
+      size_type word_index =
+        (first) ? cudf::word_index(first_bit_index) : cudf::word_index(last_bit_index);
       bitmask_type word = destination[word_index];
       auto slack_mask   = (first) ? set_least_significant_bits(num_slack_bits)
                                   : set_most_significant_bits(num_slack_bits);

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -74,6 +74,7 @@ __global__ void offset_bitmask_binop(Binop op,
   using BlockReduce = cub::BlockReduce<size_type, block_size>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   size_type block_valid_count = BlockReduce(temp_storage).Sum(thread_valid_count);
+
   if (threadIdx.x == 0) { atomicAdd(valid_count_ptr, block_valid_count); }
 }
 

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -75,11 +75,12 @@ __global__ void offset_bitmask_binop(Binop op,
 
   // Subtract any slack bits from the last word
   if (tid == 0) {
-    size_type const last_bit_index      = source_size_bits - 1;
+    size_type const last_bit_index = source_size_bits - 1;
     size_type const num_slack_bits = word_size - (last_bit_index % word_size) - 1;
     if (num_slack_bits > 0) {
       size_type word_index = cudf::word_index(last_bit_index);
-      thread_valid_count -= __popc(destination[word_index] & set_most_significant_bits(num_slack_bits));
+      thread_valid_count -=
+        __popc(destination[word_index] & set_most_significant_bits(num_slack_bits));
     }
   }
 

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -85,13 +85,12 @@ __global__ void offset_bitmask_binop(Binop op,
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
 template <typename Binop>
-std::pair<rmm::device_buffer, size_type> bitmask_binop(
-  Binop op,
-  host_span<bitmask_type const*> masks,
-  host_span<size_type const> masks_begin_bits,
-  size_type mask_size_bits,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
+bitmask bitmask_binop(Binop op,
+                      host_span<bitmask_type const*> masks,
+                      host_span<size_type const> masks_begin_bits,
+                      size_type mask_size_bits,
+                      rmm::cuda_stream_view stream,
+                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto dest_mask = rmm::device_buffer{bitmask_allocation_size_bytes(mask_size_bits), stream, mr};
 
@@ -104,8 +103,9 @@ std::pair<rmm::device_buffer, size_type> bitmask_binop(
                           mask_size_bits,
                           stream,
                           mr);
+  auto null_count = mask_size_bits - valid_count;
 
-  return std::make_pair(std::move(dest_mask), valid_count);
+  return bitmask{std::move(dest_mask), valid_count, null_count};
 }
 
 /**

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -73,28 +73,13 @@ __global__ void offset_bitmask_binop(Binop op,
     thread_valid_count += __popc(destination_word);
   }
 
-  // Subtract any slack bits counted from the first and last word
-  // Two threads handle this -- one for first word, one for last
-  if (tid < 2) {
-    bool const first{tid == 0};
-    bool const last{not first};
-
-    auto constexpr first_bit_index = 0;
-    auto const last_bit_index      = source_size_bits - 1;
-
-    size_type bit_index = (first) ? first_bit_index : last_bit_index;
-
-    size_type num_slack_bits = bit_index % word_size;
-    if (last) { num_slack_bits = word_size - num_slack_bits - 1; }
-
+  // Subtract any slack bits from the last word
+  if (tid == 0) {
+    size_type const last_bit_index      = source_size_bits - 1;
+    size_type const num_slack_bits = word_size - (last_bit_index % word_size) - 1;
     if (num_slack_bits > 0) {
-      size_type word_index =
-        (first) ? cudf::word_index(first_bit_index) : cudf::word_index(last_bit_index);
-      bitmask_type word = destination[word_index];
-      auto slack_mask   = (first) ? set_least_significant_bits(num_slack_bits)
-                                  : set_most_significant_bits(num_slack_bits);
-
-      thread_valid_count -= __popc(word & slack_mask);
+      size_type word_index = cudf::word_index(last_bit_index);
+      thread_valid_count -= __popc(destination[word_index] & set_most_significant_bits(num_slack_bits));
     }
   }
 

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -23,11 +23,15 @@
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_scalar.hpp>
 
 namespace cudf {
 namespace detail {
 /**
  * @brief Computes the merger of an array of bitmasks using a binary operator
+ *
+ * @tparam block_size Number of threads in each thread block
+ * @tparam Binop Type of binary operator
  *
  * @param op The binary operator used to combine the bitmasks
  * @param destination The bitmask to write result into
@@ -35,14 +39,18 @@ namespace detail {
  * @param source_begin_bits Array of offsets into corresponding @p source masks.
  *                          Must be same size as source array
  * @param source_size_bits Number of bits in each mask in @p source
+ * @param count Pointer to valid-bit counter
  */
-template <typename Binop>
+template <int block_size, typename Binop>
 __global__ void offset_bitmask_binop(Binop op,
                                      device_span<bitmask_type> destination,
                                      device_span<bitmask_type const*> source,
                                      device_span<size_type const> source_begin_bits,
-                                     size_type source_size_bits)
+                                     size_type source_size_bits,
+                                     size_type* valid_count_ptr)
 {
+  size_type thread_valid_count = 0;
+
   for (size_type destination_word_index = threadIdx.x + blockIdx.x * blockDim.x;
        destination_word_index < destination.size();
        destination_word_index += blockDim.x * gridDim.x) {
@@ -52,17 +60,21 @@ __global__ void offset_bitmask_binop(Binop op,
                                    source_begin_bits[0],
                                    source_begin_bits[0] + source_size_bits);
     for (size_type i = 1; i < source.size(); i++) {
-      destination_word =
-
-        op(destination_word,
-           detail::get_mask_offset_word(source[i],
-                                        destination_word_index,
-                                        source_begin_bits[i],
-                                        source_begin_bits[i] + source_size_bits));
+      destination_word = op(destination_word,
+                            detail::get_mask_offset_word(source[i],
+                                                         destination_word_index,
+                                                         source_begin_bits[i],
+                                                         source_begin_bits[i] + source_size_bits));
     }
 
     destination[destination_word_index] = destination_word;
+    thread_valid_count += __popc(destination_word);
   }
+
+  using BlockReduce = cub::BlockReduce<size_type, block_size>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  size_type block_valid_count = BlockReduce(temp_storage).Sum(thread_valid_count);
+  if (threadIdx.x == 0) { atomicAdd(valid_count_ptr, block_valid_count); }
 }
 
 /**
@@ -72,7 +84,7 @@ __global__ void offset_bitmask_binop(Binop op,
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
 template <typename Binop>
-rmm::device_buffer bitmask_binop(
+std::pair<rmm::device_buffer, size_type> bitmask_binop(
   Binop op,
   host_span<bitmask_type const*> masks,
   host_span<size_type const> masks_begin_bits,
@@ -82,33 +94,34 @@ rmm::device_buffer bitmask_binop(
 {
   auto dest_mask = rmm::device_buffer{bitmask_allocation_size_bytes(mask_size_bits), stream, mr};
 
-  inplace_bitmask_binop(op,
-                        device_span<bitmask_type>(static_cast<bitmask_type*>(dest_mask.data()),
-                                                  num_bitmask_words(mask_size_bits)),
-                        masks,
-                        masks_begin_bits,
-                        mask_size_bits,
-                        stream,
-                        mr);
+  auto valid_count =
+    inplace_bitmask_binop(op,
+                          device_span<bitmask_type>(static_cast<bitmask_type*>(dest_mask.data()),
+                                                    num_bitmask_words(mask_size_bits)),
+                          masks,
+                          masks_begin_bits,
+                          mask_size_bits,
+                          stream,
+                          mr);
 
-  return dest_mask;
+  return std::make_pair(std::move(dest_mask), valid_count);
 }
 
 /**
  * @brief Performs a merge of the specified bitmasks using the binary operator
- *        provided, and writes in place to destination
+ *        provided, writes in place to destination and returns count of valid bits
  *
- * @param op The binary operator used to combine the bitmasks
- * @param dest_mask Destination to which the merged result is written
- * @param masks The list of data pointers of the bitmasks to be merged
- * @param masks_begin_bits The bit offsets from which each mask is to be merged
- * @param mask_size_bits The number of bits to be ANDed in each mask
- * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned device_buffer
- * @return rmm::device_buffer Output bitmask
+ * @param[in] op The binary operator used to combine the bitmasks
+ * @param[out] dest_mask Destination to which the merged result is written
+ * @param[in] masks The list of data pointers of the bitmasks to be merged
+ * @param[in] masks_begin_bits The bit offsets from which each mask is to be merged
+ * @param[in] mask_size_bits The number of bits to be ANDed in each mask
+ * @param[in] stream CUDA stream used for device memory operations and kernel launches
+ * @param[in] mr Device memory resource used to allocate the returned device_buffer
+ * @return size_type Count of valid bits
  */
 template <typename Binop>
-void inplace_bitmask_binop(
+size_type inplace_bitmask_binop(
   Binop op,
   device_span<bitmask_type> dest_mask,
   host_span<bitmask_type const*> masks,
@@ -124,6 +137,7 @@ void inplace_bitmask_binop(
   CUDF_EXPECTS(std::all_of(masks.begin(), masks.end(), [](auto p) { return p != nullptr; }),
                "Mask pointer cannot be null");
 
+  rmm::device_scalar<size_type> d_counter{0, stream, mr};
   rmm::device_uvector<bitmask_type const*> d_masks(masks.size(), stream, mr);
   rmm::device_uvector<size_type> d_begin_bits(masks_begin_bits.size(), stream, mr);
 
@@ -135,11 +149,13 @@ void inplace_bitmask_binop(
                            cudaMemcpyHostToDevice,
                            stream.value()));
 
-  cudf::detail::grid_1d config(dest_mask.size(), 256);
-  offset_bitmask_binop<<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
-    op, dest_mask, d_masks, d_begin_bits, mask_size_bits);
+  auto constexpr block_size = 256;
+  cudf::detail::grid_1d config(dest_mask.size(), block_size);
+  offset_bitmask_binop<block_size>
+    <<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
+      op, dest_mask, d_masks, d_begin_bits, mask_size_bits, d_counter.data());
   CHECK_CUDA(stream.value());
-  stream.synchronize();
+  return d_counter.value(stream);
 }
 
 /**

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -50,12 +50,7 @@ __global__ void offset_bitmask_binop(Binop op,
                                      size_type* valid_count_ptr)
 {
   constexpr auto const word_size{detail::size_in_bits<bitmask_type>()};
-
-  auto const tid             = threadIdx.x + blockIdx.x * blockDim.x;
-  auto const first_bit_index = 0;
-  auto const last_bit_index  = source_size_bits - 1;
-  auto const first_word_index{word_index(first_bit_index)};
-  auto const last_word_index{word_index(last_bit_index)};
+  auto const tid = threadIdx.x + blockIdx.x * blockDim.x;
 
   size_type thread_valid_count = 0;
 
@@ -84,8 +79,12 @@ __global__ void offset_bitmask_binop(Binop op,
     bool const first{tid == 0};
     bool const last{not first};
 
-    size_type bit_index  = (first) ? first_bit_index : last_bit_index;
-    size_type word_index = (first) ? first_word_index : last_word_index;
+    auto const first_bit_index = 0;
+    auto const last_bit_index  = source_size_bits - 1;
+
+    size_type bit_index = (first) ? first_bit_index : last_bit_index;
+    size_type word_index =
+      (first) ? cudf::word_index(first_bit_index) : cudf::word_index(last_bit_index);
 
     size_type num_slack_bits = bit_index % word_size;
     if (last) { num_slack_bits = word_size - num_slack_bits - 1; }

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -23,9 +23,6 @@
 #include <vector>
 
 namespace cudf {
-
-struct bitmask;
-
 namespace detail {
 
 /**
@@ -117,29 +114,32 @@ rmm::device_buffer copy_bitmask(
  *
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
-bitmask bitmask_and(host_span<bitmask_type const*> masks,
-                    host_span<size_type const> masks_begin_bits,
-                    size_type mask_size_bits,
-                    rmm::cuda_stream_view stream,
-                    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::pair<rmm::device_buffer, size_type> bitmask_and(
+  host_span<bitmask_type const*> masks,
+  host_span<size_type const> masks_begin_bits,
+  size_type mask_size_bits,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @copydoc cudf::bitmask_and
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
-bitmask bitmask_and(table_view const& view,
-                    rmm::cuda_stream_view stream,
-                    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::pair<rmm::device_buffer, size_type> bitmask_and(
+  table_view const& view,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @copydoc cudf::bitmask_or
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
-bitmask bitmask_or(table_view const& view,
-                   rmm::cuda_stream_view stream,
-                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::pair<rmm::device_buffer, size_type> bitmask_or(
+  table_view const& view,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Performs a bitwise AND of the specified bitmasks,

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -114,7 +114,7 @@ rmm::device_buffer copy_bitmask(
  *
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
-rmm::device_buffer bitmask_and(
+std::pair<rmm::device_buffer, size_type> bitmask_and(
   host_span<bitmask_type const*> masks,
   host_span<size_type const> masks_begin_bits,
   size_type mask_size_bits,
@@ -126,7 +126,7 @@ rmm::device_buffer bitmask_and(
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
-rmm::device_buffer bitmask_and(
+std::pair<rmm::device_buffer, size_type> bitmask_and(
   table_view const& view,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -137,10 +137,9 @@ bitmask bitmask_and(table_view const& view,
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
-rmm::device_buffer bitmask_or(
-  table_view const& view,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+bitmask bitmask_or(table_view const& view,
+                   rmm::cuda_stream_view stream,
+                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Performs a bitwise AND of the specified bitmasks,

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -23,6 +23,9 @@
 #include <vector>
 
 namespace cudf {
+
+struct bitmask;
+
 namespace detail {
 
 /**
@@ -114,22 +117,20 @@ rmm::device_buffer copy_bitmask(
  *
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
-std::pair<rmm::device_buffer, size_type> bitmask_and(
-  host_span<bitmask_type const*> masks,
-  host_span<size_type const> masks_begin_bits,
-  size_type mask_size_bits,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+bitmask bitmask_and(host_span<bitmask_type const*> masks,
+                    host_span<size_type const> masks_begin_bits,
+                    size_type mask_size_bits,
+                    rmm::cuda_stream_view stream,
+                    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @copydoc cudf::bitmask_and
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
-std::pair<rmm::device_buffer, size_type> bitmask_and(
-  table_view const& view,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+bitmask bitmask_and(table_view const& view,
+                    rmm::cuda_stream_view stream,
+                    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @copydoc cudf::bitmask_or

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -25,15 +25,6 @@
 namespace cudf {
 
 /**
- * @brief Bitmask output type.
- */
-struct bitmask {
-  rmm::device_buffer mask;   ///< Resulting bitmask
-  size_type num_set_bits;    ///< Number of set bits
-  size_type num_unset_bits;  ///< Number of unset bits
-};
-
-/**
  * @addtogroup column_nullmask
  * @{
  * @file
@@ -211,32 +202,32 @@ rmm::device_buffer copy_bitmask(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Returns a struct of bitwise AND of the bitmasks of columns of a table,
- * count of valid bits and count of null bits
+ * @brief Returns a pair of bitwise AND of the bitmasks of columns of a table and count of null bits
  *
  * If any of the columns isn't nullable, it is considered all valid.
  * If no column in the table is nullable, an empty bitmask is returned.
  *
  * @param view The table of columns
  * @param mr Device memory resource used to allocate the returned device_buffer
- * @return A struct of resulting bitmask, count of valid bits and count of null bits
+ * @return A pair of resulting bitmask and count of null bits
  */
-bitmask bitmask_and(table_view const& view,
-                    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::pair<rmm::device_buffer, size_type> bitmask_and(
+  table_view const& view,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Returns a struct of bitwise OR of the bitmasks of columns of a table,
- * count of valid bits and count of null bits
+ * @brief Returns a pair of bitwise OR of the bitmasks of columns of a table and count of null bits
  *
  * If any of the columns isn't nullable, it is considered all valid.
  * If no column in the table is nullable, an empty bitmask is returned.
  *
  * @param view The table of columns
  * @param mr Device memory resource used to allocate the returned device_buffer
- * @return rmm::device_buffer Output bitmask
+ * @return A pair of resulting bitmask and count of null bits
  */
-bitmask bitmask_or(table_view const& view,
-                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::pair<rmm::device_buffer, size_type> bitmask_or(
+  table_view const& view,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group
 }  // namespace cudf

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -225,7 +225,8 @@ bitmask bitmask_and(table_view const& view,
                     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Returns a bitwise OR of the bitmasks of columns of a table
+ * @brief Returns a struct of bitwise OR of the bitmasks of columns of a table,
+ * count of valid bits and count of null bits
  *
  * If any of the columns isn't nullable, it is considered all valid.
  * If no column in the table is nullable, an empty bitmask is returned.
@@ -234,9 +235,8 @@ bitmask bitmask_and(table_view const& view,
  * @param mr Device memory resource used to allocate the returned device_buffer
  * @return rmm::device_buffer Output bitmask
  */
-rmm::device_buffer bitmask_or(
-  table_view const& view,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+bitmask bitmask_or(table_view const& view,
+                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group
 }  // namespace cudf

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -202,16 +202,17 @@ rmm::device_buffer copy_bitmask(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Returns a bitwise AND of the bitmasks of columns of a table
+ * @brief Returns a bitwise AND of the bitmasks of columns of a table and count
+ * of valid bits
  *
  * If any of the columns isn't nullable, it is considered all valid.
  * If no column in the table is nullable, an empty bitmask is returned.
  *
  * @param view The table of columns
  * @param mr Device memory resource used to allocate the returned device_buffer
- * @return rmm::device_buffer Output bitmask
+ * @return Output bitmask and count of valid bits
  */
-rmm::device_buffer bitmask_and(
+std::pair<rmm::device_buffer, size_type> bitmask_and(
   table_view const& view,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -202,28 +202,30 @@ rmm::device_buffer copy_bitmask(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Returns a pair of bitwise AND of the bitmasks of columns of a table and count of null bits
+ * @brief Performs bitwise AND of the bitmasks of columns of a table. Returns
+ * a pair of resulting mask and count of unset bits.
  *
  * If any of the columns isn't nullable, it is considered all valid.
  * If no column in the table is nullable, an empty bitmask is returned.
  *
  * @param view The table of columns
  * @param mr Device memory resource used to allocate the returned device_buffer
- * @return A pair of resulting bitmask and count of null bits
+ * @return A pair of resulting bitmask and count of unset bits
  */
 std::pair<rmm::device_buffer, size_type> bitmask_and(
   table_view const& view,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Returns a pair of bitwise OR of the bitmasks of columns of a table and count of null bits
+ * @brief Performs bitwise OR of the bitmasks of columns of a table. Returns
+ * a pair of resulting mask and count of unset bits.
  *
  * If any of the columns isn't nullable, it is considered all valid.
  * If no column in the table is nullable, an empty bitmask is returned.
  *
  * @param view The table of columns
  * @param mr Device memory resource used to allocate the returned device_buffer
- * @return A pair of resulting bitmask and count of null bits
+ * @return A pair of resulting bitmask and count of unset bits
  */
 std::pair<rmm::device_buffer, size_type> bitmask_or(
   table_view const& view,

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -25,6 +25,15 @@
 namespace cudf {
 
 /**
+ * @brief Bitmask output type.
+ */
+struct bitmask {
+  rmm::device_buffer mask;   ///< Resulting bitmask
+  size_type num_set_bits;    ///< Number of set bits
+  size_type num_unset_bits;  ///< Number of unset bits
+};
+
+/**
  * @addtogroup column_nullmask
  * @{
  * @file
@@ -202,19 +211,18 @@ rmm::device_buffer copy_bitmask(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Returns a bitwise AND of the bitmasks of columns of a table and count
- * of valid bits
+ * @brief Returns a struct of bitwise AND of the bitmasks of columns of a table,
+ * count of valid bits and count of null bits
  *
  * If any of the columns isn't nullable, it is considered all valid.
  * If no column in the table is nullable, an empty bitmask is returned.
  *
  * @param view The table of columns
  * @param mr Device memory resource used to allocate the returned device_buffer
- * @return Output bitmask and count of valid bits
+ * @return A struct of resulting bitmask, count of valid bits and count of null bits
  */
-std::pair<rmm::device_buffer, size_type> bitmask_and(
-  table_view const& view,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+bitmask bitmask_and(table_view const& view,
+                    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Returns a bitwise OR of the bitmasks of columns of a table

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -392,7 +392,7 @@ std::unique_ptr<column> make_fixed_width_column_for_output(column_view const& lh
   if (binops::is_null_dependent(op)) {
     return make_fixed_width_column(output_type, rhs.size(), mask_state::ALL_VALID, stream, mr);
   } else {
-    auto new_mask = cudf::detail::bitmask_and(table_view({lhs, rhs}), stream, mr);
+    auto [new_mask, _] = cudf::detail::bitmask_and(table_view({lhs, rhs}), stream, mr);
     return make_fixed_width_column(
       output_type, lhs.size(), std::move(new_mask), cudf::UNKNOWN_NULL_COUNT, stream, mr);
   }
@@ -799,8 +799,8 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
 
   CUDF_EXPECTS((lhs.size() == rhs.size()), "Column sizes don't match");
 
-  auto new_mask = bitmask_and(table_view({lhs, rhs}), stream, mr);
-  auto out      = make_fixed_width_column(
+  auto [new_mask, _] = bitmask_and(table_view({lhs, rhs}), stream, mr);
+  auto out           = make_fixed_width_column(
     output_type, lhs.size(), std::move(new_mask), cudf::UNKNOWN_NULL_COUNT, stream, mr);
 
   // Check for 0 sized data

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -392,7 +392,7 @@ std::unique_ptr<column> make_fixed_width_column_for_output(column_view const& lh
   if (binops::is_null_dependent(op)) {
     return make_fixed_width_column(output_type, rhs.size(), mask_state::ALL_VALID, stream, mr);
   } else {
-    auto [new_mask, _] = cudf::detail::bitmask_and(table_view({lhs, rhs}), stream, mr);
+    auto new_mask = std::move(cudf::detail::bitmask_and(table_view({lhs, rhs}), stream, mr).mask);
     return make_fixed_width_column(
       output_type, lhs.size(), std::move(new_mask), cudf::UNKNOWN_NULL_COUNT, stream, mr);
   }
@@ -799,8 +799,8 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
 
   CUDF_EXPECTS((lhs.size() == rhs.size()), "Column sizes don't match");
 
-  auto [new_mask, _] = bitmask_and(table_view({lhs, rhs}), stream, mr);
-  auto out           = make_fixed_width_column(
+  auto new_mask = std::move(bitmask_and(table_view({lhs, rhs}), stream, mr).mask);
+  auto out      = make_fixed_width_column(
     output_type, lhs.size(), std::move(new_mask), cudf::UNKNOWN_NULL_COUNT, stream, mr);
 
   // Check for 0 sized data

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -356,11 +356,11 @@ void inplace_bitmask_and(device_span<bitmask_type> dest_mask,
 }
 
 // Bitwise AND of the masks
-bitmask bitmask_and(host_span<bitmask_type const*> masks,
-                    host_span<size_type const> begin_bits,
-                    size_type mask_size,
-                    rmm::cuda_stream_view stream,
-                    rmm::mr::device_memory_resource* mr)
+std::pair<rmm::device_buffer, size_type> bitmask_and(host_span<bitmask_type const*> masks,
+                                                     host_span<size_type const> begin_bits,
+                                                     size_type mask_size,
+                                                     rmm::cuda_stream_view stream,
+                                                     rmm::mr::device_memory_resource* mr)
 {
   return bitmask_binop(
     [] __device__(bitmask_type left, bitmask_type right) { return left & right; },
@@ -372,14 +372,14 @@ bitmask bitmask_and(host_span<bitmask_type const*> masks,
 }
 
 // Returns the bitwise AND of the null masks of all columns in the table view
-bitmask bitmask_and(table_view const& view,
-                    rmm::cuda_stream_view stream,
-                    rmm::mr::device_memory_resource* mr)
+std::pair<rmm::device_buffer, size_type> bitmask_and(table_view const& view,
+                                                     rmm::cuda_stream_view stream,
+                                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   rmm::device_buffer null_mask{0, stream, mr};
   if (view.num_rows() == 0 or view.num_columns() == 0) {
-    return bitmask{std::move(null_mask), 0, 0};
+    return std::make_pair(std::move(null_mask), 0);
   }
 
   std::vector<bitmask_type const*> masks;
@@ -401,18 +401,18 @@ bitmask bitmask_and(table_view const& view,
       mr);
   }
 
-  return bitmask{std::move(null_mask), 0, 0};
+  return std::make_pair(std::move(null_mask), 0);
 }
 
 // Returns the bitwise OR of the null masks of all columns in the table view
-bitmask bitmask_or(table_view const& view,
-                   rmm::cuda_stream_view stream,
-                   rmm::mr::device_memory_resource* mr)
+std::pair<rmm::device_buffer, size_type> bitmask_or(table_view const& view,
+                                                    rmm::cuda_stream_view stream,
+                                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   rmm::device_buffer null_mask{0, stream, mr};
   if (view.num_rows() == 0 or view.num_columns() == 0) {
-    return bitmask{std::move(null_mask), 0, 0};
+    return std::make_pair(std::move(null_mask), 0);
   }
 
   std::vector<bitmask_type const*> masks;
@@ -434,7 +434,7 @@ bitmask bitmask_or(table_view const& view,
       mr);
   }
 
-  return bitmask{std::move(null_mask), 0, 0};
+  return std::make_pair(std::move(null_mask), 0);
 }
 
 /**
@@ -506,12 +506,14 @@ rmm::device_buffer copy_bitmask(column_view const& view, rmm::mr::device_memory_
   return detail::copy_bitmask(view, rmm::cuda_stream_default, mr);
 }
 
-bitmask bitmask_and(table_view const& view, rmm::mr::device_memory_resource* mr)
+std::pair<rmm::device_buffer, size_type> bitmask_and(table_view const& view,
+                                                     rmm::mr::device_memory_resource* mr)
 {
   return detail::bitmask_and(view, rmm::cuda_stream_default, mr);
 }
 
-bitmask bitmask_or(table_view const& view, rmm::mr::device_memory_resource* mr)
+std::pair<rmm::device_buffer, size_type> bitmask_or(table_view const& view,
+                                                    rmm::mr::device_memory_resource* mr)
 {
   return detail::bitmask_or(view, rmm::cuda_stream_default, mr);
 }

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -318,11 +318,11 @@ void inplace_bitmask_and(device_span<bitmask_type> dest_mask,
 }
 
 // Bitwise AND of the masks
-rmm::device_buffer bitmask_and(host_span<bitmask_type const*> masks,
-                               host_span<size_type const> begin_bits,
-                               size_type mask_size,
-                               rmm::cuda_stream_view stream,
-                               rmm::mr::device_memory_resource* mr)
+std::pair<rmm::device_buffer, size_type> bitmask_and(host_span<bitmask_type const*> masks,
+                                                     host_span<size_type const> begin_bits,
+                                                     size_type mask_size,
+                                                     rmm::cuda_stream_view stream,
+                                                     rmm::mr::device_memory_resource* mr)
 {
   return bitmask_binop(
     [] __device__(bitmask_type left, bitmask_type right) { return left & right; },
@@ -331,6 +331,39 @@ rmm::device_buffer bitmask_and(host_span<bitmask_type const*> masks,
     mask_size,
     stream,
     mr);
+}
+
+// Returns the bitwise AND of the null masks of all columns in the table view
+std::pair<rmm::device_buffer, size_type> bitmask_and(table_view const& view,
+                                                     rmm::cuda_stream_view stream,
+                                                     rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  rmm::device_buffer null_mask{0, stream, mr};
+  if (view.num_rows() == 0 or view.num_columns() == 0) {
+    return std::make_pair(std::move(null_mask), 0);
+  }
+
+  std::vector<bitmask_type const*> masks;
+  std::vector<size_type> offsets;
+  for (auto&& col : view) {
+    if (col.nullable()) {
+      masks.push_back(col.null_mask());
+      offsets.push_back(col.offset());
+    }
+  }
+
+  if (masks.size() > 0) {
+    return cudf::detail::bitmask_binop(
+      [] __device__(bitmask_type left, bitmask_type right) { return left & right; },
+      masks,
+      offsets,
+      view.num_rows(),
+      stream,
+      mr);
+  }
+
+  return std::make_pair(std::move(null_mask), 0);
 }
 
 cudf::size_type count_set_bits(bitmask_type const* bitmask,
@@ -371,37 +404,6 @@ cudf::size_type count_unset_bits(bitmask_type const* bitmask,
   return (num_bits - detail::count_set_bits(bitmask, start, stop, stream));
 }
 
-// Returns the bitwise AND of the null masks of all columns in the table view
-rmm::device_buffer bitmask_and(table_view const& view,
-                               rmm::cuda_stream_view stream,
-                               rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  rmm::device_buffer null_mask{0, stream, mr};
-  if (view.num_rows() == 0 or view.num_columns() == 0) { return null_mask; }
-
-  std::vector<bitmask_type const*> masks;
-  std::vector<size_type> offsets;
-  for (auto&& col : view) {
-    if (col.nullable()) {
-      masks.push_back(col.null_mask());
-      offsets.push_back(col.offset());
-    }
-  }
-
-  if (masks.size() > 0) {
-    return cudf::detail::bitmask_binop(
-      [] __device__(bitmask_type left, bitmask_type right) { return left & right; },
-      masks,
-      offsets,
-      view.num_rows(),
-      stream,
-      mr);
-  }
-
-  return null_mask;
-}
-
 // Returns the bitwise OR of the null masks of all columns in the table view
 rmm::device_buffer bitmask_or(table_view const& view,
                               rmm::cuda_stream_view stream,
@@ -422,12 +424,13 @@ rmm::device_buffer bitmask_or(table_view const& view,
 
   if (static_cast<size_type>(masks.size()) == view.num_columns()) {
     return cudf::detail::bitmask_binop(
-      [] __device__(bitmask_type left, bitmask_type right) { return left | right; },
-      masks,
-      offsets,
-      view.num_rows(),
-      stream,
-      mr);
+             [] __device__(bitmask_type left, bitmask_type right) { return left | right; },
+             masks,
+             offsets,
+             view.num_rows(),
+             stream,
+             mr)
+      .first;
   }
 
   return null_mask;
@@ -502,7 +505,8 @@ rmm::device_buffer copy_bitmask(column_view const& view, rmm::mr::device_memory_
   return detail::copy_bitmask(view, rmm::cuda_stream_default, mr);
 }
 
-rmm::device_buffer bitmask_and(table_view const& view, rmm::mr::device_memory_resource* mr)
+std::pair<rmm::device_buffer, size_type> bitmask_and(table_view const& view,
+                                                     rmm::mr::device_memory_resource* mr)
 {
   return detail::bitmask_and(view, rmm::cuda_stream_default, mr);
 }

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -364,9 +364,9 @@ std::unique_ptr<column> add_calendrical_months(column_view const& timestamp_colu
                                 stream,
                                 mr);
 
-  auto output_null_mask = std::move(
-    cudf::detail::bitmask_and(table_view{{timestamp_column, months_column}}, stream, mr).mask);
-  output->set_null_mask(std::move(output_null_mask));
+  auto bitmask_output =
+    cudf::detail::bitmask_and(table_view{{timestamp_column, months_column}}, stream, mr);
+  output->set_null_mask(std::move(bitmask_output.mask), bitmask_output.num_unset_bits);
   return output;
 }
 

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -364,8 +364,8 @@ std::unique_ptr<column> add_calendrical_months(column_view const& timestamp_colu
                                 stream,
                                 mr);
 
-  auto [output_null_mask, _] =
-    cudf::detail::bitmask_and(table_view{{timestamp_column, months_column}}, stream, mr);
+  auto output_null_mask = std::move(
+    cudf::detail::bitmask_and(table_view{{timestamp_column, months_column}}, stream, mr).mask);
   output->set_null_mask(std::move(output_null_mask));
   return output;
 }

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -364,9 +364,9 @@ std::unique_ptr<column> add_calendrical_months(column_view const& timestamp_colu
                                 stream,
                                 mr);
 
-  auto bitmask_output =
+  auto [output_null_mask, null_count] =
     cudf::detail::bitmask_and(table_view{{timestamp_column, months_column}}, stream, mr);
-  output->set_null_mask(std::move(bitmask_output.mask), bitmask_output.num_unset_bits);
+  output->set_null_mask(std::move(output_null_mask), null_count);
   return output;
 }
 

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -364,7 +364,7 @@ std::unique_ptr<column> add_calendrical_months(column_view const& timestamp_colu
                                 stream,
                                 mr);
 
-  auto output_null_mask =
+  auto [output_null_mask, _] =
     cudf::detail::bitmask_and(table_view{{timestamp_column, months_column}}, stream, mr);
   output->set_null_mask(std::move(output_null_mask));
   return output;

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -390,7 +390,8 @@ void sparse_to_dense_results(table_view const& keys,
                              rmm::cuda_stream_view stream,
                              rmm::mr::device_memory_resource* mr)
 {
-  auto [row_bitmask, _]         = bitmask_and(keys, stream, rmm::mr::get_current_device_resource());
+  auto row_bitmask =
+    std::move(bitmask_and(keys, stream, rmm::mr::get_current_device_resource()).mask);
   bool skip_key_rows_with_nulls = keys_have_nulls and include_null_keys == null_policy::EXCLUDE;
   bitmask_type const* row_bitmask_ptr =
     skip_key_rows_with_nulls ? static_cast<bitmask_type*>(row_bitmask.data()) : nullptr;
@@ -501,8 +502,9 @@ void compute_single_pass_aggs(table_view const& keys,
 
   bool skip_key_rows_with_nulls = keys_have_nulls and include_null_keys == null_policy::EXCLUDE;
 
-  auto row_bitmask =
-    skip_key_rows_with_nulls ? cudf::detail::bitmask_and(keys, stream).first : rmm::device_buffer{};
+  auto row_bitmask = skip_key_rows_with_nulls
+                       ? std::move(cudf::detail::bitmask_and(keys, stream).mask)
+                       : rmm::device_buffer{};
   thrust::for_each_n(
     rmm::exec_policy(stream),
     thrust::make_counting_iterator(0),

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -390,7 +390,7 @@ void sparse_to_dense_results(table_view const& keys,
                              rmm::cuda_stream_view stream,
                              rmm::mr::device_memory_resource* mr)
 {
-  auto row_bitmask = bitmask_and(keys, stream, rmm::mr::get_current_device_resource()).mask;
+  auto row_bitmask = bitmask_and(keys, stream, rmm::mr::get_current_device_resource()).first;
   bool skip_key_rows_with_nulls = keys_have_nulls and include_null_keys == null_policy::EXCLUDE;
   bitmask_type const* row_bitmask_ptr =
     skip_key_rows_with_nulls ? static_cast<bitmask_type*>(row_bitmask.data()) : nullptr;
@@ -502,7 +502,7 @@ void compute_single_pass_aggs(table_view const& keys,
   bool skip_key_rows_with_nulls = keys_have_nulls and include_null_keys == null_policy::EXCLUDE;
 
   auto row_bitmask =
-    skip_key_rows_with_nulls ? cudf::detail::bitmask_and(keys, stream).mask : rmm::device_buffer{};
+    skip_key_rows_with_nulls ? cudf::detail::bitmask_and(keys, stream).first : rmm::device_buffer{};
   thrust::for_each_n(
     rmm::exec_policy(stream),
     thrust::make_counting_iterator(0),

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -390,8 +390,7 @@ void sparse_to_dense_results(table_view const& keys,
                              rmm::cuda_stream_view stream,
                              rmm::mr::device_memory_resource* mr)
 {
-  auto row_bitmask =
-    std::move(bitmask_and(keys, stream, rmm::mr::get_current_device_resource()).mask);
+  auto row_bitmask = bitmask_and(keys, stream, rmm::mr::get_current_device_resource()).mask;
   bool skip_key_rows_with_nulls = keys_have_nulls and include_null_keys == null_policy::EXCLUDE;
   bitmask_type const* row_bitmask_ptr =
     skip_key_rows_with_nulls ? static_cast<bitmask_type*>(row_bitmask.data()) : nullptr;
@@ -502,9 +501,8 @@ void compute_single_pass_aggs(table_view const& keys,
 
   bool skip_key_rows_with_nulls = keys_have_nulls and include_null_keys == null_policy::EXCLUDE;
 
-  auto row_bitmask = skip_key_rows_with_nulls
-                       ? std::move(cudf::detail::bitmask_and(keys, stream).mask)
-                       : rmm::device_buffer{};
+  auto row_bitmask =
+    skip_key_rows_with_nulls ? cudf::detail::bitmask_and(keys, stream).mask : rmm::device_buffer{};
   thrust::for_each_n(
     rmm::exec_policy(stream),
     thrust::make_counting_iterator(0),

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -390,7 +390,7 @@ void sparse_to_dense_results(table_view const& keys,
                              rmm::cuda_stream_view stream,
                              rmm::mr::device_memory_resource* mr)
 {
-  auto row_bitmask{bitmask_and(keys, stream, rmm::mr::get_current_device_resource())};
+  auto [row_bitmask, _]         = bitmask_and(keys, stream, rmm::mr::get_current_device_resource());
   bool skip_key_rows_with_nulls = keys_have_nulls and include_null_keys == null_policy::EXCLUDE;
   bitmask_type const* row_bitmask_ptr =
     skip_key_rows_with_nulls ? static_cast<bitmask_type*>(row_bitmask.data()) : nullptr;
@@ -502,7 +502,7 @@ void compute_single_pass_aggs(table_view const& keys,
   bool skip_key_rows_with_nulls = keys_have_nulls and include_null_keys == null_policy::EXCLUDE;
 
   auto row_bitmask =
-    skip_key_rows_with_nulls ? cudf::detail::bitmask_and(keys, stream) : rmm::device_buffer{};
+    skip_key_rows_with_nulls ? cudf::detail::bitmask_and(keys, stream).first : rmm::device_buffer{};
   thrust::for_each_n(
     rmm::exec_policy(stream),
     thrust::make_counting_iterator(0),

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -538,9 +538,9 @@ void aggregate_result_functor::operator()<aggregation::MERGE_M2>(aggregation con
  */
 auto column_view_with_common_nulls(column_view const& column_0, column_view const& column_1)
 {
-  auto [new_nullmask, _] = cudf::bitmask_and(table_view{{column_0, column_1}});
-  auto null_count        = cudf::count_unset_bits(
-    static_cast<cudf::bitmask_type const*>(new_nullmask.data()), 0, column_0.size());
+  auto table                      = table_view{{column_0, column_1}};
+  auto [new_nullmask, null_count] = cudf::bitmask_and(table);
+
   if (null_count == 0) { return std::make_tuple(std::move(new_nullmask), column_0, column_1); }
   auto column_view_with_new_nullmask = [](auto const& col, void* nullmask, auto null_count) {
     return column_view(col.type(),

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -538,8 +538,9 @@ void aggregate_result_functor::operator()<aggregation::MERGE_M2>(aggregation con
  */
 auto column_view_with_common_nulls(column_view const& column_0, column_view const& column_1)
 {
-  auto table                      = table_view{{column_0, column_1}};
-  auto [new_nullmask, null_count] = cudf::bitmask_and(table);
+  auto bitmask_output = cudf::bitmask_and(table_view{{column_0, column_1}});
+  auto new_nullmask   = std::move(bitmask_output.mask);
+  auto null_count     = bitmask_output.num_unset_bits;
 
   if (null_count == 0) { return std::make_tuple(std::move(new_nullmask), column_0, column_1); }
   auto column_view_with_new_nullmask = [](auto const& col, void* nullmask, auto null_count) {

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -538,8 +538,8 @@ void aggregate_result_functor::operator()<aggregation::MERGE_M2>(aggregation con
  */
 auto column_view_with_common_nulls(column_view const& column_0, column_view const& column_1)
 {
-  rmm::device_buffer new_nullmask = cudf::bitmask_and(table_view{{column_0, column_1}});
-  auto null_count                 = cudf::count_unset_bits(
+  auto [new_nullmask, _] = cudf::bitmask_and(table_view{{column_0, column_1}});
+  auto null_count        = cudf::count_unset_bits(
     static_cast<cudf::bitmask_type const*>(new_nullmask.data()), 0, column_0.size());
   if (null_count == 0) { return std::make_tuple(std::move(new_nullmask), column_0, column_1); }
   auto column_view_with_new_nullmask = [](auto const& col, void* nullmask, auto null_count) {

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -538,10 +538,7 @@ void aggregate_result_functor::operator()<aggregation::MERGE_M2>(aggregation con
  */
 auto column_view_with_common_nulls(column_view const& column_0, column_view const& column_1)
 {
-  auto bitmask_output = cudf::bitmask_and(table_view{{column_0, column_1}});
-  auto new_nullmask   = std::move(bitmask_output.mask);
-  auto null_count     = bitmask_output.num_unset_bits;
-
+  auto [new_nullmask, null_count] = cudf::bitmask_and(table_view{{column_0, column_1}});
   if (null_count == 0) { return std::make_tuple(std::move(new_nullmask), column_0, column_1); }
   auto column_view_with_new_nullmask = [](auto const& col, void* nullmask, auto null_count) {
     return column_view(col.type(),

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -276,12 +276,12 @@ column_view sort_groupby_helper::keys_bitmask_column(rmm::cuda_stream_view strea
 {
   if (_keys_bitmask_column) return _keys_bitmask_column->view();
 
-  auto row_bitmask = std::move(cudf::detail::bitmask_and(_keys, stream).mask);
+  auto bitmask_output = cudf::detail::bitmask_and(_keys, stream);
 
   _keys_bitmask_column = make_numeric_column(data_type(type_id::INT8),
                                              _keys.num_rows(),
-                                             std::move(row_bitmask),
-                                             cudf::UNKNOWN_NULL_COUNT,
+                                             std::move(bitmask_output.mask),
+                                             bitmask_output.num_unset_bits,
                                              stream);
 
   auto keys_bitmask_view = _keys_bitmask_column->mutable_view();

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -276,7 +276,7 @@ column_view sort_groupby_helper::keys_bitmask_column(rmm::cuda_stream_view strea
 {
   if (_keys_bitmask_column) return _keys_bitmask_column->view();
 
-  auto row_bitmask = cudf::detail::bitmask_and(_keys, stream);
+  auto [row_bitmask, _] = cudf::detail::bitmask_and(_keys, stream);
 
   _keys_bitmask_column = make_numeric_column(data_type(type_id::INT8),
                                              _keys.num_rows(),

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -276,13 +276,10 @@ column_view sort_groupby_helper::keys_bitmask_column(rmm::cuda_stream_view strea
 {
   if (_keys_bitmask_column) return _keys_bitmask_column->view();
 
-  auto bitmask_output = cudf::detail::bitmask_and(_keys, stream);
+  auto [row_bitmask, null_count] = cudf::detail::bitmask_and(_keys, stream);
 
-  _keys_bitmask_column = make_numeric_column(data_type(type_id::INT8),
-                                             _keys.num_rows(),
-                                             std::move(bitmask_output.mask),
-                                             bitmask_output.num_unset_bits,
-                                             stream);
+  _keys_bitmask_column = make_numeric_column(
+    data_type(type_id::INT8), _keys.num_rows(), std::move(row_bitmask), null_count, stream);
 
   auto keys_bitmask_view = _keys_bitmask_column->mutable_view();
   using T                = id_to_type<type_id::INT8>;

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -276,7 +276,7 @@ column_view sort_groupby_helper::keys_bitmask_column(rmm::cuda_stream_view strea
 {
   if (_keys_bitmask_column) return _keys_bitmask_column->view();
 
-  auto [row_bitmask, _] = cudf::detail::bitmask_and(_keys, stream);
+  auto row_bitmask = std::move(cudf::detail::bitmask_and(_keys, stream).mask);
 
   _keys_bitmask_column = make_numeric_column(data_type(type_id::INT8),
                                              _keys.num_rows(),

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -92,7 +92,7 @@ void build_join_hash_table(cudf::table_view const& build,
     hash_table.insert(iter, iter + build_table_num_rows, stream.value());
   } else {
     thrust::counting_iterator<size_type> stencil(0);
-    auto const row_bitmask = std::move(cudf::detail::bitmask_and(build, stream).mask);
+    auto const row_bitmask = cudf::detail::bitmask_and(build, stream).mask;
     row_is_valid pred{static_cast<bitmask_type const*>(row_bitmask.data())};
 
     // insert valid rows

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -92,7 +92,7 @@ void build_join_hash_table(cudf::table_view const& build,
     hash_table.insert(iter, iter + build_table_num_rows, stream.value());
   } else {
     thrust::counting_iterator<size_type> stencil(0);
-    auto const row_bitmask = cudf::detail::bitmask_and(build, stream).mask;
+    auto const row_bitmask = cudf::detail::bitmask_and(build, stream).first;
     row_is_valid pred{static_cast<bitmask_type const*>(row_bitmask.data())};
 
     // insert valid rows

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -92,7 +92,7 @@ void build_join_hash_table(cudf::table_view const& build,
     hash_table.insert(iter, iter + build_table_num_rows, stream.value());
   } else {
     thrust::counting_iterator<size_type> stencil(0);
-    auto const [row_bitmask, _] = cudf::detail::bitmask_and(build, stream);
+    auto const row_bitmask = std::move(cudf::detail::bitmask_and(build, stream).mask);
     row_is_valid pred{static_cast<bitmask_type const*>(row_bitmask.data())};
 
     // insert valid rows

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -92,7 +92,7 @@ void build_join_hash_table(cudf::table_view const& build,
     hash_table.insert(iter, iter + build_table_num_rows, stream.value());
   } else {
     thrust::counting_iterator<size_type> stencil(0);
-    auto const row_bitmask = cudf::detail::bitmask_and(build, stream);
+    auto const [row_bitmask, _] = cudf::detail::bitmask_and(build, stream);
     row_is_valid pred{static_cast<bitmask_type const*>(row_bitmask.data())};
 
     // insert valid rows

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -97,7 +97,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_anti_join(
   // contain a NULL in any column as they will never compare to equal.
   auto const row_bitmask = (compare_nulls == null_equality::EQUAL)
                              ? rmm::device_buffer{}
-                             : cudf::detail::bitmask_and(right_flattened_keys, stream);
+                             : cudf::detail::bitmask_and(right_flattened_keys, stream).first;
   // skip rows that are null here.
   thrust::for_each_n(
     rmm::exec_policy(stream),

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -95,10 +95,9 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_anti_join(
 
   // if compare_nulls == UNEQUAL, we can simply ignore any rows that
   // contain a NULL in any column as they will never compare to equal.
-  auto const row_bitmask =
-    (compare_nulls == null_equality::EQUAL)
-      ? rmm::device_buffer{}
-      : std::move(cudf::detail::bitmask_and(right_flattened_keys, stream).mask);
+  auto const row_bitmask = (compare_nulls == null_equality::EQUAL)
+                             ? rmm::device_buffer{}
+                             : cudf::detail::bitmask_and(right_flattened_keys, stream).mask;
   // skip rows that are null here.
   thrust::for_each_n(
     rmm::exec_policy(stream),

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -95,9 +95,10 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_anti_join(
 
   // if compare_nulls == UNEQUAL, we can simply ignore any rows that
   // contain a NULL in any column as they will never compare to equal.
-  auto const row_bitmask = (compare_nulls == null_equality::EQUAL)
-                             ? rmm::device_buffer{}
-                             : cudf::detail::bitmask_and(right_flattened_keys, stream).first;
+  auto const row_bitmask =
+    (compare_nulls == null_equality::EQUAL)
+      ? rmm::device_buffer{}
+      : std::move(cudf::detail::bitmask_and(right_flattened_keys, stream).mask);
   // skip rows that are null here.
   thrust::for_each_n(
     rmm::exec_policy(stream),

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -97,7 +97,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_anti_join(
   // contain a NULL in any column as they will never compare to equal.
   auto const row_bitmask = (compare_nulls == null_equality::EQUAL)
                              ? rmm::device_buffer{}
-                             : cudf::detail::bitmask_and(right_flattened_keys, stream).mask;
+                             : cudf::detail::bitmask_and(right_flattened_keys, stream).first;
   // skip rows that are null here.
   thrust::for_each_n(
     rmm::exec_policy(stream),

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -319,14 +319,14 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
   // We generate new bitmask by AND of the input columns' bitmasks.
   // Note that if the input columns are nullable, the output column will also be nullable (which may
   // not have nulls).
-  auto bitmask_out =
+  auto [null_mask, null_count] =
     cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr);
 
   return make_strings_column(strings_count,
                              std::move(offsets_column),
                              std::move(chars_column),
-                             bitmask_out.num_unset_bits,
-                             std::move(bitmask_out.mask));
+                             null_count,
+                             std::move(null_mask));
 }
 
 std::pair<std::unique_ptr<column>, int64_t> repeat_strings_output_sizes(

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -319,14 +319,14 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
   // We generate new bitmask by AND of the input columns' bitmasks.
   // Note that if the input columns are nullable, the output column will also be nullable (which may
   // not have nulls).
-  auto bitmask_output =
-    cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr);
+  auto null_mask = std::move(
+    cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr).mask);
 
   return make_strings_column(strings_count,
                              std::move(offsets_column),
                              std::move(chars_column),
-                             bitmask_output.num_unset_bits,
-                             std::move(bitmask_output.mask));
+                             UNKNOWN_NULL_COUNT,
+                             std::move(null_mask));
 }
 
 std::pair<std::unique_ptr<column>, int64_t> repeat_strings_output_sizes(

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -319,14 +319,14 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
   // We generate new bitmask by AND of the input columns' bitmasks.
   // Note that if the input columns are nullable, the output column will also be nullable (which may
   // not have nulls).
-  auto null_mask = std::move(
-    cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr).mask);
+  auto bitmask_output =
+    cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr);
 
   return make_strings_column(strings_count,
                              std::move(offsets_column),
                              std::move(chars_column),
-                             UNKNOWN_NULL_COUNT,
-                             std::move(null_mask));
+                             bitmask_output.num_unset_bits,
+                             std::move(bitmask_output.mask));
 }
 
 std::pair<std::unique_ptr<column>, int64_t> repeat_strings_output_sizes(

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -319,8 +319,8 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
   // We generate new bitmask by AND of the input columns' bitmasks.
   // Note that if the input columns are nullable, the output column will also be nullable (which may
   // not have nulls).
-  auto [null_mask, _] =
-    cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr);
+  auto null_mask = std::move(
+    cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr).mask);
 
   return make_strings_column(strings_count,
                              std::move(offsets_column),

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -319,14 +319,14 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
   // We generate new bitmask by AND of the input columns' bitmasks.
   // Note that if the input columns are nullable, the output column will also be nullable (which may
   // not have nulls).
-  auto null_mask = std::move(
-    cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr).mask);
+  auto bitmask_out =
+    cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr);
 
   return make_strings_column(strings_count,
                              std::move(offsets_column),
                              std::move(chars_column),
-                             UNKNOWN_NULL_COUNT,
-                             std::move(null_mask));
+                             bitmask_out.num_unset_bits,
+                             std::move(bitmask_out.mask));
 }
 
 std::pair<std::unique_ptr<column>, int64_t> repeat_strings_output_sizes(

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -319,7 +319,7 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
   // We generate new bitmask by AND of the input columns' bitmasks.
   // Note that if the input columns are nullable, the output column will also be nullable (which may
   // not have nulls).
-  auto null_mask =
+  auto [null_mask, _] =
     cudf::detail::bitmask_and(table_view{{input.parent(), repeat_times}}, stream, mr);
 
   return make_strings_column(strings_count,

--- a/cpp/src/structs/utilities.cpp
+++ b/cpp/src/structs/utilities.cpp
@@ -383,7 +383,8 @@ std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_paren
                                                                std::vector<size_type>{0, 0},
                                                                child.offset() + child.size(),
                                                                stream,
-                                                               mr));
+                                                               mr)
+                                       .first);
       return reinterpret_cast<bitmask_type const*>(ret_validity_buffers.back().data());
     }();
 

--- a/cpp/src/structs/utilities.cpp
+++ b/cpp/src/structs/utilities.cpp
@@ -379,12 +379,13 @@ std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_paren
       // and the _null_mask(). It would be better to AND the bits from the beginning, and apply
       // offset() uniformly.
       // Alternatively, one could construct a big enough buffer, and use inplace_bitwise_and.
-      ret_validity_buffers.push_back(cudf::detail::bitmask_and(parent_child_null_masks,
-                                                               std::vector<size_type>{0, 0},
-                                                               child.offset() + child.size(),
-                                                               stream,
-                                                               mr)
-                                       .first);
+      ret_validity_buffers.push_back(
+        std::move(cudf::detail::bitmask_and(parent_child_null_masks,
+                                            std::vector<size_type>{0, 0},
+                                            child.offset() + child.size(),
+                                            stream,
+                                            mr)
+                    .mask));
       return reinterpret_cast<bitmask_type const*>(ret_validity_buffers.back().data());
     }();
 

--- a/cpp/src/structs/utilities.cpp
+++ b/cpp/src/structs/utilities.cpp
@@ -379,15 +379,14 @@ std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_paren
       // and the _null_mask(). It would be better to AND the bits from the beginning, and apply
       // offset() uniformly.
       // Alternatively, one could construct a big enough buffer, and use inplace_bitwise_and.
-      auto bitmask_output = cudf::detail::bitmask_and(parent_child_null_masks,
-                                                      std::vector<size_type>{0, 0},
-                                                      child.offset() + child.size(),
-                                                      stream,
-                                                      mr);
-      ret_validity_buffers.push_back(std::move(bitmask_output.mask));
+      auto [new_mask, null_count] = cudf::detail::bitmask_and(parent_child_null_masks,
+                                                              std::vector<size_type>{0, 0},
+                                                              child.offset() + child.size(),
+                                                              stream,
+                                                              mr);
+      ret_validity_buffers.push_back(std::move(new_mask));
       return std::make_pair(
-        reinterpret_cast<bitmask_type const*>(ret_validity_buffers.back().data()),
-        bitmask_output.num_unset_bits);
+        reinterpret_cast<bitmask_type const*>(ret_validity_buffers.back().data()), null_count);
     }();
 
     return cudf::column_view(

--- a/cpp/src/structs/utilities.cpp
+++ b/cpp/src/structs/utilities.cpp
@@ -366,10 +366,10 @@ std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_paren
     auto parent_child_null_masks =
       std::vector<cudf::bitmask_type const*>{structs_column.null_mask(), child.null_mask()};
 
-    auto new_child_mask = [&] {
+    auto [new_child_mask, null_count] = [&] {
       if (not child.nullable()) {
         // Adopt parent STRUCT's null mask.
-        return structs_column.null_mask();
+        return std::make_pair(structs_column.null_mask(), 0);
       }
 
       // Both STRUCT and child are nullable. AND() for the child's new null mask.
@@ -379,14 +379,15 @@ std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_paren
       // and the _null_mask(). It would be better to AND the bits from the beginning, and apply
       // offset() uniformly.
       // Alternatively, one could construct a big enough buffer, and use inplace_bitwise_and.
-      ret_validity_buffers.push_back(
-        std::move(cudf::detail::bitmask_and(parent_child_null_masks,
-                                            std::vector<size_type>{0, 0},
-                                            child.offset() + child.size(),
-                                            stream,
-                                            mr)
-                    .mask));
-      return reinterpret_cast<bitmask_type const*>(ret_validity_buffers.back().data());
+      auto bitmask_output = cudf::detail::bitmask_and(parent_child_null_masks,
+                                                      std::vector<size_type>{0, 0},
+                                                      child.offset() + child.size(),
+                                                      stream,
+                                                      mr);
+      ret_validity_buffers.push_back(std::move(bitmask_output.mask));
+      return std::make_pair(
+        reinterpret_cast<bitmask_type const*>(ret_validity_buffers.back().data()),
+        bitmask_output.num_unset_bits);
     }();
 
     return cudf::column_view(
@@ -394,7 +395,7 @@ std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_paren
       child.size(),
       child.head(),
       new_child_mask,
-      cudf::UNKNOWN_NULL_COUNT,
+      null_count,
       child.offset(),
       std::vector<cudf::column_view>{child.child_begin(), child.child_end()});
   };

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -545,9 +545,9 @@ TEST_F(MergeBitmaskTest, TestBitmaskAnd)
   auto const input2 = cudf::table_view({bools_col1, bools_col2});
   auto const input3 = cudf::table_view({bools_col1, bools_col2, bools_col3});
 
-  rmm::device_buffer result1 = cudf::bitmask_and(input1);
-  rmm::device_buffer result2 = cudf::bitmask_and(input2);
-  rmm::device_buffer result3 = cudf::bitmask_and(input3);
+  auto [result1, count1] = cudf::bitmask_and(input1);
+  auto [result2, count2] = cudf::bitmask_and(input2);
+  auto [result3, count3] = cudf::bitmask_and(input3);
 
   auto odd_indices =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -580,19 +580,29 @@ TEST_F(MergeBitmaskTest, TestBitmaskOr)
   auto const input2 = cudf::table_view({bools_col1, bools_col2});
   auto const input3 = cudf::table_view({bools_col1, bools_col2, bools_col3});
 
-  rmm::device_buffer result1 = cudf::bitmask_or(input1);
-  rmm::device_buffer result2 = cudf::bitmask_or(input2);
-  rmm::device_buffer result3 = cudf::bitmask_or(input3);
+  auto result1 = cudf::bitmask_or(input1);
+  auto result2 = cudf::bitmask_or(input2);
+  auto result3 = cudf::bitmask_or(input3);
+
+  constexpr cudf::size_type gold_valid_count = 4;
+  constexpr cudf::size_type gold_null_count  = 1;
+
+  EXPECT_EQ(result1.num_set_bits, 0);
+  EXPECT_EQ(result1.num_unset_bits, 0);
+  EXPECT_EQ(result2.num_set_bits, gold_valid_count);
+  EXPECT_EQ(result2.num_unset_bits, gold_null_count);
+  EXPECT_EQ(result3.num_set_bits, 0);
+  EXPECT_EQ(result3.num_unset_bits, 0);
 
   auto all_but_index3 =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
   auto null3 =
     cudf::test::detail::make_null_mask(all_but_index3, all_but_index3 + input2.num_rows());
 
-  EXPECT_EQ(nullptr, result1.data());
+  EXPECT_EQ(nullptr, result1.mask.data());
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    result2.data(), null3.data(), cudf::num_bitmask_words(input2.num_rows()));
-  EXPECT_EQ(nullptr, result3.data());
+    result2.mask.data(), null3.data(), cudf::num_bitmask_words(input2.num_rows()));
+  EXPECT_EQ(nullptr, result3.mask.data());
 }
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -545,19 +545,19 @@ TEST_F(MergeBitmaskTest, TestBitmaskAnd)
   auto const input2 = cudf::table_view({bools_col1, bools_col2});
   auto const input3 = cudf::table_view({bools_col1, bools_col2, bools_col3});
 
-  auto [result1, count1] = cudf::bitmask_and(input1);
-  auto [result2, count2] = cudf::bitmask_and(input2);
-  auto [result3, count3] = cudf::bitmask_and(input3);
+  auto result1 = cudf::bitmask_and(input1);
+  auto result2 = cudf::bitmask_and(input2);
+  auto result3 = cudf::bitmask_and(input3);
 
   auto odd_indices =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
   auto odd = cudf::test::detail::make_null_mask(odd_indices, odd_indices + input2.num_rows());
 
-  EXPECT_EQ(nullptr, result1.data());
+  EXPECT_EQ(nullptr, result1.mask.data());
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    result2.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
+    result2.mask.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    result3.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
+    result3.mask.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
 }
 
 TEST_F(MergeBitmaskTest, TestBitmaskOr)

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -545,29 +545,25 @@ TEST_F(MergeBitmaskTest, TestBitmaskAnd)
   auto const input2 = cudf::table_view({bools_col1, bools_col2});
   auto const input3 = cudf::table_view({bools_col1, bools_col2, bools_col3});
 
-  auto result1 = cudf::bitmask_and(input1);
-  auto result2 = cudf::bitmask_and(input2);
-  auto result3 = cudf::bitmask_and(input3);
+  auto [result1_mask, result1_null_count] = cudf::bitmask_and(input1);
+  auto [result2_mask, result2_null_count] = cudf::bitmask_and(input2);
+  auto [result3_mask, result3_null_count] = cudf::bitmask_and(input3);
 
-  constexpr cudf::size_type gold_valid_count = 2;
-  constexpr cudf::size_type gold_null_count  = 3;
+  constexpr cudf::size_type gold_null_count = 3;
 
-  EXPECT_EQ(result1.num_set_bits, 0);
-  EXPECT_EQ(result1.num_unset_bits, 0);
-  EXPECT_EQ(result2.num_set_bits, gold_valid_count);
-  EXPECT_EQ(result2.num_unset_bits, gold_null_count);
-  EXPECT_EQ(result3.num_set_bits, gold_valid_count);
-  EXPECT_EQ(result3.num_unset_bits, gold_null_count);
+  EXPECT_EQ(result1_null_count, 0);
+  EXPECT_EQ(result2_null_count, gold_null_count);
+  EXPECT_EQ(result3_null_count, gold_null_count);
 
   auto odd_indices =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
   auto odd = cudf::test::detail::make_null_mask(odd_indices, odd_indices + input2.num_rows());
 
-  EXPECT_EQ(nullptr, result1.mask.data());
+  EXPECT_EQ(nullptr, result1_mask.data());
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    result2.mask.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
+    result2_mask.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    result3.mask.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
+    result3_mask.data(), odd.data(), cudf::num_bitmask_words(input2.num_rows()));
 }
 
 TEST_F(MergeBitmaskTest, TestBitmaskOr)
@@ -580,29 +576,23 @@ TEST_F(MergeBitmaskTest, TestBitmaskOr)
   auto const input2 = cudf::table_view({bools_col1, bools_col2});
   auto const input3 = cudf::table_view({bools_col1, bools_col2, bools_col3});
 
-  auto result1 = cudf::bitmask_or(input1);
-  auto result2 = cudf::bitmask_or(input2);
-  auto result3 = cudf::bitmask_or(input3);
+  auto [result1_mask, result1_null_count] = cudf::bitmask_or(input1);
+  auto [result2_mask, result2_null_count] = cudf::bitmask_or(input2);
+  auto [result3_mask, result3_null_count] = cudf::bitmask_or(input3);
 
-  constexpr cudf::size_type gold_valid_count = 4;
-  constexpr cudf::size_type gold_null_count  = 1;
-
-  EXPECT_EQ(result1.num_set_bits, 0);
-  EXPECT_EQ(result1.num_unset_bits, 0);
-  EXPECT_EQ(result2.num_set_bits, gold_valid_count);
-  EXPECT_EQ(result2.num_unset_bits, gold_null_count);
-  EXPECT_EQ(result3.num_set_bits, 0);
-  EXPECT_EQ(result3.num_unset_bits, 0);
+  EXPECT_EQ(result1_null_count, 0);
+  EXPECT_EQ(result2_null_count, 1);
+  EXPECT_EQ(result3_null_count, 0);
 
   auto all_but_index3 =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
   auto null3 =
     cudf::test::detail::make_null_mask(all_but_index3, all_but_index3 + input2.num_rows());
 
-  EXPECT_EQ(nullptr, result1.mask.data());
+  EXPECT_EQ(nullptr, result1_mask.data());
   CUDF_TEST_EXPECT_EQUAL_BUFFERS(
-    result2.mask.data(), null3.data(), cudf::num_bitmask_words(input2.num_rows()));
-  EXPECT_EQ(nullptr, result3.mask.data());
+    result2_mask.data(), null3.data(), cudf::num_bitmask_words(input2.num_rows()));
+  EXPECT_EQ(nullptr, result3_mask.data());
 }
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -549,6 +549,16 @@ TEST_F(MergeBitmaskTest, TestBitmaskAnd)
   auto result2 = cudf::bitmask_and(input2);
   auto result3 = cudf::bitmask_and(input3);
 
+  constexpr cudf::size_type gold_valid_count = 2;
+  constexpr cudf::size_type gold_null_count  = 3;
+
+  EXPECT_EQ(result1.num_set_bits, 0);
+  EXPECT_EQ(result1.num_unset_bits, 0);
+  EXPECT_EQ(result2.num_set_bits, gold_valid_count);
+  EXPECT_EQ(result2.num_unset_bits, gold_null_count);
+  EXPECT_EQ(result3.num_set_bits, gold_valid_count);
+  EXPECT_EQ(result3.num_unset_bits, gold_null_count);
+
   auto odd_indices =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
   auto odd = cudf::test::detail::make_null_mask(odd_indices, odd_indices + input2.num_rows());

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1492,12 +1492,16 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
 
     cudf::binary_operator op = static_cast<cudf::binary_operator>(bin_op);
     switch (op) {
-      case cudf::binary_operator::BITWISE_AND:
-        copy->set_null_mask(cudf::bitmask_and(*input_table));
+      case cudf::binary_operator::BITWISE_AND: {
+        auto bitmask_output = cudf::bitmask_and(*input_table);
+        copy->set_null_mask(std::move(bitmask_output.mask), bitmask_output.num_unset_bits);
         break;
-      case cudf::binary_operator::BITWISE_OR:
-        copy->set_null_mask(cudf::bitmask_or(*input_table));
+      }
+      case cudf::binary_operator::BITWISE_OR: {
+        auto bitmask_output = cudf::bitmask_or(*input_table);
+        copy->set_null_mask(std::move(bitmask_output.mask), bitmask_output.num_unset_bits);
         break;
+      }
       default: JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Unsupported merge operation", 0);
     }
 

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1493,13 +1493,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
     cudf::binary_operator op = static_cast<cudf::binary_operator>(bin_op);
     switch (op) {
       case cudf::binary_operator::BITWISE_AND: {
-        auto bitmask_output = cudf::bitmask_and(*input_table);
-        copy->set_null_mask(std::move(bitmask_output.mask), bitmask_output.num_unset_bits);
+        auto [new_bitmask, null_count] = cudf::bitmask_and(*input_table);
+        copy->set_null_mask(std::move(new_bitmask), null_count);
         break;
       }
       case cudf::binary_operator::BITWISE_OR: {
-        auto bitmask_output = cudf::bitmask_or(*input_table);
-        copy->set_null_mask(std::move(bitmask_output.mask), bitmask_output.num_unset_bits);
+        auto [new_bitmask, null_count] = cudf::bitmask_or(*input_table);
+        copy->set_null_mask(std::move(new_bitmask), null_count);
         break;
       }
       default: JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Unsupported merge operation", 0);


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/9176

- [x] Update `bitmask_and` and `bitmask_or` to return both resulting mask and count of unset bits
- [x] Refactor related implementations to use new `bitmask_and/or`
- [x] Update unit tests