### PR TITLE
JNI: Support appending DECIMAL128 into ColumnBuilder in terms of byte array

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -1344,6 +1344,23 @@ public final class HostColumnVector extends HostColumnVectorCore {
       return this;
     }
 
+    /**
+     * Accepts a byte array containing the two's-complement representation of the unscaled value, which
+     * is in big-endian byte-order. Then, transforms it into the representation of cuDF Decimal128 for
+     * appending.
+     * This method is more efficient than `append(BigInteger unscaledVal)` if we can directly access the
+     * two's-complement representation of a BigDecimal without encoding via the method `toByteArray`.
+     */
+    public ColumnBuilder appendDecimal128(byte[] binary) {
+      growFixedWidthBuffersAndRows();
+      assert type.getTypeId().equals(DType.DTypeEnum.DECIMAL128);
+      assert currentIndex < rows;
+      assert binary.length <= type.getSizeInBytes();
+      byte[] cuBinary = convertDecimal128FromJavaToCudf(binary);
+      data.setBytes(currentIndex++ << bitShiftBySize, cuBinary, 0, cuBinary.length);
+      return this;
+    }
+
     public ColumnBuilder getChild(int index) {
       return childBuilders.get(index);
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnBuilderHelper.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnBuilderHelper.java
@@ -18,6 +18,7 @@
 package ai.rapids.cudf;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -47,6 +48,17 @@ public class ColumnBuilderHelper {
       init.accept(b);
       return b.buildAndPutOnDevice();
     }
+  }
+
+  public static HostColumnVector decimalFromBigInts(int scale, BigInteger... values) {
+    return ColumnBuilderHelper.build(
+        new HostColumnVector.BasicType(true, DType.create(DType.DTypeEnum.DECIMAL128, -scale)),
+        values.length,
+        (b) -> {
+          for (BigInteger v : values)
+            if (v == null) b.appendNull();
+            else b.appendDecimal128(v.toByteArray());
+        });
   }
 
   public static HostColumnVector fromBoxedBytes(boolean signed, Byte... values) {


### PR DESCRIPTION
This PR is to add new append method for `HostColumnVector.ColumnBuilder`. This newly-added method `appendDecimal128` allows users to add binary data, which represents the unscaled value of BigDecimal, as cuDF Decimal128.
This PR serves as a prerequisite of https://github.com/NVIDIA/spark-rapids/issues/4784.