### PR TITLE
Load libcufile.so with RTLD_NODELETE flag

### DIFF
--- a/cpp/src/io/utilities/file_io_utilities.cpp
+++ b/cpp/src/io/utilities/file_io_utilities.cpp
@@ -75,8 +75,8 @@ class cufile_shim {
 
   ~cufile_shim()
   {
-    if (driver_close) driver_close();
-    if (cf_lib) dlclose(cf_lib);
+    if (driver_close != nullptr) driver_close();
+    if (cf_lib != nullptr) dlclose(cf_lib);
   }
 
   decltype(cuFileHandleRegister)* handle_register     = nullptr;
@@ -117,7 +117,8 @@ void cufile_shim::modify_cufile_json() const
 
 void cufile_shim::load_cufile_lib()
 {
-  cf_lib      = dlopen("libcufile.so", RTLD_NOW);
+  cf_lib = dlopen("libcufile.so", RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
+  CUDF_EXPECTS(cf_lib != nullptr, "Failed to load cuFile library");
   driver_open = reinterpret_cast<decltype(driver_open)>(dlsym(cf_lib, "cuFileDriverOpen"));
   CUDF_EXPECTS(driver_open != nullptr, "could not find cuFile cuFileDriverOpen symbol");
   driver_close = reinterpret_cast<decltype(driver_close)>(dlsym(cf_lib, "cuFileDriverClose"));


### PR DESCRIPTION
Workaround for a known cuFile issue that can lead to segfault if cuFile library is dynamically unloaded.
Using `RTLD_NODELETE` when calling `dlopen` so that the library is not unloaded in `dlclose`.

Also adds a check for the result of dlopen, to help triage cuFile use issues.