### PR TITLE
Use `_gather` internal for `sort_*`

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -6337,17 +6337,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
         return super()._explode(column, ignore_index)
 
-    def _gather(self, gather_map, keep_index=True, nullify=False):
-        out = super()._gather(
-            gather_map, keep_index=keep_index, nullify=nullify
-        )
-        # TODO: ideally dataframe factory functions should handle the .columns
-        # attribute correctly so this logic doesn't have to be applied case
-        # by case.
-        if isinstance(self.columns, pd.core.indexes.multi.MultiIndex):
-            out.columns = self.columns
-        return out
-
 
 def make_binop_func(op, postprocess=None):
     # This function is used to wrap binary operations in Frame with an

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -6337,6 +6337,17 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
         return super()._explode(column, ignore_index)
 
+    def _gather(self, gather_map, keep_index=True, nullify=False):
+        out = super()._gather(
+            gather_map, keep_index=keep_index, nullify=nullify
+        )
+        # TODO: ideally dataframe factory functions should handle the .columns
+        # attribute correctly so this logic doesn't have to be applied case
+        # by case.
+        if isinstance(self.columns, pd.core.indexes.multi.MultiIndex):
+            out.columns = self.columns
+        return out
+
 
 def make_binop_func(op, postprocess=None):
     # This function is used to wrap binary operations in Frame with an

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -399,6 +399,14 @@ class IndexedFrame(Frame):
                     ascending=ascending, na_position=na_position
                 )
                 out = self._gather(inds)
+                # TODO: frame factory function should handle multilevel column
+                # names
+                if isinstance(
+                    self, cudf.core.dataframe.DataFrame
+                ) and isinstance(
+                    self.columns, pd.core.indexes.multi.MultiIndex
+                ):
+                    out.columns = self.columns
             elif (ascending and idx.is_monotonic_increasing) or (
                 not ascending and idx.is_monotonic_decreasing
             ):
@@ -408,6 +416,12 @@ class IndexedFrame(Frame):
                     ascending=ascending, na_position=na_position
                 )
                 out = self._gather(inds)
+                if isinstance(
+                    self, cudf.core.dataframe.DataFrame
+                ) and isinstance(
+                    self.columns, pd.core.indexes.multi.MultiIndex
+                ):
+                    out.columns = self.columns
         else:
             labels = sorted(self._data.names, reverse=not ascending)
             out = self[labels]
@@ -490,6 +504,10 @@ class IndexedFrame(Frame):
             ),
             keep_index=not ignore_index,
         )
+        if isinstance(self, cudf.core.dataframe.DataFrame) and isinstance(
+            self.columns, pd.core.indexes.multi.MultiIndex
+        ):
+            out.columns = self.columns
         return out
 
     def _n_largest_or_smallest(self, largest, n, columns, keep):

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -398,9 +398,6 @@ class IndexedFrame(Frame):
                 inds = idx._get_sorted_inds(
                     ascending=ascending, na_position=na_position
                 )
-                # TODO: This line is abusing the fact that _gather accepts a
-                # column, not just user-facing objects. We will want to
-                # refactor that in the future.
                 out = self._gather(inds)
                 # TODO: frame factory function should handle multilevel column
                 # names

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -398,10 +398,18 @@ class IndexedFrame(Frame):
                 inds = idx._get_sorted_inds(
                     ascending=ascending, na_position=na_position
                 )
-                # TODO: This line is abusing the fact that take accepts a
+                # TODO: This line is abusing the fact that _gather accepts a
                 # column, not just user-facing objects. We will want to
                 # refactor that in the future.
-                out = self.take(inds)
+                out = self._gather(inds)
+                # TODO: frame factory function should handle multilevel column
+                # names
+                if isinstance(
+                    self, cudf.core.dataframe.DataFrame
+                ) and isinstance(
+                    self.columns, pd.core.indexes.multi.MultiIndex
+                ):
+                    out.columns = self.columns
             elif (ascending and idx.is_monotonic_increasing) or (
                 not ascending and idx.is_monotonic_decreasing
             ):
@@ -410,7 +418,13 @@ class IndexedFrame(Frame):
                 inds = idx.argsort(
                     ascending=ascending, na_position=na_position
                 )
-                out = self.take(inds)
+                out = self._gather(inds)
+                if isinstance(
+                    self, cudf.core.dataframe.DataFrame
+                ) and isinstance(
+                    self.columns, pd.core.indexes.multi.MultiIndex
+                ):
+                    out.columns = self.columns
         else:
             labels = sorted(self._data.names, reverse=not ascending)
             out = self[labels]
@@ -487,12 +501,17 @@ class IndexedFrame(Frame):
             return self
 
         # argsort the `by` column
-        return self.take(
+        out = self._gather(
             self._get_columns_by_label(by)._get_sorted_inds(
                 ascending=ascending, na_position=na_position
             ),
             keep_index=not ignore_index,
         )
+        if isinstance(self, cudf.core.dataframe.DataFrame) and isinstance(
+            self.columns, pd.core.indexes.multi.MultiIndex
+        ):
+            out.columns = self.columns
+        return out
 
     def _n_largest_or_smallest(self, largest, n, columns, keep):
         # Get column to operate on

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -399,14 +399,6 @@ class IndexedFrame(Frame):
                     ascending=ascending, na_position=na_position
                 )
                 out = self._gather(inds)
-                # TODO: frame factory function should handle multilevel column
-                # names
-                if isinstance(
-                    self, cudf.core.dataframe.DataFrame
-                ) and isinstance(
-                    self.columns, pd.core.indexes.multi.MultiIndex
-                ):
-                    out.columns = self.columns
             elif (ascending and idx.is_monotonic_increasing) or (
                 not ascending and idx.is_monotonic_decreasing
             ):
@@ -416,12 +408,6 @@ class IndexedFrame(Frame):
                     ascending=ascending, na_position=na_position
                 )
                 out = self._gather(inds)
-                if isinstance(
-                    self, cudf.core.dataframe.DataFrame
-                ) and isinstance(
-                    self.columns, pd.core.indexes.multi.MultiIndex
-                ):
-                    out.columns = self.columns
         else:
             labels = sorted(self._data.names, reverse=not ascending)
             out = self[labels]
@@ -504,10 +490,6 @@ class IndexedFrame(Frame):
             ),
             keep_index=not ignore_index,
         )
-        if isinstance(self, cudf.core.dataframe.DataFrame) and isinstance(
-            self.columns, pd.core.indexes.multi.MultiIndex
-        ):
-            out.columns = self.columns
         return out
 
     def _n_largest_or_smallest(self, largest, n, columns, keep):


### PR DESCRIPTION
closes #9667 

This PR evades deprecation warning for `sort_*` apis. There's a corner case that the name of columns are multi level, and it's handled ad-hoc here. But should use more refactoring to the factory method.