### PR TITLE
[REVIEW] Fix `usecols` parameter handling in `dask_cudf.read_csv`

### DIFF
--- a/python/dask_cudf/dask_cudf/io/csv.py
+++ b/python/dask_cudf/dask_cudf/io/csv.py
@@ -111,9 +111,7 @@ def _internal_read_csv(path, chunksize="256 MiB", **kwargs):
         return read_csv_without_chunksize(path, **kwargs)
 
     dask_reader = make_reader(cudf.read_csv, "read_csv", "CSV")
-    usecols = kwargs.get("usecols", None)
-    if usecols is not None:
-        kwargs.pop("usecols")
+    usecols = kwargs.pop("usecols", None)
     meta = dask_reader(filenames[0], **kwargs)._meta
 
     dsk = {}

--- a/python/dask_cudf/dask_cudf/io/csv.py
+++ b/python/dask_cudf/dask_cudf/io/csv.py
@@ -111,6 +111,9 @@ def _internal_read_csv(path, chunksize="256 MiB", **kwargs):
         return read_csv_without_chunksize(path, **kwargs)
 
     dask_reader = make_reader(cudf.read_csv, "read_csv", "CSV")
+    usecols = kwargs.get("usecols", None)
+    if usecols is not None:
+        kwargs.pop("usecols")
     meta = dask_reader(filenames[0], **kwargs)._meta
 
     dsk = {}
@@ -130,11 +133,14 @@ def _internal_read_csv(path, chunksize="256 MiB", **kwargs):
                     "names"
                 ] = meta.columns  # no header in the middle of the file
                 kwargs2["header"] = None
+            kwargs2["usecols"] = usecols
             dsk[(name, i)] = (apply, _read_csv, [fn, dtypes], kwargs2)
 
             i += 1
 
     divisions = [None] * (len(dsk) + 1)
+    if usecols is not None:
+        meta = meta[usecols]
     return dd.core.new_dd_object(dsk, name, meta, divisions)
 
 

--- a/python/dask_cudf/dask_cudf/io/tests/test_csv.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_csv.py
@@ -134,3 +134,19 @@ def test_read_csv_chunksize_none(tmp_path, compression, size):
     df.to_csv(path, index=False, compression=compression)
     df2 = dask_cudf.read_csv(path, chunksize=None, dtype=typ)
     dd.assert_eq(df, df2)
+
+
+def test_csv_reader_usecols(tmp_path):
+    df = cudf.DataFrame(
+        {
+            "a": [1, 2, 3, 4] * 100,
+            "b": ["a", "b", "c", "d"] * 100,
+            "c": [10, 11, 12, 13] * 100,
+        }
+    )
+    csv_path = str(tmp_path / "usecols_data.csv")
+    df.to_csv(csv_path, index=False)
+    ddf = dask_cudf.from_cudf(df[["b", "c"]], npartitions=5)
+    ddf2 = dask_cudf.read_csv(csv_path, usecols=["b", "c"])
+
+    dd.assert_eq(ddf, ddf2, check_divisions=False, check_index=False)


### PR DESCRIPTION
Fixes: #9387 

This PR fixes `usecols` parameter usage in `dask_cudf.read_csv`. When the csv read using byterange's the csv reader has to be passed complete column names in `names` param but should pass `usecols` to return the exact columns that are needed only.


<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
