### PR TITLE
Include <cstddef> to fix compilation of parquet reader on GCC 11.

### DIFF
--- a/cpp/include/cudf/table/experimental/row_operators.cuh
+++ b/cpp/include/cudf/table/experimental/row_operators.cuh
@@ -34,6 +34,7 @@
 
 #include <limits>
 #include <memory>
+#include <optional>
 #include <utility>
 
 namespace cudf {

--- a/cpp/src/io/parquet/compact_protocol_reader.hpp
+++ b/cpp/src/io/parquet/compact_protocol_reader.hpp
@@ -19,6 +19,7 @@
 #include "parquet.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Includes `<cstddef>` for `ptrdiff_t` in `parquet/compact_protocol_reader.hpp`. Compilation fails on GCC 11 without this include. Targeting 22.04 since this was broken yesterday in #10063.

Error output:
```
cudf/cpp/src/io/parquet/compact_protocol_reader.hpp:51:17: error: 'ptrdiff_t' does not name a type
   51 |   [[nodiscard]] ptrdiff_t bytecount() const noexcept { return m_cur - m_base; }
      |
cudf/cpp/src/io/parquet/compact_protocol_reader.hpp:22:1: note: 'ptrdiff_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
```

Also includes `<optional>` in `cpp/include/cudf/table/experimental/row_operators.cuh`, which was broken by #10164.
