### PR TITLE
Replace custom CUDA bindings previously provided by RMM with official CUDA Python bindings

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -33,6 +33,7 @@ dependencies:
   - ipython
   - pandoc=<2.0.0
   - cudatoolkit=11.5
+  - cuda-python >=11.5,<12.0
   - pip
   - flake8=3.8.3
   - black=19.10

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - packaging
     - cachetools
     - ptxcompiler  # [linux64]  # CUDA enhanced compatibility. See https://github.com/rapidsai/ptxcompiler
-
+    - cuda-python >=11.5,<12.0
 test:                                   # [linux64]
   requires:                             # [linux64]
     - cudatoolkit {{ cuda_version }}.*  # [linux64]

--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -15,10 +15,10 @@ def validate_setup():
 
     import warnings
 
+    from cuda.cudart import cudaDeviceAttr, cudaError_t
+
     from rmm._cuda.gpu import (
         CUDARuntimeError,
-        cudaDeviceAttr,
-        cudaError,
         deviceGetName,
         driverGetVersion,
         getDeviceAttribute,
@@ -30,30 +30,30 @@ def validate_setup():
         try:
             # CUDA 10.2+ symbols
             return [
-                cudaError.cudaErrorDeviceUninitialized,
-                cudaError.cudaErrorTimeout,
+                cudaError_t.cudaErrorDeviceUninitialized,
+                cudaError_t.cudaErrorTimeout,
             ]
         except AttributeError:
             # CUDA 10.1 symbols
-            return [cudaError.cudaErrorDeviceUninitilialized]
+            return [cudaError_t.cudaErrorDeviceUninitilialized]
 
     notify_caller_errors = {
-        cudaError.cudaErrorInitializationError,
-        cudaError.cudaErrorInsufficientDriver,
-        cudaError.cudaErrorInvalidDeviceFunction,
-        cudaError.cudaErrorInvalidDevice,
-        cudaError.cudaErrorStartupFailure,
-        cudaError.cudaErrorInvalidKernelImage,
-        cudaError.cudaErrorAlreadyAcquired,
-        cudaError.cudaErrorOperatingSystem,
-        cudaError.cudaErrorNotPermitted,
-        cudaError.cudaErrorNotSupported,
-        cudaError.cudaErrorSystemNotReady,
-        cudaError.cudaErrorSystemDriverMismatch,
-        cudaError.cudaErrorCompatNotSupportedOnDevice,
+        cudaError_t.cudaErrorInitializationError,
+        cudaError_t.cudaErrorInsufficientDriver,
+        cudaError_t.cudaErrorInvalidDeviceFunction,
+        cudaError_t.cudaErrorInvalidDevice,
+        cudaError_t.cudaErrorStartupFailure,
+        cudaError_t.cudaErrorInvalidKernelImage,
+        cudaError_t.cudaErrorAlreadyAcquired,
+        cudaError_t.cudaErrorOperatingSystem,
+        cudaError_t.cudaErrorNotPermitted,
+        cudaError_t.cudaErrorNotSupported,
+        cudaError_t.cudaErrorSystemNotReady,
+        cudaError_t.cudaErrorSystemDriverMismatch,
+        cudaError_t.cudaErrorCompatNotSupportedOnDevice,
         *_try_get_old_or_new_symbols(),
-        cudaError.cudaErrorUnknown,
-        cudaError.cudaErrorApiFailureBase,
+        cudaError_t.cudaErrorUnknown,
+        cudaError_t.cudaErrorApiFailureBase,
     }
 
     try:

--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -15,7 +15,7 @@ def validate_setup():
 
     import warnings
 
-    from cuda.cudart import cudaDeviceAttr, cudaError_t
+    from cuda.cudart import cudaError_t
 
     from rmm._cuda.gpu import (
         CUDARuntimeError,
@@ -68,11 +68,7 @@ def validate_setup():
         # Cupy throws RunTimeException to get GPU count,
         # hence obtaining GPU count by in-house cpp api above
 
-        # 75 - Indicates to get "cudaDevAttrComputeCapabilityMajor" attribute
-        # 0 - Get GPU 0
-        major_version = getDeviceAttribute(
-            cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, 0
-        )
+        major_version = getDeviceAttribute("ComputeCapabilityMajor", 0)
 
         if major_version >= 6:
             # You have a GPU with NVIDIA Pascal™ architecture or better
@@ -86,9 +82,7 @@ def validate_setup():
             pass
         else:
             device_name = deviceGetName(0)
-            minor_version = getDeviceAttribute(
-                cudaDeviceAttr.cudaDevAttrComputeCapabilityMinor, 0
-            )
+            minor_version = getDeviceAttribute("ComputeCapabilityMinor", 0)
             warnings.warn(
                 f"You will need a GPU with NVIDIA Pascal™ or "
                 f"newer architecture"

--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -15,7 +15,7 @@ def validate_setup():
 
     import warnings
 
-    from cuda.cudart import cudaError_t
+    from cuda.cudart import cudaDeviceAttr, cudaError_t
 
     from rmm._cuda.gpu import (
         CUDARuntimeError,
@@ -68,7 +68,9 @@ def validate_setup():
         # Cupy throws RunTimeException to get GPU count,
         # hence obtaining GPU count by in-house cpp api above
 
-        major_version = getDeviceAttribute("ComputeCapabilityMajor", 0)
+        major_version = getDeviceAttribute(
+            cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, 0
+        )
 
         if major_version >= 6:
             # You have a GPU with NVIDIA Pascal™ architecture or better
@@ -82,7 +84,9 @@ def validate_setup():
             pass
         else:
             device_name = deviceGetName(0)
-            minor_version = getDeviceAttribute("ComputeCapabilityMinor", 0)
+            minor_version = getDeviceAttribute(
+                cudaDeviceAttr.cudaDevAttrComputeCapabilityMinor, 0
+            )
             warnings.warn(
                 f"You will need a GPU with NVIDIA Pascal™ or "
                 f"newer architecture"


### PR DESCRIPTION
This PR replaces custom CUDA bindings that are provided by RMM, with official CUDA Python bindings. This PR should be merged after the RMM PR  https://github.com/rapidsai/rmm/pull/930