### PR TITLE
Hide warnings from pandas in test_array_ufunc.py.

### DIFF
--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -22,7 +22,8 @@ _UFUNCS = [
 @contextmanager
 def _hide_ufunc_warnings(ufunc):
     # pandas raises warnings for some inputs to the following ufuncs:
-    if ufunc.__name__ in {
+    name = ufunc.__name__
+    if name in {
         "arccos",
         "arccosh",
         "arcsin",
@@ -34,7 +35,16 @@ def _hide_ufunc_warnings(ufunc):
         "reciprocal",
     }:
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=RuntimeWarning)
+            warnings.filterwarnings(
+                "ignore",
+                f"invalid value encountered in {name}",
+                category=RuntimeWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                f"divide by zero encountered in {name}",
+                category=RuntimeWarning,
+            )
             yield
     else:
         yield


### PR DESCRIPTION
This PR hides pandas warnings in `test_array_ufunc.py`. (I am working through one test file at a time so we can enable `-Werr` in the future.) These warnings come from specific functions like `arccos` for which the provided integer inputs are out-of-range. It is fine for us to hide these warnings because they do not come from cudf.

Alternatives and why I chose against them:
- Why not limit the test data input to be in the domain of the ufunc? Limiting data inputs would hide the warning. However, it would decrease our coverage that ensures cudf and pandas agree on those results for values outside the domain of the ufunc (particularly trigonometric functions). It would additionally require inputs to be generated based on the ufunc, which would be lengthy.
- Why not make cudf raise a warning and ensure that pandas/cudf agree on warning behavior? I chose against this because we generally avoid data introspection in cudf, and this would involve a significantly more complex approach to ufunc execution.