### PR TITLE
`decimal128` Support for `to/from_arrow`

### DIFF
--- a/cpp/src/interop/from_arrow.cu
+++ b/cpp/src/interop/from_arrow.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -177,6 +177,40 @@ std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<numeric::decimal64>(
 }
 
 template <>
+std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<numeric::decimal128>(
+  column_view input,
+  cudf::type_id,
+  column_metadata const&,
+  arrow::MemoryPool* ar_mr,
+  rmm::cuda_stream_view stream)
+{
+  using DeviceType = __int128_t;
+
+  rmm::device_uvector<DeviceType> buf(input.size(), stream);
+
+  thrust::copy(rmm::exec_policy(stream),  //
+               input.begin<DeviceType>(),
+               input.end<DeviceType>(),
+               buf.begin());
+
+  auto const buf_size_in_bytes = buf.size() * sizeof(DeviceType);
+  auto data_buffer             = allocate_arrow_buffer(buf_size_in_bytes, ar_mr);
+
+  CUDA_TRY(cudaMemcpyAsync(data_buffer->mutable_data(),
+                           buf.data(),
+                           buf_size_in_bytes,
+                           cudaMemcpyDeviceToHost,
+                           stream.value()));
+
+  auto type    = arrow::decimal(18, -input.type().scale());
+  auto mask    = fetch_mask_buffer(input, ar_mr, stream);
+  auto buffers = std::vector<std::shared_ptr<arrow::Buffer>>{mask, std::move(data_buffer)};
+  auto data    = std::make_shared<arrow::ArrayData>(type, input.size(), buffers);
+
+  return std::make_shared<arrow::Decimal128Array>(data);
+}
+
+template <>
 std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<bool>(column_view input,
                                                                   cudf::type_id id,
                                                                   column_metadata const&,

--- a/cpp/tests/interop/arrow_utils.hpp
+++ b/cpp/tests/interop/arrow_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/interop/arrow_utils.hpp
+++ b/cpp/tests/interop/arrow_utils.hpp
@@ -178,9 +178,9 @@ std::pair<std::unique_ptr<cudf::table>, std::shared_ptr<arrow::Table>> get_table
   cudf::size_type length = 10000);
 
 template <typename T>
-auto make_decimal128_arrow_array(std::vector<T> const& data,
-                                 std::optional<std::vector<int>> const& nulls,
-                                 int32_t scale) -> std::shared_ptr<arrow::Array>
+[[nodiscard]] auto make_decimal128_arrow_array(std::vector<T> const& data,
+                                               std::optional<std::vector<int>> const& nulls,
+                                               int32_t scale) -> std::shared_ptr<arrow::Array>
 {
   auto constexpr SIZE_OF_INT128  = 16;
   auto constexpr BIT_WIDTH_RATIO = SIZE_OF_INT128 / sizeof(T);

--- a/cpp/tests/interop/arrow_utils.hpp
+++ b/cpp/tests/interop/arrow_utils.hpp
@@ -179,18 +179,17 @@ std::pair<std::unique_ptr<cudf::table>, std::shared_ptr<arrow::Table>> get_table
 
 template <typename T>
 [[nodiscard]] auto make_decimal128_arrow_array(std::vector<T> const& data,
-                                               std::optional<std::vector<int>> const& nulls,
+                                               std::optional<std::vector<int>> const& validity,
                                                int32_t scale) -> std::shared_ptr<arrow::Array>
 {
-  auto constexpr SIZE_OF_INT128  = 16;
-  auto constexpr BIT_WIDTH_RATIO = SIZE_OF_INT128 / sizeof(T);
+  auto constexpr BIT_WIDTH_RATIO = sizeof(__int128_t) / sizeof(T);
 
   std::shared_ptr<arrow::Array> arr;
   arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
                                            arrow::default_memory_pool());
 
   for (T i = 0; i < static_cast<T>(data.size() / BIT_WIDTH_RATIO); ++i) {
-    if (nulls.has_value() and not nulls.value()[i]) {
+    if (validity.has_value() and not validity.value()[i]) {
       decimal_builder.AppendNull();
     } else {
       decimal_builder.Append(reinterpret_cast<const uint8_t*>(data.data() + BIT_WIDTH_RATIO * i));

--- a/cpp/tests/interop/from_arrow_test.cpp
+++ b/cpp/tests/interop/from_arrow_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/interop/from_arrow_test.cpp
+++ b/cpp/tests/interop/from_arrow_test.cpp
@@ -450,12 +450,9 @@ TEST_F(FromArrowTest, FixedPoint128TableNullsLarge)
 
     std::shared_ptr<arrow::Array> arr;
     arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -i), arrow::default_memory_pool());
-    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
-      if (i % 2 == 0) {
-        decimal_builder.Append(reinterpret_cast<const uint8_t*>(data.data() + i));
-      } else {
-        decimal_builder.AppendNull();
-      }
+    for (int64_t i = 0; i < NUM_ELEMENTS; i += 2) {
+      decimal_builder.Append(reinterpret_cast<const uint8_t*>(data.data() + i));
+      decimal_builder.AppendNull();
     }
 
     CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");

--- a/cpp/tests/interop/from_arrow_test.cpp
+++ b/cpp/tests/interop/from_arrow_test.cpp
@@ -358,13 +358,14 @@ TEST_F(FromArrowTest, FixedPoint128Table)
 {
   using namespace numeric;
 
-  for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
+  for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
     auto const data     = std::vector<__int128_t>{1, 2, 3, 4, 5, 6};
-    auto const col      = fp_wrapper<__int128_t>(data.cbegin(), data.cend(), scale_type{i});
+    auto const col      = fp_wrapper<__int128_t>(data.cbegin(), data.cend(), scale_type{scale});
     auto const expected = cudf::table_view({col});
 
     std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -i), arrow::default_memory_pool());
+    arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -scale),
+                                             arrow::default_memory_pool());
     decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()), data.size());
     CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
 
