### PR TITLE
Fix documentation issues [skip ci]

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -258,8 +258,6 @@ class IndexedFrame(Frame):
 
         Selecting rows and column by position.
 
-        Examples
-        --------
         >>> df = cudf.DataFrame({'a': range(20),
         ...                      'b': range(20),
         ...                      'c': range(20)})


### PR DESCRIPTION
The doc string for the `iloc` function has two `Examples` sections, which throws an error during doc builds. This PR removes the second extraneous section.