### PR TITLE
Skip cufile tests in JNI build script

### DIFF
--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-set -e
+set -ex
 gcc --version
 
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
@@ -58,7 +58,7 @@ make -j$PARALLEL_LEVEL
 make install DESTDIR=$INSTALL_PREFIX
 
 ###### Build cudf jar ######
-BUILD_ARG="-Dmaven.repo.local=\"$WORKSPACE/.m2\" -DskipTests=$SKIP_JAVA_TESTS -DPER_THREAD_DEFAULT_STREAM=$ENABLE_PTDS -DRMM_LOGGING_LEVEL=$RMM_LOGGING_LEVEL -DUSE_GDS=$ENABLE_GDS"
+BUILD_ARG="-Dmaven.repo.local=\"$WORKSPACE/.m2\" -DskipTests=$SKIP_JAVA_TESTS -DPER_THREAD_DEFAULT_STREAM=$ENABLE_PTDS -DRMM_LOGGING_LEVEL=$RMM_LOGGING_LEVEL -DUSE_GDS=$ENABLE_GDS -Dtest=*,!CuFileTest"
 if [ "$SIGN_FILE" == true ]; then
     # Build javadoc and sources only when SIGN_FILE is true
     BUILD_ARG="$BUILD_ARG -Prelease"


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

related to #9722 
skip cufile test in JNI build while we have a separate pipeline for GDS testing

