### PR TITLE
Add CMake `install` rule for tests

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -86,9 +86,16 @@ function(ConfigureNVBench CMAKE_BENCH_NAME)
   set_target_properties(
     ${CMAKE_BENCH_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                    "$<BUILD_INTERFACE:${CUDF_BINARY_DIR}/benchmarks>"
+                                   INSTALL_RPATH "\$ORIGIN/../../../lib"
   )
   target_link_libraries(
     ${CMAKE_BENCH_NAME} PRIVATE cudf_benchmark_common cudf_datagen nvbench::main
+  )
+  install(
+    TARGETS ${CMAKE_BENCH_NAME}
+    COMPONENT testing
+    DESTINATION bin/benchmarks/libcudf
+    EXCLUDE_FROM_ALL
   )
 endfunction()
 

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -56,9 +56,9 @@ add_custom_command(
 function(ConfigureBench CMAKE_BENCH_NAME)
   add_executable(${CMAKE_BENCH_NAME} ${ARGN})
   set_target_properties(
-    ${CMAKE_BENCH_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                                   "$<BUILD_INTERFACE:${CUDF_BINARY_DIR}/benchmarks>"
-                                   INSTALL_RPATH "\$ORIGIN/../../../lib"
+    ${CMAKE_BENCH_NAME}
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUDF_BINARY_DIR}/benchmarks>"
+               INSTALL_RPATH "\$ORIGIN/../../../lib"
   )
   target_link_libraries(
     ${CMAKE_BENCH_NAME} PRIVATE cudf_benchmark_common cudf_datagen benchmark::benchmark_main
@@ -84,9 +84,9 @@ endfunction()
 function(ConfigureNVBench CMAKE_BENCH_NAME)
   add_executable(${CMAKE_BENCH_NAME} ${ARGN})
   set_target_properties(
-    ${CMAKE_BENCH_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                                   "$<BUILD_INTERFACE:${CUDF_BINARY_DIR}/benchmarks>"
-                                   INSTALL_RPATH "\$ORIGIN/../../../lib"
+    ${CMAKE_BENCH_NAME}
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUDF_BINARY_DIR}/benchmarks>"
+               INSTALL_RPATH "\$ORIGIN/../../../lib"
   )
   target_link_libraries(
     ${CMAKE_BENCH_NAME} PRIVATE cudf_benchmark_common cudf_datagen nvbench::main

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -58,6 +58,7 @@ function(ConfigureBench CMAKE_BENCH_NAME)
   set_target_properties(
     ${CMAKE_BENCH_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                    "$<BUILD_INTERFACE:${CUDF_BINARY_DIR}/benchmarks>"
+                                   INSTALL_RPATH "\$ORIGIN/../../../lib"
   )
   target_link_libraries(
     ${CMAKE_BENCH_NAME} PRIVATE cudf_benchmark_common cudf_datagen benchmark::benchmark_main
@@ -68,6 +69,13 @@ function(ConfigureBench CMAKE_BENCH_NAME)
             --benchmark_out=results/${CMAKE_BENCH_NAME}.json
     APPEND
     COMMENT "Adding ${CMAKE_BENCH_NAME}"
+  )
+
+  install(
+    TARGETS ${CMAKE_BENCH_NAME}
+    COMPONENT testing
+    DESTINATION bin/benchmarks/libcudf
+    EXCLUDE_FROM_ALL
   )
 endfunction()
 

--- a/cpp/libcudf_kafka/tests/CMakeLists.txt
+++ b/cpp/libcudf_kafka/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ function(ConfigureTest test_name)
   install(
     TARGETS ${test_name}
     COMPONENT testing
+    DESTINATION bin/gtests/libcudf_kafka
     EXCLUDE_FROM_ALL
   )
 endfunction()

--- a/cpp/libcudf_kafka/tests/CMakeLists.txt
+++ b/cpp/libcudf_kafka/tests/CMakeLists.txt
@@ -20,8 +20,9 @@
 function(ConfigureTest test_name)
   add_executable(${test_name} ${ARGN})
   set_target_properties(
-    ${test_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                            "$<BUILD_INTERFACE:${CUDA_KAFKA_BINARY_DIR}/gtests>"
+    ${test_name}
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUDA_KAFKA_BINARY_DIR}/gtests>"
+               INSTALL_RPATH "\$ORIGIN/../lib"
   )
   target_link_libraries(
     ${test_name} PRIVATE GTest::gmock GTest::gmock_main GTest::gtest_main cudf_kafka

--- a/cpp/libcudf_kafka/tests/CMakeLists.txt
+++ b/cpp/libcudf_kafka/tests/CMakeLists.txt
@@ -27,7 +27,11 @@ function(ConfigureTest test_name)
     ${test_name} PRIVATE GTest::gmock GTest::gmock_main GTest::gtest_main cudf_kafka
   )
   add_test(NAME ${test_name} COMMAND ${test_name})
-  install(TARGETS ${test_name} COMPONENT testing EXCLUDE_FROM_ALL)
+  install(
+    TARGETS ${test_name}
+    COMPONENT testing
+    EXCLUDE_FROM_ALL
+  )
 endfunction()
 
 # ##################################################################################################

--- a/cpp/libcudf_kafka/tests/CMakeLists.txt
+++ b/cpp/libcudf_kafka/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ function(ConfigureTest test_name)
     ${test_name} PRIVATE GTest::gmock GTest::gmock_main GTest::gtest_main cudf_kafka
   )
   add_test(NAME ${test_name} COMMAND ${test_name})
+  install(${test_name} COMPONENT testing EXCLUDE_FROM_ALL)
 endfunction()
 
 # ##################################################################################################

--- a/cpp/libcudf_kafka/tests/CMakeLists.txt
+++ b/cpp/libcudf_kafka/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ function(ConfigureTest test_name)
   set_target_properties(
     ${test_name}
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUDA_KAFKA_BINARY_DIR}/gtests>"
-               INSTALL_RPATH "\$ORIGIN/../lib"
+               INSTALL_RPATH "\$ORIGIN/../../../lib"
   )
   target_link_libraries(
     ${test_name} PRIVATE GTest::gmock GTest::gmock_main GTest::gtest_main cudf_kafka

--- a/cpp/libcudf_kafka/tests/CMakeLists.txt
+++ b/cpp/libcudf_kafka/tests/CMakeLists.txt
@@ -27,7 +27,7 @@ function(ConfigureTest test_name)
     ${test_name} PRIVATE GTest::gmock GTest::gmock_main GTest::gtest_main cudf_kafka
   )
   add_test(NAME ${test_name} COMMAND ${test_name})
-  install(${test_name} COMPONENT testing EXCLUDE_FROM_ALL)
+  install(TARGETS ${test_name} COMPONENT testing EXCLUDE_FROM_ALL)
 endfunction()
 
 # ##################################################################################################

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ function(ConfigureTest CMAKE_TEST_NAME)
   )
   target_link_libraries(${CMAKE_TEST_NAME} PRIVATE cudftestutil GTest::gmock_main GTest::gtest_main)
   add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
+  install(${CMAKE_TEST_NAME} COMPONENT testing EXCLUDE_FROM_ALL)
 endfunction()
 
 # ##################################################################################################

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ function(ConfigureTest CMAKE_TEST_NAME)
   )
   target_link_libraries(${CMAKE_TEST_NAME} PRIVATE cudftestutil GTest::gmock_main GTest::gtest_main)
   add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
-  install(${CMAKE_TEST_NAME} COMPONENT testing EXCLUDE_FROM_ALL)
+  install(TARGETS ${CMAKE_TEST_NAME} COMPONENT testing EXCLUDE_FROM_ALL)
 endfunction()
 
 # ##################################################################################################

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -25,7 +25,11 @@ function(ConfigureTest CMAKE_TEST_NAME)
   )
   target_link_libraries(${CMAKE_TEST_NAME} PRIVATE cudftestutil GTest::gmock_main GTest::gtest_main)
   add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
