### PR TITLE
Drop unsupported method argument from nunique and distinct_count.

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -846,10 +846,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
         col_keys = self.take(col_inds)
         return col_keys, col_inds
 
-    def distinct_count(self, method: str = "sort", dropna: bool = True) -> int:
-        if method != "sort":
-            msg = "non sort based distinct_count() not implemented yet"
-            raise NotImplementedError(msg)
+    def distinct_count(self, dropna: bool = True) -> int:
         try:
             return self._distinct_count[dropna]
         except KeyError:

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -6020,7 +6020,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         if axis != 0:
             raise NotImplementedError("axis parameter is not supported yet.")
 
-        return cudf.Series(super().nunique(method="sort", dropna=dropna))
+        return cudf.Series(super().nunique(dropna=dropna))
 
     def _sample_axis_1(
         self,

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -6327,15 +6327,13 @@ class Frame(BinaryOperand, Scannable):
             other=other, op="__ge__", fill_value=fill_value, can_reindex=True
         )
 
-    def nunique(self, method: str = "sort", dropna: bool = True):
+    def nunique(self, dropna: bool = True):
         """
         Returns a per column mapping with counts of unique values for
         each column.
 
         Parameters
         ----------
-        method : str, default "sort"
-            Method used by cpp_distinct_count
         dropna : bool, default True
             Don't include NaN in the counts.
 
@@ -6345,7 +6343,7 @@ class Frame(BinaryOperand, Scannable):
             Name and unique value counts of each column in frame.
         """
         return {
-            name: col.distinct_count(method=method, dropna=dropna)
+            name: col.distinct_count(dropna=dropna)
             for name, col in self._data.items()
         }
 

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -360,14 +360,12 @@ class SingleColumnFrame(Frame, NotIterable):
         return {result_name: (self._column, other, reflect, fill_value)}
 
     @_cudf_nvtx_annotate
-    def nunique(self, method: str = "sort", dropna: bool = True):
+    def nunique(self, dropna: bool = True):
         """
         Return count of unique values for the column.
 
         Parameters
         ----------
-        method : str, default "sort"
-            Method used by cpp_distinct_count
         dropna : bool, default True
             Don't include NaN in the counts.
 
@@ -378,4 +376,4 @@ class SingleColumnFrame(Frame, NotIterable):
         """
         if self._column.null_count == len(self):
             return 0
-        return self._column.distinct_count(method=method, dropna=dropna)
+        return self._column.distinct_count(dropna=dropna)


### PR DESCRIPTION
The APIs `DataFrame.nunique`, `Series.nunique`, and `ColumnBase.distinct_count` have a `method` argument. The pandas API for `nunique` [does not have a `method` argument](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.nunique.html). This `method` argument was meant to distinguish distinct counts computed by sort/hash approaches, but there are two issues: only `"sort"` is supported as an input value, and the algorithm in libcudf actually uses a _hash-based approach_. To resolve this inconsistency and align with the pandas API, I have removed the `method` parameter from `DataFrame.nunique`, `Series.nunique`, and `ColumnBase.distinct_count`.

This is a breaking change but I don't think a deprecation is needed. The `nunique` feature was added in 22.04 via #10077, so it has not yet been released. The internal changes to `distinct_count` can be made without a deprecation.