### PR TITLE
Fix for integer overflow in contiguous-split

### DIFF
--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -821,7 +821,7 @@ void copy_data(int num_bufs,
     chunks.begin(),
     [desired_chunk_size] __device__(dst_buf_info const& buf) -> thrust::pair<size_t, size_t> {
       // Total bytes for this incoming partition
-      size_t const bytes = buf.num_elements * buf.element_size;
+      size_t const bytes = static_cast<size_t>(buf.num_elements) * static_cast<size_t>(buf.element_size);
 
       // This clause handles nested data types (e.g. list or string) that store no data in the roow
       // columns, only in their children.

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -820,8 +820,8 @@ void copy_data(int num_bufs,
     _d_dst_buf_info,
     _d_dst_buf_info + num_bufs,
     chunks.begin(),
-    [desired_chunk_size] __device__(dst_buf_info const& buf) ->
-      thrust::pair<std::size_t, std::size_t> {
+    [desired_chunk_size] __device__(
+      dst_buf_info const& buf) -> thrust::pair<std::size_t, std::size_t> {
       // Total bytes for this incoming partition
       std::size_t const bytes =
         static_cast<std::size_t>(buf.num_elements) * static_cast<std::size_t>(buf.element_size);

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -821,7 +821,8 @@ void copy_data(int num_bufs,
     chunks.begin(),
     [desired_chunk_size] __device__(dst_buf_info const& buf) -> thrust::pair<size_t, size_t> {
       // Total bytes for this incoming partition
-      size_t const bytes = static_cast<size_t>(buf.num_elements) * static_cast<size_t>(buf.element_size);
+      size_t const bytes =
+        static_cast<size_t>(buf.num_elements) * static_cast<size_t>(buf.element_size);
 
       // This clause handles nested data types (e.g. list or string) that store no data in the roow
       // columns, only in their children.

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -1357,6 +1357,15 @@ TEST_F(ContiguousSplitUntypedTest, ValidityEdgeCase)
   }
 }
 
+TEST_F(ContiguousSplitUntypedTest, CalculationOverflow)
+{
+  // tests an edge case where buf.elements * buf.element_size overflows an INT32.
+  auto col = cudf::make_fixed_width_column(
+    cudf::data_type{cudf::type_id::INT64}, 400 * 1024 * 1024, cudf::mask_state::UNALLOCATED);
+  auto result = cudf::contiguous_split(cudf::table_view{{*col}}, {});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*col, result[0].table.column(0));
+}
+
 // contiguous split with strings
 struct ContiguousSplitStringTableTest : public SplitTest<std::string> {
 };


### PR DESCRIPTION
This is a fix for an integer overflow in `contiguous_split.cu::copy_data`. 

We encountered this problem when running a large query with the spark-rapids plug-in.  The plug-in OOM callback was reporting negative numbers for some failed allocations.  It treats the allocation size as a `long`.   The allocations were coming from `contiguous_split` with a large number of rows (399,000,000) of type `UINT64`.

With help from @nvdbaranec, I was able to isolate the problem to this line:
```
size_t const bytes = buf.num_elements * buf.element_size;
```

The two operands are both `INT32`.  So the result of the multiply is being sign-extended when assigning to `bytes`.

The fix is to cast these to `size_t` before the multiply.
