### PR TITLE
[REVIEW] Optimize `DataFrame` creation across code-base

### DIFF
--- a/python/cudf/cudf/core/column/methods.py
+++ b/python/cudf/cudf/core/column/methods.py
@@ -84,7 +84,7 @@ class ColumnMethods:
                     idx.names = None
                     return idx
                 else:
-                    return self._parent._constructor_expanddim(
+                    return self._parent._constructor_expanddim._from_data(
                         data=table._data, index=self._parent.index
                     )
             elif isinstance(self._parent, cudf.Series):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -349,7 +349,7 @@ class _DataFrameIlocIndexer(_DataFrameIndexer):
     def _getitem_tuple_arg(self, arg):
         # Iloc Step 1:
         # Gather the columns specified by the second tuple arg
-        columns_df = DataFrame(self._frame._get_columns_by_index(arg[1]))
+        columns_df = self._frame._get_columns_by_index(arg[1])
 
         columns_df._index = self._frame._index
 
@@ -399,7 +399,7 @@ class _DataFrameIlocIndexer(_DataFrameIndexer):
 
     @annotate("ILOC_SETITEM", color="blue", domain="cudf_python")
     def _setitem_tuple_arg(self, key, value):
-        columns = DataFrame(self._frame._get_columns_by_index(key[1]))
+        columns = self._frame._get_columns_by_index(key[1])
 
         for col in columns:
             self._frame[col].iloc[key[0]] = value
@@ -569,9 +569,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                     }
                 )
         elif isinstance(data, ColumnAccessor):
-            result = self._from_data(data, index, columns)
-            self._data = result._data
-            self._index = result._index
+            raise TypeError(
+                "Use cudf.Series._from_data for constructing a Series from "
+                "ColumnAccessor"
+            )
         elif hasattr(data, "__cuda_array_interface__"):
             arr_interface = data.__cuda_array_interface__
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -568,6 +568,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                         for k in columns
                     }
                 )
