### PR TITLE
Dont recompute output size if it is already available

### DIFF
--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -132,8 +132,11 @@ probe_join_hash_table(cudf::table_device_view build_table,
   constexpr cudf::detail::join_kind ProbeJoinKind = (JoinKind == cudf::detail::join_kind::FULL_JOIN)
                                                       ? cudf::detail::join_kind::LEFT_JOIN
                                                       : JoinKind;
-  std::size_t const join_size = output_size.value_or(compute_join_output_size<ProbeJoinKind>(
-    build_table, probe_table, hash_table, compare_nulls, stream));
+
+  size_t const join_size = output_size
+                             ? *output_size
+                             : compute_join_output_size<ProbeJoinKind>(
+                                 build_table, probe_table, hash_table, compare_nulls, stream);
 
   // If output size is zero, return immediately
   if (join_size == 0) {

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -133,10 +133,10 @@ probe_join_hash_table(cudf::table_device_view build_table,
                                                       ? cudf::detail::join_kind::LEFT_JOIN
                                                       : JoinKind;
 
-  size_t const join_size = output_size
-                             ? *output_size
-                             : compute_join_output_size<ProbeJoinKind>(
-                                 build_table, probe_table, hash_table, compare_nulls, stream);
+  std::size_t const join_size = output_size
+                                  ? *output_size
+                                  : compute_join_output_size<ProbeJoinKind>(
+                                      build_table, probe_table, hash_table, compare_nulls, stream);
 
   // If output size is zero, return immediately
   if (join_size == 0) {


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/9647. 

This is a simple fix in `probe_join_hash_table` where `compute_join_output_size` was being invoked non-lazily when checking if the optional `output_size` was set. The whole point of the check is to not call `compute_join_output_size` again, since its value gets discarded given a passed `output_size`

We are trying to add (https://github.com/NVIDIA/spark-rapids/pull/4036) some performance optimizations in Spark, and we noticed an extra call to this kernel that accounted for ~10s extra time in our query.
