### PR TITLE
Fix warnings in test_categorical.py.

### DIFF
--- a/python/cudf/cudf/core/_compat.py
+++ b/python/cudf/cudf/core/_compat.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 
 import pandas as pd
 from packaging import version
@@ -9,4 +9,5 @@ PANDAS_GE_110 = PANDAS_VERSION >= version.parse("1.1")
 PANDAS_GE_120 = PANDAS_VERSION >= version.parse("1.2")
 PANDAS_LE_122 = PANDAS_VERSION <= version.parse("1.2.2")
 PANDAS_GE_130 = PANDAS_VERSION >= version.parse("1.3.0")
+PANDAS_GE_134 = PANDAS_VERSION >= version.parse("1.3.4")
 PANDAS_LT_140 = PANDAS_VERSION < version.parse("1.4.0")

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -2,6 +2,7 @@
 
 import operator
 import string
+from contextlib import contextmanager
 from textwrap import dedent
 
 import numpy as np
@@ -15,6 +16,18 @@ from cudf.testing._utils import (
     assert_eq,
     assert_exceptions_equal,
 )
+
+
+@contextmanager
+def _hide_deprecated_pandas_categorical_inplace_warnings(function_name):
+    with pytest.warns(
+        FutureWarning,
+        match=(
+            f"The `inplace` parameter in pandas.Categorical.{function_name} "
+            "is deprecated and will be removed in a future version."
+        ),
+    ):
+        yield
 
 
 @pytest.fixture
@@ -409,7 +422,10 @@ def test_categorical_reorder_categories(
 
     kwargs = dict(ordered=to_ordered, inplace=inplace)
 
-    pd_sr_1 = pd_sr.cat.reorder_categories(list("cba"), **kwargs)
+    with _hide_deprecated_pandas_categorical_inplace_warnings(
+        "reorder_categories"
+    ):
+        pd_sr_1 = pd_sr.cat.reorder_categories(list("cba"), **kwargs)
     cd_sr_1 = cd_sr.cat.reorder_categories(list("cba"), **kwargs)
     if inplace:
         pd_sr_1 = pd_sr
@@ -442,7 +458,10 @@ def test_categorical_add_categories(pd_str_cat, inplace):
 
     assert str(pd_sr) == str(cd_sr)
 
-    pd_sr_1 = pd_sr.cat.add_categories(["d"], inplace=inplace)
+    with _hide_deprecated_pandas_categorical_inplace_warnings(
+        "add_categories"
+    ):
+        pd_sr_1 = pd_sr.cat.add_categories(["d"], inplace=inplace)
     cd_sr_1 = cd_sr.cat.add_categories(["d"], inplace=inplace)
     if inplace:
         pd_sr_1 = pd_sr
@@ -476,7 +495,10 @@ def test_categorical_remove_categories(pd_str_cat, inplace):
 
     assert str(pd_sr) == str(cd_sr)
 
-    pd_sr_1 = pd_sr.cat.remove_categories(["a"], inplace=inplace)
+    with _hide_deprecated_pandas_categorical_inplace_warnings(
+        "remove_categories"
+    ):
+        pd_sr_1 = pd_sr.cat.remove_categories(["a"], inplace=inplace)
     cd_sr_1 = cd_sr.cat.remove_categories(["a"], inplace=inplace)
     if inplace:
         pd_sr_1 = pd_sr

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -2,6 +2,7 @@
 
 import operator
 import string
+from textwrap import dedent
 
 import numpy as np
 import pandas as pd
@@ -51,9 +52,8 @@ t a
     assert_eq(cat.codes, cudf_cat.codes.to_numpy())
 
 
+@pytest.mark.skipif(not PANDAS_GE_110, reason="requires pandas>=1.1.0")
 def test_categorical_integer():
-    if not PANDAS_GE_110:
-        pytest.xfail(reason="pandas >=1.1 required")
     cat = pd.Categorical(["a", "_", "_", "c", "a"], categories=["a", "b", "c"])
     pdsr = pd.Series(cat)
     sr = cudf.Series(cat)
@@ -67,17 +67,17 @@ def test_categorical_integer():
         sr.cat.codes.astype(pdsr.cat.codes.dtype).fillna(-1).to_numpy(),
     )
 
