### PR TITLE
Correctly construct `data_column` variable when `drop_nan == False` in `_drop_na_rows`

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1351,7 +1351,7 @@ class IndexedFrame(Frame):
                 for col in self._columns
             ]
             if drop_nan
-            else self._columns
+            else list(self._columns)
         )
 
         return self._from_columns_like_self(

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1351,12 +1351,12 @@ class IndexedFrame(Frame):
                 for col in self._columns
             ]
             if drop_nan
-            else list(self._columns)
+            else self._columns
         )
 
         return self._from_columns_like_self(
             libcudf.stream_compaction.drop_nulls(
-                list(self._index._data.columns) + data_columns,
+                [*self._index._data.columns, *data_columns],
                 how=how,
                 keys=self._positions_from_column_names(
                     subset, offset_by_index_columns=True

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1324,6 +1324,8 @@ class IndexedFrame(Frame):
         thresh: int, optional
             If specified, then drops every row containing
             less than `thresh` non-null values.
+        drop_nan: bool
+            `nan` is also considered as `NA`
         """
         if subset is None:
             subset = self._column_names
@@ -1341,13 +1343,16 @@ class IndexedFrame(Frame):
         if len(subset) == 0:
             return self.copy(deep=True)
 
-        if drop_nan:
-            data_columns = [
+        data_columns = (
+            [
                 col.nans_to_nulls()
                 if isinstance(col, cudf.core.column.NumericalColumn)
                 else col
                 for col in self._columns
             ]
+            if drop_nan
+            else self._columns
+        )
 
         return self._from_columns_like_self(
             libcudf.stream_compaction.drop_nulls(

--- a/python/cudf/cudf/tests/test_dropna.py
+++ b/python/cudf/cudf/tests/test_dropna.py
@@ -290,3 +290,17 @@ def test_dropna_multiindex_2(data, how):
     got = gi.dropna(how)
 
     assert_eq(expect, got)
+
+
+@pytest.mark.parametrize("drop_nan", [True, False])
+def test_drop_na_rows_dropnan(drop_nan):
+    col1 = cudf.Series([1, 2, np.nan], nan_as_null=False, dtype="float64")
+    gdf = cudf.DataFrame({"a": col1})
+
+    if drop_nan:
+        got = cudf.DataFrame({"a": [1, 2]}, dtype="float64")
+    else:
+        got = cudf.DataFrame({"a": col1})
+    expected = gdf._drop_na_rows(how="any", drop_nan=drop_nan)
+
+    assert_eq(expected, got)


### PR DESCRIPTION
Currently when `drop_nan == False`, variable `data_columns` was not created and referenced below. This PR fixes that.