### PR TITLE
Fix bitmask of the output for JNI of `lists::drop_list_duplicates`

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -479,6 +479,33 @@ public final class ColumnVector extends ColumnView {
   }
 
   /**
+   * Create a LIST column from the current column and a given offsets column and a template bitmask
+   * column. The output column will contain lists having elements that are copied from the current
+   * column. The lists sizes are determined by the given offsets and their bitmask is copied from
+   * the given template bitmask column.
+   *
+   * Note that the caller is responsible to make sure the given offsets column is of type INT32 and
+   * it contains valid indices to create a LIST column. Similarly, the caller is also responsible
+   * to make sure the given template bitmask column has size equal to the given rows parameter.
+   *
+   * There will not be any validity check for these offsets and template bitmask during calling to
+   * this function. If any of the given offsets or template bitmask is invalid, we may have bad
+   * memory accesses and/or data corruption.
+   *
+   * @param rows the number of rows to create.
+   * @param offsets the offsets pointing to row indices of the current column to create an output
+   *                LIST column.
+   * @param templateBitmask a column from which the bitmask will be copied to the output column.
+   */
+  public ColumnVector makeListFromOffsetsAndTemplateBitmask(long rows, ColumnView offsets,
+                                                       ColumnView templateBitmask) {
+    return new ColumnVector(makeListFromOffsetsAndTemplateBitmask(getNativeView(),
+                                                             offsets.getNativeView(),
+                                                             templateBitmask.getNativeView(),
+                                                             rows));
+  }
+
+  /**
    * Create a new vector of length rows, starting at the initialValue and going by step each time.
    * Only numeric types are supported.
    * @param initialValue the initial value to start at.
@@ -846,6 +873,12 @@ public final class ColumnVector extends ColumnView {
       throws CudfException;
 
   private static native long makeListFromOffsets(long childHandle, long offsetsHandle, long rows)
+      throws CudfException;
+
+  private static native long makeListFromOffsetsAndTemplateBitmask(long childHandle, 
+                                                                   long offsetsHandle,
+                                                                   long templateBitmask,
+                                                                   long rows)
       throws CudfException;
 
   private static native long concatenate(long[] viewHandles) throws CudfException;

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -827,19 +827,6 @@ public final class ColumnVector extends ColumnView {
     return super.castTo(type);
   }
 
-  /**
-   * Create a new column that has data copied from the current column and a new bitmask copied from
-   * the given templateBitmask column.
-   *
-   * The caller is responsible for any data corruption that is make by calling to this function.
-   *
-   * @param templateBitmask a column from which the bitmask will be copied to the output column.
-   */
-  public ColumnVector replaceBitmask(ColumnView templateBitmask) {
-    assert templateBitmask.getRowCount() == getRowCount();
-    return new ColumnVector(replaceBitmask(getNativeView(), templateBitmask.getNativeView()));
-  }
-
   /////////////////////////////////////////////////////////////////////////////
   // NATIVE METHODS
   /////////////////////////////////////////////////////////////////////////////
