### PR TITLE
Upgrade thrust version to 1.15

### DIFF
--- a/cpp/cmake/thirdparty/get_thrust.cmake
+++ b/cpp/cmake/thirdparty/get_thrust.cmake
@@ -80,6 +80,6 @@ function(find_and_configure_thrust VERSION)
   endif()
 endfunction()
 
-set(CUDF_MIN_VERSION_Thrust 1.12.0)
+set(CUDF_MIN_VERSION_Thrust 1.15.0)
 
 find_and_configure_thrust(${CUDF_MIN_VERSION_Thrust})


### PR DESCRIPTION
Compile times between 1.12 and 1.15 are comparable.
libcudf library size with 1.15 is < 1MB smaller compared to 1.12
