### PR TITLE
Use cuFile direct device reads/writes by default in cuIO

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -547,8 +547,8 @@ if(TARGET conda_env)
 endif()
 
 # Add cuFile interface if available
-if(TARGET cuFile::cuFile_interface)
-  target_link_libraries(cudf PRIVATE cuFile::cuFile_interface)
+if(NOT TARGET cuFile::cuFile_interface)
+  message(FATAL_ERROR "cuFile includes not found.")
 endif()
 
 if(CUDA_STATIC_RUNTIME)

--- a/cpp/cmake/Modules/FindcuFile.cmake
+++ b/cpp/cmake/Modules/FindcuFile.cmake
@@ -86,7 +86,6 @@ if(cuFile_INCLUDE_DIR AND NOT TARGET cuFile::cuFile_interface)
     cuFile::cuFile_interface INTERFACE "$<BUILD_INTERFACE:${cuFile_INCLUDE_DIR}>"
   )
   target_compile_options(cuFile::cuFile_interface INTERFACE "${cuFile_COMPILE_OPTIONS}")
-  target_compile_definitions(cuFile::cuFile_interface INTERFACE CUFILE_FOUND)
 endif()
 
 if(cuFile_FOUND AND NOT TARGET cuFile::cuFile)

--- a/cpp/src/io/utilities/config_utils.hpp
+++ b/cpp/src/io/utilities/config_utils.hpp
@@ -30,6 +30,41 @@ inline std::string getenv_or(std::string const& env_var_name, std::string_view d
   return std::string{(env_val == nullptr) ? default_val : env_val};
 }
 
+namespace cufile_integration {
+
+namespace {
+/**
+ * @brief Defines which cuFile usage to enable.
+ */
+enum class usage_policy : uint8_t { OFF, GDS, ALWAYS };
+
+/**
+ * @brief Get the current usage policy.
+ */
+inline usage_policy get_env_policy()
+{
+  static auto const env_val = getenv_or("LIBCUDF_CUFILE_POLICY", "GDS");
+  if (env_val == "OFF") return usage_policy::OFF;
+  if (env_val == "ALWAYS") return usage_policy::ALWAYS;
+  return usage_policy::GDS;
+}
+}  // namespace
+
+/**
+ * @brief Returns true if cuFile and its compatiblity mode are enabled.
+ */
+inline bool is_always_enabled() { return get_env_policy() == usage_policy::ALWAYS; }
+
+/**
+ * @brief Returns true if only direct IO through cuFile are enabled (compatiblity mode is disabled).
+ */
+inline bool is_gds_enabled()
+{
+  return is_always_enabled() or get_env_policy() == usage_policy::GDS;
+}
+
+}  // namespace cufile_integration
+
 namespace nvcomp_integration {
 
 namespace {
@@ -64,4 +99,5 @@ inline bool is_stable_enabled()
 }
 
 }  // namespace nvcomp_integration
+
 }  // namespace cudf::io::detail

