### PR TITLE
Update cudf JNI to 22.02.0-SNAPSHOT

### DIFF
--- a/java/ci/Dockerfile.centos7
+++ b/java/ci/Dockerfile.centos7
@@ -17,11 +17,13 @@
 ###
 # Build the image for cudf development environment.
 #
-# Arguments: CUDA_VERSION=11.0, 11.1, 11.2.0 or 11.2.2
+# Arguments: CUDA_VERSION=11.5.0
 #
 ###
-ARG CUDA_VERSION
-FROM nvidia/cuda:$CUDA_VERSION-devel-centos7
+ARG CUDA_VERSION=11.5.0
+# use rapids gpuci/cuda images until nvidia/cuda cuda 11.5+ images are available in docker hub
+# FROM nvidia/cuda:$CUDA_VERSION-devel-centos7
+FROM gpuci/cuda:$CUDA_VERSION-devel-centos7
 
 ### Install basic requirements
 RUN yum install -y centos-release-scl

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -11,14 +11,14 @@
 
 In the root path of cuDF repo, run below command to build the docker image.
 ```bash
-docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.2.2 -t cudf-build:11.2.2-devel-centos7 .
+docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.5.0 -t cudf-build:11.5.0-devel-centos7 .
 ```
 
 The following CUDA versions are supported w/ CUDA Enhanced Compatibility:
 * CUDA 11.0+
 
 Change the --build-arg CUDA_VERSION to what you need.
-You can replace the tag "cudf-build:11.2.2-devel-centos7" with another name you like.
+You can replace the tag "cudf-build:11.5.0-devel-centos7" with another name you like.
 
 ## Start the docker then build
 
@@ -26,7 +26,7 @@ You can replace the tag "cudf-build:11.2.2-devel-centos7" with another name you 
 
 Run below command to start a docker container with GPU.
 ```bash
-nvidia-docker run -it cudf-build:11.2.2-devel-centos7 bash
+nvidia-docker run -it cudf-build:11.5.0-devel-centos7 bash
 ```
 
 ### Download the cuDF source code
@@ -34,7 +34,7 @@ nvidia-docker run -it cudf-build:11.2.2-devel-centos7 bash
 You can download the cuDF repo in the docker container or you can mount it into the container.
 Here I choose to download again in the container.
 ```bash
-git clone --recursive https://github.com/rapidsai/cudf.git -b branch-21.12
+git clone --recursive https://github.com/rapidsai/cudf.git -b branch-22.02
 ```
 
 ### Build cuDF jar with devtoolset
@@ -47,5 +47,5 @@ scl enable devtoolset-9 "java/ci/build-in-docker.sh"
 
 ### The output
 
-You can find the cuDF jar in java/target/ like cudf-21.12.0-SNAPSHOT-cuda11.jar.
+You can find the cuDF jar in java/target/ like cudf-22.02.0-SNAPSHOT-cuda11.jar.
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>ai.rapids</groupId>
     <artifactId>cudf</artifactId>
-    <version>21.12.0-SNAPSHOT</version>
+    <version>22.02.0-SNAPSHOT</version>
 
     <name>cudfjni</name>
     <description>

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -26,7 +26,7 @@ rapids_cuda_init_architectures(CUDF_JNI)
 
 project(
   CUDF_JNI
-  VERSION 21.12.00
+  VERSION 22.02.00
   LANGUAGES C CXX CUDA
 )
 


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

cudfjni version update.

NOTE: this includes change to use gpuci/cuda images since official cuda images is not ready yet on docker hub