### PR TITLE
Reduce pytest runtime

### DIFF
--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from io import BytesIO, StringIO
 from pathlib import Path
 
+import cupy as cp
 import numpy as np
 import pandas as pd
 import pytest
@@ -1009,17 +1010,17 @@ def test_small_zip(tmpdir):
 def test_csv_reader_carriage_return(tmpdir):
     rows = 1000
     names = ["int_row", "int_double_row"]
-
     buffer = ",".join(names) + "\r\n"
     for row in range(rows):
         buffer += str(row) + ", " + str(2 * row) + "\r\n"
 
     df = read_csv(StringIO(buffer))
+    expect = cudf.DataFrame(
+        {"int_row": cp.arange(rows), "int_double_row": cp.arange(rows) * 2}
+    )
 
     assert len(df) == rows
-    for row in range(0, rows):
-        assert df[names[0]][row] == row
-        assert df[names[1]][row] == 2 * row
+    assert_eq(expect, df)
 
 
 def test_csv_reader_tabs():

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -1294,8 +1294,8 @@ def test_loc_datetime_index(sli, is_dataframe):
 @pytest.mark.parametrize(
     "gdf",
     [
-        cudf.DataFrame({"a": range(1000000)}),
-        cudf.DataFrame({"a": range(1000000), "b": range(1000000)}),
+        cudf.DataFrame({"a": range(100000)}),
+        cudf.DataFrame({"a": range(100000), "b": range(100000)}),
         cudf.DataFrame({"a": range(20), "b": range(20)}),
         cudf.DataFrame(
             {
@@ -1305,25 +1305,23 @@ def test_loc_datetime_index(sli, is_dataframe):
             }
         ),
         cudf.DataFrame(index=[1, 2, 3]),
-        cudf.DataFrame(index=range(1000000)),
+        cudf.DataFrame(index=range(100000)),
         cudf.DataFrame(columns=["a", "b", "c", "d"]),
-        cudf.DataFrame(columns=["a"], index=range(1000000)),
-        cudf.DataFrame(
-            columns=["a", "col2", "...col n"], index=range(1000000)
-        ),
-        cudf.DataFrame(index=cudf.Series(range(1000000)).astype("str")),
+        cudf.DataFrame(columns=["a"], index=range(100000)),
+        cudf.DataFrame(columns=["a", "col2", "...col n"], index=range(100000)),
+        cudf.DataFrame(index=cudf.Series(range(100000)).astype("str")),
         cudf.DataFrame(
             columns=["a", "b", "c", "d"],
-            index=cudf.Series(range(1000000)).astype("str"),
+            index=cudf.Series(range(100000)).astype("str"),
         ),
     ],
 )
 @pytest.mark.parametrize(
     "slice",
     [
-        slice(250000, 500000),
-        slice(250000, 250001),
-        slice(500000),
+        slice(25000, 50000),
+        slice(25000, 25001),
+        slice(50000),
         slice(1, 10),
         slice(10, 20),
         slice(15, 24000),

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -16,6 +16,7 @@ import pytest
 
 import cudf
 from cudf.io.orc import ORCWriter
+from cudf.testing import assert_frame_equal
 from cudf.testing._utils import (
     assert_eq,
     gen_rand_series,
@@ -93,7 +94,7 @@ def test_orc_reader_basic(datadir, inputfile, columns, use_index, engine):
         path, engine=engine, columns=columns, use_index=use_index
     )
 
-    assert_eq(expect, got, check_categorical=False)
+    assert_frame_equal(cudf.from_pandas(expect), got, check_categorical=False)
 
 
 def test_orc_reader_filenotfound(tmpdir):
@@ -388,7 +389,7 @@ def test_orc_writer(datadir, tmpdir, reference_file, columns, compression):
     cudf.from_pandas(expect).to_orc(gdf_fname.strpath, compression=compression)
     got = pa.orc.ORCFile(gdf_fname).read(columns=columns).to_pandas()
 
-    assert_eq(expect, got)
+    assert_frame_equal(cudf.from_pandas(expect), cudf.from_pandas(got))
 
 
 @pytest.mark.parametrize("stats_freq", ["NONE", "STRIPE", "ROWGROUP"])
@@ -409,7 +410,7 @@ def test_orc_writer_statistics_frequency(datadir, tmpdir, stats_freq):
     cudf.from_pandas(expect).to_orc(gdf_fname.strpath, statistics=stats_freq)
     got = pa.orc.ORCFile(gdf_fname).read().to_pandas()
 
-    assert_eq(expect, got)
+    assert_frame_equal(cudf.from_pandas(expect), cudf.from_pandas(got))
 
 
 @pytest.mark.parametrize("stats_freq", ["NONE", "STRIPE", "ROWGROUP"])
@@ -492,8 +493,7 @@ def test_chunked_orc_writer(
     writer.close()
 
     got = pa.orc.ORCFile(gdf_fname).read(columns=columns).to_pandas()
-
-    assert_eq(expect, got)
+    assert_frame_equal(cudf.from_pandas(expect), cudf.from_pandas(got))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR reduces the overall runtime of the cuDF pytest suite. Changes include:

- asserting equal on the GPU where possible for large datasets
- in some cases reducing excessive test data size

part of https://github.com/rapidsai/cudf/issues/9999