### PR TITLE
Remove unnecessary nunique function in Series.

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2722,42 +2722,6 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         res = self._column.unique()
         return Series(res, name=self.name)
 
-    def nunique(self, method="sort", dropna=True):
-        """Returns the number of unique values of the Series: approximate version,
-        and exact version to be moved to libcudf
-
-        Excludes NA values by default.
-
-        Parameters
-        ----------
-        dropna : bool, default True
-            Don't include NA values in the count.
-
-        Returns
-        -------
-        int
-
-        Examples
-        --------
-        >>> import cudf
-        >>> s = cudf.Series([1, 3, 5, 7, 7])
-        >>> s
-        0    1
-        1    3
-        2    5
-        3    7
-        4    7
-        dtype: int64
-        >>> s.nunique()
-        4
-        """
-        if method != "sort":
-            msg = "non sort based distinct_count() not implemented yet"
-            raise NotImplementedError(msg)
-        if self.null_count == len(self):
-            return 0
-        return super().nunique(method, dropna)
-
     def value_counts(
         self,
         normalize=False,

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -343,4 +343,6 @@ class SingleColumnFrame(Frame):
         int
             Number of unique values in the column.
         """
+        if self._column.null_count == len(self):
+            return 0
         return self._column.distinct_count(method=method, dropna=dropna)


### PR DESCRIPTION
Removes unnecessary nunique function in Series, as indicated by @vyasr here https://github.com/rapidsai/cudf/pull/10077#discussion_r796134577.

Seem to have made a mistake when correcting the style of my last commit and not have kept the original changes of that commit.