### PR TITLE
Change output of `M2` groupby aggregation from a single double column into a structs column

### DIFF
--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -200,6 +200,10 @@ std::unique_ptr<Base> make_mean_aggregation();
  * deviation across multiple discrete sets. See
  * `https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm` for more
  * detail.
+ *
+ * The results of M2 aggregation are structs whose the last member is the computed M2 values. The
+ * first two members store the results of `COUNT_VALID` and `MEAN` aggregation that were used to
+ * compute these M2 values.
  */
 template <typename Base = aggregation>
 std::unique_ptr<Base> make_m2_aggregation();

--- a/cpp/include/cudf/detail/aggregation/aggregation.hpp
+++ b/cpp/include/cudf/detail/aggregation/aggregation.hpp
@@ -1138,10 +1138,10 @@ struct target_type_impl<Source, k, std::enable_if_t<is_chrono<Source>() && is_su
   using type = Source;
 };
 
-// Always use `double` for M2
+// Always use struct for M2
 template <typename SourceType>
 struct target_type_impl<SourceType, aggregation::M2> {
-  using type = double;
+  using type = struct_view;
 };
 
 // Always use `double` for VARIANCE

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -254,14 +254,19 @@ void aggregate_result_functor::operator()<aggregation::M2>(aggregation const& ag
 {
   if (cache.has_result(values, agg)) return;
 
-  auto const mean_agg = make_mean_aggregation();
+  auto const count_agg = make_count_aggregation();
+  auto const mean_agg  = make_mean_aggregation();
+  operator()<aggregation::COUNT_VALID>(*count_agg);
   operator()<aggregation::MEAN>(*mean_agg);
-  auto const mean_result = cache.get_result(values, *mean_agg);
+
+  auto const count_result = cache.get_result(values, *count_agg);
+  auto const mean_result  = cache.get_result(values, *mean_agg);
 
   cache.add_result(
     values,
     agg,
-    detail::group_m2(get_grouped_values(), mean_result, helper.group_labels(stream), stream, mr));
+    detail::group_m2(
+      get_grouped_values(), count_result, mean_result, helper.group_labels(stream), stream, mr));
 };
 
 template <>

--- a/cpp/src/groupby/sort/group_m2.cu
+++ b/cpp/src/groupby/sort/group_m2.cu
@@ -19,6 +19,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/unary.hpp>
 #include <cudf/dictionary/detail/iterator.cuh>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/utilities/span.hpp>
