### PR TITLE
Add tests of reflected ufuncs and fix behavior of logical reflected ufuncs

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -998,8 +998,8 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         # First look for methods of the class.
         fname = ufunc.__name__
         if fname in binary_operations:
-            not_reflect = self is inputs[0]
-            other = inputs[not_reflect]
+            reflect = self is not inputs[0]
+            other = inputs[0] if reflect else inputs[1]
 
             # These operators need to be mapped to their inverses when
             # performing a reflected operation because no reflected version of
@@ -1009,16 +1009,16 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
                 "ge": "le",
                 "lt": "gt",
                 "le": "ge",
-                # ne and eq are symmetric
+                # ne and eq are symmetric, so they are their own inverse op
                 "ne": "ne",
                 "eq": "eq",
             }
 
             op = binary_operations[fname]
-            if op in ops_without_reflection and not not_reflect:
+            if reflect and op in ops_without_reflection:
                 op = ops_without_reflection[op]
-                not_reflect = True
-            op = f"__{'' if not_reflect else 'r'}{op}__"
+                reflect = False
+            op = f"__{'r' if reflect else ''}{op}__"
 
             # pandas bitwise operations return bools if indexes are misaligned.
             # TODO: Generalize for other types of Frames

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1000,11 +1000,23 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         if fname in binary_operations:
             not_reflect = self is inputs[0]
             other = inputs[not_reflect]
+
+            # These operators need to be mapped to their inverses when
+            # performing a reflected operation because no reflected version of
+            # the operators themselves exist.
+            ops_without_reflection = {
+                "gt": "lt",
+                "ge": "le",
+                "lt": "gt",
+                "le": "ge",
+                # ne and eq are symmetric
+                "ne": "ne",
+                "eq": "eq",
+            }
+
             op = binary_operations[fname]
-            ops_without_reflection = ("gt", "ge", "lt", "le", "ne", "eq")
             if op in ops_without_reflection and not not_reflect:
-                # This replacement will ignore eq and ne, which don't need it.
-                op = op.replace(*(("g", "l") if "g" in op else ("l", "g")))
+                op = ops_without_reflection[op]
                 not_reflect = True
             op = f"__{'' if not_reflect else 'r'}{op}__"
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1000,7 +1000,13 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         if fname in binary_operations:
             not_reflect = self is inputs[0]
             other = inputs[not_reflect]
-            op = f"__{'' if not_reflect else 'r'}{binary_operations[fname]}__"
+            op = binary_operations[fname]
+            ops_without_reflection = ("gt", "gte", "lt", "lte", "ne", "eq")
+            if op in ops_without_reflection and not not_reflect:
+                # This replacement will ignore eq and ne, which don't need it.
+                op = op.replace(*(("g", "l") if "g" in op else ("l", "g")))
+                not_reflect = True
+            op = f"__{'' if not_reflect else 'r'}{op}__"
 
             # pandas bitwise operations return bools if indexes are misaligned.
             # TODO: Generalize for other types of Frames

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1001,7 +1001,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
             not_reflect = self is inputs[0]
             other = inputs[not_reflect]
             op = binary_operations[fname]
-            ops_without_reflection = ("gt", "gte", "lt", "lte", "ne", "eq")
+            ops_without_reflection = ("gt", "ge", "lt", "le", "ne", "eq")
             if op in ops_without_reflection and not not_reflect:
                 # This replacement will ignore eq and ne, which don't need it.
                 op = op.replace(*(("g", "l") if "g" in op else ("l", "g")))

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+
 import operator
 from functools import reduce
 

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -98,14 +98,16 @@ def test_ufunc_series(ufunc, has_nulls, indexed):
         raise
 
 
-@pytest.mark.parametrize("ufunc", [np.add, np.greater, np.logical_and])
+@pytest.mark.parametrize(
+    "ufunc", [np.add, np.greater, np.greater_equal, np.logical_and]
+)
 @pytest.mark.parametrize("has_nulls", [True, False])
 @pytest.mark.parametrize("indexed", [True, False])
 @pytest.mark.parametrize("type_", ["cupy", "numpy", "list"])
 @pytest.mark.parametrize("reflect", [True, False])
 def test_binary_ufunc_series_array(ufunc, has_nulls, indexed, type_, reflect):
     fname = ufunc.__name__
-    if fname == "greater" and has_nulls:
+    if fname in ("greater", "greater_equal") and has_nulls:
         pytest.xfail(
             "The way cudf casts nans in arrays to nulls during binops with "
             "cudf objects is currently incompatible with pandas."


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This PR fixes cases like `cupy.array([1, 2, 3]) < cudf.Series([1, 2, 3])`. The code would previously attempt to find a reflected operator `Series.__rle__`, but no such operator exists because of the inherent symmetry in comparison operators. These changes fix the detection of such operators to just use operator `__ge__` in this case.