-    string = str(sr)
-    expect_str = """
-0 a
-1 <NA>
-2 <NA>
-3 c
-4 a
-dtype: category
-Categories (3, object): ['a', 'b', 'c']
-"""
-    assert string.split() == expect_str.split()
+    expect_str = dedent(
+        """\
+        0       a
+        1    <NA>
+        2    <NA>
+        3       c
+        4       a
+        dtype: category
+        Categories (3, object): ['a', 'b', 'c']"""
+    )
+    assert str(sr) == expect_str
 
 
 def test_categorical_compare_unordered():

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 import operator
 import string
@@ -154,21 +154,6 @@ def test_categorical_binary_add():
         rfunc_args_and_kwargs=([sr, sr],),
         expected_error_message="Series of dtype `category` cannot perform "
         "the operation: add",
-    )
-
-
-def test_categorical_unary_ceil():
-    cat = pd.Categorical(["a", "a", "b", "c", "a"], categories=["a", "b", "c"])
-    pdsr = pd.Series(cat)
-    sr = cudf.Series(cat)
-
-    assert_exceptions_equal(
-        lfunc=getattr,
-        rfunc=sr.ceil,
-        lfunc_args_and_kwargs=([pdsr, "ceil"],),
-        check_exception_type=False,
-        expected_error_message="Series of dtype `category` cannot "
-        "perform the operation: ceil",
     )
 
 

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_GE_110
+from cudf.core._compat import PANDAS_GE_110, PANDAS_GE_134
 from cudf.testing._utils import (
     NUMERIC_TYPES,
     assert_eq,
@@ -352,8 +352,9 @@ def test_categorical_as_ordered(pd_str_cat, inplace):
 
     pd_sr_1 = pd_sr.cat.as_ordered(inplace=inplace)
     cd_sr_1 = cd_sr.cat.as_ordered(inplace=inplace)
-    pd_sr_1 = pd_sr if pd_sr_1 is None else pd_sr_1
-    cd_sr_1 = cd_sr if cd_sr_1 is None else cd_sr_1
+    if inplace:
+        pd_sr_1 = pd_sr
+        cd_sr_1 = cd_sr
 
     assert cd_sr_1.cat.ordered is True
     assert cd_sr_1.cat.ordered == pd_sr_1.cat.ordered
@@ -371,8 +372,9 @@ def test_categorical_as_unordered(pd_str_cat, inplace):
 
     pd_sr_1 = pd_sr.cat.as_unordered(inplace=inplace)
     cd_sr_1 = cd_sr.cat.as_unordered(inplace=inplace)
-    pd_sr_1 = pd_sr if pd_sr_1 is None else pd_sr_1
-    cd_sr_1 = cd_sr if cd_sr_1 is None else cd_sr_1
+    if inplace:
+        pd_sr_1 = pd_sr
+        cd_sr_1 = cd_sr
 
     assert cd_sr_1.cat.ordered is False
     assert cd_sr_1.cat.ordered == pd_sr_1.cat.ordered
@@ -386,8 +388,9 @@ def test_categorical_as_unordered(pd_str_cat, inplace):
     [
         pytest.param(
             True,
-            marks=pytest.mark.xfail(
-                reason="https://github.com/pandas-dev/pandas/issues/43232"
+            marks=pytest.mark.skipif(
+                not PANDAS_GE_134,
+                reason="https://github.com/pandas-dev/pandas/issues/43232",
             ),
         ),
         False,
@@ -408,8 +411,9 @@ def test_categorical_reorder_categories(
 
     pd_sr_1 = pd_sr.cat.reorder_categories(list("cba"), **kwargs)
     cd_sr_1 = cd_sr.cat.reorder_categories(list("cba"), **kwargs)
-    pd_sr_1 = pd_sr if pd_sr_1 is None else pd_sr_1
-    cd_sr_1 = cd_sr if cd_sr_1 is None else cd_sr_1
+    if inplace:
+        pd_sr_1 = pd_sr
+        cd_sr_1 = cd_sr
 
     assert_eq(pd_sr_1, cd_sr_1)
 
@@ -421,8 +425,9 @@ def test_categorical_reorder_categories(
     [
         pytest.param(
             True,
-            marks=pytest.mark.xfail(
-                reason="https://github.com/pandas-dev/pandas/issues/43232"
+            marks=pytest.mark.skipif(
+                not PANDAS_GE_134,
+                reason="https://github.com/pandas-dev/pandas/issues/43232",
             ),
         ),
         False,
@@ -439,8 +444,9 @@ def test_categorical_add_categories(pd_str_cat, inplace):
 
     pd_sr_1 = pd_sr.cat.add_categories(["d"], inplace=inplace)
     cd_sr_1 = cd_sr.cat.add_categories(["d"], inplace=inplace)
-    pd_sr_1 = pd_sr if pd_sr_1 is None else pd_sr_1
-    cd_sr_1 = cd_sr if cd_sr_1 is None else cd_sr_1
+    if inplace:
+        pd_sr_1 = pd_sr
+        cd_sr_1 = cd_sr
 
     assert "d" in pd_sr_1.cat.categories.to_list()
     assert "d" in cd_sr_1.cat.categories.to_pandas().to_list()
@@ -453,8 +459,9 @@ def test_categorical_add_categories(pd_str_cat, inplace):
     [
         pytest.param(
             True,
-            marks=pytest.mark.xfail(
-                reason="https://github.com/pandas-dev/pandas/issues/43232"
+            marks=pytest.mark.skipif(
+                not PANDAS_GE_134,
+                reason="https://github.com/pandas-dev/pandas/issues/43232",
             ),
         ),
         False,
@@ -471,8 +478,9 @@ def test_categorical_remove_categories(pd_str_cat, inplace):
 
     pd_sr_1 = pd_sr.cat.remove_categories(["a"], inplace=inplace)
     cd_sr_1 = cd_sr.cat.remove_categories(["a"], inplace=inplace)
-    pd_sr_1 = pd_sr if pd_sr_1 is None else pd_sr_1
-    cd_sr_1 = cd_sr if cd_sr_1 is None else cd_sr_1
+    if inplace:
+        pd_sr_1 = pd_sr
+        cd_sr_1 = cd_sr
 
     assert "a" not in pd_sr_1.cat.categories.to_list()
     assert "a" not in cd_sr_1.cat.categories.to_pandas().to_list()

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -152,8 +152,9 @@ def test_categorical_binary_add():
         rfunc=operator.add,
         lfunc_args_and_kwargs=([pdsr, pdsr],),
         rfunc_args_and_kwargs=([sr, sr],),
-        expected_error_message="Series of dtype `category` cannot perform "
-        "the operation: add",
+        expected_error_message=(
+            "Series of dtype `category` cannot perform the operation: add"
+        ),
     )
 
 
@@ -223,26 +224,25 @@ def test_cat_series_binop_error():
     df["a"] = pd.Categorical(list("aababcabbc"), categories=list("abc"))
     df["b"] = np.arange(len(df))
 
-    dfa = df["a"]
-    dfb = df["b"]
+    pdf = df.to_pandas()
 
-    # lhs is a categorical
+    # lhs is categorical
     assert_exceptions_equal(
         lfunc=operator.add,
         rfunc=operator.add,
-        lfunc_args_and_kwargs=([dfa, dfb],),
-        rfunc_args_and_kwargs=([dfa, dfb],),
-        check_exception_type=False,
-        expected_error_message="Series of dtype `category` cannot "
-        "perform the operation: add",
+        lfunc_args_and_kwargs=([pdf["a"], pdf["b"]],),
+        rfunc_args_and_kwargs=([df["a"], df["b"]],),
+        expected_error_message=(
+            "Series of dtype `category` cannot perform the operation: add"
+        ),
     )
-    # if lhs is a numerical
+
+    # lhs is numerical
     assert_exceptions_equal(
         lfunc=operator.add,
         rfunc=operator.add,
-        lfunc_args_and_kwargs=([dfb, dfa],),
-        rfunc_args_and_kwargs=([dfb, dfa],),
-        check_exception_type=False,
+        lfunc_args_and_kwargs=([pdf["b"], pdf["a"]],),
+        rfunc_args_and_kwargs=([df["b"], df["a"]],),
         expected_error_message="'add' operator not supported",
     )
 


### PR DESCRIPTION
This PR catches or silences warnings in `test_categorical.py`. (I am working through one test file at a time so we can enable `-Werr` in the future.) Most of the warnings come from deprecated `inplace` arguments to pandas' categorical functions. The `inplace` argument will be removed in pandas 2.0. Until then, we should just hide the warning.

Additionally, I refactored some `inplace` behavior to make the expected behavior of the test clearer.