### PR TITLE
Fix UDF Caching

### DIFF
--- a/python/cudf/cudf/core/udf/pipeline.py
+++ b/python/cudf/cudf/core/udf/pipeline.py
@@ -69,7 +69,9 @@ def generate_cache_key(frame, func: Callable):
     - The existence of the input columns masks
     """
     return (
-        *cudautils.make_cache_key(func, all_dtypes_from_frame(frame).values()),
+        *cudautils.make_cache_key(
+            func, tuple(all_dtypes_from_frame(frame).values())
+        ),
         *(col.mask is None for col in frame._data.values()),
         *frame._data.keys(),
     )

--- a/python/cudf/cudf/tests/test_udf_masked_ops.py
+++ b/python/cudf/cudf/tests/test_udf_masked_ops.py
@@ -13,6 +13,7 @@ from cudf.core.udf._ops import (
     comparison_ops,
     unary_ops,
 )
+from cudf.core.udf.pipeline import precompiled
 from cudf.testing._utils import NUMERIC_TYPES, _decimal_series, assert_eq
 
 
@@ -612,3 +613,16 @@ def test_masked_udf_caching():
     expect = data ** 3
     got = data.applymap(lambda x: x ** 3)
     assert_eq(expect, got, check_dtype=False)
+
+    # make sure we get a hit when reapplying
+    def f(x):
+        return x + 1
+
+    precompiled.clear()
+    assert precompiled.currsize == 0
+    data.apply(f)
+
+    assert precompiled.currsize == 1
+    data.apply(f)
+
+    assert precompiled.currsize == 1


### PR DESCRIPTION
This PR fixes an issue in caching `apply` UDFs where we were incorrectly getting a cache miss on the same function/dataframe. This was happening because `dict_values` objects don't compare as equal. 