### PR TITLE
Fix links in C++ Developer Guide.

### DIFF
--- a/cpp/docs/BENCHMARKING.md
+++ b/cpp/docs/BENCHMARKING.md
@@ -8,16 +8,16 @@ other benchmarks in `cpp/benchmarks` to understand the options.
 
 ## Directory and File Naming
 
-The naming of unit benchmark directories and source files should be consistent with the feature 
-being benchmarked. For example, the benchmarks for APIs in `copying.hpp` should live in 
-`cudf/cpp/benchmarks/copying`. Each feature (or set of related features) should have its own 
+The naming of unit benchmark directories and source files should be consistent with the feature
+being benchmarked. For example, the benchmarks for APIs in `copying.hpp` should live in
+`cudf/cpp/benchmarks/copying`. Each feature (or set of related features) should have its own
 benchmark source file named `<feature>_benchmark.cu/cpp`. For example,
-`cudf/cpp/src/copying/scatter.cu` has benchmarks in 
+`cudf/cpp/src/copying/scatter.cu` has benchmarks in
 `cudf/cpp/benchmarks/copying/scatter_benchmark.cu`.
 
-In the interest of improving compile time, whenever possible, test source files should be `.cpp` 
+In the interest of improving compile time, whenever possible, test source files should be `.cpp`
 files because `nvcc` is slower than `gcc` in compiling host code. Note that `thrust::device_vector`
-includes device code, and so must only be used in `.cu` files. `rmm::device_uvector`, 
+includes device code, and so must only be used in `.cu` files. `rmm::device_uvector`,
 `rmm::device_buffer` and the various `column_wrapper` types described in [Testing](TESTING.md)
 can be used in `.cpp` files, and are therefore preferred in test code over `thrust::device_vector`.
 
@@ -25,7 +25,7 @@ can be used in `.cpp` files, and are therefore preferred in test code over `thru
 
 CUDA computations and operations like copies are typically asynchronous with respect to host code,
 so it is important to carefully synchronize in order to ensure the benchmark timing is not stopped
-before the feature you are benchmarking has completed. An RAII helper class `cuda_event_timer` is 
+before the feature you are benchmarking has completed. An RAII helper class `cuda_event_timer` is
 provided in `cpp/benchmarks/synchronization/synchronization.hpp` to help with this. This class
 can also optionally clear the GPU L2 cache in order to ensure cache hits do not artificially inflate
 performance in repeated iterations.
@@ -35,10 +35,10 @@ performance in repeated iterations.
 In general, we should benchmark all features over a range of data sizes and types, so that we can
 catch regressions across libcudf changes. However, running many benchmarks is expensive, so ideally
 we should sample the parameter space in such a way to get good coverage without having to test
-exhaustively. 
+exhaustively.
 
-A rule of thumb is that we should benchmark with enough data to reach the point where the algorithm 
-reaches its saturation bottleneck, whether that bottleneck is bandwidth or computation. Using data 
+A rule of thumb is that we should benchmark with enough data to reach the point where the algorithm
+reaches its saturation bottleneck, whether that bottleneck is bandwidth or computation. Using data
 sets larger than this point is generally not helpful, except in specific cases where doing so
-exercises different code and can therefore uncover regressions that smaller benchmarks will not 
+exercises different code and can therefore uncover regressions that smaller benchmarks will not
 (this should be rare).

--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -5,7 +5,7 @@ to these additional files for further documentation of libcudf best practices.
 
 * [Documentation Guide](DOCUMENTATION.md) for guidelines on documenting libcudf code.
 * [Testing Guide](TESTING.md) for guidelines on writing unit tests.
-* [Benchmarking Guide](TODO) for guidelines on writing unit benchmarks.
+* [Benchmarking Guide](BENCHMARKING.md) for guidelines on writing unit benchmarks.
 
 # Overview
 
@@ -25,7 +25,7 @@ A column is an array of data of a single type. Along with Tables, columns are th
 structures used in libcudf. Most libcudf algorithms operate on columns. Columns may have a validity
 mask representing whether each element is valid or null (invalid). Columns of nested types are 
 supported, meaning that a column may have child columns. A column is the C++ equivalent to a cuDF
-Python [series](https://docs.rapids.ai/api/cudf/stable/api.html#series)
+Python [Series](https://docs.rapids.ai/api/cudf/stable/api_docs/series.html).
 
 ### Element
 
@@ -37,13 +37,13 @@ A type representing a single element of a data type.
 
 ### Table
 
-A table is a collection of columns with equal number of elements. A table is the C++ equivalent to 
-a cuDF Python [data frame](https://docs.rapids.ai/api/cudf/stable/api.html#dataframe).
+A table is a collection of columns with equal number of elements. A table is the C++ equivalent to
+a cuDF Python [DataFrame](https://docs.rapids.ai/api/cudf/stable/api_docs/dataframe.html).
 
 ### View
 
-A view is a non-owning object that provides zero-copy access (possibly with slicing or offsets) data 
-owned by another object. Examples are column views and table views.
+A view is a non-owning object that provides zero-copy access (possibly with slicing or offsets) to
+data owned by another object. Examples are column views and table views.
 
 # Directory Structure and File Naming
 
@@ -75,10 +75,12 @@ execution policy (always `rmm::exec_policy` in libcudf).
 
 ## Code and Documentation Style and Formatting
 
-libcudf code uses [snake_case](https://en.wikipedia.org/wiki/Snake_case) for all names except in a 
-few cases: template parameters, unit tests and test case names may use Pascal case, aka 
-[UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case). We do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), except sometimes when naming device data variables and their corresponding
-host copies. Private member variables are typically prefixed with an underscore.
+libcudf code uses [snake_case](https://en.wikipedia.org/wiki/Snake_case) for all names except in a
+few cases: template parameters, unit tests and test case names may use Pascal case, aka
+[UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case). We do not use
+[Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), except sometimes when naming
+device data variables and their corresponding host copies. Private member variables are typically
+prefixed with an underscore.
 
 ```c++
 template <typename IteratorType>
@@ -138,7 +140,7 @@ The following guidelines apply to organizing `#include` lines.
    from other RAPIDS libraries, then includes from related libraries, like `<thrust/...>`, then 
    includes from dependencies installed with cuDF, and then standard headers (for example `<string>`, 
    `<iostream>`).
- * Use <> instead of "" unless the header is in the same directory as the source file.
+ * Use `<>` instead of `""` unless the header is in the same directory as the source file.
  * Tools like `clangd` often auto-insert includes when they can, but they usually get the grouping
    and brackets wrong.
  * Always check that includes are only necessary for the file in which they are included. 

--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -119,7 +119,7 @@ recommend watching Sean Parent's [C++ Seasoning talk](https://www.youtube.com/wa
 and we try to follow his rules: "No raw loops. No raw pointers. No raw synchronization primitives." 
 
  * Prefer algorithms from STL and Thrust to raw loops.
