### PR TITLE
Add `cudf::stable_sort_by_key`

### DIFF
--- a/cpp/include/cudf/detail/sorting.hpp
+++ b/cpp/include/cudf/detail/sorting.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,19 @@ std::unique_ptr<column> stable_sorted_order(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<table> sort_by_key(
+  table_view const& values,
+  table_view const& keys,
+  std::vector<order> const& column_order         = {},
+  std::vector<null_order> const& null_precedence = {},
+  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
+
+/**
+ * @copydoc cudf::stable_sort_by_key
+ *
+ * @param[in] stream CUDA stream used for device memory operations and kernel launches.
+ */
+std::unique_ptr<table> stable_sort_by_key(
   table_view const& values,
   table_view const& keys,
   std::vector<order> const& column_order         = {},

--- a/cpp/include/cudf/sorting.hpp
+++ b/cpp/include/cudf/sorting.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,6 +139,36 @@ std::unique_ptr<table> sort(
  * the rows of `keys`.
  */
 std::unique_ptr<table> sort_by_key(
+  table_view const& values,
+  table_view const& keys,
+  std::vector<order> const& column_order         = {},
+  std::vector<null_order> const& null_precedence = {},
+  rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
+
+/**
+ * @brief Performs a key-value stable sort.
+ *
+ * Creates a new table that reorders the rows of `values` according to the
+ * lexicographic ordering of the rows of `keys`.
+ *
+ * The order of equivalent elements is guaranteed to be preserved.
+ *
+ * @throws cudf::logic_error if `values.num_rows() != keys.num_rows()`.
+ *
+ * @param values The table to reorder
+ * @param keys The table that determines the ordering
+ * @param column_order The desired order for each column in `keys`. Size must be
+ * equal to `keys.num_columns()` or empty. If empty, all columns are sorted in
+ * ascending order.
+ * @param null_precedence The desired order of a null element compared to other
+ * elements for each column in `keys`. Size must be equal to
+ * `keys.num_columns()` or empty. If empty, all columns will be sorted with
+ * `null_order::BEFORE`.
+ * @param mr Device memory resource used to allocate the returned table's device memory
+ * @return The reordering of `values` determined by the lexicographic order of
+ * the rows of `keys`.
+ */
+std::unique_ptr<table> stable_sort_by_key(
   table_view const& values,
   table_view const& keys,
   std::vector<order> const& column_order         = {},

--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -45,8 +45,7 @@ std::unique_ptr<table> sort_by_key(table_view const& values,
   CUDF_EXPECTS(values.num_rows() == keys.num_rows(),
                "Mismatch in number of rows for values and keys");
 
-  auto sorted_order = detail::sorted_order(
-    keys, column_order, null_precedence, stream, rmm::mr::get_current_device_resource());
+  auto sorted_order = detail::sorted_order(keys, column_order, null_precedence, stream, mr);
 
   return detail::gather(values,
                         sorted_order->view(),

--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -45,7 +45,8 @@ std::unique_ptr<table> sort_by_key(table_view const& values,
   CUDF_EXPECTS(values.num_rows() == keys.num_rows(),
                "Mismatch in number of rows for values and keys");
 
-  auto sorted_order = detail::sorted_order(keys, column_order, null_precedence, stream, mr);
+  auto sorted_order = detail::sorted_order(
+    keys, column_order, null_precedence, stream, rmm::mr::get_current_device_resource());
 
   return detail::gather(values,
                         sorted_order->view(),

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include "sort_impl.cuh"
 
 #include <cudf/column/column.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/sorting.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
@@ -34,6 +35,26 @@ std::unique_ptr<column> stable_sorted_order(table_view const& input,
   return sorted_order<true>(input, column_order, null_precedence, stream, mr);
 }
 
+std::unique_ptr<table> stable_sort_by_key(table_view const& values,
+                                          table_view const& keys,
+                                          std::vector<order> const& column_order,
+                                          std::vector<null_order> const& null_precedence,
+                                          rmm::cuda_stream_view stream,
+                                          rmm::mr::device_memory_resource* mr)
+{
+  CUDF_EXPECTS(values.num_rows() == keys.num_rows(),
+               "Mismatch in number of rows for values and keys");
+
+  auto sorted_order = detail::stable_sorted_order(
+    keys, column_order, null_precedence, stream, rmm::mr::get_current_device_resource());
+
+  return detail::gather(values,
+                        sorted_order->view(),
+                        out_of_bounds_policy::DONT_CHECK,
+                        detail::negative_index_policy::NOT_ALLOWED,
+                        stream,
+                        mr);
+}
 }  // namespace detail
 
 std::unique_ptr<column> stable_sorted_order(table_view const& input,
@@ -43,6 +64,17 @@ std::unique_ptr<column> stable_sorted_order(table_view const& input,
 {
   return detail::stable_sorted_order(
     input, column_order, null_precedence, rmm::cuda_stream_default, mr);
+}
+
+std::unique_ptr<table> stable_sort_by_key(table_view const& values,
+                                          table_view const& keys,
+                                          std::vector<order> const& column_order,
+                                          std::vector<null_order> const& null_precedence,
+                                          rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::stable_sort_by_key(
+    values, keys, column_order, null_precedence, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -45,8 +45,7 @@ std::unique_ptr<table> stable_sort_by_key(table_view const& values,
   CUDF_EXPECTS(values.num_rows() == keys.num_rows(),
                "Mismatch in number of rows for values and keys");
 
-  auto sorted_order = detail::stable_sorted_order(
-    keys, column_order, null_precedence, stream, rmm::mr::get_current_device_resource());
+  auto sorted_order = detail::stable_sorted_order(keys, column_order, null_precedence, stream, mr);
 
   return detail::gather(values,
                         sorted_order->view(),

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -45,7 +45,8 @@ std::unique_ptr<table> stable_sort_by_key(table_view const& values,
   CUDF_EXPECTS(values.num_rows() == keys.num_rows(),
                "Mismatch in number of rows for values and keys");
 
-  auto sorted_order = detail::stable_sorted_order(keys, column_order, null_precedence, stream, mr);
+  auto sorted_order = detail::stable_sorted_order(
+    keys, column_order, null_precedence, stream, rmm::mr::get_current_device_resource());
 
   return detail::gather(values,
                         sorted_order->view(),

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -223,7 +223,12 @@ endif()
 
 # ##################################################################################################
 # * sort tests ------------------------------------------------------------------------------------
-ConfigureTest(SORT_TEST sort/segmented_sort_tests.cpp sort/sort_test.cpp sort/rank_test.cpp)
+ConfigureTest(
+  SORT_TEST
+  sort/segmented_sort_tests.cpp
+  sort/sort_test.cpp
+  sort/stable_sort_tests.cpp
+  sort/rank_test.cpp)
 
 # ##################################################################################################
 # * copying tests ---------------------------------------------------------------------------------

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -224,11 +224,9 @@ endif()
 # ##################################################################################################
 # * sort tests ------------------------------------------------------------------------------------
 ConfigureTest(
-  SORT_TEST
-  sort/segmented_sort_tests.cpp
-  sort/sort_test.cpp
-  sort/stable_sort_tests.cpp
-  sort/rank_test.cpp)
+  SORT_TEST sort/segmented_sort_tests.cpp sort/sort_test.cpp sort/stable_sort_tests.cpp
+  sort/rank_test.cpp
+)
 
 # ##################################################################################################
 # * copying tests ---------------------------------------------------------------------------------

--- a/cpp/tests/sort/sort_test.cpp
+++ b/cpp/tests/sort/sort_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -616,6 +616,7 @@ TYPED_TEST(Sort, MisMatchInColumnOrderSize)
   EXPECT_THROW(stable_sorted_order(input, column_order), logic_error);
   EXPECT_THROW(sort(input, column_order), logic_error);
   EXPECT_THROW(sort_by_key(input, input, column_order), logic_error);
+  EXPECT_THROW(stable_sort_by_key(input, input, column_order), logic_error);
 }
 
 TYPED_TEST(Sort, MisMatchInNullPrecedenceSize)
@@ -634,6 +635,7 @@ TYPED_TEST(Sort, MisMatchInNullPrecedenceSize)
   EXPECT_THROW(stable_sorted_order(input, column_order, null_precedence), logic_error);
   EXPECT_THROW(sort(input, column_order, null_precedence), logic_error);
   EXPECT_THROW(sort_by_key(input, input, column_order, null_precedence), logic_error);
+  EXPECT_THROW(stable_sort_by_key(input, input, column_order, null_precedence), logic_error);
 }
 
 TYPED_TEST(Sort, ZeroSizedColumns)
@@ -654,10 +656,10 @@ TYPED_TEST(Sort, ZeroSizedColumns)
   run_sort_test(input, expected, column_order);
 }
 
-struct SortByKey : public BaseFixture {
+struct SortByKeyCommon : public BaseFixture {
 };
 
-TEST_F(SortByKey, ValueKeysSizeMismatch)
+TEST_F(SortByKeyCommon, ValueKeysSizeMismatch)
 {
   using T = int64_t;
 
@@ -670,6 +672,7 @@ TEST_F(SortByKey, ValueKeysSizeMismatch)
   table_view keys{{key_col}};
 
   EXPECT_THROW(sort_by_key(values, keys), logic_error);
+  EXPECT_THROW(stable_sort_by_key(values, keys), logic_error);
 }
 
 template <typename T>

--- a/cpp/tests/sort/sort_test.cpp
+++ b/cpp/tests/sort/sort_test.cpp
@@ -584,23 +584,6 @@ TYPED_TEST(Sort, WithStructColumnCombinationsWithoutNulls)
   run_sort_test(input, expected4, column_order2, {null_order::AFTER});
 }
 
-TYPED_TEST(Sort, Stable)
-{
-  using T = TypeParam;
-  using R = int32_t;
-
-  fixed_width_column_wrapper<T> col1({0, 1, 1, 0, 0, 1, 0, 1}, {0, 1, 1, 1, 1, 1, 1, 1});
-  strings_column_wrapper col2({"2", "a", "b", "x", "k", "a", "x", "a"}, {1, 1, 1, 1, 0, 1, 1, 1});
-
-  fixed_width_column_wrapper<R> expected{{4, 3, 6, 1, 5, 7, 2, 0}};
-
-  auto got = stable_sorted_order(table_view({col1, col2}),
-                                 {order::ASCENDING, order::ASCENDING},
-                                 {null_order::AFTER, null_order::BEFORE});
-
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, got->view());
-}
-
 TYPED_TEST(Sort, MisMatchInColumnOrderSize)
 {
   using T = TypeParam;
@@ -613,10 +596,8 @@ TYPED_TEST(Sort, MisMatchInColumnOrderSize)
   std::vector<order> column_order{order::ASCENDING, order::DESCENDING};
 
   EXPECT_THROW(sorted_order(input, column_order), logic_error);
-  EXPECT_THROW(stable_sorted_order(input, column_order), logic_error);
   EXPECT_THROW(sort(input, column_order), logic_error);
   EXPECT_THROW(sort_by_key(input, input, column_order), logic_error);
-  EXPECT_THROW(stable_sort_by_key(input, input, column_order), logic_error);
 }
 
 TYPED_TEST(Sort, MisMatchInNullPrecedenceSize)
@@ -632,10 +613,8 @@ TYPED_TEST(Sort, MisMatchInNullPrecedenceSize)
   std::vector<null_order> null_precedence{null_order::AFTER, null_order::BEFORE};
 
   EXPECT_THROW(sorted_order(input, column_order, null_precedence), logic_error);
-  EXPECT_THROW(stable_sorted_order(input, column_order, null_precedence), logic_error);
   EXPECT_THROW(sort(input, column_order, null_precedence), logic_error);
   EXPECT_THROW(sort_by_key(input, input, column_order, null_precedence), logic_error);
-  EXPECT_THROW(stable_sort_by_key(input, input, column_order, null_precedence), logic_error);
 }
 
 TYPED_TEST(Sort, ZeroSizedColumns)
@@ -656,10 +635,10 @@ TYPED_TEST(Sort, ZeroSizedColumns)
   run_sort_test(input, expected, column_order);
 }
 
-struct SortByKeyCommon : public BaseFixture {
+struct SortByKey : public BaseFixture {
 };
 
-TEST_F(SortByKeyCommon, ValueKeysSizeMismatch)
+TEST_F(SortByKey, ValueKeysSizeMismatch)
 {
   using T = int64_t;
 
@@ -672,7 +651,6 @@ TEST_F(SortByKeyCommon, ValueKeysSizeMismatch)
   table_view keys{{key_col}};
 
   EXPECT_THROW(sort_by_key(values, keys), logic_error);
-  EXPECT_THROW(stable_sort_by_key(values, keys), logic_error);
 }
 
 template <typename T>

--- a/cpp/tests/sort/stable_sort_tests.cpp
+++ b/cpp/tests/sort/stable_sort_tests.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/table_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
+#include <cudf/sorting.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <vector>
+
+namespace cudf {
+namespace test {
+void run_stable_sort_test(table_view input,
+                          column_view expected_sorted_indices,
+                          std::vector<order> column_order         = {},
+                          std::vector<null_order> null_precedence = {})
+{
+  auto got_sort_by_key_table      = sort_by_key(input, input, column_order, null_precedence);
+  auto expected_sort_by_key_table = gather(input, expected_sorted_indices);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_sort_by_key_table->view(), got_sort_by_key_table->view());
+}
+
+using TestTypes = cudf::test::Concat<cudf::test::IntegralTypesNotBool,
+                                     cudf::test::FloatingPointTypes,
+                                     cudf::test::DurationTypes,
+                                     cudf::test::TimestampTypes>;
+
+template <typename T>
+struct StableSort : public BaseFixture {
+};
+
+TYPED_TEST_SUITE(StableSort, TestTypes);
+
+TYPED_TEST(StableSort, WithNullMax)
+{
+  using T = TypeParam;
+
+  fixed_width_column_wrapper<T> col1{{5, 4, 3, 5, 8, 5}, {1, 1, 0, 1, 1, 1}};
+  strings_column_wrapper col2({"d", "e", "a", "d", "k", "d"}, {1, 1, 0, 1, 1, 1});
+  fixed_width_column_wrapper<T> col3{{10, 40, 70, 10, 2, 10}, {1, 1, 0, 1, 1, 1}};
+  table_view input{{col1, col2, col3}};
+
+  fixed_width_column_wrapper<int32_t> expected{{1, 0, 3, 5, 4, 2}};
+  std::vector<order> column_order{order::ASCENDING, order::ASCENDING, order::DESCENDING};
+  std::vector<null_order> null_precedence{null_order::AFTER, null_order::AFTER, null_order::AFTER};
+
+  auto got = stable_sorted_order(input, column_order, null_precedence);
+
+  if (not std::is_same_v<T, bool>) {
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, got->view());
+
+    run_stable_sort_test(input, expected, column_order, null_precedence);
+  } else {
+    // for bools only validate that the null element landed at the back, since
+    // the rest of the values are equivalent and yields random sorted order.
+    auto to_host = [](column_view const& col) {
+      thrust::host_vector<int32_t> h_data(col.size());
+      CUDA_TRY(cudaMemcpy(
+        h_data.data(), col.data<int32_t>(), h_data.size() * sizeof(int32_t), cudaMemcpyDefault));
+      return h_data;
+    };
+    thrust::host_vector<int32_t> h_exp = to_host(expected);
+    thrust::host_vector<int32_t> h_got = to_host(got->view());
+    EXPECT_EQ(h_exp[h_exp.size() - 1], h_got[h_got.size() - 1]);
+
+    fixed_width_column_wrapper<int32_t> expected_for_bool{{0, 3, 5, 1, 4, 2}};
+    run_stable_sort_test(input, expected_for_bool, column_order, null_precedence);
+  }
+}
+
+TYPED_TEST(StableSort, WithNullMin)
+{
+  using T = TypeParam;
+
+  fixed_width_column_wrapper<T> col1{{5, 4, 3, 5, 8}, {1, 1, 0, 1, 1}};
+  strings_column_wrapper col2({"d", "e", "a", "d", "k"}, {1, 1, 0, 1, 1});
+  fixed_width_column_wrapper<T> col3{{10, 40, 70, 10, 2}, {1, 1, 0, 1, 1}};
+  table_view input{{col1, col2, col3}};
+
+  fixed_width_column_wrapper<int32_t> expected{{2, 1, 0, 3, 4}};
+  std::vector<order> column_order{order::ASCENDING, order::ASCENDING, order::DESCENDING};
+
+  auto got = stable_sorted_order(input, column_order);
+
+  if (!std::is_same_v<T, bool>) {
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, got->view());
+
+    run_stable_sort_test(input, expected, column_order);
+  } else {
+    // for bools only validate that the null element landed at the front, since
+    // the rest of the values are equivalent and yields random sorted order.
+    auto to_host = [](column_view const& col) {
+      thrust::host_vector<int32_t> h_data(col.size());
+      CUDA_TRY(cudaMemcpy(
+        h_data.data(), col.data<int32_t>(), h_data.size() * sizeof(int32_t), cudaMemcpyDefault));
+      return h_data;
+    };
+    thrust::host_vector<int32_t> h_exp = to_host(expected);
+    thrust::host_vector<int32_t> h_got = to_host(got->view());
+    EXPECT_EQ(h_exp.front(), h_got.front());
+
+    fixed_width_column_wrapper<int32_t> expected_for_bool{{2, 0, 3, 1, 4}};
+    run_stable_sort_test(input, expected_for_bool, column_order);
+  }
+}
+
+TYPED_TEST(StableSort, WithAllValid)
+{
+  using T = TypeParam;
+
+  fixed_width_column_wrapper<T> col1{{5, 4, 3, 5, 8}};
+  strings_column_wrapper col2({"d", "e", "a", "d", "k"});
+  fixed_width_column_wrapper<T> col3{{10, 40, 70, 10, 2}};
+  table_view input{{col1, col2, col3}};
+
+  fixed_width_column_wrapper<int32_t> expected{{2, 1, 0, 3, 4}};
+  std::vector<order> column_order{order::ASCENDING, order::ASCENDING, order::DESCENDING};
+
+  auto got = stable_sorted_order(input, column_order);
+
+  // Skip validating bools order. Valid true bools are all
+  // equivalent, and yield random order after thrust::sort
+  if (!std::is_same_v<T, bool>) {
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, got->view());
+
+    run_stable_sort_test(input, expected, column_order);
+  } else {
+    fixed_width_column_wrapper<int32_t> expected_for_bool{{2, 0, 3, 1, 4}};
+    run_stable_sort_test(input, expected_for_bool, column_order);
+  }
+}
+
+TYPED_TEST(StableSort, MisMatchInColumnOrderSize)
+{
+  using T = TypeParam;
+
+  fixed_width_column_wrapper<T> col1{{5, 4, 3, 5, 8}};
+  strings_column_wrapper col2({"d", "e", "a", "d", "k"});
+  fixed_width_column_wrapper<T> col3{{10, 40, 70, 5, 2}};
+  table_view input{{col1, col2, col3}};
+
+  std::vector<order> column_order{order::ASCENDING, order::DESCENDING};
+
+  EXPECT_THROW(stable_sorted_order(input, column_order), logic_error);
+  EXPECT_THROW(stable_sort_by_key(input, input, column_order), logic_error);
+}
+
+TYPED_TEST(StableSort, MisMatchInNullPrecedenceSize)
+{
+  using T = TypeParam;
+
+  fixed_width_column_wrapper<T> col1{{5, 4, 3, 5, 8}};
+  strings_column_wrapper col2({"d", "e", "a", "d", "k"});
+  fixed_width_column_wrapper<T> col3{{10, 40, 70, 5, 2}};
+  table_view input{{col1, col2, col3}};
+
+  std::vector<order> column_order{order::ASCENDING, order::DESCENDING, order::DESCENDING};
+  std::vector<null_order> null_precedence{null_order::AFTER, null_order::BEFORE};
+
+  EXPECT_THROW(stable_sorted_order(input, column_order, null_precedence), logic_error);
+  EXPECT_THROW(stable_sort_by_key(input, input, column_order, null_precedence), logic_error);
+}
+
+TYPED_TEST(StableSort, ZeroSizedColumns)
+{
+  using T = TypeParam;
+
+  fixed_width_column_wrapper<T> col1{};
+  table_view input{{col1}};
+
+  fixed_width_column_wrapper<int32_t> expected{};
+  std::vector<order> column_order{order::ASCENDING};
+
+  auto got = stable_sorted_order(input, column_order);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, got->view());
+
+  run_stable_sort_test(input, expected, column_order);
+}
+
+struct StableSortByKey : public BaseFixture {
+};
+
+TEST_F(StableSortByKey, ValueKeysSizeMismatch)
+{
+  using T = int64_t;
+
+  fixed_width_column_wrapper<T> col1{{5, 4, 3, 5, 8}};
+  strings_column_wrapper col2({"d", "e", "a", "d", "k"});
+  fixed_width_column_wrapper<T> col3{{10, 40, 70, 5, 2}};
+  table_view values{{col1, col2, col3}};
+
+  fixed_width_column_wrapper<T> key_col{{5, 4, 3, 5}};
+  table_view keys{{key_col}};
+
+  EXPECT_THROW(stable_sort_by_key(values, keys), logic_error);
+}
+
+}  // namespace test
+}  // namespace cudf

--- a/cpp/tests/sort/stable_sort_tests.cpp
+++ b/cpp/tests/sort/stable_sort_tests.cpp
@@ -54,6 +54,23 @@ struct StableSort : public BaseFixture {
 
 TYPED_TEST_SUITE(StableSort, TestTypes);
 
+TYPED_TEST(StableSort, MixedNullOrder)
+{
+  using T = TypeParam;
+  using R = int32_t;
+
+  fixed_width_column_wrapper<T> col1({0, 1, 1, 0, 0, 1, 0, 1}, {0, 1, 1, 1, 1, 1, 1, 1});
+  strings_column_wrapper col2({"2", "a", "b", "x", "k", "a", "x", "a"}, {1, 1, 1, 1, 0, 1, 1, 1});
+
+  fixed_width_column_wrapper<R> expected{{4, 3, 6, 1, 5, 7, 2, 0}};
+
+  auto got = stable_sorted_order(table_view({col1, col2}),
+                                 {order::ASCENDING, order::ASCENDING},
+                                 {null_order::AFTER, null_order::BEFORE});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, got->view());
+}
+
 TYPED_TEST(StableSort, WithNullMax)
 {
   using T = TypeParam;

--- a/cpp/tests/sort/stable_sort_tests.cpp
+++ b/cpp/tests/sort/stable_sort_tests.cpp
@@ -20,14 +20,12 @@
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
-#include <cudf/utilities/type_dispatcher.hpp>
 
+#include <type_traits>
 #include <vector>
 
 namespace cudf {
@@ -43,10 +41,8 @@ void run_stable_sort_test(table_view input,
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected_sort_by_key_table->view(), got_sort_by_key_table->view());
 }
 
-using TestTypes = cudf::test::Concat<cudf::test::IntegralTypesNotBool,
-                                     cudf::test::FloatingPointTypes,
-                                     cudf::test::DurationTypes,
-                                     cudf::test::TimestampTypes>;
+using TestTypes = cudf::test::Concat<cudf::test::NumericTypes,  // include integers, floats and bool
+                                     cudf::test::ChronoTypes>;  // include timestamps and durations
 
 template <typename T>
 struct StableSort : public BaseFixture {


### PR DESCRIPTION
This PR adds a new `stable_sort_by_key` API into libcudf. The new API is helpful to simplify Cython/JNI bindings of `drop_duplicates` (https://github.com/rapidsai/cudf/pull/10370).