### PR TITLE
Fix compile error in `binaryop/compiled/util.cpp`

### DIFF
--- a/cpp/src/binaryop/compiled/util.cpp
+++ b/cpp/src/binaryop/compiled/util.cpp
@@ -45,6 +45,10 @@ struct common_type_functor {
         // Eg. d=t-t
         return data_type{type_to_id<TypeCommon>()};
       }
+
+      // A compiler bug may cause a compilation error when using empty initialize list to construct
+      // an std::optional object containing no `data_type` value. Therefore, we should explicitly
+      // return `std::nullopt` instead.
       return std::nullopt;
     }
   };

--- a/cpp/src/binaryop/compiled/util.cpp
+++ b/cpp/src/binaryop/compiled/util.cpp
@@ -45,7 +45,7 @@ struct common_type_functor {
         // Eg. d=t-t
         return data_type{type_to_id<TypeCommon>()};
       }
-      return {};
+      return std::nullopt;
     }
   };
   template <typename TypeLhs, typename TypeRhs>

--- a/cpp/src/binaryop/compiled/util.cpp
+++ b/cpp/src/binaryop/compiled/util.cpp
@@ -46,9 +46,9 @@ struct common_type_functor {
         return data_type{type_to_id<TypeCommon>()};
       }
 
-      // A compiler bug may cause a compilation error when using empty initializer list to construct
-      // an std::optional object containing no `data_type` value. Therefore, we should explicitly
-      // return `std::nullopt` instead.
+      // A GCC-10 compiler bug may cause a compilation error when using empty initializer list to
+      // construct an std::optional object containing no `data_type` value. Therefore, we should
+      // explicitly return `std::nullopt` instead.
       return std::nullopt;
     }
   };

--- a/cpp/src/binaryop/compiled/util.cpp
+++ b/cpp/src/binaryop/compiled/util.cpp
@@ -46,9 +46,9 @@ struct common_type_functor {
         return data_type{type_to_id<TypeCommon>()};
       }
 
-      // A GCC-10 compiler bug may cause a compilation error when using empty initializer list to
-      // construct an std::optional object containing no `data_type` value. Therefore, we should
-      // explicitly return `std::nullopt` instead.
+      // A compiler bug may cause a compilation error when using empty initializer list to construct
+      // an std::optional object containing no `data_type` value. Therefore, we should explicitly
+      // return `std::nullopt` instead.
       return std::nullopt;
     }
   };

--- a/cpp/src/binaryop/compiled/util.cpp
+++ b/cpp/src/binaryop/compiled/util.cpp
@@ -46,7 +46,7 @@ struct common_type_functor {
         return data_type{type_to_id<TypeCommon>()};
       }
 
-      // A compiler bug may cause a compilation error when using empty initialize list to construct
+      // A compiler bug may cause a compilation error when using empty initializer list to construct
       // an std::optional object containing no `data_type` value. Therefore, we should explicitly
       // return `std::nullopt` instead.
       return std::nullopt;


### PR DESCRIPTION
This PR fixes a compile error in `binaryop/compiled/util.cpp`, when a function with return type `std::optional` return `{}` instead of `std::nullopt`. As such, nvcc 11.5/g++-10.3 yell:
```
../src/binaryop/compiled/util.cpp: In function 'std::optional<cudf::data_type> cudf::binops::compiled::get_common_type(cudf::data_type, cudf::data_type, cudf::data_type)':
../src/binaryop/compiled/util.cpp:48:15: error: '<anonymous>' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   48 |       return {};
      |               ^
```