@@ -384,14 +385,15 @@ TEST_F(FromArrowTest, FixedPoint128TableLarge)
   using namespace numeric;
   auto constexpr NUM_ELEMENTS = 1000;
 
-  for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
+  for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
     auto iota           = thrust::make_counting_iterator(1);
     auto const data     = std::vector<__int128_t>(iota, iota + NUM_ELEMENTS);
-    auto const col      = fp_wrapper<__int128_t>(iota, iota + NUM_ELEMENTS, scale_type{i});
+    auto const col      = fp_wrapper<__int128_t>(iota, iota + NUM_ELEMENTS, scale_type{scale});
     auto const expected = cudf::table_view({col});
 
     std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -i), arrow::default_memory_pool());
+    arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -scale),
+                                             arrow::default_memory_pool());
     decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()), NUM_ELEMENTS);
     CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
 
@@ -410,14 +412,15 @@ TEST_F(FromArrowTest, FixedPoint128TableNulls)
 {
   using namespace numeric;
 
-  for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
+  for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
     auto const data = std::vector<__int128_t>{1, 2, 3, 4, 5, 6};
     auto const col =
-      fp_wrapper<__int128_t>({1, 2, 3, 4, 5, 6, 0, 0}, {1, 1, 1, 1, 1, 1, 0, 0}, scale_type{i});
+      fp_wrapper<__int128_t>({1, 2, 3, 4, 5, 6, 0, 0}, {1, 1, 1, 1, 1, 1, 0, 0}, scale_type{scale});
     auto const expected = cudf::table_view({col});
 
     std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -i), arrow::default_memory_pool());
+    arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -scale),
+                                             arrow::default_memory_pool());
     decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()), data.size());
     decimal_builder.AppendNull();
     decimal_builder.AppendNull();
@@ -440,16 +443,17 @@ TEST_F(FromArrowTest, FixedPoint128TableNullsLarge)
   using namespace numeric;
   auto constexpr NUM_ELEMENTS = 1000;
 
-  for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
-    auto every_other    = [](auto i) { return i % 2 ? 0 : 1; };
-    auto nulls          = cudf::detail::make_counting_transform_iterator(0, every_other);
-    auto iota           = thrust::make_counting_iterator(1);
-    auto const data     = std::vector<__int128_t>(iota, iota + NUM_ELEMENTS);
-    auto const col      = fp_wrapper<__int128_t>(iota, iota + NUM_ELEMENTS, nulls, scale_type{i});
+  for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
+    auto every_other = [](auto i) { return i % 2 ? 0 : 1; };
+    auto nulls       = cudf::detail::make_counting_transform_iterator(0, every_other);
+    auto iota        = thrust::make_counting_iterator(1);
+    auto const data  = std::vector<__int128_t>(iota, iota + NUM_ELEMENTS);
+    auto const col   = fp_wrapper<__int128_t>(iota, iota + NUM_ELEMENTS, nulls, scale_type{scale});
     auto const expected = cudf::table_view({col});
 
     std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -i), arrow::default_memory_pool());
+    arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -scale),
+                                             arrow::default_memory_pool());
     for (int64_t i = 0; i < NUM_ELEMENTS; i += 2) {
       decimal_builder.Append(reinterpret_cast<const uint8_t*>(data.data() + i));
       decimal_builder.AppendNull();

--- a/cpp/tests/interop/from_arrow_test.cpp
+++ b/cpp/tests/interop/from_arrow_test.cpp
@@ -354,20 +354,18 @@ TEST_P(FromArrowTestSlice, SliceTest)
 template <typename T>
 using fp_wrapper = cudf::test::fixed_point_column_wrapper<T>;
 
-TEST_F(FromArrowTest, FixedPointTable)
+TEST_F(FromArrowTest, FixedPoint128Table)
 {
   using namespace numeric;
-  auto constexpr BIT_WIDTH_RATIO = 2;  // Array::Type:type::DECIMAL (128) / int64_t
 
   for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
-    auto const data     = std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0};
-    auto const col      = fp_wrapper<int64_t>({1, 2, 3, 4, 5, 6}, scale_type{i});
+    auto const data     = std::vector<__int128_t>{1, 2, 3, 4, 5, 6};
+    auto const col      = fp_wrapper<__int128_t>(data.cbegin(), data.cend(), scale_type{i});
     auto const expected = cudf::table_view({col});
 
     std::shared_ptr<arrow::Array> arr;
     arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -i), arrow::default_memory_pool());
