### PR TITLE
Use std::size_t when computing join output size

### DIFF
--- a/cpp/src/join/hash_join.cuh
+++ b/cpp/src/join/hash_join.cuh
@@ -79,7 +79,6 @@ class make_pair_function {
  * joining two tables together.
  *
  * @throw cudf::logic_error if JoinKind is not INNER_JOIN or LEFT_JOIN
- * @throw cudf::logic_error if the exact size overflows cudf::size_type
  *
  * @tparam JoinKind The type of join to be performed
  * @tparam multimap_type The type of the hash table
@@ -126,13 +125,11 @@ std::size_t compute_join_output_size(table_device_view build_table,
 
   auto iter = cudf::detail::make_counting_transform_iterator(0, pair_func);
 
-  size_type size;
+  std::size_t size;
   if constexpr (JoinKind == join_kind::LEFT_JOIN) {
-    size = static_cast<size_type>(
-      hash_table.pair_count_outer(iter, iter + probe_table_num_rows, equality, stream.value()));
+    size = hash_table.pair_count_outer(iter, iter + probe_table_num_rows, equality, stream.value());
   } else {
-    size = static_cast<size_type>(
-      hash_table.pair_count(iter, iter + probe_table_num_rows, equality, stream.value()));
+    size = hash_table.pair_count(iter, iter + probe_table_num_rows, equality, stream.value());
   }
 
   return size;

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -1418,6 +1418,19 @@ TEST_F(JoinTest, HashJoinWithStructsAndNulls)
   }
 }
 
+TEST_F(JoinTest, HashJoinLargeOutputSize)
+{
+  // self-join a table of zeroes to generate an output row count that would overflow int32_t
+  std::size_t col_size = 65567;
+  rmm::device_buffer zeroes(col_size * sizeof(int32_t), rmm::cuda_stream_default);
+  CUDA_TRY(cudaMemsetAsync(zeroes.data(), 0, zeroes.size(), rmm::cuda_stream_default.value()));
+  cudf::column_view col_zeros(cudf::data_type{cudf::type_id::INT32}, col_size, zeroes.data());
+  cudf::table_view tview{{col_zeros}};
+  cudf::hash_join hash_join(tview, cudf::null_equality::UNEQUAL);
+  std::size_t output_size = hash_join.inner_join_size(tview);
+  EXPECT_EQ(col_size * col_size, output_size);
+}
+
 struct JoinDictionaryTest : public cudf::test::BaseFixture {
 };
 


### PR DESCRIPTION
Fixes #9625.  Updates `hash_join::compute_join_output_size` to use std::size_t instead of cudf::size_type as the intermediate type to hold the computed output size.