### PR TITLE
[REVIEW] Enable caching for `memory_usage` calculation in `Column`

### DIFF
--- a/python/cudf/cudf/_lib/column.pyi
+++ b/python/cudf/cudf/_lib/column.pyi
@@ -19,7 +19,6 @@ class Column:
     _size: int
     _offset: int
     _null_count: int
-    _cached_sizeof: int
     _children: Tuple[ColumnBase, ...]
     _base_children: Tuple[ColumnBase, ...]
     _distinct_count: Dict[bool, int]

--- a/python/cudf/cudf/_lib/column.pyi
+++ b/python/cudf/cudf/_lib/column.pyi
@@ -19,6 +19,7 @@ class Column:
     _size: int
     _offset: int
     _null_count: int
+    _cached_sizeof: int
     _children: Tuple[ColumnBase, ...]
     _base_children: Tuple[ColumnBase, ...]
     _distinct_count: Dict[bool, int]

--- a/python/cudf/cudf/_lib/column.pyx
+++ b/python/cudf/cudf/_lib/column.pyx
@@ -368,6 +368,7 @@ cdef class Column:
         self._null_count = None
         self._children = None
         self._data = None
+        self._memory_usage = None
 
         return mutable_column_view(
             dtype,

--- a/python/cudf/cudf/_lib/column.pyx
+++ b/python/cudf/cudf/_lib/column.pyx
@@ -74,7 +74,6 @@ cdef class Column:
     ):
 
         self._size = size
-        self._cached_sizeof = None
         self._distinct_count = {}
         self._dtype = dtype
         self._offset = offset
@@ -204,7 +203,11 @@ cdef class Column:
 
     def _clear_cache(self):
         self._distinct_count = {}
-        self._cached_sizeof = None
+        try:
+            del self.memory_usage
+        except AttributeError:
+            # `self.memory_usage` was never called before, So ignore.
+            pass
         self._null_count = None
 
     def set_mask(self, value):

--- a/python/cudf/cudf/_lib/column.pyx
+++ b/python/cudf/cudf/_lib/column.pyx
@@ -371,7 +371,6 @@ cdef class Column:
         self._null_count = None
         self._children = None
         self._data = None
-        self._memory_usage = None
 
         return mutable_column_view(
             dtype,

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pickle
 from collections.abc import MutableSequence
+from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1335,8 +1336,9 @@ class CategoricalColumn(column.ColumnBase):
                 size=self.size,
             )
 
+    @cached_property
     def memory_usage(self) -> int:
-        return self.categories.memory_usage() + self.codes.memory_usage()
+        return self.categories.memory_usage + self.codes.memory_usage
 
     def _mimic_inplace(
         self, other_col: ColumnBase, inplace: bool = False

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import builtins
 import pickle
 import warnings
+from functools import cached_property
 from types import SimpleNamespace
 from typing import (
     Any,
@@ -297,15 +298,14 @@ class ColumnBase(Column, Serializable, NotIterable):
             self.base_mask, self.offset, self.offset + len(self)
         )
 
+    @cached_property
     def memory_usage(self) -> int:
-        if self._cached_sizeof is None:
-            n = 0
-            if self.data is not None:
-                n += self.data.size
-            if self.nullable:
-                n += bitmask_allocation_size_bytes(self.size)
-            self._cached_sizeof = n
-        return self._cached_sizeof
+        n = 0
+        if self.data is not None:
+            n += self.data.size
+        if self.nullable:
+            n += bitmask_allocation_size_bytes(self.size)
+        return n
 
     def _fill(
         self,

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -298,12 +298,14 @@ class ColumnBase(Column, Serializable, NotIterable):
         )
 
     def memory_usage(self) -> int:
-        n = 0
-        if self.data is not None:
-            n += self.data.size
-        if self.nullable:
-            n += bitmask_allocation_size_bytes(self.size)
-        return n
+        if self._cached_sizeof is None:
+            n = 0
+            if self.data is not None:
+                n += self.data.size
+            if self.nullable:
+                n += bitmask_allocation_size_bytes(self.size)
+            self._cached_sizeof = n
+        return self._cached_sizeof
 
     def _fill(
         self,

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -360,7 +360,7 @@ class Frame:
                 "The deep parameter is ignored and is only included "
                 "for pandas compatibility."
             )
-        return {name: col.memory_usage() for name, col in self._data.items()}
+        return {name: col.memory_usage for name, col in self._data.items()}
 
     def __len__(self):
         return self._num_rows

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1415,7 +1415,7 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
                 usage += level.memory_usage(deep=deep)
         if self.codes:
             for col in self.codes._data.columns:
-                usage += col.memory_usage()
+                usage += col.memory_usage
         return usage
 
     def difference(self, other, sort=None):

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -5195,8 +5195,8 @@ def test_memory_usage_cat():
     gdf = cudf.from_pandas(df)
 
     expected = (
-        gdf.B._column.categories.memory_usage()
-        + gdf.B._column.codes.memory_usage()
+        gdf.B._column.categories.memory_usage
+        + gdf.B._column.codes.memory_usage
     )
 
     # Check cat column
@@ -5209,8 +5209,7 @@ def test_memory_usage_cat():
 def test_memory_usage_list():
     df = cudf.DataFrame({"A": [[0, 1, 2, 3], [4, 5, 6], [7, 8], [9]]})
     expected = (
-        df.A._column.offsets.memory_usage()
-        + df.A._column.elements.memory_usage()
+        df.A._column.offsets.memory_usage + df.A._column.elements.memory_usage
     )
     assert expected == df.A.memory_usage()
 


### PR DESCRIPTION
We previously used to cache the `Column.memory_usage` output in `Column._cached_sizeof` but it probably was missed to be included in the recent refactors. This PR re-enables caching of `memory_usage`.

`Column.memory_usage` should be a no-op on consecutive calls and **60% faster**:
```python
In [1]: import cudf

In [2]: s = cudf.Series(["abc ", " d e", None, "10 11 234355"] * 10000000)

In [3]: s
Out[3]: 
0                   abc 
1                    d e
2                   <NA>
3           10 11 234355
4                   abc 
                ...     
39999995    10 11 234355
39999996            abc 
39999997             d e
39999998            <NA>
39999999    10 11 234355
Length: 40000000, dtype: object



# branch-22.04
In [3]: %timeit s.memory_usage()
2.86 µs ± 53.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

# THIS PR

In [3]: %timeit s.memory_usage()
1.77 µs ± 10.8 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
