### PR TITLE
Prevent internal usage of expensive APIs

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 ##############################################
 # cuDF GPU build and test script for CI      #
 ##############################################
@@ -249,15 +249,15 @@ fi
 
 cd "$WORKSPACE/python/cudf"
 gpuci_logger "Python py.test for cuDF"
-py.test -n 8 --cache-clear --basetemp="$WORKSPACE/cudf-cuda-tmp" --ignore="$WORKSPACE/python/cudf/cudf/benchmarks" --junitxml="$WORKSPACE/junit-cudf.xml" -v --cov-config=.coveragerc --cov=cudf --cov-report=xml:"$WORKSPACE/python/cudf/cudf-coverage.xml" --cov-report term --dist=loadscope
+py.test -n 8 --cache-clear --basetemp="$WORKSPACE/cudf-cuda-tmp" --ignore="$WORKSPACE/python/cudf/cudf/benchmarks" --junitxml="$WORKSPACE/junit-cudf.xml" -v --cov-config=.coveragerc --cov=cudf --cov-report=xml:"$WORKSPACE/python/cudf/cudf-coverage.xml" --cov-report term --dist=loadscope cudf
 
 cd "$WORKSPACE/python/dask_cudf"
 gpuci_logger "Python py.test for dask-cudf"
-py.test -n 8 --cache-clear --basetemp="$WORKSPACE/dask-cudf-cuda-tmp" --junitxml="$WORKSPACE/junit-dask-cudf.xml" -v --cov-config=.coveragerc --cov=dask_cudf --cov-report=xml:"$WORKSPACE/python/dask_cudf/dask-cudf-coverage.xml" --cov-report term
+py.test -n 8 --cache-clear --basetemp="$WORKSPACE/dask-cudf-cuda-tmp" --junitxml="$WORKSPACE/junit-dask-cudf.xml" -v --cov-config=.coveragerc --cov=dask_cudf --cov-report=xml:"$WORKSPACE/python/dask_cudf/dask-cudf-coverage.xml" --cov-report term dask_cudf
 
 cd "$WORKSPACE/python/custreamz"
 gpuci_logger "Python py.test for cuStreamz"
-py.test -n 8 --cache-clear --basetemp="$WORKSPACE/custreamz-cuda-tmp" --junitxml="$WORKSPACE/junit-custreamz.xml" -v --cov-config=.coveragerc --cov=custreamz --cov-report=xml:"$WORKSPACE/python/custreamz/custreamz-coverage.xml" --cov-report term
+py.test -n 8 --cache-clear --basetemp="$WORKSPACE/custreamz-cuda-tmp" --junitxml="$WORKSPACE/junit-custreamz.xml" -v --cov-config=.coveragerc --cov=custreamz --cov-report=xml:"$WORKSPACE/python/custreamz/custreamz-coverage.xml" --cov-report term custreamz
 
 gpuci_logger "Test notebooks"
 "$WORKSPACE/ci/gpu/test-notebooks.sh" 2>&1 | tee nbtest.log

--- a/python/cudf/cudf/tests/conftest.py
+++ b/python/cudf/cudf/tests/conftest.py
@@ -32,5 +32,8 @@ def pytest_sessionfinish(session, exitstatus):
     Called after whole test run finished, right before
     returning the exit status to the system.
     """
-    del os.environ["NO_EXTERNAL_ONLY_APIS"]
-    del os.environ["_CUDF_TEST_ROOT"]
+    try:
+        del os.environ["NO_EXTERNAL_ONLY_APIS"]
+        del os.environ["_CUDF_TEST_ROOT"]
+    except KeyError:
+        pass

--- a/python/cudf/cudf/tests/conftest.py
+++ b/python/cudf/cudf/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 import rmm  # noqa: F401
 
-_CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+_CURRENT_DIRECTORY = str(pathlib.Path(__file__).resolve().parent)
 
 
 @pytest.fixture(scope="session")
@@ -18,7 +18,7 @@ def datadir():
 # To set and remove the NO_EXTERNAL_ONLY_APIS environment variable we must use
 # the sessionstart and sessionfinish hooks rather than a simple autouse,
 # session-scope fixture because we need to set these variable before collection
-# occurs because the envrionment variable will be checked as soon as cudf is
+# occurs because the environment variable will be checked as soon as cudf is
 # imported anywhere.
 def pytest_sessionstart(session):
     """

--- a/python/cudf/cudf/tests/conftest.py
+++ b/python/cudf/cudf/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 
 import rmm  # noqa: F401
 
+_CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+
 
 @pytest.fixture(scope="session")
 def datadir():
@@ -22,6 +24,7 @@ def pytest_sessionstart(session):
     before performing collection and entering the run test loop.
     """
     os.environ["NO_EXTERNAL_ONLY_APIS"] = "1"
+    os.environ["_CUDF_TEST_ROOT"] = _CURRENT_DIRECTORY
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -30,3 +33,4 @@ def pytest_sessionfinish(session, exitstatus):
     returning the exit status to the system.
     """
     del os.environ["NO_EXTERNAL_ONLY_APIS"]