- * Prefer libcudf and RMM [owning data structures and views](libcudf-data-structures) to raw pointers
+ * Prefer libcudf and RMM [owning data structures and views](#libcudf-data-structures) to raw pointers
    and raw memory allocation.
  * libcudf doesn't have a lot of CPU-thread concurrency, but there is some. And currently libcudf
    does use raw synchronization primitives. So we should revisit Parent's third rule and improve 

--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -1,6 +1,6 @@
 # libcudf C++ Developer Guide
 
-This document serves as a guide for contributors to libcudf C++ code. Developers should also refer 
+This document serves as a guide for contributors to libcudf C++ code. Developers should also refer
 to these additional files for further documentation of libcudf best practices.
 
 * [Documentation Guide](DOCUMENTATION.md) for guidelines on documenting libcudf code.
@@ -9,21 +9,21 @@ to these additional files for further documentation of libcudf best practices.
 
 # Overview
 
-libcudf is a C++ library that provides GPU-accelerated data-parallel algorithms for processing 
-column-oriented tabular data. libcudf provides algorithms including slicing, filtering, sorting, 
+libcudf is a C++ library that provides GPU-accelerated data-parallel algorithms for processing
+column-oriented tabular data. libcudf provides algorithms including slicing, filtering, sorting,
 various types of aggregations, and database-type operations such as grouping and joins. libcudf
 serves a number of clients via multiple language interfaces, including Python and Java. Users may
 also use libcudf directly from C++ code.
 
 ## Lexicon
 
-This section defines terminology used within libcudf
+This section defines terminology used within libcudf.
 
 ### Column
 
-A column is an array of data of a single type. Along with Tables, columns are the fundamental data 
+A column is an array of data of a single type. Along with Tables, columns are the fundamental data
 structures used in libcudf. Most libcudf algorithms operate on columns. Columns may have a validity
-mask representing whether each element is valid or null (invalid). Columns of nested types are 
+mask representing whether each element is valid or null (invalid). Columns of nested types are
 supported, meaning that a column may have child columns. A column is the C++ equivalent to a cuDF
 Python [Series](https://docs.rapids.ai/api/cudf/stable/api_docs/series.html).
 
@@ -47,19 +47,19 @@ data owned by another object. Examples are column views and table views.
 
 # Directory Structure and File Naming
 
-External/public libcudf APIs are grouped based on functionality into an appropriately titled 
-header file  in `cudf/cpp/include/cudf/`. For example, `cudf/cpp/include/cudf/copying.hpp` 
-contains the APIs for functions related to copying from one column to another. Note the  `.hpp` 
+External/public libcudf APIs are grouped based on functionality into an appropriately titled
+header file in `cudf/cpp/include/cudf/`. For example, `cudf/cpp/include/cudf/copying.hpp`
+contains the APIs for functions related to copying from one column to another. Note the `.hpp`
 file extension used to indicate a C++ header file.
 
-Header files should use the `#pragma once` include guard. 
+Header files should use the `#pragma once` include guard.
 
-The naming of external API headers should be consistent with the name of the folder that contains 
+The naming of external API headers should be consistent with the name of the folder that contains
 the source files that implement the API. For example, the implementation of the APIs found in
-`cudf/cpp/include/cudf/copying.hpp` are located in `cudf/src/copying`. Likewise, the unit tests for 
+`cudf/cpp/include/cudf/copying.hpp` are located in `cudf/src/copying`. Likewise, the unit tests for
 the APIs reside in `cudf/tests/copying/`.
 
-Internal API headers containing `detail` namespace definitions that are used across translation 
+Internal API headers containing `detail` namespace definitions that are used across translation
 units inside libcudf should be placed in `include/cudf/detail`.
 
 ## File extensions
@@ -84,15 +84,15 @@ prefixed with an underscore.
 
 ```c++
 template <typename IteratorType>
-void algorithm_function(int x, rmm::cuda_stream_view s, rmm::device_memory_resource* mr) 
+void algorithm_function(int x, rmm::cuda_stream_view s, rmm::device_memory_resource* mr)
 {
   ...
 }
 
-class utility_class 
+class utility_class
 {
   ...
- private:
+private:
   int _rating{};
   std::unique_ptr<cudf::column> _column{};
 }
@@ -105,26 +105,26 @@ TYPED_TEST(RepeatTypedTestFixture, RepeatScalarCount)
 }
 ```
 
-C++ formatting is enforced using `clang-format`. You should configure `clang-format` on your 
-machine to use the `cudf/cpp/.clang-format` configuration file, and run `clang-format` on all 
-changed code before committing it. The easiest way to do this is to configure your editor to 
-"format on save".
+C++ formatting is enforced using `clang-format`. You should configure `clang-format` on your
+machine to use the `cudf/cpp/.clang-format` configuration file, and run `clang-format` on all
+changed code before committing it. The easiest way to do this is to configure your editor to
+"format on save."
 
 Aspects of code style not discussed in this document and not automatically enforceable are typically
 caught during code review, or not enforced.
 
 ### C++ Guidelines
 
-In general, we recommend following 
-[C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines). We also 
-recommend watching Sean Parent's [C++ Seasoning talk](https://www.youtube.com/watch?v=W2tWOdzgXHA), 
-and we try to follow his rules: "No raw loops. No raw pointers. No raw synchronization primitives." 
+In general, we recommend following
+[C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines). We also
+recommend watching Sean Parent's [C++ Seasoning talk](https://www.youtube.com/watch?v=W2tWOdzgXHA),
+and we try to follow his rules: "No raw loops. No raw pointers. No raw synchronization primitives."
 
  * Prefer algorithms from STL and Thrust to raw loops.
  * Prefer libcudf and RMM [owning data structures and views](#libcudf-data-structures) to raw pointers
    and raw memory allocation.
  * libcudf doesn't have a lot of CPU-thread concurrency, but there is some. And currently libcudf
-   does use raw synchronization primitives. So we should revisit Parent's third rule and improve 
+   does use raw synchronization primitives. So we should revisit Parent's third rule and improve
    here.
 
 Documentation is discussed in the [Documentation Guide](DOCUMENTATION.md).
@@ -133,28 +133,28 @@ Documentation is discussed in the [Documentation Guide](DOCUMENTATION.md).
 
 The following guidelines apply to organizing `#include` lines.
 
- * Group includes by library (e.g. cuDF, RMM, Thrust, STL). `clang-format` will respect the 
+ * Group includes by library (e.g. cuDF, RMM, Thrust, STL). `clang-format` will respect the
    groupings and sort the individual includes within a group lexicographically.
  * Separate groups by a blank line.
- * Order the groups from "nearest" to "farthest". In other words, local includes, then includes 
-   from other RAPIDS libraries, then includes from related libraries, like `<thrust/...>`, then 
-   includes from dependencies installed with cuDF, and then standard headers (for example `<string>`, 
+ * Order the groups from "nearest" to "farthest". In other words, local includes, then includes
+   from other RAPIDS libraries, then includes from related libraries, like `<thrust/...>`, then
+   includes from dependencies installed with cuDF, and then standard headers (for example `<string>`,
    `<iostream>`).
  * Use `<>` instead of `""` unless the header is in the same directory as the source file.
  * Tools like `clangd` often auto-insert includes when they can, but they usually get the grouping
    and brackets wrong.
- * Always check that includes are only necessary for the file in which they are included. 
-   Try to avoid excessive including especially in header files. Double check this when you remove 
+ * Always check that includes are only necessary for the file in which they are included.
+   Try to avoid excessive including especially in header files. Double check this when you remove
    code.
  * Use quotes `"` to include local headers from the same relative source directory. This should only
-   occur in source files and non-public header files. Otherwise use angle brackets `<>` around 
+   occur in source files and non-public header files. Otherwise use angle brackets `<>` around
    included header filenames.
- * Avoid relative paths with `..` when possible. Paths with `..` are necessary when including 
-   (internal) headers from source paths not in the same directory as the including file, 
+ * Avoid relative paths with `..` when possible. Paths with `..` are necessary when including
+   (internal) headers from source paths not in the same directory as the including file,
    because source paths are not passed with `-I`.
  * Avoid including library internal headers from non-internal files. For example, try not to include
-   headers from libcudf `src` directories in tests or in libcudf public headers. If you find 
-   yourself doing this, start a discussion about moving (parts of) the included internal header 
+   headers from libcudf `src` directories in tests or in libcudf public headers. If you find
+   yourself doing this, start a discussion about moving (parts of) the included internal header
    to a public header.
 
 # libcudf Data Structures
@@ -164,14 +164,14 @@ data structures you will use when developing libcudf code.
 
 ## Views and Ownership
 
-Resource ownership is an essential concept in libcudf. In short, an "owning" object owns a 
-resource (such as device memory). It acquires that resource during construction and releases the 
+Resource ownership is an essential concept in libcudf. In short, an "owning" object owns a
+resource (such as device memory). It acquires that resource during construction and releases the
 resource in destruction ([RAII](https://en.cppreference.com/w/cpp/language/raii)). A "non-owning"
 object does not own resources. Any class in libcudf with the `*_view` suffix is non-owning. For more
 detail see the [`libcudf++` presentation.](https://docs.google.com/presentation/d/1zKzAtc1AWFKfMhiUlV5yRZxSiPLwsObxMlWRWz_f5hA/edit?usp=sharing)
 
 libcudf functions typically take views as input (`column_view`, `table_view`, or `scalar_view`)
-and produce `unique_ptr`s to owning objects as output. For example, 
+and produce `unique_ptr`s to owning objects as output. For example,
 
 ```c++
 std::unique_ptr<table> sort(table_view const& input);
@@ -179,25 +179,25 @@ std::unique_ptr<table> sort(table_view const& input);
 
 ## `rmm::device_memory_resource`<a name="memory_resource"></a>
 
-libcudf Allocates all device memory via RMM memory resources (MR). See the 
+libcudf allocates all device memory via RMM memory resources (MR). See the
 [RMM documentation](https://github.com/rapidsai/rmm/blob/main/README.md) for details.
 
 ### Current Device Memory Resource
 
 RMM provides a "default" memory resource for each device that can be accessed and updated via the
-`rmm::mr::get_current_device_resource()` and `rmm::mr::set_current_device_resource(...)` functions, 
-respectively. All memory resource parameters should be defaulted to use the return value of 
-`rmm::mr::get_current_device_resource()`. 
+`rmm::mr::get_current_device_resource()` and `rmm::mr::set_current_device_resource(...)` functions,
+respectively. All memory resource parameters should be defaulted to use the return value of
+`rmm::mr::get_current_device_resource()`.
 
 ## `cudf::column`
 
-`cudf::column` is a core owning data structure in libcudf. Most libcudf public APIs produce either 
-a `cudf::column` or a `cudf::table` as output. A `column` contains `device_buffer`s which own the 
-device memory for the elements of a column and an optional null indicator bitmask. 
+`cudf::column` is a core owning data structure in libcudf. Most libcudf public APIs produce either
+a `cudf::column` or a `cudf::table` as output. A `column` contains `device_buffer`s which own the
+device memory for the elements of a column and an optional null indicator bitmask.
 
-Implicitly convertible to `column_view` and `mutable_column_view`. 
+Implicitly convertible to `column_view` and `mutable_column_view`.
 
-Movable and copyable. A copy performs a deep copy of the column's contents, whereas a move moves 
+Movable and copyable. A copy performs a deep copy of the column's contents, whereas a move moves
 the contents from one column to another.
 
 Example:
@@ -216,13 +216,13 @@ A `column` may have nested (child) columns, depending on the data type of the co
 
 ### `cudf::column_view`
 
-`cudf::column_view` is a core non-owning data structure in libcudf. It is an immutable, 
+`cudf::column_view` is a core non-owning data structure in libcudf. It is an immutable,
 non-owning view of device memory as a column. Most libcudf public APIs take views as inputs.
 
-A `column_view` may be a view of a "slice" of a column. For example, it might view rows 75-150 of a 
-column with 1000 rows. The `size()` of this `column_view` would be `75`, and accessing index `0` of 
-the view would return the element at index `75` of the owning `column`. Internally, this is 
-implemented by storing in the view a pointer, an offset, and a size. `column_view::data<T>()` 
+A `column_view` may be a view of a "slice" of a column. For example, it might view rows 75-150 of a
+column with 1000 rows. The `size()` of this `column_view` would be `75`, and accessing index `0` of
+the view would return the element at index `75` of the owning `column`. Internally, this is
+implemented by storing in the view a pointer, an offset, and a size. `column_view::data<T>()`
 returns a pointer iterator to `column_view::head<T>() + offset`.
 
 ### `cudf::mutable_column_view`
@@ -232,29 +232,29 @@ APIs that modify columns in place.
 
 ### `cudf::column_device_view`
 
-An immutable, non-owning view of device data as a column of elements that is trivially copyable and 
-usable in CUDA device code. Used to pass `column_view` data as input to CUDA kernels and device 
+An immutable, non-owning view of device data as a column of elements that is trivially copyable and
+usable in CUDA device code. Used to pass `column_view` data as input to CUDA kernels and device
 functions (including Thrust algorithms)
 
 ### `cudf::mutable_column_device_view`
 
-A mutable, non-owning view of device data as a column of elements that is trivially copyable and 
+A mutable, non-owning view of device data as a column of elements that is trivially copyable and
 usable in CUDA device code. Used to pass `column_view` data to be modified on the device by CUDA
 kernels and device functions (including Thrust algorithms).
 
 ## `cudf::table`
 
-Owning class for a set of `cudf::column`s all with equal number of elements. This is the C++ 
-equivalent to a data frame. 
+Owning class for a set of `cudf::column`s all with equal number of elements. This is the C++
+equivalent to a data frame.
 
 Implicitly convertible to `cudf::table_view` and `cudf::mutable_table_view`
 
-Movable and copyable. A copy performs a deep copy of all columns, whereas a move moves all columns 
+Movable and copyable. A copy performs a deep copy of all columns, whereas a move moves all columns
 from one table to another.
 
 ### `cudf::table_view`
 
-An *immutable*, non-owning view of a table. 
+An *immutable*, non-owning view of a table.
 
 ### `cudf::mutable_table_view`
 
@@ -263,20 +263,20 @@ A *mutable*, non-owning view of a table.
 ## Spans
 
 libcudf provides `span` classes that mimic C++20 `std::span`, which is a lightweight
-view of a contiguous sequence of objects. libcudf provides two classes, `host_span` and 
-`device_span`, which can be constructed from multiple container types, or from a pointer 
-(host or device, respectively) and size, or from iterators. `span` types are useful for defining 
+view of a contiguous sequence of objects. libcudf provides two classes, `host_span` and
+`device_span`, which can be constructed from multiple container types, or from a pointer
+(host or device, respectively) and size, or from iterators. `span` types are useful for defining
 generic (internal) interfaces which work with multiple input container types. `device_span` can be
-constructed from `thrust::device_vector`, `rmm::device_vector`, or `rmm::device_uvector`. 
+constructed from `thrust::device_vector`, `rmm::device_vector`, or `rmm::device_uvector`.
 `host_span` can be constructed from `thrust::host_vector`, `std::vector`, or `std::basic_string`.
 
-If you are definining internal (detail) functions that operate on vectors, use spans for the input 
+If you are defining internal (detail) functions that operate on vectors, use spans for the input
 vector parameters rather than a specific vector type, to make your functions more widely applicable.
 
 When a `span` refers to immutable elements, use `span<T const>`, not `span<T> const`. Since a span
 is lightweight view, it does not propagate `const`-ness. Therefore, `const` should be applied to
-the template type parameter, not to the `span` itself. Also, `span` should be passed by value 
-because it is a lightweight view. APIS in libcudf that take spans as input will look like the 
+the template type parameter, not to the `span` itself. Also, `span` should be passed by value
+because it is a lightweight view. APIS in libcudf that take spans as input will look like the
 following function that copies device data to a host `std::vector`.
 
 ```c++
@@ -286,15 +286,15 @@ std::vector<T> make_std_vector_async(device_span<T const> v, rmm::cuda_stream_vi
 
 ## `cudf::scalar`
 
-A `cudf::scalar` is an object that can represent a singular, nullable value of any of the types 
-currently supported by cudf. Each type of value is represented by a separate type of scalar class 
-which are all derived from `cudf::scalar`. e.g. A `numeric_scalar` holds a single numerical value, 
+A `cudf::scalar` is an object that can represent a singular, nullable value of any of the types
+currently supported by cudf. Each type of value is represented by a separate type of scalar class
+which are all derived from `cudf::scalar`. e.g. A `numeric_scalar` holds a single numerical value,
 a `string_scalar` holds a single string. The data for the stored value resides in device memory.
 
-A `list_scalar` holds the underlying data of a single list. This means the underlying data can be any type
-that cudf supports. For example, a `list_scalar` representing a list of integers stores a `cudf::column`
-of type `INT32`. A `list_scalar` representing a list of lists of integers stores a `cudf::column` of
-type `LIST`, which in turn stores a column of type `INT32`.
+A `list_scalar` holds the underlying data of a single list. This means the underlying data can be
+any type that cudf supports. For example, a `list_scalar` representing a list of integers stores a
+`cudf::column` of type `INT32`. A `list_scalar` representing a list of lists of integers stores a
+`cudf::column` of type `LIST`, which in turn stores a column of type `INT32`.
 
 |Value type|Scalar class|Notes|
 |-|-|-|
@@ -307,16 +307,16 @@ type `LIST`, which in turn stores a column of type `INT32`.
 |list|`list_scalar`| Underlying data can be any type supported by cudf |
 
 ### Construction
-`scalar`s can be created using either their respective constructors or using factory functions like 
-`make_numeric_scalar()`, `make_timestamp_scalar()` or `make_string_scalar()`. 
+`scalar`s can be created using either their respective constructors or using factory functions like
+`make_numeric_scalar()`, `make_timestamp_scalar()` or `make_string_scalar()`.
 
 ### Casting
-All the factory methods return a `unique_ptr<scalar>` which needs to be statically downcasted to 
-its respective scalar class type before accessing its value. Their validity (nullness) can be 
-accessed without casting. Generally, the value needs to be accessed from a function that is aware 
-of the value type e.g. a functor that is dispatched from `type_dispatcher`. To cast to the 
-requisite scalar class type given the value type, use the mapping utility `scalar_type_t` provided 
-in `type_dispatcher.hpp` : 
+All the factory methods return a `unique_ptr<scalar>` which needs to be statically downcasted to
+its respective scalar class type before accessing its value. Their validity (nullness) can be
+accessed without casting. Generally, the value needs to be accessed from a function that is aware
+of the value type e.g. a functor that is dispatched from `type_dispatcher`. To cast to the
+requisite scalar class type given the value type, use the mapping utility `scalar_type_t` provided
+in `type_dispatcher.hpp` :
 
 ```c++
 //unique_ptr<scalar> s = make_numeric_scalar(...);
@@ -328,8 +328,8 @@ auto s1 = static_cast<ScalarType *>(s.get());
 
 ### Passing to device
 Each scalar type, except `list_scalar`, has a corresponding non-owning device view class which allows
-access to the value and its validity from the device. This can be obtained using the function 
-`get_scalar_device_view(ScalarType s)`. Note that a device view is not provided for a base scalar 
+access to the value and its validity from the device. This can be obtained using the function
+`get_scalar_device_view(ScalarType s)`. Note that a device view is not provided for a base scalar
 object, only for the derived typed scalar class objects.
 
 The underlying data for `list_scalar` can be accessed via `view()` method. For non-nested data,
@@ -341,17 +341,17 @@ data, a specialized device view for list columns can be constructed via
 
 ## Streams
 
-CUDA streams are not yet exposed in external libcudf APIs. However, in order to ease the transition 
-to future use of streams, all libcudf APIs that allocate device memory or execute a kernel should be 
+CUDA streams are not yet exposed in external libcudf APIs. However, in order to ease the transition
+to future use of streams, all libcudf APIs that allocate device memory or execute a kernel should be
 implemented using asynchronous APIs on the default stream (e.g., stream 0).
 
-The recommended pattern for doing this is to make the definition of the external API invoke an 
-internal API in the `detail` namespace. The internal `detail` API has the same parameters as the 
-public API, plus a `rmm::cuda_stream_view` parameter at the end defaulted to 
-`rmm::cuda_stream_default`. The implementation should be wholly contained in the `detail` API 
+The recommended pattern for doing this is to make the definition of the external API invoke an
+internal API in the `detail` namespace. The internal `detail` API has the same parameters as the
+public API, plus a `rmm::cuda_stream_view` parameter at the end defaulted to
+`rmm::cuda_stream_default`. The implementation should be wholly contained in the `detail` API
 definition and use only asynchronous versions of CUDA APIs with the stream parameter.
 
-In order to make the `detail` API callable from other libcudf functions, it should be exposed in a 
+In order to make the `detail` API callable from other libcudf functions, it should be exposed in a
 header placed in the `cudf/cpp/include/detail/` directory.
 
 For example:
@@ -384,55 +384,57 @@ void external_function(...){
 ```
 
 **Note:** It is important to synchronize the stream if *and only if* it is necessary. For example,
-when a non-pointer value is returned from the API that is the result of an asynchronous 
+when a non-pointer value is returned from the API that is the result of an asynchronous
 device-to-host copy, the stream used for the copy should be synchronized before returning. However,
-when a column is returned, the stream should not be synchronized because doing so will break 
+when a column is returned, the stream should not be synchronized because doing so will break
 asynchrony if and when we add an asynchronous API to libcudf.
 
 **Note:** `cudaDeviceSynchronize()` should *never* be used.
- This limits the ability to do any multi-stream/multi-threaded work with libcudf APIs.
+This limits the ability to do any multi-stream/multi-threaded work with libcudf APIs.
 
  ### NVTX Ranges
 
- In order to aid in performance optimization and debugging, all compute intensive libcudf functions should have a corresponding NVTX range.
- In libcudf, we have a convenience macro `CUDF_FUNC_RANGE()` that will automatically annotate the lifetime of the enclosing function and use the functions name as the name of the NVTX range. 
- For more information about NVTX, see [here](https://github.com/NVIDIA/NVTX/tree/dev/cpp).
+In order to aid in performance optimization and debugging, all compute intensive libcudf functions
+should have a corresponding NVTX range. In libcudf, we have a convenience macro `CUDF_FUNC_RANGE()`
+that will automatically annotate the lifetime of the enclosing function and use the function's name
+as the name of the NVTX range. For more information about NVTX, see
+[here](https://github.com/NVIDIA/NVTX/tree/dev/cpp).
 
  ### Stream Creation
 
-There may be times in implementing libcudf features where it would be advantageous to use streams 
-*internally*, i.e., to accomplish overlap in implementing an algorithm. However, dynamically 
-creating a stream can be expensive. RMM has a stream pool class to help avoid dynamic stream 
-creation. However, this is not yet exposed in libcudf, so for the time being, libcudf features 
+There may be times in implementing libcudf features where it would be advantageous to use streams
+*internally*, i.e., to accomplish overlap in implementing an algorithm. However, dynamically
+creating a stream can be expensive. RMM has a stream pool class to help avoid dynamic stream
+creation. However, this is not yet exposed in libcudf, so for the time being, libcudf features
 should avoid creating streams (even if it is slightly less efficient). It is a good idea to leave a
 `// TODO:` note indicating where using a stream would be beneficial.
 
 ## Memory Allocation
 
-Device [memory resources](#memory_resource) are used in libcudf to abstract and control how device 
-memory is allocated. 
+Device [memory resources](#memory_resource) are used in libcudf to abstract and control how device
+memory is allocated.
 
 ### Output Memory
 
-Any libcudf API that allocates memory that is *returned* to a user must accept a pointer to a 
+Any libcudf API that allocates memory that is *returned* to a user must accept a pointer to a
 `device_memory_resource` as the last parameter. Inside the API, this memory resource must be used
 to allocate any memory for returned objects. It should therefore be passed into functions whose
 outputs will be returned. Example:
 
 ```c++
-// Returned `column` contains newly allocated memory, 
+// Returned `column` contains newly allocated memory,
 // therefore the API must accept a memory resource pointer
 std::unique_ptr<column> returns_output_memory(
   ..., rmm::device_memory_resource * mr = rmm::mr::get_current_device_resource());
 
 // This API does not allocate any new *output* memory, therefore
 // a memory resource is unnecessary
-void does_not_allocate_output_memory(...);                                              
+void does_not_allocate_output_memory(...);
 ```
 
 ### Temporary Memory
 
-Not all memory allocated within a libcudf API is returned to the caller. Often algorithms must 
+Not all memory allocated within a libcudf API is returned to the caller. Often algorithms must
 allocate temporary, scratch memory for intermediate results. Always use the default resource
 obtained from `rmm::mr::get_current_device_resource()` for temporary memory allocations. Example:
 
@@ -453,70 +455,70 @@ libcudf code generally eschews raw pointers and direct memory allocation. Use RM
 use `device_memory_resource`(*)s for device memory allocation with automated lifetime management.
 
 #### `rmm::device_buffer`
-Allocates a specified number of bytes of untyped, uninitialized device memory using a 
-`device_memory_resource`. If no resource is explicitly provided, uses 
-`rmm::mr::get_current_device_resource()`. 
+Allocates a specified number of bytes of untyped, uninitialized device memory using a
+`device_memory_resource`. If no resource is explicitly provided, uses
+`rmm::mr::get_current_device_resource()`.
 
-`rmm::device_buffer` is movable and copyable on a stream. A copy performs a deep copy of the 
-`device_buffer`'s device memory on the specified stream, whereas a move moves ownership of the 
+`rmm::device_buffer` is movable and copyable on a stream. A copy performs a deep copy of the
+`device_buffer`'s device memory on the specified stream, whereas a move moves ownership of the
 device memory from one `device_buffer` to another.
 
 ```c++
-// Allocates at least 100 bytes of uninitialized device memory 
+// Allocates at least 100 bytes of uninitialized device memory
 // using the specified resource and stream
-rmm::device_buffer buff(100, stream, mr); 
+rmm::device_buffer buff(100, stream, mr);
 void * raw_data = buff.data(); // Raw pointer to underlying device memory
 
 // Deep copies `buff` into `copy` on `stream`
-rmm::device_buffer copy(buff, stream); 
+rmm::device_buffer copy(buff, stream);
 
 // Moves contents of `buff` into `moved_to`
-rmm::device_buffer moved_to(std::move(buff)); 
+rmm::device_buffer moved_to(std::move(buff));
 
 custom_memory_resource *mr...;
 // Allocates 100 bytes from the custom_memory_resource
-rmm::device_buffer custom_buff(100, mr, stream); 
+rmm::device_buffer custom_buff(100, mr, stream);
 ```
 
 #### `rmm::device_scalar<T>`
-Allocates a single element of the specified type initialized to the specified value. Use this for 
-scalar input/outputs into device kernels, e.g., reduction results, null count, etc. This is 
+Allocates a single element of the specified type initialized to the specified value. Use this for
+scalar input/outputs into device kernels, e.g., reduction results, null count, etc. This is
 effectively a convenience wrapper around a `rmm::device_vector<T>` of length 1.
 
 ```c++
 // Allocates device memory for a single int using the specified resource and stream
 // and initializes the value to 42
-rmm::device_scalar<int> int_scalar{42, stream, mr}; 
+rmm::device_scalar<int> int_scalar{42, stream, mr};
 
 // scalar.data() returns pointer to value in device memory
 kernel<<<...>>>(int_scalar.data(),...);
 
-// scalar.value() synchronizes the scalar's stream and copies the 
+// scalar.value() synchronizes the scalar's stream and copies the
 // value from device to host and returns the value
 int host_value = int_scalar.value();
 ```
 
 #### `rmm::device_vector<T>`
 
-Allocates a specified number of elements of the specified type. If no initialization value is 
+Allocates a specified number of elements of the specified type. If no initialization value is
 provided, all elements are default initialized (this incurs a kernel launch).
 
 **Note**: We have removed all usage of `rmm::device_vector` and `thrust::device_vector` from
-libcudf, and you should not use it in new code in libcudf without careful consideration. Instead, 
-use `rmm::device_uvector` along with the utility factories in `device_factories.hpp`. These 
+libcudf, and you should not use it in new code in libcudf without careful consideration. Instead,
+use `rmm::device_uvector` along with the utility factories in `device_factories.hpp`. These
 utilities enable creation of `uvector`s from host-side vectors, or creating zero-initialized
 `uvector`s, so that they are as convenient to use as `device_vector`. Avoiding `device_vector` has
 a number of benefits, as described in the following section on `rmm::device_uvector`.
 
 #### `rmm::device_uvector<T>`
 
-Similar to a `device_vector`, allocates a contiguous set of elements in device memory but with key 
+Similar to a `device_vector`, allocates a contiguous set of elements in device memory but with key
 differences:
 - As an optimization, elements are uninitialized and no synchronization occurs at construction.
 This limits the types `T` to trivially copyable types.
-- All operations are stream ordered (i.e., they accept a `cuda_stream_view` specifying the stream 
+- All operations are stream ordered (i.e., they accept a `cuda_stream_view` specifying the stream
 on which the operation is performed). This improves safety when using non-default streams.
-- `device_uvector.hpp` does not include any `__device__` code, unlike `thrust/device_vector.hpp`, 
+- `device_uvector.hpp` does not include any `__device__` code, unlike `thrust/device_vector.hpp`,
   which means `device_uvector`s can be used in `.cpp` files, rather than just in `.cu` files.
 
 ```c++
@@ -525,21 +527,21 @@ cuda_stream s;
 // default resource
 rmm::device_uvector<int32_t> v(100, s);
 // Initializes the elements to 0
-thrust::uninitialized_fill(thrust::cuda::par.on(s.value()), v.begin(), v.end(), int32_t{0}); 
+thrust::uninitialized_fill(thrust::cuda::par.on(s.value()), v.begin(), v.end(), int32_t{0});
 
 rmm::mr::device_memory_resource * mr = new my_custom_resource{...};
 // Allocates uninitialized storage for 100 `int32_t` elements on stream `s` using the resource `mr`
-rmm::device_uvector<int32_t> v2{100, s, mr}; 
+rmm::device_uvector<int32_t> v2{100, s, mr};
 ```
 
 ## Input/Output Style<a name="inout_style"></a>
 
 The preferred style for how inputs are passed in and outputs are returned is the following:
--   Inputs
-	- Columns:
-		- `column_view const&`
-	- Tables:
-		- `table_view const&`
+- Inputs
+  - Columns:
+    - `column_view const&`
+  - Tables:
+    - `table_view const&`
     - Scalar:
         - `scalar const&`
     - Everything else:
@@ -547,30 +549,30 @@ The preferred style for how inputs are passed in and outputs are returned is the
           - Pass by value
        - Non-trivial or expensive to copy types
           - Pass by `const&`
--   In/Outs  
-	- Columns:
-		- `mutable_column_view&`
-	- Tables:
-		- `mutable_table_view&`
+- In/Outs
+  - Columns:
+    - `mutable_column_view&`
+  - Tables:
+    - `mutable_table_view&`
     - Everything else:
         - Pass by via raw pointer
--   Outputs 
-	- Outputs should be *returned*, i.e., no output parameters
-	- Columns:
-		- `std::unique_ptr<column>`
-	- Tables:
-		- `std::unique_ptr<table>`
+- Outputs
+  - Outputs should be *returned*, i.e., no output parameters
+  - Columns:
+    - `std::unique_ptr<column>`
+  - Tables:
+    - `std::unique_ptr<table>`
     - Scalars:
         - `std::unique_ptr<scalar>`
 
 
 ### Multiple Return Values
 
-Sometimes it is necessary for functions to have multiple outputs. There are a few ways this can be 
-done in C++ (including creating a `struct` for the output). One convenient way to do this is 
-using `std::tie`  and `std::make_pair`. Note that objects passed to `std::make_pair` will invoke 
-either the copy constructor or the move constructor of the object, and it may be preferable to move 
-non-trivially copyable objects (and required for types with deleted copy constructors, like 
+Sometimes it is necessary for functions to have multiple outputs. There are a few ways this can be
+done in C++ (including creating a `struct` for the output). One convenient way to do this is
+using `std::tie`  and `std::make_pair`. Note that objects passed to `std::make_pair` will invoke
+either the copy constructor or the move constructor of the object, and it may be preferable to move
+non-trivially copyable objects (and required for types with deleted copy constructors, like
 `std::unique_ptr`).
 
 ```c++
@@ -579,7 +581,7 @@ std::pair<table, table> return_two_tables(void){
   cudf::table out1;
   ...
   // Do stuff with out0, out1
-  
+
   // Return a std::pair of the two outputs
   return std::make_pair(std::move(out0), std::move(out1));
 }
@@ -589,19 +591,20 @@ cudf::table out1;
 std::tie(out0, out1) = cudf::return_two_outputs();
 ```
 
-Note:  `std::tuple`  _could_  be used if not for the fact that Cython does not support 
-`std::tuple`. Therefore, libcudf APIs must use `std::pair`, and are therefore limited to return 
-only two objects of different types. Multiple objects of the same type may be returned via a 
+Note: `std::tuple` _could_ be used if not for the fact that Cython does not support
+`std::tuple`. Therefore, libcudf APIs must use `std::pair`, and are therefore limited to return
+only two objects of different types. Multiple objects of the same type may be returned via a
 `std::vector<T>`.
 
-Alternatively, with C++17 (supported from cudf v0.20), [structured binding](https://en.cppreference.com/w/cpp/language/structured_binding) 
+Alternatively, with C++17 (supported from cudf v0.20),
+[structured binding](https://en.cppreference.com/w/cpp/language/structured_binding)
 may be used to disaggregate multiple return values:
 
 ```c++
 auto [out0, out1] = cudf::return_two_outputs();
 ```
 
-Note that the compiler might not support capturing aliases defined in a structured binding 
+Note that the compiler might not support capturing aliases defined in a structured binding
 in a lambda. One may work around this by using a capture with an initializer instead:
 
 ```c++
@@ -620,10 +623,10 @@ auto foo = [&out0 = out0] {
 
 ## Iterator-based interfaces
 
-Increasingly, libcudf is moving toward internal (`detail`) APIs with iterator parameters rather 
-than explicit `column`/`table`/`scalar` parameters. As with STL, iterators enable generic 
-algorithms to be applied to arbitrary containers. A good example of this is `cudf::copy_if_else`. 
-This function takes two inputs, and a Boolean mask. It copies the corresponding element from the 
+Increasingly, libcudf is moving toward internal (`detail`) APIs with iterator parameters rather
+than explicit `column`/`table`/`scalar` parameters. As with STL, iterators enable generic
+algorithms to be applied to arbitrary containers. A good example of this is `cudf::copy_if_else`.
+This function takes two inputs, and a Boolean mask. It copies the corresponding element from the
 first or second input depending on whether the mask at that index is `true` or `false`. Implementing
 `copy_if_else` for all combinations of `column` and `scalar` parameters is simplified by using
 iterators in the `detail` API.
@@ -638,15 +641,15 @@ std::unique_ptr<column> copy_if_else(
   FilterFn filter,
   ...);
 ```
-`LeftIter` and `RightIter` need only implement the necessary interface for an iterator. libcudf 
-provides a number of iterator types and utilities that are useful with iterator-based APIs from 
-libcudf as well as Thrust algorithms. Most are defined in `include/detail/iterator.cuh`. 
+`LeftIter` and `RightIter` need only implement the necessary interface for an iterator. libcudf
+provides a number of iterator types and utilities that are useful with iterator-based APIs from
+libcudf as well as Thrust algorithms. Most are defined in `include/detail/iterator.cuh`.
 
 ### Pair iterator
 
-The pair iterator is used to access elements of nullable columns as a pair containing an element's 
-value and validity. `cudf::detail::make_pair_iterator` can be used to create a pair iterator from a 
-`column_device_view` or a `cudf::scalar`. `make_pair_iterator` is not available for 
+The pair iterator is used to access elements of nullable columns as a pair containing an element's
+value and validity. `cudf::detail::make_pair_iterator` can be used to create a pair iterator from a
+`column_device_view` or a `cudf::scalar`. `make_pair_iterator` is not available for
 `mutable_column_device_view`.
 
 ### Null-replacement iterator
@@ -656,20 +659,20 @@ This iterator replaces the null/validity value for each element with a specified
 
 ### Validity iterator
 
-This iterator returns the validity of the underlying element (`true` or `false`). Created using 
+This iterator returns the validity of the underlying element (`true` or `false`). Created using
 `cudf::detail::make_validity_iterator`.
 
 ### Index-normalizing iterators
 
 The proliferation of data types supported by libcudf can result in long compile times. One area
 where compile time was a problem is in types used to store indices, which can be any integer type.
-The "Indexalator", or index-normalizing iterator (`include/cudf/detail/indexalator.cuh`), can be 
-used for index types (integers) without requiring a type-specific instance. It can be used for any 
-iterator interface for reading an array of integer values of type `int8`, `int16`, `int32`, 
-`int64`, `uint8`, `uint16`, `uint32`, or `uint64`. Reading specific elements always return a 
+The "Indexalator", or index-normalizing iterator (`include/cudf/detail/indexalator.cuh`), can be
+used for index types (integers) without requiring a type-specific instance. It can be used for any
+iterator interface for reading an array of integer values of type `int8`, `int16`, `int32`,
+`int64`, `uint8`, `uint16`, `uint32`, or `uint64`. Reading specific elements always return a
 `cudf::size_type` integer.
 
-Use the `indexalator_factory` to create an appropriate input iterator from a column_view. Example 
+Use the `indexalator_factory` to create an appropriate input iterator from a column_view. Example
 input iterator usage:
 
 ```c++
@@ -701,20 +704,20 @@ namespace cudf{
 } // namespace cudf
 ```
 
-The top-level `cudf` namespace is sufficient for most of the public API. However, to logically 
-group a broad set of functions, further namespaces may be used. For example, there are numerous 
-functions that are specific to columns of Strings. These functions reside in the `cudf::strings::` 
-namespace. Similarly, functionality used exclusively for unit testing is in the `cudf::test::` 
-namespace. 
+The top-level `cudf` namespace is sufficient for most of the public API. However, to logically
+group a broad set of functions, further namespaces may be used. For example, there are numerous
+functions that are specific to columns of Strings. These functions reside in the `cudf::strings::`
+namespace. Similarly, functionality used exclusively for unit testing is in the `cudf::test::`
+namespace.
 
 ### Internal
 
-Many functions are not meant for public use, so place them in either the `detail` or an *anonymous* 
+Many functions are not meant for public use, so place them in either the `detail` or an *anonymous*
 namespace, depending on the situation.
 
 #### `detail` namespace
 
-Functions or objects that will be used across *multiple* translation units (i.e., source files), 
+Functions or objects that will be used across *multiple* translation units (i.e., source files),
 should be exposed in an internal header file and placed in the `detail` namespace. Example:
 
 ```c++
@@ -728,7 +731,7 @@ void reusable_helper_function(...);
 
 #### Anonymous namespace
 
-Functions or objects that will only be used in a *single* translation unit should be defined in an 
+Functions or objects that will only be used in a *single* translation unit should be defined in an
 *anonymous* namespace in the source file where it is used. Example:
 
 ```c++
@@ -738,12 +741,12 @@ void isolated_helper_function(...);
 } // anonymous namespace
 ```
 
-[**Anonymous namespaces should *never* be used in a header file.**](https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL59-CPP.+Do+not+define+an+unnamed+namespace+in+a+header+file) 
+[**Anonymous namespaces should *never* be used in a header file.**](https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL59-CPP.+Do+not+define+an+unnamed+namespace+in+a+header+file)
 
 # Error Handling
 
-libcudf follows conventions (and provides utilities) enforcing compile-time and run-time 
-conditions and detecting and handling CUDA errors. Communication of errors is always via C++ 
+libcudf follows conventions (and provides utilities) enforcing compile-time and run-time
+conditions and detecting and handling CUDA errors. Communication of errors is always via C++
 exceptions.
 
 ## Runtime Conditions
@@ -755,13 +758,14 @@ Example usage:
 CUDF_EXPECTS(lhs.type() == rhs.type(), "Column type mismatch");
 ```
 
-The first argument is the conditional expression expected to resolve to  `true`  under normal 
-conditions. If the conditional evaluates to  `false`, then an error has occurred and an instance of  `cudf::logic_error` is thrown. The second argument to  `CUDF_EXPECTS` is a short description of the 
-error that has occurred and is used for the exception's `what()` message. 
+The first argument is the conditional expression expected to resolve to `true` under normal
+conditions. If the conditional evaluates to `false`, then an error has occurred and an instance of
+`cudf::logic_error` is thrown. The second argument to `CUDF_EXPECTS` is a short description of the
+error that has occurred and is used for the exception's `what()` message.
 
-There are times where a particular code path, if reached, should indicate an error no matter what. 
-For example, often the `default` case of a `switch` statement represents an invalid alternative. 
-Use the `CUDF_FAIL` macro for such errors. This is effectively the same as calling 
+There are times where a particular code path, if reached, should indicate an error no matter what.
+For example, often the `default` case of a `switch` statement represents an invalid alternative.
+Use the `CUDF_FAIL` macro for such errors. This is effectively the same as calling
 `CUDF_EXPECTS(false, reason)`.
 
 Example:
@@ -771,9 +775,9 @@ CUDF_FAIL("This code path should not be reached.");
 
 ### CUDA Error Checking
 
-Use the `CUDA_TRY` macro to check for the successful completion of CUDA runtime API functions. This 
-macro throws a `cudf::cuda_error` exception if the CUDA API return value is not `cudaSuccess`. The 
-thrown exception includes a description of the CUDA error code in it's  `what()`  message.
+Use the `CUDA_TRY` macro to check for the successful completion of CUDA runtime API functions. This
+macro throws a `cudf::cuda_error` exception if the CUDA API return value is not `cudaSuccess`. The
+thrown exception includes a description of the CUDA error code in its `what()` message.
 
 Example:
 
@@ -788,7 +792,7 @@ Use `static_assert` to enforce compile-time conditions. For example,
 ```c++
 template <typename T>
 void trivial_types_only(T t){
-   static_assert(std::is_trivial<T>::value, "This function requires a trivial type.");
+  static_assert(std::is_trivial<T>::value, "This function requires a trivial type.");
 ...
 }
 ```
@@ -807,7 +811,7 @@ Columns may contain data of a number of types (see `enum class type_id` in `incl
  * Lists of any type
  * Structs of columns of any type
 
-Most algorithms must support columns of any data type. This leads to complexity in the code, and 
+Most algorithms must support columns of any data type. This leads to complexity in the code, and
 is one of the primary challenges a libcudf developer faces. Sometimes we develop new algorithms with
 gradual support for more data types to make this easier. Typically we start with fixed-width data
 types such as numeric types and timestamps/durations, adding support for nested types later.
@@ -817,21 +821,21 @@ as discussed in [Specializing Type-Dispatched Code Paths](#specializing-type-dis
 
 # Type Dispatcher
 
-libcudf stores data (for columns and scalars) "type erased" in `void*` device memory. This 
-*type-erasure* enables interoperability with other languages and type systems, such as Python and 
-Java. In order to determine the type, libcudf algorithms must use the run-time information stored 
-in the column `type()` to reconstruct the data type `T` by casting the `void*` to the appropriate 
+libcudf stores data (for columns and scalars) "type erased" in `void*` device memory. This
+*type-erasure* enables interoperability with other languages and type systems, such as Python and
+Java. In order to determine the type, libcudf algorithms must use the run-time information stored
+in the column `type()` to reconstruct the data type `T` by casting the `void*` to the appropriate
 `T*`.
 
-This so-called *type dispatch* is pervasive throughout libcudf. The `type_dispatcher` is a 
-central utility that automates the process of mapping the runtime type information in `data_type` 
+This so-called *type dispatch* is pervasive throughout libcudf. The `type_dispatcher` is a
+central utility that automates the process of mapping the runtime type information in `data_type`
 to a concrete C++ type.
 
-At a high level, you call the `type_dispatcher` with a `data_type` and a function object (also 
-known as a *functor*) with an `operator()` template. Based on the value of `data_type::id()`, the 
-type dispatcher invokes the corresponding instantiation of the `operator()` template. 
+At a high level, you call the `type_dispatcher` with a `data_type` and a function object (also
+known as a *functor*) with an `operator()` template. Based on the value of `data_type::id()`, the
+type dispatcher invokes the corresponding instantiation of the `operator()` template.
 
-This simplified example shows how the value of `data_type::id()` determines which instantiation of 
+This simplified example shows how the value of `data_type::id()` determines which instantiation of
 the `F::operator()` template is invoked.
 
 ```c++
@@ -845,7 +849,7 @@ void type_dispatcher(data_type t, F f){
 }
 ```
 
-The following example shows a function object called `size_of_functor` that returns the size of the 
+The following example shows a function object called `size_of_functor` that returns the size of the
 dispatched type.
 
 ```c++
@@ -859,9 +863,9 @@ cudf::type_dispatcher(data_type{type_id::INT32}, size_of_functor{});  // returns
 cudf::type_dispatcher(data_type{type_id::FLOAT64}, size_of_functor{});  // returns 8
 ```
 
-By default, `type_dispatcher` uses `cudf::type_to_id<t>` to provide the mapping of `cudf::type_id` 
-to dispatched C++ types. However, this mapping may be customized by explicitly specifying a 
-user-defined trait for the `IdTypeMap`. For example, to always dispatch `int32_t` for all values of 
+By default, `type_dispatcher` uses `cudf::type_to_id<t>` to provide the mapping of `cudf::type_id`
+to dispatched C++ types. However, this mapping may be customized by explicitly specifying a
+user-defined trait for the `IdTypeMap`. For example, to always dispatch `int32_t` for all values of
 `cudf::type_id`:
 
 ```c++
@@ -873,18 +877,18 @@ cudf::type_dispatcher<always_int>(data_type, f);
 
 ## Avoid Multiple Type Dispatch
 
-Avoid multiple type-dispatch if possible. The compiler creates a code path for every type 
-dispatched, so a second-level type dispatch results in quadratic growth in compilation time and 
+Avoid multiple type-dispatch if possible. The compiler creates a code path for every type
+dispatched, so a second-level type dispatch results in quadratic growth in compilation time and
 object code size. As a large library with many types and functions, we are constantly working to
 reduce compilation time and code size.
 
 ## Specializing Type-Dispatched Code Paths
 
-It is often necessary to customize the dispatched `operator()` for different types. This can be 
+It is often necessary to customize the dispatched `operator()` for different types. This can be
 done in several ways.
 
-The first method is to use explicit, full template specialization. This is useful for specializing 
-behavior for single types. The following example function object prints `"int32_t"` or `"double"` 
+The first method is to use explicit, full template specialization. This is useful for specializing
+behavior for single types. The following example function object prints `"int32_t"` or `"double"`
 when invoked with either of those types, or `"unhandled type"` otherwise.
 
 ```c++
@@ -902,8 +906,8 @@ template <>
 void type_printer::operator()<double>() { std::cout << "double\n"; }
 ```
 
-The second method is to use [SFINAE](https://en.cppreference.com/w/cpp/language/sfinae) with 
-`std::enable_if_t`. This is useful to partially specialize for a set of types with a common trait. 
+The second method is to use [SFINAE](https://en.cppreference.com/w/cpp/language/sfinae) with
+`std::enable_if_t`. This is useful to partially specialize for a set of types with a common trait.
 The following example functor prints `integral` or `floating point` for integral or floating point
 types, respectively.
 
@@ -911,7 +915,7 @@ types, respectively.
 struct integral_or_floating_point {
 template <typename ColumnType,
           std::enable_if_t<not std::is_integral<ColumnType>::value and
-                           not std::is_floating_point<ColumnType>::value>* = nullptr> 
+                           not std::is_floating_point<ColumnType>::value>* = nullptr>
 void operator()() { std::cout << "neither integral nor floating point\n"; }
 
 template <typename ColumnType,
@@ -919,33 +923,33 @@ template <typename ColumnType,
 void operator()() { std::cout << "integral\n"; }
 
 template < typename ColumnType,
-           std::enable_if_t<std::is_floating_point<ColumnType>::value>* = nullptr> 
+           std::enable_if_t<std::is_floating_point<ColumnType>::value>* = nullptr>
 void operator()() { std::cout << "floating point\n"; }
 };
 ```
 
 For more info on SFINAE with `std::enable_if`, [see this post](https://eli.thegreenplace.net/2014/sfinae-and-enable_if).
 
-There are a number of traits defined in `include/cudf/utilities/traits.hpp` that are useful for 
-partial specialization of dispatched function objects. For example `is_numeric<T>()` can be used to 
+There are a number of traits defined in `include/cudf/utilities/traits.hpp` that are useful for
+partial specialization of dispatched function objects. For example `is_numeric<T>()` can be used to
 specialize for any numeric type.
 
 # Variable-Size and Nested Data Types
 
-libcudf supports a number of variable-size and nested data types, including strings, lists, and 
-structs. 
- 
- * `string`: Simply a character string, but a column of strings may have a different-length string 
+libcudf supports a number of variable-size and nested data types, including strings, lists, and
+structs.
+
+ * `string`: Simply a character string, but a column of strings may have a different-length string
    in each row.
- * `list`: A list of elements of any type, so a column of lists of integers has rows with a list of 
-   integers, possibly of a different length, in each row. 
+ * `list`: A list of elements of any type, so a column of lists of integers has rows with a list of
+   integers, possibly of a different length, in each row.
  * `struct`: In a column of structs, each row is a structure comprising one or more fields. These
    fields are stored in structure-of-arrays format, so that the column of structs has a nested
-   column for each field of the structure. 
+   column for each field of the structure.
 
-As the heading implies, list and struct columns may be nested arbitrarily. One may create a column 
-of lists of structs, where the fields of the struct may be of any type, including strings, lists and 
-structs. Thinking about deeply nested data types can be confusing for column-based data, even with 
+As the heading implies, list and struct columns may be nested arbitrarily. One may create a column
+of lists of structs, where the fields of the struct may be of any type, including strings, lists and
+structs. Thinking about deeply nested data types can be confusing for column-based data, even with
 experience. Therefore it is important to carefully write algorithms, and to test and document them
 well.
 
@@ -954,13 +958,13 @@ well.
 In order to represent variable-width elements, libcudf columns contain a vector of child columns.
 For list columns, the parent column's type is `LIST` and contains no data, but its size represents
 the number of lists in the column, and its null mask represents the validity of each list element.
-The parent has two children. 
+The parent has two children.
 
 1. A non-nullable column of `INT32` elements that indicates the offset to the beginning of each list
    in a dense column of elements.
-2. A column containing the actual data and optional null mask for all elements of all the lists 
+2. A column containing the actual data and optional null mask for all elements of all the lists
    packed together.
-   
+
 With this representation, `data[offsets[i]]` is the first element of list `i`, and the size of list
 `i` is given by `offsets[i+1] - offsets[i]`.
 
@@ -969,9 +973,9 @@ of any type. Note also that not only is each list nullable (using the null mask 
 each list element may be nullable. So you may have a lists column with null row 3, and also null
 element 2 of row 4.
 
-The underlying data for a lists column is always bundled into a single leaf column at the very 
-bottom of the hierarchy (ignoring structs, which conceptually "reset" the root of the hierarchy), 
-regardless of the level of nesting. So a `List<List<List<List<int>>>>>` column has a single `int` 
+The underlying data for a lists column is always bundled into a single leaf column at the very
+bottom of the hierarchy (ignoring structs, which conceptually "reset" the root of the hierarchy),
+regardless of the level of nesting. So a `List<List<List<List<int>>>>` column has a single `int`
 column at the very bottom. The following is a visual representation of this.
 
 ```
@@ -999,17 +1003,17 @@ This is related to [Arrow's "Variable-Size List" memory layout](https://arrow.ap
 
 ## Strings columns
 
-Strings are represented in much the same way as lists, except that the data child column is always 
+Strings are represented in much the same way as lists, except that the data child column is always
 a non-nullable column of `INT8` data. The parent column's type is `STRING` and contains no data,
-but its size represents the number of strings in the column, and its null mask represents the 
+but its size represents the number of strings in the column, and its null mask represents the
 validity of each string. To summarize, the strings column children are:
 
-1. A non-nullable column of `INT32` elements that indicates the offset to the beginning of each 
+1. A non-nullable column of `INT32` elements that indicates the offset to the beginning of each
    string in a dense column of all characters.
-2. A non-nullable column of `INT8` elements of all the characters across all the strings packed 
+2. A non-nullable column of `INT8` elements of all the characters across all the strings packed
    together.
 
-With this representation, `characters[offsets[i]]` is the first character of string `i`, and the 
+With this representation, `characters[offsets[i]]` is the first character of string `i`, and the
 size of string `i` is given by `offsets[i+1] - offsets[i]`. The following image shows an example of
 this compound column representation of strings.
 
@@ -1028,10 +1032,10 @@ null mask represents the validity of each struct element.
 With this representation, `child[0][10]` is row 10 of the first field of the struct, `child[1][42]`
 is row 42 of the second field of the struct.
 
-Notice that in addition to the struct column's null mask, each struct field column has its own optional null
-mask. A struct field's validity can vary independently from the corresponding struct row. For
-instance, a non-null struct row might have a null field. However, the fields of a null struct row
-are deemed to be null as well. For example, consider a struct column of type 
+Notice that in addition to the struct column's null mask, each struct field column has its own
+optional null mask. A struct field's validity can vary independently from the corresponding struct
+row. For instance, a non-null struct row might have a null field. However, the fields of a null
+struct row are deemed to be null as well. For example, consider a struct column of type
 `STRUCT<FLOAT32, INT32>`. If the contents are `[ {1.0, 2}, {4.0, 5}, null, {8.0, null} ]`, the
 struct column's layout is as follows. (Note that null masks should be read from right to left.)
 
@@ -1041,46 +1045,46 @@ struct column's layout is as follows. (Note that null masks should be read from 
   null_mask = [1, 1, 0, 1]
   null_count = 1
   children = {
-    {   
+    {
       type = FLOAT32
       data =       [1.0, 4.0, X, 8.0]
       null_mask  = [  1,   1, 0,   1]
       null_count = 1
-    },  
-    {   
+    },
+    {
       type = INT32
       data =       [2, 5, X, X]
       null_mask  = [1, 1, 0, 0]
       null_count = 2
-    }  
-  }   
+    }
+  }
 }
 ```
 
-The last struct row (index 3) is not null, but has a null value in the INT32 field. Also, row 2 of 
-the struct column is null, making its corresponding fields also null. Therefore, bit 2 is unset in 
+The last struct row (index 3) is not null, but has a null value in the INT32 field. Also, row 2 of
+the struct column is null, making its corresponding fields also null. Therefore, bit 2 is unset in
 the null masks of both struct fields.
 
 ## Dictionary columns
 
-Dictionaries provide an efficient way to represent low-cardinality data by storing a single copy 
-of each value. A dictionary comprises a column of sorted keys and a column containing an index into 
-the keys column for each row of the parent column. The keys column may have any libcudf data type, 
-such as a numerical type or strings. The indices represent the corresponding positions of each 
-element's value in the keys. The indices child column can have any unsigned integer type 
+Dictionaries provide an efficient way to represent low-cardinality data by storing a single copy
+of each value. A dictionary comprises a column of sorted keys and a column containing an index into
+the keys column for each row of the parent column. The keys column may have any libcudf data type,
+such as a numerical type or strings. The indices represent the corresponding positions of each
+element's value in the keys. The indices child column can have any unsigned integer type
 (`UINT8`, `UINT16`, `UINT32`, or `UINT64`).
 
 ## Nested column challenges
 
-The first challenge with nested columns is that it is effectively impossible to do any operation 
-that modifies the length of any string or list in place. For example, consider trying to append the 
+The first challenge with nested columns is that it is effectively impossible to do any operation
+that modifies the length of any string or list in place. For example, consider trying to append the
 character `'a'` to the end of each string. This requires dynamically resizing the characters column
-to allow inserting `'a'` at the end of each string, and then modifying the offsets column to 
+to allow inserting `'a'` at the end of each string, and then modifying the offsets column to
 indicate the new size of each element. As a result, every operation that can modify the strings or
 lists in a column must be done out-of-place.
 
 The second challenge is that in an out-of-place operation on a strings column, unlike with fixed-
-width elements, the size of the output cannot be known *a priori*. For example, consider scattering 
+width elements, the size of the output cannot be known *a priori*. For example, consider scattering
 into a column of strings:
 
 ```c++
@@ -1092,7 +1096,7 @@ result:         {"this", "red", "a", "green", "of", "blue"}
 ```
 
 In this example, the strings "red", "green", and "blue" will respectively be scattered into
-positions `1`, `3`, and `5` of `destination`. Recall from above that this operation cannot be done 
+positions `1`, `3`, and `5` of `destination`. Recall from above that this operation cannot be done
 in place, therefore `result` will be generated by selectively copying strings from `destination` and
 `scatter_values`. Notice that `result`'s child column of characters requires storage for `19`
 characters. However, there is no way to know ahead of time that `result` will require `19`
@@ -1104,9 +1108,9 @@ approach:
 2. Allocate sufficient storage for all of the output characters and materialize each output string.
 
 In scatter, the first phase consists of using the `scatter_map` to determine whether string `i` in
-the output will come from `destination` or from `scatter_values` and use the corresponding size(s) 
-to materialize the offsets column and determine the size of the output. Then, in the second phase, 
-sufficient storage is allocated for the output's characters, and then the characters are filled 
+the output will come from `destination` or from `scatter_values` and use the corresponding size(s)
+to materialize the offsets column and determine the size of the output. Then, in the second phase,
+sufficient storage is allocated for the output's characters, and then the characters are filled
 with the corresponding strings from either `destination` or `scatter_values`.
 
 ## Nested Type Views
@@ -1115,15 +1119,15 @@ libcudf provides view types for nested column types as well as for the data elem
 
 ### `cudf::strings_column_view` and `cudf::string_view`
 
-`cudf::strings_column_view` is a view of a strings column, like `cudf::column_view` is a view of 
-any `cudf::column`. `cudf::string_view` is a view of a single string, and therefore 
+`cudf::strings_column_view` is a view of a strings column, like `cudf::column_view` is a view of
+any `cudf::column`. `cudf::string_view` is a view of a single string, and therefore
 `cudf::string_view` is the data type of a `cudf::column` of type `STRING` just like `int32_t` is the
-data type for a `cudf::column` of type `INT32`. As it's name implies, this is a read-only object 
+data type for a `cudf::column` of type `INT32`. As it's name implies, this is a read-only object
 instance that points to device memory inside the strings column. It's lifespan is the same (or less)
 as the column it views.
 
 Use the `column_device_view::element` method to access an individual row element. Like any other
-column, do not call `element()` on a row that is null. 
+column, do not call `element()` on a row that is null.
 
 ```c++
    cudf::column_device_view d_strings;
@@ -1134,11 +1138,11 @@ column, do not call `element()` on a row that is null.
    }
 ```
 
-A null string is not the same as an empty string. Use the `string_scalar` class if you need an 
+A null string is not the same as an empty string. Use the `string_scalar` class if you need an
 instance of a class object to represent a null string.
 
-The `string_view` contains comparison operators `<,>,==,<=,>=` that can be used in many cudf 
-functions like `sort` without string-specific code. The data for a `string_view` instance is 
+The `string_view` contains comparison operators `<,>,==,<=,>=` that can be used in many cudf
+functions like `sort` without string-specific code. The data for a `string_view` instance is
 required to be [UTF-8](#UTF-8) and all operators and methods expect this encoding. Unless documented
 otherwise, position and length parameters are specified in characters and not bytes. The class also
 includes a `string_view::const_iterator` which can be used to navigate through individual characters
@@ -1148,13 +1152,13 @@ within the string.
 
 #### UTF-8
 
-The libcudf strings column only supports UTF-8 encoding for strings data. 
-[UTF-8](https://en.wikipedia.org/wiki/UTF-8) is a variable-length character encoding wherein each 
+The libcudf strings column only supports UTF-8 encoding for strings data.
+[UTF-8](https://en.wikipedia.org/wiki/UTF-8) is a variable-length character encoding wherein each
 character can be 1-4 bytes. This means the length of a string is not the same as its size in bytes.
 For this reason, it is recommended to use the `string_view` class to access these characters for
 most operations.
 
-The `string_view.cuh` header also includes some utility methods for reading and writing 
+The `string_view.cuh` header also includes some utility methods for reading and writing
 (`to_char_utf8/from_char_utf8`) individual UTF-8 characters to/from byte arrays.
 
 ### `cudf::lists_column_view` and `cudf::lists_view`
@@ -1173,7 +1177,7 @@ struct, and therefore `cudf::struct_view` is the data type of a `cudf::column` o
 
 # cuIO: file reading and writing
 
-cuIO is a component of libcudf that provides GPU-accelerated reading and writing of data file 
+cuIO is a component of libcudf that provides GPU-accelerated reading and writing of data file
 formats commonly used in data analytics, including CSV, Parquet, ORC, Avro, and JSON_Lines.
 
 // TODO: add more detail and move to a separate file.

--- a/cpp/docs/TESTING.md
+++ b/cpp/docs/TESTING.md
@@ -1,68 +1,68 @@
 # Unit Testing in libcudf
 
-Unit tests in libcudf are written using 
+Unit tests in libcudf are written using
 [Google Test](https://github.com/google/googletest/blob/master/docs/primer.md).
 
-**Important:** Instead of including `gtest/gtest.h` directly, use 
+**Important:** Instead of including `gtest/gtest.h` directly, use
 `#include <cudf_test/cudf_gtest.hpp>`.
 
 ## Best Practices: What Should We Test?
 
-In general we should test to make sure all code paths are covered. This is not always easy or 
+In general we should test to make sure all code paths are covered. This is not always easy or
 possible. But generally this means we test all supported combinations of algorithms and data types,
-and all operators supported by algorithms that support multiple operators (e.g. reductions, 
+and all operators supported by algorithms that support multiple operators (e.g. reductions,
 groupby).  Here are some other guidelines.
 
  * In general empty input is not an error in libcudf. Typically empty input results in empty output.
    Tests should verify this.
 
- * Anything that involves manipulating bitmasks (especially hand-rolled kernels) should have tests 
+ * Anything that involves manipulating bitmasks (especially hand-rolled kernels) should have tests
    that check varying number of rows, especially around boundaries like the warp size (32). So, test
    fewer than 32 rows, more than 32 rows, exactly 32 rows, and greater than 64 rows.
 
- * Most algorithms should have one or more tests exercising inputs with a large enough number of 
-   rows to require launching multiple thread blocks, especially when values are ultimately 
-   communicated between blocks (e.g. reductions). This is especially important for custom kernels 
-   but also applies to Thrust and CUB algorithm calls with lambdas / functors. 
+ * Most algorithms should have one or more tests exercising inputs with a large enough number of
+   rows to require launching multiple thread blocks, especially when values are ultimately
+   communicated between blocks (e.g. reductions). This is especially important for custom kernels
+   but also applies to Thrust and CUB algorithm calls with lambdas / functors.
 
  * For anything involving strings or lists, test exhaustive combinations of empty strings/lists,
-   null strings/lists and strings/lists with null elements. 
-   
+   null strings/lists and strings/lists with null elements.
+
  * Strings tests should include a mixture of non-ASCII UTF-8 characters like `é` in test data.
 
  * Test sliced columns as input (that is, columns that have a nonzero `offset`). This is an easy to
    forget case.
 
- * Tests that verify various forms of "degenerate" column inputs, for example: empty 
-   string columns that have no children (not many paths in cudf can generate these but it 
-   does happen); columns with zero size but that somehow have non-null data pointers; and struct 
+ * Tests that verify various forms of "degenerate" column inputs, for example: empty
+   string columns that have no children (not many paths in cudf can generate these but it
+   does happen); columns with zero size but that somehow have non-null data pointers; and struct
    columns with no children.
 
- * Decimal types are not included in the `NumericTypes` type list, but are included in 
-   `FixedWidthTypes`, so be careful that tests either include or exclude decimal types as 
+ * Decimal types are not included in the `NumericTypes` type list, but are included in
+   `FixedWidthTypes`, so be careful that tests either include or exclude decimal types as
    appropriate.
 
 
 ## Directory and File Naming
 
-The naming of unit test directories and source files should be consistent with the feature being 
+The naming of unit test directories and source files should be consistent with the feature being
 tested. For example, the tests for APIs in `copying.hpp` should live in `cudf/cpp/tests/copying`.
-Each feature (or set of related features) should have its own test source file named 
-`<feature>_tests.cu/cpp`. For example, `cudf/cpp/src/copying/scatter.cu` has tests in 
+Each feature (or set of related features) should have its own test source file named
+`<feature>_tests.cu/cpp`. For example, `cudf/cpp/src/copying/scatter.cu` has tests in
 `cudf/cpp/tests/copying/scatter_tests.cu`.
 
-In the interest of improving compile time, whenever possible, test source files should be `.cpp` 
+In the interest of improving compile time, whenever possible, test source files should be `.cpp`
 files because `nvcc` is slower than `gcc` in compiling host code. Note that `thrust::device_vector`
-includes device code, and so must only be used in `.cu` files. `rmm::device_uvector`, 
-`rmm::device_buffer` and the various `column_wrapper` types described later can be used in `.cpp` 
+includes device code, and so must only be used in `.cu` files. `rmm::device_uvector`,
+`rmm::device_buffer` and the various `column_wrapper` types described later can be used in `.cpp`
 files, and are therefore preferred in test code over `thrust::device_vector`.
 
 ## Base Fixture
 
 All libcudf unit tests should make use of a GTest ["Test Fixture"](https://github.com/google/googletest/blob/master/docs/primer.md#test-fixtures-using-the-same-data-configuration-for-multiple-tests-same-data-multiple-tests).
-Even if the fixture is empty, it should inherit from the base fixture `cudf::test::BaseFixture` 
-found in `include/cudf_test/base_fixture.hpp`. This ensures that RMM is properly initialized and 
-finalized. `cudf::test::BaseFixture` already inherits from `::testing::Test` and therefore it is 
+Even if the fixture is empty, it should inherit from the base fixture `cudf::test::BaseFixture`
+found in `include/cudf_test/base_fixture.hpp`. This ensures that RMM is properly initialized and
+finalized. `cudf::test::BaseFixture` already inherits from `::testing::Test` and therefore it is
 not necessary for your test fixtures to inherit from it.
 
 Example:
@@ -74,7 +74,7 @@ class MyTestFixture : public cudf::test::BaseFixture {...};
 
 In general, libcudf features must work across all of the supported types (there are exceptions e.g.
 not all binary operations are supported for all types). In order to automate the process of running
-the same tests across multiple types, we use GTest's 
+the same tests across multiple types, we use GTest's
 [Typed Tests](https://github.com/google/googletest/blob/master/docs/advanced.md#typed-tests).
 Typed tests allow you to write a test once and run it across a list of types.
 
@@ -92,15 +92,15 @@ TYPED_TEST(TypedTestFixture, FirstTest){
 ```
 
 To specify the list of types to use, instead of GTest's `::testing::Types<...>`, libcudf provides `cudf::test::Types<...>` which is a custom, drop-in replacement for `::testing::Types`.
-In this example, all tests using the `TypedTestFixture` fixture will run once for each type in the 
+In this example, all tests using the `TypedTestFixture` fixture will run once for each type in the
 list defined in `TestTypes` (`int, float, double`).
 
 ### Type Lists
 
-The list of types that are used in tests should be consistent across all tests. To ensure 
-consistency, several sets of common type lists are provided in 
+The list of types that are used in tests should be consistent across all tests. To ensure
+consistency, several sets of common type lists are provided in
 `include/cudf_test/type_lists.hpp`. For example, `NumericTypes` is a type list of all numeric types,
-`FixedWidthTypes` is a list of all fixed-width element types, and `AllTypes` is a list of every 
+`FixedWidthTypes` is a list of all fixed-width element types, and `AllTypes` is a list of every
 element type that libcudf supports.
 
 ```c++
@@ -110,17 +110,17 @@ element type that libcudf supports.
 TYPED_TEST_SUITE(TypedTestFixture, cudf::test::NumericTypes);
 ```
 
-Whenever possible, use one of the type list provided in `include/utilities/test/type_lists.hpp` 
+Whenever possible, use one of the type list provided in `include/utilities/test/type_lists.hpp`
 rather than creating new custom lists.
 
 #### Advanced Type Lists
 
-Sometimes it is necessary to generate more advanced type lists than the simple lists of single types 
-in the `TypeList` example above. libcudf provides a set of meta-programming utilities in 
+Sometimes it is necessary to generate more advanced type lists than the simple lists of single types
+in the `TypeList` example above. libcudf provides a set of meta-programming utilities in
 `include/cudf_test/type_list_utilities.hpp` for generating and composing more advanced type lists.
 
 For example, it may be useful to generate a *nested* type list where each element in the list is two
-types. In a nested type list, each element in the list is itself another list. In order to access 
+types. In a nested type list, each element in the list is itself another list. In order to access
 the `N`th type within the nested list, use `GetType<NestedList, N>`.
 
 Imagine testing all possible two-type combinations of `<int,float>`. This could be done manually:
@@ -129,7 +129,7 @@ Imagine testing all possible two-type combinations of `<int,float>`. This could 
 using namespace cudf::test;
 template <typename TwoTypes>
 TwoTypesFixture : BaseFixture{...};
-using TwoTypesList = Types< Types<int, int>, Types<int, float>, 
+using TwoTypesList = Types< Types<int, int>, Types<int, float>,
                             Types<float, int>, Types<float, float> >;
 TYPED_TEST_SUITE(TwoTypesFixture, TwoTypesList);
 TYPED_TEST(TwoTypesFixture, FirstTest){
@@ -140,49 +140,49 @@ TYPED_TEST(TwoTypesFixture, FirstTest){
 }
 ```
 
-The above example manually specifies all pairs composed of `int` and `float`. `CrossProduct` is a 
+The above example manually specifies all pairs composed of `int` and `float`. `CrossProduct` is a
 utility in `type_list_utilities.hpp` which materializes this cross product automatically.
 
 ```c++
-using TwoTypesList = Types< Types<int, int>, Types<int, float>, 
+using TwoTypesList = Types< Types<int, int>, Types<int, float>,
                             Types<float, int>, Types<float, float> >;
 using CrossProductTypeList = CrossProduct< Types<int, float>, Types<int, float> >;
 // TwoTypesList and CrossProductTypeList are identical
 ```
 
 `CrossProduct` can be used with an arbitrary number of type lists to generate nested type lists of
-two or more types. **However**, overuse of `CrossProduct` can dramatically inflate compile time. 
-The cross product of two type lists of size `n` and `m` will result in a new list with 
-`n*m` nested type lists. This means `n*m` templates will be instantiated; `n` and `m` need not be 
+two or more types. **However**, overuse of `CrossProduct` can dramatically inflate compile time.
+The cross product of two type lists of size `n` and `m` will result in a new list with
+`n*m` nested type lists. This means `n*m` templates will be instantiated; `n` and `m` need not be
 large before compile time becomes unreasonable.
 
-There are a number of other utilities in `type_list_utilities.hpp`. For more details, see the 
-documentation in that file and their associated tests in 
+There are a number of other utilities in `type_list_utilities.hpp`. For more details, see the
+documentation in that file and their associated tests in
 `cudf/cpp/tests/utilities_tests/type_list_tests.cpp`.
 
 ## Utilities
 
 libcudf provides a number of utilities in `include/cudf_test` to make common testing operations more
-convenient. Before creating your own test utilities, look to see if one already exists that does 
-what you need. If not, consider adding a new utility to do what you need. However, make sure that 
-the utility is generic enough to be useful for other tests and is not overly tailored to your 
+convenient. Before creating your own test utilities, look to see if one already exists that does
+what you need. If not, consider adding a new utility to do what you need. However, make sure that
+the utility is generic enough to be useful for other tests and is not overly tailored to your
 specific testing need.
 
 ### Column Wrappers
 
 In order to make generating input columns easier, libcudf provides the `*_column_wrapper` classes in
 `include/cudf_test/column_wrapper.hpp`. These classes wrap a `cudf::column` and provide constructors
-for initializing a `cudf::column` object usable with libcudf APIs. Any `*_column_wrapper` class is 
-implicitly convertible to a `column_view` or `mutable_column_view` and therefore may be 
+for initializing a `cudf::column` object usable with libcudf APIs. Any `*_column_wrapper` class is
+implicitly convertible to a `column_view` or `mutable_column_view` and therefore may be
 transparently passed to any API expecting a `column_view` or `mutable_column_view` argument.
 
 #### `fixed_width_column_wrapper`
 
 The `fixed_width_column_wrapper` class should be used for constructing and initializing columns of
-any fixed-width element type, e.g., numeric types, timestamp types, Boolean, etc. 
-`fixed_width_column_wrapper` provides constructors that accept an iterator range to generate each 
-element in the column. For nullable columns, an additional iterator can be provided to indicate the 
-validity of each element. There are also constructors that accept a `std::initializer_list<T>` for 
+any fixed-width element type, e.g., numeric types, timestamp types, Boolean, etc.
+`fixed_width_column_wrapper` provides constructors that accept an iterator range to generate each
+element in the column. For nullable columns, an additional iterator can be provided to indicate the
+validity of each element. There are also constructors that accept a `std::initializer_list<T>` for
 the column elements and optionally for the validity of each element.
 
 Example:
@@ -207,9 +207,9 @@ fixed_width_column_wrapper<int32_t> w{ {1,2,3,4}, {1, 0, 1, 0}};
 #### `fixed_point_column_wrapper`
 
 The `fixed_point_column_wrapper` class should be used for constructing and initializing columns of
-any fixed-point element type (DECIMAL32 or DECIMAL64). `fixed_point_column_wrapper` provides 
-constructors that accept an iterator range to generate each element in the column. For nullable 
-columns, an additional iterator can be provided to indicate the validity of each element. 
+any fixed-point element type (DECIMAL32 or DECIMAL64). `fixed_point_column_wrapper` provides
+constructors that accept an iterator range to generate each element in the column. For nullable
+columns, an additional iterator can be provided to indicate the validity of each element.
 Constructors also take the scale of the fixed-point values to create.
 
 Example:
@@ -226,10 +226,10 @@ fixed_point_column_wrapper<int32_t> w(elements, elements + 5, validity, 2);
 
 #### `dictionary_column_wrapper`
 
-The `dictionary_column_wrapper` class should be used to create dictionary columns. 
-`dictionary_column_wrapper` provides constructors that accept an iterator range to generate each 
-element in the column. For nullable columns, an additional iterator can be provided to indicate the 
-validity of each element. There are also constructors that accept a `std::initializer_list<T>` for 
+The `dictionary_column_wrapper` class should be used to create dictionary columns.
+`dictionary_column_wrapper` provides constructors that accept an iterator range to generate each
+element in the column. For nullable columns, an additional iterator can be provided to indicate the
+validity of each element. There are also constructors that accept a `std::initializer_list<T>` for
 the column elements and optionally for the validity of each element.
 
 Example:
@@ -273,30 +273,30 @@ dictionary_column_wrapper<std::string> d({"", "bb", "", "bb", "", "a", ""}, vali
 
 #### `strings_column_wrapper`
 
-The `strings_column_wrapper` class should be used to create columns of strings. It provides 
-constructors that accept an iterator range to generate each string in the column. For nullable 
-columns, an additional iterator can be provided to indicate the validity of each string. There are 
-also constructors that accept a `std::initializer_list<std::string>` for the column's strings and 
+The `strings_column_wrapper` class should be used to create columns of strings. It provides
+constructors that accept an iterator range to generate each string in the column. For nullable
+columns, an additional iterator can be provided to indicate the validity of each string. There are
+also constructors that accept a `std::initializer_list<std::string>` for the column's strings and
 optionally for the validity of each element.
 
 Example:
 ```c++
-// Creates a non-nullable STRING column with 7 string elements: 
+// Creates a non-nullable STRING column with 7 string elements:
 // {"", "this", "is", "a", "column", "of", "strings"}
 std::vector<std::string> strings{"", "this", "is", "a", "column", "of", "strings"};
 strings_column_wrapper s(strings.begin(), strings.end());
 
-// Creates a nullable STRING column with 7 string elements: 
+// Creates a nullable STRING column with 7 string elements:
 // {NULL, "this", NULL, "a", NULL, "of", NULL}
 std::vector<std::string> strings{"", "this", "is", "a", "column", "of", "strings"};
 auto validity = make_counting_transform_iterator(0, [](auto i){return i%2;});
 strings_column_wrapper s(strings.begin(), strings.end(), validity);
 
-// Creates a non-nullable STRING column with 7 string elements: 
+// Creates a non-nullable STRING column with 7 string elements:
 // {"", "this", "is", "a", "column", "of", "strings"}
 strings_column_wrapper s({"", "this", "is", "a", "column", "of", "strings"});
 
-// Creates a nullable STRING column with 7 string elements: 
+// Creates a nullable STRING column with 7 string elements:
 // {NULL, "this", NULL, "a", NULL, "of", NULL}
 auto validity = make_counting_transform_iterator(0, [](auto i){return i%2;});
 strings_column_wrapper s({"", "this", "is", "a", "column", "of", "strings"}, validity);
@@ -304,10 +304,10 @@ strings_column_wrapper s({"", "this", "is", "a", "column", "of", "strings"}, val
 
 #### `lists_column_wrapper`
 
-The `lists_column_wrapper` class should be used to create columns of lists. It provides 
-constructors that accept an iterator range to generate each list in the column. For nullable 
-columns, an additional iterator can be provided to indicate the validity of each list. There are 
-also constructors that accept a `std::initializer_list<T>` for the column's lists and 
+The `lists_column_wrapper` class should be used to create columns of lists. It provides
+constructors that accept an iterator range to generate each list in the column. For nullable
+columns, an additional iterator can be provided to indicate the validity of each list. There are
+also constructors that accept a `std::initializer_list<T>` for the column's lists and
 optionally for the validity of each element. A number of other constructors are available.
 
 Example:
@@ -357,9 +357,9 @@ lists_column_wrapper l{ {{{0, 1}, {2, 3}}, validity}, {{{4, 5}, {6, 7}}, validit
 
 #### `structs_column_wrapper`
 
-The `structs_column_wrapper` class should be used to create columns of structs. It provides 
+The `structs_column_wrapper` class should be used to create columns of structs. It provides
 constructors that accept a vector or initializer list of pre-constructed columns or column wrappers
-for child columns. For nullable columns, an additional iterator can be provided to indicate the 
+for child columns. For nullable columns, an additional iterator can be provided to indicate the
 validity of each struct.
 
 Examples:
@@ -413,29 +413,29 @@ have the same metadata.
 
 #### `expect_column_properties_equal`
 
-Verifies that two columns have the same type, size, and nullability. For nested types, recursively 
+Verifies that two columns have the same type, size, and nullability. For nested types, recursively
 verifies the equality of type, size and nullability of all nested children.
 
 #### `expect_column_properties_equivalent`
 
-Verifies that two columns have equivalent type and equal size, ignoring nullability. For nested 
+Verifies that two columns have equivalent type and equal size, ignoring nullability. For nested
 types, recursively verifies the equivalence of type, and equality of size of all nested children,
 ignoring nullability.
 
 Note "equivalent type". Most types are equivalent if and only they are equal. `fixed_point` types
-are one exception. They are equivalent if the representation type is equal, even if they have 
-different scales. Nested type columns can be equivalent in the case where they both have zero size, 
-but one has children (also empty) and the other does not. For columns with nonzero size, both equals 
+are one exception. They are equivalent if the representation type is equal, even if they have
+different scales. Nested type columns can be equivalent in the case where they both have zero size,
+but one has children (also empty) and the other does not. For columns with nonzero size, both equals
 and equivalent expect equal number of children.
 
 #### `expect_columns_equal`
 
-Verifies that two columns have equal properties and verifies elementwise equality of the column 
+Verifies that two columns have equal properties and verifies elementwise equality of the column
 data. Null elements are treated as equal.
 
 #### `expect_columns_equivalent`
 
-Verifies that two columns have equivalent properties and verifies elementwise equivalence of the 
+Verifies that two columns have equivalent properties and verifies elementwise equivalence of the
 column data. Null elements are treated as equivalent.
 
 #### `expect_equal_buffers`
@@ -444,6 +444,6 @@ Verifies the bitwise equality of two device memory buffers.
 
 ### Printing and accessing column data
 
-`include/cudf_test/column_utilities.hpp` defines various functions and overloads for printing 
+`include/cudf_test/column_utilities.hpp` defines various functions and overloads for printing
 columns (`print`), converting column data to string (`to_string`, `to_strings`), and copying data to
 the host (`to_host).


### PR DESCRIPTION
This PR improves the C++ developer guide.

My primary goal was to fix some invalid links.

The diff is a bit large because of some minor changes in the interest of establishing consistent style and improving the reading/editing experience. (e.g. replacing a few instances of tabs with spaces, trimming trailing whitespace, wrapping sections that were not wrapped like the rest of the file, and correcting typos that I came across while reading). To save time, I recommend that reviewers use the option in GitHub's review tab that will ignore whitespace changes.