### PR TITLE
Update `DEFAULT_CUDA_VER` in `ci/cpu/prebuild.sh`

### DIFF
--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -3,15 +3,7 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 set -e
 
-ARCH=$(arch)
-if [ "${ARCH}" = "x86_64" ]; then
-    DEFAULT_CUDA_VER="11.0"
-elif [ "${ARCH}" = "aarch64" ]; then
-    DEFAULT_CUDA_VER="11.2"
-else
-    echo "Unsupported arch ${ARCH}"
-    exit 1
-fi
+DEFAULT_CUDA_VER="11.5"
 
 #Always upload cudf Python package
 export UPLOAD_CUDF=1


### PR DESCRIPTION
Now that we only do `11.5` builds for RAPIDS, the `DEFAULT_CUDA_VER` variable in `ci/cpu/prebuild.sh` should be set to `11.5` so that the rest of the logic in the file works correctly.