### PR TITLE
Fix debug compile error in device_span to column_view conversion

### DIFF
--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -393,8 +393,9 @@ class column_view : public detail::column_view_base {
     : column_view(
         cudf::data_type{cudf::type_to_id<T>()}, data.size(), data.data(), nullptr, 0, 0, {})
   {
-    CUDF_EXPECTS(data.size() < std::numeric_limits<cudf::size_type>::max(),
-                 "Data exceeds the maximum size of a column view.");
+    CUDF_EXPECTS(
+      data.size() < static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max()),
+      "Data exceeds the maximum size of a column view.");
   }
 
   /**


### PR DESCRIPTION
Fixes a compile error in `column_view(device_span)` constructor when building libcudf in Debug.

```
Building CXX object tests/CMakeFi...TEST.dir/column/column_view_device_span_test.cpp.o
FAILED: tests/CMakeFiles/COLUMN_TEST.dir/column/column_view_device_span_test.cpp.o 
/usr/local/bin/g++ -DCUDF_VERSION=22.04.00 -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -DJITIFY_USE_CACHE -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I/cudf/cpp -I/cudf/cpp/src -I/cudf/cpp/build/_deps/dlpack-src/include -I/cudf/cpp/build/_deps/jitify-src -I/cudf/cpp/include -I/cudf/cpp/build/include -I/conda/envs/rapids/include/rapids/libcudacxx -I/cudf/cpp/build/_deps/thrust-src -I/cudf/cpp/build/_deps/thrust-src/dependencies/cub -isystem /conda/envs/rapids/include -isystem /usr/local/cuda/include -fdiagnostics-color=always -g -fPIE -Wall -Werror -Wno-unknown-pragmas -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -std=gnu++17 -MD -MT tests/CMakeFiles/COLUMN_TEST.dir/column/column_view_device_span_test.cpp.o -MF tests/CMakeFiles/COLUMN_TEST.dir/column/column_view_device_span_test.cpp.o.d -o tests/CMakeFiles/COLUMN_TEST.dir/column/column_view_device_span_test.cpp.o -c /cudf/cpp/tests/column/column_view_device_span_test.cpp
In file included from /cudf/cpp/include/cudf/column/column_view.hpp:19,
                 from /cudf/cpp/tests/column/column_view_device_span_test.cpp:17:
/cudf/cpp/include/cudf/column/column_view.hpp: In instantiation of ‘cudf::column_view::column_view(cudf::device_span<const T>) [with T = float; std::enable_if_t<(is_numeric<T>() || is_chrono<T>())>* <anonymous> = 0]’:
/cudf/cpp/tests/column/column_view_device_span_test.cpp:55:21:   required from ‘void ColumnViewDeviceSpanTests_conversion_round_trip_Test<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = float]’
/cudf/cpp/tests/column/column_view_device_span_test.cpp:48:1:   required from here
/cudf/cpp/include/cudf/column/column_view.hpp:396:30: error: comparison of integer expressions of different signedness: ‘cudf::detail::span_base<const float, 18446744073709551615, cudf::device_span<const float> >::size_type’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
  396 |     CUDF_EXPECTS(data.size() < std::numeric_limits<cudf::size_type>::max(),

```

The above also includes the command line compile that creates the error.
The solution implemented casts the `size_type` `max()` value to `std::size_t` before comparing it to the span's `size()` value.

The change implemented in #10302 introduced this conversion.