### PR TITLE
Use `cuda::std::is_arithmetic` in `cudf::is_numeric` trait.

### DIFF
--- a/cpp/include/cudf/utilities/traits.hpp
+++ b/cpp/include/cudf/utilities/traits.hpp
@@ -177,7 +177,7 @@ inline bool is_equality_comparable(data_type type)
 template <typename T>
 constexpr inline bool is_numeric()
 {
-  return cuda::std::is_integral<T>() or std::is_floating_point<T>::value;
+  return cuda::std::is_arithmetic<T>();
 }
 
 struct is_numeric_impl {


### PR DESCRIPTION
The current implementation of `cudf::is_numeric` is equivalent to the implementation of `cuda::std::is_arithmetic`. This PR simplifies the implementation in cuDF and aligns it with libcudacxx.

Notes:
- `bool` returns true from both `(cuda::)std::is_integral` and `(cuda::)std::is_arithmetic`, so `bool` is considered a "numeric" type. This behavior is unchanged.
- We must use `cuda::std::is_arithmetic` rather than `std::is_arithmetic` to [support 128-bit integer types](https://github.com/NVIDIA/libcudacxx/blob/05e3bae155a17759bc7fd4d1904b6b5da4c9be51/include/cuda/std/detail/libcxx/include/type_traits#L754-L757) (as we do with `cuda::std::is_integral` in the current implementation)

See also: https://en.cppreference.com/w/cpp/types/is_arithmetic