-    decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()),
-                                 data.size() / BIT_WIDTH_RATIO);
+    decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()), data.size());
     CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
 
     auto const field         = arrow::field("a", arr->type());
@@ -381,18 +379,15 @@ TEST_F(FromArrowTest, FixedPointTable)
   }
 }
 
-TEST_F(FromArrowTest, FixedPointTableLarge)
+TEST_F(FromArrowTest, FixedPoint128TableLarge)
 {
   using namespace numeric;
-  auto constexpr BIT_WIDTH_RATIO = 2;  // Array::Type:type::DECIMAL (128) / int64_t
-  auto constexpr NUM_ELEMENTS    = 1000;
+  auto constexpr NUM_ELEMENTS = 1000;
 
   for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
-    auto every_other = [](auto i) { return i % BIT_WIDTH_RATIO ? 0 : i / BIT_WIDTH_RATIO; };
-    auto transform   = cudf::detail::make_counting_transform_iterator(BIT_WIDTH_RATIO, every_other);
-    auto const data  = std::vector<int64_t>(transform, transform + NUM_ELEMENTS * BIT_WIDTH_RATIO);
-    auto iota        = thrust::make_counting_iterator(1);
-    auto const col   = fp_wrapper<int64_t>(iota, iota + NUM_ELEMENTS, scale_type{i});
+    auto iota           = thrust::make_counting_iterator(1);
+    auto const data     = std::vector<__int128_t>(iota, iota + NUM_ELEMENTS);
+    auto const col      = fp_wrapper<__int128_t>(iota, iota + NUM_ELEMENTS, scale_type{i});
     auto const expected = cudf::table_view({col});
 
     std::shared_ptr<arrow::Array> arr;
@@ -411,21 +406,19 @@ TEST_F(FromArrowTest, FixedPointTableLarge)
   }
 }
 
-TEST_F(FromArrowTest, FixedPointTableNulls)
+TEST_F(FromArrowTest, FixedPoint128TableNulls)
 {
   using namespace numeric;
-  auto constexpr BIT_WIDTH_RATIO = 2;  // Array::Type:type::DECIMAL (128) / int64_t
 
   for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
-    auto const data = std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0};
+    auto const data = std::vector<__int128_t>{1, 2, 3, 4, 5, 6};
     auto const col =
-      fp_wrapper<int64_t>({1, 2, 3, 4, 5, 6, 0, 0}, {1, 1, 1, 1, 1, 1, 0, 0}, scale_type{i});
+      fp_wrapper<__int128_t>({1, 2, 3, 4, 5, 6, 0, 0}, {1, 1, 1, 1, 1, 1, 0, 0}, scale_type{i});
     auto const expected = cudf::table_view({col});
 
     std::shared_ptr<arrow::Array> arr;
     arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -i), arrow::default_memory_pool());
-    decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()),
-                                 data.size() / BIT_WIDTH_RATIO);
+    decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()), data.size());
     decimal_builder.AppendNull();
     decimal_builder.AppendNull();
 
@@ -442,25 +435,27 @@ TEST_F(FromArrowTest, FixedPointTableNulls)
   }
 }
 
