### PR TITLE
Correct `to_cupy`/`to_numpy` order

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -634,16 +634,18 @@ class Frame:
         # Early exit for an empty Frame.
         ncol = self._num_columns
         if ncol == 0:
-            return make_empty_matrix(shape=(0, 0), dtype=np.dtype("float64"),
-                                     order='F')
+            return make_empty_matrix(
+                shape=(0, 0), dtype=np.dtype("float64"), order="F"
+            )
 
         if dtype is None:
             dtype = find_common_type(
                 [col.dtype for col in self._data.values()]
             )
 
-        matrix = make_empty_matrix(shape=(len(self), ncol), dtype=dtype,
-                                   order='F')
+        matrix = make_empty_matrix(
+            shape=(len(self), ncol), dtype=dtype, order="F"
+        )
         for i, col in enumerate(self._data.values()):
             # TODO: col.values may fail if there is nullable data or an
             # unsupported dtype. We may want to catch and provide a more

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -634,14 +634,16 @@ class Frame:
         # Early exit for an empty Frame.
         ncol = self._num_columns
         if ncol == 0:
-            return make_empty_matrix(shape=(0, 0), dtype=np.dtype("float64"))
+            return make_empty_matrix(shape=(0, 0), dtype=np.dtype("float64"),
+                                     order='F')
 
         if dtype is None:
             dtype = find_common_type(
                 [col.dtype for col in self._data.values()]
             )
 
-        matrix = make_empty_matrix(shape=(len(self), ncol), dtype=dtype)
+        matrix = make_empty_matrix(shape=(len(self), ncol), dtype=dtype,
+                                   order='F')
         for i, col in enumerate(self._data.values()):
             # TODO: col.values may fail if there is nullable data or an
             # unsupported dtype. We may want to catch and provide a more

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -968,8 +968,13 @@ def test_dataframe_to_cupy():
         df[k] = np.random.random(nelem)
 
     # Check all columns
+    mat = df.to_cupy()
+    assert mat.shape == (nelem, 4)
+    assert mat.strides == (8, 984)
+
     mat = df.to_numpy()
     assert mat.shape == (nelem, 4)
+    assert mat.strides == (8, 984)
     for i, k in enumerate(df.columns):
         np.testing.assert_array_equal(df[k].to_numpy(), mat[:, i])
 


### PR DESCRIPTION
If I'm not mistaken, before this patch, the new functions `to_cupy`/`to_numpy`  are creating arrays with the wrong/unexpected order  'C' (given that is not configurable) as opposed to 'F' major corresponding to cuDF's column ordering. This is very important for cuML interoperability since it makes cuML do conversions unnecessarily. 

Before the patch:

```python
>>> import cudf
>>> a = cudf.DataFrame([[1, 2, 3], [3, 4, 5]])
>>> b = a.to_cupy()
>>> b
array([[1, 2, 3],
       [3, 4, 5]])
>>> b.__cuda_array_interface__
{'shape': (2, 3), 'typestr': '<i8', 'descr': [('', '<i8')], 'stream': 1, 'version': 3, 'strides': None, 'data': (139637687322112, False)}
>>> c = a.to_numpy() # 'strides': None means 'C' major
>>> c.__array_interface__
{'data': (94439112776176, False), 'strides': None, 'descr': [('', '<i8')], 'typestr': '<i8', 'shape': (2, 3), 'version': 3}
```

After the patch:

```python
>>> import cudf
>>> a = cudf.DataFrame([[1, 2, 3], [3, 4, 5]])
>>> b = a.to_cupy()
>>> b
array([[1, 2, 3],
       [3, 4, 5]])
>>> b.__cuda_array_interface__
{'shape': (2, 3), 'typestr': '<i8', 'descr': [('', '<i8')], 'stream': 1, 'version': 3, 'strides': (8, 16), 'data': (140499969115648, False)}
>>> c = a.to_numpy() # strides show 'F' major now :) 
>>> c.__array_interface__
{'data': (94695880007152, False), 'strides': (8, 16), 'descr': [('', '<i8')], 'typestr': '<i8', 'shape': (2, 3), 'version': 3}
```