@@ -35,18 +36,18 @@ namespace groupby {
 namespace detail {
 namespace {
 
-template <typename ResultType, typename Iterator>
+template <typename FloatType, typename Iterator>
 struct m2_transform {
   column_device_view const d_values;
-  Iterator const values_iter;
-  ResultType const* d_means;
+  Iterator const d_values_iter;
+  FloatType const* d_means;
   size_type const* d_group_labels;
 
-  __device__ ResultType operator()(size_type const idx) const noexcept
+  __device__ FloatType operator()(size_type const idx) const noexcept
   {
     if (d_values.is_null(idx)) { return 0.0; }
 
-    auto const x         = static_cast<ResultType>(values_iter[idx]);
+    auto const x         = static_cast<FloatType>(d_values_iter[idx]);
     auto const group_idx = d_group_labels[idx];
     auto const mean      = d_means[group_idx];
     auto const diff      = x - mean;
@@ -54,25 +55,24 @@ struct m2_transform {
   }
 };
 
-template <typename ResultType, typename Iterator>
-void compute_m2_fn(column_device_view const& values,
-                   Iterator values_iter,
+template <typename FloatType, typename Iterator>
+void compute_m2_fn(column_device_view const& d_values,
+                   Iterator d_values_iter,
                    cudf::device_span<size_type const> group_labels,
-                   ResultType const* d_means,
-                   ResultType* d_result,
+                   FloatType const* d_means,
+                   FloatType* d_m2s,
                    rmm::cuda_stream_view stream)
 {
   auto const var_iter = cudf::detail::make_counting_transform_iterator(
     size_type{0},
-    m2_transform<ResultType, decltype(values_iter)>{
-      values, values_iter, d_means, group_labels.data()});
+    m2_transform<FloatType, Iterator>{d_values, d_values_iter, d_means, group_labels.data()});
 
   thrust::reduce_by_key(rmm::exec_policy(stream),
                         group_labels.begin(),
                         group_labels.end(),
                         var_iter,
                         thrust::make_discard_iterator(),
-                        d_result);
+                        d_m2s);
 }
 
 struct m2_functor {
@@ -84,34 +84,35 @@ struct m2_functor {
     rmm::cuda_stream_view stream,
     rmm::mr::device_memory_resource* mr)
   {
-    using result_type = cudf::detail::target_type_t<T, aggregation::Kind::M2>;
-    auto result       = make_numeric_column(data_type(type_to_id<result_type>()),
-                                      group_means.size(),
-                                      mask_state::UNALLOCATED,
-                                      stream,
-                                      mr);
+    // Output double type for m2 values.
+    using float_type = id_to_type<type_id::FLOAT64>;
+    CUDF_EXPECTS(group_means.type().id() == type_to_id<float_type>(),
+                 "Input `group_means` column must have double type.");
+
+    auto m2s = make_numeric_column(
+      data_type(type_to_id<float_type>()), group_means.size(), mask_state::UNALLOCATED, stream, mr);
 
     auto const values_dv_ptr = column_device_view::create(values, stream);
     auto const d_values      = *values_dv_ptr;
-    auto const d_means       = group_means.data<result_type>();
-    auto const d_result      = result->mutable_view().data<result_type>();
+    auto const d_means       = group_means.data<float_type>();
+    auto const d_m2s         = m2s->mutable_view().data<float_type>();
 
     if (!cudf::is_dictionary(values.type())) {
-      auto const values_iter = d_values.begin<T>();
-      compute_m2_fn(d_values, values_iter, group_labels, d_means, d_result, stream);
+      auto const d_values_iter = d_values.template begin<T>();
+      compute_m2_fn(d_values, d_values_iter, group_labels, d_means, d_m2s, stream);
     } else {
-      auto const values_iter =
+      auto const d_values_iter =
         cudf::dictionary::detail::make_dictionary_iterator<T>(*values_dv_ptr);
-      compute_m2_fn(d_values, values_iter, group_labels, d_means, d_result, stream);
+      compute_m2_fn(d_values, d_values_iter, group_labels, d_means, d_m2s, stream);
     }
 
     // M2 column values should have the same bitmask as means's.
     if (group_means.nullable()) {
-      result->set_null_mask(cudf::detail::copy_bitmask(group_means, stream, mr),
-                            group_means.null_count());
+      m2s->set_null_mask(cudf::detail::copy_bitmask(group_means, stream, mr),
+                         group_means.null_count());
     }
 
-    return result;
+    return m2s;
   }
 
   template <typename T, typename... Args>
@@ -124,6 +125,7 @@ struct m2_functor {
 }  // namespace
 
 std::unique_ptr<column> group_m2(column_view const& values,
+                                 column_view const& group_counts,
                                  column_view const& group_means,
                                  cudf::device_span<size_type const> group_labels,
                                  rmm::cuda_stream_view stream,
@@ -133,7 +135,22 @@ std::unique_ptr<column> group_m2(column_view const& values,
                        ? dictionary_column_view(values).keys().type()
                        : values.type();
 
-  return type_dispatcher(values_type, m2_functor{}, values, group_means, group_labels, stream, mr);
+  // Firstly compute m2 values.
+  auto m2s =
+    type_dispatcher(values_type, m2_functor{}, values, group_means, group_labels, stream, mr);
+
+  // Then build the output structs column having double members (count, mean, m2).
+  std::vector<std::unique_ptr<column>> output_members;
+  output_members.emplace_back(cudf::detail::cast(group_counts, group_means.type(), stream, mr));
+  output_members.emplace_back(std::make_unique<column>(group_means, stream, mr));
+  output_members.emplace_back(std::move(m2s));
+
+  return make_structs_column(group_counts.size(),
+                             std::move(output_members),
+                             0,
+                             rmm::device_buffer{0, stream, mr},
+                             stream,
+                             mr);
 }
 
 }  // namespace detail

--- a/cpp/src/groupby/sort/group_reductions.hpp
+++ b/cpp/src/groupby/sort/group_reductions.hpp
@@ -230,12 +230,14 @@ std::unique_ptr<column> group_count_all(cudf::device_span<size_type const> group
  * @endcode
  *
  * @param values Grouped values to compute M2 values
+ * @param group_counts Number of non-null values in each group.
  * @param group_means Pre-computed groupwise MEAN
  * @param group_labels ID of group corresponding value in @p values belongs to
  * @param stream CUDA stream used for device memory operations and kernel launches.
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<column> group_m2(column_view const& values,
+                                 column_view const& group_counts,
                                  column_view const& group_means,
                                  cudf::device_span<size_type const> group_labels,
                                  rmm::cuda_stream_view stream,


### PR DESCRIPTION
Currently, `M2` groupby aggregation only outputs a single double type column. During computing the `m2` values, the intermediate results including groupby `count` and `mean` are all discarded. However, for merging these `m2` values, we must have the values `count` and `mean` available. As such, in Spark plugin, we have to re-compute these values again, which seems to be too inefficient.

This PR addresses that issue: The intermediate values `count` and `mean` are all output together with `m2` values. In particular, the output result of the `M2` groupby aggregation now is a structs column containing tuples of (`count`, `mean`, `m2`).