-TEST_F(FromArrowTest, FixedPointTableNullsLarge)
+TEST_F(FromArrowTest, FixedPoint128TableNullsLarge)
 {
   using namespace numeric;
-  auto constexpr BIT_WIDTH_RATIO = 2;  // Array::Type:type::DECIMAL (128) / int64_t
-  auto constexpr NUM_ELEMENTS    = 1000;
+  auto constexpr NUM_ELEMENTS = 1000;
 
   for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
-    auto every_other = [](auto i) { return i % BIT_WIDTH_RATIO ? 0 : i / BIT_WIDTH_RATIO; };
-    auto transform   = cudf::detail::make_counting_transform_iterator(BIT_WIDTH_RATIO, every_other);
-    auto const data  = std::vector<int64_t>(transform, transform + NUM_ELEMENTS * BIT_WIDTH_RATIO);
-    auto iota        = thrust::make_counting_iterator(1);
-    auto const col   = fp_wrapper<int64_t>(iota, iota + NUM_ELEMENTS, transform, scale_type{i});
+    auto every_other    = [](auto i) { return i % 2 ? 0 : 1; };
+    auto nulls          = cudf::detail::make_counting_transform_iterator(0, every_other);
+    auto iota           = thrust::make_counting_iterator(1);
+    auto const data     = std::vector<__int128_t>(iota, iota + NUM_ELEMENTS);
+    auto const col      = fp_wrapper<__int128_t>(iota, iota + NUM_ELEMENTS, nulls, scale_type{i});
     auto const expected = cudf::table_view({col});
 
     std::shared_ptr<arrow::Array> arr;
     arrow::Decimal128Builder decimal_builder(arrow::decimal(10, -i), arrow::default_memory_pool());
-    for (int64_t i = 0; i < NUM_ELEMENTS / BIT_WIDTH_RATIO; ++i) {
-      decimal_builder.Append(reinterpret_cast<const uint8_t*>(data.data() + 4 * i));
-      decimal_builder.AppendNull();
+    for (int64_t i = 0; i < NUM_ELEMENTS; ++i) {
+      if (i % 2 == 0) {
+        decimal_builder.Append(reinterpret_cast<const uint8_t*>(data.data() + i));
+      } else {
+        decimal_builder.AppendNull();
+      }
     }
 
     CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");

--- a/cpp/tests/interop/to_arrow_test.cpp
+++ b/cpp/tests/interop/to_arrow_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/interop/to_arrow_test.cpp
+++ b/cpp/tests/interop/to_arrow_test.cpp
@@ -354,31 +354,6 @@ TEST_F(ToArrowTest, StructColumn)
 }
 
 template <typename T>
-auto make_decimal128_arrow_array(std::vector<T> const& data,
-                                 std::optional<std::vector<int>> const& nulls,
-                                 int32_t scale) -> std::shared_ptr<arrow::Array>
-{
-  auto constexpr SIZE_OF_INT128  = 16;
-  auto constexpr BIT_WIDTH_RATIO = SIZE_OF_INT128 / sizeof(T);
-
-  std::shared_ptr<arrow::Array> arr;
-  arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
-                                           arrow::default_memory_pool());
-
-  for (T i = 0; i < static_cast<T>(data.size() / BIT_WIDTH_RATIO); ++i) {
-    if (nulls.has_value() and not nulls.value()[i]) {
-      decimal_builder.AppendNull();
-    } else {
-      decimal_builder.Append(reinterpret_cast<const uint8_t*>(data.data() + BIT_WIDTH_RATIO * i));
-    }
-  }
-
-  CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
-
-  return arr;
-}
-
-template <typename T>
 using fp_wrapper = cudf::test::fixed_point_column_wrapper<T>;
 
 TEST_F(ToArrowTest, FixedPoint64Table)
@@ -571,7 +546,7 @@ TEST_F(ToArrowTest, FixedPoint128TableNulls)
     auto const schema               = std::make_shared<arrow::Schema>(schema_vector);
     auto const expected_arrow_table = arrow::Table::Make(schema, {arr});
 
-    auto got_arrow_table = cudf::to_arrow(input, {{"a"}});
+    auto const got_arrow_table = cudf::to_arrow(input, {{"a"}});
 
     ASSERT_TRUE(expected_arrow_table->Equals(*got_arrow_table, true));
   }

--- a/cpp/tests/interop/to_arrow_test.cpp
+++ b/cpp/tests/interop/to_arrow_test.cpp
@@ -458,13 +458,13 @@ TEST_F(ToArrowTest, FixedPoint64TableNullsSimple)
   using namespace numeric;
 
   for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
-    auto const data  = std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 0, 0, 0, 0};
-    auto const nulls = std::vector<int32_t>{1, 1, 1, 1, 1, 1, 0, 0};
+    auto const data     = std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 0, 0, 0, 0};
+    auto const validity = std::vector<int32_t>{1, 1, 1, 1, 1, 1, 0, 0};
     auto const col =
       fp_wrapper<int64_t>({1, 2, 3, 4, 5, 6, 0, 0}, {1, 1, 1, 1, 1, 1, 0, 0}, scale_type{scale});
     auto const input = cudf::table_view({col});
 
-    auto const arr = make_decimal128_arrow_array(data, nulls, scale);
+    auto const arr = make_decimal128_arrow_array(data, validity, scale);
 
     auto const field         = arrow::field("a", arr->type());
     auto const schema_vector = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -482,13 +482,13 @@ TEST_F(ToArrowTest, FixedPoint128TableNullsSimple)
   using namespace numeric;
 
   for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
-    auto const data  = std::vector<__int128_t>{1, 2, 3, 4, 5, 6, 0, 0};
-    auto const nulls = std::vector<int32_t>{1, 1, 1, 1, 1, 1, 0, 0};
+    auto const data     = std::vector<__int128_t>{1, 2, 3, 4, 5, 6, 0, 0};
+    auto const validity = std::vector<int32_t>{1, 1, 1, 1, 1, 1, 0, 0};
     auto const col =
       fp_wrapper<__int128_t>({1, 2, 3, 4, 5, 6, 0, 0}, {1, 1, 1, 1, 1, 1, 0, 0}, scale_type{scale});
     auto const input = cudf::table_view({col});
 
-    auto const arr = make_decimal128_arrow_array(data, nulls, scale);
+    auto const arr = make_decimal128_arrow_array(data, validity, scale);
 
     auto const field         = arrow::field("a", arr->type());
     auto const schema_vector = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -512,9 +512,9 @@ TEST_F(ToArrowTest, FixedPoint64TableNulls)
 
     auto const expect_data =
       std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10, 0};
