### PR TITLE
Support `percent_rank()` aggregation

### DIFF
--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -316,12 +316,12 @@ std::unique_ptr<Base> make_row_number_aggregation();
  *  [ //      venue,           driver,           time
  *    {   "silverstone",  "HAM" ("hamilton"),   15823},
  *    {   "silverstone",  "LEC" ("leclerc"),    15827},
- *    {   "silverstone",  "BOT" ("bottas"),     15834},  // <-- TIE!
- *    {   "silverstone",  "NOR" ("norris"),     15834},  // <-- TIE!
+ *    {   "silverstone",  "BOT" ("bottas"),     15834},  // <-- Tied for 3rd place.
+ *    {   "silverstone",  "NOR" ("norris"),     15834},  // <-- Tied for 3rd place.
  *    {   "silverstone",  "RIC" ("ricciardo"),  15905},
  *    {      "monza",     "RIC" ("ricciardo"),  12154},
- *    {      "monza",     "NOR" ("norris"),     12156},  // <-- TIE!
- *    {      "monza",     "BOT" ("bottas"),     12156},  // <-- TIE!
+ *    {      "monza",     "NOR" ("norris"),     12156},  // <-- Tied for 2nd place.
+ *    {      "monza",     "BOT" ("bottas"),     12156},  // <-- Tied for 2nd place.
  *    {      "monza",     "LEC" ("leclerc"),    12201},
  *    {      "monza",     "PER" ("perez"),      12203}
  *  ]
@@ -368,12 +368,12 @@ std::unique_ptr<Base> make_rank_aggregation();
  *  [ //      venue,           driver,           time
  *    {   "silverstone",  "HAM" ("hamilton"),   15823},
  *    {   "silverstone",  "LEC" ("leclerc"),    15827},
- *    {   "silverstone",  "BOT" ("bottas"),     15834},  // <-- TIE!
- *    {   "silverstone",  "NOR" ("norris"),     15834},  // <-- TIE!
+ *    {   "silverstone",  "BOT" ("bottas"),     15834},  // <-- Tied for 3rd place.
+ *    {   "silverstone",  "NOR" ("norris"),     15834},  // <-- Tied for 3rd place.
  *    {   "silverstone",  "RIC" ("ricciardo"),  15905},
  *    {      "monza",     "RIC" ("ricciardo"),  12154},
- *    {      "monza",     "NOR" ("norris"),     12156},  // <-- TIE!
- *    {      "monza",     "BOT" ("bottas"),     12156},  // <-- TIE!
+ *    {      "monza",     "NOR" ("norris"),     12156},  // <-- Tied for 2nd place.
+ *    {      "monza",     "BOT" ("bottas"),     12156},  // <-- Tied for 2nd place.
  *    {      "monza",     "LEC" ("leclerc"),    12201},
  *    {      "monza",     "PER" ("perez"),      12203}
  *  ]
@@ -423,12 +423,12 @@ std::unique_ptr<Base> make_dense_rank_aggregation();
  *  [ //      venue,           driver,           time
  *    {   "silverstone",  "HAM" ("hamilton"),   15823},
  *    {   "silverstone",  "LEC" ("leclerc"),    15827},
- *    {   "silverstone",  "BOT" ("bottas"),     15834},  // <-- TIE!
- *    {   "silverstone",  "NOR" ("norris"),     15834},  // <-- TIE!
+ *    {   "silverstone",  "BOT" ("bottas"),     15834},  // <-- Tied for 3rd place.
+ *    {   "silverstone",  "NOR" ("norris"),     15834},  // <-- Tied for 3rd place.
  *    {   "silverstone",  "RIC" ("ricciardo"),  15905},
  *    {      "monza",     "RIC" ("ricciardo"),  12154},
- *    {      "monza",     "NOR" ("norris"),     12156},  // <-- TIE!
- *    {      "monza",     "BOT" ("bottas"),     12156},  // <-- TIE!
+ *    {      "monza",     "NOR" ("norris"),     12156},  // <-- Tied for 2nd place.
+ *    {      "monza",     "BOT" ("bottas"),     12156},  // <-- Tied for 2nd place.
  *    {      "monza",     "LEC" ("leclerc"),    12201},
  *    {      "monza",     "PER" ("perez"),      12203}
  *  ]

--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -79,7 +79,7 @@ class aggregation {
     ROW_NUMBER,      ///< get row-number of current index (relative to rolling window)
     RANK,            ///< get rank       of current index
     DENSE_RANK,      ///< get dense rank of current index
-    PERCENT_RANK,    ///< get percent rank of current index
+    PERCENT_RANK,    ///< get percent (i.e. fractional) rank of current index
     COLLECT_LIST,    ///< collect values into a list
     COLLECT_SET,     ///< collect values into a list without duplicate entries
     LEAD,            ///< window function, accesses row at specified offset following current row
@@ -306,34 +306,34 @@ std::unique_ptr<Base> make_row_number_aggregation();
  *  3. `RANK` aggregations are not compatible with exclusive scans.
  *
  * @code{.pseudo}
- * Example: Consider an motor-racing statistics dataset, containing the following columns:
- *   1. driver_name:   (STRING) Name of the car driver
- *   2. num_overtakes: (INT32)  Number of times the driver overtook another car in a lap
- *   3. lap_number:    (INT32)  The number of the lap
+ * Example: Consider a motor-racing statistics dataset, containing the following columns:
+ *   1. venue:  (STRING) Location of the race event
+ *   2. driver: (STRING) Name of the car driver (abbreviated to 3 characters)
+ *   3. time:   (INT32)  Time taken to complete the circuit
  *
  * For the following presorted data:
  *
- *  [ // driver_name,  num_overtakes,  lap_number
- *    {   "bottas",        2,            3        },
- *    {   "bottas",        2,            7        },
- *    {   "bottas",        2,            7        },
- *    {   "bottas",        1,            1        },
- *    {   "bottas",        1,            2        },
- *    {   "hamilton",      4,            1        },
- *    {   "hamilton",      4,            1        },
- *    {   "hamilton",      3,            4        },
- *    {   "hamilton",      2,            4        }
+ *  [ //      venue,           driver,           time
+ *    {   "silverstone",  "HAM" ("hamilton"),   15823},
+ *    {   "silverstone",  "LEC" ("leclerc"),    15827},
+ *    {   "silverstone",  "BOT" ("bottas"),     15834},  // <-- TIE!
+ *    {   "silverstone",  "NOR" ("norris"),     15834},  // <-- TIE!
+ *    {   "silverstone",  "RIC" ("ricciardo"),  15905},
+ *    {      "monza",     "RIC" ("ricciardo"),  12154},
+ *    {      "monza",     "NOR" ("norris"),     12156},  // <-- TIE!
+ *    {      "monza",     "BOT" ("bottas"),     12156},  // <-- TIE!
+ *    {      "monza",     "LEC" ("leclerc"),    12201},
+ *    {      "monza",     "PER" ("perez"),      12203}
  *  ]
  *
  * A grouped rank aggregation scan with:
- *   groupby column      : driver_name
- *   input orderby column: struct_column{num_overtakes, lap_number}
- *  result: column<size_type>{1, 2, 2, 4, 5, 1, 1, 3, 4}
- *
- * A grouped rank aggregation scan with:
- *   groupby column      : driver_name
- *   input orderby column: num_overtakes
- *  result: column<size_type>{1, 1, 1, 4, 4, 1, 1, 3, 4}
+ *   groupby column      : venue
+ *   input orderby column: time
+ * Produces the following rank column:
+ * {   1,     2,     3,     3,     5,      1,     2,     2,     4,     5}
+ * (This corresponds to the following grouping and `driver` rows:)
+ * { "HAM", "LEC", "BOT", "NOR", "RIC",  "RIC", "NOR", "BOT", "LEC", "PER" }
+ *   <----------silverstone----------->|<-------------monza-------------->
  * @endcode
  */
 template <typename Base = aggregation>
@@ -358,39 +358,92 @@ std::unique_ptr<Base> make_rank_aggregation();
  *  3. `DENSE_RANK` aggregations are not compatible with exclusive scans.
  *
  * @code{.pseudo}
- * Example: Consider an motor-racing statistics dataset, containing the following columns:
- *   1. driver_name:   (STRING) Name of the car driver
- *   2. num_overtakes: (INT32)  Number of times the driver overtook another car in a lap
- *   3. lap_number:    (INT32)  The number of the lap
+ * Example: Consider a motor-racing statistics dataset, containing the following columns:
+ *   1. venue:  (STRING) Location of the race event
+ *   2. driver: (STRING) Name of the car driver (abbreviated to 3 characters)
+ *   3. time:   (INT32)  Time taken to complete the circuit
  *
  * For the following presorted data:
  *
- *  [ // driver_name,  num_overtakes,  lap_number
- *    {   "bottas",        2,            3        },
- *    {   "bottas",        2,            7        },
- *    {   "bottas",        2,            7        },
- *    {   "bottas",        1,            1        },
- *    {   "bottas",        1,            2        },
- *    {   "hamilton",      4,            1        },
- *    {   "hamilton",      4,            1        },
- *    {   "hamilton",      3,            4        },
- *    {   "hamilton",      2,            4        }
+ *  [ //      venue,           driver,           time
+ *    {   "silverstone",  "HAM" ("hamilton"),   15823},
+ *    {   "silverstone",  "LEC" ("leclerc"),    15827},
+ *    {   "silverstone",  "BOT" ("bottas"),     15834},  // <-- TIE!
+ *    {   "silverstone",  "NOR" ("norris"),     15834},  // <-- TIE!
+ *    {   "silverstone",  "RIC" ("ricciardo"),  15905},
+ *    {      "monza",     "RIC" ("ricciardo"),  12154},
+ *    {      "monza",     "NOR" ("norris"),     12156},  // <-- TIE!
+ *    {      "monza",     "BOT" ("bottas"),     12156},  // <-- TIE!
+ *    {      "monza",     "LEC" ("leclerc"),    12201},
+ *    {      "monza",     "PER" ("perez"),      12203}
  *  ]
  *
  * A grouped dense rank aggregation scan with:
- *   groupby column      : driver_name
- *   input orderby column: struct_column{num_overtakes, lap_number}
- *  result: column<size_type>{1, 2, 2, 3, 4, 1, 1, 2, 3}
- *
- * A grouped dense rank aggregation scan with:
- *   groupby column      : driver_name
- *   input orderby column: num_overtakes
- *  result: column<size_type>{1, 1, 1, 2, 2, 1, 1, 2, 3}
+ *   groupby column      : venue
+ *   input orderby column: time
+ * Produces the following dense rank column:
+ * {   1,     2,     3,     3,     4,      1,     2,     2,     3,     4}
+ * (This corresponds to the following grouping and `driver` rows:)
+ * { "HAM", "LEC", "BOT", "NOR", "RIC",  "RIC", "NOR", "BOT", "LEC", "PER" }
+ *   <----------silverstone----------->|<-------------monza-------------->
  * @endcode
  */
 template <typename Base = aggregation>
 std::unique_ptr<Base> make_dense_rank_aggregation();
 
+/**
+ * @brief Factory to create a PERCENT_RANK aggregation
+ *
+ * `PERCENT_RANK` returns a non-nullable column of double precision "fractional" ranks.
+ * For row index `i`, the percent rank of row `i` is defined as:
+ *   percent_rank = (rank - 1) / (group_row_count - 1)
+ * where,
+ *   1. rank is the `RANK` of the row within the group
+ *   2. group_row_count is the number of rows in the group
+ *
+ * This aggregation only works with "scan" algorithms. The input to the grouped or
+ * ungrouped scan is an orderby column that orders the rows that the aggregate function ranks.
+ * If rows are ordered by more than one column, the orderby input column should be a struct
+ * column containing the ordering columns.
+ *
+ * Note:
+ *  1. This method requires that the rows are presorted by the group keys and order_by columns.
+ *  2. `PERCENT_RANK` aggregations will return a fully valid column regardless of null_handling
+ *     policy specified in the scan.
+ *  3. `PERCENT_RANK` aggregations are not compatible with exclusive scans.
+ *
+ * @code{.pseudo}
+ * Example: Consider a motor-racing statistics dataset, containing the following columns:
+ *   1. venue:  (STRING) Location of the race event
+ *   2. driver: (STRING) Name of the car driver (abbreviated to 3 characters)
+ *   3. time:   (INT32)  Time taken to complete the circuit
+ *
+ * For the following presorted data:
+ *
+ *  [ //      venue,           driver,           time
+ *    {   "silverstone",  "HAM" ("hamilton"),   15823},
+ *    {   "silverstone",  "LEC" ("leclerc"),    15827},
+ *    {   "silverstone",  "BOT" ("bottas"),     15834},  // <-- TIE!
+ *    {   "silverstone",  "NOR" ("norris"),     15834},  // <-- TIE!
+ *    {   "silverstone",  "RIC" ("ricciardo"),  15905},
+ *    {      "monza",     "RIC" ("ricciardo"),  12154},
+ *    {      "monza",     "NOR" ("norris"),     12156},  // <-- TIE!
+ *    {      "monza",     "BOT" ("bottas"),     12156},  // <-- TIE!
+ *    {      "monza",     "LEC" ("leclerc"),    12201},
+ *    {      "monza",     "PER" ("perez"),      12203}
+ *  ]
+ *
+ * A grouped percent rank aggregation scan with:
+ *   groupby column      : venue
+ *   input orderby column: time
+ * Produces the following percent rank column:
+ * { 0.00,  0.25,  0.50,  0.50,  1.00,   0.00,  0.25,  0.25,  0.75,  1.00 }
+ *
+ * (This corresponds to the following grouping and `driver` rows:)
+ * { "HAM", "LEC", "BOT", "NOR", "RIC",  "RIC", "NOR", "BOT", "LEC", "PER" }
+ *   <----------silverstone----------->|<-------------monza-------------->
+ * @endcode
+ */
 template <typename Base = aggregation>
 std::unique_ptr<Base> make_percent_rank_aggregation();
 

--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -79,6 +79,7 @@ class aggregation {
     ROW_NUMBER,      ///< get row-number of current index (relative to rolling window)
     RANK,            ///< get rank       of current index
     DENSE_RANK,      ///< get dense rank of current index
+    PERCENT_RANK,    ///< get percent rank of current index
     COLLECT_LIST,    ///< collect values into a list
     COLLECT_SET,     ///< collect values into a list without duplicate entries
     LEAD,            ///< window function, accesses row at specified offset following current row
@@ -389,6 +390,9 @@ std::unique_ptr<Base> make_rank_aggregation();
  */
 template <typename Base = aggregation>
 std::unique_ptr<Base> make_dense_rank_aggregation();
+
+template <typename Base = aggregation>
+std::unique_ptr<Base> make_percent_rank_aggregation();
 
 /**
  * @brief Factory to create a COLLECT_LIST aggregation

--- a/cpp/include/cudf/detail/aggregation/aggregation.hpp
+++ b/cpp/include/cudf/detail/aggregation/aggregation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/detail/scan.hpp
+++ b/cpp/include/cudf/detail/scan.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/detail/scan.hpp
+++ b/cpp/include/cudf/detail/scan.hpp
@@ -102,5 +102,17 @@ std::unique_ptr<column> inclusive_dense_rank_scan(column_view const& order_by,
                                                   rmm::cuda_stream_view stream,
                                                   rmm::mr::device_memory_resource* mr);
 
+/**
+ * @brief Generate row percent ranks for a column.
+ *
+ * @param order_by Input column to generate ranks for.
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param mr Device memory resource used to allocate the returned column's device memory.
+ * @return rank values.
+ */
+std::unique_ptr<column> inclusive_percent_rank_scan(column_view const& order_by,
+                                                    rmm::cuda_stream_view stream,
+                                                    rmm::mr::device_memory_resource* mr);
+
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/rolling.hpp
+++ b/cpp/include/cudf/rolling.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/rolling.hpp
+++ b/cpp/include/cudf/rolling.hpp
@@ -451,7 +451,7 @@ std::unique_ptr<column> grouped_time_range_rolling_window(
  *      should be the exact same type (`INT32`).
  *
  * @code{.pseudo}
- * Example: Consider an motor-racing statistics dataset, containing the following columns:
+ * Example: Consider a motor-racing statistics dataset, containing the following columns:
  *   1. driver_name:   (STRING) Name of the car driver
  *   2. num_overtakes: (INT32)  Number of times the driver overtook another car in a lap
  *   3. lap_number:    (INT32)  The number of the lap

--- a/cpp/src/aggregation/aggregation.cpp
+++ b/cpp/src/aggregation/aggregation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/aggregation/aggregation.cpp
+++ b/cpp/src/aggregation/aggregation.cpp
@@ -161,6 +161,12 @@ std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
 }
 
 std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
+  data_type col_type, percent_rank_aggregation const& agg)
+{
+  return visit(col_type, static_cast<aggregation const&>(agg));
+}
+
+std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
   data_type col_type, collect_list_aggregation const& agg)
 {
   return visit(col_type, static_cast<aggregation const&>(agg));
@@ -329,6 +335,11 @@ void aggregation_finalizer::visit(rank_aggregation const& agg)
 }
 
 void aggregation_finalizer::visit(dense_rank_aggregation const& agg)
+{
+  visit(static_cast<aggregation const&>(agg));
+}
+
+void aggregation_finalizer::visit(percent_rank_aggregation const& agg)
 {
   visit(static_cast<aggregation const&>(agg));
 }
@@ -615,6 +626,16 @@ std::unique_ptr<Base> make_dense_rank_aggregation()
 template std::unique_ptr<aggregation> make_dense_rank_aggregation<aggregation>();
 template std::unique_ptr<groupby_scan_aggregation>
 make_dense_rank_aggregation<groupby_scan_aggregation>();
+
+/// Factory to create a PERCENT aggregation
+template <typename Base>
+std::unique_ptr<Base> make_percent_rank_aggregation()
+{
+  return std::make_unique<detail::percent_rank_aggregation>();
+}
+template std::unique_ptr<aggregation> make_percent_rank_aggregation<aggregation>();
+template std::unique_ptr<groupby_scan_aggregation>
+make_percent_rank_aggregation<groupby_scan_aggregation>();
 
 /// Factory to create a COLLECT_LIST aggregation
 template <typename Base>

--- a/cpp/src/aggregation/aggregation.cpp
+++ b/cpp/src/aggregation/aggregation.cpp
@@ -627,7 +627,7 @@ template std::unique_ptr<aggregation> make_dense_rank_aggregation<aggregation>()
 template std::unique_ptr<groupby_scan_aggregation>
 make_dense_rank_aggregation<groupby_scan_aggregation>();
 
-/// Factory to create a PERCENT aggregation
+/// Factory to create a PERCENT_RANK aggregation
 template <typename Base>
 std::unique_ptr<Base> make_percent_rank_aggregation()
 {

--- a/cpp/src/groupby/sort/group_rank_scan.cu
+++ b/cpp/src/groupby/sort/group_rank_scan.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/groupby/sort/group_scan.hpp
+++ b/cpp/src/groupby/sort/group_scan.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/groupby/sort/group_scan.hpp
+++ b/cpp/src/groupby/sort/group_scan.hpp
@@ -116,6 +116,11 @@ std::unique_ptr<column> dense_rank_scan(column_view const& order_by,
                                         rmm::cuda_stream_view stream,
                                         rmm::mr::device_memory_resource* mr);
 
+std::unique_ptr<column> percent_rank_scan(column_view const& order_by,
+                                          device_span<size_type const> group_labels,
+                                          device_span<size_type const> group_offsets,
+                                          rmm::cuda_stream_view stream,
+                                          rmm::mr::device_memory_resource* mr);
 }  // namespace detail
 }  // namespace groupby
 }  // namespace cudf

