### PR TITLE
Update gpu_utils.py to reflect current CUDA support.

### DIFF
--- a/python/cudf/cudf/errors.py
+++ b/python/cudf/cudf/errors.py
@@ -1,9 +1,5 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
 
-class UnSupportedGPUError(Exception):
-    pass
-
-
-class UnSupportedCUDAError(Exception):
+class UnsupportedCUDAError(Exception):
     pass

--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -15,8 +15,6 @@ def validate_setup():
 
     import warnings
 
-    from cudf.errors import UnsupportedCUDAError
-
     from cuda.cudart import cudaDeviceAttr, cudaError_t
 
     from rmm._cuda.gpu import (
@@ -27,6 +25,8 @@ def validate_setup():
         getDeviceCount,
         runtimeGetVersion,
     )
+
+    from cudf.errors import UnsupportedCUDAError
 
     notify_caller_errors = {
         cudaError_t.cudaErrorInitializationError,
@@ -132,14 +132,11 @@ def validate_setup():
             pass
         else:
             raise UnsupportedCUDAError(
-                f"Please update your NVIDIA GPU Driver to support CUDA "
-                f"Runtime.\n"
-                f"Detected CUDA Runtime version : {cuda_runtime_version}"
-                f"\n"
-                f"Latest version of CUDA supported by current "
+                "Please update your NVIDIA GPU Driver to support CUDA "
+                "Runtime.\n"
+                f"Detected CUDA Runtime version : {cuda_runtime_version}\n"
+                "Latest version of CUDA supported by current "
                 f"NVIDIA GPU Driver : {cuda_driver_supported_rt_version}"
             )
-
     else:
-
         warnings.warn("No NVIDIA GPU detected")

--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -15,6 +15,8 @@ def validate_setup():
 
     import warnings
 
+    from cudf.errors import UnsupportedCUDAError
+
     from cuda.cudart import cudaDeviceAttr, cudaError_t
 
     from rmm._cuda.gpu import (
@@ -86,18 +88,14 @@ def validate_setup():
 
         cuda_runtime_version = runtimeGetVersion()
 
-        if cuda_runtime_version >= 10000:
-            # CUDA Runtime Version Check: Runtime version is greater than 10000
-            pass
-        else:
-            from cudf.errors import UnsupportedCUDAError
-
+        if cuda_runtime_version < 11000:
+            # Require CUDA Runtime version 11.0 or greater.
             major_version = cuda_runtime_version // 1000
             minor_version = (cuda_runtime_version % 1000) // 10
             raise UnsupportedCUDAError(
-                f"Detected CUDA Runtime version is "
+                "Detected CUDA Runtime version is "
                 f"{major_version}.{minor_version}. "
-                f"Please update your CUDA Runtime to 11.0 or above."
+                "Please update your CUDA Runtime to 11.0 or above."
             )
 
         cuda_driver_supported_rt_version = driverGetVersion()
@@ -113,15 +111,12 @@ def validate_setup():
         # https://docs.nvidia.com/deploy/cuda-compatibility/index.html
 
         if cuda_driver_supported_rt_version == 0:
-            from cudf.errors import UnsupportedCUDAError
-
             raise UnsupportedCUDAError(
                 "We couldn't detect the GPU driver properly. Please follow "
                 "the installation guide to ensure your driver is properly "
                 "installed: "
                 "https://docs.nvidia.com/cuda/cuda-installation-guide-linux/"
             )
-
         elif cuda_driver_supported_rt_version >= cuda_runtime_version:
             # CUDA Driver Version Check:
             # Driver Runtime version is >= Runtime version
@@ -136,8 +131,6 @@ def validate_setup():
             # version 450.80.02 supports.
             pass
         else:
-            from cudf.errors import UnsupportedCUDAError
-
             raise UnsupportedCUDAError(
                 f"Please update your NVIDIA GPU Driver to support CUDA "
                 f"Runtime.\n"


### PR DESCRIPTION
This PR resolves #10076. It improves `gpu_utils.py` by removing code for handling CUDA < 11.0, which we no longer support.

This is marked as "breaking" because of minor Python API changes. I changed the name of an error class from `UnSupportedCUDAError` to `UnsupportedCUDAError` and removed an unused error class named `UnSupportedGPUError`. It appears the `UnSupportedGPUError` class was introduced in #4692 but has never been used in the code.