-    auto const nulls = std::vector<int32_t>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+    auto const validity = std::vector<int32_t>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
 
-    auto arr = make_decimal128_arrow_array(expect_data, nulls, scale);
+    auto arr = make_decimal128_arrow_array(expect_data, validity, scale);
 
     auto const field                = arrow::field("a", arr->type());
     auto const schema_vector        = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -537,9 +537,9 @@ TEST_F(ToArrowTest, FixedPoint128TableNulls)
     auto const input = cudf::table_view({col});
 
     auto const expect_data = std::vector<__int128_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    auto const nulls       = std::vector<int32_t>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+    auto const validity    = std::vector<int32_t>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
 
-    auto arr = make_decimal128_arrow_array(expect_data, nulls, scale);
+    auto arr = make_decimal128_arrow_array(expect_data, validity, scale);
 
     auto const field                = arrow::field("a", arr->type());
     auto const schema_vector        = std::vector<std::shared_ptr<arrow::Field>>({field});

--- a/cpp/tests/interop/to_arrow_test.cpp
+++ b/cpp/tests/interop/to_arrow_test.cpp
@@ -354,24 +354,43 @@ TEST_F(ToArrowTest, StructColumn)
 }
 
 template <typename T>
+auto make_decimal128_arrow_array(std::vector<T> const& data,
+                                 std::optional<std::vector<int>> const& nulls,
+                                 int32_t scale) -> std::shared_ptr<arrow::Array>
+{
+  auto constexpr SIZE_OF_INT128  = 16;
+  auto constexpr BIT_WIDTH_RATIO = SIZE_OF_INT128 / sizeof(T);
+
+  std::shared_ptr<arrow::Array> arr;
+  arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
+                                           arrow::default_memory_pool());
+
+  for (T i = 0; i < static_cast<T>(data.size() / BIT_WIDTH_RATIO); ++i) {
+    if (nulls.has_value() and not nulls.value()[i]) {
+      decimal_builder.AppendNull();
+    } else {
+      decimal_builder.Append(reinterpret_cast<const uint8_t*>(data.data() + BIT_WIDTH_RATIO * i));
+    }
+  }
+
+  CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+
+  return arr;
+}
+
+template <typename T>
 using fp_wrapper = cudf::test::fixed_point_column_wrapper<T>;
 
 TEST_F(ToArrowTest, FixedPoint64Table)
 {
   using namespace numeric;
-  auto constexpr const BIT_WIDTH_RATIO = 2;  // Array::Type:type::DECIMAL (128) / int64_t
 
   for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
-    auto const col   = fp_wrapper<int64_t>({-1, 2, 3, 4, 5, 6}, scale_type{scale});
-    auto const input = cudf::table_view({col});
-
+    auto const col         = fp_wrapper<int64_t>({-1, 2, 3, 4, 5, 6}, scale_type{scale});
+    auto const input       = cudf::table_view({col});
     auto const expect_data = std::vector<int64_t>{-1, -1, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0};
-    std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
-                                             arrow::default_memory_pool());
-    decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(expect_data.data()),
-                                 expect_data.size() / BIT_WIDTH_RATIO);
-    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+
+    auto const arr = make_decimal128_arrow_array(expect_data, std::nullopt, scale);
 
     auto const field                = arrow::field("a", arr->type());
     auto const schema_vector        = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -389,16 +408,11 @@ TEST_F(ToArrowTest, FixedPoint128Table)
   using namespace numeric;
 
   for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
-    auto const col   = fp_wrapper<__int128_t>({-1, 2, 3, 4, 5, 6}, scale_type{scale});
-    auto const input = cudf::table_view({col});
-
+    auto const col         = fp_wrapper<__int128_t>({-1, 2, 3, 4, 5, 6}, scale_type{scale});
+    auto const input       = cudf::table_view({col});
     auto const expect_data = std::vector<__int128_t>{-1, 2, 3, 4, 5, 6};
-    std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
-                                             arrow::default_memory_pool());
-    decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(expect_data.data()),
-                                 expect_data.size());
-    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+
+    auto const arr = make_decimal128_arrow_array(expect_data, std::nullopt, scale);
 
     auto const field                = arrow::field("a", arr->type());
     auto const schema_vector        = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -418,24 +432,16 @@ TEST_F(ToArrowTest, FixedPoint64TableLarge)
   auto constexpr NUM_ELEMENTS    = 1000;
 
   for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
-    auto iota        = thrust::make_counting_iterator(1);
+    auto const iota  = thrust::make_counting_iterator(1);
     auto const col   = fp_wrapper<int64_t>(iota, iota + NUM_ELEMENTS, scale_type{scale});
     auto const input = cudf::table_view({col});
 
