### PR TITLE
Add `cppcoreguidelines-*` to `clang-tidy`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,8 +3,11 @@ Checks:
       'modernize-*,
        -modernize-use-equals-default,
        -modernize-concat-nested-namespaces,
-       -modernize-use-trailing-return-type'
-      
+       -modernize-use-trailing-return-type,
+       cppcoreguidelines-*,
+       -cppcoreguidelines-init-variables,
+       -cppcoreguidelines-pro-type-member-init'
+
       # -modernize-use-equals-default        # auto-fix is broken (doesn't insert =default correctly)
       # -modernize-concat-nested-namespaces  # auto-fix is broken (can delete code)
       # -modernize-use-trailing-return-type  # just a preference

--- a/cpp/include/cudf/lists/detail/scatter.cuh
+++ b/cpp/include/cudf/lists/detail/scatter.cuh
@@ -223,7 +223,7 @@ std::unique_ptr<column> scatter(
   auto const num_rows = target.size();
   if (num_rows == 0) { return cudf::empty_like(target); }
 
-  auto lv        = static_cast<list_scalar const*>(&slr);
+  auto lv        = dynamic_cast<list_scalar const*>(&slr);
   bool slr_valid = slr.is_valid(stream);
   rmm::device_buffer null_mask =
     slr_valid ? cudf::detail::create_null_mask(1, mask_state::UNALLOCATED, stream, mr)

--- a/cpp/src/copying/copy.cpp
+++ b/cpp/src/copying/copy.cpp
@@ -62,7 +62,7 @@ template <>
 struct scalar_empty_like_functor_impl<cudf::list_view> {
   std::unique_ptr<column> operator()(scalar const& input)
   {
-    auto ls = static_cast<list_scalar const*>(&input);
+    auto ls = dynamic_cast<list_scalar const*>(&input);
 
     // TODO:  add a manual constructor for lists_column_view.
     column_view offsets{cudf::data_type{cudf::type_id::INT32}, 0, nullptr};
@@ -79,7 +79,7 @@ template <>
 struct scalar_empty_like_functor_impl<cudf::struct_view> {
   std::unique_ptr<column> operator()(scalar const& input)
   {
-    auto ss = static_cast<struct_scalar const*>(&input);
+    auto ss = dynamic_cast<struct_scalar const*>(&input);
 
     // TODO: add a manual constructor for structs_column_view
     // TODO: add cudf::get_element() support for structs

--- a/cpp/src/interop/from_arrow.cu
+++ b/cpp/src/interop/from_arrow.cu
@@ -55,7 +55,7 @@ data_type arrow_to_cudf_type(arrow::DataType const& arrow_type)
     case arrow::Type::DOUBLE: return data_type(type_id::FLOAT64);
     case arrow::Type::DATE32: return data_type(type_id::TIMESTAMP_DAYS);
     case arrow::Type::TIMESTAMP: {
-      auto type = static_cast<arrow::TimestampType const*>(&arrow_type);
+      auto type = dynamic_cast<arrow::TimestampType const*>(&arrow_type);
       switch (type->unit()) {
         case arrow::TimeUnit::type::SECOND: return data_type(type_id::TIMESTAMP_SECONDS);
         case arrow::TimeUnit::type::MILLI: return data_type(type_id::TIMESTAMP_MILLISECONDS);
@@ -65,7 +65,7 @@ data_type arrow_to_cudf_type(arrow::DataType const& arrow_type)
       }
     }
     case arrow::Type::DURATION: {
-      auto type = static_cast<arrow::DurationType const*>(&arrow_type);
+      auto type = dynamic_cast<arrow::DurationType const*>(&arrow_type);
       switch (type->unit()) {
         case arrow::TimeUnit::type::SECOND: return data_type(type_id::DURATION_SECONDS);
         case arrow::TimeUnit::type::MILLI: return data_type(type_id::DURATION_MILLISECONDS);
@@ -78,7 +78,7 @@ data_type arrow_to_cudf_type(arrow::DataType const& arrow_type)
     case arrow::Type::DICTIONARY: return data_type(type_id::DICTIONARY32);
     case arrow::Type::LIST: return data_type(type_id::LIST);
     case arrow::Type::DECIMAL: {
-      auto const type = static_cast<arrow::Decimal128Type const*>(&arrow_type);
+      auto const type = dynamic_cast<arrow::Decimal128Type const*>(&arrow_type);
       return data_type{type_id::DECIMAL128, -type->scale()};
     }
     case arrow::Type::STRUCT: return data_type(type_id::STRUCT);
@@ -298,7 +298,7 @@ std::unique_ptr<column> dispatch_to_cudf_column::operator()<cudf::dictionary32>(
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr)
 {
-  auto dict_array  = static_cast<arrow::DictionaryArray const*>(&array);
+  auto dict_array  = dynamic_cast<arrow::DictionaryArray const*>(&array);
   auto dict_type   = arrow_to_cudf_type(*(dict_array->dictionary()->type()));
   auto keys_column = get_column(*(dict_array->dictionary()), dict_type, true, stream, mr);
   auto ind_type    = arrow_to_cudf_type(*(dict_array->indices()->type()));
@@ -328,7 +328,7 @@ std::unique_ptr<column> dispatch_to_cudf_column::operator()<cudf::struct_view>(
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr)
 {
-  auto struct_array = static_cast<arrow::StructArray const*>(&array);
+  auto struct_array = dynamic_cast<arrow::StructArray const*>(&array);
   std::vector<std::unique_ptr<column>> child_columns;
   // Offsets have already been applied to child
   arrow::ArrayVector array_children = struct_array->fields();

--- a/cpp/src/strings/copying/shift.cu
+++ b/cpp/src/strings/copying/shift.cu
@@ -92,7 +92,7 @@ std::unique_ptr<column> shift(strings_column_view const& input,
                               rmm::cuda_stream_view stream,
                               rmm::mr::device_memory_resource* mr)
 {
-  auto d_fill_str = static_cast<string_scalar const&>(fill_value).value(stream);
+  auto d_fill_str = dynamic_cast<string_scalar const&>(fill_value).value(stream);
 
   // output offsets column is the same size as the input
   auto const input_offsets =


### PR DESCRIPTION
This is a follow up PR to: https://github.com/rapidsai/cudf/pull/9860

It should ideally be merged after: https://github.com/rapidsai/cudf/pull/10064