### PR TITLE
Fix error thrown in compiled-binaryop benchmark

### DIFF
--- a/cpp/benchmarks/binaryop/compiled_binaryop.cpp
+++ b/cpp/benchmarks/binaryop/compiled_binaryop.cpp
@@ -28,11 +28,12 @@ void BM_compiled_binaryop(benchmark::State& state, cudf::binary_operator binop)
 {
   auto const column_size{static_cast<cudf::size_type>(state.range(0))};
 
-  auto const source_table = create_sequence_table(
+  auto const source_table = create_random_table(
     {cudf::type_to_id<TypeLhs>(), cudf::type_to_id<TypeRhs>()}, row_count{column_size});
 
-  auto lhs          = cudf::column_view(source_table->get_column(0));
-  auto rhs          = cudf::column_view(source_table->get_column(1));
+  auto lhs = cudf::column_view(source_table->get_column(0));
+  auto rhs = cudf::column_view(source_table->get_column(1));
+
   auto output_dtype = cudf::data_type(cudf::type_to_id<TypeOut>());
 
   // Call once for hot cache.


### PR DESCRIPTION
Fixes `BINARYOP_BENCH` which is throwing an error for non-numeric types:
```
terminate called after throwing an instance of 'cudf::logic_error'
  what():  cuDF failure at: /cudf/cpp/src/filling/sequence.cu:139: init scalar type must be numeric
```

The `compiled_binaryop.cpp` was recently changed in #10300 to create test columns using the benchmark utility `create_sequence_table` which internally calls `cudf::sequence` API. Unfortunately, [only `numeric` types can be used with this API](https://github.com/rapidsai/cudf/blob/a9b6cb113bcacecd0752d2957971c0d417cf719e/cpp/src/filling/sequence.cu#L139) which throws an error for types like `timestamp, duration, and decimal` which are being measured in this file. https://docs.rapids.ai/api/libcudf/stable/group__transformation__fill.html#gaeda630c9dcdd152eeecf0a1b636244ac

The fix replaces the `create_sequence_table` call with `create_random_table` to generate the source columns instead.