### PR TITLE
Fix out-of-memory error in compiled-binaryop benchmark

### DIFF
--- a/cpp/benchmarks/binaryop/compiled_binaryop.cpp
+++ b/cpp/benchmarks/binaryop/compiled_binaryop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@
 class COMPILED_BINARYOP : public cudf::benchmark {
 };
 
-template <typename TypeLhs, typename TypeRhs, typename TypeOut, cudf::binary_operator binop>
-void BM_compiled_binaryop(benchmark::State& state)
+template <typename TypeLhs, typename TypeRhs, typename TypeOut>
+void BM_compiled_binaryop(benchmark::State& state, cudf::binary_operator binop)
 {
   const cudf::size_type column_size{(cudf::size_type)state.range(0)};
 
@@ -50,20 +50,25 @@ void BM_compiled_binaryop(benchmark::State& state)
 }
 
 // TODO tparam boolean for null.
-#define BINARYOP_BENCHMARK_DEFINE(TypeLhs, TypeRhs, binop, TypeOut) \
-  TEMPLATED_BENCHMARK_F(COMPILED_BINARYOP,                          \
-                        BM_compiled_binaryop,                       \
-                        TypeLhs,                                    \
-                        TypeRhs,                                    \
-                        TypeOut,                                    \
-                        cudf::binary_operator::binop)               \
-    ->Unit(benchmark::kMicrosecond)                                 \
-    ->UseManualTime()                                               \
-    ->Arg(10000)      /* 10k */                                     \
-    ->Arg(100000)     /* 100k */                                    \
-    ->Arg(1000000)    /* 1M */                                      \
-    ->Arg(10000000)   /* 10M */                                     \
+#define BM_BINARYOP_BENCHMARK_DEFINE(name, lhs, rhs, bop, tout)           \
+  BENCHMARK_DEFINE_F(COMPILED_BINARYOP, name)                             \
+  (::benchmark::State & st)                                               \
+  {                                                                       \
+    BM_compiled_binaryop<lhs, rhs, tout>(st, cudf::binary_operator::bop); \
+  }                                                                       \
+  BENCHMARK_REGISTER_F(COMPILED_BINARYOP, name)                           \
+    ->Unit(benchmark::kMicrosecond)                                       \
+    ->UseManualTime()                                                     \
+    ->Arg(10000)      /* 10k */                                           \
+    ->Arg(100000)     /* 100k */                                          \
+    ->Arg(1000000)    /* 1M */                                            \
+    ->Arg(10000000)   /* 10M */                                           \
     ->Arg(100000000); /* 100M */
+
+#define build_name(a, b, c, d) a##_##b##_##c##_##d
+
+#define BINARYOP_BENCHMARK_DEFINE(lhs, rhs, bop, tout) \
+  BM_BINARYOP_BENCHMARK_DEFINE(build_name(bop, lhs, rhs, tout), lhs, rhs, bop, tout)
 
 using namespace cudf;
 using namespace numeric;


### PR DESCRIPTION
Fixes out-of-memory error that occurs when running the `BINARYOP_BENCH` `COMPILED_BINARYOP` benchmark combined with the `BINARYOP` benchmark. The following minimal command shows the error:

```
benchmarks/BINARYOP_BENCH '--benchmark_filter=COMPILED_BINARYOP|100000000/10'
...
BINARYOP<double, TreeType::IMBALANCED_LEFT, false>/binaryop_double_imbalanced_unique/100000000/10/manual_time                              40.4 ms         40.4 ms           17 bytes_per_second=202.953G/s
terminate called after throwing an instance of 'rmm::out_of_memory'
  what():  std::bad_alloc: out_of_memory: RMM failure at:/conda/envs/rapids/include/rmm/mr/device/pool_memory_resource.hpp:192: Maximum pool size exceeded
Aborted (core dumped)
```

The `COMPILED_BINARYOP` is using a `TEMPLATED_BENCHMARK_F` macro which causes a new separate memory pool to be created instead of reusing the one already created by `BINARYOP`.
This PR reworks the benchmark macros in `compiled_binaryop.cpp` to avoid using `TEMPLATED_BENCHMARK_F` allowing it share the existing memory pool.

Similar to #10258 

