### PR TITLE
Limiting async allocator using alignment of 512

### DIFF
--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -356,8 +356,10 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(JNIEnv *env, j
     } else if (use_cuda_async_alloc) {
       // Use `limiting_resource_adaptor` to set a hard limit on the max pool size since
       // `cuda_async_memory_resource` only has a release threshold.
+      auto const alignment = 512;  // Async allocator aligns to 512.
       Initialized_resource = rmm::mr::make_owning_wrapper<rmm::mr::limiting_resource_adaptor>(
-          std::make_shared<rmm::mr::cuda_async_memory_resource>(pool_size, pool_size), pool_size);
+          std::make_shared<rmm::mr::cuda_async_memory_resource>(pool_size, pool_size), pool_size,
+          alignment);
     } else if (use_managed_mem) {
       Initialized_resource = std::make_shared<rmm::mr::managed_memory_resource>();
     } else {

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -356,7 +356,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_initializeInternal(JNIEnv *env, j
     } else if (use_cuda_async_alloc) {
       // Use `limiting_resource_adaptor` to set a hard limit on the max pool size since
       // `cuda_async_memory_resource` only has a release threshold.
-      auto const alignment = 512;  // Async allocator aligns to 512.
+      auto const alignment = 512; // Async allocator aligns to 512.
       Initialized_resource = rmm::mr::make_owning_wrapper<rmm::mr::limiting_resource_adaptor>(
           std::make_shared<rmm::mr::cuda_async_memory_resource>(pool_size, pool_size), pool_size,
           alignment);


### PR DESCRIPTION
We use the `limiting_resource_adaptor` in front of the async allocator to track the total size of allocations and trigger spills. By default the adaptor aligns to 256, but the async allocator internally aligns to 512. This causes the limiting adaptor to under count allocation sizes, leading to OOMs in the async allocator. This PR changes the limiting adaptor to also use 512. This seems to help with a customer query that we were seeing OOMs before.

Note that CUDA is planning to switch back to 256 in the future so this may need to be revisited.

Fixes #10384 