-  install(TARGETS ${CMAKE_TEST_NAME} COMPONENT testing EXCLUDE_FROM_ALL)
+  install(
+    TARGETS ${CMAKE_TEST_NAME}
+    COMPONENT testing
+    EXCLUDE_FROM_ALL
+  )
 endfunction()
 
 # ##################################################################################################

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ function(ConfigureTest CMAKE_TEST_NAME)
   set_target_properties(
     ${CMAKE_TEST_NAME}
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUDF_BINARY_DIR}/gtests>"
-               INSTALL_RPATH "\$ORIGIN/../lib"
+               INSTALL_RPATH "\$ORIGIN/../../../lib"
   )
   target_link_libraries(${CMAKE_TEST_NAME} PRIVATE cudftestutil GTest::gmock_main GTest::gtest_main)
   add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -20,8 +20,9 @@
 function(ConfigureTest CMAKE_TEST_NAME)
   add_executable(${CMAKE_TEST_NAME} ${ARGN})
   set_target_properties(
-    ${CMAKE_TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                                  "$<BUILD_INTERFACE:${CUDF_BINARY_DIR}/gtests>"
+    ${CMAKE_TEST_NAME}
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUDF_BINARY_DIR}/gtests>"
+               INSTALL_RPATH "\$ORIGIN/../lib"
   )
   target_link_libraries(${CMAKE_TEST_NAME} PRIVATE cudftestutil GTest::gmock_main GTest::gtest_main)
   add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ function(ConfigureTest CMAKE_TEST_NAME)
   install(
     TARGETS ${CMAKE_TEST_NAME}
     COMPONENT testing
+    DESTINATION bin/gtests/libcudf
     EXCLUDE_FROM_ALL
   )
 endfunction()


### PR DESCRIPTION
This PR adds a CMake `install` rule for test targets. This step is a prerequisite to being able to package tests in their own `conda` package, which will enable us to deprecate _Project Flash_.