### PR TITLE
Allow Java bindings to use default decimal precisions when writing columns

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2021, NVIDIA CORPORATION.
+ *  Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -39,6 +39,9 @@ public class ColumnWriterOptions {
     this.childColumnOptions =
         (ColumnWriterOptions[]) builder.children.toArray(new ColumnWriterOptions[0]);
   }
+
+  // The sentinel value of unknown precision (default value)
+  public static int UNKNOWN_PRECISION = -1;
 
   /**
    * Constructor used for list
@@ -103,7 +106,7 @@ public class ColumnWriterOptions {
 
     protected ColumnWriterOptions withTimestamp(String name, boolean isInt96,
                                                 boolean isNullable) {
-      return new ColumnWriterOptions(name, isInt96, 0, isNullable);
+      return new ColumnWriterOptions(name, isInt96, UNKNOWN_PRECISION, isNullable);
     }
 
     /**
@@ -243,7 +246,7 @@ public class ColumnWriterOptions {
 
   public ColumnWriterOptions(String columnName, boolean isNullable) {
     this.isTimestampTypeInt96 = false;
-    this.precision = 0;
+    this.precision = UNKNOWN_PRECISION;
     this.isNullable = isNullable;
     this.columnName = columnName;
   }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -677,8 +677,10 @@ int set_column_metadata(cudf::io::column_in_metadata &column_metadata,
   for (int i = 0; i < num_children; i++, write_index++) {
     cudf::io::column_in_metadata child;
     child.set_name(col_names[read_index])
-        .set_decimal_precision(precisions[read_index])
         .set_nullability(nullability[read_index]);
+    if (precisions[read_index] > - 1) {
+      child.set_decimal_precision(precisions[read_index]);
+    }
     if (!is_int96.is_null()) {
       child.set_int96_timestamps(is_int96[read_index]);
     }
@@ -717,8 +719,11 @@ void createTableMetaData(JNIEnv *env, jint num_children, jobjectArray &j_col_nam
   for (int i = read_index, write_index = 0; i < top_level_children; i++, write_index++) {
     metadata.column_metadata[write_index]
         .set_name(cpp_names[read_index])
-        .set_nullability(col_nullability[read_index])
-        .set_decimal_precision(precisions[read_index]);
+        .set_nullability(col_nullability[read_index]);
+    if (precisions[read_index] > - 1) {
+      metadata.column_metadata[write_index]
+          .set_decimal_precision(precisions[read_index]);
+    }
     if (!is_int96.is_null()) {
       metadata.column_metadata[write_index].set_int96_timestamps(is_int96[read_index]);
     }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -676,9 +676,8 @@ int set_column_metadata(cudf::io::column_in_metadata &column_metadata,
   int write_index = 0;
   for (int i = 0; i < num_children; i++, write_index++) {
     cudf::io::column_in_metadata child;
-    child.set_name(col_names[read_index])
-        .set_nullability(nullability[read_index]);
-    if (precisions[read_index] > - 1) {
+    child.set_name(col_names[read_index]).set_nullability(nullability[read_index]);
+    if (precisions[read_index] > -1) {
       child.set_decimal_precision(precisions[read_index]);
     }
     if (!is_int96.is_null()) {
@@ -720,9 +719,8 @@ void createTableMetaData(JNIEnv *env, jint num_children, jobjectArray &j_col_nam
     metadata.column_metadata[write_index]
         .set_name(cpp_names[read_index])
         .set_nullability(col_nullability[read_index]);
-    if (precisions[read_index] > - 1) {
-      metadata.column_metadata[write_index]
-          .set_decimal_precision(precisions[read_index]);
+    if (precisions[read_index] > -1) {
+      metadata.column_metadata[write_index].set_decimal_precision(precisions[read_index]);
     }
     if (!is_int96.is_null()) {
       metadata.column_metadata[write_index].set_int96_timestamps(is_int96[read_index]);


### PR DESCRIPTION
Closes #9851

This PR is to fix the bug raised in #9851 : Currently, Java bindings set decimal precision for each column when building OrcWriterOptions. It fills zero for non-decimal columns which do not carry precision information. In principle, we should only set precision for decimal columns.

It is not easy to write a test for this change, since we won't try to read non-decimal data as decimal type in both spark-rapids and cuDF Java.