### PR TITLE
Add const qualifier to MurmurHash3_32::hash_combine

### DIFF
--- a/cpp/include/cudf/detail/utilities/hash_functions.cuh
+++ b/cpp/include/cudf/detail/utilities/hash_functions.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ struct MurmurHash3_32 {
    *
    * @returns A hash value that intelligently combines the lhs and rhs hash values
    */
-  [[nodiscard]] __device__ inline result_type hash_combine(result_type lhs, result_type rhs)
+  constexpr result_type hash_combine(result_type lhs, result_type rhs) const
   {
     result_type combined{lhs};
 


### PR DESCRIPTION
Fixes declaration of the internal `MurmurHash3_32::hash_combine()` to add the `const` qualifier.

Found this while working on #10270 and trying to call `hash_combine` from a `const` instance.