### PR TITLE
Make snappy decompress check more efficient

### DIFF
--- a/cpp/src/io/comp/unsnap.cu
+++ b/cpp/src/io/comp/unsnap.cu
@@ -707,6 +707,17 @@ __global__ void __launch_bounds__(block_size)
   }
 }
 
+__global__ void snappy_decompress_check(gpu_inflate_status_s* outputs,
+                                        int count,
+                                        bool* any_page_failure) {
+  auto tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid < count) {
+    if (outputs[tid].status != 0) {
+      any_page_failure[0] = true; // Doesn't need to be atomic
+    }
+  }
+}
+
 cudaError_t __host__ gpu_unsnap(gpu_inflate_input_s* inputs,
                                 gpu_inflate_status_s* outputs,
                                 int count,

--- a/cpp/src/io/comp/unsnap.cu
+++ b/cpp/src/io/comp/unsnap.cu
@@ -707,17 +707,6 @@ __global__ void __launch_bounds__(block_size)
   }
 }
 
-__global__ void snappy_decompress_check(gpu_inflate_status_s* outputs,
-                                        int count,
-                                        bool* any_page_failure) {
-  auto tid = blockIdx.x * blockDim.x + threadIdx.x;
-  if (tid < count) {
-    if (outputs[tid].status != 0) {
-      any_page_failure[0] = true; // Doesn't need to be atomic
-    }
-  }
-}
-
 cudaError_t __host__ gpu_unsnap(gpu_inflate_input_s* inputs,
                                 gpu_inflate_status_s* outputs,
                                 int count,

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -260,12 +260,13 @@ auto decimal_column_type(std::vector<std::string> const& float64_columns,
 
 }  // namespace
 
-__global__ void decompress_check_kernel(device_span<gpu_inflate_status_s> stats, bool* any_block_failure)
+__global__ void decompress_check_kernel(device_span<gpu_inflate_status_s> stats,
+                                        bool* any_block_failure)
 {
   auto tid = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid < stats.size()) {
     if (stats[tid].status != 0) {
-      any_block_failure[0] = true; // Doesn't need to be atomic
+      any_block_failure[0] = true;  // Doesn't need to be atomic
     }
   }
 }
@@ -285,7 +286,7 @@ __global__ void convert_nvcomp_status(nvcompStatus_t* nvcomp_stats,
 {
   auto tid = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid < stats.size()) {
-    stats[tid].status = static_cast<uint32_t>(nvcomp_stats[tid]);
+    stats[tid].status        = static_cast<uint32_t>(nvcomp_stats[tid]);
     stats[tid].bytes_written = actual_uncompressed_sizes[tid];
   }
 }