--- a/cpp/src/io/utilities/config_utils.hpp
+++ b/cpp/src/io/utilities/config_utils.hpp
@@ -51,12 +51,12 @@ inline usage_policy get_env_policy()
 }  // namespace
 
 /**
- * @brief Returns true if cuFile and its compatiblity mode are enabled.
+ * @brief Returns true if cuFile and its compatibility mode is enabled.
  */
 inline bool is_always_enabled() { return get_env_policy() == usage_policy::ALWAYS; }
 
 /**
- * @brief Returns true if only direct IO through cuFile are enabled (compatiblity mode is disabled).
+ * @brief Returns true if only direct IO through cuFile is enabled (compatibility mode is disabled).
  */
 inline bool is_gds_enabled()
 {

--- a/cpp/src/io/utilities/data_sink.cpp
+++ b/cpp/src/io/utilities/data_sink.cpp
@@ -78,7 +78,7 @@ class file_sink : public data_sink {
  private:
   std::ofstream _output_stream;
   size_t _bytes_written = 0;
-  std::unique_ptr<detail::cufile_output_impl> _cufile_out;
+  std::unique_ptr<detail::cufile_output> _cufile_out;
 };
 
 /**

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -238,12 +238,10 @@ std::unique_ptr<datasource> datasource::create(const std::string& filepath,
                                                size_t offset,
                                                size_t size)
 {
-#ifdef CUFILE_FOUND
   if (detail::cufile_config::instance()->is_required()) {
     // avoid mmap as GDS is expected to be used for most reads
     return std::make_unique<direct_read_source>(filepath.c_str());
   }
-#endif
   // Use our own memory mapping implementation for direct file reads
   return std::make_unique<memory_mapped_source>(filepath.c_str(), offset, size);
 }

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -84,7 +84,7 @@ class file_source : public datasource {
   detail::file_wrapper _file;
 
  private:
-  std::unique_ptr<detail::cufile_input_impl> _cufile_in;
+  std::unique_ptr<detail::cufile_input> _cufile_in;
 };
 
 /**

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
+#include "file_io_utilities.hpp"
+
 #include <cudf/io/datasource.hpp>
+#include <cudf/utilities/error.hpp>
+#include <io/utilities/config_utils.hpp>
 
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <unistd.h>
-
-#include <cudf/utilities/error.hpp>
-#include "file_io_utilities.hpp"
 
 namespace cudf {
 namespace io {
@@ -238,7 +239,7 @@ std::unique_ptr<datasource> datasource::create(const std::string& filepath,
                                                size_t offset,
                                                size_t size)
 {
-  if (detail::cufile_config::instance()->is_required()) {
+  if (detail::cufile_integration::is_always_enabled()) {
     // avoid mmap as GDS is expected to be used for most reads
     return std::make_unique<direct_read_source>(filepath.c_str());
   }

--- a/cpp/src/io/utilities/file_io_utilities.cpp
+++ b/cpp/src/io/utilities/file_io_utilities.cpp
@@ -49,8 +49,6 @@ file_wrapper::file_wrapper(std::string const& filepath, int flags, mode_t mode)
 
 file_wrapper::~file_wrapper() { close(fd); }
 
-#ifdef CUFILE_FOUND
-
 cufile_config::cufile_config() : policy{getenv_or("LIBCUDF_CUFILE_POLICY", default_policy)}
 {
   if (is_enabled()) {
@@ -280,11 +278,9 @@ std::future<void> cufile_output_impl::write_async(void const* data, size_t offse
   // writes.
   return std::async(std::launch::deferred, waiter, std::move(slice_tasks));
 }
-#endif
 
 std::unique_ptr<cufile_input_impl> make_cufile_input(std::string const& filepath)
 {
-#ifdef CUFILE_FOUND
   if (cufile_config::instance()->is_enabled()) {
     try {
       return std::make_unique<cufile_input_impl>(filepath);
@@ -292,13 +288,11 @@ std::unique_ptr<cufile_input_impl> make_cufile_input(std::string const& filepath
       if (cufile_config::instance()->is_required()) throw;
     }
   }
-#endif
   return nullptr;
 }
 
 std::unique_ptr<cufile_output_impl> make_cufile_output(std::string const& filepath)
 {
-#ifdef CUFILE_FOUND
   if (cufile_config::instance()->is_enabled()) {
     try {
       return std::make_unique<cufile_output_impl>(filepath);
@@ -306,7 +300,6 @@ std::unique_ptr<cufile_output_impl> make_cufile_output(std::string const& filepa
       if (cufile_config::instance()->is_required()) throw;
     }
   }
-#endif
   return nullptr;
 }
 

--- a/cpp/src/io/utilities/file_io_utilities.hpp
+++ b/cpp/src/io/utilities/file_io_utilities.hpp
@@ -76,32 +76,6 @@ class cufile_io_base {
 class cufile_shim;
 
 /**
- * @brief Class that manages cuFile configuration.
- */
-class cufile_config {
-  std::string const default_policy    = "OFF";
-  std::string const json_path_env_var = "CUFILE_ENV_PATH_JSON";
-
-  std::string const policy = default_policy;
-  temp_directory tmp_config_dir{"cudf_cufile_config"};
-
-  cufile_config();
-
- public:
-  /**
-   * @brief Returns true when cuFile use is enabled.
-   */
-  bool is_enabled() const { return policy == "ALWAYS" or policy == "GDS"; }
-
-  /**
-   * @brief Returns true when cuDF should not fall back to host IO.
-   */
-  bool is_required() const { return policy == "ALWAYS"; }
-
-  static cufile_config const* instance();
-};
-
-/**
  * @brief Class that provides RAII for cuFile file registration.
  */
 struct cufile_registered_file {

--- a/cpp/src/io/utilities/file_io_utilities.hpp
+++ b/cpp/src/io/utilities/file_io_utilities.hpp
@@ -16,12 +16,10 @@
 
 #pragma once
 
-#ifdef CUFILE_FOUND
 #include "thread_pool.hpp"
 
 #include <cufile.h>
 #include <cudf_test/file_utilities.hpp>
-#endif
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -158,8 +156,6 @@ class cufile_output : public cufile_io_base {
   virtual std::future<void> write_async(void const* data, size_t offset, size_t size) = 0;
 };
 
-#ifdef CUFILE_FOUND
-
 class cufile_shim;
 
 /**
@@ -263,43 +259,6 @@ class cufile_output_impl final : public cufile_output {
   cufile_registered_file const cf_file;
   cudf::detail::thread_pool pool;
 };
-#else
-
-class cufile_input_impl final : public cufile_input {
- public:
-  std::unique_ptr<datasource::buffer> read(size_t offset,
-                                           size_t size,
-                                           rmm::cuda_stream_view stream) override
-  {
-    CUDF_FAIL("Only used to compile without cufile library, should not be called");
-  }
-
-  size_t read(size_t offset, size_t size, uint8_t* dst, rmm::cuda_stream_view stream) override
-  {
-    CUDF_FAIL("Only used to compile without cufile library, should not be called");
-  }
-
-  std::future<size_t> read_async(size_t offset,
-                                 size_t size,
-                                 uint8_t* dst,
-                                 rmm::cuda_stream_view stream) override
-  {
-    CUDF_FAIL("Only used to compile without cufile library, should not be called");
-  }
-};
-
-class cufile_output_impl final : public cufile_output {
- public:
-  void write(void const* data, size_t offset, size_t size) override
-  {
-    CUDF_FAIL("Only used to compile without cufile library, should not be called");
-  }
-  std::future<void> write_async(void const* data, size_t offset, size_t size) override
-  {
-    CUDF_FAIL("Only used to compile without cufile library, should not be called");
-  }
-};
-#endif
 
 /**
  * @brief Creates a `cufile_input_impl` object

--- a/docs/cudf/source/basics/io-gds-integration.rst
+++ b/docs/cudf/source/basics/io-gds-integration.rst
@@ -4,9 +4,9 @@ GPUDirect Storage Integration
 Many IO APIs can use GPUDirect Storage (GDS) library to optimize IO operations. 
 GDS enables a direct data path for direct memory access (DMA) transfers between GPU memory and storage, which avoids a bounce buffer through the CPU. 
 GDS also has a compatibility mode that allows the library to fall back to copying through a CPU bounce buffer. 
-The SDK is available for download `here <https://developer.nvidia.com/gpudirect-storage>`_.
+The SDK is available for download `here <https://developer.nvidia.com/gpudirect-storage>`_. Newer versions are also a part of CUDA toolkit (11.4 and higher).
 
-Use of GPUDirect Storage in cuDF is disabled by default, and can be enabled through environment variable ``LIBCUDF_CUFILE_POLICY``. 
+Use of GPUDirect Storage in cuDF is enabled by default, but can be disabled through environment variable ``LIBCUDF_CUFILE_POLICY``. 
 This variable also controls the GDS compatibility mode. 
 
 There are three special values for the environment variable:
@@ -15,7 +15,7 @@ There are three special values for the environment variable:
 - "ALWAYS": Enable GDS use; GDS compatibility mode is *on*.
 - "OFF": Compretely disable GDS use.
 
-Any other value (or no value set) will keep the GDS disabled for use in cuDF and IO will be done using cuDF's CPU bounce buffers.
+Any other value (or no value set) will enable the GDS use, with compatibility mode turned *off*.
 
 This environment variable also affects how cuDF treats GDS errors.
 When ``LIBCUDF_CUFILE_POLICY`` is set to "GDS" and a GDS API call fails for any reason, cuDF falls back to the internal implementation with bounce buffers.
@@ -31,4 +31,3 @@ Operations that support the use of GPUDirect Storage:
 - `to_parquet`
 - `to_orc`
 
-NOTE: current GDS integration is not fully optimized and enabling GDS will not lead to performance improvements in all cases.


### PR DESCRIPTION
Making this change early in 22.02 to test through internal use + nightly builds before the release.

- Modify the way cuFile integration is enabled to match the nvCOMP integration.
- Change the default from OFF to GDS (GDS on, only for direct reads/writes, no compatibility mode).
- Make the cuFile include files a requirement for compilation - should be always present as we now compile with 11.5. 
- cuFile JSON config file is now modified on first cuFile use (same time as the driver), instead of the first query that checks if GDS use is enabled.