+        elif isinstance(data, ColumnAccessor):
+            result = self._from_data(data, index, columns)
+            self._data = result._data
+            self._index = result._index
         elif hasattr(data, "__cuda_array_interface__"):
             arr_interface = data.__cuda_array_interface__
 

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -563,7 +563,7 @@ class Frame:
 
         """
         data = self._data.select_by_index(indices)
-        return self.__class__(
+        return self.__class__._from_data(
             data, columns=data.to_pandas_index(), index=self.index
         )
 

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -239,7 +239,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
 
         if ignore_index:
             if axis == 1:
-                result = cudf.DataFrame(
+                result = cudf.DataFrame._from_data(
                     data=obj._data.copy(deep=True),
                     index=obj.index.copy(deep=True),
                 )
@@ -249,13 +249,17 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
                 # after construction.
                 result.columns = pd.RangeIndex(len(obj._data.names))
             elif axis == 0:
-                if isinstance(obj, (pd.Series, cudf.Series)):
-                    result = cudf.Series(
+                if isinstance(obj, cudf.Series):
+                    result = cudf.Series._from_data(
                         data=obj._data.copy(deep=True),
                         index=cudf.RangeIndex(len(obj)),
                     )
+                elif isinstance(obj, pd.Series):
+                    result = cudf.Series(
+                        data=obj, index=cudf.RangeIndex(len(obj)),
+                    )
                 else:
-                    result = cudf.DataFrame(
+                    result = cudf.DataFrame._from_data(
                         data=obj._data.copy(deep=True),
                         index=cudf.RangeIndex(len(obj)),
                     )
@@ -370,7 +374,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
             return cudf.DataFrame()
         elif len(objs) == 1:
             obj = objs[0]
-            result = cudf.DataFrame(
+            result = cudf.DataFrame._from_data(
                 data=None if join == "inner" else obj._data.copy(deep=True),
                 index=cudf.RangeIndex(len(obj))
                 if ignore_index

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -408,7 +408,10 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
             if dtype is not None:
                 data = data.astype(dtype)
         elif isinstance(data, ColumnAccessor):
-            name, data = data.names[0], data.columns[0]
+            raise TypeError(
+                "Use cudf.Series._from_data for constructing a Series from "
+                "ColumnAccessor"
+            )
 
         if isinstance(data, Series):
             index = data._index if index is None else index
@@ -579,7 +582,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         new_data = super()._get_columns_by_label(labels, downcast)
 
         return (
-            self.__class__(data=new_data, index=self.index)
+            self.__class__._from_data(data=new_data, index=self.index)
             if len(new_data) > 0
             else self.__class__(dtype=self.dtype, name=self.name)
         )

--- a/python/cudf/cudf/tests/test_pack.py
+++ b/python/cudf/cudf/tests/test_pack.py
@@ -62,7 +62,7 @@ def assert_packed_frame_equality(df):
     packed = pack(df)
     del df
     tbl = unpack(packed)
-    unpacked = DataFrame(tbl._data, tbl._index)
+    unpacked = DataFrame._from_data(tbl._data, tbl._index)
 
     assert_eq(unpacked, pdf)
 
@@ -198,14 +198,14 @@ def check_packed_pickled_equality(df):
         for b in buffers:
             assert isinstance(b, pickle.PickleBuffer)
         tbl = unpack(pickle.loads(serialbytes, buffers=buffers))
-        loaded = DataFrame(tbl._data, tbl._index)
+        loaded = DataFrame._from_data(tbl._data, tbl._index)
         assert_eq(loaded, df)
 
 
 def assert_packed_frame_picklable(df):
     serialbytes = pickle.dumps(pack(df))
     tbl = unpack(pickle.loads(serialbytes))
-    loaded = DataFrame(tbl._data, tbl._index)
+    loaded = DataFrame._from_data(tbl._data, tbl._index)
     assert_eq(loaded, df)
 
 
@@ -271,7 +271,7 @@ def assert_packed_frame_serializable(df):
     packed = pack(df)
     header, frames = packed.serialize()
     tbl = unpack(packed.deserialize(header, frames))
-    loaded = DataFrame(tbl._data, tbl._index)
+    loaded = DataFrame._from_data(tbl._data, tbl._index)
     assert_eq(loaded, df)
 
 


### PR DESCRIPTION
After internal profiling, it appears that `_init_from_dict_like` was being repeatedly called even for `ColumnAccessor` inputs, which is not necessary and is an expensive method where we do proper index re-alignment. This PR handles by raising an error when a developer tries to create a `DataFrame` with `ColumnAccessor`, and also changes multiple of those instances where such calls are present to `_from_data` call which will now avoid going through `_init_from_dict_like` method for `ColumnAccessor` input. For a dataframe of shape `30_00_000 x 3` the speed up is about **2.5x to 4x**.

```python
In [1]: import cudf

In [2]: x = cudf.DataFrame(
   ...:     {
   ...:         "a": [1, 2, 3] * 10_00_000,
   ...:         "b": [3, 4, 5] * 10_00_000,
   ...:         "c": ["a", "b", "c"] * 10_00_000,
   ...:     },
   ...:     index=list(range(0, 3000000)),
   ...: )

In [3]: x
Out[3]: 
         a  b  c
0        1  3  a
1        2  4  b
2        3  5  c
3        1  3  a
4        2  4  b
...     .. .. ..
2999995  2  4  b
2999996  3  5  c
2999997  1  3  a
2999998  2  4  b
2999999  3  5  c

[3000000 rows x 3 columns]

In [4]: x.index
Out[4]: 
Int64Index([      0,       1,       2,       3,       4,       5,       6,
                  7,       8,       9,
            ...
            2999990, 2999991, 2999992, 2999993, 2999994, 2999995, 2999996,
            2999997, 2999998, 2999999],
           dtype='int64', length=3000000)
```
On `branch-22.04`:
```python
In [3]: %timeit cudf.DataFrame(x._data, x._index)
35.4 µs ± 240 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [4]: %timeit cudf.DataFrame(x._data)
40.6 µs ± 242 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

```

This `PR`:

```python
In [4]: %timeit cudf.DataFrame._from_data(x._data, x._index)
8.11 µs ± 169 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %timeit cudf.DataFrame._from_data(x._data)
16.9 µs ± 220 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```





<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
