### PR TITLE
Enforce boolean `ascending` for dask-cudf `sort_values`

### DIFF
--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -23,6 +23,7 @@ def set_index_post(df, index_name, drop, column_dtype):
 
 
 def _set_partitions_pre(s, divisions, ascending=True, na_position="last"):
+    breakpoint()
     if ascending:
         partitions = divisions.searchsorted(s, side="right") - 1
     else:
@@ -224,6 +225,8 @@ def sort_values(
     na_position="last",
 ):
     """Sort by the given list/tuple of column names."""
+    # if not isinstance(ascending, bool):
+    #     raise ValueError("ascending must be either True or False")
     if na_position not in ("first", "last"):
         raise ValueError("na_position must be either 'first' or 'last'")
 

--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -23,7 +23,6 @@ def set_index_post(df, index_name, drop, column_dtype):
 
 
 def _set_partitions_pre(s, divisions, ascending=True, na_position="last"):
-    breakpoint()
     if ascending:
         partitions = divisions.searchsorted(s, side="right") - 1
     else:

--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -224,8 +224,8 @@ def sort_values(
     na_position="last",
 ):
     """Sort by the given list/tuple of column names."""
-    # if not isinstance(ascending, bool):
-    #     raise ValueError("ascending must be either True or False")
+    if not isinstance(ascending, bool):
+        raise ValueError("ascending must be either True or False")
     if na_position not in ("first", "last"):
         raise ValueError("na_position must be either 'first' or 'last'")
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

It is possible to pass a list of `ascending` booleans to dask-cudf's `sort_values`, which is not yet supported by `quantile_divisions` (which computes divisions for all sort-by columns sorted in ascending order), and can cause undefined behavior.

This small PR adds a check that `ascending` is a boolean before computing quantile divisions; note that this check happens _after_ the single-partition case is handled, as cuDF can handle lists of `ascending` booleans.