### PR TITLE
Update dask_cudf imports to be compatible with latest dask

### DIFF
--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -6,7 +6,6 @@ import cupy as cp
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-
 from pandas.api.types import is_scalar
 
 from dask.dataframe.core import get_parallel_type, meta_nonempty
@@ -26,8 +25,8 @@ from dask.dataframe.utils import (
     _scalar_from_dtype,
     make_meta_obj,
 )
-from dask.utils import is_arraylike
 from dask.sizeof import sizeof as sizeof_dispatch
+from dask.utils import is_arraylike
 
 import cudf
 from cudf.api.types import is_string_dtype

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -7,6 +7,8 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
+from pandas.api.types import is_scalar
+
 from dask.dataframe.core import get_parallel_type, meta_nonempty
 from dask.dataframe.dispatch import (
     categorical_dtype_dispatch,
@@ -22,10 +24,9 @@ from dask.dataframe.utils import (
     UNKNOWN_CATEGORIES,
     _nonempty_scalar,
     _scalar_from_dtype,
-    is_arraylike,
-    is_scalar,
     make_meta_obj,
 )
+from dask.utils import is_arraylike
 from dask.sizeof import sizeof as sizeof_dispatch
 
 import cudf


### PR DESCRIPTION
Updated imports to be compatible with latest dask after https://github.com/dask/dask/pull/8796
This change is also compatible with dask versions prior to the above dask PR.

Tested `import dask_cudf` with both dask `2022.02.2a220314` and `2022.02.2a220315`.