### PR TITLE
Update JNI for cudf::hash_join probe-time null equality parameter removal

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -539,14 +539,11 @@ public final class Table implements AutoCloseable {
   private static native long[] leftJoinGatherMaps(long leftKeys, long rightKeys,
                                                   boolean compareNullsEqual) throws CudfException;
 
-  private static native long leftJoinRowCount(long leftTable, long rightHashJoin,
-                                              boolean nullsEqual) throws CudfException;
+  private static native long leftJoinRowCount(long leftTable, long rightHashJoin) throws CudfException;
 
-  private static native long[] leftHashJoinGatherMaps(long leftTable, long rightHashJoin,
-                                                      boolean nullsEqual) throws CudfException;
+  private static native long[] leftHashJoinGatherMaps(long leftTable, long rightHashJoin) throws CudfException;
 
   private static native long[] leftHashJoinGatherMapsWithCount(long leftTable, long rightHashJoin,
-                                                               boolean nullsEqual,
                                                                long outputRowCount) throws CudfException;
 
   private static native long[] innerJoin(long leftTable, int[] leftJoinCols, long rightTable,
@@ -555,14 +552,11 @@ public final class Table implements AutoCloseable {
   private static native long[] innerJoinGatherMaps(long leftKeys, long rightKeys,
                                                    boolean compareNullsEqual) throws CudfException;
 
-  private static native long innerJoinRowCount(long table, long hashJoin,
-                                               boolean nullsEqual) throws CudfException;
+  private static native long innerJoinRowCount(long table, long hashJoin) throws CudfException;
 
-  private static native long[] innerHashJoinGatherMaps(long table, long hashJoin,
-                                                       boolean nullsEqual) throws CudfException;
+  private static native long[] innerHashJoinGatherMaps(long table, long hashJoin) throws CudfException;
 
   private static native long[] innerHashJoinGatherMapsWithCount(long table, long hashJoin,
-                                                                boolean nullsEqual,
                                                                 long outputRowCount) throws CudfException;
 
   private static native long[] fullJoin(long leftTable, int[] leftJoinCols, long rightTable,
@@ -571,14 +565,11 @@ public final class Table implements AutoCloseable {
   private static native long[] fullJoinGatherMaps(long leftKeys, long rightKeys,
                                                   boolean compareNullsEqual) throws CudfException;
 
-  private static native long fullJoinRowCount(long leftTable, long rightHashJoin,
-                                              boolean nullsEqual) throws CudfException;
+  private static native long fullJoinRowCount(long leftTable, long rightHashJoin) throws CudfException;
 
-  private static native long[] fullHashJoinGatherMaps(long leftTable, long rightHashJoin,
-                                                      boolean nullsEqual) throws CudfException;
+  private static native long[] fullHashJoinGatherMaps(long leftTable, long rightHashJoin) throws CudfException;
 
   private static native long[] fullHashJoinGatherMapsWithCount(long leftTable, long rightHashJoin,
-                                                               boolean nullsEqual,
                                                                long outputRowCount) throws CudfException;
 
   private static native long[] leftSemiJoin(long leftTable, int[] leftJoinCols, long rightTable,
@@ -2318,8 +2309,7 @@ public final class Table implements AutoCloseable {
       throw new IllegalArgumentException("column count mismatch, this: " + getNumberOfColumns() +
           "rightKeys: " + rightHash.getNumberOfColumns());
     }
-    return leftJoinRowCount(getNativeView(), rightHash.getNativeView(),
-        rightHash.getCompareNulls());
+    return leftJoinRowCount(getNativeView(), rightHash.getNativeView());
   }
 
   /**
@@ -2337,9 +2327,7 @@ public final class Table implements AutoCloseable {
       throw new IllegalArgumentException("column count mismatch, this: " + getNumberOfColumns() +
           "rightKeys: " + rightHash.getNumberOfColumns());
     }
-    long[] gatherMapData =
-        leftHashJoinGatherMaps(getNativeView(), rightHash.getNativeView(),
-            rightHash.getCompareNulls());
+    long[] gatherMapData = leftHashJoinGatherMaps(getNativeView(), rightHash.getNativeView());
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2363,9 +2351,8 @@ public final class Table implements AutoCloseable {
       throw new IllegalArgumentException("column count mismatch, this: " + getNumberOfColumns() +
           "rightKeys: " + rightHash.getNumberOfColumns());
     }
-    long[] gatherMapData =
-        leftHashJoinGatherMapsWithCount(getNativeView(), rightHash.getNativeView(),
-            rightHash.getCompareNulls(), outputRowCount);
+    long[] gatherMapData = leftHashJoinGatherMapsWithCount(getNativeView(),
+        rightHash.getNativeView(), outputRowCount);
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2545,8 +2532,7 @@ public final class Table implements AutoCloseable {
       throw new IllegalArgumentException("column count mismatch, this: " + getNumberOfColumns() +
           "otherKeys: " + otherHash.getNumberOfColumns());
     }
-    return innerJoinRowCount(getNativeView(), otherHash.getNativeView(),
-        otherHash.getCompareNulls());
+    return innerJoinRowCount(getNativeView(), otherHash.getNativeView());
   }
 
   /**
@@ -2564,9 +2550,7 @@ public final class Table implements AutoCloseable {
       throw new IllegalArgumentException("column count mismatch, this: " + getNumberOfColumns() +
           "rightKeys: " + rightHash.getNumberOfColumns());
     }
-    long[] gatherMapData =
-        innerHashJoinGatherMaps(getNativeView(), rightHash.getNativeView(),
-            rightHash.getCompareNulls());
+    long[] gatherMapData = innerHashJoinGatherMaps(getNativeView(), rightHash.getNativeView());
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2590,9 +2574,8 @@ public final class Table implements AutoCloseable {
       throw new IllegalArgumentException("column count mismatch, this: " + getNumberOfColumns() +
           "rightKeys: " + rightHash.getNumberOfColumns());
     }
-    long[] gatherMapData =
-        innerHashJoinGatherMapsWithCount(getNativeView(), rightHash.getNativeView(),
-            rightHash.getCompareNulls(), outputRowCount);
+    long[] gatherMapData = innerHashJoinGatherMapsWithCount(getNativeView(),
+        rightHash.getNativeView(), outputRowCount);
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2778,8 +2761,7 @@ public final class Table implements AutoCloseable {
       throw new IllegalArgumentException("column count mismatch, this: " + getNumberOfColumns() +
           "rightKeys: " + rightHash.getNumberOfColumns());
     }
-    return fullJoinRowCount(getNativeView(), rightHash.getNativeView(),
-        rightHash.getCompareNulls());
+    return fullJoinRowCount(getNativeView(), rightHash.getNativeView());
   }
 
   /**
@@ -2797,9 +2779,7 @@ public final class Table implements AutoCloseable {
       throw new IllegalArgumentException("column count mismatch, this: " + getNumberOfColumns() +
           "rightKeys: " + rightHash.getNumberOfColumns());
     }
-    long[] gatherMapData =
-        fullHashJoinGatherMaps(getNativeView(), rightHash.getNativeView(),
-            rightHash.getCompareNulls());
+    long[] gatherMapData = fullHashJoinGatherMaps(getNativeView(), rightHash.getNativeView());
     return buildJoinGatherMaps(gatherMapData);
   }
 
@@ -2823,9 +2803,8 @@ public final class Table implements AutoCloseable {
       throw new IllegalArgumentException("column count mismatch, this: " + getNumberOfColumns() +
           "rightKeys: " + rightHash.getNumberOfColumns());
     }
-    long[] gatherMapData =
-        fullHashJoinGatherMapsWithCount(getNativeView(), rightHash.getNativeView(),
-            rightHash.getCompareNulls(), outputRowCount);
+    long[] gatherMapData = fullHashJoinGatherMapsWithCount(getNativeView(),
+        rightHash.getNativeView(), outputRowCount);
     return buildJoinGatherMaps(gatherMapData);
   }
 

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -812,15 +812,14 @@ jlongArray join_gather_maps(JNIEnv *env, jlong j_left_keys, jlong j_right_keys,
 // a hash table built from the join's right table.
 template <typename T>
 jlongArray hash_join_gather_maps(JNIEnv *env, jlong j_left_keys, jlong j_right_hash_join,
-                                 jboolean compare_nulls_equal, T join_func) {
+                                 T join_func) {
   JNI_NULL_CHECK(env, j_left_keys, "left table is null", NULL);
   JNI_NULL_CHECK(env, j_right_hash_join, "hash join is null", NULL);
   try {
     cudf::jni::auto_set_device(env);
     auto left_keys = reinterpret_cast<cudf::table_view const *>(j_left_keys);
     auto hash_join = reinterpret_cast<cudf::hash_join const *>(j_right_hash_join);
-    auto nulleq = compare_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
-    return gather_maps_to_java(env, join_func(*left_keys, *hash_join, nulleq));
+    return gather_maps_to_java(env, join_func(*left_keys, *hash_join));
   }
   CATCH_STD(env, NULL);
 }
@@ -2172,41 +2171,36 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftJoinGatherMaps(
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_leftJoinRowCount(JNIEnv *env, jclass,
                                                                    jlong j_left_table,
-                                                                   jlong j_right_hash_join,
-                                                                   jboolean compare_nulls_equal) {
+                                                                   jlong j_right_hash_join) {
   JNI_NULL_CHECK(env, j_left_table, "left table is null", 0);
   JNI_NULL_CHECK(env, j_right_hash_join, "right hash join is null", 0);
   try {
     cudf::jni::auto_set_device(env);
     auto left_table = reinterpret_cast<cudf::table_view const *>(j_left_table);
     auto hash_join = reinterpret_cast<cudf::hash_join const *>(j_right_hash_join);
-    auto nulleq = compare_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
-    auto row_count = hash_join->left_join_size(*left_table, nulleq);
+    auto row_count = hash_join->left_join_size(*left_table);
     return static_cast<jlong>(row_count);
   }
   CATCH_STD(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftHashJoinGatherMaps(
-    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join,
-    jboolean compare_nulls_equal) {
+    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join) {
   return cudf::jni::hash_join_gather_maps(
-      env, j_left_table, j_right_hash_join, compare_nulls_equal,
-      [](cudf::table_view const &left, cudf::hash_join const &hash, cudf::null_equality nulleq) {
-        return hash.left_join(left, nulleq);
+      env, j_left_table, j_right_hash_join,
+      [](cudf::table_view const &left, cudf::hash_join const &hash) {
+        return hash.left_join(left);
       });
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftHashJoinGatherMapsWithCount(
-    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join, jboolean compare_nulls_equal,
-    jlong j_output_row_count) {
+    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join, jlong j_output_row_count) {
   auto output_row_count = static_cast<std::size_t>(j_output_row_count);
-  return cudf::jni::hash_join_gather_maps(env, j_left_table, j_right_hash_join, compare_nulls_equal,
-                                          [output_row_count](cudf::table_view const &left,
-                                                             cudf::hash_join const &hash,
-                                                             cudf::null_equality nulleq) {
-                                            return hash.left_join(left, nulleq, output_row_count);
-                                          });
+  return cudf::jni::hash_join_gather_maps(
+      env, j_left_table, j_right_hash_join,
+      [output_row_count](cudf::table_view const &left, cudf::hash_join const &hash) {
+        return hash.left_join(left, output_row_count);
+      });
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalLeftJoinRowCount(JNIEnv *env, jclass,
@@ -2305,41 +2299,36 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerJoinGatherMaps(
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_innerJoinRowCount(JNIEnv *env, jclass,
                                                                     jlong j_left_table,
-                                                                    jlong j_right_hash_join,
-                                                                    jboolean compare_nulls_equal) {
+                                                                    jlong j_right_hash_join) {
   JNI_NULL_CHECK(env, j_left_table, "left table is null", 0);
   JNI_NULL_CHECK(env, j_right_hash_join, "right hash join is null", 0);
   try {
     cudf::jni::auto_set_device(env);
     auto left_table = reinterpret_cast<cudf::table_view const *>(j_left_table);
     auto hash_join = reinterpret_cast<cudf::hash_join const *>(j_right_hash_join);
-    auto nulleq = compare_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
-    auto row_count = hash_join->inner_join_size(*left_table, nulleq);
+    auto row_count = hash_join->inner_join_size(*left_table);
     return static_cast<jlong>(row_count);
   }
   CATCH_STD(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerHashJoinGatherMaps(
-    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join,
-    jboolean compare_nulls_equal) {
+    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join) {
   return cudf::jni::hash_join_gather_maps(
-      env, j_left_table, j_right_hash_join, compare_nulls_equal,
-      [](cudf::table_view const &left, cudf::hash_join const &hash, cudf::null_equality nulleq) {
-        return hash.inner_join(left, nulleq);
+      env, j_left_table, j_right_hash_join,
+      [](cudf::table_view const &left, cudf::hash_join const &hash) {
+        return hash.inner_join(left);
       });
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerHashJoinGatherMapsWithCount(
-    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join, jboolean compare_nulls_equal,
-    jlong j_output_row_count) {
+    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join, jlong j_output_row_count) {
   auto output_row_count = static_cast<std::size_t>(j_output_row_count);
-  return cudf::jni::hash_join_gather_maps(env, j_left_table, j_right_hash_join, compare_nulls_equal,
-                                          [output_row_count](cudf::table_view const &left,
-                                                             cudf::hash_join const &hash,
-                                                             cudf::null_equality nulleq) {
-                                            return hash.inner_join(left, nulleq, output_row_count);
-                                          });
+  return cudf::jni::hash_join_gather_maps(
+      env, j_left_table, j_right_hash_join,
+      [output_row_count](cudf::table_view const &left, cudf::hash_join const &hash) {
+        return hash.inner_join(left, output_row_count);
+      });
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalInnerJoinRowCount(JNIEnv *env, jclass,
@@ -2438,41 +2427,36 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_fullJoinGatherMaps(
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_fullJoinRowCount(JNIEnv *env, jclass,
                                                                    jlong j_left_table,
-                                                                   jlong j_right_hash_join,
-                                                                   jboolean compare_nulls_equal) {
+                                                                   jlong j_right_hash_join) {
   JNI_NULL_CHECK(env, j_left_table, "left table is null", 0);
   JNI_NULL_CHECK(env, j_right_hash_join, "right hash join is null", 0);
   try {
     cudf::jni::auto_set_device(env);
     auto left_table = reinterpret_cast<cudf::table_view const *>(j_left_table);
     auto hash_join = reinterpret_cast<cudf::hash_join const *>(j_right_hash_join);
-    auto nulleq = compare_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
-    auto row_count = hash_join->full_join_size(*left_table, nulleq);
+    auto row_count = hash_join->full_join_size(*left_table);
     return static_cast<jlong>(row_count);
   }
   CATCH_STD(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_fullHashJoinGatherMaps(
-    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join,
-    jboolean compare_nulls_equal) {
+    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join) {
   return cudf::jni::hash_join_gather_maps(
-      env, j_left_table, j_right_hash_join, compare_nulls_equal,
-      [](cudf::table_view const &left, cudf::hash_join const &hash, cudf::null_equality nulleq) {
-        return hash.full_join(left, nulleq);
+      env, j_left_table, j_right_hash_join,
+      [](cudf::table_view const &left, cudf::hash_join const &hash) {
+        return hash.full_join(left);
       });
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_fullHashJoinGatherMapsWithCount(
-    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join, jboolean compare_nulls_equal,
-    jlong j_output_row_count) {
+    JNIEnv *env, jclass, jlong j_left_table, jlong j_right_hash_join, jlong j_output_row_count) {
   auto output_row_count = static_cast<std::size_t>(j_output_row_count);
-  return cudf::jni::hash_join_gather_maps(env, j_left_table, j_right_hash_join, compare_nulls_equal,
-                                          [output_row_count](cudf::table_view const &left,
-                                                             cudf::hash_join const &hash,
-                                                             cudf::null_equality nulleq) {
-                                            return hash.full_join(left, nulleq, output_row_count);
-                                          });
+  return cudf::jni::hash_join_gather_maps(
+      env, j_left_table, j_right_hash_join,
+      [output_row_count](cudf::table_view const &left, cudf::hash_join const &hash) {
+        return hash.full_join(left, output_row_count);
+      });
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_conditionalFullJoinGatherMaps(


### PR DESCRIPTION
Depends on #10260.

Updates the Java JNI code for the removal of the probe-time null equality parameter in cudf::hash_join.