@@ -339,9 +340,8 @@ void snappy_decompress(device_span<gpu_inflate_input_s> comp_in,
 
   dim3 block(128);
   dim3 grid(cudf::util::div_rounding_up_safe(num_blocks, static_cast<size_t>(block.x)));
-  convert_nvcomp_status<<<grid, block, 0, stream.value()>>>(statuses.data(),
-                                                            actual_uncompressed_data_sizes.data(),
-                                                            comp_stat);
+  convert_nvcomp_status<<<grid, block, 0, stream.value()>>>(
+    statuses.data(), actual_uncompressed_data_sizes.data(), comp_stat);
 }
 
 rmm::device_buffer reader::impl::decompress_stripe_data(

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -286,7 +286,7 @@ __global__ void convert_nvcomp_status(nvcompStatus_t* nvcomp_stats,
 {
   auto tid = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid < stats.size()) {
-    stats[tid].status        = static_cast<uint32_t>(nvcomp_stats[tid]);
+    stats[tid].status = nvcomp_stats[tid] == nvcompStatus_t::nvcompSuccess ? 0 : 1;
     stats[tid].bytes_written = actual_uncompressed_sizes[tid];
   }
 }
@@ -451,7 +451,7 @@ rmm::device_buffer reader::impl::decompress_stripe_data(
   compinfo.device_to_host(stream, true);
 
   // We can check on host after stream synchronize
-  CUDF_EXPECTS(any_block_failure[0] == false, "Error during snappy decompression");
+  CUDF_EXPECTS(any_block_failure[0] == false, "Error during decompression");
 
   const size_t num_columns = chunks.size().second;
 

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -286,7 +286,7 @@ __global__ void convert_nvcomp_status(nvcompStatus_t* nvcomp_stats,
 {
   auto tid = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid < stats.size()) {
-    stats[tid].status = nvcomp_stats[tid] == nvcompStatus_t::nvcompSuccess ? 0 : 1;
+    stats[tid].status        = nvcomp_stats[tid] == nvcompStatus_t::nvcompSuccess ? 0 : 1;
     stats[tid].bytes_written = actual_uncompressed_sizes[tid];
   }
 }

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -275,6 +275,8 @@ void decompress_check(device_span<gpu_inflate_status_s> stats,
                       bool* any_block_failure,
                       rmm::cuda_stream_view stream)
 {
+  if (stats.empty()) { retrun; }  // early exit for empty stats
+  
   dim3 block(128);
   dim3 grid(cudf::util::div_rounding_up_safe(stats.size(), static_cast<size_t>(block.x)));
   decompress_check_kernel<<<grid, block, 0, stream.value()>>>(stats, any_block_failure);

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -275,8 +275,8 @@ void decompress_check(device_span<gpu_inflate_status_s> stats,
                       bool* any_block_failure,
                       rmm::cuda_stream_view stream)
 {
-  if (stats.empty()) { retrun; }  // early exit for empty stats
-  
+  if (stats.empty()) { return; }  // early exit for empty stats
+
   dim3 block(128);
   dim3 grid(cudf::util::div_rounding_up_safe(stats.size(), static_cast<size_t>(block.x)));
   decompress_check_kernel<<<grid, block, 0, stream.value()>>>(stats, any_block_failure);

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -1060,7 +1060,9 @@ __global__ void convert_nvcomp_status(nvcompStatus_t* nvcomp_stats,
                                       device_span<gpu_inflate_status_s> stats)
 {
   auto tid = blockIdx.x * blockDim.x + threadIdx.x;
-  if (tid < stats.size()) { stats[tid].status = static_cast<uint32_t>(nvcomp_stats[tid]); }
+  if (tid < stats.size()) {
+    stats[tid].status = nvcomp_stats[tid] == nvcompStatus_t::nvcompSuccess ? 0 : 1;
+  }
 }
 
 void snappy_decompress(device_span<gpu_inflate_input_s> comp_in,
@@ -1259,7 +1261,7 @@ rmm::device_buffer reader::impl::decompress_page_data(
 
   decompress_check(inflate_out_view, stream, any_block_failure.device_ptr());
   any_block_failure.device_to_host(stream, true);  // synchronizes stream
-  CUDF_EXPECTS(any_block_failure[0] == false, "Error during snappy decompression");
+  CUDF_EXPECTS(any_block_failure[0] == false, "Error during decompression");
 
   // Update the page information in device memory with the updated value of
   // page_data; it now points to the uncompressed data buffer

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -1051,6 +1051,8 @@ void decompress_check(device_span<gpu_inflate_status_s> stats,
                       bool* any_block_failure,
                       rmm::cuda_stream_view stream)
 {
+  if (stats.empty()) { retrun; }  // early exit for empty stats
+  
   dim3 block(128);
   dim3 grid(cudf::util::div_rounding_up_safe(stats.size(), static_cast<size_t>(block.x)));
   decompress_check_kernel<<<grid, block, 0, stream.value()>>>(stats, any_block_failure);

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -1051,8 +1051,8 @@ void decompress_check(device_span<gpu_inflate_status_s> stats,
                       bool* any_block_failure,
                       rmm::cuda_stream_view stream)
 {
-  if (stats.empty()) { retrun; }  // early exit for empty stats
-  
+  if (stats.empty()) { return; }  // early exit for empty stats
+
   dim3 block(128);
   dim3 grid(cudf::util::div_rounding_up_safe(stats.size(), static_cast<size_t>(block.x)));
   decompress_check_kernel<<<grid, block, 0, stream.value()>>>(stats, any_block_failure);


### PR DESCRIPTION
- Add status checking of decompressed snappy parquet pages when using cuDF snappy decompression.
- Improve the performance of checking decompressed snappy parquet pages when using nvCOMP snappy decompression by reducing the number of synchronizes.