+    del os.environ["_CUDF_TEST_ROOT"]

--- a/python/cudf/cudf/tests/conftest.py
+++ b/python/cudf/cudf/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 
 import pytest
@@ -8,3 +9,24 @@ import rmm  # noqa: F401
 @pytest.fixture(scope="session")
 def datadir():
     return pathlib.Path(__file__).parent / "data"
+
+
+# To set and remove the NO_EXTERNAL_ONLY_APIS environment variable we must use
+# the sessionstart and sessionfinish hooks rather than a simple autouse,
+# session-scope fixture because we need to set these variable before collection
+# occurs because the envrionment variable will be checked as soon as cudf is
+# imported anywhere.
+def pytest_sessionstart(session):
+    """
+    Called after the Session object has been created and
+    before performing collection and entering the run test loop.
+    """
+    os.environ["NO_EXTERNAL_ONLY_APIS"] = "1"
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """
+    Called after whole test run finished, right before
+    returning the exit status to the system.
+    """
+    del os.environ["NO_EXTERNAL_ONLY_APIS"]

--- a/python/cudf/cudf/tests/conftest.py
+++ b/python/cudf/cudf/tests/conftest.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+
 import os
 import pathlib
 

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -45,7 +45,7 @@ if NO_EXTERNAL_ONLY_APIS in ("True", "1", "TRUE"):
     _cudf_root = os.path.join("python", "cudf", "cudf")
     _tests_root = os.path.join(_cudf_root, "tests")
 
-    def _external_only_api(func):
+    def _external_only_api(func, alternative=""):
         """Decorator to indicate that a function should not be used internally.
 
         cudf contains many APIs that exist for pandas compatibility but are
@@ -58,13 +58,25 @@ if NO_EXTERNAL_ONLY_APIS in ("True", "1", "TRUE"):
         it easy to identify and excise such usage.
         """
 
+        # If the first arg is a string then an alternative function to use in
+        # place of this API was provided, so we pass that to a subsequent call.
+        # It would be cleaner to implement this pattern by using a class
+        # decorator with a factory method, but there is no way to generically
+        # wrap docstrings on a class (we would need the docstring to be on the
+        # class itself, not instances, because that's what `help` looks at) and
+        # there is also no way to make mypy happy with that approach.
+        if isinstance(func, str):
+            return lambda actual_func: _external_only_api(actual_func, func)
+
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             # Check the immediately preceding frame to see if it's in cudf.
             frame, lineno = next(traceback.walk_stack(None))
             fn = frame.f_code.co_filename
             if _cudf_root in fn and _tests_root not in fn:
                 raise RuntimeError(
-                    f"External-only API called in {fn} at line {lineno}."
+                    f"External-only API called in {fn} at line {lineno}. "
+                    f"{alternative}"
                 )
             return func(*args, **kwargs)
 
@@ -73,8 +85,11 @@ if NO_EXTERNAL_ONLY_APIS in ("True", "1", "TRUE"):
 
 else:
 
-    def _external_only_api(func):
+    def _external_only_api(func, alternative=""):
         """The default implementation is a no-op."""
+        if isinstance(func, str):
+            return lambda actual_func: _external_only_api(actual_func, func)
+
         return func
 
 

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -39,11 +39,16 @@ _EQUALITY_OPS = {
 }
 
 
+# The test root is set by pytest to support situations where tests are run from
+# a source tree on a built version of cudf.
 NO_EXTERNAL_ONLY_APIS = os.getenv("NO_EXTERNAL_ONLY_APIS")
+_CUDF_TEST_ROOT = os.getenv("_CUDF_TEST_ROOT")
 
 if NO_EXTERNAL_ONLY_APIS in ("True", "1", "TRUE"):
-    _cudf_root = os.path.join("python", "cudf", "cudf")
-    _tests_root = os.path.join(_cudf_root, "tests")
+    _cudf_root = cudf.__file__.replace("/__init__.py", "")
+    # If the environment variable for the test root is not set, we default to
+    # using the path relative to the cudf root directory.
+    _tests_root = _CUDF_TEST_ROOT or os.path.join(_cudf_root, "tests")
 
     def _external_only_api(func, alternative=""):
         """Decorator to indicate that a function should not be used internally.


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This PR introduces a decorator that can be used to mark APIs that are unnecessarily expensive and should be avoided in internal usage. The decorator does nothing by default, but when the corresponding environment variable is set the decorator wraps decorated functions in a check of the current call stack. If the caller of that API is within the cudf source tree, it will raise an exception that may optionally also indicate an alternate API for developers to use instead. This implementation is completely transparent to users (including having no performance impact aside from some negligible additional import time from applying the decorator) but can be an invaluable tool to developers seeking to reduce Python overheads in cuDF Python. This decorator has been tested and shown to work (both locally and on CI) for `DataFrame.columns`, but those changes are not included in this PR in order to keep the changeset clean.