### PR TITLE
Fix doxygen for enum types in libcudf

### DIFF
--- a/cpp/include/cudf/ast/detail/expression_parser.hpp
+++ b/cpp/include/cudf/ast/detail/expression_parser.hpp
@@ -37,9 +37,9 @@ namespace detail {
  * linearization process but cannot be explicitly created by the user.
  */
 enum class device_data_reference_type {
-  COLUMN,       // A value in a table column
-  LITERAL,      // A literal value
-  INTERMEDIATE  // An internal temporary value
+  COLUMN,       ///< A value in a table column
+  LITERAL,      ///< A literal value
+  INTERMEDIATE  ///< An internal temporary value
 };
 
 /**

--- a/cpp/include/cudf/ast/expressions.hpp
+++ b/cpp/include/cudf/ast/expressions.hpp
@@ -122,9 +122,9 @@ enum class ast_operator {
  * This determines which table to use in cases with two tables (e.g. joins).
  */
 enum class table_reference {
-  LEFT,   // Column index in the left table
-  RIGHT,  // Column index in the right table
-  OUTPUT  // Column index in the output table
+  LEFT,   ///< Column index in the left table
+  RIGHT,  ///< Column index in the right table
+  OUTPUT  ///< Column index in the output table
 };
 
 /**

--- a/cpp/include/cudf/copying.hpp
+++ b/cpp/include/cudf/copying.hpp
@@ -41,8 +41,8 @@ namespace cudf {
  */
 
 enum class out_of_bounds_policy : bool {
-  NULLIFY,    /// Output values corresponding to out-of-bounds indices are null
-  DONT_CHECK  /// No bounds checking is performed, better performance
+  NULLIFY,    ///< Output values corresponding to out-of-bounds indices are null
+  DONT_CHECK  ///< No bounds checking is performed, better performance
 };
 
 /**
@@ -901,8 +901,8 @@ std::unique_ptr<scalar> get_element(
  * @brief Indicates whether a row can be sampled more than once.
  */
 enum class sample_with_replacement : bool {
-  FALSE,  // A row can be sampled only once
-  TRUE    // A row can be sampled more than once
+  FALSE,  ///< A row can be sampled only once
+  TRUE    ///< A row can be sampled more than once
 };
 
 /**

--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -66,9 +66,9 @@ struct bounds_checker {
  * @brief The operation to perform when a gather map index is out of bounds
  */
 enum class gather_bitmask_op {
-  DONT_CHECK,   // Don't check for out of bounds indices
-  PASSTHROUGH,  // Preserve mask at rows with out of bounds indices
-  NULLIFY,      // Nullify rows with out of bounds indices
+  DONT_CHECK,   ///< Don't check for out of bounds indices
+  PASSTHROUGH,  ///< Preserve mask at rows with out of bounds indices
+  NULLIFY,      ///< Nullify rows with out of bounds indices
 };
 
 template <gather_bitmask_op Op, typename MapIterator>

--- a/cpp/include/cudf/detail/structs/utilities.hpp
+++ b/cpp/include/cudf/detail/structs/utilities.hpp
@@ -28,8 +28,8 @@ namespace structs {
 namespace detail {
 
 enum class column_nullability {
-  MATCH_INCOMING,  // generate a null column if the incoming column has nulls
-  FORCE            // always generate a null column
+  MATCH_INCOMING,  ///< generate a null column if the incoming column has nulls
+  FORCE            ///< always generate a null column
 };
 
 /**

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -87,9 +87,9 @@ enum class quote_style {
  * @brief Column statistics granularity type for parquet/orc writers
  */
 enum statistics_freq {
-  STATISTICS_NONE     = 0,  //!< No column statistics
-  STATISTICS_ROWGROUP = 1,  //!< Per-Rowgroup column statistics
-  STATISTICS_PAGE     = 2,  //!< Per-page column statistics
+  STATISTICS_NONE     = 0,  ///< No column statistics
+  STATISTICS_ROWGROUP = 1,  ///< Per-Rowgroup column statistics
+  STATISTICS_PAGE     = 2,  ///< Per-page column statistics
 };
 
 /**

--- a/cpp/include/cudf/strings/char_types/char_types.hpp
+++ b/cpp/include/cudf/strings/char_types/char_types.hpp
@@ -37,16 +37,16 @@ namespace strings {
  * does not match to any explicitly named enumerator.
  */
 enum string_character_types : uint32_t {
-  DECIMAL    = 1 << 0,                             /// all decimal characters
-  NUMERIC    = 1 << 1,                             /// all numeric characters
-  DIGIT      = 1 << 2,                             /// all digit characters
-  ALPHA      = 1 << 3,                             /// all alphabetic characters
-  SPACE      = 1 << 4,                             /// all space characters
-  UPPER      = 1 << 5,                             /// all upper case characters
-  LOWER      = 1 << 6,                             /// all lower case characters
-  ALPHANUM   = DECIMAL | NUMERIC | DIGIT | ALPHA,  /// all alphanumeric characters
-  CASE_TYPES = UPPER | LOWER,                      /// all case-able characters
-  ALL_TYPES  = ALPHANUM | CASE_TYPES | SPACE       /// all character types
+  DECIMAL    = 1 << 0,                             ///< all decimal characters
+  NUMERIC    = 1 << 1,                             ///< all numeric characters
+  DIGIT      = 1 << 2,                             ///< all digit characters
+  ALPHA      = 1 << 3,                             ///< all alphabetic characters
+  SPACE      = 1 << 4,                             ///< all space characters
+  UPPER      = 1 << 5,                             ///< all upper case characters
+  LOWER      = 1 << 6,                             ///< all lower case characters
+  ALPHANUM   = DECIMAL | NUMERIC | DIGIT | ALPHA,  ///< all alphanumeric characters
+  CASE_TYPES = UPPER | LOWER,                      ///< all case-able characters
+  ALL_TYPES  = ALPHANUM | CASE_TYPES | SPACE       ///< all character types
 };
 
 /**

--- a/cpp/include/cudf/strings/regex/flags.hpp
+++ b/cpp/include/cudf/strings/regex/flags.hpp
@@ -33,9 +33,9 @@ namespace strings {
  * and to match the Python flag values.
  */
 enum regex_flags : uint32_t {
-  DEFAULT   = 0,  /// default
-  MULTILINE = 8,  /// the '^' and '$' honor new-line characters
-  DOTALL    = 16  /// the '.' matching includes new-line characters
+  DEFAULT   = 0,  ///< default
+  MULTILINE = 8,  ///< the '^' and '$' honor new-line characters
+  DOTALL    = 16  ///< the '.' matching includes new-line characters
 };
 
 /**

--- a/cpp/include/cudf/strings/strip.hpp
+++ b/cpp/include/cudf/strings/strip.hpp
@@ -31,9 +31,9 @@ namespace strings {
  * @brief Direction identifier for strip() function.
  */
 enum class strip_type {
-  LEFT,   //<< strip characters from the beginning of the string
-  RIGHT,  //<< strip characters from the end of the string
-  BOTH    //<< strip characters from the beginning and end of the string
+  LEFT,   ///< strip characters from the beginning of the string
+  RIGHT,  ///< strip characters from the end of the string
+  BOTH    ///< strip characters from the beginning and end of the string
 };
 
 /**

--- a/cpp/include/cudf/strings/translate.hpp
+++ b/cpp/include/cudf/strings/translate.hpp
@@ -60,7 +60,10 @@ std::unique_ptr<column> translate(
 /**
  * @brief Removes or keeps the specified character ranges in cudf::strings::filter_characters
  */
-enum class filter_type : bool { KEEP, REMOVE };
+enum class filter_type : bool {
+  KEEP,   ///< All characters but those specified are removed
+  REMOVE  ///< Only the specified characters are removed
+};
 
 /**
  * @brief Removes ranges of characters from each string in a strings column.

--- a/cpp/include/cudf/unary.hpp
+++ b/cpp/include/cudf/unary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,28 +28,28 @@ namespace cudf {
  */
 
 enum class unary_operator : int32_t {
-  SIN,         // < Trigonometric sine
-  COS,         // < Trigonometric cosine
-  TAN,         // < Trigonometric tangent
-  ARCSIN,      // < Trigonometric sine inverse
-  ARCCOS,      // < Trigonometric cosine inverse
-  ARCTAN,      // < Trigonometric tangent inverse
-  SINH,        // < Hyperbolic sine
-  COSH,        // < Hyperbolic cosine
-  TANH,        // < Hyperbolic tangent
-  ARCSINH,     // < Hyperbolic sine inverse
-  ARCCOSH,     // < Hyperbolic cosine inverse
-  ARCTANH,     // < Hyperbolic tangent inverse
-  EXP,         // < Exponential (base e, Euler number)
-  LOG,         // < Natural Logarithm (base e)
-  SQRT,        // < Square-root (x^0.5)
-  CBRT,        // < Cube-root (x^(1.0/3))
-  CEIL,        // < Smallest integer value not less than arg
-  FLOOR,       // < largest integer value not greater than arg
-  ABS,         // < Absolute value
-  RINT,        // < Rounds the floating-point argument arg to an integer value
-  BIT_INVERT,  // < Bitwise Not (~)
-  NOT,         // < Logical Not (!)
+  SIN,         ///< Trigonometric sine
+  COS,         ///< Trigonometric cosine
+  TAN,         ///< Trigonometric tangent
+  ARCSIN,      ///< Trigonometric sine inverse
+  ARCCOS,      ///< Trigonometric cosine inverse
+  ARCTAN,      ///< Trigonometric tangent inverse
+  SINH,        ///< Hyperbolic sine
+  COSH,        ///< Hyperbolic cosine
+  TANH,        ///< Hyperbolic tangent
+  ARCSINH,     ///< Hyperbolic sine inverse
+  ARCCOSH,     ///< Hyperbolic cosine inverse
+  ARCTANH,     ///< Hyperbolic tangent inverse
+  EXP,         ///< Exponential (base e, Euler number)
+  LOG,         ///< Natural Logarithm (base e)
+  SQRT,        ///< Square-root (x^0.5)
+  CBRT,        ///< Cube-root (x^(1.0/3))
+  CEIL,        ///< Smallest integer value not less than arg
+  FLOOR,       ///< largest integer value not greater than arg
+  ABS,         ///< Absolute value
+  RINT,        ///< Rounds the floating-point argument arg to an integer value
+  BIT_INVERT,  ///< Bitwise Not (~)
+  NOT,         ///< Logical Not (!)
 };
 
 /**


### PR DESCRIPTION
Fix some doxygen formatting errors around enum types found when looking at various pages in the published docs: https://docs.rapids.ai/api/libcudf/stable/namespacecudf.html