--- a/cpp/src/groupby/sort/group_scan.hpp
+++ b/cpp/src/groupby/sort/group_scan.hpp
@@ -116,6 +116,16 @@ std::unique_ptr<column> dense_rank_scan(column_view const& order_by,
                                         rmm::cuda_stream_view stream,
                                         rmm::mr::device_memory_resource* mr);
 
+/**
+ * @brief Internal API to calculate groupwise percent rank value
+ *
+ * @param order_by column or struct column by which the rows within a group are sorted
+ * @param group_labels ID of group to which the row belongs
+ * @param group_offsets group index offsets with group ID indices
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return Column of type `double` of percent rank values
+ */
 std::unique_ptr<column> percent_rank_scan(column_view const& order_by,
                                           device_span<size_type const> group_labels,
                                           device_span<size_type const> group_offsets,

--- a/cpp/src/groupby/sort/scan.cpp
+++ b/cpp/src/groupby/sort/scan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/reductions/scan/rank_scan.cu
+++ b/cpp/src/reductions/scan/rank_scan.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/reductions/scan/rank_scan.cu
+++ b/cpp/src/reductions/scan/rank_scan.cu
@@ -90,7 +90,7 @@ std::unique_ptr<column> inclusive_dense_rank_scan(column_view const& order_by,
   return rank_generator(
     order_by,
     has_nested_nulls(table_view{{order_by}}),
-    [] __device__(bool unequal, auto row_index) { return unequal; },
+    [] __device__(bool unequal, auto row_index) { return unequal ? 1 : 0; },
     DeviceSum{},
     stream,
     mr);
@@ -115,17 +115,19 @@ std::unique_ptr<column> inclusive_percent_rank_scan(column_view const& order_by,
                                                     rmm::cuda_stream_view stream,
                                                     rmm::mr::device_memory_resource* mr)
 {
-  auto const rank_column   = inclusive_rank_scan(order_by, stream, mr);
+  auto const rank_column =
+    inclusive_rank_scan(order_by, stream, rmm::mr::get_current_device_resource());
   auto const rank          = rank_column->view();
   auto percent_rank_result = cudf::make_fixed_width_column(
     data_type{type_to_id<double>()}, rank.size(), mask_state::UNALLOCATED, stream, mr);
 
-  thrust::transform(
-    rmm::exec_policy(stream),
-    rank.begin<size_type>(),
-    rank.end<size_type>(),
-    percent_rank_result->mutable_view().begin<double>(),
-    [n_rows = rank.size()] __device__(auto const& rank) { return (rank - 1.0) / (n_rows - 1); });
+  thrust::transform(rmm::exec_policy(stream),
+                    rank.begin<size_type>(),
+                    rank.end<size_type>(),
+                    percent_rank_result->mutable_view().begin<double>(),
+                    [n_rows = rank.size()] __device__(auto const& rank) {
+                      return n_rows == 1 ? 0.0 : ((rank - 1.0) / (n_rows - 1));
+                    });
   return percent_rank_result;
 }
 

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -42,7 +42,11 @@ std::unique_ptr<column> scan(column_view const& input,
                  "Unsupported dense rank aggregation operator for exclusive scan");
     return inclusive_dense_rank_scan(input, rmm::cuda_stream_default, mr);
   }
-
+  if (agg->kind == aggregation::PERCENT_RANK) {
+    CUDF_EXPECTS(inclusive == scan_type::INCLUSIVE,
+                 "Unsupported percent rank aggregation operator for exclusive scan");
+    return inclusive_percent_rank_scan(input, rmm::cuda_stream_default, mr);
+  }
   return inclusive == scan_type::EXCLUSIVE
            ? detail::scan_exclusive(input, agg, null_handling, rmm::cuda_stream_default, mr)
            : detail::scan_inclusive(input, agg, null_handling, rmm::cuda_stream_default, mr);

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -47,6 +47,7 @@ std::unique_ptr<column> scan(column_view const& input,
                  "Percent rank aggregation operator requires an inclusive scan");
     return inclusive_percent_rank_scan(input, rmm::cuda_stream_default, mr);
   }
