### PR TITLE
Remove doc for deprecated function `one_hot_encoding`

### DIFF
--- a/docs/cudf/source/api_docs/dataframe.rst
+++ b/docs/cudf/source/api_docs/dataframe.rst
@@ -219,7 +219,6 @@ Combining / comparing / joining / merging / encoding
    DataFrame.join
    DataFrame.merge
    DataFrame.update
-   DataFrame.one_hot_encoding
 
 Numerical operations
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/cudf/source/api_docs/dataframe.rst
+++ b/docs/cudf/source/api_docs/dataframe.rst
@@ -209,7 +209,7 @@ Reshaping, sorting, transposing
    DataFrame.T
    DataFrame.transpose
 
-Combining / comparing / joining / merging / encoding
+Combining / comparing / joining / merging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: api/

--- a/docs/cudf/source/api_docs/dataframe.rst
+++ b/docs/cudf/source/api_docs/dataframe.rst
@@ -210,7 +210,7 @@ Reshaping, sorting, transposing
    DataFrame.transpose
 
 Combining / comparing / joining / merging
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: api/
 

--- a/docs/cudf/source/api_docs/series.rst
+++ b/docs/cudf/source/api_docs/series.rst
@@ -214,7 +214,6 @@ Combining / comparing / joining / merging / encoding
 
    Series.append
    Series.update
-   Series.one_hot_encoding
 
 Numerical operations
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/cudf/source/api_docs/series.rst
+++ b/docs/cudf/source/api_docs/series.rst
@@ -208,7 +208,7 @@ Reshaping, sorting
    Series.transpose
 
 Combining / comparing / joining / merging
-----------------------------------------------------
+-----------------------------------------
 .. autosummary::
    :toctree: api/
 

--- a/docs/cudf/source/api_docs/series.rst
+++ b/docs/cudf/source/api_docs/series.rst
@@ -207,7 +207,7 @@ Reshaping, sorting
    Series.repeat
    Series.transpose
 
-Combining / comparing / joining / merging / encoding
+Combining / comparing / joining / merging
 ----------------------------------------------------
 .. autosummary::
    :toctree: api/


### PR DESCRIPTION
This PR removes doc item for deprecated function `one_hot_encoding`.