### PR TITLE
Fix benchmarks to work with new aggregation types

### DIFF
--- a/cpp/benchmarks/reduction/anyall.cpp
+++ b/cpp/benchmarks/reduction/anyall.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/anyall.cpp
+++ b/cpp/benchmarks/reduction/anyall.cpp
@@ -28,7 +28,8 @@ class Reduction : public cudf::benchmark {
 };
 
 template <typename type>
-void BM_reduction_anyall(benchmark::State& state, std::unique_ptr<cudf::aggregation> const& agg)
+void BM_reduction_anyall(benchmark::State& state,
+                         std::unique_ptr<cudf::reduce_aggregation> const& agg)
 {
   const cudf::size_type column_size{static_cast<cudf::size_type>(state.range(0))};
 
@@ -48,7 +49,7 @@ void BM_reduction_anyall(benchmark::State& state, std::unique_ptr<cudf::aggregat
 }
 
 #define concat(a, b, c) a##b##c
-#define get_agg(op)     concat(cudf::make_, op, _aggregation())
+#define get_agg(op)     concat(cudf::make_, op, _aggregation<cudf::reduce_aggregation>())
 
 // TYPE, OP
 #define RBM_BENCHMARK_DEFINE(name, type, aggregation)             \

--- a/cpp/benchmarks/reduction/dictionary.cpp
+++ b/cpp/benchmarks/reduction/dictionary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/dictionary.cpp
+++ b/cpp/benchmarks/reduction/dictionary.cpp
@@ -28,7 +28,8 @@ class ReductionDictionary : public cudf::benchmark {
 };
 
 template <typename T>
-void BM_reduction_dictionary(benchmark::State& state, std::unique_ptr<cudf::aggregation> const& agg)
+void BM_reduction_dictionary(benchmark::State& state,
+                             std::unique_ptr<cudf::reduce_aggregation> const& agg)
 {
   const cudf::size_type column_size{static_cast<cudf::size_type>(state.range(0))};
 
@@ -53,7 +54,7 @@ void BM_reduction_dictionary(benchmark::State& state, std::unique_ptr<cudf::aggr
 }
 
 #define concat(a, b, c) a##b##c
-#define get_agg(op)     concat(cudf::make_, op, _aggregation())
+#define get_agg(op)     concat(cudf::make_, op, _aggregation<cudf::reduce_aggregation>())
 
 // TYPE, OP
 #define RBM_BENCHMARK_DEFINE(name, type, aggregation)                       \

--- a/cpp/benchmarks/reduction/reduce.cpp
+++ b/cpp/benchmarks/reduction/reduce.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/reduce.cpp
+++ b/cpp/benchmarks/reduction/reduce.cpp
@@ -30,7 +30,7 @@ class Reduction : public cudf::benchmark {
 };
 
 template <typename type>
-void BM_reduction(benchmark::State& state, std::unique_ptr<cudf::aggregation> const& agg)
+void BM_reduction(benchmark::State& state, std::unique_ptr<cudf::reduce_aggregation> const& agg)
 {
   const cudf::size_type column_size{(cudf::size_type)state.range(0)};
 
@@ -54,7 +54,7 @@ void BM_reduction(benchmark::State& state, std::unique_ptr<cudf::aggregation> co
 }
 
 #define concat(a, b, c) a##b##c
-#define get_agg(op)     concat(cudf::make_, op, _aggregation())
+#define get_agg(op)     concat(cudf::make_, op, _aggregation<cudf::reduce_aggregation>())
 
 // TYPE, OP
 #define RBM_BENCHMARK_DEFINE(name, type, aggregation)             \

--- a/cpp/benchmarks/reduction/scan.cpp
+++ b/cpp/benchmarks/reduction/scan.cpp
@@ -39,7 +39,8 @@ static void BM_reduction_scan(benchmark::State& state, bool include_nulls)
 
   for (auto _ : state) {
     cuda_event_timer timer(state, true);
-    auto result = cudf::scan(input, cudf::make_min_aggregation(), cudf::scan_type::INCLUSIVE);
+    auto result = cudf::scan(
+      input, cudf::make_min_aggregation<cudf::scan_aggregation>(), cudf::scan_type::INCLUSIVE);
   }
 }
 


### PR DESCRIPTION
Fixes benchmarks compile errors introduced by #10357 

Example:
```
/cudf/cpp/benchmarks/reduction/reduce.cpp: In function ‘void BM_reduction(benchmark::State&, const std::unique_ptr<cudf::aggregation>&)’:
/cudf/cpp/benchmarks/reduction/reduce.cpp:52:46: error: invalid initialization of reference of type ‘const std::unique_ptr<cudf::reduce_aggregation>&’ from expression of type ‘const std::unique_ptr<cudf::aggregation>’
   52 |     auto result = cudf::reduce(input_column, agg, output_dtype);
```

Aggregation types for reduce and scan were modified to include template types.