### PR TITLE
Remove documentation for methods removed in #10124.

### DIFF
--- a/docs/cudf/source/api_docs/dataframe.rst
+++ b/docs/cudf/source/api_docs/dataframe.rst
@@ -219,7 +219,6 @@ Combining / comparing / joining / merging / encoding
    DataFrame.join
    DataFrame.merge
    DataFrame.update
-   DataFrame.label_encoding
    DataFrame.one_hot_encoding
 
 Numerical operations
@@ -249,8 +248,6 @@ Serialization / IO / conversion
 .. autosummary::
    :toctree: api/
 
-   DataFrame.as_gpu_matrix
-   DataFrame.as_matrix
    DataFrame.from_arrow
    DataFrame.from_pandas
    DataFrame.from_records

--- a/docs/cudf/source/api_docs/index_objects.rst
+++ b/docs/cudf/source/api_docs/index_objects.rst
@@ -34,7 +34,7 @@ Properties
    Index.shape
    Index.size
    Index.values
-   
+
 
 Modifying and computations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -94,7 +94,6 @@ Conversion
    Index.astype
    Index.to_arrow
    Index.to_list
-   Index.to_numpy
    Index.to_series
    Index.to_frame
    Index.to_pandas

--- a/docs/cudf/source/api_docs/series.rst
+++ b/docs/cudf/source/api_docs/series.rst
@@ -44,7 +44,6 @@ Conversion
    Series.copy
    Series.to_list
    Series.__array__
-   Series.as_mask
    Series.scale
 
 
@@ -172,9 +171,7 @@ Reindexing / selection / label manipulation
    Series.reindex
    Series.rename
    Series.reset_index
-   Series.reverse
    Series.sample
-   Series.set_mask
    Series.take
    Series.tail
    Series.tile
@@ -217,7 +214,6 @@ Combining / comparing / joining / merging / encoding
 
    Series.append
    Series.update
-   Series.label_encoding
    Series.one_hot_encoding
 
 Numerical operations
@@ -409,12 +405,10 @@ Serialization / IO / conversion
    :toctree: api/
 
    Series.to_arrow
-   Series.to_cupy
    Series.to_dlpack
    Series.to_frame
    Series.to_hdf
    Series.to_json
-   Series.to_numpy
    Series.to_pandas
    Series.to_string
    Series.from_arrow


### PR DESCRIPTION
PR #10124 removed several deprecated methods. This PR also removes their documentation. cc: @vyasr