### PR TITLE
Fix warnings in test_binops.py.

### DIFF
--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -1763,6 +1763,8 @@ def test_binops_with_lhs_numpy_scalar(frame, dtype):
     else:
         val = cudf.dtype(dtype).type(4)
 
+    # Compare equality with series on left side to dispatch to the pandas/cudf
+    # __eq__ operator and avoid a DeprecationWarning from numpy.
     expected = data.to_pandas() == val
     got = data == val
 

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -4,6 +4,7 @@
 import decimal
 import operator
 import random
+from contextlib import contextmanager
 from itertools import combinations_with_replacement, product
 
 import cupy as cp
@@ -25,6 +26,24 @@ from cudf.utils.dtypes import (
 )
 
 STRING_TYPES = {"str"}
+
+
+@contextmanager
+def _hide_deprecated_ops_warnings(func, lhs, rhs):
+    if func in {
+        cudf.logical_and,
+        cudf.logical_or,
+        cudf.remainder,
+    } and isinstance(lhs, cudf.Series):
+        name = func.__name__
+        with pytest.warns(
+            FutureWarning,
+            match=f"Series.{name} is deprecated and will be removed.",
+        ):
+            yield
+    else:
+        yield
+
 
 _binops = [
     operator.add,
@@ -170,7 +189,8 @@ def test_series_logical_binop(lhstype, rhstype, binop, cubinop):
         arr2 = arr2 * (np.random.random(10) * 100).astype(rhstype)
     sr2 = Series(arr2)
 
-    result = cubinop(sr1, sr2)
+    with _hide_deprecated_ops_warnings(cubinop, sr1, sr2):
+        result = cubinop(sr1, sr2)
     expect = binop(arr1, arr2)
 
     utils.assert_eq(result, expect)
@@ -955,7 +975,9 @@ def test_ufunc_ops(lhs, rhs, ops):
         curhs = rhs
 
     expect = np_op(lhs, rhs)
-    got = cu_op(culhs, curhs)
+    with _hide_deprecated_ops_warnings(cu_op, culhs, curhs):
+        got = cu_op(culhs, curhs)
+
     if np.isscalar(expect):
         assert got == expect
     else:

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -1763,8 +1763,8 @@ def test_binops_with_lhs_numpy_scalar(frame, dtype):
     else:
         val = cudf.dtype(dtype).type(4)
 
-    expected = val == data.to_pandas()
-    got = val == data
+    expected = data.to_pandas() == val
+    got = data == val
 
     # In case of index, expected would be a numpy array
     if isinstance(data, cudf.BaseIndex):


### PR DESCRIPTION
This PR catches or silences warnings in `test_binops.py`. (I am working through one test file at a time so we can enable `-Werr` in the future.) Most of the warnings come from deprecated binops inside cudf. Once the deprecated code is removed, these tests will fail until the workaround is removed.

Another warning comes from numpy, `DeprecationWarning: elementwise comparison failed; this will raise an error in the future.`. This warning can be circumvented by comparing with `series == scalar` instead of `scalar == series`. I believe that seeing this warning is expected when comparing `scalar == series`, if both numpy and pandas/cudf implement `__eq__` that accept one another's array-like types, but I'm not certain.