### PR TITLE
Remove `TODO` in `libcudf_kafka` recipe

### DIFF
--- a/conda/recipes/libcudf_kafka/meta.yaml
+++ b/conda/recipes/libcudf_kafka/meta.yaml
@@ -27,8 +27,6 @@ requirements:
   host:
     - libcudf {{version}}
     - librdkafka >=1.7.0,<1.8.0a0
-  run:
-    - {{ pin_compatible('librdkafka', max_pin='x.x') }} #TODO: librdkafka should be automatically included here by run_exports but is not
 
 test:
   commands:


### PR DESCRIPTION
From my local testing, it seems that the `librdkafka` `run_exports` is now fixed, so this line can be safely removed.
