### PR TITLE
[REVIEW] Fix error in `cudf.to_numeric` when a `bool` input is passed

### DIFF
--- a/python/cudf/cudf/core/tools/numeric.py
+++ b/python/cudf/cudf/core/tools/numeric.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 import warnings
 
@@ -19,6 +19,17 @@ from cudf.api.types import (
 )
 from cudf.core.column import as_column
 from cudf.utils.dtypes import can_convert_to_column
+
+DOWNCAST_TYPE_MAP = {
+    "integer": list(np.typecodes["Integer"]),
+    "signed": list(np.typecodes["Integer"]),
+    "unsigned": list(np.typecodes["UnsignedInteger"]),
+}
+float_types = list(np.typecodes["Float"])
+# we only support float32 & float64
+min_idx = float_types.index(cudf.dtype(np.float32).char)
+max_idx = float_types.index(cudf.dtype(np.float64).char) + 1
+DOWNCAST_TYPE_MAP["float"] = float_types[min_idx:max_idx]
 
 
 def to_numeric(arg, errors="raise", downcast=None):
@@ -144,16 +155,7 @@ def to_numeric(arg, errors="raise", downcast=None):
         col = col.as_numerical_column("d")
 
     if downcast:
-        downcast_type_map = {
-            "integer": list(np.typecodes["Integer"]),
-            "signed": list(np.typecodes["Integer"]),
-            "unsigned": list(np.typecodes["UnsignedInteger"]),
-        }
-        float_types = list(np.typecodes["Float"])
-        idx = float_types.index(cudf.dtype(np.float32).char)
-        downcast_type_map["float"] = float_types[idx:]
-
-        type_set = downcast_type_map[downcast]
+        type_set = DOWNCAST_TYPE_MAP[downcast]
 
         for t in type_set:
             downcast_dtype = cudf.dtype(t)

--- a/python/cudf/cudf/core/tools/numeric.py
+++ b/python/cudf/cudf/core/tools/numeric.py
@@ -20,17 +20,6 @@ from cudf.api.types import (
 from cudf.core.column import as_column
 from cudf.utils.dtypes import can_convert_to_column
 
-DOWNCAST_TYPE_MAP = {
-    "integer": list(np.typecodes["Integer"]),
-    "signed": list(np.typecodes["Integer"]),
-    "unsigned": list(np.typecodes["UnsignedInteger"]),
-}
-float_types = list(np.typecodes["Float"])
-# we only support float32 & float64
-min_idx = float_types.index(cudf.dtype(np.float32).char)
-max_idx = float_types.index(cudf.dtype(np.float64).char) + 1
-DOWNCAST_TYPE_MAP["float"] = float_types[min_idx:max_idx]
-
 
 def to_numeric(arg, errors="raise", downcast=None):
     """
@@ -155,7 +144,16 @@ def to_numeric(arg, errors="raise", downcast=None):
         col = col.as_numerical_column("d")
 
     if downcast:
-        type_set = DOWNCAST_TYPE_MAP[downcast]
+        if downcast == "float":
+            # we support only float32 & float64
+            type_set = [
+                cudf.dtype(np.float32).char,
+                cudf.dtype(np.float64).char,
+            ]
+        elif downcast in ("integer", "signed"):
+            type_set = list(np.typecodes["Integer"])
+        elif downcast == "unsigned":
+            type_set = list(np.typecodes["UnsignedInteger"])
 
         for t in type_set:
             downcast_dtype = cudf.dtype(t)

--- a/python/cudf/cudf/tests/test_numerical.py
+++ b/python/cudf/cudf/tests/test_numerical.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 
 import numpy as np
 import pandas as pd
@@ -396,4 +396,20 @@ def test_series_construction_with_nulls(dtype, input_obj):
 
     expect = pd.Series(np_data, dtype=np_dtypes_to_pandas_dtypes[dtype])
     got = cudf.Series(np_data, dtype=dtype).to_pandas(nullable=True)
+    assert_eq(expect, got)
+
+
+@pytest.mark.parametrize(
+    "data", [[True, False, True]],
+)
+@pytest.mark.parametrize(
+    "downcast", ["signed", "integer", "unsigned", "float"]
+)
+def test_series_to_numeric_bool(data, downcast):
+    ps = pd.Series(data)
+    gs = cudf.from_pandas(ps)
+
+    expect = pd.to_numeric(ps, downcast=downcast)
+    got = cudf.to_numeric(gs, downcast=downcast)
+
     assert_eq(expect, got)


### PR DESCRIPTION
Fixes: #10049 

This PR fixes an incorrect error being displayed when `cudf.to_numeric` is called by passing an input with `bool` dtype. Technically `bool` is the lowest `dtype` size possible in `numpy` so this is a no-op because `to_numeric` is aimed at downcasting inputs.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
