### PR TITLE
Load native dependencies when Java ColumnView is loaded

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -30,6 +30,10 @@ import static ai.rapids.cudf.HostColumnVector.OFFSET_SIZE;
  */
 public class ColumnView implements AutoCloseable, BinaryOperable {
 
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
   public static final long UNKNOWN_NULL_COUNT = -1;
 
   protected long viewHandle;


### PR DESCRIPTION
The Java ColumnView class has native methods but does not ensure the corresponding native libraries that implement those methods are loaded.  This adds a static code block to the ColumnView class to load the native libraries when the ColumnView class is loaded.