### PR TITLE
Implement JNI for `cudf::scatter` APIs

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -650,9 +650,11 @@ public final class Table implements AutoCloseable {
   private static native long[] gather(long tableHandle, long gatherView, boolean checkBounds);
 
   private static native long[] scatterTable(long srcTableHandle, long scatterView,
-                                            long targetTableHandle, boolean checkBounds);
+                                            long targetTableHandle, boolean checkBounds)
+                                            throws CudfException;
   private static native long[] scatterScalars(long[] srcScalarHandles, long scatterView,
-                                             long targetTableHandle, boolean checkBounds);
+                                             long targetTableHandle, boolean checkBounds)
+                                             throws CudfException;
 
   private static native long[] convertToRows(long nativeHandle);
 
@@ -2063,7 +2065,7 @@ public final class Table implements AutoCloseable {
   /**
    * Scatters values from the source table into the target table out-of-place,
    * returning a "destination table". The scatter is performed according to a
-   * scatter map such that row `scatter_map[i]` of the destination table gets row
+   * scatter map such that row `scatterMap[i]` of the destination table gets row
    * `i` of the source table. All other rows of the destination table equal
    * corresponding rows of the target table.
    *
@@ -2088,8 +2090,8 @@ public final class Table implements AutoCloseable {
   /**
    * Scatters values from the source row into the target table out-of-place,
    * returning a "destination table". The scatter is performed according to a
-   * scatter map such that row `scatter_map[i]` of the destination table is
-   * replaced by the source row. All other rows of the destination table equal
+   * scatter map such that row `scatterMap[i]` of the destination table is
+   * replaced by the source row `i`. All other rows of the destination table equal
    * corresponding rows of the target table.
    *
    * The number of elements in source must match the number of columns in target

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -2063,25 +2063,25 @@ public final class Table implements AutoCloseable {
   }
 
   /**
-   * Scatters values from the source table into the target table out-of-place,
-   * returning a "destination table". The scatter is performed according to a
-   * scatter map such that row `scatterMap[i]` of the destination table gets row
-   * `i` of the source table. All other rows of the destination table equal
-   * corresponding rows of the target table.
+   * Scatters values from the source table into the target table out-of-place, returning a new
+   * result table. The scatter is performed according to a scatter map such that row `scatterMap[i]`
+   * of the destination table gets row `i` of the source table. All other rows of the destination
+   * table equal corresponding rows of the target table.
    *
-   * The number of columns in source must match the number of columns in target
-   * and their corresponding data types must be the same.
+   * The number of columns in source must match the number of columns in target and their
+   * corresponding data types must be the same.
    *
-   * If the same index appears more than once in the scatter map, the result is
-   * undefined.
+   * If the same index appears more than once in the scatter map, the result is undefined.
    *
-   * A negative value `i` in the `scatter_map` is interpreted as `i+n`, where `n`
-   * is the number of rows in the `target` table.
+   * A negative value `i` in the `scatterMap` is interpreted as `i + n`, where `n` is the number of
+   * rows in the `target` table.
    *
    * @param scatterMap The map of indexes. Must be non-nullable and integral type.
-   * @param target The table where rows from the current table are scattered into.
-   * @param checkBounds Optionally perform bounds checking on the values of`scatterMap`
-   *                    and throw an error if any of its values are out of bounds.
+   * @param target The table into which rows from the current table are to be scattered out-of-place.
+   * @param checkBounds Optionally perform bounds checking on the values of`scatterMap` and throw
+   *                    an exception if any of its values are out of bounds.
+   * @return A new table which is the result of out-of-place scattering the source table into the
+   *         target table.
    */
   public Table scatter(ColumnView scatterMap, Table target, boolean checkBounds) {
     return new Table(scatterTable(nativeHandle, scatterMap.getNativeView(), target.getNativeView(),
@@ -2089,23 +2089,26 @@ public final class Table implements AutoCloseable {
   }
 
   /**
-   * Scatters values from the source row into the target table out-of-place,
-   * returning a "destination table". The scatter is performed according to a
-   * scatter map such that row `scatterMap[i]` of the destination table is
-   * replaced by the source row `i`. All other rows of the destination table equal
-   * corresponding rows of the target table.
+   * Scatters values from the source rows into the target table out-of-place, returning a new result
+   * table. The scatter is performed according to a scatter map such that row `scatterMap[i]` of the
+   * destination table is replaced by the source row `i`. All other rows of the destination table
+   * equal corresponding rows of the target table.
    *
-   * The number of elements in source must match the number of columns in target
-   * and their corresponding data types must be the same.
+   * The number of elements in source must match the number of columns in target and their
+   * corresponding data types must be the same.
    *
-   * If the same index appears more than once in the scatter map, the result is
-   * undefined.
+   * If the same index appears more than once in the scatter map, the result is undefined.
+   *
+   * A negative value `i` in the `scatterMap` is interpreted as `i + n`, where `n` is the number of
+   * rows in the `target` table.
    *
    * @param source The input scalars containing values to be scattered into the target table.
    * @param scatterMap The map of indexes. Must be non-nullable and integral type.
-   * @param target The table where rows from the current table are scattered into.
-   * @param checkBounds Optionally perform bounds checking on the values of`scatterMap`
-   *                    and throw an error if any of its values are out of bounds.
+   * @param target The table into which the values from source are to be scattered out-of-place.
+   * @param checkBounds Optionally perform bounds checking on the values of`scatterMap` and throw
+   *                    an exception if any of its values are out of bounds.
+   * @return A new table which is the result of out-of-place scattering the source values into the
+   *         target table.
    */
   public static Table scatter(Scalar[] source, ColumnView scatterMap, Table target,
                               boolean checkBounds) {

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -2079,6 +2079,7 @@ public final class Table implements AutoCloseable {
    * is the number of rows in the `target` table.
    *
    * @param scatterMap The map of indexes. Must be non-nullable and integral type.
+   * @param target The table where rows from the current table are scattered into.
    * @param checkBounds Optionally perform bounds checking on the values of`scatterMap`
    *                    and throw an error if any of its values are out of bounds.
    */
@@ -2100,7 +2101,9 @@ public final class Table implements AutoCloseable {
    * If the same index appears more than once in the scatter map, the result is
    * undefined.
    *
+   * @param source The input scalars containing values to be scattered into the target table.
    * @param scatterMap The map of indexes. Must be non-nullable and integral type.
+   * @param target The table where rows from the current table are scattered into.
    * @param checkBounds Optionally perform bounds checking on the values of`scatterMap`
    *                    and throw an error if any of its values are out of bounds.
    */

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -649,9 +649,9 @@ public final class Table implements AutoCloseable {
 
   private static native long[] gather(long tableHandle, long gatherView, boolean checkBounds);
 
-  private static native long[] scatter(long srcTableHandle, long scatterView,
+  private static native long[] scatterTable(long srcTableHandle, long scatterView,
                                             long targetTableHandle, boolean checkBounds);
-  private static native long[] scatter(long[] srcScalarHandles, long scatterView,
+  private static native long[] scatterScalars(long[] srcScalarHandles, long scatterView,
                                              long targetTableHandle, boolean checkBounds);
 
   private static native long[] convertToRows(long nativeHandle);
@@ -2081,7 +2081,7 @@ public final class Table implements AutoCloseable {
    *                    and throw an error if any of its values are out of bounds.
    */
   public Table scatter(ColumnView scatterMap, Table target, boolean checkBounds) {
-    return new Table(scatter(nativeHandle, scatterMap.getNativeView(), target.getNativeView(),
+    return new Table(scatterTable(nativeHandle, scatterMap.getNativeView(), target.getNativeView(),
         checkBounds));
   }
 
@@ -2109,7 +2109,7 @@ public final class Table implements AutoCloseable {
       assert source[i] != null : "Scalar vectors passed in should not contain null";
       srcScalarHandles[i] = source[i].getScalarHandle();
     }
-    return new Table(scatter(srcScalarHandles, scatterMap.getNativeView(),
+    return new Table(scatterScalars(srcScalarHandles, scatterMap.getNativeView(),
         target.getNativeView(), checkBounds));
   }
 

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -649,9 +649,9 @@ public final class Table implements AutoCloseable {
 
   private static native long[] gather(long tableHandle, long gatherView, boolean checkBounds);
 
-  private static native long[] scatterTable(long srcTableHandle, long scatterView,
+  private static native long[] scatter(long srcTableHandle, long scatterView,
                                             long targetTableHandle, boolean checkBounds);
-  private static native long[] scatterScalars(long[] srcScalarHandles, long scatterView,
+  private static native long[] scatter(long[] srcScalarHandles, long scatterView,
                                              long targetTableHandle, boolean checkBounds);
 
   private static native long[] convertToRows(long nativeHandle);
@@ -2081,7 +2081,7 @@ public final class Table implements AutoCloseable {
    *                    and throw an error if any of its values are out of bounds.
    */
   public Table scatter(ColumnView scatterMap, Table target, boolean checkBounds) {
-    return new Table(scatterTable(nativeHandle, scatterMap.getNativeView(), target.getNativeView(),
+    return new Table(scatter(nativeHandle, scatterMap.getNativeView(), target.getNativeView(),
         checkBounds));
   }
 
@@ -2109,7 +2109,7 @@ public final class Table implements AutoCloseable {
       assert source[i] != null : "Scalar vectors passed in should not contain null";
       srcScalarHandles[i] = source[i].getScalarHandle();
     }
-    return new Table(scatterScalars(srcScalarHandles, scatterMap.getNativeView(),
+    return new Table(scatter(srcScalarHandles, scatterMap.getNativeView(),
         target.getNativeView(), checkBounds));
   }
 

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -6367,25 +6367,20 @@ public class TableTest extends CudfTestBase {
 
   @Test
   void testScatterScalars() {
-    Scalar[] srcScalars = new Scalar[] { Scalar.fromInt(0), Scalar.fromString("A") };
-    try {
-      try (ColumnVector scatterMap = ColumnVector.fromInts(0, 2, 4);
-           Table targetTable = new Table.TestBuilder()
-               .column(-1, -2, -3, -4, -5)
-               .column("B", "BB", "BBB", "BBBB", "BBBBB")
-               .build();
-           Table expected = new Table.TestBuilder()
-               .column(0, -2, 0, -4, 0)
-               .column("A", "BB", "A", "BBBB", "A")
-               .build();
-           Table result = Table.scatter(srcScalars, scatterMap, targetTable, false)) {
-         assertTablesAreEqual(expected, result);
-       }
-    } finally {
-      for (Scalar scalar : srcScalars) {
-        scalar.close();
-      }
-    }
+    try (Scalar s1 = Scalar.fromInt(0);
+         Scalar s2 = Scalar.fromString("A");
+         ColumnVector scatterMap = ColumnVector.fromInts(0, 2, 4);
+         Table targetTable = new Table.TestBuilder()
+            .column(-1, -2, -3, -4, -5)
+            .column("B", "BB", "BBB", "BBBB", "BBBBB")
+            .build();
+         Table expected = new Table.TestBuilder()
+            .column(0, -2, 0, -4, 0)
+            .column("A", "BB", "A", "BBBB", "A")
+            .build();
+         Table result = Table.scatter(new Scalar[] { s1, s2 }, scatterMap, targetTable, false)) {
+       assertTablesAreEqual(expected, result);
+     }
   }
 
   @Test

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -6369,7 +6369,7 @@ public class TableTest extends CudfTestBase {
   void testScatterScalars() {
     try (Scalar s1 = Scalar.fromInt(0);
          Scalar s2 = Scalar.fromString("A");
-         ColumnVector scatterMap = ColumnVector.fromInts(0, 2, 4);
+         ColumnVector scatterMap = ColumnVector.fromInts(0, 2, -1);
          Table targetTable = new Table.TestBuilder()
             .column(-1, -2, -3, -4, -5)
             .column("B", "BB", "BBB", "BBBB", "BBBBB")


### PR DESCRIPTION
This PR adds Java binding for both `cudf::scatter` APIs:
```
std::unique_ptr<table> scatter(
  table_view const& source,
  column_view const& scatter_map,
  table_view const& target,
...)
```
and
```
std::unique_ptr<table> scatter(
  std::vector<std::reference_wrapper<const scalar>> const& source,
  column_view const& indices,
  table_view const& target,
...)
```

Closes #9892.