### PR TITLE
Fix findall_record to return empty list for no matches

### DIFF
--- a/cpp/doxygen/regex.md
+++ b/cpp/doxygen/regex.md
@@ -6,7 +6,9 @@ This page specifies which regular expression (regex) features are currently supp
 - cudf::strings::matches_re()
 - cudf::strings::count_re()
 - cudf::strings::extract()
-- cudf::strings::findall_re()
+- cudf::strings::extract_all_record()
+- cudf::strings::findall()
+- cudf::strings::findall_record()
 - cudf::strings::replace_re()
 - cudf::strings::replace_with_backrefs()
 

--- a/cpp/include/cudf/strings/findall.hpp
+++ b/cpp/include/cudf/strings/findall.hpp
@@ -72,11 +72,10 @@ std::unique_ptr<table> findall(
  *  [ ["b"]
  *    ["a","b","b"]
  *    ["a"]
- *    null ]
+ *    [] ]
  * @endcode
  *
- * A null output row results if the pattern is not found in the corresponding row
- * input string.
+ * A null output row occurs if the corresponding input row is null.
  *
  * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
  *

--- a/cpp/include/cudf/strings/findall.hpp
+++ b/cpp/include/cudf/strings/findall.hpp
@@ -64,10 +64,13 @@ std::unique_ptr<table> findall(
  * @brief Returns a lists column of strings for each matching occurrence of the
  * regex pattern within each string.
  *
+ * Each output row includes all the substrings within the corresponding input row
+ * that match the given pattern. If no matches are found, the output row is empty.
+ *
  * @code{.pseudo}
  * Example:
  * s = ["bunny", "rabbit", "hare", "dog"]
- * r = findall_record(s, "[ab]"")
+ * r = findall_record(s, "[ab]")
  * r is now a lists column like:
  *  [ ["b"]
  *    ["a","b","b"]

--- a/cpp/src/strings/search/findall_record.cu
+++ b/cpp/src/strings/search/findall_record.cu
@@ -117,26 +117,6 @@ std::unique_ptr<column> findall_record(
   auto offsets   = count_matches(*d_strings, *d_prog, stream, mr);
   auto d_offsets = offsets->mutable_view().data<offset_type>();
 
-  // Compute null output rows
-  auto [null_mask, null_count] = cudf::detail::valid_if(
-    d_offsets,
-    d_offsets + strings_count,
-    [] __device__(auto const v) { return v > 0; },
-    stream,
-    mr);
-
-  auto const valid_count = strings_count - null_count;
-  // Return an empty lists column if there are no valid rows
-  if (valid_count == 0) {
-    return make_lists_column(0,
-                             make_empty_column(type_to_id<offset_type>()),
-                             make_empty_column(type_id::STRING),
-                             0,
-                             rmm::device_buffer{},
-                             stream,
-                             mr);
-  }
-
   // Convert counts into offsets
   thrust::exclusive_scan(
     rmm::exec_policy(stream), d_offsets, d_offsets + strings_count + 1, d_offsets);
@@ -152,8 +132,8 @@ std::unique_ptr<column> findall_record(
   return make_lists_column(strings_count,
                            std::move(offsets),
                            std::move(strings_output),
-                           null_count,
-                           std::move(null_mask),
+                           input.null_count(),
+                           cudf::detail::copy_bitmask(input.parent(), stream, mr),
                            stream,
                            mr);
 }

--- a/cpp/tests/strings/findall_tests.cpp
+++ b/cpp/tests/strings/findall_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/strings/findall_tests.cpp
+++ b/cpp/tests/strings/findall_tests.cpp
@@ -77,14 +77,14 @@ TEST_F(StringsFindallTests, FindallTest)
 
 TEST_F(StringsFindallTests, FindallRecord)
 {
+  bool valids[] = {1, 1, 1, 1, 1, 0, 1, 1};
   cudf::test::strings_column_wrapper input(
     {"3-A", "4-May 5-Day 6-Hay", "12-Dec-2021-Jan", "Feb-March", "4 ABC", "", "", "25-9000-Hal"},
-    {1, 1, 1, 1, 1, 0, 1, 1});
+    valids);
 
   auto results = cudf::strings::findall_record(cudf::strings_column_view(input), "(\\d+)-(\\w+)");
 
-  bool valids[] = {1, 1, 1, 0, 0, 0, 0, 1};
-  using LCW     = cudf::test::lists_column_wrapper<cudf::string_view>;
+  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
   LCW expected({LCW{"3-A"},
                 LCW{"4-May", "5-Day", "6-Hay"},
                 LCW{"12-Dec", "2021-Jan"},
@@ -94,7 +94,7 @@ TEST_F(StringsFindallTests, FindallRecord)
                 LCW{},
                 LCW{"25-9000"}},
                valids);
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
 }
 
 TEST_F(StringsFindallTests, Multiline)
@@ -108,15 +108,14 @@ TEST_F(StringsFindallTests, Multiline)
       cudf::test::strings_column_wrapper({"abc", "abc", "abc", "", "abc"}, {1, 1, 1, 0, 1});
     auto col1     = cudf::test::strings_column_wrapper({"abc", "", "", "", ""}, {1, 0, 0, 0, 0});
     auto expected = cudf::table_view({col0, col1});
-    CUDF_TEST_EXPECT_TABLES_EQUAL(results->view(), expected);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(results->view(), expected);
   }
   {
     auto results =
       cudf::strings::findall_record(view, "(^abc$)", cudf::strings::regex_flags::MULTILINE);
-    bool valids[] = {1, 1, 1, 0, 1};
-    using LCW     = cudf::test::lists_column_wrapper<cudf::string_view>;
-    LCW expected({LCW{"abc", "abc"}, LCW{"abc"}, LCW{"abc"}, LCW{}, LCW{"abc"}}, valids);
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+    LCW expected({LCW{"abc", "abc"}, LCW{"abc"}, LCW{"abc"}, LCW{}, LCW{"abc"}});
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
   }
 }
 
@@ -130,15 +129,14 @@ TEST_F(StringsFindallTests, DotAll)
     auto col0 =
       cudf::test::strings_column_wrapper({"bc\nfa\nef", "bbc\nfff", "bcdef", ""}, {1, 1, 1, 0});
     auto expected = cudf::table_view({col0});
-    CUDF_TEST_EXPECT_TABLES_EQUAL(results->view(), expected);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(results->view(), expected);
   }
   {
     auto results =
       cudf::strings::findall_record(view, "(b.*f)", cudf::strings::regex_flags::DOTALL);
-    bool valids[] = {1, 1, 1, 0};
-    using LCW     = cudf::test::lists_column_wrapper<cudf::string_view>;
-    LCW expected({LCW{"bc\nfa\nef"}, LCW{"bbc\nfff"}, LCW{"bcdef"}, LCW{}}, valids);
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+    using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+    LCW expected({LCW{"bc\nfa\nef"}, LCW{"bbc\nfff"}, LCW{"bcdef"}, LCW{}});
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
   }
 }
 


### PR DESCRIPTION
Closes #10458 

Change the behavior of `cudf::strings::findall_record` to return an empty row when the search results in no matches for the corresponding input strings row. The previous behavior was returning a null row when no matches are found.