+
   return inclusive == scan_type::EXCLUSIVE
            ? detail::scan_exclusive(input, agg, null_handling, rmm::cuda_stream_default, mr)
            : detail::scan_inclusive(input, agg, null_handling, rmm::cuda_stream_default, mr);

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -34,17 +34,17 @@ std::unique_ptr<column> scan(column_view const& input,
 
   if (agg->kind == aggregation::RANK) {
     CUDF_EXPECTS(inclusive == scan_type::INCLUSIVE,
-                 "Unsupported rank aggregation operator for exclusive scan");
+                 "Rank aggregation operator requires an inclusive scan");
     return inclusive_rank_scan(input, rmm::cuda_stream_default, mr);
   }
   if (agg->kind == aggregation::DENSE_RANK) {
     CUDF_EXPECTS(inclusive == scan_type::INCLUSIVE,
-                 "Unsupported dense rank aggregation operator for exclusive scan");
+                 "Dense rank aggregation operator requires an inclusive scan");
     return inclusive_dense_rank_scan(input, rmm::cuda_stream_default, mr);
   }
   if (agg->kind == aggregation::PERCENT_RANK) {
     CUDF_EXPECTS(inclusive == scan_type::INCLUSIVE,
-                 "Unsupported percent rank aggregation operator for exclusive scan");
+                 "Percent rank aggregation operator requires an inclusive scan");
     return inclusive_percent_rank_scan(input, rmm::cuda_stream_default, mr);
   }
   return inclusive == scan_type::EXCLUSIVE

--- a/cpp/tests/groupby/groupby_test_util.hpp
+++ b/cpp/tests/groupby/groupby_test_util.hpp
@@ -127,12 +127,6 @@ inline void test_single_scan(column_view const& keys,
   auto result = gb_obj.scan(requests);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({expect_keys}), result.first->view());
-  /*
-  std::cout << "Expected: (Type == " << static_cast<int32_t>(expect_vals.type().id()) << ")" <<
-  std::endl; print(expect_vals); std::cout << "Got: (Type == " <<
-  static_cast<int32_t>(result.second[0].results[0]->type().id()) << ")" << std::endl;
-  print(*result.second[0].results[0]);
-  */
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     expect_vals, *result.second[0].results[0], debug_output_level::ALL_ERRORS);
 }

--- a/cpp/tests/groupby/groupby_test_util.hpp
+++ b/cpp/tests/groupby/groupby_test_util.hpp
@@ -127,6 +127,12 @@ inline void test_single_scan(column_view const& keys,
   auto result = gb_obj.scan(requests);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({expect_keys}), result.first->view());
