### PR TITLE
Don't overflow on preceding and following computation

### DIFF
--- a/cpp/src/rolling/rolling_detail.cuh
+++ b/cpp/src/rolling/rolling_detail.cuh
@@ -950,8 +950,10 @@ __launch_bounds__(block_size) __global__
     int64_t following_window = following_window_begin[i];
 
     // compute bounds
-    size_type start = static_cast<size_type>(min(static_cast<int64_t>(input.size()), max(0L, i - preceding_window + 1)));
-    size_type end   = static_cast<size_type>(min(static_cast<int64_t>(input.size()), max(0L, i + following_window + 1)));
+    size_type start = static_cast<size_type>(
+            min(static_cast<int64_t>(input.size()), max(0L, i - preceding_window + 1)));
+    size_type end   = static_cast<size_type>(
+            min(static_cast<int64_t>(input.size()), max(0L, i + following_window + 1)));
     size_type start_index = min(start, end);
     size_type end_index   = max(start, end);
 

--- a/cpp/src/rolling/rolling_detail.cuh
+++ b/cpp/src/rolling/rolling_detail.cuh
@@ -945,12 +945,13 @@ __launch_bounds__(block_size) __global__
 
   auto active_threads = __ballot_sync(0xffffffff, i < input.size());
   while (i < input.size()) {
-    size_type preceding_window = preceding_window_begin[i];
-    size_type following_window = following_window_begin[i];
+    // to prevent overflow issues when computing bounds use int64_t
+    int64_t preceding_window = preceding_window_begin[i];
+    int64_t following_window = following_window_begin[i];
 
     // compute bounds
-    size_type start       = min(input.size(), max(0, i - preceding_window + 1));
-    size_type end         = min(input.size(), max(0, i + following_window + 1));
+    size_type start = min(static_cast<int64_t>(input.size()), max(0L, i - preceding_window + 1));
+    size_type end   = min(static_cast<int64_t>(input.size()), max(0L, i + following_window + 1));
     size_type start_index = min(start, end);
     size_type end_index   = max(start, end);
 

--- a/cpp/src/rolling/rolling_detail.cuh
+++ b/cpp/src/rolling/rolling_detail.cuh
@@ -951,9 +951,9 @@ __launch_bounds__(block_size) __global__
 
     // compute bounds
     size_type start = static_cast<size_type>(
-            min(static_cast<int64_t>(input.size()), max(0L, i - preceding_window + 1)));
-    size_type end   = static_cast<size_type>(
-            min(static_cast<int64_t>(input.size()), max(0L, i + following_window + 1)));
+      min(static_cast<int64_t>(input.size()), max(0L, i - preceding_window + 1)));
+    size_type end = static_cast<size_type>(
+      min(static_cast<int64_t>(input.size()), max(0L, i + following_window + 1)));
     size_type start_index = min(start, end);
     size_type end_index   = max(start, end);
 

--- a/cpp/src/rolling/rolling_detail.cuh
+++ b/cpp/src/rolling/rolling_detail.cuh
@@ -950,8 +950,8 @@ __launch_bounds__(block_size) __global__
     int64_t following_window = following_window_begin[i];
 
     // compute bounds
-    size_type start = min(static_cast<int64_t>(input.size()), max(0L, i - preceding_window + 1));
-    size_type end   = min(static_cast<int64_t>(input.size()), max(0L, i + following_window + 1));
+    size_type start = static_cast<size_type>(min(static_cast<int64_t>(input.size()), max(0L, i - preceding_window + 1)));
+    size_type end   = static_cast<size_type>(min(static_cast<int64_t>(input.size()), max(0L, i + following_window + 1)));
     size_type start_index = min(start, end);
     size_type end_index   = max(start, end);
 

--- a/cpp/tests/rolling/grouped_rolling_test.cpp
+++ b/cpp/tests/rolling/grouped_rolling_test.cpp
@@ -638,6 +638,29 @@ TYPED_TEST(GroupedRollingTest, ZeroWindow)
     grouping_keys, input, expected_group_offsets, preceding_window, following_window, 1);
 }
 
+using GroupedRollingTestInts = GroupedRollingTest<int32_t>;
+
+TEST_F(GroupedRollingTestInts, SumLargeWindow)
+{
+  fixed_width_column_wrapper<int32_t, int32_t> input({1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+
+  size_type preceding_window = 2147483640;
+  size_type following_window = 2147483642;
+
+  cudf::table_view groupby_keys;
+
+  auto result =
+    cudf::grouped_rolling_window(groupby_keys,
+                                 input,
+                                 preceding_window,
+                                 following_window,
+                                 1,
+                                 *cudf::make_sum_aggregation<cudf::rolling_aggregation>());
+
+  fixed_width_column_wrapper<int64_t, int32_t> expected({10, 10, 10, 10, 10, 10, 10, 10, 10, 10});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, expected);
+}
+
 // ------------- non-fixed-width types --------------------
 
 using GroupedRollingTestStrings = GroupedRollingTest<cudf::string_view>;


### PR DESCRIPTION
This fixes #9672

I am no C++ expert so I am happy to change anything about this.