### PR TITLE
Convert Column Name to String Before Using Struct Column Factory

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1665,7 +1665,7 @@ def build_struct_column(
     """
     if dtype is None:
         dtype = StructDtype(
-            fields={name: col.dtype for name, col in zip(names, children)}
+            fields={str(name): col.dtype for name, col in zip(names, children)}
         )
 
     result = build_column(

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1654,8 +1654,8 @@ def build_struct_column(
 
     Parameters
     ----------
-    names : list-like
-        Field names to map to children dtypes
+    names : sequence of strings
+        Field names to map to children dtypes, must be strings.
     children : tuple
 
     mask: Buffer
@@ -1665,7 +1665,7 @@ def build_struct_column(
     """
     if dtype is None:
         dtype = StructDtype(
-            fields={str(name): col.dtype for name, col in zip(names, children)}
+            fields={name: col.dtype for name, col in zip(names, children)}
         )
 
     result = build_column(

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5869,8 +5869,8 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         if not all(isinstance(name, str) for name in self._data.names):
             warnings.warn(
                 "DataFrame contains non-string column name(s). Struct column "
-                "requires field name to be string. Non-string column names will "
-                "be casted to string as the field name."
+                "requires field name to be string. Non-string column names "
+                "will be casted to string as the field name."
             )
         field_names = [str(name) for name in self._data.names]
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5866,8 +5866,18 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         -----
         Note that a copy of the columns is made.
         """
+        if not all(isinstance(name, str) for name in self._data.names):
+            warnings.warn(
+                "DataFrame contains non-string column name(s). Struct column "
+                "require string as field name. Non-string column names will "
+                "be casted to string as the field name."
+            )
+            field_names = [str(name) for name in self._data.names]
+        else:
+            field_names = self._data.names
+
         col = cudf.core.column.build_struct_column(
-            names=self._data.names, children=self._data.columns, size=len(self)
+            names=field_names, children=self._data.columns, size=len(self)
         )
         return cudf.Series._from_data(
             cudf.core.column_accessor.ColumnAccessor(

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5869,7 +5869,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         if not all(isinstance(name, str) for name in self._data.names):
             warnings.warn(
                 "DataFrame contains non-string column name(s). Struct column "
-                "require string as field name. Non-string column names will "
+                "requires field name to be string. Non-string column names will "
                 "be casted to string as the field name."
             )
             field_names = [str(name) for name in self._data.names]

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5872,9 +5872,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 "requires field name to be string. Non-string column names will "
                 "be casted to string as the field name."
             )
-            field_names = [str(name) for name in self._data.names]
-        else:
-            field_names = self._data.names
+        field_names = [str(name) for name in self._data.names]
 
         col = cudf.core.column.build_struct_column(
             names=field_names, children=self._data.columns, size=len(self)

--- a/python/cudf/cudf/tests/test_struct.py
+++ b/python/cudf/cudf/tests/test_struct.py
@@ -207,13 +207,11 @@ def test_dataframe_to_struct():
 
     # check that a non-string (but convertible to string) named column can be
     # converted to struct
+    df = cudf.DataFrame([[1, 2], [3, 4]], columns=[(1, "b"), 0])
+    expect = cudf.Series([{"(1, 'b')": 1, "0": 2}, {"(1, 'b')": 3, "0": 4}])
     with pytest.warns(UserWarning, match="will be casted"):
-        df = cudf.DataFrame([[1, 2], [3, 4]], columns=[(1, "b"), 0])
-        expect = cudf.Series(
-            [{"(1, 'b')": 1, "0": 2}, {"(1, 'b')": 3, "0": 4}]
-        )
         got = df.to_struct()
-        assert_eq(got, expect)
+    assert_eq(got, expect)
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_struct.py
+++ b/python/cudf/cudf/tests/test_struct.py
@@ -205,6 +205,13 @@ def test_dataframe_to_struct():
     df["a"][0] = 5
     assert_eq(got, expect)
 
+    # check that a non-string (but convertible to string) named column can be
+    # converted to struct
+    df = cudf.DataFrame([[1, 2], [3, 4]], columns=[(1, "b"), 0])
+    expect = cudf.Series([{"(1, 'b')": 1, "0": 2}, {"(1, 'b')": 3, "0": 4}])
+    got = df.to_struct()
+    assert_eq(got, expect)
+
 
 @pytest.mark.parametrize(
     "series, slce",

--- a/python/cudf/cudf/tests/test_struct.py
+++ b/python/cudf/cudf/tests/test_struct.py
@@ -207,10 +207,13 @@ def test_dataframe_to_struct():
 
     # check that a non-string (but convertible to string) named column can be
     # converted to struct
-    df = cudf.DataFrame([[1, 2], [3, 4]], columns=[(1, "b"), 0])
-    expect = cudf.Series([{"(1, 'b')": 1, "0": 2}, {"(1, 'b')": 3, "0": 4}])
-    got = df.to_struct()
-    assert_eq(got, expect)
+    with pytest.warns(UserWarning, match="will be casted"):
+        df = cudf.DataFrame([[1, 2], [3, 4]], columns=[(1, "b"), 0])
+        expect = cudf.Series(
+            [{"(1, 'b')": 1, "0": 2}, {"(1, 'b')": 3, "0": 4}]
+        )
+        got = df.to_struct()
+        assert_eq(got, expect)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #10155 

`build_struct_column` requires that the field names to be strings. But dataframe column names can be any hashable types. Passing in column names as field names in `to_struct` is thus unsafe. This PR adds a check and raise a warning if the cast to string is required to take place.