### PR TITLE
add run_benchmarks target for running benchmarks with json output

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -42,6 +42,14 @@ add_library(
                                synchronization/synchronization.cpp io/cuio_benchmark_common.cpp
 )
 target_link_libraries(cudf_benchmark_common PRIVATE cudf_datagen)
+add_custom_command(
+  OUTPUT CUDF_BENCHMARKS
+  COMMAND echo Running benchmarks
+  COMMAND mkdir -p results
+  VERBATIM
+  COMMENT "Running cudf benchmarks."
+  USES_TERMINAL
+)
 
 # This function takes in a benchmark name and benchmark source and handles setting all of the
 # associated properties and linking to build the benchmark
@@ -53,6 +61,13 @@ function(ConfigureBench CMAKE_BENCH_NAME)
   )
   target_link_libraries(
     ${CMAKE_BENCH_NAME} PRIVATE cudf_benchmark_common cudf_datagen benchmark::benchmark_main
+  )
+  add_custom_command(
+    OUTPUT CUDF_BENCHMARKS
+    COMMAND ${CMAKE_BENCH_NAME} --benchmark_out_format=json
+            --benchmark_out=results/${CMAKE_BENCH_NAME}.json
+    APPEND
+    COMMENT "Adding ${CMAKE_BENCH_NAME}"
   )
 endfunction()
 
@@ -254,3 +269,9 @@ ConfigureBench(JSON_BENCH string/json_benchmark.cpp)
 # ##################################################################################################
 # * io benchmark ---------------------------------------------------------------------
 ConfigureBench(MULTIBYTE_SPLIT_BENCHMARK io/text/multibyte_split_benchmark.cpp)
+
+add_custom_target(
+  run_benchmarks
+  DEPENDS CUDF_BENCHMARKS
+  COMMENT "Custom command for running cudf benchmarks."
+)


### PR DESCRIPTION
closes https://github.com/rapidsai/cudf/issues/2784
Adds run_benchmarks target for running benchmarks with json output

You can run all benchmarks with  `make run_benchmarks` or `ninja run_benchmarks`
json will be stored in `benchmarks/results/*.json`
The benchmark stdout will still print.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
