### PR TITLE
Consolidate offset string handling into factory `_from_str`

### DIFF
--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -842,18 +842,17 @@ def date_range(
     if isinstance(freq, DateOffset):
         offset = freq
     elif isinstance(freq, str):
-        if (
-            any(
-                x in freq.upper()
-                for x in {"Y", "A", "Q", "B", "SM", "SMS", "CBMS", "M"}
-            )
-            or "MS" in freq
-        ):
-            raise ValueError(
-                "date_range does not yet support month, quarter, year-anchored"
-                "or business-date frequency."
-            )
-        offset = DateOffset._from_str(freq)
+        e = ValueError(
+            f"Unrecognized frequency string {freq}. cuDF does"
+            " not yet support month, quarter, year-anchored frequency."
+        )
+
+        if "M" in freq or "Y" in freq.upper():
+            raise e
+        try:
+            offset = DateOffset._from_str(freq)
+        except ValueError:
+            raise e
     else:
         raise TypeError("`freq` must be a `str` or cudf.DateOffset object.")
 

--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -652,7 +652,6 @@ class DateOffset:
 
         sign = -1 if sign_part else 1
         n = int(numeric_part) if numeric_part else 1
-        code = _offset_alias_to_code[freq_part]
 
         return cls(**{cls._CODES_TO_UNITS[code]: n * sign})
 

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -1583,6 +1583,46 @@ def test_date_range_raise_overflow():
         cudf.date_range(start=start, periods=periods, freq=freq)
 
 
+@pytest.mark.parametrize(
+    "freqstr_unsupported",
+    [
+        "1M",
+        "2SM",
+        "3MS",
+        "4BM",
+        "5CBM",
+        "6SMS",
+        "7BMS",
+        "8CBMS",
+        "Q",
+        "2BQ",
+        "3BQS",
+        "10A",
+        "10Y",
+        "9BA",
+        "9BY",
+        "8AS",
+        "8YS",
+        "7BAS",
+        "7BYS",
+        "BH",
+        "B",
+    ],
+)
+def test_date_range_raise_unsupported(freqstr_unsupported):
+    s, e = "2001-01-01", "2008-01-31"
+    pd.date_range(start=s, end=e, freq=freqstr_unsupported)
+    with pytest.raises(ValueError, match="does not yet support"):
+        cudf.date_range(start=s, end=e, freq=freqstr_unsupported)
+
+    # 3ms would mean a millisecondly frequencies, not month start frequencies
+    if not freqstr_unsupported == "3MS":
+        freqstr_unsupported = freqstr_unsupported.lower()
+        pd.date_range(start=s, end=e, freq=freqstr_unsupported)
+        with pytest.raises(ValueError, match="does not yet support"):
+            cudf.date_range(start=s, end=e, freq=freqstr_unsupported)
+
+
 ##################################################################
 #                    End of Date Range Test                      #
 ##################################################################


### PR DESCRIPTION
Currently, when `freq` is a string in `date_range`, we first map the frequency part to [time unit codes](https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units), then again map them to `DateOffset` object via `_from_freqstr`. However, `freqstr` relates to [frequency string](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects) in pandas, and does not always 1-1 map to time unit codes.

This PR proposes to unify frequency string handling into factory `DateOffset._from_str`. This function performs 1 regex matching to extract the frequency part and polls through possible sets of abbreviations in `_offset_alias_to_codes` and `_CODES_TO_UNITS` to find matches.

Besides, a test case is added for `date_range` make sure unsupported frequency types are raised with sensible error message.