### PR TITLE
Fixes up the overflowed fixed-point round on nullable column

### DIFF
--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -261,10 +261,10 @@ std::unique_ptr<column> round_with(column_view const& input,
   // overflow. Under this circumstance, we can simply output a zero column because no digits can
   // survive such a large scale movement.
   if (scale_movement > cuda::std::numeric_limits<Type>::digits10) {
-    thrust::fill(rmm::exec_policy(stream),
-                 out_view.template begin<Type>(),
-                 out_view.template end<Type>(),
-                 static_cast<Type>(0));
+    thrust::uninitialized_fill(rmm::exec_policy(stream),
+                               out_view.template begin<Type>(),
+                               out_view.template end<Type>(),
+                               static_cast<Type>(0));
   } else {
     Type const n = std::pow(10, scale_movement);
     thrust::transform(rmm::exec_policy(stream),

--- a/cpp/tests/round/round_tests.cpp
+++ b/cpp/tests/round/round_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: sperlingxx <lovedreamf@gmail.com>

Fixes up the overflow round on `nullable` fixed-point columns. In previous implementation, we built the zero replacement column via `cudf::detail::fill_in_place` with a zero scalar. However, this API overwrites the null mask of original column with the validity of the zero scalar, which is unexpected.