### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/conda/environments/cudf_dev_cuda11.0.yml
+++ b/conda/environments/cudf_dev_cuda11.0.yml
@@ -9,7 +9,7 @@ channels:
 dependencies:
   - clang=11.0.0
   - clang-tools=11.0.0
-  - cupy>7.1.0,<10.0.0a0
+  - cupy>=9.5.0,<10.0.0a0
   - rmm=21.12.*
   - cmake>=3.20.1
   - cmake_setuptools>=0.1.3

--- a/conda/environments/cudf_dev_cuda11.0.yml
+++ b/conda/environments/cudf_dev_cuda11.0.yml
@@ -7,8 +7,8 @@ channels:
   - rapidsai-nightly
   - conda-forge
 dependencies:
-  - clang=11.0.0
-  - clang-tools=11.0.0
+  - clang=11.1.0
+  - clang-tools=11.1.0
   - cupy>=9.5.0,<10.0.0a0
   - rmm=21.12.*
   - cmake>=3.20.1

--- a/conda/environments/cudf_dev_cuda11.2.yml
+++ b/conda/environments/cudf_dev_cuda11.2.yml
@@ -9,7 +9,7 @@ channels:
 dependencies:
   - clang=11.0.0
   - clang-tools=11.0.0
-  - cupy>7.1.0,<10.0.0a0
+  - cupy>=9.5.0,<10.0.0a0
   - rmm=21.12.*
   - cmake>=3.20.1
   - cmake_setuptools>=0.1.3

--- a/conda/environments/cudf_dev_cuda11.2.yml
+++ b/conda/environments/cudf_dev_cuda11.2.yml
@@ -7,8 +7,8 @@ channels:
   - rapidsai-nightly
   - conda-forge
 dependencies:
-  - clang=11.0.0
-  - clang-tools=11.0.0
+  - clang=11.1.0
+  - clang-tools=11.1.0
   - cupy>=9.5.0,<10.0.0a0
   - rmm=21.12.*
   - cmake>=3.20.1

--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -9,7 +9,7 @@ channels:
 dependencies:
   - clang=11.0.0
   - clang-tools=11.0.0
-  - cupy>7.1.0,<10.0.0a0
+  - cupy>=9.5.0,<10.0.0a0
   - rmm=21.12.*
   - cmake>=3.20.1
   - cmake_setuptools>=0.1.3

--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -7,8 +7,8 @@ channels:
   - rapidsai-nightly
   - conda-forge
 dependencies:
-  - clang=11.0.0
-  - clang-tools=11.0.0
+  - clang=11.1.0
+  - clang-tools=11.1.0
   - cupy>=9.5.0,<10.0.0a0
   - rmm=21.12.*
   - cmake>=3.20.1

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - python
     - typing_extensions
     - pandas >=1.0,<1.4.0dev0
-    - cupy >7.1.0,<10.0.0a0
+    - cupy >=9.5.0,<10.0.0a0
     - numba >=0.53.1
     - numpy
     - {{ pin_compatible('pyarrow', max_pin='x.x.x') }} *cuda

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import tempfile
 
-EXPECTED_VERSION = "11.0.0"
+EXPECTED_VERSION = "11.1.0"
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
 # NOTE: populate this list with more top-level dirs as we add more of them to
 # the cudf repo

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -576,7 +576,7 @@ def test_concat_empty_dataframes(df, other, ignore_index):
     if expected.shape != df.shape:
         for key, col in actual[actual.columns].iteritems():
             if is_categorical_dtype(col.dtype):
-                if expected[key].dtype != "category":
+                if not is_categorical_dtype(expected[key].dtype):
                     # TODO: Pandas bug:
                     # https://github.com/pandas-dev/pandas/issues/42840
                     expected[key] = expected[key].fillna("-1").astype("str")
@@ -1186,7 +1186,7 @@ def test_concat_join_empty_dataframes(
         if axis == 0:
             for key, col in actual[actual.columns].iteritems():
                 if is_categorical_dtype(col.dtype):
-                    if expected[key].dtype != "category":
+                    if not is_categorical_dtype(expected[key].dtype):
                         # TODO: Pandas bug:
                         # https://github.com/pandas-dev/pandas/issues/42840
                         expected[key] = (


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.