### PR TITLE
Fix clang-format version check for 11.1.0

### DIFF
--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import tempfile
 
-EXPECTED_VERSION = "11.0.0"
+EXPECTED_VERSION = "11.1.0"
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
 # NOTE: populate this list with more top-level dirs as we add more of them to
 # the cudf repo


### PR DESCRIPTION
Fixes CI builds failing style checks which stop the build from compiling and executing tests.
