### PR TITLE
Use str instead of builtins.str.

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import builtins
 import pickle
 import warnings
 from functools import cached_property
@@ -621,7 +620,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
     def fillna(
         self: T,
         value: Any = None,
-        method: builtins.str = None,
+        method: str = None,
         dtype: Dtype = None,
     ) -> T:
         """Fill null values with ``value``.
@@ -810,7 +809,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
         )
 
     def get_slice_bound(
-        self, label: ScalarLike, side: builtins.str, kind: builtins.str
+        self, label: ScalarLike, side: str, kind: str
     ) -> int:
         """
         Calculate slice bound that corresponds to given label.
@@ -846,7 +845,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
     def sort_by_values(
         self: ColumnBase,
         ascending: bool = True,
-        na_position: builtins.str = "last",
+        na_position: str = "last",
     ) -> Tuple[ColumnBase, "cudf.core.column.NumericalColumn"]:
         col_inds = self.as_frame()._get_sorted_inds(
             ascending=ascending, na_position=na_position
@@ -855,7 +854,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
         return col_keys, col_inds
 
     def distinct_count(
-        self, method: builtins.str = "sort", dropna: bool = True
+        self, method: str = "sort", dropna: bool = True
     ) -> int:
         if method != "sort":
             msg = "non sort based distinct_count() not implemented yet"
@@ -1013,7 +1012,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
         )
 
     def argsort(
-        self, ascending: bool = True, na_position: builtins.str = "last"
+        self, ascending: bool = True, na_position: str = "last"
     ) -> ColumnBase:
 
         return self.as_frame()._get_sorted_inds(
@@ -1089,9 +1088,9 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
     def searchsorted(
         self,
         value,
-        side: builtins.str = "left",
+        side: str = "left",
         ascending: bool = True,
-        na_position: builtins.str = "last",
+        na_position: str = "last",
     ):
         values = as_column(value).as_frame()
         return self.as_frame().searchsorted(
@@ -1140,13 +1139,13 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
             data=data, dtype=dtype, mask=mask, size=header.get("size", None)
         )
 
-    def unary_operator(self, unaryop: builtins.str):
+    def unary_operator(self, unaryop: str):
         raise TypeError(
             f"Operation {unaryop} not supported for dtype {self.dtype}."
         )
 
     def binary_operator(
-        self, op: builtins.str, other: BinaryOperand, reflect: bool = False
+        self, op: str, other: BinaryOperand, reflect: bool = False
     ) -> ColumnBase:
         raise TypeError(
             f"Operation {op} not supported between dtypes {self.dtype} and "

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -618,10 +618,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
                 raise ValueError(msg)
 
     def fillna(
-        self: T,
-        value: Any = None,
-        method: str = None,
-        dtype: Dtype = None,
+        self: T, value: Any = None, method: str = None, dtype: Dtype = None,
     ) -> T:
         """Fill null values with ``value``.
 
@@ -808,9 +805,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
             ascending=[False], null_position=None
         )
 
-    def get_slice_bound(
-        self, label: ScalarLike, side: str, kind: str
-    ) -> int:
+    def get_slice_bound(self, label: ScalarLike, side: str, kind: str) -> int:
         """
         Calculate slice bound that corresponds to given label.
         Returns leftmost (one-past-the-rightmost if ``side=='right'``) position
@@ -843,9 +838,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
             raise ValueError(f"Invalid value for side: {side}")
 
     def sort_by_values(
-        self: ColumnBase,
-        ascending: bool = True,
-        na_position: str = "last",
+        self: ColumnBase, ascending: bool = True, na_position: str = "last",
     ) -> Tuple[ColumnBase, "cudf.core.column.NumericalColumn"]:
         col_inds = self.as_frame()._get_sorted_inds(
             ascending=ascending, na_position=na_position
@@ -853,9 +846,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
         col_keys = self.take(col_inds)
         return col_keys, col_inds
 
-    def distinct_count(
-        self, method: str = "sort", dropna: bool = True
-    ) -> int:
+    def distinct_count(self, method: str = "sort", dropna: bool = True) -> int:
         if method != "sort":
             msg = "non sort based distinct_count() not implemented yet"
             raise NotImplementedError(msg)

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import builtins
 import datetime as dt
 import locale
 import re
@@ -277,7 +276,7 @@ class DatetimeColumn(column.ColumnBase):
         )
 
     @property
-    def __cuda_array_interface__(self) -> Mapping[builtins.str, Any]:
+    def __cuda_array_interface__(self) -> Mapping[str, Any]:
         output = {
             "shape": (len(self),),
             "strides": (self.dtype.itemsize,),

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import builtins
 import pickle
 import re
 import warnings
@@ -5400,7 +5399,7 @@ class StringColumn(column.ColumnBase):
     def fillna(
         self,
         fill_value: Any = None,
-        method: builtins.str = None,
+        method: str = None,
         dtype: Dtype = None,
     ) -> StringColumn:
         if fill_value is not None:
@@ -5450,7 +5449,7 @@ class StringColumn(column.ColumnBase):
             raise TypeError(f"cannot broadcast {type(other)}")
 
     def binary_operator(
-        self, op: builtins.str, rhs, reflect: bool = False
+        self, op: str, rhs, reflect: bool = False
     ) -> "column.ColumnBase":
         lhs = self
         if reflect:

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5397,10 +5397,7 @@ class StringColumn(column.ColumnBase):
         return libcudf.replace.replace(res, df._data["old"], df._data["new"])
 
     def fillna(
-        self,
-        fill_value: Any = None,
-        method: str = None,
-        dtype: Dtype = None,
+        self, fill_value: Any = None, method: str = None, dtype: Dtype = None,
     ) -> StringColumn:
         if fill_value is not None:
             if not is_scalar(fill_value):

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import builtins
 import copy
 import pickle
 import warnings
@@ -6328,14 +6327,14 @@ class Frame(BinaryOperand, Scannable):
             other=other, op="__ge__", fill_value=fill_value, can_reindex=True
         )
 
-    def nunique(self, method: builtins.str = "sort", dropna: bool = True):
+    def nunique(self, method: str = "sort", dropna: bool = True):
         """
         Returns a per column mapping with counts of unique values for
         each column.
 
         Parameters
         ----------
-        method : builtins.str, default "sort"
+        method : str, default "sort"
             Method used by cpp_distinct_count
         dropna : bool, default True
             Don't include NaN in the counts.

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import builtins
 from typing import (
     Any,
     Dict,
@@ -361,13 +360,13 @@ class SingleColumnFrame(Frame, NotIterable):
         return {result_name: (self._column, other, reflect, fill_value)}
 
     @_cudf_nvtx_annotate
-    def nunique(self, method: builtins.str = "sort", dropna: bool = True):
+    def nunique(self, method: str = "sort", dropna: bool = True):
         """
         Return count of unique values for the column.
 
         Parameters
         ----------
-        method : builtins.str, default "sort"
+        method : str, default "sort"
             Method used by cpp_distinct_count
         dropna : bool, default True
             Don't include NaN in the counts.


### PR DESCRIPTION
This fixes an unnecessary import. `str` is equivalent to `builtins.str`, so we don't need to `import builtins`.