-    auto every_other = [](auto i) { return i % 2 == 0 ? i / 2 : 0; };
-    auto transform   = cudf::detail::make_counting_transform_iterator(2, every_other);
+    auto const every_other = [](auto i) { return i % 2 == 0 ? i / 2 : 0; };
+    auto const transform   = cudf::detail::make_counting_transform_iterator(2, every_other);
     auto const expect_data =
       std::vector<int64_t>{transform, transform + NUM_ELEMENTS * BIT_WIDTH_RATIO};
-    std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
-                                             arrow::default_memory_pool());
 
-    // Note: For some reason, decimal_builder.AppendValues with NUM_ELEMENTS >= 1000 doesn't work
-    for (int i = 0; i < NUM_ELEMENTS; ++i)
-      decimal_builder.Append(
-        reinterpret_cast<const uint8_t*>(expect_data.data() + BIT_WIDTH_RATIO * i));
-
-    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+    auto const arr = make_decimal128_arrow_array(expect_data, std::nullopt, scale);
 
     auto const field                = arrow::field("a", arr->type());
     auto const schema_vector        = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -454,20 +460,12 @@ TEST_F(ToArrowTest, FixedPoint128TableLarge)
   auto constexpr NUM_ELEMENTS = 1000;
 
   for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
-    auto iota        = thrust::make_counting_iterator(1);
-    auto const col   = fp_wrapper<__int128_t>(iota, iota + NUM_ELEMENTS, scale_type{scale});
-    auto const input = cudf::table_view({col});
-
+    auto const iota        = thrust::make_counting_iterator(1);
+    auto const col         = fp_wrapper<__int128_t>(iota, iota + NUM_ELEMENTS, scale_type{scale});
+    auto const input       = cudf::table_view({col});
     auto const expect_data = std::vector<__int128_t>{iota, iota + NUM_ELEMENTS};
-    std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
-                                             arrow::default_memory_pool());
 
-    // Note: For some reason, decimal_builder.AppendValues with NUM_ELEMENTS >= 1000 doesn't work
-    for (int i = 0; i < NUM_ELEMENTS; ++i)
-      decimal_builder.Append(reinterpret_cast<const uint8_t*>(expect_data.data() + i));
-
-    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+    auto const arr = make_decimal128_arrow_array(expect_data, std::nullopt, scale);
 
     auto const field                = arrow::field("a", arr->type());
     auto const schema_vector        = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -483,23 +481,15 @@ TEST_F(ToArrowTest, FixedPoint128TableLarge)
 TEST_F(ToArrowTest, FixedPoint64TableNullsSimple)
 {
   using namespace numeric;
-  auto constexpr BIT_WIDTH_RATIO = 2;  // Array::Type:type::DECIMAL (128) / int64_t
 
   for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
-    auto const data = std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0};
+    auto const data  = std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 0, 0, 0, 0};
+    auto const nulls = std::vector<int32_t>{1, 1, 1, 1, 1, 1, 0, 0};
     auto const col =
       fp_wrapper<int64_t>({1, 2, 3, 4, 5, 6, 0, 0}, {1, 1, 1, 1, 1, 1, 0, 0}, scale_type{scale});
     auto const input = cudf::table_view({col});
 
-    std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
-                                             arrow::default_memory_pool());
-    decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()),
-                                 data.size() / BIT_WIDTH_RATIO);
-    decimal_builder.AppendNull();
-    decimal_builder.AppendNull();
-
-    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+    auto const arr = make_decimal128_arrow_array(data, nulls, scale);
 
     auto const field         = arrow::field("a", arr->type());
     auto const schema_vector = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -517,19 +507,13 @@ TEST_F(ToArrowTest, FixedPoint128TableNullsSimple)
   using namespace numeric;
 
   for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
-    auto const data = std::vector<__int128_t>{1, 2, 3, 4, 5, 6};
+    auto const data  = std::vector<__int128_t>{1, 2, 3, 4, 5, 6, 0, 0};
+    auto const nulls = std::vector<int32_t>{1, 1, 1, 1, 1, 1, 0, 0};
     auto const col =
       fp_wrapper<__int128_t>({1, 2, 3, 4, 5, 6, 0, 0}, {1, 1, 1, 1, 1, 1, 0, 0}, scale_type{scale});
     auto const input = cudf::table_view({col});
 