+  /*
+  std::cout << "Expected: (Type == " << static_cast<int32_t>(expect_vals.type().id()) << ")" <<
+  std::endl; print(expect_vals); std::cout << "Got: (Type == " <<
+  static_cast<int32_t>(result.second[0].results[0]->type().id()) << ")" << std::endl;
+  print(*result.second[0].results[0]);
+  */
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     expect_vals, *result.second[0].results[0], debug_output_level::ALL_ERRORS);
 }

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -41,9 +41,7 @@ inline void test_rank_scans(column_view const& keys,
                             column_view const& order,
                             column_view const& expected_dense,
                             column_view const& expected_rank,
-                            column_view const& expected_percent_rank,
-                            null_policy include_null_keys = null_policy::INCLUDE,
-                            sorted keys_are_sorted        = sorted::YES)
+                            column_view const& expected_percent_rank)
 {
   test_single_scan(keys,
                    order,

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -29,9 +29,11 @@ namespace test {
 using namespace iterators;
 
 template <typename T>
-using input              = fixed_width_column_wrapper<T>;
-using rank_result_col    = fixed_width_column_wrapper<size_type>;
-using percent_result_col = fixed_width_column_wrapper<double>;
+using input           = fixed_width_column_wrapper<T>;
+using rank_result_col = fixed_width_column_wrapper<size_type>;
+using percent_result_t =
+  cudf::detail::target_type_t<int32_t, cudf::aggregation::Kind::PERCENT_RANK>;
+using percent_result_col = fixed_width_column_wrapper<percent_result_t>;
 using null_iter_t        = decltype(nulls_at({}));
 
 auto constexpr X     = int32_t{0};  // Placeholder for NULL rows.

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -34,7 +34,7 @@ using rank_result_col    = fixed_width_column_wrapper<size_type>;
 using percent_result_col = fixed_width_column_wrapper<double>;
 using null_iter_t        = decltype(nulls_at({}));
 
-auto constexpr X     = int32_t{-1};  // Placeholder for NULL rows.
+auto constexpr X     = int32_t{0};  // Placeholder for NULL rows.
 auto const all_valid = nulls_at({});
 
 inline void test_rank_scans(column_view const& keys,

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,17 +23,27 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-using namespace cudf::test::iterators;
-
 namespace cudf {
 namespace test {
 
-inline void test_pair_rank_scans(column_view const& keys,
-                                 column_view const& order,
-                                 column_view const& expected_dense,
-                                 column_view const& expected_rank,
-                                 null_policy include_null_keys = null_policy::INCLUDE,
-                                 sorted keys_are_sorted        = sorted::YES)
+using namespace iterators;
+
+template <typename T>
+using input              = fixed_width_column_wrapper<T>;
+using rank_result_col    = fixed_width_column_wrapper<size_type>;
+using percent_result_col = fixed_width_column_wrapper<double>;
+using null_iter_t        = decltype(nulls_at({}));
+
+auto constexpr X     = int32_t{-1};  // Placeholder for NULL rows.
+auto const all_valid = nulls_at({});
+
+inline void test_rank_scans(column_view const& keys,
+                            column_view const& order,
+                            column_view const& expected_dense,
+                            column_view const& expected_rank,
+                            column_view const& expected_percent_rank,
+                            null_policy include_null_keys = null_policy::INCLUDE,
+                            sorted keys_are_sorted        = sorted::YES)
 {
   test_single_scan(keys,
                    order,
@@ -47,6 +57,13 @@ inline void test_pair_rank_scans(column_view const& keys,
                    keys,
                    expected_rank,
                    make_rank_aggregation<groupby_scan_aggregation>(),
+                   null_policy::INCLUDE,
+                   sorted::YES);
+  test_single_scan(keys,
+                   order,
+                   keys,
+                   expected_percent_rank,
+                   make_percent_rank_aggregation<groupby_scan_aggregation>(),
                    null_policy::INCLUDE,
                    sorted::YES);
 }
@@ -70,248 +87,283 @@ TYPED_TEST(typed_groupby_rank_scan_test, empty_cols)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T> keys{};
-  fixed_width_column_wrapper<T> order_col{};
-  structs_column_wrapper struct_order{};
+  auto const keys            = input<T>{};
+  auto const order_by        = input<T>{};
+  auto const order_by_struct = structs_column_wrapper{};
 
-  fixed_width_column_wrapper<size_type> expected_dense_vals{};
-  fixed_width_column_wrapper<size_type> expected_rank_vals{};
+  auto const expected_dense   = rank_result_col{};
+  auto const expected_rank    = rank_result_col{};
+  auto const expected_percent = percent_result_col{};
 
-  test_pair_rank_scans(keys, order_col, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order, expected_dense_vals, expected_rank_vals);
+  test_rank_scans(keys, order_by, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(keys, order_by_struct, expected_dense, expected_rank, expected_percent);
 }
 
 TYPED_TEST(typed_groupby_rank_scan_test, zero_valid_keys)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T> keys{{1, 2, 3}, all_nulls()};
-  fixed_width_column_wrapper<T> order_col1{3, 3, 1};
-  fixed_width_column_wrapper<T> order_col2{3, 3, 1};
-  fixed_width_column_wrapper<T> order_col3{3, 3, 1};
-  structs_column_wrapper struct_order{order_col2, order_col3};
+  auto const keys            = input<T>{{X, X, X}, all_nulls()};
+  auto const order_by        = input<T>{{3, 3, 1}};
+  auto const order_by_struct = [] {
+    auto member_1 = input<T>{{3, 3, 1}};
+    auto member_2 = input<T>{{3, 3, 1}};
+    return structs_column_wrapper{member_1, member_2};
+  }();
 
-  fixed_width_column_wrapper<size_type> expected_dense_vals{1, 1, 2};
-  fixed_width_column_wrapper<size_type> expected_rank_vals{1, 1, 3};
+  auto const dense_rank_results  = rank_result_col{1, 1, 2};
+  auto const rank_results        = rank_result_col{1, 1, 3};
+  auto const percent_rank_result = percent_result_col{0, 0, 1};
 
-  test_pair_rank_scans(keys, order_col1, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order, expected_dense_vals, expected_rank_vals);
+  test_rank_scans(keys, order_by, dense_rank_results, rank_results, percent_rank_result);
+  test_rank_scans(keys, order_by_struct, dense_rank_results, rank_results, percent_rank_result);
 }
 
 TYPED_TEST(typed_groupby_rank_scan_test, zero_valid_orders)
 {
-  using T = TypeParam;
+  using T           = TypeParam;
+  using null_iter_t = decltype(all_nulls());
 
-  fixed_width_column_wrapper<T> keys{1, 1, 3, 3};
-  fixed_width_column_wrapper<T> order_col1{{5, 6, 7, 8}, all_nulls()};
-  fixed_width_column_wrapper<T> order_col2{{5, 6, 7, 8}, all_nulls()};
-  fixed_width_column_wrapper<T> order_col3{{5, 6, 7, 8}, all_nulls()};
-  fixed_width_column_wrapper<T> order_col4{{5, 6, 7, 8}, all_nulls()};
-  fixed_width_column_wrapper<T> order_col5{{5, 6, 7, 8}, all_nulls()};
-  structs_column_wrapper struct_order{order_col2, order_col3};
-  structs_column_wrapper struct_order_with_nulls{{order_col4, order_col5}, all_nulls()};
+  auto const keys                 = input<T>{{1, 1, 3, 3}};
+  auto const make_order_by        = [&] { return input<T>{{X, X, X, X}, all_nulls()}; };
+  auto const make_struct_order_by = [&](null_iter_t const& null_iter = no_nulls()) {
+    auto member1 = make_order_by();
+    auto member2 = make_order_by();
+    return structs_column_wrapper{{member1, member2}, null_iter};
+  };
+  auto const order_by                  = make_order_by();
+  auto const order_by_struct           = make_struct_order_by();
+  auto const order_by_struct_all_nulls = make_struct_order_by(all_nulls());
 
-  fixed_width_column_wrapper<size_type> expected_dense_vals{1, 1, 1, 1};
-  fixed_width_column_wrapper<size_type> expected_rank_vals{1, 1, 1, 1};
+  auto const expected_dense   = rank_result_col{1, 1, 1, 1};
+  auto const expected_rank    = rank_result_col{1, 1, 1, 1};
+  auto const expected_percent = percent_result_col{0, 0, 0, 0};
 
-  test_pair_rank_scans(keys, order_col1, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order_with_nulls, expected_dense_vals, expected_rank_vals);
+  test_rank_scans(keys, order_by, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(keys, order_by_struct, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(keys, order_by_struct_all_nulls, expected_dense, expected_rank, expected_percent);
 }
 
 TYPED_TEST(typed_groupby_rank_scan_test, basic)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T> keys{0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
-  fixed_width_column_wrapper<T> order_col1{5, 5, 5, 4, 4, 4, 3, 3, 2, 2, 1, 1};
-  fixed_width_column_wrapper<T> order_col2{5, 5, 5, 4, 4, 4, 3, 3, 2, 2, 1, 1};
-  fixed_width_column_wrapper<T> order_col3{5, 5, 5, 4, 4, 4, 3, 3, 2, 2, 1, 1};
-  structs_column_wrapper struct_order{order_col2, order_col3};
+  auto const keys            = input<T>{0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
+  auto const make_order_by   = [&] { return input<T>{5, 5, 5, 4, 4, 4, 3, 3, 2, 2, 1, 1}; };
+  auto const order_by        = make_order_by();
+  auto const order_by_struct = [&] {
+    auto order2 = make_order_by();
+    auto order3 = make_order_by();
+    return structs_column_wrapper{order2, order3};
+  }();
 
-  fixed_width_column_wrapper<size_type> expected_dense_vals = {
-    {1, 1, 1, 2, 2, 2, 3, 1, 2, 2, 3, 3}};
-  fixed_width_column_wrapper<size_type> expected_rank_vals =
-    fixed_width_column_wrapper<size_type>{{1, 1, 1, 4, 4, 4, 7, 1, 2, 2, 4, 4}};
+  auto const expected_dense   = rank_result_col{1, 1, 1, 2, 2, 2, 3, 1, 2, 2, 3, 3};
+  auto const expected_rank    = rank_result_col{1, 1, 1, 4, 4, 4, 7, 1, 2, 2, 4, 4};
+  auto const expected_percent = percent_result_col{
+    0.0, 0.0, 0.0, 3.0 / 6, 3.0 / 6, 3.0 / 6, 6.0 / 6, 0.0, 1.0 / 4, 1.0 / 4, 3.0 / 4, 3.0 / 4};
 
-  test_pair_rank_scans(keys, order_col1, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order, expected_dense_vals, expected_rank_vals);
+  test_rank_scans(keys, order_by, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(keys, order_by_struct, expected_dense, expected_rank, expected_percent);
 }
 
 TYPED_TEST(typed_groupby_rank_scan_test, null_orders)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T> keys{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
-  fixed_width_column_wrapper<T> order_col1{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -5},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<T> order_col2{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -5},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<T> order_col3{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -5},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<T> order_col4{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -5},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<T> order_col5{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -5},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  structs_column_wrapper struct_order{order_col2, order_col3};
-  structs_column_wrapper struct_order_with_nulls{{order_col4, order_col5},
-                                                 {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
+  auto const null_mask     = nulls_at({2, 8});
+  auto const keys          = input<T>{{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1}};
+  auto const make_order_by = [&] {
+    return input<T>{{-1, -2, X, -2, -3, -3, -4, -4, X, -5, -5, -5}, null_mask};
+  };
+  auto const make_struct_order_by = [&](null_iter_t const& null_iter = all_valid) {
+    auto member1 = make_order_by();
+    auto member2 = make_order_by();
+    return structs_column_wrapper{{member1, member2}, null_iter};
+  };
+  auto const order_by                   = make_order_by();
+  auto const order_by_struct            = make_struct_order_by();
+  auto const order_by_struct_with_nulls = make_struct_order_by(null_mask);
 
-  fixed_width_column_wrapper<size_type> expected_dense_vals{{1, 2, 3, 4, 5, 5, 1, 1, 2, 3, 3, 3}};
-  fixed_width_column_wrapper<size_type> expected_rank_vals{{1, 2, 3, 4, 5, 5, 1, 1, 3, 4, 4, 4}};
+  auto const expected_dense   = rank_result_col{1, 2, 3, 4, 5, 5, 1, 1, 2, 3, 3, 3};
+  auto const expected_rank    = rank_result_col{1, 2, 3, 4, 5, 5, 1, 1, 3, 4, 4, 4};
+  auto const expected_percent = percent_result_col{
+    0.0, 1.0 / 5, 2.0 / 5, 3.0 / 5, 4.0 / 5, 4.0 / 5, 0.0, 0.0, 2.0 / 5, 3.0 / 5, 3.0 / 5, 3.0 / 5};
 
-  test_pair_rank_scans(keys, order_col1, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order, expected_dense_vals, expected_rank_vals);
+  test_rank_scans(keys, order_by, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(keys, order_by_struct, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(
+    keys, order_by_struct_with_nulls, expected_dense, expected_rank, expected_percent);
 }
 
 TYPED_TEST(typed_groupby_rank_scan_test, null_orders_and_keys)
 {
   using T = TypeParam;
 
-  fixed_width_column_wrapper<T> keys = {{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1},
-                                        {1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0}};
-  fixed_width_column_wrapper<T> order_col1{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -6},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<T> order_col2{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -6},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<T> order_col3{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -6},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<T> order_col4{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -6},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<T> order_col5{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -6},
-                                           {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  structs_column_wrapper struct_order{order_col2, order_col3};
-  structs_column_wrapper struct_order_with_nulls{{order_col4, order_col5},
-                                                 {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
+  auto const null_mask     = nulls_at({2, 8});
+  auto const keys          = input<T>{{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1}, nulls_at({9, 10, 11})};
+  auto const make_order_by = [&] {
+    return input<T>{{-1, -2, -2, -2, -3, -3, -4, -4, -4, -5, -5, -6}, null_mask};
+  };
+  auto const make_struct_order_by = [&](null_iter_t const& null_iter = all_valid) {
+    auto member1 = make_order_by();
+    auto member2 = make_order_by();
+    return structs_column_wrapper{{member1, member2}, null_iter};
+  };
+  auto const order_by                   = make_order_by();
+  auto const order_by_struct            = make_struct_order_by();
+  auto const order_by_struct_with_nulls = make_struct_order_by(null_mask);
 
-  fixed_width_column_wrapper<size_type> expected_dense_vals{{1, 2, 3, 4, 5, 5, 1, 1, 2, 1, 1, 2}};
-  fixed_width_column_wrapper<size_type> expected_rank_vals{{1, 2, 3, 4, 5, 5, 1, 1, 3, 1, 1, 3}};
+  auto const expected_dense   = rank_result_col{{1, 2, 3, 4, 5, 5, 1, 1, 2, 1, 1, 2}};
+  auto const expected_rank    = rank_result_col{{1, 2, 3, 4, 5, 5, 1, 1, 3, 1, 1, 3}};
+  auto const expected_percent = percent_result_col{
+    {0.0, 1.0 / 5, 2.0 / 5, 3.0 / 5, 4.0 / 5, 4.0 / 5, 0.0, 0.0, 2.0 / 2, 0.0, 0.0, 2.0 / 2}};
 
-  test_pair_rank_scans(keys, order_col1, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order_with_nulls, expected_dense_vals, expected_rank_vals);
+  test_rank_scans(keys, order_by, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(keys, order_by_struct, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(
+    keys, order_by_struct_with_nulls, expected_dense, expected_rank, expected_percent);
 }
 
 TYPED_TEST(typed_groupby_rank_scan_test, mixedStructs)
 {
-  auto col     = fixed_width_column_wrapper<int>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-  auto strings = strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
-  auto struct_col = structs_column_wrapper{{col, strings}, null_at(11)}.release();
+  auto const struct_col = [] {
+    auto nums    = input<TypeParam>{{0, 0, 7, 7, 7, X, 4, 4, 4, 9, 9, 9}, null_at(5)};
+    auto strings = strings_column_wrapper{
+      {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "XX", "9", "9", "10d"}, null_at(8)};
+    return structs_column_wrapper{{nums, strings}, null_at(11)}.release();
+  }();
 
-  strings_column_wrapper keys = {{"0", "0", "0", "0", "0", "0", "1", "1", "1", "1", "0", "1"},
-                                 {1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0}};
-  auto expected_dense_vals =
-    fixed_width_column_wrapper<size_type>{1, 1, 2, 2, 3, 4, 1, 1, 2, 1, 1, 2};
-  auto expected_rank_vals =
-    fixed_width_column_wrapper<size_type>{1, 1, 3, 3, 5, 6, 1, 1, 3, 1, 1, 3};
+  auto const keys = strings_column_wrapper{
+    {"0", "0", "0", "0", "0", "0", "1", "1", "1", "X", "X", "X"}, nulls_at({9, 10, 11})};
+
+  auto const expected_dense   = rank_result_col{1, 1, 2, 2, 3, 4, 1, 1, 2, 1, 1, 2};
+  auto const expected_rank    = rank_result_col{1, 1, 3, 3, 5, 6, 1, 1, 3, 1, 1, 3};
+  auto const expected_percent = percent_result_col{
+    0.0, 0.0, 2.0 / 5, 2.0 / 5, 4.0 / 5, 5.0 / 5, 0.0, 0.0, 2.0 / 2, 0.0, 0.0, 2.0 / 2};
 
   std::vector<groupby::scan_request> requests;
   requests.emplace_back(groupby::scan_request());
   requests[0].values = *struct_col;
   requests[0].aggregations.push_back(make_dense_rank_aggregation<groupby_scan_aggregation>());
   requests[0].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>());
+  requests[0].aggregations.push_back(make_percent_rank_aggregation<groupby_scan_aggregation>());
 
   groupby::groupby gb_obj(table_view({keys}), null_policy::INCLUDE, sorted::YES);
-  auto result = gb_obj.scan(requests);
+  auto [result_keys, agg_results] = gb_obj.scan(requests);
 
-  CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({keys}), result.first->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result.second[0].results[0], expected_dense_vals);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result.second[0].results[1], expected_rank_vals);
+  CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({keys}), result_keys->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[0], expected_dense);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[1], expected_rank);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[2], expected_percent);
 }
 
 TYPED_TEST(typed_groupby_rank_scan_test, nestedStructs)
 {
   using T = TypeParam;
 
-  auto col1     = fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-  auto col2     = fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-  auto col3     = fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-  auto col4     = fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-  auto strings1 = strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
-  auto strings2 = strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
-  auto struct_col    = structs_column_wrapper{col1, strings1};
-  auto nested_col    = structs_column_wrapper{struct_col, col2}.release();
-  auto flattened_col = structs_column_wrapper{col3, strings2, col4}.release();
+  auto nested_structs = [] {
+    auto structs_member = [] {
+      auto nums_member    = input<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
+      auto strings_member = strings_column_wrapper{
+        {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
+      return structs_column_wrapper{nums_member, strings_member};
+    }();
+    auto nums_member = input<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
+    return structs_column_wrapper{structs_member, nums_member}.release();
+  }();
 
-  strings_column_wrapper keys = {{"0", "0", "0", "0", "0", "0", "1", "1", "1", "1", "0", "1"},
-                                 {1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0}};
+  auto flat_struct = [] {
+    auto nums_member    = input<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
+    auto strings_member = strings_column_wrapper{
+      {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
+    auto nuther_nums =
+      fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
+    return structs_column_wrapper{nums_member, strings_member, nuther_nums}.release();
+  }();
+
+  auto const keys = strings_column_wrapper{
+    {"0", "0", "0", "0", "0", "0", "1", "1", "1", "1", "0", "1"}, nulls_at({9, 10, 11})};
 
   std::vector<groupby::scan_request> requests;
   requests.emplace_back(groupby::scan_request());
   requests.emplace_back(groupby::scan_request());
-  requests[0].values = *nested_col;
+  requests[0].values = *nested_structs;
   requests[0].aggregations.push_back(make_dense_rank_aggregation<groupby_scan_aggregation>());
   requests[0].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>());
-  requests[1].values = *flattened_col;
+  requests[0].aggregations.push_back(make_percent_rank_aggregation<groupby_scan_aggregation>());
+  requests[1].values = *flat_struct;
   requests[1].aggregations.push_back(make_dense_rank_aggregation<groupby_scan_aggregation>());
   requests[1].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>());
+  requests[1].aggregations.push_back(make_percent_rank_aggregation<groupby_scan_aggregation>());
 
   groupby::groupby gb_obj(table_view({keys}), null_policy::INCLUDE, sorted::YES);
-  auto result = gb_obj.scan(requests);
+  auto [result_keys, agg_results] = gb_obj.scan(requests);
 
-  CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({keys}), result.first->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result.second[0].results[0], *result.second[1].results[0]);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result.second[0].results[1], *result.second[1].results[1]);
+  CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({keys}), result_keys->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[0], *agg_results[1].results[0]);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[1], *agg_results[1].results[1]);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[2], *agg_results[1].results[2]);
 }
 
 TYPED_TEST(typed_groupby_rank_scan_test, structsWithNullPushdown)
 {
   using T = TypeParam;
 
-  auto col1     = fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-  auto col2     = fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-  auto strings1 = strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
-  auto strings2 = strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
+  auto constexpr num_rows = 12;
 
-  std::vector<std::unique_ptr<column>> struct_columns;
-  struct_columns.push_back(col1.release());
-  struct_columns.push_back(strings1.release());
-  auto struct_col =
-    cudf::make_structs_column(12, std::move(struct_columns), 0, rmm::device_buffer{});
-  auto const struct_nulls =
-    thrust::host_vector<bool>(std::vector<bool>{1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0});
-  struct_col->set_null_mask(
-    cudf::test::detail::make_null_mask(struct_nulls.begin(), struct_nulls.end()));
+  auto get_struct_column = [] {
+    auto nums_member =
+      fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
+    auto strings_member = strings_column_wrapper{
+      {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
+    auto struct_column = structs_column_wrapper{nums_member, strings_member}.release();
+    // Reset null-mask, a posteriori. Nulls will not be pushed down to children.
+    auto const null_iter = nulls_at({1, 2, 11});
+    struct_column->set_null_mask(
+      cudf::test::detail::make_null_mask(null_iter, null_iter + num_rows));
+    return struct_column;
+  };
 
-  std::vector<std::unique_ptr<column>> null_struct_columns;
-  null_struct_columns.push_back(col2.release());
-  null_struct_columns.push_back(strings2.release());
-  auto null_col =
-    cudf::make_structs_column(12, std::move(null_struct_columns), 0, rmm::device_buffer{});
-  null_col->set_null_mask(create_null_mask(12, cudf::mask_state::ALL_NULL));
+  auto const possibly_null_structs = get_struct_column();
 
-  strings_column_wrapper keys = {{"0", "0", "0", "0", "0", "0", "1", "1", "1", "1", "0", "1"},
-                                 {1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0}};
+  auto const definitely_null_structs = [&] {
+    auto struct_column = get_struct_column();
+    struct_column->set_null_mask(create_null_mask(num_rows, mask_state::ALL_NULL));
+    return struct_column;
+  }();
+
+  strings_column_wrapper keys = {{"0", "0", "0", "0", "0", "0", "1", "1", "1", "X", "X", "X"},
+                                 nulls_at({9, 10, 11})};
 
   std::vector<groupby::scan_request> requests;
   requests.emplace_back(groupby::scan_request());
   requests.emplace_back(groupby::scan_request());
-  requests[0].values = *struct_col;
+  requests[0].values = *possibly_null_structs;
   requests[0].aggregations.push_back(make_dense_rank_aggregation<groupby_scan_aggregation>());
   requests[0].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>());
-  requests[1].values = *null_col;
+  requests[0].aggregations.push_back(make_percent_rank_aggregation<groupby_scan_aggregation>());
+  requests[1].values = *definitely_null_structs;
   requests[1].aggregations.push_back(make_dense_rank_aggregation<groupby_scan_aggregation>());
   requests[1].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>());
+  requests[1].aggregations.push_back(make_percent_rank_aggregation<groupby_scan_aggregation>());
 
   groupby::groupby gb_obj(table_view({keys}), null_policy::INCLUDE, sorted::YES);
-  auto result = gb_obj.scan(requests);
+  auto [result_keys, agg_results] = gb_obj.scan(requests);
 
-  auto expected_dense_vals =
-    fixed_width_column_wrapper<size_type>{1, 2, 2, 3, 4, 5, 1, 1, 2, 1, 1, 2};
-  auto expected_rank_vals =
-    fixed_width_column_wrapper<size_type>{1, 2, 2, 4, 5, 6, 1, 1, 3, 1, 1, 3};
-  auto expected_null_result =
-    fixed_width_column_wrapper<size_type>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  auto expected_dense   = rank_result_col{1, 2, 2, 3, 4, 5, 1, 1, 2, 1, 1, 2};
+  auto expected_rank    = rank_result_col{1, 2, 2, 4, 5, 6, 1, 1, 3, 1, 1, 3};
+  auto expected_percent = percent_result_col{
+    0.0, 1.0 / 5, 1.0 / 5, 3.0 / 5, 4.0 / 5, 5.0 / 5, 0.0, 0.0, 2.0 / 2, 0.0, 0.0, 2.0 / 2};
+  auto expected_rank_for_null = rank_result_col{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  auto expected_percent_for_null =
+    percent_result_col{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result.second[0].results[0], expected_dense_vals);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result.second[0].results[1], expected_rank_vals);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result.second[1].results[0], expected_null_result);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result.second[1].results[1], expected_null_result);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[0], expected_dense);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[1], expected_rank);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[2], expected_percent);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[1].results[0], expected_rank_for_null);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[1].results[1], expected_rank_for_null);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[1].results[2], expected_percent_for_null);
 }
 
 /* List support dependent on https://github.com/rapidsai/cudf/issues/8683
@@ -372,67 +424,72 @@ TYPED_TEST(list_groupby_rank_scan_test, lists)
 
 TEST(groupby_rank_scan_test, bools)
 {
-  fixed_width_column_wrapper<bool> keys = {{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1},
-                                           {1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0}};
-  fixed_width_column_wrapper<bool> order_col1{{0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1},
-                                              {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<bool> order_col2{{0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1},
-                                              {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<bool> order_col3{{0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1},
-                                              {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<bool> order_col4{{0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1},
-                                              {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1}};
-  fixed_width_column_wrapper<bool> order_col5{{0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1},
-                                              {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1}};
-  structs_column_wrapper struct_order{order_col2, order_col3};
-  structs_column_wrapper struct_order_with_nulls{{order_col4, order_col5},
-                                                 {1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1}};
+  using bools       = fixed_width_column_wrapper<bool>;
+  using null_iter_t = decltype(nulls_at({}));
 
-  fixed_width_column_wrapper<size_type> expected_dense_vals{{1, 1, 2, 2, 2, 2, 1, 2, 3, 1, 1, 2}};
-  fixed_width_column_wrapper<size_type> expected_rank_vals{{1, 1, 3, 3, 3, 3, 1, 2, 3, 1, 1, 3}};
+  auto const keys          = bools{{0, 0, 0, 0, 0, 0, 1, 1, 1, X, X, X}, nulls_at({9, 10, 11})};
+  auto const nulls_6_8     = nulls_at({6, 8});
+  auto const make_order_by = [&] { return bools{{0, 0, 1, 1, 1, 1, X, 1, X, 0, 0, 1}, nulls_6_8}; };
+  auto const make_structs  = [&](null_iter_t const& null_iter = all_valid) {
+    auto member_1 = make_order_by();
+    auto member_2 = make_order_by();
+    return structs_column_wrapper{{member_1, member_2}, null_iter};
+  };
 
-  test_pair_rank_scans(keys, order_col1, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order_with_nulls, expected_dense_vals, expected_rank_vals);
+  auto const order_by                    = make_order_by();
+  auto const order_by_structs            = make_structs();
+  auto const order_by_structs_with_nulls = make_structs(nulls_6_8);
+
+  auto const expected_dense   = rank_result_col{{1, 1, 2, 2, 2, 2, 1, 2, 3, 1, 1, 2}};
+  auto const expected_rank    = rank_result_col{{1, 1, 3, 3, 3, 3, 1, 2, 3, 1, 1, 3}};
+  auto const expected_percent = percent_result_col{
+    {0.0, 0.0, 2.0 / 5, 2.0 / 5, 2.0 / 5, 2.0 / 5, 0.0, 1.0 / 2, 2.0 / 2, 0.0, 0.0, 2.0 / 2}};
+
+  test_rank_scans(keys, order_by, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(keys, order_by_structs, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(
+    keys, order_by_structs_with_nulls, expected_dense, expected_rank, expected_percent);
 }
 
 TEST(groupby_rank_scan_test, strings)
 {
-  strings_column_wrapper keys = {{"0", "0", "0", "0", "0", "0", "1", "1", "1", "1", "0", "1"},
-                                 {1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0}};
-  strings_column_wrapper order_col1{
-    {"-1", "-2", "-2", "-2", "-3", "-3", "-4", "-4", "-4", "-5", "-5", "-6"},
-    {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  strings_column_wrapper order_col2{
-    {"-1", "-2", "-2", "-2", "-3", "-3", "-4", "-4", "-4", "-5", "-5", "-6"},
-    {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  strings_column_wrapper order_col3{
-    {"-1", "-2", "-2", "-2", "-3", "-3", "-4", "-4", "-4", "-5", "-5", "-6"},
-    {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  strings_column_wrapper order_col4{
-    {"-1", "-2", "-2", "-2", "-3", "-3", "-4", "-4", "-4", "-5", "-5", "-6"},
-    {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  strings_column_wrapper order_col5{
-    {"-1", "-2", "-2", "-2", "-3", "-3", "-4", "-4", "-4", "-5", "-5", "-6"},
-    {1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1}};
-  structs_column_wrapper struct_order{order_col2, order_col3};
-  structs_column_wrapper struct_order_with_nulls{{order_col4, order_col5},
-                                                 {1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0}};
+  using strings     = strings_column_wrapper;
+  using null_iter_t = decltype(nulls_at({}));
 
-  fixed_width_column_wrapper<size_type> expected_dense_vals{{1, 2, 3, 4, 5, 5, 1, 1, 2, 1, 1, 2}};
-  fixed_width_column_wrapper<size_type> expected_rank_vals{{1, 2, 3, 4, 5, 5, 1, 1, 3, 1, 1, 3}};
+  auto const keys =
+    strings{{"0", "0", "0", "0", "0", "0", "1", "1", "1", "X", "X", "X"}, nulls_at({9, 10, 11})};
+  auto const nulls_2_8     = nulls_at({2, 8});
+  auto const make_order_by = [&] {
+    return strings{{"-1", "-2", "X", "-2", "-3", "-3", "-4", "-4", "X", "-5", "-5", "-6"},
+                   nulls_2_8};
+  };
+  auto const make_structs = [&](null_iter_t const& null_iter = all_valid) {
+    auto member_1 = make_order_by();
+    auto member_2 = make_order_by();
+    return structs_column_wrapper{{member_1, member_2}, null_iter};
+  };
 
-  test_pair_rank_scans(keys, order_col1, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order, expected_dense_vals, expected_rank_vals);
-  test_pair_rank_scans(keys, struct_order_with_nulls, expected_dense_vals, expected_rank_vals);
+  auto const order_by                    = make_order_by();
+  auto const order_by_structs            = make_structs();
+  auto const order_by_structs_with_nulls = make_structs(nulls_at({4, 5, 11}));
+
+  auto const expected_dense   = rank_result_col{{1, 2, 3, 4, 5, 5, 1, 1, 2, 1, 1, 2}};
+  auto const expected_rank    = rank_result_col{{1, 2, 3, 4, 5, 5, 1, 1, 3, 1, 1, 3}};
+  auto const expected_percent = percent_result_col{
+    {0.0, 1.0 / 5, 2.0 / 5, 3.0 / 5, 4.0 / 5, 4.0 / 5, 0.0, 0.0, 2.0 / 2, 0.0, 0.0, 2.0 / 2}};
+
+  test_rank_scans(keys, order_by, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(keys, order_by_structs, expected_dense, expected_rank, expected_percent);
+  test_rank_scans(
+    keys, order_by_structs_with_nulls, expected_dense, expected_rank, expected_percent);
 }
 
 TEST_F(groupby_rank_scan_test_failures, test_exception_triggers)
 {
   using T = uint32_t;
 
-  fixed_width_column_wrapper<T> keys{{1, 2, 3}, {1, 1, 0}};
-  fixed_width_column_wrapper<T> col{3, 3, 1};
+  auto const keys = input<T>{{1, 2, 3}, null_at(2)};
+  auto const col  = input<T>{3, 3, 1};
 
   CUDF_EXPECT_THROW_MESSAGE(
     test_single_scan(keys,

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -34,9 +34,11 @@ namespace cudf::test {
 using namespace iterators;
 
 template <typename T>
-using input              = fixed_width_column_wrapper<T>;
-using rank_result_col    = fixed_width_column_wrapper<size_type>;
-using percent_result_col = fixed_width_column_wrapper<double>;
+using input           = fixed_width_column_wrapper<T>;
+using rank_result_col = fixed_width_column_wrapper<size_type>;
+using percent_result_t =
+  cudf::detail::target_type_t<int32_t, cudf::aggregation::Kind::PERCENT_RANK>;
+using percent_result_col = fixed_width_column_wrapper<percent_result_t>;
 
 auto const rank         = cudf::make_rank_aggregation();
 auto const dense_rank   = cudf::make_dense_rank_aggregation();

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -43,13 +43,16 @@ auto const rank         = cudf::make_rank_aggregation();
 auto const dense_rank   = cudf::make_dense_rank_aggregation();
 auto const percent_rank = cudf::make_percent_rank_aggregation();
 
+auto constexpr INCLUSIVE_SCAN = cudf::scan_type::INCLUSIVE;
+auto constexpr INCLUDE_NULLS  = cudf::null_policy::INCLUDE;
+
 template <typename T>
 struct TypedRankScanTest : BaseScanTest<T> {
   inline void test_ungrouped_rank_scan(cudf::column_view const& input,
                                        cudf::column_view const& expect_vals,
                                        std::unique_ptr<aggregation> const& agg)
   {
-    auto col_out = cudf::scan(input, agg, scan_type::INCLUSIVE, cudf::null_policy::INCLUDE);
+    auto col_out = cudf::scan(input, agg, INCLUSIVE_SCAN, INCLUDE_NULLS);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect_vals, col_out->view());
   }
 };
@@ -191,20 +194,16 @@ TYPED_TEST(TypedRankScanTest, NestedStructs)
     return structs_column_wrapper{{col, strings_col, nuther_col}};
   }();
 
-  auto const dense_out =
-    cudf::scan(nested_col, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto const dense_expected =
-    cudf::scan(flat_col, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto const dense_out      = cudf::scan(nested_col, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const dense_expected = cudf::scan(flat_col, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_out->view(), dense_expected->view());
 
-  auto const rank_out = cudf::scan(nested_col, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto const rank_expected = cudf::scan(flat_col, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto const rank_out      = cudf::scan(nested_col, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const rank_expected = cudf::scan(flat_col, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_out->view(), rank_expected->view());
 
-  auto const percent_out =
-    cudf::scan(nested_col, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto const percent_expected =
-    cudf::scan(flat_col, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto const percent_out      = cudf::scan(nested_col, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const percent_expected = cudf::scan(flat_col, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_out->view(), percent_expected->view());
 }
 
@@ -219,16 +218,12 @@ TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
     auto const expected_null_result = rank_result_col{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     auto const expected_percent_rank_null_result =
       percent_result_col{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-    auto const dense_null_out =
-      cudf::scan(*struct_col, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-    auto const rank_null_out =
-      cudf::scan(*struct_col, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-    auto const percent_null_out =
-      cudf::scan(*struct_col, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_null_out->view(), expected_null_result);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_null_out->view(), expected_null_result);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_null_out->view(),
-                                        expected_percent_rank_null_result);
+    auto const dense_out   = cudf::scan(*struct_col, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const rank_out    = cudf::scan(*struct_col, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const percent_out = cudf::scan(*struct_col, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_out->view(), expected_null_result);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_out->view(), expected_null_result);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_out->view(), expected_percent_rank_null_result);
   }
 
   // Next, verify that if the structs column a null mask that is NOT pushed down to members,
@@ -251,11 +246,9 @@ TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
                                                      9.0 / 11,
                                                      9.0 / 11,
                                                      11.0 / 11};
-    auto const dense_out =
-      cudf::scan(*struct_col, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-    auto const rank_out = cudf::scan(*struct_col, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-    auto const percent_out =
-      cudf::scan(*struct_col, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+    auto const dense_out   = cudf::scan(*struct_col, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const rank_out    = cudf::scan(*struct_col, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const percent_out = cudf::scan(*struct_col, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_out->view(), expected_dense);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_out->view(), expected_rank);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_out->view(), expected_percent);
@@ -283,10 +276,9 @@ TEST(RankScanTest, BoolRank)
                                                    3.0 / 11,
                                                    3.0 / 11};
 
-  auto const dense_out = cudf::scan(vals, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto const rank_out  = cudf::scan(vals, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto const percent_out =
-    cudf::scan(vals, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto const dense_out   = cudf::scan(vals, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const rank_out    = cudf::scan(vals, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const percent_out = cudf::scan(vals, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_dense, dense_out->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_rank, rank_out->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_percent, percent_out->view());
@@ -310,11 +302,9 @@ TEST(RankScanTest, BoolRankWithNull)
                                                    8.0 / 11,
                                                    8.0 / 11};
 
-  auto nullable_dense_out =
-    cudf::scan(vals, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto nullable_rank_out = cudf::scan(vals, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto nullable_percent_out =
-    cudf::scan(vals, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto nullable_dense_out   = cudf::scan(vals, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto nullable_rank_out    = cudf::scan(vals, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto nullable_percent_out = cudf::scan(vals, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_dense, nullable_dense_out->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_rank, nullable_rank_out->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_percent, nullable_percent_out->view());
@@ -324,14 +314,12 @@ TEST(RankScanTest, ExclusiveScan)
 {
   auto const vals = input<uint32_t>{3, 4, 5};
 
-  CUDF_EXPECT_THROW_MESSAGE(
-    cudf::scan(vals, dense_rank, scan_type::EXCLUSIVE, null_policy::INCLUDE),
-    "Dense rank aggregation operator requires an inclusive scan");
-  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, rank, scan_type::EXCLUSIVE, null_policy::INCLUDE),
+  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, dense_rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
+                            "Dense rank aggregation operator requires an inclusive scan");
+  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
                             "Rank aggregation operator requires an inclusive scan");
-  CUDF_EXPECT_THROW_MESSAGE(
-    cudf::scan(vals, percent_rank, scan_type::EXCLUSIVE, null_policy::INCLUDE),
-    "Percent rank aggregation operator requires an inclusive scan");
+  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, percent_rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
+                            "Percent rank aggregation operator requires an inclusive scan");
 }
 
 }  // namespace cudf::test

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "cudf/aggregation.hpp"
+#include "cudf/types.hpp"
 #include "scan_tests.hpp"
 
 #include <cudf_test/column_utilities.hpp>
@@ -22,20 +24,32 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/reduction.hpp>
+#include <type_traits>
 
 using aggregation = cudf::aggregation;
 using cudf::null_policy;
 using cudf::scan_type;
-using namespace cudf::test::iterators;
+
+namespace cudf::test {
+
+using namespace iterators;
+
+template <typename T>
+using input              = fixed_width_column_wrapper<T>;
+using rank_result_col    = fixed_width_column_wrapper<size_type>;
+using percent_result_col = fixed_width_column_wrapper<double>;
+
+auto const rank         = cudf::make_rank_aggregation();
+auto const dense_rank   = cudf::make_dense_rank_aggregation();
+auto const percent_rank = cudf::make_percent_rank_aggregation();
 
 template <typename T>
 struct TypedRankScanTest : BaseScanTest<T> {
   inline void test_ungrouped_rank_scan(cudf::column_view const& input,
                                        cudf::column_view const& expect_vals,
-                                       std::unique_ptr<aggregation> const& agg,
-                                       null_policy null_handling)
+                                       std::unique_ptr<aggregation> const& agg)
   {
-    auto col_out = cudf::scan(input, agg, scan_type::INCLUSIVE, null_handling);
+    auto col_out = cudf::scan(input, agg, scan_type::INCLUSIVE, cudf::null_policy::INCLUDE);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect_vals, col_out->view());
   }
 };
@@ -55,16 +69,25 @@ TYPED_TEST(TypedRankScanTest, Rank)
       return make_vector<TypeParam>({-120, -120, -120, -16, -16, 5, 6, 6, 6, 6, 34, 113});
     return make_vector<TypeParam>({5, 5, 5, 6, 6, 9, 11, 11, 11, 11, 14, 34});
   }();
-  auto col = this->make_column(v);
+  auto const col = this->make_column(v);
 
-  auto const expected_dense_vals =
-    cudf::test::fixed_width_column_wrapper<cudf::size_type>{1, 1, 1, 2, 2, 3, 4, 4, 4, 4, 5, 6};
-  auto const expected_rank_vals =
-    cudf::test::fixed_width_column_wrapper<cudf::size_type>{1, 1, 1, 4, 4, 6, 7, 7, 7, 7, 11, 12};
-  this->test_ungrouped_rank_scan(
-    *col, expected_dense_vals, cudf::make_dense_rank_aggregation(), null_policy::INCLUDE);
-  this->test_ungrouped_rank_scan(
-    *col, expected_rank_vals, cudf::make_rank_aggregation(), null_policy::INCLUDE);
+  auto const expected_dense   = rank_result_col{1, 1, 1, 2, 2, 3, 4, 4, 4, 4, 5, 6};
+  auto const expected_rank    = rank_result_col{1, 1, 1, 4, 4, 6, 7, 7, 7, 7, 11, 12};
+  auto const expected_percent = percent_result_col{0.0,
+                                                   0.0,
+                                                   0.0,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   5.0 / 11,
+                                                   6.0 / 11,
+                                                   6.0 / 11,
+                                                   6.0 / 11,
+                                                   6.0 / 11,
+                                                   10.0 / 11,
+                                                   11.0 / 11};
+  this->test_ungrouped_rank_scan(*col, expected_dense, dense_rank);
+  this->test_ungrouped_rank_scan(*col, expected_rank, rank);
+  this->test_ungrouped_rank_scan(*col, expected_percent, percent_rank);
 }
 
 TYPED_TEST(TypedRankScanTest, RankWithNulls)
@@ -74,132 +97,169 @@ TYPED_TEST(TypedRankScanTest, RankWithNulls)
       return make_vector<TypeParam>({-120, -120, -120, -16, -16, 5, 6, 6, 6, 6, 34, 113});
     return make_vector<TypeParam>({5, 5, 5, 6, 6, 9, 11, 11, 11, 11, 14, 34});
   }();
-  auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 1, 1, 0, 1, 1, 0, 0, 1, 1, 1, 0});
-  auto col     = this->make_column(v, b);
+  auto const null_iter = nulls_at({3, 6, 7, 11});
+  auto const b         = thrust::host_vector<bool>(null_iter, null_iter + v.size());
+  auto col             = this->make_column(v, b);
 
-  auto const expected_dense_vals =
-    cudf::test::fixed_width_column_wrapper<cudf::size_type>{1, 1, 1, 2, 3, 4, 5, 5, 6, 6, 7, 8};
-  auto const expected_rank_vals =
-    cudf::test::fixed_width_column_wrapper<cudf::size_type>{1, 1, 1, 4, 5, 6, 7, 7, 9, 9, 11, 12};
-  this->test_ungrouped_rank_scan(
-    *col, expected_dense_vals, cudf::make_dense_rank_aggregation(), null_policy::INCLUDE);
-  this->test_ungrouped_rank_scan(
-    *col, expected_rank_vals, cudf::make_rank_aggregation(), null_policy::INCLUDE);
+  auto const expected_dense   = rank_result_col{1, 1, 1, 2, 3, 4, 5, 5, 6, 6, 7, 8};
+  auto const expected_rank    = rank_result_col{1, 1, 1, 4, 5, 6, 7, 7, 9, 9, 11, 12};
+  auto const expected_percent = percent_result_col{0.0,
+                                                   0.0,
+                                                   0.0,
+                                                   3.0 / 11,
+                                                   4.0 / 11,
+                                                   5.0 / 11,
+                                                   6.0 / 11,
+                                                   6.0 / 11,
+                                                   8.0 / 11,
+                                                   8.0 / 11,
+                                                   10.0 / 11,
+                                                   11.0 / 11};
+  this->test_ungrouped_rank_scan(*col, expected_dense, dense_rank);
+  this->test_ungrouped_rank_scan(*col, expected_rank, rank);
+  this->test_ungrouped_rank_scan(*col, expected_percent, percent_rank);
 }
+
+namespace {
+template <typename TypeParam>
+auto make_input_column()
+{
+  if constexpr (std::is_same_v<TypeParam, cudf::string_view>) {
+    return strings_column_wrapper{{"0", "0", "4", "4", "4", "5", "7", "7", "7", "9", "9", "9"},
+                                  null_at(5)};
+  } else {
+    return (std::is_signed_v<TypeParam>)
+             ? input<TypeParam>{{-1, -1, -4, -4, -4, 5, 7, 7, 7, 9, 9, 9}, null_at(5)}
+             : input<TypeParam>{{0, 0, 4, 4, 4, 5, 7, 7, 7, 9, 9, 9}, null_at(5)};
+  }
+}
+
+auto make_strings_column()
+{
+  return strings_column_wrapper{
+    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
+}
+
+template <typename TypeParam>
+auto make_mixed_structs_column()
+{
+  auto col     = make_input_column<TypeParam>();
+  auto strings = make_strings_column();
+  return structs_column_wrapper{{col, strings}};
+}
+}  // namespace
 
 TYPED_TEST(TypedRankScanTest, MixedStructs)
 {
-  auto const v = [] {
-    if (std::is_signed<TypeParam>::value)
-      return make_vector<TypeParam>({-1, -1, -4, -4, -4, 5, 7, 7, 7, 9, 9, 9});
-    return make_vector<TypeParam>({0, 0, 4, 4, 4, 5, 7, 7, 7, 9, 9, 9});
-  }();
-  auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1});
-  auto col     = this->make_column(v, b);
-  auto strings = cudf::test::strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
-  std::vector<std::unique_ptr<cudf::column>> vector_of_columns;
-  vector_of_columns.push_back(std::move(col));
-  vector_of_columns.push_back(strings.release());
-  auto struct_col = cudf::test::structs_column_wrapper{std::move(vector_of_columns)}.release();
+  auto const struct_col       = make_mixed_structs_column<TypeParam>();
+  auto const expected_dense   = rank_result_col{1, 1, 2, 2, 3, 4, 5, 5, 6, 7, 7, 8};
+  auto const expected_rank    = rank_result_col{1, 1, 3, 3, 5, 6, 7, 7, 9, 10, 10, 12};
+  auto const expected_percent = percent_result_col{0.0,
+                                                   0.0,
+                                                   2.0 / 11,
+                                                   2.0 / 11,
+                                                   4.0 / 11,
+                                                   5.0 / 11,
+                                                   6.0 / 11,
+                                                   6.0 / 11,
+                                                   8.0 / 11,
+                                                   9.0 / 11,
+                                                   9.0 / 11,
+                                                   11.0 / 11};
 
-  auto expected_dense_vals =
-    cudf::test::fixed_width_column_wrapper<cudf::size_type>{1, 1, 2, 2, 3, 4, 5, 5, 6, 7, 7, 8};
-  auto expected_rank_vals =
-    cudf::test::fixed_width_column_wrapper<cudf::size_type>{1, 1, 3, 3, 5, 6, 7, 7, 9, 10, 10, 12};
-
-  this->test_ungrouped_rank_scan(
-    *struct_col, expected_dense_vals, cudf::make_dense_rank_aggregation(), null_policy::INCLUDE);
-  this->test_ungrouped_rank_scan(
-    *struct_col, expected_rank_vals, cudf::make_rank_aggregation(), null_policy::INCLUDE);
+  this->test_ungrouped_rank_scan(struct_col, expected_dense, dense_rank);
+  this->test_ungrouped_rank_scan(struct_col, expected_rank, rank);
+  this->test_ungrouped_rank_scan(struct_col, expected_percent, percent_rank);
 }
 
 TYPED_TEST(TypedRankScanTest, NestedStructs)
 {
-  auto const v = [] {
-    if (std::is_signed<TypeParam>::value)
-      return make_vector<TypeParam>({-1, -1, -4, -4, -4, 5, 7, 7, 7, 9, 9, 9});
-    return make_vector<TypeParam>({0, 0, 4, 4, 4, 5, 7, 7, 7, 9, 9, 9});
+  auto const nested_col = [&] {
+    auto struct_col = [&] {
+      auto col     = make_input_column<TypeParam>();
+      auto strings = make_strings_column();
+      return structs_column_wrapper{{col, strings}};
+    }();
+    auto col = make_input_column<TypeParam>();
+    return structs_column_wrapper{{struct_col, col}};
   }();
-  auto const b  = thrust::host_vector<bool>(std::vector<bool>{1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1});
-  auto col1     = this->make_column(v, b);
-  auto col2     = this->make_column(v, b);
-  auto col3     = this->make_column(v, b);
-  auto col4     = this->make_column(v, b);
-  auto strings1 = cudf::test::strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
-  auto strings2 = cudf::test::strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
 
-  std::vector<std::unique_ptr<cudf::column>> struct_columns;
-  struct_columns.push_back(std::move(col1));
-  struct_columns.push_back(strings1.release());
-  auto struct_col = cudf::test::structs_column_wrapper{std::move(struct_columns)};
-  std::vector<std::unique_ptr<cudf::column>> nested_columns;
-  nested_columns.push_back(struct_col.release());
-  nested_columns.push_back(std::move(col2));
-  auto nested_col = cudf::test::structs_column_wrapper{std::move(nested_columns)};
-  std::vector<std::unique_ptr<cudf::column>> flat_columns;
-  flat_columns.push_back(std::move(col3));
-  flat_columns.push_back(strings2.release());
-  flat_columns.push_back(std::move(col4));
-  auto flat_col = cudf::test::structs_column_wrapper{std::move(flat_columns)};
+  auto const flat_col = [&] {
+    auto col         = make_input_column<TypeParam>();
+    auto strings_col = make_strings_column();
+    auto nuther_col  = make_input_column<TypeParam>();
+    return structs_column_wrapper{{col, strings_col, nuther_col}};
+  }();
 
-  auto dense_out = cudf::scan(
-    nested_col, cudf::make_dense_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto dense_expected = cudf::scan(
-    flat_col, cudf::make_dense_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto rank_out = cudf::scan(
-    nested_col, cudf::make_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto rank_expected =
-    cudf::scan(flat_col, cudf::make_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-
+  auto const dense_out =
+    cudf::scan(nested_col, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto const dense_expected =
+    cudf::scan(flat_col, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_out->view(), dense_expected->view());
+
+  auto const rank_out = cudf::scan(nested_col, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto const rank_expected = cudf::scan(flat_col, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_out->view(), rank_expected->view());
+
+  auto const percent_out =
+    cudf::scan(nested_col, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto const percent_expected =
+    cudf::scan(flat_col, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_out->view(), percent_expected->view());
 }
 
-TYPED_TEST(TypedRankScanTest, structsWithNullPushdown)
+TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
 {
-  auto const v = [] {
-    if (std::is_signed<TypeParam>::value)
-      return make_vector<TypeParam>({-1, -1, -4, -4, -4, 5, 7, 7, 7, 9, 9, 9});
-    return make_vector<TypeParam>({0, 0, 4, 4, 4, 5, 7, 7, 7, 9, 9, 9});
-  }();
-  auto const b = thrust::host_vector<bool>(std::vector<bool>{1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1});
-  auto col     = this->make_column(v, b);
-  auto strings = cudf::test::strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
-  std::vector<std::unique_ptr<cudf::column>> struct_columns;
-  struct_columns.push_back(std::move(col));
-  struct_columns.push_back(strings.release());
+  auto struct_col = make_mixed_structs_column<TypeParam>().release();
 
-  auto struct_col =
-    cudf::make_structs_column(12, std::move(struct_columns), 0, rmm::device_buffer{});
+  // First, verify that if the structs column has only nulls, all output rows are ranked 1.
+  {
+    struct_col->set_null_mask(
+      create_null_mask(12, cudf::mask_state::ALL_NULL));  // Null mask not pushed down to members.
+    auto const expected_null_result = rank_result_col{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    auto const expected_percent_rank_null_result =
+      percent_result_col{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    auto const dense_null_out =
+      cudf::scan(*struct_col, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+    auto const rank_null_out =
+      cudf::scan(*struct_col, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+    auto const percent_null_out =
+      cudf::scan(*struct_col, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_null_out->view(), expected_null_result);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_null_out->view(), expected_null_result);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_null_out->view(),
+                                        expected_percent_rank_null_result);
+  }
 
-  struct_col->set_null_mask(create_null_mask(12, cudf::mask_state::ALL_NULL));
-  auto expected_null_result =
-    cudf::test::fixed_width_column_wrapper<cudf::size_type>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-  auto dense_null_out = cudf::scan(
-    *struct_col, cudf::make_dense_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto rank_null_out = cudf::scan(
-    *struct_col, cudf::make_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_null_out->view(), expected_null_result);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_null_out->view(), expected_null_result);
-
-  auto const struct_nulls =
-    thrust::host_vector<bool>(std::vector<bool>{1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1});
-  struct_col->set_null_mask(
-    cudf::test::detail::make_null_mask(struct_nulls.begin(), struct_nulls.end()));
-  auto expected_dense_vals =
-    cudf::test::fixed_width_column_wrapper<cudf::size_type>{1, 2, 2, 3, 4, 5, 6, 6, 7, 8, 8, 9};
-  auto expected_rank_vals =
-    cudf::test::fixed_width_column_wrapper<cudf::size_type>{1, 2, 2, 4, 5, 6, 7, 7, 9, 10, 10, 12};
-  auto dense_out = cudf::scan(
-    *struct_col, cudf::make_dense_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto rank_out = cudf::scan(
-    *struct_col, cudf::make_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_out->view(), expected_dense_vals);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_out->view(), expected_rank_vals);
+  // Next, verify that if the structs column a null mask that is NOT pushed down to members,
+  // the ranks are still correct.
+  {
+    auto const null_iter = nulls_at({1, 2});
+    struct_col->set_null_mask(
+      cudf::test::detail::make_null_mask(null_iter, null_iter + struct_col->size()));
+    auto const expected_dense   = rank_result_col{1, 2, 2, 3, 4, 5, 6, 6, 7, 8, 8, 9};
+    auto const expected_rank    = rank_result_col{1, 2, 2, 4, 5, 6, 7, 7, 9, 10, 10, 12};
+    auto const expected_percent = percent_result_col{0.0,
+                                                     1.0 / 11,
+                                                     1.0 / 11,
+                                                     3.0 / 11,
+                                                     4.0 / 11,
+                                                     5.0 / 11,
+                                                     6.0 / 11,
+                                                     6.0 / 11,
+                                                     8.0 / 11,
+                                                     9.0 / 11,
+                                                     9.0 / 11,
+                                                     11.0 / 11};
+    auto const dense_out =
+      cudf::scan(*struct_col, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+    auto const rank_out = cudf::scan(*struct_col, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+    auto const percent_out =
+      cudf::scan(*struct_col, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_out->view(), expected_dense);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_out->view(), expected_rank);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_out->view(), expected_percent);
+  }
 }
 
 struct RankScanTest : public cudf::test::BaseFixture {
@@ -207,49 +267,71 @@ struct RankScanTest : public cudf::test::BaseFixture {
 
 TEST(RankScanTest, BoolRank)
 {
-  cudf::test::fixed_width_column_wrapper<bool> vals{0, 0, 0, 6, 6, 9, 11, 11, 11, 11, 14, 34};
-  cudf::test::fixed_width_column_wrapper<cudf::size_type> expected_dense_vals{
-    1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2};
-  cudf::test::fixed_width_column_wrapper<cudf::size_type> expected_rank_vals{
-    1, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4};
+  auto const vals             = input<bool>{0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  auto const expected_dense   = rank_result_col{1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+  auto const expected_rank    = rank_result_col{1, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4};
+  auto const expected_percent = percent_result_col{0.0,
+                                                   0.0,
+                                                   0.0,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11};
 
-  auto dense_out = cudf::scan(
-    vals, cudf::make_dense_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto rank_out =
-    cudf::scan(vals, cudf::make_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_dense_vals, dense_out->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_rank_vals, rank_out->view());
+  auto const dense_out = cudf::scan(vals, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto const rank_out  = cudf::scan(vals, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto const percent_out =
+    cudf::scan(vals, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_dense, dense_out->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_rank, rank_out->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_percent, percent_out->view());
 }
 
 TEST(RankScanTest, BoolRankWithNull)
 {
-  cudf::test::fixed_width_column_wrapper<bool> vals{{0, 0, 0, 6, 6, 9, 11, 11, 11, 11, 14, 34},
-                                                    {1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0}};
-  cudf::table_view order_table{std::vector<cudf::column_view>{vals}};
-  cudf::test::fixed_width_column_wrapper<cudf::size_type> expected_dense_vals{
-    1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3};
-  cudf::test::fixed_width_column_wrapper<cudf::size_type> expected_rank_vals{
-    1, 1, 1, 4, 4, 4, 4, 4, 9, 9, 9, 9};
+  auto const vals = input<bool>{{0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, nulls_at({8, 9, 10, 11})};
+  auto const expected_dense   = rank_result_col{1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3};
+  auto const expected_rank    = rank_result_col{1, 1, 1, 4, 4, 4, 4, 4, 9, 9, 9, 9};
+  auto const expected_percent = percent_result_col{0.0,
+                                                   0.0,
+                                                   0.0,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   3.0 / 11,
+                                                   8.0 / 11,
+                                                   8.0 / 11,
+                                                   8.0 / 11,
+                                                   8.0 / 11};
 
-  auto nullable_dense_out = cudf::scan(
-    vals, cudf::make_dense_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  auto nullable_rank_out =
-    cudf::scan(vals, cudf::make_rank_aggregation(), scan_type::INCLUSIVE, null_policy::INCLUDE);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_dense_vals, nullable_dense_out->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_rank_vals, nullable_rank_out->view());
+  auto nullable_dense_out =
+    cudf::scan(vals, dense_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto nullable_rank_out = cudf::scan(vals, rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  auto nullable_percent_out =
+    cudf::scan(vals, percent_rank, scan_type::INCLUSIVE, null_policy::INCLUDE);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_dense, nullable_dense_out->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_rank, nullable_rank_out->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_percent, nullable_percent_out->view());
 }
 
 TEST(RankScanTest, ExclusiveScan)
 {
-  cudf::test::fixed_width_column_wrapper<uint32_t> vals{3, 4, 5};
-  cudf::test::fixed_width_column_wrapper<uint32_t> order_col{3, 3, 1};
-  cudf::table_view order_table{std::vector<cudf::column_view>{order_col}};
+  auto const vals = input<uint32_t>{3, 4, 5};
 
   CUDF_EXPECT_THROW_MESSAGE(
-    cudf::scan(
-      vals, cudf::make_dense_rank_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE),
-    "Unsupported dense rank aggregation operator for exclusive scan");
+    cudf::scan(vals, dense_rank, scan_type::EXCLUSIVE, null_policy::INCLUDE),
+    "Dense rank aggregation operator requires an inclusive scan");
+  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, rank, scan_type::EXCLUSIVE, null_policy::INCLUDE),
+                            "Rank aggregation operator requires an inclusive scan");
   CUDF_EXPECT_THROW_MESSAGE(
-    cudf::scan(vals, cudf::make_rank_aggregation(), scan_type::EXCLUSIVE, null_policy::INCLUDE),
-    "Unsupported rank aggregation operator for exclusive scan");
+    cudf::scan(vals, percent_rank, scan_type::EXCLUSIVE, null_policy::INCLUDE),
+    "Percent rank aggregation operator requires an inclusive scan");
 }
+
+}  // namespace cudf::test

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-#include "cudf/aggregation.hpp"
-#include "cudf/types.hpp"
 #include "scan_tests.hpp"
 
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 
+#include <cudf/aggregation.hpp>
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/reduction.hpp>
-#include <type_traits>
+#include <cudf/types.hpp>
 
 using aggregation = cudf::aggregation;
 using cudf::null_policy;

--- a/java/src/main/java/ai/rapids/cudf/Aggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/Aggregation.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ *  Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/java/ai/rapids/cudf/Aggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/Aggregation.java
@@ -66,8 +66,9 @@ abstract class Aggregation {
         MERGE_M2(27),
         RANK(28),
         DENSE_RANK(29),
-        TDIGEST(30), // This can take a delta argument for accuracy level
-        MERGE_TDIGEST(31); // This can take a delta argument for accuracy level
+        PERCENT_RANK(30),
+        TDIGEST(31), // This can take a delta argument for accuracy level
+        MERGE_TDIGEST(32); // This can take a delta argument for accuracy level
 
         final int nativeId;
 
@@ -752,6 +753,19 @@ abstract class Aggregation {
      */
     static DenseRankAggregation denseRank() {
         return new DenseRankAggregation();
+    }
+
+    static final class PercentRankAggregation extends NoParamAggregation {
+        private PercentRankAggregation() {
+            super(Kind.PERCENT_RANK);
+        }
+    }
+
+    /**
+     * Get the row's percent ranking.
+     */
+    static PercentRankAggregation percentRank() {
+        return new PercentRankAggregation();
     }
 
     /**

--- a/java/src/main/java/ai/rapids/cudf/GroupByScanAggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/GroupByScanAggregation.java
@@ -115,4 +115,11 @@ public final class GroupByScanAggregation {
   public static GroupByScanAggregation denseRank() {
     return new GroupByScanAggregation(Aggregation.denseRank());
   }
+
+  /**
+   * Get the row's percent ranking.
+   */
+  public static GroupByScanAggregation percentRank() {
+    return new GroupByScanAggregation(Aggregation.percentRank());
+  }
 }

--- a/java/src/main/java/ai/rapids/cudf/GroupByScanAggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/GroupByScanAggregation.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2021, NVIDIA CORPORATION.
+ *  Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/java/ai/rapids/cudf/ScanAggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/ScanAggregation.java
@@ -97,4 +97,11 @@ public final class ScanAggregation {
   public static ScanAggregation denseRank() {
     return new ScanAggregation(Aggregation.denseRank());
   }
+
+  /**
+   * Get the row's percent rank.
+   */
+  public static ScanAggregation percentRank() {
+    return new ScanAggregation(Aggregation.percentRank());
+  }
 }

--- a/java/src/main/java/ai/rapids/cudf/ScanAggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/ScanAggregation.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2021, NVIDIA CORPORATION.
+ *  Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/AggregationJni.cpp
+++ b/java/src/main/native/src/AggregationJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/AggregationJni.cpp
+++ b/java/src/main/native/src/AggregationJni.cpp
@@ -85,6 +85,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNoParamAgg(JNIEnv 
           return cudf::make_rank_aggregation();
         case 29: // DENSE_RANK
           return cudf::make_dense_rank_aggregation();
+        case 30: // PERCENT_RANK
+          return cudf::make_percent_rank_aggregation();
         default: throw std::logic_error("Unsupported No Parameter Aggregation Operation");
       }
     }();
