### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/docs/cudf/source/api_docs/general_functions.rst
+++ b/docs/cudf/source/api_docs/general_functions.rst
@@ -10,8 +10,9 @@ Data manipulations
    :toctree: api/
 
    cudf.concat
-   cudf.melt
+   cudf.cut
    cudf.get_dummies
+   cudf.melt
    cudf.merge_sorted
    cudf.pivot
    cudf.unstack


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.