-    std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
-                                             arrow::default_memory_pool());
-    decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()), data.size());
-    decimal_builder.AppendNull();
-    decimal_builder.AppendNull();
-
-    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+    auto const arr = make_decimal128_arrow_array(data, nulls, scale);
 
     auto const field         = arrow::field("a", arr->type());
     auto const schema_vector = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -545,7 +529,6 @@ TEST_F(ToArrowTest, FixedPoint128TableNullsSimple)
 TEST_F(ToArrowTest, FixedPoint64TableNulls)
 {
   using namespace numeric;
-  auto constexpr BIT_WIDTH_RATIO = 2;  // Array::Type:type::DECIMAL (128) / int64_t
 
   for (auto const scale : {3, 2, 1, 0, -1, -2, -3}) {
     auto const col = fp_wrapper<int64_t>(
@@ -554,16 +537,9 @@ TEST_F(ToArrowTest, FixedPoint64TableNulls)
 
     auto const expect_data =
       std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10, 0};
-    std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
-                                             arrow::default_memory_pool());
-    for (int64_t i = 0; i < input.column(0).size(); i += 2) {
-      decimal_builder.Append(
-        reinterpret_cast<const uint8_t*>(expect_data.data() + BIT_WIDTH_RATIO * i));
-      decimal_builder.AppendNull();
-    }
+    auto const nulls = std::vector<int32_t>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
 
-    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+    auto arr = make_decimal128_arrow_array(expect_data, nulls, scale);
 
     auto const field                = arrow::field("a", arr->type());
     auto const schema_vector        = std::vector<std::shared_ptr<arrow::Field>>({field});
@@ -586,15 +562,9 @@ TEST_F(ToArrowTest, FixedPoint128TableNulls)
     auto const input = cudf::table_view({col});
 
     auto const expect_data = std::vector<__int128_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    std::shared_ptr<arrow::Array> arr;
-    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -scale),
-                                             arrow::default_memory_pool());
-    for (int64_t i = 0; i < input.column(0).size(); i += 2) {
-      decimal_builder.Append(reinterpret_cast<const uint8_t*>(expect_data.data() + i));
-      decimal_builder.AppendNull();
-    }
+    auto const nulls       = std::vector<int32_t>{1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
 
-    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+    auto arr = make_decimal128_arrow_array(expect_data, nulls, scale);
 
     auto const field                = arrow::field("a", arr->type());
     auto const schema_vector        = std::vector<std::shared_ptr<arrow::Field>>({field});

--- a/cpp/tests/interop/to_arrow_test.cpp
+++ b/cpp/tests/interop/to_arrow_test.cpp
@@ -550,13 +550,10 @@ TEST_F(ToArrowTest, FixedPoint64TableNulls)
       std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10, 0};
     std::shared_ptr<arrow::Array> arr;
     arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -i), arrow::default_memory_pool());
-    for (int64_t i = 0; i < input.column(0).size(); ++i) {
-      if (i % 2 == 0) {
-        decimal_builder.Append(
-          reinterpret_cast<const uint8_t*>(expect_data.data() + BIT_WIDTH_RATIO * i));
-      } else {
-        decimal_builder.AppendNull();
-      }
+    for (int64_t i = 0; i < input.column(0).size(); i += 2) {
+      decimal_builder.Append(
+        reinterpret_cast<const uint8_t*>(expect_data.data() + BIT_WIDTH_RATIO * i));
+      decimal_builder.AppendNull();
     }
 
     CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
@@ -584,12 +581,9 @@ TEST_F(ToArrowTest, FixedPoint128TableNulls)
     auto const expect_data = std::vector<__int128_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::shared_ptr<arrow::Array> arr;
     arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -i), arrow::default_memory_pool());
-    for (int64_t i = 0; i < input.column(0).size(); ++i) {
-      if (i % 2 == 0) {
-        decimal_builder.Append(reinterpret_cast<const uint8_t*>(expect_data.data() + i));
-      } else {
-        decimal_builder.AppendNull();
-      }
+    for (int64_t i = 0; i < input.column(0).size(); i += 2) {
+      decimal_builder.Append(reinterpret_cast<const uint8_t*>(expect_data.data() + i));
+      decimal_builder.AppendNull();
     }
 
     CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");

--- a/cpp/tests/interop/to_arrow_test.cpp
+++ b/cpp/tests/interop/to_arrow_test.cpp
@@ -454,8 +454,6 @@ TEST_F(ToArrowTest, FixedPoint128TableLarge)
     auto const col   = fp_wrapper<__int128_t>(iota, iota + NUM_ELEMENTS, scale_type{i});
     auto const input = cudf::table_view({col});
 
-    // auto every_other       = [](auto i) { return i % 2 == 0 ? i / 2 : 0; };
-    // auto transform         = cudf::detail::make_counting_transform_iterator(2, every_other);
     auto const expect_data = std::vector<__int128_t>{iota, iota + NUM_ELEMENTS};
     std::shared_ptr<arrow::Array> arr;
     arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -i), arrow::default_memory_pool());

--- a/cpp/tests/interop/to_arrow_test.cpp
+++ b/cpp/tests/interop/to_arrow_test.cpp
@@ -429,7 +429,8 @@ TEST_F(ToArrowTest, FixedPoint64TableLarge)
 
     // Note: For some reason, decimal_builder.AppendValues with NUM_ELEMENTS >= 1000 doesn't work
     for (int i = 0; i < NUM_ELEMENTS; ++i)
-      decimal_builder.Append(reinterpret_cast<const uint8_t*>(expect_data.data() + 2 * i));
+      decimal_builder.Append(
+        reinterpret_cast<const uint8_t*>(expect_data.data() + BIT_WIDTH_RATIO * i));
 
     CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
 
@@ -475,7 +476,7 @@ TEST_F(ToArrowTest, FixedPoint128TableLarge)
   }
 }
 
