### PR TITLE
Add conversions between column_view and device_span<T const>.

### DIFF
--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -385,8 +385,8 @@ class column_view : public detail::column_view_base {
    *
    * Only numeric and chrono types are supported.
    *
-   * @tparam T The device_span data type.
-   * @param data The device_span containing the column elements.
+   * @tparam The device span type. Must be const and match the column view's type.
+   * @param data A typed device span containing the column view's data.
    */
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
   [[nodiscard]] column_view(device_span<T const> data)
@@ -404,11 +404,9 @@ class column_view : public detail::column_view_base {
    * be nullable.
    *
    * @tparam The device span type. Must be const and match the column view's type.
-   *
    * @throws cudf::logic_error if the column view type does not match the span type.
    * @throws cudf::logic_error if the column view is nullable.
-   *
-   * @return device_span<T const> A typed device span of the column view.
+   * @return device_span<T const> A typed device span of the column view's data.
    */
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
   [[nodiscard]] operator device_span<T const>() const

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -400,14 +400,15 @@ class column_view : public detail::column_view_base {
   /**
    * @brief Converts a column view into a device span.
    *
-   * Only numeric and chrono types are supported.
+   * Only numeric and chrono data types are supported. The column view must not
+   * be nullable.
    *
    * @tparam The device span type. Must be const and match the column view's type.
    *
-   * @throws cudf::logic_error if the column view has nulls.
    * @throws cudf::logic_error if the column view type does not match the span type.
+   * @throws cudf::logic_error if the column view is nullable.
    *
-   * @return device_span<T> A typed device span of the column view.
+   * @return device_span<T const> A typed device span of the column view.
    */
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
   [[nodiscard]] operator device_span<T const>() const

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -399,7 +399,7 @@ class column_view : public detail::column_view_base {
                   {})
   {
     CUDF_EXPECTS(data.size() < std::numeric_limits<cudf::size_type>::max(),
-                 "Device span exceeds maximum size of a column view.");
+                 "Data exceeds the maximum size of a column view.");
   }
 
   /**
@@ -407,7 +407,7 @@ class column_view : public detail::column_view_base {
    *
    * Only numeric and chrono types are supported.
    *
-   * @tparam The device_span type. Must be const and match the column view's type.
+   * @tparam The device span type. Must be const and match the column view's type.
    *
    * @throws cudf::logic_error if the column view has nulls.
    * @throws cudf::logic_error if the column view type does not match the span type.
@@ -420,8 +420,8 @@ class column_view : public detail::column_view_base {
   [[nodiscard]] operator device_span<T>() const
   {
     CUDF_EXPECTS(type() == cudf::data_type{cudf::type_to_id<std::remove_const_t<T>>()},
-                 "Type of span must match column view type.");
-    CUDF_EXPECTS(!has_nulls(), "Column view with null values cannot be converted to device_span.");
+                 "Device span type must match column view type.");
+    CUDF_EXPECTS(!has_nulls(), "Column view with null values cannot be converted to device span.");
     return device_span<T>(data<T>(), size());
   }
 

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -379,7 +379,24 @@ class column_view : public detail::column_view_base {
   auto child_end() const noexcept { return _children.cend(); }
 
   /**
+   * @brief Construct a column view from a device_span<T>.
+   *
+   * Only numeric and chrono types are supported.
+   *
+   * @tparam T The device_span data type.
+   * @param data The device_span containing the column elements.
+   */
+  template <typename T, std::enable_if_t<cudf::is_numeric<T>() or cudf::is_chrono<T>()>* = nullptr>
+  [[nodiscard]] column_view(device_span<T> data)
+    : column_view(
+        cudf::data_type{cudf::type_to_id<T>()}, data.size(), data.data(), nullptr, 0, 0, {})
+  {
+  }
+
+  /**
    * @brief Converts a column view into a device span.
+   *
+   * Only numeric and chrono types are supported.
    *
    * @tparam The device_span type. Must match the column view's type.
    *
@@ -388,7 +405,7 @@ class column_view : public detail::column_view_base {
    *
    * @return device_span<T> A typed device span of the column view.
    */
-  template <typename T>
+  template <typename T, std::enable_if_t<cudf::is_numeric<T>() || cudf::is_chrono<T>()>* = nullptr>
   [[nodiscard]] operator device_span<const T>() const
   {
     CUDF_EXPECTS(type() == type_to_id<T>(), "Type of span must match column view type.");

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -383,6 +383,9 @@ class column_view : public detail::column_view_base {
    *
    * The column view must have no nulls, and its type must match the type of the span.
    *
+   * @throws cudf::logic_error if the column view has nulls.
+   * @throws cudf::logic_error if the column view type does not match the span type.
+   *
    * @return device_span<T> A typed device span of the column view.
    */
   template <typename T>

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -406,7 +406,7 @@ class column_view : public detail::column_view_base {
    * @tparam The device span type. Must be const and match the column view's type.
    * @throws cudf::logic_error if the column view type does not match the span type.
    * @throws cudf::logic_error if the column view is nullable.
-   * @return device_span<T const> A typed device span of the column view's data.
+   * @return A typed device span of the column view's data.
    */
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
   [[nodiscard]] operator device_span<T const>() const

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -381,7 +381,7 @@ class column_view : public detail::column_view_base {
   /**
    * @brief Converts a column view into a device span.
    *
-   * The column view must have no nulls, and its type must match the type of the span.
+   * @tparam The device_span type. Must match the column view's type.
    *
    * @throws cudf::logic_error if the column view has nulls.
    * @throws cudf::logic_error if the column view type does not match the span type.

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -414,7 +414,7 @@ class column_view : public detail::column_view_base {
   {
     CUDF_EXPECTS(type() == cudf::data_type{cudf::type_to_id<T>()},
                  "Device span type must match column view type.");
-    CUDF_EXPECTS(!has_nulls(), "Column view with null values cannot be converted to device span.");
+    CUDF_EXPECTS(!nullable(), "A nullable column view cannot be converted to a device span.");
     return device_span<T const>(data<T>(), size());
   }
 

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -21,6 +21,7 @@
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
+#include <limits>
 #include <type_traits>
 #include <vector>
 
@@ -389,9 +390,16 @@ class column_view : public detail::column_view_base {
    */
   template <typename T, std::enable_if_t<cudf::is_numeric<T>() or cudf::is_chrono<T>()>* = nullptr>
   [[nodiscard]] column_view(device_span<T> data)
-    : column_view(
-        cudf::data_type{cudf::type_to_id<T>()}, data.size(), data.data(), nullptr, 0, 0, {})
+    : column_view(cudf::data_type{cudf::type_to_id<std::remove_const<T>>()},
+                  data.size(),
+                  data.data(),
+                  nullptr,
+                  0,
+                  0,
+                  {})
   {
+    CUDF_EXPECTS(data.size() < std::numeric_limits<cudf::size_type>::max(),
+                 "Device span exceeds maximum size of a column view.");
   }
 
   /**

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -389,7 +389,7 @@ class column_view : public detail::column_view_base {
    * @param data A typed device span containing the column view's data.
    */
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
-  [[nodiscard]] column_view(device_span<T const> data)
+  column_view(device_span<T const> data)
     : column_view(
         cudf::data_type{cudf::type_to_id<T>()}, data.size(), data.data(), nullptr, 0, 0, {})
   {

--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -385,7 +385,7 @@ class column_view : public detail::column_view_base {
    *
    * Only numeric and chrono types are supported.
    *
-   * @tparam The device span type. Must be const and match the column view's type.
+   * @tparam T The device span type. Must be const and match the column view's type.
    * @param data A typed device span containing the column view's data.
    */
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
@@ -403,7 +403,7 @@ class column_view : public detail::column_view_base {
    * Only numeric and chrono data types are supported. The column view must not
    * be nullable.
    *
-   * @tparam The device span type. Must be const and match the column view's type.
+   * @tparam T The device span type. Must be const and match the column view's type.
    * @throws cudf::logic_error if the column view type does not match the span type.
    * @throws cudf::logic_error if the column view is nullable.
    * @return A typed device span of the column view's data.

--- a/cpp/include/cudf/utilities/span.hpp
+++ b/cpp/include/cudf/utilities/span.hpp
@@ -196,11 +196,6 @@ struct device_span : public cudf::detail::span_base<T, Extent, device_span<T, Ex
 
   constexpr device_span() noexcept : base() {}  // required to compile on centos
 
-  constexpr device_span(typename base::pointer data, typename base::size_type size) noexcept
-    : base(data, size)
-  {
-  }
-
   template <
     typename C,
     // Only supported containers of types convertible to T

--- a/cpp/include/cudf/utilities/span.hpp
+++ b/cpp/include/cudf/utilities/span.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,6 +195,11 @@ struct device_span : public cudf::detail::span_base<T, Extent, device_span<T, Ex
   using base::base;
 
   constexpr device_span() noexcept : base() {}  // required to compile on centos
+
+  constexpr device_span(typename base::pointer data, typename base::size_type size) noexcept
+    : base(data, size)
+  {
+  }
 
   template <
     typename C,

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -41,8 +41,13 @@ endfunction()
 # ##################################################################################################
 # * column tests ----------------------------------------------------------------------------------
 ConfigureTest(
-  COLUMN_TEST column/bit_cast_test.cpp column/column_view_shallow_test.cpp column/column_test.cu
-  column/column_device_view_test.cu column/compound_test.cu
+  COLUMN_TEST
+  column/bit_cast_test.cpp
+  column/column_device_view_test.cu
+  column/column_test.cu
+  column/column_view_device_span_test.cpp
+  column/column_view_shallow_test.cpp
+  column/compound_test.cu
 )
 
 # ##################################################################################################

--- a/cpp/tests/column/column_view_device_span_test.cpp
+++ b/cpp/tests/column/column_view_device_span_test.cpp
@@ -50,9 +50,11 @@ TYPED_TEST_SUITE(ColumnViewDeviceSpanTests, DeviceSpanTypes);
 
 TYPED_TEST(ColumnViewDeviceSpanTests, conversion_round_trip)
 {
-  auto col                   = example_column<TypeParam>();
-  auto col_view              = cudf::column_view{*col};
-  auto device_span_from_view = static_cast<cudf::device_span<const TypeParam>>(col_view);
-  auto col_view_from_span    = cudf::column_view(device_span_from_view);
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_view, col_view_from_span);
+  auto col      = example_column<TypeParam>();
+  auto col_view = cudf::column_view{*col};
+
+  // Test implicit conversion, round trip
+  cudf::device_span<const TypeParam> device_span_from_col_view = col_view;
+  cudf::column_view col_view_from_device_span                  = device_span_from_col_view;
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_view, col_view_from_device_span);
 }

--- a/cpp/tests/column/column_view_device_span_test.cpp
+++ b/cpp/tests/column/column_view_device_span_test.cpp
@@ -44,8 +44,7 @@ template <typename T>
 struct ColumnViewDeviceSpanTests : public cudf::test::BaseFixture {
 };
 
-using DeviceSpanTypes =
-  cudf::test::Types<int32_t>;  // cudf::test::FixedWidthTypesWithoutFixedPoint;
+using DeviceSpanTypes = cudf::test::FixedWidthTypesWithoutFixedPoint;
 TYPED_TEST_SUITE(ColumnViewDeviceSpanTests, DeviceSpanTypes);
 
 TYPED_TEST(ColumnViewDeviceSpanTests, conversion_round_trip)

--- a/cpp/tests/column/column_view_device_span_test.cpp
+++ b/cpp/tests/column/column_view_device_span_test.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
+#include <cudf/utilities/traits.hpp>
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/cudf_gtest.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+
+#include <memory>
+#include <type_traits>
+
+// fixed_width, dict, string, list, struct
+template <typename T, std::enable_if_t<cudf::is_fixed_width<T>()>* = nullptr>
+std::unique_ptr<cudf::column> example_column()
+{
+  auto begin = thrust::make_counting_iterator(1);
+  auto end   = thrust::make_counting_iterator(16);
+  return cudf::test::fixed_width_column_wrapper<T>(begin, end).release();
+}
+
+template <typename T>
+struct ColumnViewDeviceSpanTests : public cudf::test::BaseFixture {
+};
+
+using DeviceSpanTypes =
+  cudf::test::Types<int32_t>;  // cudf::test::FixedWidthTypesWithoutFixedPoint;
+TYPED_TEST_SUITE(ColumnViewDeviceSpanTests, DeviceSpanTypes);
+
+TYPED_TEST(ColumnViewDeviceSpanTests, conversion_round_trip)
+{
+  auto col                   = example_column<TypeParam>();
+  auto col_view              = cudf::column_view{*col};
+  auto device_span_from_view = static_cast<cudf::device_span<const TypeParam>>(col_view);
+  auto col_view_from_span    = cudf::column_view(device_span_from_view);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_view, col_view_from_span);
+}

--- a/cpp/tests/column/column_view_device_span_test.cpp
+++ b/cpp/tests/column/column_view_device_span_test.cpp
@@ -15,24 +15,19 @@
  */
 
 #include <cudf/column/column_view.hpp>
-#include <cudf/null_mask.hpp>
-#include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
-#include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 
 #include <memory>
-#include <type_traits>
 
-// fixed_width, dict, string, list, struct
-template <typename T, std::enable_if_t<cudf::is_fixed_width<T>()>* = nullptr>
+template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
 std::unique_ptr<cudf::column> example_column()
 {
   auto begin = thrust::make_counting_iterator(1);


### PR DESCRIPTION
This PR adds an implicit conversion operator from `column_view` to `device_span<T const>`. The immediate purpose of this PR is to make it possible to use the API `segmented_reduce(column_view data, device_span<size_type> offsets, ...)` in PR #9621.

This PR also resolves #9656 by adding a `column_view` constructor from `device_span<T const>`.

More broadly, this PR should make it easier to refactor instances where `column.data()` is used with counting iterators to build transform iterators, or other patterns that require a length (e.g. vector factories to copy to host).