### PR TITLE
add const when getting data from a JNI data wrapper

### DIFF
--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -328,7 +328,7 @@ public:
     return data()[index];
   }
 
-  T *const *data() const { return reinterpret_cast<T * const*>(wrapped.data()); }
+  T *const *data() const { return reinterpret_cast<T *const *>(wrapped.data()); }
 
   T **data() { return reinterpret_cast<T **>(wrapped.data()); }
 

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -328,7 +328,7 @@ public:
     return data()[index];
   }
 
-  T *const *data() const { return reinterpret_cast<T **>(wrapped.data()); }
+  T *const *data() const { return reinterpret_cast<T * const*>(wrapped.data()); }
 
   T **data() { return reinterpret_cast<T **>(wrapped.data()); }
 


### PR DESCRIPTION
when calling from a .cu file which will be compiled by nvcc, the following error will be thrown:

```
/cudf-src/java/src/main/native/include/jni_utils.hpp(331): error: reinterpret_cast cannot cast away const or other type qualifiers
```

Add the const keyword to get rid of this error.

Signed-off-by: Allen Xu <allxu@nvidia.com>

Co-authored-by: Jiaming Yuan <jiamingy@nvidia.com>
