### PR TITLE
fix cuio tests segfault in CUDA 11.0, 11.2 

### DIFF
--- a/cpp/src/io/utilities/file_io_utilities.cpp
+++ b/cpp/src/io/utilities/file_io_utilities.cpp
@@ -75,8 +75,8 @@ class cufile_shim {
 
   ~cufile_shim()
   {
-    driver_close();
-    dlclose(cf_lib);
+    if (driver_close) driver_close();
+    if (cf_lib) dlclose(cf_lib);
   }
 
   decltype(cuFileHandleRegister)* handle_register     = nullptr;


### PR DESCRIPTION
Added nullptr check in `~cufile_shim` destructor
