### PR TITLE
Fix out-of-memory error in UrlDecode benchmark

### DIFF
--- a/cpp/benchmarks/string/url_decode.cpp
+++ b/cpp/benchmarks/string/url_decode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,8 +70,7 @@ cudf::test::strings_column_wrapper generate_column(cudf::size_type num_rows,
 class UrlDecode : public cudf::benchmark {
 };
 
-template <int esc_seq_pct>
-void BM_url_decode(benchmark::State& state)
+void BM_url_decode(benchmark::State& state, int esc_seq_pct)
 {
   cudf::size_type const num_rows      = state.range(0);
   cudf::size_type const chars_per_row = state.range(1);
@@ -88,12 +87,14 @@ void BM_url_decode(benchmark::State& state)
                           (chars_per_row + sizeof(cudf::size_type)));
 }
 
-#define URLD_BENCHMARK_DEFINE(esc_seq_pct)                     \
-  TEMPLATED_BENCHMARK_F(UrlDecode, BM_url_decode, esc_seq_pct) \
-    ->Args({100000000, 10})                                    \
-    ->Args({10000000, 100})                                    \
-    ->Args({1000000, 1000})                                    \
-    ->Unit(benchmark::kMillisecond)                            \
+#define URLD_BENCHMARK_DEFINE(esc_seq_pct)                      \
+  BENCHMARK_DEFINE_F(UrlDecode, esc_seq_pct)                    \
+  (::benchmark::State & st) { BM_url_decode(st, esc_seq_pct); } \
+  BENCHMARK_REGISTER_F(UrlDecode, esc_seq_pct)                  \
+    ->Args({100000000, 10})                                     \
+    ->Args({10000000, 100})                                     \
+    ->Args({1000000, 1000})                                     \
+    ->Unit(benchmark::kMillisecond)                             \
     ->UseManualTime();
 
 URLD_BENCHMARK_DEFINE(10)


### PR DESCRIPTION
Fixes out-of-memory error that occurs when running the `STRINGS_BENCH` `UrlDecode` benchmark combined with any other benchmark. The following minimal command shows the error:
```
benchmarks/STRINGS_BENCH '--benchmark_filter=UrlDecode|translate_large/16'
...
------------------------------------------------------------------------------------------------------------------
Benchmark                                                        Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------------
StringTranslate/translate_large/16777216/32/manual_time       17.4 ms         17.5 ms           40 bytes_per_second=15.8359G/s
terminate called after throwing an instance of 'rmm::out_of_memory'
  what():  std::bad_alloc: out_of_memory: RMM failure at:/cudf/cpp/build/_deps/rmm-src/include/rmm/mr/device/pool_memory_resource.hpp:192: Maximum pool size exceeded
```

The `UrlDecode` is the only benchmark in the `STRINGS_BENCH` using a `TEMPLATED_BENCHMARK_F` which causes a new separate memory pool to be created instead of reusing the one already created from the previous benchmark.
This PR reworks the benchmark macros in `url_decode.cpp` to avoid using `TEMPLATED_BENCHMARK_F` which fixes the issue.

