### PR TITLE
Update developer guide to recommend no default stream parameter.

### DIFF
--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -347,10 +347,11 @@ implemented using asynchronous APIs on the default stream (e.g., stream 0).
 
 The recommended pattern for doing this is to make the definition of the external API invoke an
 internal API in the `detail` namespace. The internal `detail` API has the same parameters as the
-public API, plus a `rmm::cuda_stream_view` parameter at the end with no default value. The public
-API will call the detail API and provide `rmm::cuda_stream_default`. The implementation should be
-wholly contained in the `detail` API definition and use only asynchronous versions of CUDA APIs
-with the stream parameter.
+public API, plus a `rmm::cuda_stream_view` parameter at the end with no default value. If the
+detail API also accepts a memory resource parameter, the stream parameter should be ideally placed
+just *before* the memory resource. The public API will call the detail API and provide
+`rmm::cuda_stream_default`. The implementation should be wholly contained in the `detail` API
+definition and use only asynchronous versions of CUDA APIs with the stream parameter.
 
 In order to make the `detail` API callable from other libcudf functions, it should be exposed in a
 header placed in the `cudf/cpp/include/detail/` directory.

--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -369,9 +369,9 @@ void external_function(..., rmm::cuda_stream_view stream)
 
 // cudf/src/implementation.cpp
 namespace detail{
-    // Use stream parameter in detail implementation.
+    // Use the stream parameter in the detail implementation.
     void external_function(..., rmm::cuda_stream_view stream){
-        // Implementation uses stream with async APIs.
+        // Implementation uses the stream with async APIs.
         rmm::device_buffer buff(...,stream);
         CUDA_TRY(cudaMemcpyAsync(...,stream.value()));
         kernel<<<..., stream>>>(...);
@@ -380,7 +380,7 @@ namespace detail{
 } // namespace detail
 
 void external_function(...){
-    CUDF_FUNC_RANGE(); // Generates NVTX range for lifetime of this function.
+    CUDF_FUNC_RANGE(); // Generates an NVTX range for the lifetime of this function.
     detail::external_function(..., rmm::cuda_stream_default);
 }
 ```

--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -368,9 +368,9 @@ void external_function(..., rmm::cuda_stream_view stream)
 
 // cudf/src/implementation.cpp
 namespace detail{
-    // use stream parameter in detail implementation
+    // Use stream parameter in detail implementation.
     void external_function(..., rmm::cuda_stream_view stream){
-        // implementation uses stream with async APIs
+        // Implementation uses stream with async APIs.
         rmm::device_buffer buff(...,stream);
         CUDA_TRY(cudaMemcpyAsync(...,stream.value()));
         kernel<<<..., stream>>>(...);
@@ -379,7 +379,7 @@ namespace detail{
 } // namespace detail
 
 void external_function(...){
-    CUDF_FUNC_RANGE(); // Auto generates NVTX range for lifetime of this function
+    CUDF_FUNC_RANGE(); // Generates NVTX range for lifetime of this function.
     detail::external_function(..., rmm::cuda_stream_default);
 }
 ```


### PR DESCRIPTION
Updates the developer guide to address #9854. With this change, any new or refactored detail APIs should have no default stream parameter. We may resolve that issue or perhaps leave it open until a majority of code has no default stream.