-TEST_F(ToArrowTest, FixedPointTableNullsSimple)
+TEST_F(ToArrowTest, FixedPoint64TableNullsSimple)
 {
   using namespace numeric;
   auto constexpr BIT_WIDTH_RATIO = 2;  // Array::Type:type::DECIMAL (128) / int64_t
@@ -506,7 +507,36 @@ TEST_F(ToArrowTest, FixedPointTableNullsSimple)
   }
 }
 
-TEST_F(ToArrowTest, FixedPointTableNulls)
+TEST_F(ToArrowTest, FixedPoint128TableNullsSimple)
+{
+  using namespace numeric;
+
+  for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
+    auto const data = std::vector<__int128_t>{1, 2, 3, 4, 5, 6};
+    auto const col =
+      fp_wrapper<__int128_t>({1, 2, 3, 4, 5, 6, 0, 0}, {1, 1, 1, 1, 1, 1, 0, 0}, scale_type{i});
+    auto const input = cudf::table_view({col});
+
+    std::shared_ptr<arrow::Array> arr;
+    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -i), arrow::default_memory_pool());
+    decimal_builder.AppendValues(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+    decimal_builder.AppendNull();
+    decimal_builder.AppendNull();
+
+    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+
+    auto const field         = arrow::field("a", arr->type());
+    auto const schema_vector = std::vector<std::shared_ptr<arrow::Field>>({field});
+    auto const schema        = std::make_shared<arrow::Schema>(schema_vector);
+    auto const arrow_table   = arrow::Table::Make(schema, {arr});
+
+    auto got_arrow_table = cudf::to_arrow(input, {{"a"}});
+
+    ASSERT_TRUE(arrow_table->Equals(*got_arrow_table, true));
+  }
+}
+
+TEST_F(ToArrowTest, FixedPoint64TableNulls)
 {
   using namespace numeric;
   auto constexpr BIT_WIDTH_RATIO = 2;  // Array::Type:type::DECIMAL (128) / int64_t
@@ -520,9 +550,46 @@ TEST_F(ToArrowTest, FixedPointTableNulls)
       std::vector<int64_t>{1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10, 0};
     std::shared_ptr<arrow::Array> arr;
     arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -i), arrow::default_memory_pool());
-    for (int64_t i = 0; i < input.column(0).size() / BIT_WIDTH_RATIO; ++i) {
-      decimal_builder.Append(reinterpret_cast<const uint8_t*>(expect_data.data() + 4 * i));
-      decimal_builder.AppendNull();
+    for (int64_t i = 0; i < input.column(0).size(); ++i) {
+      if (i % 2 == 0) {
+        decimal_builder.Append(
+          reinterpret_cast<const uint8_t*>(expect_data.data() + BIT_WIDTH_RATIO * i));
+      } else {
+        decimal_builder.AppendNull();
+      }
+    }
+
+    CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");
+
+    auto const field                = arrow::field("a", arr->type());
+    auto const schema_vector        = std::vector<std::shared_ptr<arrow::Field>>({field});
+    auto const schema               = std::make_shared<arrow::Schema>(schema_vector);
+    auto const expected_arrow_table = arrow::Table::Make(schema, {arr});
+
+    auto got_arrow_table = cudf::to_arrow(input, {{"a"}});
+
+    ASSERT_TRUE(expected_arrow_table->Equals(*got_arrow_table, true));
+  }
+}
+
+TEST_F(ToArrowTest, FixedPoint128TableNulls)
+{
+  using namespace numeric;
+
+  for (auto const i : {3, 2, 1, 0, -1, -2, -3}) {
+    auto const col = fp_wrapper<__int128_t>(
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {1, 0, 1, 0, 1, 0, 1, 0, 1, 0}, scale_type{i});
+    auto const input = cudf::table_view({col});
+
+    auto const expect_data = std::vector<__int128_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    std::shared_ptr<arrow::Array> arr;
+    arrow::Decimal128Builder decimal_builder(arrow::decimal(18, -i), arrow::default_memory_pool());
+    for (int64_t i = 0; i < input.column(0).size(); ++i) {
+      if (i % 2 == 0) {
+        decimal_builder.Append(reinterpret_cast<const uint8_t*>(expect_data.data() + i));
+      } else {
+        decimal_builder.AppendNull();
+      }
     }
 
     CUDF_EXPECTS(decimal_builder.Finish(&arr).ok(), "Failed to build array");


### PR DESCRIPTION
Resolves C++ side of https://github.com/rapidsai/cudf/issues/9980.

The reason this PR is breaking is because Arrow only has a notion of `decimal128` (see `arrow::Type::DECIMAL`). We can still support both `decimal64` **and** `decimal128` for `to_arrow` but for `from_arrow` it only makes sense to support one of them, and `decimal128` (now that we have it) is the logical choice. Therfore, the switching of the return type of a column coming `from_arrow` from `decimal64` to `decimal128` is a breaking change.

Requires:
* https://github.com/rapidsai/cudf/issues/7314
* https://github.com/rapidsai/cudf/pull/9533