### PR TITLE
Include <optional> in multibyte split.

### DIFF
--- a/cpp/include/cudf/io/text/multibyte_split.hpp
+++ b/cpp/include/cudf/io/text/multibyte_split.hpp
@@ -23,6 +23,7 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <memory>
+#include <optional>
 
 namespace cudf {
 namespace io {

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -40,6 +40,7 @@
 #include <cub/block/block_scan.cuh>
 
 #include <memory>
+#include <optional>
 
 namespace {
 


### PR DESCRIPTION
#10150 broke compiler support for GCC 11 (built locally) because it was missing `#include <optional>` in a couple files. This fixes it. cc: @cwharris