### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/python/cudf/cudf/_lib/column.pyx
+++ b/python/cudf/cudf/_lib/column.pyx
@@ -291,9 +291,17 @@ cdef class Column:
             if self.base_children == ():
                 self._children = ()
             else:
-                self._children = Column.from_unique_ptr(
+                children = Column.from_unique_ptr(
                     make_unique[column](self.view())
                 ).base_children
+                dtypes = [
+                    base_child.dtype for base_child in self.base_children
+                ]
+                self._children = [
+                    child._with_type_metadata(dtype) for child, dtype in zip(
+                        children, dtypes
+                    )
+                ]
         return self._children
 
     def set_base_children(self, value):

--- a/python/cudf/cudf/tests/test_struct.py
+++ b/python/cudf/cudf/tests/test_struct.py
@@ -207,7 +207,7 @@ def test_dataframe_to_struct():
 
 
 @pytest.mark.parametrize(
-    "series, start, end",
+    "series, slce",
     [
         (
             [
@@ -216,8 +216,7 @@ def test_dataframe_to_struct():
                 {},
                 None,
             ],
-            1,
-            None,
+            slice(1, None),
         ),
         (
             [
@@ -229,8 +228,7 @@ def test_dataframe_to_struct():
                 None,
                 cudf.NA,
             ],
-            1,
-            5,
+            slice(1, 5),
         ),
         (
             [
@@ -242,22 +240,15 @@ def test_dataframe_to_struct():
                 None,
                 cudf.NA,
             ],
-            None,
-            4,
+            slice(None, 4),
         ),
+        ([{"a": {"b": 42, "c": -1}}, {"a": {"b": 0, "c": None}}], slice(0, 1)),
     ],
 )
-def test_struct_slice(series, start, end):
-    sr = cudf.Series(series)
-    if not end:
-        expected = cudf.Series(series[start:])
-        assert sr[start:].to_arrow() == expected.to_arrow()
-    elif not start:
-        expected = cudf.Series(series[:end])
-        assert sr[:end].to_arrow() == expected.to_arrow()
-    else:
-        expected = cudf.Series(series[start:end])
-        assert sr[start:end].to_arrow() == expected.to_arrow()
+def test_struct_slice(series, slce):
+    got = cudf.Series(series)[slce]
+    expected = cudf.Series(series[slce])
+    assert got.to_arrow() == expected.to_arrow()
 
 
 def test_struct_slice_nested_struct():
@@ -268,8 +259,7 @@ def test_struct_slice_nested_struct():
 
     got = cudf.Series(data)[0:1]
     expect = cudf.Series(data[0:1])
-    assert got.__repr__() == expect.__repr__()
-    assert got.dtype.to_arrow() == expect.dtype.to_arrow()
+    assert got.to_arrow() == expect.to_arrow()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.