@@ -139,10 +141,10 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createTDigestAgg(JNIEnv 
     std::unique_ptr<cudf::aggregation> ret;
     // These numbers come from Aggregation.java and must stay in sync
     switch (kind) {
-      case 30: // TDIGEST
+      case 31: // TDIGEST
         ret = cudf::make_tdigest_aggregation<cudf::groupby_aggregation>(delta);
         break;
-      case 31: // MERGE_TDIGEST
+      case 32: // MERGE_TDIGEST
         ret = cudf::make_merge_tdigest_aggregation<cudf::groupby_aggregation>(delta);
         break;
       default: throw std::logic_error("Unsupported TDigest Aggregation Operation");

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -3100,6 +3100,28 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testScanPercentRank() {
+    try (ColumnVector col1 = ColumnVector.fromBoxedInts(-97, -97, -97, null, -16, 5, null, null, 6, 6, 34, null);
+         ColumnVector col2 = ColumnVector.fromBoxedInts(  3,   3,   4,    7,   7, 7,    7,    7, 8, 8,  8,    9);
+         ColumnVector struct_order = ColumnVector.makeStruct(col1, col2);
+         ColumnVector expected = ColumnVector.fromBoxedDoubles(
+            0.0, 0.0, 2.0/11, 3.0/11, 4.0/11, 5.0/11, 6.0/11, 6.0/11, 8.0/11, 8.0/11, 10.0/11, 1.0)) {
+      try (ColumnVector result = struct_order.scan(ScanAggregation.percentRank(),
+              ScanType.INCLUSIVE, NullPolicy.INCLUDE)) {
+        assertColumnsAreEqual(expected, result);
+      }
+
+      // Exclude should have identical results
+      try (ColumnVector result = struct_order.scan(ScanAggregation.percentRank(),
+              ScanType.INCLUSIVE, NullPolicy.EXCLUDE)) {
+        assertColumnsAreEqual(expected, result);
+      }
+
+      // Percent rank aggregations do not support ScanType.EXCLUSIVE
+    }
+  }
+
+  @Test
   void testWindowStatic() {
     try (Scalar one = Scalar.fromInt(1);
          Scalar two = Scalar.fromInt(2);

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -3930,8 +3930,8 @@ public class TableTest extends CudfTestBase {
   @Test
   void testGroupByScan() {
     try (Table t1 = new Table.TestBuilder()
-        .column( "1",  "1",  "1",  "1",  "1",  "1",  "1",  "2",  "2",  "2",  "2")
-        .column(   0,    1,    3,    3,    5,    5,    5,    5,    5,    5,    5)
+        .column(  "1",  "1",  "1",  "1",  "1",  "1",  "1",  "2",  "2",  "2",  "2") // GBY Key#0
+        .column(   0,    1,    3,    3,    5,    5,    5,    5,    5,    5,    5)  // GBY Key#1
         .column(12.0, 14.0, 13.0, 17.0, 17.0, 17.0, null, null, 11.0, null, 10.0)
         .column(  -9, null,   -5,   0,     4,    4,    8,    2,    2,    2, null)
         .build()) {
@@ -3945,16 +3945,18 @@ public class TableTest extends CudfTestBase {
               GroupByScanAggregation.min().onColumn(2),
               GroupByScanAggregation.max().onColumn(2),
               GroupByScanAggregation.rank().onColumn(3),
-              GroupByScanAggregation.denseRank().onColumn(3));
+              GroupByScanAggregation.denseRank().onColumn(3),
+              GroupByScanAggregation.percentRank().onColumn(3));
            Table expected = new Table.TestBuilder()
-               .column( "1",  "1",  "1",  "1",  "1",  "1",  "1",  "2",  "2",  "2",  "2")
+               .column(  "1",  "1",  "1",  "1",  "1",  "1",  "1",  "2",  "2",  "2",  "2")
                .column(   0,    1,    3,    3,    5,    5,    5,    5,    5,    5,    5)
                .column(12.0, 14.0, 13.0, 30.0, 17.0, 34.0, null, null, 11.0, null, 21.0)
                .column(   0,    0,    0,    1,    0,    1,    2,    0,    1,    2,    3) // odd why is this not 1 based?
                .column(12.0, 14.0, 13.0, 13.0, 17.0, 17.0, null, null, 11.0, null, 10.0)
                .column(12.0, 14.0, 13.0, 17.0, 17.0, 17.0, null, null, 11.0, null, 11.0)
-               .column(1, 1, 1, 2, 1, 1, 3, 1, 1, 1, 4)
-               .column(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 2)
+               .column(   1,    1,    1,    2,    1,    1,    3,    1,    1,    1,    4)
+               .column(   1,    1,    1,    2,    1,    1,    2,    1,    1,    1,    2)
+               .column( 0.0,  0.0,  0.0,  1.0,  0.0,  0.0,  1.0,  0.0,  0.0,  0.0,  1.0)
                .build()) {
         assertTablesAreEqual(expected, result);
       }


### PR DESCRIPTION
Fixes #9644.

The `percent_rank()` aggregation is a ranking function, similar
to `rank()` and `dense_rank()`. It calculates the fractional/relative
rank of a row within a group of rows in a column, and returns a double
value in the range [0.0, 1.0] for each row in the group/column.

This commit includes the `libcudf` changes to support `percent_rank()`
aggregations, and the supporting JNI bindings.

Note that `percent_rank()` is typically used as a window aggregation. It
is implemented as a (grouped) scan aggregation, just as `rank()` and
`dense_rank()` because it operates across the whole group of rows. (i.e.
the window specification if fixed, spanning the entire group.)

References:
1. [SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/functions/percent-rank-transact-sql)
2. [PostgreSQL](https://www.postgresql.org/docs/10/functions-window.html)
3. [SparkSQL](https://sparkbyexamples.com/spark/spark-sql-window-functions/#ranking-functions)