@@ -860,8 +847,6 @@ public final class ColumnVector extends ColumnView {
 
   private static native long makeListFromOffsets(long childHandle, long offsetsHandle, long rows)
       throws CudfException;
-
-  private static native long replaceBitmask(long nativeHandle, long templateBitmaskHandle);
 
   private static native long concatenate(long[] viewHandles) throws CudfException;
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -478,33 +478,7 @@ public final class ColumnVector extends ColumnView {
     return new ColumnVector(makeListFromOffsets(getNativeView(), offsets.getNativeView(), rows));
   }
 
-  /**
-   * Create a LIST column from the current column and a given offsets column and a template bitmask
-   * column. The output column will contain lists having elements that are copied from the current
-   * column. The lists sizes are determined by the given offsets and their bitmask is copied from
-   * the given template bitmask column.
-   *
-   * Note that the caller is responsible to make sure the given offsets column is of type INT32 and
-   * it contains valid indices to create a LIST column.
-   *
-   * There will not be any validity check for the offsets during calling to this function. If any
-   * of the given offsets is invalid, we may have bad memory accesses and/or data corruption.
-   *
-   * @param rows the number of rows to create.
-   * @param offsets the offsets pointing to row indices of the current column to create an output
-   *                LIST column.
-   * @param templateBitmask a column from which the bitmask will be copied to the output column.
-   */
-  public ColumnVector makeListFromOffsetsAndTemplateBitmask(long rows, ColumnView offsets,
-                                                       ColumnView templateBitmask) {
-    assert templateBitmask.getRowCount() == rows;
-    return new ColumnVector(makeListFromOffsetsAndTemplateBitmask(getNativeView(),
-                                                             offsets.getNativeView(),
-                                                             templateBitmask.getNativeView(),
-                                                             rows));
-  }
-
-  /**
+    /**
    * Create a new vector of length rows, starting at the initialValue and going by step each time.
    * Only numeric types are supported.
    * @param initialValue the initial value to start at.
@@ -853,6 +827,19 @@ public final class ColumnVector extends ColumnView {
     return super.castTo(type);
   }
 
+  /**
+   * Create a new column that has data copied from the current column and a new bitmask copied from
+   * the given templateBitmask column.
+   *
+   * The caller is responsible for any data corruption that is make by calling to this function.
+   *
+   * @param templateBitmask a column from which the bitmask will be copied to the output column.
+   */
+  public ColumnVector replaceBitmask(ColumnView templateBitmask) {
+    assert templateBitmask.getRowCount() == getRowCount();
+    return new ColumnVector(replaceBitmask(getNativeView(), templateBitmask.getNativeView()));
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // NATIVE METHODS
   /////////////////////////////////////////////////////////////////////////////
@@ -874,11 +861,7 @@ public final class ColumnVector extends ColumnView {
   private static native long makeListFromOffsets(long childHandle, long offsetsHandle, long rows)
       throws CudfException;
 
-  private static native long makeListFromOffsetsAndTemplateBitmask(long childHandle,
-                                                                   long offsetsHandle,
-                                                                   long templateBitmask,
-                                                                   long rows)
-      throws CudfException;
+  private static native long replaceBitmask(long nativeHandle, long templateBitmaskHandle);
 
   private static native long concatenate(long[] viewHandles) throws CudfException;
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -485,12 +485,10 @@ public final class ColumnVector extends ColumnView {
    * the given template bitmask column.
    *
    * Note that the caller is responsible to make sure the given offsets column is of type INT32 and
-   * it contains valid indices to create a LIST column. Similarly, the caller is also responsible
-   * to make sure the given template bitmask column has size equal to the given rows parameter.
+   * it contains valid indices to create a LIST column.
    *
-   * There will not be any validity check for these offsets and template bitmask during calling to
-   * this function. If any of the given offsets or template bitmask is invalid, we may have bad
-   * memory accesses and/or data corruption.
+   * There will not be any validity check for the offsets during calling to this function. If any
+   * of the given offsets is invalid, we may have bad memory accesses and/or data corruption.
    *
    * @param rows the number of rows to create.
    * @param offsets the offsets pointing to row indices of the current column to create an output
@@ -499,6 +497,7 @@ public final class ColumnVector extends ColumnView {
    */
   public ColumnVector makeListFromOffsetsAndTemplateBitmask(long rows, ColumnView offsets,
                                                        ColumnView templateBitmask) {
+    assert templateBitmask.getRowCount() == rows;
     return new ColumnVector(makeListFromOffsetsAndTemplateBitmask(getNativeView(),
                                                              offsets.getNativeView(),
                                                              templateBitmask.getNativeView(),
@@ -875,7 +874,7 @@ public final class ColumnVector extends ColumnView {
   private static native long makeListFromOffsets(long childHandle, long offsetsHandle, long rows)
       throws CudfException;
 
-  private static native long makeListFromOffsetsAndTemplateBitmask(long childHandle, 
+  private static native long makeListFromOffsetsAndTemplateBitmask(long childHandle,
                                                                    long offsetsHandle,
                                                                    long templateBitmask,
                                                                    long rows)

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -478,7 +478,7 @@ public final class ColumnVector extends ColumnView {
     return new ColumnVector(makeListFromOffsets(getNativeView(), offsets.getNativeView(), rows));
   }
 
-    /**
+   /**
    * Create a new vector of length rows, starting at the initialValue and going by step each time.
    * Only numeric types are supported.
    * @param initialValue the initial value to start at.

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -478,7 +478,7 @@ public final class ColumnVector extends ColumnView {
     return new ColumnVector(makeListFromOffsets(getNativeView(), offsets.getNativeView(), rows));
   }
 
-   /**
+  /**
    * Create a new vector of length rows, starting at the initialValue and going by step each time.
    * Only numeric types are supported.
    * @param initialValue the initial value to start at.

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -252,14 +252,37 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeListFromOffsets(
   JNI_NULL_CHECK(env, offsets_handle, "offsets_handle is null", 0)
   try {
     cudf::jni::auto_set_device(env);
-    auto const *child_cv = reinterpret_cast<cudf::column_view const *>(child_handle);
-    auto const *offsets_cv = reinterpret_cast<cudf::column_view const *>(offsets_handle);
+    auto const child_cv = reinterpret_cast<cudf::column_view const *>(child_handle);
+    auto const offsets_cv = reinterpret_cast<cudf::column_view const *>(offsets_handle);
     CUDF_EXPECTS(offsets_cv->type().id() == cudf::type_id::INT32,
                  "Input offsets does not have type INT32.");
 
     return release_as_jlong(cudf::make_lists_column(
         static_cast<cudf::size_type>(row_count), std::make_unique<cudf::column>(*offsets_cv),
         std::make_unique<cudf::column>(*child_cv), 0, {}));
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeListFromOffsetsAndTemplateBitmask(
+    JNIEnv *env, jobject j_object, jlong child_handle, jlong offsets_handle,
+    jlong template_bitmask_handle, jlong row_count) {
+  JNI_NULL_CHECK(env, child_handle, "child_handle is null", 0)
+  JNI_NULL_CHECK(env, offsets_handle, "offsets_handle is null", 0)
+  JNI_NULL_CHECK(env, template_bitmask_handle, "template_bitmask_handle is null", 0)
+  try {
+    cudf::jni::auto_set_device(env);
+    auto const child_cv = reinterpret_cast<cudf::column_view const *>(child_handle);
+    auto const offsets_cv = reinterpret_cast<cudf::column_view const *>(offsets_handle);
+    auto const template_bitmask_cv =
+        reinterpret_cast<cudf::column_view const *>(template_bitmask_handle);
+    CUDF_EXPECTS(offsets_cv->type().id() == cudf::type_id::INT32,
+                 "Input offsets does not have type INT32.");
+
+    return release_as_jlong(cudf::make_lists_column(
+        static_cast<cudf::size_type>(row_count), std::make_unique<cudf::column>(*offsets_cv),
+        std::make_unique<cudf::column>(*child_cv), template_bitmask_cv->null_count(),
+        cudf::copy_bitmask(*template_bitmask_cv)));
   }
   CATCH_STD(env, 0);
 }

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -264,24 +264,6 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeListFromOffsets(
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_replaceBitmask(
-    JNIEnv *env, jobject j_object, jlong native_handle, jlong template_bitmask_handle) {
-  JNI_NULL_CHECK(env, native_handle, "native_handle is null", 0)
-  JNI_NULL_CHECK(env, template_bitmask_handle, "template_bitmask_handle is null", 0)
-  try {
-    cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const *>(native_handle);
-    auto const template_bitmask_cv =
-        reinterpret_cast<cudf::column_view const *>(template_bitmask_handle);
-
-    auto result = std::make_unique<cudf::column>(*input_cv);
-    result->set_null_mask(cudf::copy_bitmask(*template_bitmask_cv),
-                          template_bitmask_cv->null_count());
-    return release_as_jlong(result);
-  }
-  CATCH_STD(env, 0);
-}
-
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromScalar(JNIEnv *env, jclass,
                                                                     jlong j_scalar,
                                                                     jint row_count) {

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -408,7 +408,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicatesWithKey
   JNI_NULL_CHECK(env, keys_vals_handle, "keys_vals_handle is null", 0);
   try {
     cudf::jni::auto_set_device(env);
-    auto const *input_cv = reinterpret_cast<cudf::column_view const *>(keys_vals_handle);
+    auto const input_cv = reinterpret_cast<cudf::column_view const *>(keys_vals_handle);
     CUDF_EXPECTS(input_cv->offset() == 0, "Input column has non-zero offset.");
     CUDF_EXPECTS(input_cv->type().id() == cudf::type_id::LIST,
                  "Input column is not a lists column.");

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -460,7 +460,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicatesWithKey
     auto out_structs =
         cudf::make_structs_column(out_child_size, std::move(out_structs_members), 0, {});
     return release_as_jlong(cudf::make_lists_column(input_cv->size(), std::move(out_offsets),
-                                                    std::move(out_structs), 0, {}));
+                                                    std::move(out_structs), input_cv->null_count(),
+                                                    cudf::copy_bitmask(*input_cv)));
   }
   CATCH_STD(env, 0);
 }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4404,7 +4404,8 @@ public class ColumnVectorTest extends CudfTestBase {
             10, 20,
             30, 40, 50,
             100, 90, 60,
-            120, 150, 140);
+            120, 150, 140
+        );
         ColumnVector expectedStructsKeysVals = ColumnVector.makeStruct(expectedChildKeys,
             expectedChildVals);
         ColumnVector expectedOffsets = ColumnVector.fromInts(0, 2, 5, 8, 11, 11);
@@ -4421,13 +4422,13 @@ public class ColumnVectorTest extends CudfTestBase {
   @Test
   void testDropListDuplicatesWithKeysValuesNullable() {
     try(ColumnVector inputChildKeys = ColumnVector.fromBoxedInts(
-        1, 2, // list1
-        // list2 (null)
-        3, 4, 5, // list3
-        null, 0, 6, 6, 0, // list4
-        null, 6, 7, null, 7 // list 5
-        // list6 (null)
-    );
+            1, 2, // list1
+            // list2 (null)
+            3, 4, 5, // list3
+            null, 0, 6, 6, 0, // list4
+            null, 6, 7, null, 7 // list 5
+            // list6 (null)
+        );
         ColumnVector inputChildVals = ColumnVector.fromBoxedInts(
             10, 20, // list1
             // list2 (null)
@@ -4457,7 +4458,7 @@ public class ColumnVectorTest extends CudfTestBase {
             100, 90, 60, // list4
             120, 150, 140 // list5
             // list6 (null)
-            );
+        );
         ColumnVector expectedStructsKeysVals = ColumnVector.makeStruct(expectedChildKeys,
             expectedChildVals);
         ColumnVector expectedOffsets = ColumnVector.fromInts(0, 2, 2, 5, 8, 11, 11);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4441,7 +4441,7 @@ public class ColumnVectorTest extends CudfTestBase {
         ColumnVector inputOffsets = ColumnVector.fromInts(0, 2, 2, 5, 10, 15, 15);
         ColumnVector tmpInputListsKeysVals = inputStructsKeysVals.makeListFromOffsets(6,inputOffsets);
         ColumnVector templateBitmask = ColumnVector.fromBoxedInts(1, null, 1, 1, 1, null);
-        ColumnVector inputListsKeysVals = tmpInputListsKeysVals.replaceBitmask(templateBitmask);
+        ColumnVector inputListsKeysVals = tmpInputListsKeysVals.mergeAndSetValidity(BinaryOp.BITWISE_AND, templateBitmask);
 
         ColumnVector expectedChildKeys = ColumnVector.fromBoxedInts(
             1, 2, // list1
@@ -4464,7 +4464,7 @@ public class ColumnVectorTest extends CudfTestBase {
         ColumnVector expectedOffsets = ColumnVector.fromInts(0, 2, 2, 5, 8, 11, 11);
         ColumnVector tmpExpectedListsKeysVals = expectedStructsKeysVals.makeListFromOffsets(6,
             expectedOffsets);
-        ColumnVector expectedListsKeysVals = tmpExpectedListsKeysVals.replaceBitmask(templateBitmask);
+        ColumnVector expectedListsKeysVals = tmpExpectedListsKeysVals.mergeAndSetValidity(BinaryOp.BITWISE_AND, templateBitmask);
 
         ColumnVector output = inputListsKeysVals.dropListDuplicatesWithKeysValues();
         ColumnVector sortedOutput = output.listSortRows(false, false);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4438,9 +4438,9 @@ public class ColumnVectorTest extends CudfTestBase {
         );
         ColumnVector inputStructsKeysVals = ColumnVector.makeStruct(inputChildKeys, inputChildVals);
         ColumnVector inputOffsets = ColumnVector.fromInts(0, 2, 2, 5, 10, 15, 15);
+        ColumnVector tmpInputListsKeysVals = inputStructsKeysVals.makeListFromOffsets(6,inputOffsets);
         ColumnVector templateBitmask = ColumnVector.fromBoxedInts(1, null, 1, 1, 1, null);
-        ColumnVector inputListsKeysVals = inputStructsKeysVals.makeListFromOffsetsAndTemplateBitmask(6,
-            inputOffsets, templateBitmask);
+        ColumnVector inputListsKeysVals = tmpInputListsKeysVals.replaceBitmask(templateBitmask);
 
         ColumnVector expectedChildKeys = ColumnVector.fromBoxedInts(
             1, 2, // list1
@@ -4461,8 +4461,9 @@ public class ColumnVectorTest extends CudfTestBase {
         ColumnVector expectedStructsKeysVals = ColumnVector.makeStruct(expectedChildKeys,
             expectedChildVals);
         ColumnVector expectedOffsets = ColumnVector.fromInts(0, 2, 2, 5, 8, 11, 11);
-        ColumnVector expectedListsKeysVals = expectedStructsKeysVals.makeListFromOffsetsAndTemplateBitmask(6,
-            expectedOffsets, templateBitmask);
+        ColumnVector tmpExpectedListsKeysVals = expectedStructsKeysVals.makeListFromOffsets(6,
+            expectedOffsets);
+        ColumnVector expectedListsKeysVals = tmpExpectedListsKeysVals.replaceBitmask(templateBitmask);
 
         ColumnVector output = inputListsKeysVals.dropListDuplicatesWithKeysValues();
         ColumnVector sortedOutput = output.listSortRows(false, false);


### PR DESCRIPTION
Previously, the Spark-rapids plugin only needs to call `lists::drop_list_duplicates` to create map which requires the input to be non-nullable. As such, the output of the JNI is just a lists column without bitmask. When operating on nullable input lists column, it produces incorrect results.

This PR fixes that.