### PR TITLE
Avoid overflow in fused_concatenate_kernel output_index

### DIFF
--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -166,7 +166,7 @@ __global__ void fused_concatenate_kernel(column_device_view const* input_views,
   auto const output_size = output_view.size();
   auto* output_data      = output_view.data<T>();
 
-  size_type output_index     = threadIdx.x + blockIdx.x * blockDim.x;
+  std::size_t output_index   = threadIdx.x + blockIdx.x * blockDim.x;
   size_type warp_valid_count = 0;
 
   unsigned active_mask;

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -166,7 +166,7 @@ __global__ void fused_concatenate_kernel(column_device_view const* input_views,
   auto const output_size = output_view.size();
   auto* output_data      = output_view.data<T>();
 
-  std::size_t output_index   = threadIdx.x + blockIdx.x * blockDim.x;
+  int64_t output_index       = threadIdx.x + blockIdx.x * blockDim.x;
   size_type warp_valid_count = 0;
 
   unsigned active_mask;

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -222,7 +222,7 @@ std::unique_ptr<column> fused_concatenate(host_span<column_view const> views,
   auto const& d_offsets   = std::get<2>(device_views);
   auto const output_size  = std::get<3>(device_views);
 
-  CUDF_EXPECTS(output_size < static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+  CUDF_EXPECTS(output_size <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
                "Total number of concatenated rows exceeds size_type range");
 
   // Allocate output

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -342,9 +342,9 @@ TEST_F(OverflowTest, OverflowTest)
   using namespace cudf;
   // should concatenate up to size_type::max - 1 rows.
   {
-    // 5 x size + size_last adds to size_type::max - 1
+    // 5 x size + size_last adds to size_type::max
     constexpr auto size      = static_cast<size_type>(static_cast<uint32_t>(250) * 1024 * 1024);
-    constexpr auto size_last = static_cast<size_type>(836763647 - 1);
+    constexpr auto size_last = static_cast<size_type>(836763647);
 
     auto many_chars      = cudf::make_fixed_width_column(data_type{type_id::INT8}, size);
     auto many_chars_last = cudf::make_fixed_width_column(data_type{type_id::INT8}, size_last);
@@ -354,7 +354,7 @@ TEST_F(OverflowTest, OverflowTest)
     std::vector<cudf::table_view> table_views_to_concat({tbl, tbl, tbl, tbl, tbl, tbl_last});
     std::unique_ptr<cudf::table> concatenated_tables = cudf::concatenate(table_views_to_concat);
     EXPECT_NO_THROW(rmm::cuda_stream_default.synchronize());
-    ASSERT_EQ(concatenated_tables->num_rows(), std::numeric_limits<size_type>::max() - 1);
+    ASSERT_EQ(concatenated_tables->num_rows(), std::numeric_limits<size_type>::max());
   }
 
   // primitive column

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -343,10 +343,10 @@ TEST_F(OverflowTest, OverflowTest)
   // should concatenate up to size_type::max - 1 rows.
   {
     // 5 x size + size_last adds to size_type::max - 1
-    constexpr auto size = static_cast<size_type>(static_cast<uint32_t>(250) * 1024 * 1024);
+    constexpr auto size      = static_cast<size_type>(static_cast<uint32_t>(250) * 1024 * 1024);
     constexpr auto size_last = static_cast<size_type>(836763647 - 1);
 
-    auto many_chars = cudf::make_fixed_width_column(data_type{type_id::INT8}, size);
+    auto many_chars      = cudf::make_fixed_width_column(data_type{type_id::INT8}, size);
     auto many_chars_last = cudf::make_fixed_width_column(data_type{type_id::INT8}, size_last);
 
     table_view tbl({*many_chars});

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -340,7 +340,7 @@ struct OverflowTest : public cudf::test::BaseFixture {
 TEST_F(OverflowTest, OverflowTest)
 {
   using namespace cudf;
-  // should concatenate up to size_type::max - 1 rows.
+  // should concatenate up to size_type::max rows.
   {
     // 5 x size + size_last adds to size_type::max
     constexpr auto size      = static_cast<size_type>(static_cast<uint32_t>(250) * 1024 * 1024);


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/10333.

The repro case in the issue showed an illegal access error where the `output_index` of the strided loop in `fused_concatenate_kernel` can overflow for a large number of rows. 

For example, given 5 tables of exactly 250M rows each we would expect a result with 1,250,000,000 rows. 

The kernel is launched with 4,882,813 blocks (# of rows / 256 threads rounded up) with a stride of 1,250,000,128 (256 * 4,882,813). When `output_index` reaches 897,483,520, it overflows `output_index` on the first iteration.

The change below prevents the overflow by making `output_index` an `int64_t` and adds a test that shows that we can now concatenate up to `size_type::max - 1` rows.
