### PR TITLE
Set column names in `_from_columns_like_self` factory

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1320,7 +1320,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         ]
         result = self._from_columns_like_self(
             libcudf.copying.columns_slice(columns_to_slice, [start, stop])[0],
-            [*self._column_names],
+            self._column_names,
             None if is_range_index else self._index.names,
         )
 
@@ -6065,7 +6065,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
     def _from_columns_like_self(
         self,
         columns: List[ColumnBase],
-        column_names: List[str],
+        column_names: Iterable[str],
         index_names: Optional[List[str]] = None,
     ) -> DataFrame:
         result = super()._from_columns_like_self(

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable, Sequence
 from typing import (
     Any,
     Dict,
+    List,
     MutableMapping,
     Optional,
     Set,
@@ -1319,13 +1320,12 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         ]
         result = self._from_columns_like_self(
             libcudf.copying.columns_slice(columns_to_slice, [start, stop])[0],
-            self._column_names,
+            [*self._column_names],
             None if is_range_index else self._index.names,
         )
 
         if is_range_index:
             result.index = self.index[start:stop]
-        result._set_column_names_like(self)
         return result
 
     @annotate("DATAFRAME_MEMORY_USAGE", color="blue", domain="cudf_python")
@@ -6060,6 +6060,18 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         if ignore_index:
             result.reset_index(drop=True)
 
+        return result
+
+    def _from_columns_like_self(
+        self,
+        columns: List[ColumnBase],
+        column_names: List[str],
+        index_names: Optional[List[str]] = None,
+    ) -> DataFrame:
+        result = super()._from_columns_like_self(
+            columns, column_names, index_names
+        )
+        result._set_column_names_like(self)
         return result
 
 

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -200,7 +200,7 @@ class Frame(BinaryOperand, Scannable):
     def _from_columns(
         cls,
         columns: List[ColumnBase],
-        column_names: List[str],
+        column_names: abc.Iterable[str],
         index_names: Optional[List[str]] = None,
     ):
         """Construct a `Frame` object from a list of columns.
@@ -233,7 +233,7 @@ class Frame(BinaryOperand, Scannable):
     def _from_columns_like_self(
         self,
         columns: List[ColumnBase],
-        column_names: List[str],
+        column_names: abc.Iterable[str],
         index_names: Optional[List[str]] = None,
     ):
         """Construct a `Frame` from a list of columns with metadata from self.


### PR DESCRIPTION
A quick fix to set column names in the `_from_columns_like_self` factory. Since dataframe column names are slightly more complex than simple Frame, this fix makes sure column name metadata (such as multi level names) are properly copied to the result dataframe.

Addresses this comment: https://github.com/rapidsai/cudf/pull/10315#issuecomment-1049285506