### PR TITLE
Fix warnings in test_csv.py.

### DIFF
--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -4,6 +4,7 @@ import gzip
 import os
 import re
 import shutil
+import warnings
 from collections import OrderedDict
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -1322,7 +1323,18 @@ def test_csv_reader_hexadecimals(pdf_dtype, gdf_dtype):
 
     if gdf_dtype is not None:
         # require explicit `hex` dtype to parse hexadecimals
-        pdf = pd.DataFrame(data=values, dtype=pdf_dtype, columns=["hex_int"])
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                (
+                    "Values are too large to be losslessly cast to int32. In "
+                    "a future version this will raise OverflowError."
+                ),
+                category=FutureWarning,
+            )
+            pdf = pd.DataFrame(
+                data=values, dtype=pdf_dtype, columns=["hex_int"]
+            )
         gdf = read_csv(StringIO(buffer), dtype=[gdf_dtype], names=["hex_int"])
         np.testing.assert_array_equal(
             pdf["hex_int"], gdf["hex_int"].to_numpy()

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -1336,7 +1336,7 @@ def test_csv_reader_hexadecimals(pdf_dtype, gdf_dtype):
 
 @pytest.mark.parametrize(
     "np_dtype, gdf_dtype",
-    [("int_", "hex"), ("int32", "hex32"), ("int64", "hex64")],
+    [("int", "hex"), ("int32", "hex32"), ("int64", "hex64")],
 )
 def test_csv_reader_hexadecimal_overflow(np_dtype, gdf_dtype):
     # This tests values which cause an overflow warning that will become an
@@ -1358,7 +1358,6 @@ def test_csv_reader_hexadecimal_overflow(np_dtype, gdf_dtype):
 
     gdf = read_csv(StringIO(buffer), dtype=[gdf_dtype], names=["hex_int"])
 
-    np_dtype = getattr(np, np_dtype)
     expected = np.array(values, dtype=np_dtype)
     actual = gdf["hex_int"].to_numpy()
     np.testing.assert_array_equal(expected, actual)


### PR DESCRIPTION
This PR silences warnings in `test_csv.py`. (I am working through one test file at a time so we can enable `-Werr` in the future.)

The only warning in this file is related to integer overflow in pandas. Currently, the test data is as follows:
https://github.com/rapidsai/cudf/blob/21325e8348f33b28e434d08d687a28f251c38f67/python/cudf/cudf/tests/test_csv.py#L1313-L1319

First, I note that this "hex" dtype is not part of the pandas API. It is a cuDF addition (#1925, #2149).

Note that there are dtypes for `int32` / `hex32`, and the test data contains both a negative value `-0x1000` and a value `9512c20b`. The negative value `-0x1000` has a sensible interpretation if the results are meant to be signed, but then the value `9512c20b` is out of range (the maximum signed 32-bit value would be `0x7FFFFFFF` and the minimum signed 32-bit value would be `0x80000000`, using the big-endian convention of the parser). Recognizing this, pandas throws a `FutureWarning` when parsing the data `9512c20b` as `int32`, and unsafely wraps it to a negative value. This behavior will eventually be replaced by an `OverflowError`.

In the future, we may need to decide if cuDF should raise an `OverflowError` when exceeding `0x7FFFFFFF` for consistency with pandas, or decide to use unsigned integers when parsing "hex" dtypes and compare to pandas' unsigned types in this test.