### PR TITLE
Clean up null mask after purging null entries

### DIFF
--- a/cpp/src/groupby/sort/group_collect.cu
+++ b/cpp/src/groupby/sort/group_collect.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/groupby/sort/group_collect.cu
+++ b/cpp/src/groupby/sort/group_collect.cu
@@ -57,6 +57,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
     cudf::detail::copy_if(table_view{{values}}, not_null_pred, stream, mr)->release();
 
   auto null_purged_values = std::move(null_purged_entries.front());
+  null_purged_values->set_null_mask(rmm::device_buffer{0, stream, mr}, 0);
 
   // Recalculate offsets after null entries are purged.
   rmm::device_uvector<size_type> null_purged_sizes(num_groups, stream);


### PR DESCRIPTION
After puring null entries via copy_if, the null mask of the input column will be preversed, despite it is useless. We can clean up the unused null mask to save some device memory.