### PR TITLE
Define proper binary operation APIs for columns

### DIFF
--- a/python/cudf/cudf/_lib/binaryop.pyx
+++ b/python/cudf/cudf/_lib/binaryop.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 
 from enum import IntEnum
 
@@ -160,6 +160,10 @@ def binaryop(lhs, rhs, op, dtype):
     """
     Dispatches a binary op call to the appropriate libcudf function:
     """
+    # TODO: Shouldn't have to keep special-casing. We need to define a separate
+    # pipeline for libcudf binops that don't map to Python binops.
+    if op != "NULL_EQUALS":
+        op = op[2:-2]
 
     op = BinaryOperation[op.upper()]
     cdef binary_operator c_op = <binary_operator> (

--- a/python/cudf/cudf/_lib/datetime.pyx
+++ b/python/cudf/cudf/_lib/datetime.pyx
@@ -1,3 +1,5 @@
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
@@ -57,7 +59,7 @@ def extract_datetime_component(Column col, object field):
     if field == "weekday":
         # Pandas counts Monday-Sunday as 0-6
         # while we count Monday-Sunday as 1-7
-        result = result.binary_operator("sub", result.dtype.type(1))
+        result = result - result.dtype.type(1)
 
     return result
 

--- a/python/cudf/cudf/_lib/datetime.pyx
+++ b/python/cudf/cudf/_lib/datetime.pyx
@@ -58,7 +58,7 @@ def extract_datetime_component(Column col, object field):
 
     if field == "weekday":
         # Pandas counts Monday-Sunday as 0-6
-        # while we count Monday-Sunday as 1-7
+        # while libcudf counts Monday-Sunday as 1-7
         result = result - result.dtype.type(1)
 
     return result

--- a/python/cudf/cudf/_typing.py
+++ b/python/cudf/cudf/_typing.py
@@ -25,7 +25,7 @@ ScalarLike = Any
 ColumnLike = Any
 
 # binary operation
-BinaryOperand = Union["cudf.Scalar", "cudf.core.column.ColumnBase"]
+ColumnBinaryOperand = Union["cudf.Scalar", "cudf.core.column.ColumnBase"]
 
 DataFrameOrSeries = Union["cudf.Series", "cudf.DataFrame"]
 SeriesOrIndex = Union["cudf.Series", "cudf.core.index.BaseIndex"]

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -630,6 +630,14 @@ class CategoricalColumn(column.ColumnBase):
     dtype: cudf.core.dtypes.CategoricalDtype
     _codes: Optional[NumericalColumn]
     _children: Tuple[NumericalColumn]
+    _VALID_BINARY_OPERATIONS = {
+        "__eq__",
+        "__ne__",
+        "__lt__",
+        "__le__",
+        "__gt__",
+        "__ge__",
+    }
 
     def __init__(
         self,
@@ -876,19 +884,6 @@ class CategoricalColumn(column.ColumnBase):
         )
 
     def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
-        if op not in {
-            "__eq__",
-            "__ne__",
-            "__lt__",
-            "__le__",
-            "__gt__",
-            "__ge__",
-            "NULL_EQUALS",
-        }:
-            raise TypeError(
-                "Series of dtype `category` cannot perform the operation: "
-                f"{op}"
-            )
         other = self._wrap_binop_normalization(other)
         # TODO: This is currently just here to make mypy happy, but eventually
         # we'll need to properly establish the APIs for these methods.

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -900,10 +900,7 @@ class CategoricalColumn(column.ColumnBase):
     def normalize_binop_value(self, other: ScalarLike) -> CategoricalColumn:
         if isinstance(other, column.ColumnBase):
             if not isinstance(other, CategoricalColumn):
-                raise ValueError(
-                    "Binary operations with categorical columns require both "
-                    "columns to be categorical."
-                )
+                return NotImplemented
             if other.dtype != self.dtype:
                 raise TypeError(
                     "Categoricals can only compare with the same type"

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -906,8 +906,6 @@ class CategoricalColumn(column.ColumnBase):
                     "Categoricals can only compare with the same type"
                 )
             return other
-        if isinstance(other, np.ndarray) and other.ndim == 0:
-            other = other.item()
 
         ary = cudf.utils.utils.scalar_broadcast_to(
             self._encode(other), size=len(self), dtype=self.codes.dtype

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -24,7 +24,7 @@ from numba import cuda
 import cudf
 from cudf import _lib as libcudf
 from cudf._lib.transform import bools_to_mask
-from cudf._typing import ColumnLike, Dtype, ScalarLike
+from cudf._typing import ColumnBinaryOperand, ColumnLike, Dtype, ScalarLike
 from cudf.api.types import is_categorical_dtype, is_interval_dtype
 from cudf.core.buffer import Buffer
 from cudf.core.column import column
@@ -875,8 +875,8 @@ class CategoricalColumn(column.ColumnBase):
             offset=codes.offset,
         )
 
-    def binary_operator(
-        self, op: str, rhs, reflect: bool = False
+    def _binaryop(
+        self, op: str, rhs: ColumnBinaryOperand, reflect: bool = False
     ) -> ColumnBase:
         if op not in {"eq", "ne", "lt", "le", "gt", "ge", "NULL_EQUALS"}:
             raise TypeError(
@@ -894,7 +894,7 @@ class CategoricalColumn(column.ColumnBase):
                 "The only binary operations supported by unordered "
                 "categorical columns are equality and inequality."
             )
-        return self.as_numerical.binary_operator(op, rhs.as_numerical)
+        return self.as_numerical._binaryop(op, rhs.as_numerical)
 
     def normalize_binop_value(self, other: ScalarLike) -> CategoricalColumn:
         if isinstance(other, column.ColumnBase):

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -875,9 +875,7 @@ class CategoricalColumn(column.ColumnBase):
             offset=codes.offset,
         )
 
-    def _binaryop(
-        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
-    ) -> ColumnBase:
+    def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
         if op not in {
             "__eq__",
             "__ne__",

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -878,7 +878,15 @@ class CategoricalColumn(column.ColumnBase):
     def _binaryop(
         self, op: str, other: ColumnBinaryOperand, reflect: bool = False
     ) -> ColumnBase:
-        if op not in {"eq", "ne", "lt", "le", "gt", "ge", "NULL_EQUALS"}:
+        if op not in {
+            "__eq__",
+            "__ne__",
+            "__lt__",
+            "__le__",
+            "__gt__",
+            "__ge__",
+            "NULL_EQUALS",
+        }:
             raise TypeError(
                 "Series of dtype `category` cannot perform the operation: "
                 f"{op}"
@@ -889,7 +897,7 @@ class CategoricalColumn(column.ColumnBase):
         if not isinstance(other, CategoricalColumn):
             raise ValueError
         # Note: at this stage we are guaranteed that the dtypes are equal.
-        if not self.ordered and op not in {"eq", "ne", "NULL_EQUALS"}:
+        if not self.ordered and op not in {"__eq__", "__ne__", "NULL_EQUALS"}:
             raise TypeError(
                 "The only binary operations supported by unordered "
                 "categorical columns are equality and inequality."

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -876,17 +876,17 @@ class CategoricalColumn(column.ColumnBase):
         )
 
     def _binaryop(
-        self, op: str, rhs: ColumnBinaryOperand, reflect: bool = False
+        self, op: str, other: ColumnBinaryOperand, reflect: bool = False
     ) -> ColumnBase:
         if op not in {"eq", "ne", "lt", "le", "gt", "ge", "NULL_EQUALS"}:
             raise TypeError(
                 "Series of dtype `category` cannot perform the operation: "
                 f"{op}"
             )
-        rhs = self._wrap_binop_normalization(rhs)
+        other = self._wrap_binop_normalization(other)
         # TODO: This is currently just here to make mypy happy, but eventually
         # we'll need to properly establish the APIs for these methods.
-        if not isinstance(rhs, CategoricalColumn):
+        if not isinstance(other, CategoricalColumn):
             raise ValueError
         # Note: at this stage we are guaranteed that the dtypes are equal.
         if not self.ordered and op not in {"eq", "ne", "NULL_EQUALS"}:
@@ -894,7 +894,7 @@ class CategoricalColumn(column.ColumnBase):
                 "The only binary operations supported by unordered "
                 "categorical columns are equality and inequality."
             )
-        return self.as_numerical._binaryop(op, rhs.as_numerical)
+        return self.as_numerical._binaryop(op, other.as_numerical)
 
     def normalize_binop_value(self, other: ScalarLike) -> CategoricalColumn:
         if isinstance(other, column.ColumnBase):

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -876,7 +876,7 @@ class CategoricalColumn(column.ColumnBase):
         )
 
     def _binaryop(
-        self, op: str, other: ColumnBinaryOperand, reflect: bool = False
+        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
     ) -> ColumnBase:
         if op not in {
             "__eq__",
@@ -902,7 +902,7 @@ class CategoricalColumn(column.ColumnBase):
                 "The only binary operations supported by unordered "
                 "categorical columns are equality and inequality."
             )
-        return self.as_numerical._binaryop(op, other.as_numerical)
+        return self.as_numerical._binaryop(other.as_numerical, op)
 
     def normalize_binop_value(self, other: ScalarLike) -> CategoricalColumn:
         if isinstance(other, column.ColumnBase):

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -185,7 +185,10 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
             return False
         if check_dtypes and (self.dtype != other.dtype):
             return False
-        return self._binaryop(other, "NULL_EQUALS").all()
+        ret = self._binaryop(other, "NULL_EQUALS")
+        if ret is NotImplemented:
+            raise TypeError
+        return ret.all()
 
     def all(self, skipna: bool = True) -> bool:
         # The skipna argument is only used for numerical columns.

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -526,6 +526,8 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
     def _wrap_binop_normalization(self, other):
         if other is cudf.NA or other is None:
             return cudf.Scalar(other, dtype=self.dtype)
+        if isinstance(other, np.ndarray) and other.ndim == 0:
+            other = other.item()
         return self.normalize_binop_value(other)
 
     def _scatter_by_slice(

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -93,7 +93,6 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
         "max",
         "min",
     }
-    _VALID_BINARY_OPERATIONS = BinaryOperand._SUPPORTED_BINARY_OPERATIONS
 
     def as_frame(self) -> "cudf.core.frame.Frame":
         """

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -68,7 +68,7 @@ from cudf.core.dtypes import (
     ListDtype,
     StructDtype,
 )
-from cudf.core.mixins import Reducible
+from cudf.core.mixins import BinaryOperand, Reducible
 from cudf.utils import utils
 from cudf.utils.dtypes import (
     cudf_dtype_from_pa_type,
@@ -86,13 +86,14 @@ T = TypeVar("T", bound="ColumnBase")
 Slice = TypeVar("Slice", bound=slice)
 
 
-class ColumnBase(Column, Serializable, Reducible, NotIterable):
+class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
     _VALID_REDUCTIONS = {
         "any",
         "all",
         "max",
         "min",
     }
+    _VALID_BINARY_OPERATIONS = BinaryOperand._SUPPORTED_BINARY_OPERATIONS
 
     def as_frame(self) -> "cudf.core.frame.Frame":
         """
@@ -1029,84 +1030,6 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
             "`__cuda_array_interface__`"
         )
 
-    def __add__(self, other):
-        return self._binaryop(other, "__add__")
-
-    def __sub__(self, other):
-        return self._binaryop(other, "__sub__")
-
-    def __mul__(self, other):
-        return self._binaryop(other, "__mul__")
-
-    def __or__(self, other):
-        return self._binaryop(other, "__or__")
-
-    def __xor__(self, other):
-        return self._binaryop(other, "__xor__")
-
-    def __and__(self, other):
-        return self._binaryop(other, "__and__")
-
-    def __floordiv__(self, other):
-        return self._binaryop(other, "__floordiv__")
-
-    def __truediv__(self, other):
-        return self._binaryop(other, "__truediv__")
-
-    def __mod__(self, other):
-        return self._binaryop(other, "__mod__")
-
-    def __pow__(self, other):
-        return self._binaryop(other, "__pow__")
-
-    def __radd__(self, other):
-        return self._binaryop(other, "__add__", reflect=True)
-
-    def __rsub__(self, other):
-        return self._binaryop(other, "__sub__", reflect=True)
-
-    def __rmul__(self, other):
-        return self._binaryop(other, "__mul__", reflect=True)
-
-    def __ror__(self, other):
-        return self._binaryop(other, "__or__", reflect=True)
-
-    def __rxor__(self, other):
-        return self._binaryop(other, "__xor__", reflect=True)
-
-    def __rand__(self, other):
-        return self._binaryop(other, "__and__", reflect=True)
-
-    def __rfloordiv__(self, other):
-        return self._binaryop(other, "__floordiv__", reflect=True)
-
-    def __rtruediv__(self, other):
-        return self._binaryop(other, "__truediv__", reflect=True)
-
-    def __rmod__(self, other):
-        return self._binaryop(other, "__mod__", reflect=True)
-
-    def __rpow__(self, other):
-        return self._binaryop(other, "__pow__", reflect=True)
-
-    def __eq__(self, other):
-        return self._binaryop(other, "__eq__")
-
-    def __ne__(self, other):
-        return self._binaryop(other, "__ne__")
-
-    def __lt__(self, other):
-        return self._binaryop(other, "__lt__")
-
-    def __gt__(self, other):
-        return self._binaryop(other, "__gt__")
-
-    def __le__(self, other):
-        return self._binaryop(other, "__le__")
-
-    def __ge__(self, other):
-        return self._binaryop(other, "__ge__")
-
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         return _array_ufunc(self, ufunc, method, inputs, kwargs)
 
@@ -1169,9 +1092,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
             f"Operation {unaryop} not supported for dtype {self.dtype}."
         )
 
-    def _binaryop(
-        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
-    ) -> ColumnBase:
+    def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
         raise TypeError(
             f"Operation {op} not supported between dtypes {self.dtype} and "
             f"{other.dtype}."

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -41,7 +41,7 @@ from cudf._lib.stream_compaction import (
     drop_nulls,
 )
 from cudf._lib.transform import bools_to_mask
-from cudf._typing import ColumnBinaryOperand, ColumnLike, Dtype, ScalarLike
+from cudf._typing import ColumnLike, Dtype, ScalarLike
 from cudf.api.types import (
     _is_non_decimal_numeric_dtype,
     _is_scalar_or_zero_d_array,
@@ -1090,12 +1090,6 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
     def unary_operator(self, unaryop: str):
         raise TypeError(
             f"Operation {unaryop} not supported for dtype {self.dtype}."
-        )
-
-    def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
-        raise TypeError(
-            f"Operation {op} not supported between dtypes {self.dtype} and "
-            f"{other.dtype}."
         )
 
     def normalize_binop_value(

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -78,55 +78,12 @@ from cudf.utils.dtypes import (
     pandas_dtypes_alias_to_cudf_alias,
     pandas_dtypes_to_np_dtypes,
 )
-from cudf.utils.utils import NotIterable, mask_dtype
+from cudf.utils.utils import NotIterable, _array_ufunc, mask_dtype
 
 T = TypeVar("T", bound="ColumnBase")
 # TODO: This workaround allows type hints for `slice`, since `slice` is a
 # method in ColumnBase.
 Slice = TypeVar("Slice", bound=slice)
-
-
-# Mapping from ufuncs to the corresponding binary operators.
-_ufunc_binary_operations = {
-    # Arithmetic binary operations.
-    "add": "add",
-    "subtract": "sub",
-    "multiply": "mul",
-    "matmul": "matmul",
-    "divide": "truediv",
-    "true_divide": "truediv",
-    "floor_divide": "floordiv",
-    "power": "pow",
-    "float_power": "pow",
-    "remainder": "mod",
-    "mod": "mod",
-    "fmod": "mod",
-    # Bitwise binary operations.
-    "bitwise_and": "and",
-    "bitwise_or": "or",
-    "bitwise_xor": "xor",
-    # Comparison binary operators
-    "greater": "gt",
-    "greater_equal": "ge",
-    "less": "lt",
-    "less_equal": "le",
-    "not_equal": "ne",
-    "equal": "eq",
-}
-
-# These operators need to be mapped to their inverses when performing a
-# reflected ufunc operation because no reflected version of the operators
-# themselves exist. When these operators are invoked directly (not via
-# __array_ufunc__) Python takes care of calling the inverse operation.
-_ops_without_reflection = {
-    "gt": "lt",
-    "ge": "le",
-    "lt": "gt",
-    "le": "ge",
-    # ne and eq are symmetric, so they are their own inverse op
-    "ne": "ne",
-    "eq": "eq",
-}
 
 
 class ColumnBase(Column, Serializable, Reducible, NotIterable):
@@ -1150,45 +1107,8 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
     def __ge__(self, other):
         return self.binary_operator("ge", other)
 
-    # TODO: Share this logic with Frame if possible (the implementation is
-    # identical at this point).
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        # We don't currently support reduction, accumulation, etc. We also
-        # don't support any special kwargs or higher arity ufuncs than binary.
-        if method != "__call__" or kwargs or ufunc.nin > 2:
-            return NotImplemented
-
-        fname = ufunc.__name__
-        if fname in _ufunc_binary_operations:
-            reflect = self is not inputs[0]
-            other = inputs[0] if reflect else inputs[1]
-
-            op = _ufunc_binary_operations[fname]
-            if reflect and op in _ops_without_reflection:
-                op = _ops_without_reflection[op]
-                reflect = False
-            op = f"__{'r' if reflect else ''}{op}__"
-
-            # Float_power returns float irrespective of the input type.
-            if fname == "float_power":
-                return getattr(self, op)(other).astype(float)
-            return getattr(self, op)(other)
-
-        # Special handling for various unary operations.
-        if fname == "negative":
-            return self * -1
-        if fname == "positive":
-            return self.copy(deep=True)
-        if fname == "invert":
-            return ~self
-        if fname == "absolute":
-            # TODO: Implement the abs operator properly.
-            return self.unary_operator("abs")
-        if fname == "fabs":
-            return self.unary_operator("abs").astype(np.float64)
-
-        # None is a sentinel used by subclasses to trigger cupy dispatch.
-        return None
+        return _array_ufunc(self, ufunc, method, inputs, kwargs)
 
     def searchsorted(
         self,

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -86,6 +86,49 @@ T = TypeVar("T", bound="ColumnBase")
 Slice = TypeVar("Slice", bound=slice)
 
 
+# Mapping from ufuncs to the corresponding binary operators.
+_ufunc_binary_operations = {
+    # Arithmetic binary operations.
+    "add": "add",
+    "subtract": "sub",
+    "multiply": "mul",
+    "matmul": "matmul",
+    "divide": "truediv",
+    "true_divide": "truediv",
+    "floor_divide": "floordiv",
+    "power": "pow",
+    "float_power": "pow",
+    "remainder": "mod",
+    "mod": "mod",
+    "fmod": "mod",
+    # Bitwise binary operations.
+    "bitwise_and": "and",
+    "bitwise_or": "or",
+    "bitwise_xor": "xor",
+    # Comparison binary operators
+    "greater": "gt",
+    "greater_equal": "ge",
+    "less": "lt",
+    "less_equal": "le",
+    "not_equal": "ne",
+    "equal": "eq",
+}
+
+# These operators need to be mapped to their inverses when performing a
+# reflected ufunc operation because no reflected version of the operators
+# themselves exist. When these operators are invoked directly (not via
+# __array_ufunc__) Python takes care of calling the inverse operation.
+_ops_without_reflection = {
+    "gt": "lt",
+    "ge": "le",
+    "lt": "gt",
+    "le": "ge",
+    # ne and eq are symmetric, so they are their own inverse op
+    "ne": "ne",
+    "eq": "eq",
+}
+
+
 class ColumnBase(Column, Serializable, Reducible, NotIterable):
     _VALID_REDUCTIONS = {
         "any",
@@ -1038,14 +1081,11 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
     def __mul__(self, other):
         return self.binary_operator("mul", other)
 
-    def __eq__(self, other):
-        return self.binary_operator("eq", other)
-
-    def __ne__(self, other):
-        return self.binary_operator("ne", other)
-
     def __or__(self, other):
         return self.binary_operator("or", other)
+
+    def __xor__(self, other):
+        return self.binary_operator("xor", other)
 
     def __and__(self, other):
         return self.binary_operator("and", other)
@@ -1062,6 +1102,42 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
     def __pow__(self, other):
         return self.binary_operator("pow", other)
 
+    def __radd__(self, other):
+        return self.binary_operator("add", other, reflect=True)
+
+    def __rsub__(self, other):
+        return self.binary_operator("sub", other, reflect=True)
+
+    def __rmul__(self, other):
+        return self.binary_operator("mul", other, reflect=True)
+
+    def __ror__(self, other):
+        return self.binary_operator("or", other, reflect=True)
+
+    def __rxor__(self, other):
+        return self.binary_operator("xor", other, reflect=True)
+
+    def __rand__(self, other):
+        return self.binary_operator("and", other, reflect=True)
+
+    def __rfloordiv__(self, other):
+        return self.binary_operator("floordiv", other, reflect=True)
+
+    def __rtruediv__(self, other):
+        return self.binary_operator("truediv", other, reflect=True)
+
+    def __rmod__(self, other):
+        return self.binary_operator("mod", other, reflect=True)
+
+    def __rpow__(self, other):
+        return self.binary_operator("pow", other, reflect=True)
+
+    def __eq__(self, other):
+        return self.binary_operator("eq", other)
+
+    def __ne__(self, other):
+        return self.binary_operator("ne", other)
+
     def __lt__(self, other):
         return self.binary_operator("lt", other)
 
@@ -1073,6 +1149,46 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
 
     def __ge__(self, other):
         return self.binary_operator("ge", other)
+
+    # TODO: Share this logic with Frame if possible (the implementation is
+    # identical at this point).
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        # We don't currently support reduction, accumulation, etc. We also
+        # don't support any special kwargs or higher arity ufuncs than binary.
+        if method != "__call__" or kwargs or ufunc.nin > 2:
+            return NotImplemented
+
+        fname = ufunc.__name__
+        if fname in _ufunc_binary_operations:
+            reflect = self is not inputs[0]
+            other = inputs[0] if reflect else inputs[1]
+
+            op = _ufunc_binary_operations[fname]
+            if reflect and op in _ops_without_reflection:
+                op = _ops_without_reflection[op]
+                reflect = False
+            op = f"__{'r' if reflect else ''}{op}__"
+
+            # Float_power returns float irrespective of the input type.
+            if fname == "float_power":
+                return getattr(self, op)(other).astype(float)
+            return getattr(self, op)(other)
+
+        # Special handling for various unary operations.
+        if fname == "negative":
+            return self * -1
+        if fname == "positive":
+            return self.copy(deep=True)
+        if fname == "invert":
+            return ~self
+        if fname == "absolute":
+            # TODO: Implement the abs operator properly.
+            return self.unary_operator("abs")
+        if fname == "fabs":
+            return self.unary_operator("abs").astype(np.float64)
+
+        # None is a sentinel used by subclasses to trigger cupy dispatch.
+        return None
 
     def searchsorted(
         self,

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1030,82 +1030,82 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
         )
 
     def __add__(self, other):
-        return self._binaryop("add", other)
+        return self._binaryop("__add__", other)
 
     def __sub__(self, other):
-        return self._binaryop("sub", other)
+        return self._binaryop("__sub__", other)
 
     def __mul__(self, other):
-        return self._binaryop("mul", other)
+        return self._binaryop("__mul__", other)
 
     def __or__(self, other):
-        return self._binaryop("or", other)
+        return self._binaryop("__or__", other)
 
     def __xor__(self, other):
-        return self._binaryop("xor", other)
+        return self._binaryop("__xor__", other)
 
     def __and__(self, other):
-        return self._binaryop("and", other)
+        return self._binaryop("__and__", other)
 
     def __floordiv__(self, other):
-        return self._binaryop("floordiv", other)
+        return self._binaryop("__floordiv__", other)
 
     def __truediv__(self, other):
-        return self._binaryop("truediv", other)
+        return self._binaryop("__truediv__", other)
 
     def __mod__(self, other):
-        return self._binaryop("mod", other)
+        return self._binaryop("__mod__", other)
 
     def __pow__(self, other):
-        return self._binaryop("pow", other)
+        return self._binaryop("__pow__", other)
 
     def __radd__(self, other):
-        return self._binaryop("add", other, reflect=True)
+        return self._binaryop("__add__", other, reflect=True)
 
     def __rsub__(self, other):
-        return self._binaryop("sub", other, reflect=True)
+        return self._binaryop("__sub__", other, reflect=True)
 
     def __rmul__(self, other):
-        return self._binaryop("mul", other, reflect=True)
+        return self._binaryop("__mul__", other, reflect=True)
 
     def __ror__(self, other):
-        return self._binaryop("or", other, reflect=True)
+        return self._binaryop("__or__", other, reflect=True)
 
     def __rxor__(self, other):
-        return self._binaryop("xor", other, reflect=True)
+        return self._binaryop("__xor__", other, reflect=True)
 
     def __rand__(self, other):
-        return self._binaryop("and", other, reflect=True)
+        return self._binaryop("__and__", other, reflect=True)
 
     def __rfloordiv__(self, other):
-        return self._binaryop("floordiv", other, reflect=True)
+        return self._binaryop("__floordiv__", other, reflect=True)
 
     def __rtruediv__(self, other):
-        return self._binaryop("truediv", other, reflect=True)
+        return self._binaryop("__truediv__", other, reflect=True)
 
     def __rmod__(self, other):
-        return self._binaryop("mod", other, reflect=True)
+        return self._binaryop("__mod__", other, reflect=True)
 
     def __rpow__(self, other):
-        return self._binaryop("pow", other, reflect=True)
+        return self._binaryop("__pow__", other, reflect=True)
 
     def __eq__(self, other):
-        return self._binaryop("eq", other)
+        return self._binaryop("__eq__", other)
 
     def __ne__(self, other):
-        return self._binaryop("ne", other)
+        return self._binaryop("__ne__", other)
 
     def __lt__(self, other):
-        return self._binaryop("lt", other)
+        return self._binaryop("__lt__", other)
 
     def __gt__(self, other):
-        return self._binaryop("gt", other)
+        return self._binaryop("__gt__", other)
 
     def __le__(self, other):
-        return self._binaryop("le", other)
+        return self._binaryop("__le__", other)
 
     def __ge__(self, other):
-        return self._binaryop("ge", other)
+        return self._binaryop("__ge__", other)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         return _array_ufunc(self, ufunc, method, inputs, kwargs)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -185,7 +185,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
             return False
         if check_dtypes and (self.dtype != other.dtype):
             return False
-        return self._binaryop("NULL_EQUALS", other).all()
+        return self._binaryop(other, "NULL_EQUALS").all()
 
     def all(self, skipna: bool = True) -> bool:
         # The skipna argument is only used for numerical columns.
@@ -1030,82 +1030,82 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
         )
 
     def __add__(self, other):
-        return self._binaryop("__add__", other)
+        return self._binaryop(other, "__add__")
 
     def __sub__(self, other):
-        return self._binaryop("__sub__", other)
+        return self._binaryop(other, "__sub__")
 
     def __mul__(self, other):
-        return self._binaryop("__mul__", other)
+        return self._binaryop(other, "__mul__")
 
     def __or__(self, other):
-        return self._binaryop("__or__", other)
+        return self._binaryop(other, "__or__")
 
     def __xor__(self, other):
-        return self._binaryop("__xor__", other)
+        return self._binaryop(other, "__xor__")
 
     def __and__(self, other):
-        return self._binaryop("__and__", other)
+        return self._binaryop(other, "__and__")
 
     def __floordiv__(self, other):
-        return self._binaryop("__floordiv__", other)
+        return self._binaryop(other, "__floordiv__")
 
     def __truediv__(self, other):
-        return self._binaryop("__truediv__", other)
+        return self._binaryop(other, "__truediv__")
 
     def __mod__(self, other):
-        return self._binaryop("__mod__", other)
+        return self._binaryop(other, "__mod__")
 
     def __pow__(self, other):
-        return self._binaryop("__pow__", other)
+        return self._binaryop(other, "__pow__")
 
     def __radd__(self, other):
-        return self._binaryop("__add__", other, reflect=True)
+        return self._binaryop(other, "__add__", reflect=True)
 
     def __rsub__(self, other):
-        return self._binaryop("__sub__", other, reflect=True)
+        return self._binaryop(other, "__sub__", reflect=True)
 
     def __rmul__(self, other):
-        return self._binaryop("__mul__", other, reflect=True)
+        return self._binaryop(other, "__mul__", reflect=True)
 
     def __ror__(self, other):
-        return self._binaryop("__or__", other, reflect=True)
+        return self._binaryop(other, "__or__", reflect=True)
 
     def __rxor__(self, other):
-        return self._binaryop("__xor__", other, reflect=True)
+        return self._binaryop(other, "__xor__", reflect=True)
 
     def __rand__(self, other):
-        return self._binaryop("__and__", other, reflect=True)
+        return self._binaryop(other, "__and__", reflect=True)
 
     def __rfloordiv__(self, other):
-        return self._binaryop("__floordiv__", other, reflect=True)
+        return self._binaryop(other, "__floordiv__", reflect=True)
 
     def __rtruediv__(self, other):
-        return self._binaryop("__truediv__", other, reflect=True)
+        return self._binaryop(other, "__truediv__", reflect=True)
 
     def __rmod__(self, other):
-        return self._binaryop("__mod__", other, reflect=True)
+        return self._binaryop(other, "__mod__", reflect=True)
 
     def __rpow__(self, other):
-        return self._binaryop("__pow__", other, reflect=True)
+        return self._binaryop(other, "__pow__", reflect=True)
 
     def __eq__(self, other):
-        return self._binaryop("__eq__", other)
+        return self._binaryop(other, "__eq__")
 
     def __ne__(self, other):
-        return self._binaryop("__ne__", other)
+        return self._binaryop(other, "__ne__")
 
     def __lt__(self, other):
-        return self._binaryop("__lt__", other)
+        return self._binaryop(other, "__lt__")
 
     def __gt__(self, other):
-        return self._binaryop("__gt__", other)
+        return self._binaryop(other, "__gt__")
 
     def __le__(self, other):
-        return self._binaryop("__le__", other)
+        return self._binaryop(other, "__le__")
 
     def __ge__(self, other):
-        return self._binaryop("__ge__", other)
+        return self._binaryop(other, "__ge__")
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         return _array_ufunc(self, ufunc, method, inputs, kwargs)
@@ -1170,7 +1170,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
         )
 
     def _binaryop(
-        self, op: str, other: ColumnBinaryOperand, reflect: bool = False
+        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
     ) -> ColumnBase:
         raise TypeError(
             f"Operation {op} not supported between dtypes {self.dtype} and "

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -524,7 +524,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
             self._mimic_inplace(out, inplace=True)
 
     def _wrap_binop_normalization(self, other):
-        if other is cudf.NA:
+        if other is cudf.NA or other is None:
             return cudf.Scalar(other, dtype=self.dtype)
         return self.normalize_binop_value(other)
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -41,7 +41,7 @@ from cudf._lib.stream_compaction import (
     drop_nulls,
 )
 from cudf._lib.transform import bools_to_mask
-from cudf._typing import BinaryOperand, ColumnLike, Dtype, ScalarLike
+from cudf._typing import ColumnBinaryOperand, ColumnLike, Dtype, ScalarLike
 from cudf.api.types import (
     _is_non_decimal_numeric_dtype,
     _is_scalar_or_zero_d_array,
@@ -185,7 +185,7 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
             return False
         if check_dtypes and (self.dtype != other.dtype):
             return False
-        return self.binary_operator("NULL_EQUALS", other).all()
+        return self._binaryop("NULL_EQUALS", other).all()
 
     def all(self, skipna: bool = True) -> bool:
         # The skipna argument is only used for numerical columns.
@@ -1030,82 +1030,82 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
         )
 
     def __add__(self, other):
-        return self.binary_operator("add", other)
+        return self._binaryop("add", other)
 
     def __sub__(self, other):
-        return self.binary_operator("sub", other)
+        return self._binaryop("sub", other)
 
     def __mul__(self, other):
-        return self.binary_operator("mul", other)
+        return self._binaryop("mul", other)
 
     def __or__(self, other):
-        return self.binary_operator("or", other)
+        return self._binaryop("or", other)
 
     def __xor__(self, other):
-        return self.binary_operator("xor", other)
+        return self._binaryop("xor", other)
 
     def __and__(self, other):
-        return self.binary_operator("and", other)
+        return self._binaryop("and", other)
 
     def __floordiv__(self, other):
-        return self.binary_operator("floordiv", other)
+        return self._binaryop("floordiv", other)
 
     def __truediv__(self, other):
-        return self.binary_operator("truediv", other)
+        return self._binaryop("truediv", other)
 
     def __mod__(self, other):
-        return self.binary_operator("mod", other)
+        return self._binaryop("mod", other)
 
     def __pow__(self, other):
-        return self.binary_operator("pow", other)
+        return self._binaryop("pow", other)
 
     def __radd__(self, other):
-        return self.binary_operator("add", other, reflect=True)
+        return self._binaryop("add", other, reflect=True)
 
     def __rsub__(self, other):
-        return self.binary_operator("sub", other, reflect=True)
+        return self._binaryop("sub", other, reflect=True)
 
     def __rmul__(self, other):
-        return self.binary_operator("mul", other, reflect=True)
+        return self._binaryop("mul", other, reflect=True)
 
     def __ror__(self, other):
-        return self.binary_operator("or", other, reflect=True)
+        return self._binaryop("or", other, reflect=True)
 
     def __rxor__(self, other):
-        return self.binary_operator("xor", other, reflect=True)
+        return self._binaryop("xor", other, reflect=True)
 
     def __rand__(self, other):
-        return self.binary_operator("and", other, reflect=True)
+        return self._binaryop("and", other, reflect=True)
 
     def __rfloordiv__(self, other):
-        return self.binary_operator("floordiv", other, reflect=True)
+        return self._binaryop("floordiv", other, reflect=True)
 
     def __rtruediv__(self, other):
-        return self.binary_operator("truediv", other, reflect=True)
+        return self._binaryop("truediv", other, reflect=True)
 
     def __rmod__(self, other):
-        return self.binary_operator("mod", other, reflect=True)
+        return self._binaryop("mod", other, reflect=True)
 
     def __rpow__(self, other):
-        return self.binary_operator("pow", other, reflect=True)
+        return self._binaryop("pow", other, reflect=True)
 
     def __eq__(self, other):
-        return self.binary_operator("eq", other)
+        return self._binaryop("eq", other)
 
     def __ne__(self, other):
-        return self.binary_operator("ne", other)
+        return self._binaryop("ne", other)
 
     def __lt__(self, other):
-        return self.binary_operator("lt", other)
+        return self._binaryop("lt", other)
 
     def __gt__(self, other):
-        return self.binary_operator("gt", other)
+        return self._binaryop("gt", other)
 
     def __le__(self, other):
-        return self.binary_operator("le", other)
+        return self._binaryop("le", other)
 
     def __ge__(self, other):
-        return self.binary_operator("ge", other)
+        return self._binaryop("ge", other)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         return _array_ufunc(self, ufunc, method, inputs, kwargs)
@@ -1169,8 +1169,8 @@ class ColumnBase(Column, Serializable, Reducible, NotIterable):
             f"Operation {unaryop} not supported for dtype {self.dtype}."
         )
 
-    def binary_operator(
-        self, op: str, other: BinaryOperand, reflect: bool = False
+    def _binaryop(
+        self, op: str, other: ColumnBinaryOperand, reflect: bool = False
     ) -> ColumnBase:
         raise TypeError(
             f"Operation {op} not supported between dtypes {self.dtype} and "

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -187,7 +187,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
             return False
         ret = self._binaryop(other, "NULL_EQUALS")
         if ret is NotImplemented:
-            raise TypeError
+            raise TypeError(f"Cannot compare equality with {type(other)}")
         return ret.all()
 
     def all(self, skipna: bool = True) -> bool:

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -278,7 +278,7 @@ class DatetimeColumn(column.ColumnBase):
         elif other is None:
             return cudf.Scalar(other, dtype=self.dtype)
 
-        raise TypeError(f"cannot normalize {type(other)}")
+        return NotImplemented
 
     @property
     def as_numerical(self) -> "cudf.core.column.NumericalColumn":
@@ -411,7 +411,8 @@ class DatetimeColumn(column.ColumnBase):
 
     def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
         reflect, op = self._check_reflected_op(op)
-        other = self._wrap_binop_normalization(other)
+        if (other := self._wrap_binop_normalization(other)) is NotImplemented:
+            return NotImplemented
         if isinstance(other, cudf.DateOffset):
             return other._datetime_binop(self, op, reflect=reflect)
 
@@ -451,10 +452,7 @@ class DatetimeColumn(column.ColumnBase):
                 f"timedelta64[{units[max(lhs_unit, rhs_unit)]}]"
             )
         else:
-            raise TypeError(
-                f"Series of dtype {self.dtype} cannot perform "
-                f" the operation {op}"
-            )
+            return NotImplemented
 
         lhs, rhs = (self, other) if not reflect else (other, self)
         return libcudf.binaryop.binaryop(lhs, rhs, op, out_dtype)

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -14,7 +14,13 @@ import pandas as pd
 
 import cudf
 from cudf import _lib as libcudf
-from cudf._typing import DatetimeLikeScalar, Dtype, DtypeObj, ScalarLike
+from cudf._typing import (
+    ColumnBinaryOperand,
+    DatetimeLikeScalar,
+    Dtype,
+    DtypeObj,
+    ScalarLike,
+)
 from cudf.api.types import is_scalar
 from cudf.core._compat import PANDAS_GE_120
 from cudf.core.buffer import Buffer
@@ -388,11 +394,8 @@ class DatetimeColumn(column.ColumnBase):
             return pd.Timestamp(result, unit=self.time_unit)
         return result.astype(self.dtype)
 
-    def binary_operator(
-        self,
-        op: str,
-        rhs: Union[ColumnBase, "cudf.Scalar"],
-        reflect: bool = False,
+    def _binaryop(
+        self, op: str, rhs: ColumnBinaryOperand, reflect: bool = False,
     ) -> ColumnBase:
         rhs = self._wrap_binop_normalization(rhs)
         if isinstance(rhs, cudf.DateOffset):

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -7,7 +7,7 @@ import locale
 import re
 from locale import nl_langinfo
 from types import SimpleNamespace
-from typing import Any, Mapping, Sequence, Union, cast
+from typing import Any, Mapping, Sequence, cast
 
 import numpy as np
 import pandas as pd

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -395,7 +395,7 @@ class DatetimeColumn(column.ColumnBase):
         return result.astype(self.dtype)
 
     def _binaryop(
-        self, op: str, other: ColumnBinaryOperand, reflect: bool = False,
+        self, other: ColumnBinaryOperand, op: str, reflect: bool = False,
     ) -> ColumnBase:
         other = self._wrap_binop_normalization(other)
         if isinstance(other, cudf.DateOffset):

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -248,8 +248,6 @@ class DatetimeColumn(column.ColumnBase):
         if isinstance(other, (cudf.Scalar, ColumnBase, cudf.DateOffset)):
             return other
 
-        if isinstance(other, np.ndarray) and other.ndim == 0:
-            other = other.item()
         if isinstance(other, dt.datetime):
             other = np.datetime64(other)
         elif isinstance(other, dt.timedelta):

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -405,17 +405,29 @@ class DatetimeColumn(column.ColumnBase):
         # requires figuring out why _timedelta_add_result_dtype and
         # _timedelta_sub_result_dtype are 1) not symmetric, and 2) different
         # from each other.
-        if op in {"eq", "ne", "lt", "gt", "le", "ge", "NULL_EQUALS"}:
+        if op in {
+            "__eq__",
+            "__ne__",
+            "__lt__",
+            "__gt__",
+            "__le__",
+            "__ge__",
+            "NULL_EQUALS",
+        }:
             out_dtype: Dtype = cudf.dtype(np.bool_)
-        elif op == "add" and pd.api.types.is_timedelta64_dtype(other.dtype):
+        elif op == "__add__" and pd.api.types.is_timedelta64_dtype(
+            other.dtype
+        ):
             out_dtype = cudf.core.column.timedelta._timedelta_add_result_dtype(
                 other, self
             )
-        elif op == "sub" and pd.api.types.is_timedelta64_dtype(other.dtype):
+        elif op == "__sub__" and pd.api.types.is_timedelta64_dtype(
+            other.dtype
+        ):
             out_dtype = cudf.core.column.timedelta._timedelta_sub_result_dtype(
                 other if reflect else self, self if reflect else other
             )
-        elif op == "sub" and pd.api.types.is_datetime64_dtype(other.dtype):
+        elif op == "__sub__" and pd.api.types.is_datetime64_dtype(other.dtype):
             units = ["s", "ms", "us", "ns"]
             lhs_time_unit = cudf.utils.dtypes.get_time_unit(self)
             lhs_unit = units.index(lhs_time_unit)

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -275,8 +275,6 @@ class DatetimeColumn(column.ColumnBase):
                 return cudf.Scalar(None, dtype=other.dtype)
 
             return cudf.Scalar(other)
-        elif other is None:
-            return cudf.Scalar(other, dtype=self.dtype)
 
         return NotImplemented
 

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -115,6 +115,21 @@ class DatetimeColumn(column.ColumnBase):
         The validity mask
     """
 
+    # TODO: Timedelta columns support more operations than this, figure out why
+    # and whether we should be exploiting reflection more.
+    _VALID_BINARY_OPERATIONS = {
+        "__eq__",
+        "__ne__",
+        "__lt__",
+        "__le__",
+        "__gt__",
+        "__ge__",
+        "__add__",
+        "__sub__",
+        "__radd__",
+        "__rsub__",
+    }
+
     def __init__(
         self,
         data: Buffer,

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -394,9 +394,8 @@ class DatetimeColumn(column.ColumnBase):
             return pd.Timestamp(result, unit=self.time_unit)
         return result.astype(self.dtype)
 
-    def _binaryop(
-        self, other: ColumnBinaryOperand, op: str, reflect: bool = False,
-    ) -> ColumnBase:
+    def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
+        reflect, op = self._check_reflected_op(op)
         other = self._wrap_binop_normalization(other)
         if isinstance(other, cudf.DateOffset):
             return other._datetime_binop(self, op, reflect=reflect)

--- a/python/cudf/cudf/core/column/decimal.py
+++ b/python/cudf/cudf/core/column/decimal.py
@@ -24,6 +24,7 @@ from cudf.core.dtypes import (
     Decimal128Dtype,
     DecimalDtype,
 )
+from cudf.core.mixins import BinaryOperand
 from cudf.utils.utils import pa_mask_buffer_to_mask
 
 from .numerical_base import NumericalBaseColumn
@@ -33,6 +34,7 @@ class DecimalBaseColumn(NumericalBaseColumn):
     """Base column for decimal32, decimal64 or decimal128 columns"""
 
     dtype: DecimalDtype
+    _VALID_BINARY_OPERATIONS = BinaryOperand._SUPPORTED_BINARY_OPERATIONS
 
     def as_decimal_column(
         self, dtype: Dtype, **kwargs

--- a/python/cudf/cudf/core/column/decimal.py
+++ b/python/cudf/cudf/core/column/decimal.py
@@ -60,7 +60,8 @@ class DecimalBaseColumn(NumericalBaseColumn):
                 "cudf.core.column.StringColumn", as_column([], dtype="object")
             )
 
-    def _binaryop(self, other: ColumnBinaryOperand, op: str, reflect=False):
+    def _binaryop(self, other: ColumnBinaryOperand, op: str):
+        reflect, op = self._check_reflected_op(op)
         other = self._wrap_binop_normalization(other)
         lhs, rhs = (other, self) if reflect else (self, other)
         # Decimals in libcudf don't support truediv, see

--- a/python/cudf/cudf/core/column/decimal.py
+++ b/python/cudf/cudf/core/column/decimal.py
@@ -60,7 +60,7 @@ class DecimalBaseColumn(NumericalBaseColumn):
                 "cudf.core.column.StringColumn", as_column([], dtype="object")
             )
 
-    def _binaryop(self, op, other: ColumnBinaryOperand, reflect=False):
+    def _binaryop(self, other: ColumnBinaryOperand, op: str, reflect=False):
         other = self._wrap_binop_normalization(other)
         lhs, rhs = (other, self) if reflect else (self, other)
         # Decimals in libcudf don't support truediv, see

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -96,7 +96,8 @@ class ListColumn(ColumnBase):
     def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
         # Lists only support __add__, which concatenates lists.
         reflect, op = self._check_reflected_op(op)
-        if (other := self._wrap_binop_normalization(other)) is NotImplemented:
+        other = self._wrap_binop_normalization(other)
+        if other is NotImplemented:
             return NotImplemented
         if isinstance(other.dtype, ListDtype):
             if op == "__add__":

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -29,6 +29,7 @@ from cudf.core.dtypes import ListDtype
 
 class ListColumn(ColumnBase):
     dtype: ListDtype
+    _VALID_BINARY_OPERATIONS = {"__add__", "__radd__"}
 
     def __init__(
         self, size, dtype, mask=None, offset=0, null_count=None, children=(),

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -92,9 +92,7 @@ class ListColumn(ColumnBase):
         # avoid it being negative
         return max(0, len(self.base_children[0]) - 1)
 
-    def _binaryop(
-        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
-    ) -> ColumnBase:
+    def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
         """
         Calls a binary operator *binop* on operands *self*
         and *other*.
@@ -106,11 +104,6 @@ class ListColumn(ColumnBase):
         binop :  binary operator
             Only "add" operator is currently being supported
             for lists concatenation functions
-
-        reflect : boolean, default False
-            If ``True``, swap the order of the operands. See
-            https://docs.python.org/3/reference/datamodel.html#object.__ror__
-            for more information on when this is necessary.
 
         Returns
         -------
@@ -133,6 +126,7 @@ class ListColumn(ColumnBase):
         Name: val, dtype: list
 
         """
+        reflect, op = self._check_reflected_op(op)
         other = self._wrap_binop_normalization(other)
         if isinstance(other.dtype, ListDtype):
             if op == "__add__":

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -93,7 +93,7 @@ class ListColumn(ColumnBase):
         return max(0, len(self.base_children[0]) - 1)
 
     def _binaryop(
-        self, op: str, other: ColumnBinaryOperand, reflect: bool = False
+        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
     ) -> ColumnBase:
         """
         Calls a binary operator *binop* on operands *self*

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -19,7 +19,7 @@ from cudf._lib.lists import (
     sort_lists,
 )
 from cudf._lib.strings.convert.convert_lists import format_list_column
-from cudf._typing import BinaryOperand, ColumnLike, Dtype, ScalarLike
+from cudf._typing import ColumnBinaryOperand, ColumnLike, Dtype, ScalarLike
 from cudf.api.types import _is_non_decimal_numeric_dtype, is_list_dtype
 from cudf.core.buffer import Buffer
 from cudf.core.column import ColumnBase, as_column, column
@@ -92,8 +92,8 @@ class ListColumn(ColumnBase):
         # avoid it being negative
         return max(0, len(self.base_children[0]) - 1)
 
-    def binary_operator(
-        self, binop: str, other: BinaryOperand, reflect: bool = False
+    def _binaryop(
+        self, binop: str, other: ColumnBinaryOperand, reflect: bool = False
     ) -> ColumnBase:
         """
         Calls a binary operator *binop* on operands *self*

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -128,7 +128,8 @@ class ListColumn(ColumnBase):
 
         """
         reflect, op = self._check_reflected_op(op)
-        other = self._wrap_binop_normalization(other)
+        if (other := self._wrap_binop_normalization(other)) is NotImplemented:
+            return NotImplemented
         if isinstance(other.dtype, ListDtype):
             if op == "__add__":
                 return concatenate_rows(
@@ -250,6 +251,8 @@ class ListColumn(ColumnBase):
         )
 
     def normalize_binop_value(self, other):
+        if not isinstance(other, ListColumn):
+            return NotImplemented
         return other
 
     def _with_type_metadata(

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -135,7 +135,7 @@ class ListColumn(ColumnBase):
         """
         other = self._wrap_binop_normalization(other)
         if isinstance(other.dtype, ListDtype):
-            if op == "add":
+            if op == "__add__":
                 return concatenate_rows(
                     cudf.core.frame.Frame({0: self, 1: other})
                 )

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -93,7 +93,7 @@ class ListColumn(ColumnBase):
         return max(0, len(self.base_children[0]) - 1)
 
     def _binaryop(
-        self, binop: str, other: ColumnBinaryOperand, reflect: bool = False
+        self, op: str, other: ColumnBinaryOperand, reflect: bool = False
     ) -> ColumnBase:
         """
         Calls a binary operator *binop* on operands *self*
@@ -135,7 +135,7 @@ class ListColumn(ColumnBase):
         """
         other = self._wrap_binop_normalization(other)
         if isinstance(other.dtype, ListDtype):
-            if binop == "add":
+            if op == "add":
                 return concatenate_rows(
                     cudf.core.frame.Frame({0: self, 1: other})
                 )

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -94,39 +94,7 @@ class ListColumn(ColumnBase):
         return max(0, len(self.base_children[0]) - 1)
 
     def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
-        """
-        Calls a binary operator *binop* on operands *self*
-        and *other*.
-
-        Parameters
-        ----------
-        self, other : list columns
-
-        binop :  binary operator
-            Only "add" operator is currently being supported
-            for lists concatenation functions
-
-        Returns
-        -------
-        Series : the output dtype is determined by the
-            input operands.
-
-        Examples
-        --------
-        >>> import cudf
-        >>> gdf = cudf.DataFrame({'val': [['a', 'a'], ['b'], ['c']]})
-        >>> gdf
-            val
-        0  [a, a]
-        1     [b]
-        2     [c]
-        >>> gdf['val'] + gdf['val']
-        0    [a, a, a, a]
-        1          [b, b]
-        2          [c, c]
-        Name: val, dtype: list
-
-        """
+        # Lists only support __add__, which concatenates lists.
         reflect, op = self._check_reflected_op(op)
         if (other := self._wrap_binop_normalization(other)) is NotImplemented:
             return NotImplemented

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -43,6 +43,7 @@ from cudf.core.column import (
     string,
 )
 from cudf.core.dtypes import CategoricalDtype
+from cudf.core.mixins import BinaryOperand
 from cudf.utils import cudautils, utils
 from cudf.utils.dtypes import (
     NUMERIC_TYPES,
@@ -69,6 +70,7 @@ class NumericalColumn(NumericalBaseColumn):
     """
 
     _nan_count: Optional[int]
+    _VALID_BINARY_OPERATIONS = BinaryOperand._SUPPORTED_BINARY_OPERATIONS
 
     def __init__(
         self,

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -235,8 +235,6 @@ class NumericalColumn(NumericalBaseColumn):
             if not isinstance(other, NumericalColumn):
                 return NotImplemented
             return other
-        if other is None:
-            return other
         if isinstance(other, cudf.Scalar):
             if self.dtype == other.dtype:
                 return other

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -159,12 +159,6 @@ class NumericalColumn(NumericalBaseColumn):
         return libcudf.unary.unary_operation(self, unaryop)
 
     def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
-        if other is not None and isinstance(
-            other, cudf.core.column.DecimalBaseColumn
-        ):
-            dtyp = other.dtype.__class__(other.dtype.MAX_PRECISION, 0)
-            return self.as_decimal_column(dtyp)._binaryop(other, op)
-
         int_float_dtype_mapping = {
             np.int8: np.float32,
             np.int16: np.float32,
@@ -238,9 +232,7 @@ class NumericalColumn(NumericalBaseColumn):
         self, other: ScalarLike
     ) -> Union[ColumnBase, ScalarLike]:
         if isinstance(other, ColumnBase):
-            if not isinstance(
-                other, (NumericalColumn, cudf.core.column.DecimalBaseColumn,),
-            ):
+            if not isinstance(other, NumericalColumn):
                 return NotImplemented
             return other
         if other is None:

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -183,7 +183,8 @@ class NumericalColumn(NumericalBaseColumn):
                 return self.astype(truediv_type)._binaryop(other, op)
 
         reflect, op = self._check_reflected_op(op)
-        other = self._wrap_binop_normalization(other)
+        if (other := self._wrap_binop_normalization(other)) is NotImplemented:
+            return NotImplemented
         out_dtype = self.dtype
         if other is not None:
             out_dtype = np.result_type(self.dtype, other.dtype)
@@ -240,10 +241,7 @@ class NumericalColumn(NumericalBaseColumn):
             if not isinstance(
                 other, (NumericalColumn, cudf.core.column.DecimalBaseColumn,),
             ):
-                raise TypeError(
-                    f"Binary operations are not supported between "
-                    f"{type(self)}and {type(other)}"
-                )
+                return NotImplemented
             return other
         if other is None:
             return other
@@ -275,7 +273,7 @@ class NumericalColumn(NumericalBaseColumn):
                     data=Buffer(ary), dtype=ary.dtype, mask=self.mask,
                 )
         else:
-            raise TypeError(f"cannot broadcast {type(other)}")
+            return NotImplemented
 
     def int2ip(self) -> "cudf.core.column.StringColumn":
         if self.dtype != cudf.dtype("int64"):

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -157,7 +157,7 @@ class NumericalColumn(NumericalBaseColumn):
         return libcudf.unary.unary_operation(self, unaryop)
 
     def _binaryop(
-        self, op: str, other: ColumnBinaryOperand, reflect: bool = False,
+        self, other: ColumnBinaryOperand, op: str, reflect: bool = False,
     ) -> ColumnBase:
         int_float_dtype_mapping = {
             np.int8: np.float32,
@@ -174,14 +174,14 @@ class NumericalColumn(NumericalBaseColumn):
         if op in {"__truediv__", "__rtruediv__"}:
             # Division with integer types results in a suitable float.
             if (truediv_type := int_float_dtype_mapping.get(self.dtype.type)) :
-                return self.astype(truediv_type)._binaryop(op, other, reflect)
+                return self.astype(truediv_type)._binaryop(other, op, reflect)
 
         other = self._wrap_binop_normalization(other)
         out_dtype = self.dtype
         if other is not None:
             if isinstance(other, cudf.core.column.DecimalBaseColumn):
                 dtyp = other.dtype.__class__(other.dtype.MAX_PRECISION, 0)
-                return self.as_decimal_column(dtyp)._binaryop(op, other)
+                return self.as_decimal_column(dtyp)._binaryop(other, op)
 
             out_dtype = np.result_type(self.dtype, other.dtype)
             if op in {"__mod__", "__floordiv__"}:

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -211,14 +211,14 @@ class NumericalColumn(NumericalBaseColumn):
         if op in {"__and__", "__or__", "__xor__"}:
             if is_float_dtype(self.dtype) or is_float_dtype(other):
                 raise TypeError(
-                    f"Operation 'bitwise {op}' not supported between "
+                    f"Operation 'bitwise {op[2:-2]}' not supported between "
                     f"{self.dtype.type.__name__} and "
                     f"{other.dtype.type.__name__}"
                 )
             if is_bool_dtype(self.dtype) or is_bool_dtype(other):
                 out_dtype = "bool"
 
-        lhs, rhs = (self, other) if not reflect else (other, self)
+        lhs, rhs = (other, self) if reflect else (self, other)
         return libcudf.binaryop.binaryop(lhs, rhs, op, out_dtype)
 
     def nans_to_nulls(self: NumericalColumn) -> NumericalColumn:

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -156,9 +156,13 @@ class NumericalColumn(NumericalBaseColumn):
         unaryop = libcudf.unary.UnaryOp[unaryop.upper()]
         return libcudf.unary.unary_operation(self, unaryop)
 
-    def _binaryop(
-        self, other: ColumnBinaryOperand, op: str, reflect: bool = False,
-    ) -> ColumnBase:
+    def _binaryop(self, other: ColumnBinaryOperand, op: str) -> ColumnBase:
+        if other is not None and isinstance(
+            other, cudf.core.column.DecimalBaseColumn
+        ):
+            dtyp = other.dtype.__class__(other.dtype.MAX_PRECISION, 0)
+            return self.as_decimal_column(dtyp)._binaryop(other, op)
+
         int_float_dtype_mapping = {
             np.int8: np.float32,
             np.int16: np.float32,
@@ -174,15 +178,12 @@ class NumericalColumn(NumericalBaseColumn):
         if op in {"__truediv__", "__rtruediv__"}:
             # Division with integer types results in a suitable float.
             if (truediv_type := int_float_dtype_mapping.get(self.dtype.type)) :
-                return self.astype(truediv_type)._binaryop(other, op, reflect)
+                return self.astype(truediv_type)._binaryop(other, op)
 
+        reflect, op = self._check_reflected_op(op)
         other = self._wrap_binop_normalization(other)
         out_dtype = self.dtype
         if other is not None:
-            if isinstance(other, cudf.core.column.DecimalBaseColumn):
-                dtyp = other.dtype.__class__(other.dtype.MAX_PRECISION, 0)
-                return self.as_decimal_column(dtyp)._binaryop(other, op)
-
             out_dtype = np.result_type(self.dtype, other.dtype)
             if op in {"__mod__", "__floordiv__"}:
                 tmp = self if reflect else other

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -202,8 +202,6 @@ class NumericalColumn(NumericalBaseColumn):
                     out_dtype = cudf.dtype("float64")
 
         if binop in {
-            "l_and",
-            "l_or",
             "lt",
             "gt",
             "le",

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -171,7 +171,7 @@ class NumericalColumn(NumericalBaseColumn):
             np.bool_: np.float32,
         }
 
-        if op in {"truediv", "rtruediv"}:
+        if op in {"__truediv__", "__rtruediv__"}:
             # Division with integer types results in a suitable float.
             if (truediv_type := int_float_dtype_mapping.get(self.dtype.type)) :
                 return self.astype(truediv_type)._binaryop(op, other, reflect)
@@ -184,7 +184,7 @@ class NumericalColumn(NumericalBaseColumn):
                 return self.as_decimal_column(dtyp)._binaryop(op, other)
 
             out_dtype = np.result_type(self.dtype, other.dtype)
-            if op in {"mod", "floordiv"}:
+            if op in {"__mod__", "__floordiv__"}:
                 tmp = self if reflect else other
                 # Guard against division by zero for integers.
                 if (
@@ -200,17 +200,17 @@ class NumericalColumn(NumericalBaseColumn):
                     out_dtype = cudf.dtype("float64")
 
         if op in {
-            "lt",
-            "gt",
-            "le",
-            "ge",
-            "eq",
-            "ne",
+            "__lt__",
+            "__gt__",
+            "__le__",
+            "__ge__",
+            "__eq__",
+            "__ne__",
             "NULL_EQUALS",
         }:
             out_dtype = "bool"
 
-        if op in {"and", "or", "xor"}:
+        if op in {"__and__", "__or__", "__xor__"}:
             if is_float_dtype(self.dtype) or is_float_dtype(other):
                 raise TypeError(
                     f"Operation 'bitwise {op}' not supported between "

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -241,8 +241,6 @@ class NumericalColumn(NumericalBaseColumn):
             # expensive device-host transfer just to
             # adjust the dtype
             other = other.value
-        elif isinstance(other, np.ndarray) and other.ndim == 0:
-            other = other.item()
         other_dtype = np.min_scalar_type(other)
         if other_dtype.kind in {"b", "i", "u", "f"}:
             if isinstance(other, cudf.Scalar):

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -50,7 +50,13 @@ def str_to_boolean(column: StringColumn):
 
 
 if TYPE_CHECKING:
-    from cudf._typing import ColumnLike, Dtype, ScalarLike, SeriesOrIndex
+    from cudf._typing import (
+        ColumnBinaryOperand,
+        ColumnLike,
+        Dtype,
+        ScalarLike,
+        SeriesOrIndex,
+    )
 
 
 _str_to_numeric_typecast_functions = {
@@ -5444,8 +5450,8 @@ class StringColumn(column.ColumnBase):
             )
         raise TypeError(f"cannot broadcast {type(other)}")
 
-    def binary_operator(
-        self, op: str, rhs, reflect: bool = False
+    def _binaryop(
+        self, op: str, rhs: ColumnBinaryOperand, reflect: bool = False
     ) -> "column.ColumnBase":
         # Handle object columns that are empty or all nulls when performing
         # binary operations

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5451,7 +5451,7 @@ class StringColumn(column.ColumnBase):
         raise TypeError(f"cannot broadcast {type(other)}")
 
     def _binaryop(
-        self, op: str, rhs: ColumnBinaryOperand, reflect: bool = False
+        self, op: str, other: ColumnBinaryOperand, reflect: bool = False
     ) -> "column.ColumnBase":
         # Handle object columns that are empty or all nulls when performing
         # binary operations
@@ -5479,10 +5479,10 @@ class StringColumn(column.ColumnBase):
             elif op == "ne":
                 return self.isnull()
 
-        rhs = self._wrap_binop_normalization(rhs)
+        other = self._wrap_binop_normalization(other)
 
-        if isinstance(rhs, (StringColumn, str, cudf.Scalar)):
-            lhs, rhs = (rhs, self) if reflect else (self, rhs)
+        if isinstance(other, (StringColumn, str, cudf.Scalar)):
+            lhs, rhs = (other, self) if reflect else (self, other)
             if op == "add":
                 return cast(
                     "column.ColumnBase",

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5451,7 +5451,7 @@ class StringColumn(column.ColumnBase):
         raise TypeError(f"cannot broadcast {type(other)}")
 
     def _binaryop(
-        self, op: str, other: ColumnBinaryOperand, reflect: bool = False
+        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
     ) -> "column.ColumnBase":
         # Handle object columns that are empty or all nulls when performing
         # binary operations

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5488,7 +5488,8 @@ class StringColumn(column.ColumnBase):
             elif op == "__ne__":
                 return self.isnull()
 
-        if (other := self._wrap_binop_normalization(other)) is NotImplemented:
+        other = self._wrap_binop_normalization(other)
+        if other is NotImplemented:
             return NotImplemented
 
         if isinstance(other, (StringColumn, str, cudf.Scalar)):

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5458,32 +5458,32 @@ class StringColumn(column.ColumnBase):
         # See https://github.com/pandas-dev/pandas/issues/46332
         if self.null_count == len(self):
             if op in {
-                "add",
-                "sub",
-                "mul",
-                "mod",
-                "pow",
-                "truediv",
-                "floordiv",
-                "radd",
-                "rsub",
-                "rmul",
-                "rmod",
-                "rpow",
-                "rtruediv",
-                "rfloordiv",
+                "__add__",
+                "__sub__",
+                "__mul__",
+                "__mod__",
+                "__pow__",
+                "__truediv__",
+                "__floordiv__",
+                "__radd__",
+                "__rsub__",
+                "__rmul__",
+                "__rmod__",
+                "__rpow__",
+                "__rtruediv__",
+                "__rfloordiv__",
             }:
                 return self
-            elif op in {"eq", "lt", "le", "gt", "ge"}:
+            elif op in {"__eq__", "__lt__", "__le__", "__gt__", "__ge__"}:
                 return self.notnull()
-            elif op == "ne":
+            elif op == "__ne__":
                 return self.isnull()
 
         other = self._wrap_binop_normalization(other)
 
         if isinstance(other, (StringColumn, str, cudf.Scalar)):
             lhs, rhs = (other, self) if reflect else (self, other)
-            if op == "add":
+            if op == "__add__":
                 return cast(
                     "column.ColumnBase",
                     libstrings.concatenate(
@@ -5492,7 +5492,15 @@ class StringColumn(column.ColumnBase):
                         na_rep=cudf.Scalar(None, "str"),
                     ),
                 )
-            elif op in {"eq", "ne", "gt", "lt", "ge", "le", "NULL_EQUALS"}:
+            elif op in {
+                "__eq__",
+                "__ne__",
+                "__gt__",
+                "__lt__",
+                "__ge__",
+                "__le__",
+                "NULL_EQUALS",
+            }:
                 return libcudf.binaryop.binaryop(
                     lhs=lhs, rhs=rhs, op=op, dtype="bool"
                 )

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5031,6 +5031,25 @@ class StringColumn(column.ColumnBase):
     _start_offset: Optional[int]
     _end_offset: Optional[int]
 
+    _VALID_BINARY_OPERATIONS = {
+        "__eq__",
+        "__ne__",
+        "__lt__",
+        "__le__",
+        "__gt__",
+        "__ge__",
+        "__add__",
+        "__radd__",
+        # These operators aren't actually supported, they only exist to allow
+        # empty column binops with scalars of arbitrary other dtypes.
+        "__sub__",
+        "__mul__",
+        "__mod__",
+        "__pow__",
+        "__truediv__",
+        "__floordiv__",
+    }
+
     def __init__(
         self,
         mask: Buffer = None,
@@ -5454,6 +5473,8 @@ class StringColumn(column.ColumnBase):
         self, other: ColumnBinaryOperand, op: str
     ) -> "column.ColumnBase":
         reflect, op = self._check_reflected_op(op)
+        # TODO: Try to find a way to disable these ops while still exposing
+        # this behavior. It may not be possible for now though.
         # Handle object columns that are empty or all nulls when performing
         # binary operations
         # See https://github.com/pandas-dev/pandas/issues/46332

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5467,7 +5467,7 @@ class StringColumn(column.ColumnBase):
             return utils.scalar_broadcast_to(
                 other.item(), size=len(self), dtype="object"
             )
-        raise TypeError(f"cannot broadcast {type(other)}")
+        return NotImplemented
 
     def _binaryop(
         self, other: ColumnBinaryOperand, op: str
@@ -5494,7 +5494,8 @@ class StringColumn(column.ColumnBase):
             elif op == "__ne__":
                 return self.isnull()
 
-        other = self._wrap_binop_normalization(other)
+        if (other := self._wrap_binop_normalization(other)) is NotImplemented:
+            return NotImplemented
 
         if isinstance(other, (StringColumn, str, cudf.Scalar)):
             lhs, rhs = (other, self) if reflect else (self, other)
@@ -5519,9 +5520,7 @@ class StringColumn(column.ColumnBase):
                 return libcudf.binaryop.binaryop(
                     lhs=lhs, rhs=rhs, op=op, dtype="bool"
                 )
-        raise TypeError(
-            f"{op} not supported between {type(self)} and {type(rhs)}"
-        )
+        return NotImplemented
 
     @copy_docstring(column.ColumnBase.view)
     def view(self, dtype) -> "cudf.core.column.ColumnBase":

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5451,8 +5451,9 @@ class StringColumn(column.ColumnBase):
         raise TypeError(f"cannot broadcast {type(other)}")
 
     def _binaryop(
-        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
+        self, other: ColumnBinaryOperand, op: str
     ) -> "column.ColumnBase":
+        reflect, op = self._check_reflected_op(op)
         # Handle object columns that are empty or all nulls when performing
         # binary operations
         # See https://github.com/pandas-dev/pandas/issues/46332
@@ -5465,13 +5466,6 @@ class StringColumn(column.ColumnBase):
                 "__pow__",
                 "__truediv__",
                 "__floordiv__",
-                "__radd__",
-                "__rsub__",
-                "__rmul__",
-                "__rmod__",
-                "__rpow__",
-                "__rtruediv__",
-                "__rfloordiv__",
             }:
                 return self
             elif op in {"__eq__", "__lt__", "__le__", "__gt__", "__ge__"}:

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5459,8 +5459,6 @@ class StringColumn(column.ColumnBase):
             and other.dtype == "object"
         ):
             return other
-        if isinstance(other, np.ndarray) and other.ndim == 0:
-            other = other.item()
         if isinstance(other, str):
             return cudf.Scalar(other)
         return NotImplemented

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -51,6 +51,27 @@ class TimeDeltaColumn(column.ColumnBase):
         If None, it is calculated automatically.
     """
 
+    _VALID_BINARY_OPERATIONS = {
+        "__eq__",
+        "__ne__",
+        "__lt__",
+        "__le__",
+        "__gt__",
+        "__ge__",
+        "__add__",
+        "__sub__",
+        "__mul__",
+        "__mod__",
+        "__truediv__",
+        "__floordiv__",
+        "__radd__",
+        "__rsub__",
+        "__rmul__",
+        "__rmod__",
+        "__rtruediv__",
+        "__rfloordiv__",
+    }
+
     def __init__(
         self,
         data: Buffer,

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -250,8 +250,6 @@ class TimeDeltaColumn(column.ColumnBase):
     def normalize_binop_value(self, other) -> ColumnBinaryOperand:
         if isinstance(other, (ColumnBase, cudf.Scalar)):
             return other
-        if isinstance(other, np.ndarray) and other.ndim == 0:
-            other = other.item()
         if isinstance(other, dt.timedelta):
             other = np.timedelta64(other)
         elif isinstance(other, pd.Timestamp):

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -191,7 +191,7 @@ class TimeDeltaColumn(column.ColumnBase):
         return this, other, out_dtype
 
     def _binaryop(
-        self, op: str, other: ColumnBinaryOperand, reflect: bool = False
+        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
     ) -> "column.ColumnBase":
         other = self._wrap_binop_normalization(other)
 

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -177,7 +177,9 @@ class TimeDeltaColumn(column.ColumnBase):
             else:
                 other = other.astype(common_dtype).astype("float64")
 
-            out_dtype = cudf.dtype("float64" if op == "truediv" else "int64")
+            out_dtype = cudf.dtype(
+                "float64" if op == "__truediv__" else "int64"
+            )
         elif other.dtype.kind in ("f", "i", "u"):
             out_dtype = self.dtype
         else:
@@ -194,18 +196,26 @@ class TimeDeltaColumn(column.ColumnBase):
         other = self._wrap_binop_normalization(other)
 
         this: ColumnBinaryOperand = self
-        if op in {"eq", "ne", "lt", "gt", "le", "ge", "NULL_EQUALS"}:
+        if op in {
+            "__eq__",
+            "__ne__",
+            "__lt__",
+            "__gt__",
+            "__le__",
+            "__ge__",
+            "NULL_EQUALS",
+        }:
             out_dtype = self._binary_op_lt_gt_le_ge_eq_ne(other)
-        elif op == "mul":
+        elif op == "__mul__":
             out_dtype = self._binary_op_mul(other)
-        elif op == "mod":
+        elif op == "__mod__":
             out_dtype = self._binary_op_mod(other)
-        elif op in {"truediv", "floordiv"}:
+        elif op in {"__truediv__", "__floordiv__"}:
             this, other, out_dtype = self._binary_op_div(other, op)
-            op = "truediv"
-        elif op == "add":
+            op = "__truediv__"
+        elif op == "__add__":
             out_dtype = _timedelta_add_result_dtype(self, other)
-        elif op == "sub":
+        elif op == "__sub__":
             out_dtype = _timedelta_sub_result_dtype(self, other)
         else:
             raise TypeError(

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -271,10 +271,7 @@ class TimeDeltaColumn(column.ColumnBase):
             return cudf.Scalar(other)
         elif np.isscalar(other):
             return cudf.Scalar(other)
-        elif other is None:
-            return cudf.Scalar(other, dtype=self.dtype)
-        else:
-            return NotImplemented
+        return NotImplemented
 
     @property
     def as_numerical(self) -> "cudf.core.column.NumericalColumn":

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -168,7 +168,7 @@ class TimeDeltaColumn(column.ColumnBase):
             out_dtype = self.dtype
         else:
             raise TypeError(
-                f"Modulus of {self.dtype} with {other.dtype} "
+                f"Modulo of {self.dtype} with {other.dtype} "
                 f"cannot be performed."
             )
         return out_dtype
@@ -215,7 +215,8 @@ class TimeDeltaColumn(column.ColumnBase):
         self, other: ColumnBinaryOperand, op: str
     ) -> "column.ColumnBase":
         reflect, op = self._check_reflected_op(op)
-        if (other := self._wrap_binop_normalization(other)) is NotImplemented:
+        other = self._wrap_binop_normalization(other)
+        if other is NotImplemented:
             return NotImplemented
 
         this: ColumnBinaryOperand = self
@@ -243,7 +244,7 @@ class TimeDeltaColumn(column.ColumnBase):
         else:
             return NotImplemented
 
-        lhs, rhs = (this, other) if not reflect else (other, this)
+        lhs, rhs = (other, this) if reflect else (this, other)
 
         return libcudf.binaryop.binaryop(lhs, rhs, op, out_dtype)
 

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -215,7 +215,8 @@ class TimeDeltaColumn(column.ColumnBase):
         self, other: ColumnBinaryOperand, op: str
     ) -> "column.ColumnBase":
         reflect, op = self._check_reflected_op(op)
-        other = self._wrap_binop_normalization(other)
+        if (other := self._wrap_binop_normalization(other)) is NotImplemented:
+            return NotImplemented
 
         this: ColumnBinaryOperand = self
         if op in {
@@ -240,10 +241,7 @@ class TimeDeltaColumn(column.ColumnBase):
         elif op == "__sub__":
             out_dtype = _timedelta_sub_result_dtype(self, other)
         else:
-            raise TypeError(
-                f"Series of dtype {self.dtype} cannot perform "
-                f"the operation {op}"
-            )
+            return NotImplemented
 
         lhs, rhs = (this, other) if not reflect else (other, this)
 
@@ -276,7 +274,7 @@ class TimeDeltaColumn(column.ColumnBase):
         elif other is None:
             return cudf.Scalar(other, dtype=self.dtype)
         else:
-            raise TypeError(f"cannot normalize {type(other)}")
+            return NotImplemented
 
     @property
     def as_numerical(self) -> "cudf.core.column.NumericalColumn":

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -191,8 +191,9 @@ class TimeDeltaColumn(column.ColumnBase):
         return this, other, out_dtype
 
     def _binaryop(
-        self, other: ColumnBinaryOperand, op: str, reflect: bool = False
+        self, other: ColumnBinaryOperand, op: str
     ) -> "column.ColumnBase":
+        reflect, op = self._check_reflected_op(op)
         other = self._wrap_binop_normalization(other)
 
         this: ColumnBinaryOperand = self

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import operator
 import pickle
 import warnings
 from collections import abc
@@ -2535,8 +2536,6 @@ class Frame(BinaryOperand, Scannable):
             A dict of columns constructed from the result of performing the
             requested operation on the operands.
         """
-        fn = fn[2:-2]
-
         # Now actually perform the binop on the columns in left and right.
         output = {}
         for (
@@ -2567,11 +2566,11 @@ class Frame(BinaryOperand, Scannable):
             # are not numerical using the new binops mixin.
 
             outcol = (
-                left_column.binary_operator(fn, right_column, reflect=reflect)
-                if right_column is not None
-                else column_empty(
-                    left_column.size, left_column.dtype, masked=True
-                )
+                column_empty(left_column.size, left_column.dtype, masked=True)
+                if right_column is None
+                else getattr(operator, fn)(right_column, left_column)
+                if reflect
+                else getattr(operator, fn)(left_column, right_column)
             )
 
             if output_mask is not None:

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -2440,30 +2440,6 @@ class Frame(BinaryOperand, Scannable):
             zip(self._column_names, data_columns), self._index
         )
 
-    def _binaryop(
-        self, other: T, op: str, fill_value: Any = None, *args, **kwargs,
-    ) -> Frame:
-        """Perform a binary operation between two frames.
-
-        Parameters
-        ----------
-        other : Frame
-            The second operand.
-        op : str
-            The operation to perform.
-        fill_value : Any, default None
-            The value to replace null values with. If ``None``, nulls are not
-            filled before the operation.
-
-        Returns
-        -------
-        Frame
-            A new instance containing the result of the operation.
-        """
-        raise NotImplementedError(
-            f"Binary operations are not supported for {self.__class__}"
-        )
-
     @classmethod
     @_cudf_nvtx_annotate
     def _colwise_binop(

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -39,7 +39,6 @@ from cudf.core.column import (
     ColumnBase,
     as_column,
     build_categorical_column,
-    column_empty,
     deserialize_columns,
     serialize_columns,
 )
@@ -2499,9 +2498,7 @@ class Frame(BinaryOperand, Scannable):
             # are not numerical using the new binops mixin.
 
             outcol = (
-                column_empty(left_column.size, left_column.dtype, masked=True)
-                if right_column is None
-                else getattr(operator, fn)(right_column, left_column)
+                getattr(operator, fn)(right_column, left_column)
                 if reflect
                 else getattr(operator, fn)(left_column, right_column)
             )

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -854,9 +854,7 @@ class GenericIndex(SingleColumnFrame, BaseIndex):
     def _binaryop(
         self, other: T, op: str, fill_value: Any = None, *args, **kwargs,
     ) -> SingleColumnFrame:
-        reflect = self._is_reflected_op(op)
-        if reflect:
-            op = op[:2] + op[3:]
+        reflect, op = self._check_reflected_op(op)
         operands = self._make_operands_for_binop(other, fill_value, reflect)
         if operands is NotImplemented:
             return NotImplemented

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2118,9 +2118,7 @@ class IndexedFrame(Frame):
         *args,
         **kwargs,
     ):
-        reflect = self._is_reflected_op(op)
-        if reflect:
-            op = op[:2] + op[3:]
+        reflect, op = self._check_reflected_op(op)
         operands, out_index = self._make_operands_and_index_for_binop(
             other, op, fill_value, reflect, can_reindex
         )

--- a/python/cudf/cudf/core/mixins/binops.py
+++ b/python/cudf/cudf/core/mixins/binops.py
@@ -49,8 +49,12 @@ BinaryOperand = _create_delegating_mixin(
 )
 
 
-def _is_reflected_op(op):
-    return op[2] == "r" and op != "__rshift__"
+# TODO: See if there is a better approach to this problem.
+def _check_reflected_op(op):
+    reflect = op[2] == "r" and op != "__rshift__"
+    if reflect:
+        op = op[:2] + op[3:]
+    return reflect, op
 
 
-BinaryOperand._is_reflected_op = staticmethod(_is_reflected_op)
+BinaryOperand._check_reflected_op = staticmethod(_check_reflected_op)

--- a/python/cudf/cudf/core/mixins/binops.py
+++ b/python/cudf/cudf/core/mixins/binops.py
@@ -54,8 +54,11 @@ BinaryOperand = _create_delegating_mixin(
 
 
 def _binaryop(self, other, op: str):
-    "The core binary_operation function. Must be overridden by subclasses, "
-    "the default implementation raises a NotImplementedError."
+    """The core binary_operation function.
+
+    Must be overridden by subclasses, the default implementation raises a
+    NotImplementedError.
+    """
     raise NotImplementedError
 
 

--- a/python/cudf/cudf/core/mixins/binops.py
+++ b/python/cudf/cudf/core/mixins/binops.py
@@ -48,13 +48,22 @@ BinaryOperand = _create_delegating_mixin(
     },
 )
 
+# TODO: See if there is a better approach to these two issues: 1) The mixin
+# assumes a single standard parameter, whereas binops have two, and 2) we need
+# a way to determine reflected vs normal ops.
 
-# TODO: See if there is a better approach to this problem.
+
+def _binaryop(self, other, op: str):
+    "The core binary_operation function. Must be overridden by subclasses, "
+    "the default implementation raises a NotImplementedError."
+    raise NotImplementedError
+
+
 def _check_reflected_op(op):
-    reflect = op[2] == "r" and op != "__rshift__"
-    if reflect:
+    if (reflect := op[2] == "r" and op != "__rshift__") :
         op = op[:2] + op[3:]
     return reflect, op
 
 
+BinaryOperand._binaryop = _binaryop
 BinaryOperand._check_reflected_op = staticmethod(_check_reflected_op)

--- a/python/cudf/cudf/core/mixins/binops.pyi
+++ b/python/cudf/cudf/core/mixins/binops.pyi
@@ -1,6 +1,6 @@
 # Copyright (c) 2022, NVIDIA CORPORATION.
 
-from typing import Set
+from typing import Set, Tuple
 
 class BinaryOperand:
     _SUPPORTED_BINARY_OPERATIONS: Set
@@ -84,5 +84,5 @@ class BinaryOperand:
         ...
 
     @staticmethod
-    def _is_reflected_op(op) -> bool:
+    def _check_reflected_op(op) -> Tuple[bool, str]:
         ...

--- a/python/cudf/cudf/core/mixins/binops.pyi
+++ b/python/cudf/cudf/core/mixins/binops.pyi
@@ -1,9 +1,15 @@
 # Copyright (c) 2022, NVIDIA CORPORATION.
 
-from typing import Set, Tuple
+from typing import Any, Set, Tuple, TypeVar
+
+# Note: It may be possible to define a narrower bound here eventually.
+BinaryOperandType = TypeVar("BinaryOperandType", bound="Any")
 
 class BinaryOperand:
     _SUPPORTED_BINARY_OPERATIONS: Set
+
+    def _binaryop(self, other: BinaryOperandType, op: str):
+        ...
 
     def __add__(self, other):
         ...

--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
 
 import math
 import re
@@ -587,12 +587,12 @@ class DateOffset:
     def _datetime_binop(
         self, datetime_col, op, reflect=False
     ) -> column.DatetimeColumn:
-        if reflect and op == "sub":
+        if reflect and op == "__sub__":
             raise TypeError(
                 f"Can not subtract a {type(datetime_col).__name__}"
                 f" from a {type(self).__name__}"
             )
-        if op not in {"add", "sub"}:
+        if op not in {"__add__", "__sub__"}:
             raise TypeError(
                 f"{op} not supported between {type(self).__name__}"
                 f" and {type(datetime_col).__name__}"
@@ -604,7 +604,7 @@ class DateOffset:
 
             for unit, value in self._scalars.items():
                 if unit != "months":
-                    value = -value if op == "sub" else value
+                    value = -value if op == "__sub__" else value
                     datetime_col += cudf.core.column.as_column(
                         value, length=len(datetime_col)
                     )
@@ -613,7 +613,7 @@ class DateOffset:
 
     def _generate_months_column(self, size, op):
         months = self._scalars["months"]
-        months = -months if op == "sub" else months
+        months = -months if op == "__sub__" else months
         # TODO: pass a scalar instead of constructing a column
         # https://github.com/rapidsai/cudf/issues/6990
         col = cudf.core.column.as_column(months, length=size)

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -381,7 +381,7 @@ def test_concatenate_rows_of_lists():
 
 
 def test_concatenate_list_with_nonlist():
-    with pytest.raises(TypeError, match="can only concatenate list to list"):
+    with pytest.raises(TypeError):
         gdf1 = cudf.DataFrame({"A": [["a", "c"], ["b", "d"], ["c", "d"]]})
         gdf2 = cudf.DataFrame({"A": ["a", "b", "c"]})
         gdf1["A"] + gdf2["A"]

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1175,8 +1175,7 @@ def test_timedelta_invalid_ops():
         lfunc_args_and_kwargs=([psr, dt_psr],),
         rfunc_args_and_kwargs=([sr, dt_sr],),
         expected_error_message=re.escape(
-            f"Modulus of {sr.dtype} with {dt_sr.dtype} "
-            f"cannot be performed."
+            f"Modulo of {sr.dtype} with {dt_sr.dtype} " f"cannot be performed."
         ),
     )
 
@@ -1186,7 +1185,7 @@ def test_timedelta_invalid_ops():
         lfunc_args_and_kwargs=([psr, "a"],),
         rfunc_args_and_kwargs=([sr, "a"],),
         expected_error_message=re.escape(
-            f"Modulus of {sr.dtype} with {np.dtype('object')} "
+            f"Modulo of {sr.dtype} with {np.dtype('object')} "
             f"cannot be performed."
         ),
     )

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1285,9 +1285,7 @@ def test_timedelta_invalid_ops():
         rfunc=operator.xor,
         lfunc_args_and_kwargs=([psr, psr],),
         rfunc_args_and_kwargs=([sr, sr],),
-        expected_error_message=re.escape(
-            f"Series of dtype {sr.dtype} cannot perform the operation __xor__"
-        ),
+        compare_error_message=False,
     )
 
 

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1286,7 +1286,7 @@ def test_timedelta_invalid_ops():
         lfunc_args_and_kwargs=([psr, psr],),
         rfunc_args_and_kwargs=([sr, sr],),
         expected_error_message=re.escape(
-            f"Series of dtype {sr.dtype} cannot perform the operation xor"
+            f"Series of dtype {sr.dtype} cannot perform the operation __xor__"
         ),
     )
 

--- a/python/cudf/cudf/utils/applyutils.py
+++ b/python/cudf/cudf/utils/applyutils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 import functools
 from typing import Any, Dict
@@ -103,7 +103,7 @@ def apply_chunks(
     return applychunks.run(df, chunks=chunks, tpb=tpb)
 
 
-def make_aggregate_nullmask(df, columns=None, op="and"):
+def make_aggregate_nullmask(df, columns=None, op="__and__"):
 
     out_mask = None
     for k in columns or df._data:

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -87,7 +87,7 @@ def _array_ufunc(obj, ufunc, method, inputs, kwargs):
             reflect = False
         op = f"__{'r' if reflect else ''}{op}__"
 
-        # Float_power returns float irrespective of the input type.
+        # float_power returns float irrespective of the input type.
         # TODO: Do not get the attribute directly, get from the operator module
         # so that we can still exploit reflection.
         if fname == "float_power":

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -24,6 +24,90 @@ from cudf.utils.dtypes import to_cudf_compatible_scalar
 mask_dtype = cudf.dtype(np.int32)
 mask_bitsize = mask_dtype.itemsize * 8
 
+# Mapping from ufuncs to the corresponding binary operators.
+_ufunc_binary_operations = {
+    # Arithmetic binary operations.
+    "add": "add",
+    "subtract": "sub",
+    "multiply": "mul",
+    "matmul": "matmul",
+    "divide": "truediv",
+    "true_divide": "truediv",
+    "floor_divide": "floordiv",
+    "power": "pow",
+    "float_power": "pow",
+    "remainder": "mod",
+    "mod": "mod",
+    "fmod": "mod",
+    # Bitwise binary operations.
+    "bitwise_and": "and",
+    "bitwise_or": "or",
+    "bitwise_xor": "xor",
+    # Comparison binary operators
+    "greater": "gt",
+    "greater_equal": "ge",
+    "less": "lt",
+    "less_equal": "le",
+    "not_equal": "ne",
+    "equal": "eq",
+}
+
+# These operators need to be mapped to their inverses when performing a
+# reflected ufunc operation because no reflected version of the operators
+# themselves exist. When these operators are invoked directly (not via
+# __array_ufunc__) Python takes care of calling the inverse operation.
+_ops_without_reflection = {
+    "gt": "lt",
+    "ge": "le",
+    "lt": "gt",
+    "le": "ge",
+    # ne and eq are symmetric, so they are their own inverse op
+    "ne": "ne",
+    "eq": "eq",
+}
+
+
+# This is the implementation of __array_ufunc__ used for Frame and Column.
+# For more detail on this function and how it should work, see
+# https://numpy.org/doc/stable/reference/ufuncs.html
+def _array_ufunc(obj, ufunc, method, inputs, kwargs):
+    # We don't currently support reduction, accumulation, etc. We also
+    # don't support any special kwargs or higher arity ufuncs than binary.
+    if method != "__call__" or kwargs or ufunc.nin > 2:
+        return NotImplemented
+
+    fname = ufunc.__name__
+    if fname in _ufunc_binary_operations:
+        reflect = obj is not inputs[0]
+        other = inputs[0] if reflect else inputs[1]
+
+        op = _ufunc_binary_operations[fname]
+        if reflect and op in _ops_without_reflection:
+            op = _ops_without_reflection[op]
+            reflect = False
+        op = f"__{'r' if reflect else ''}{op}__"
+
+        # Float_power returns float irrespective of the input type.
+        if fname == "float_power":
+            return getattr(obj, op)(other).astype(float)
+        return getattr(obj, op)(other)
+
+    # Special handling for various unary operations.
+    if fname == "negative":
+        return obj * -1
+    if fname == "positive":
+        return obj.copy(deep=True)
+    if fname == "invert":
+        return ~obj
+    if fname == "absolute":
+        # TODO: Make sure all obj (mainly Column) implement abs.
+        return abs(obj)
+    if fname == "fabs":
+        return abs(obj).astype(np.float64)
+
+    # None is a sentinel used by subclasses to trigger cupy dispatch.
+    return None
+
 
 _EQUALITY_OPS = {
     "__eq__",

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -88,6 +88,8 @@ def _array_ufunc(obj, ufunc, method, inputs, kwargs):
         op = f"__{'r' if reflect else ''}{op}__"
 
         # Float_power returns float irrespective of the input type.
+        # TODO: Do not get the attribute directly, get from the operator module
+        # so that we can still exploit reflection.
         if fname == "float_power":
             return getattr(obj, op)(other).astype(float)
         return getattr(obj, op)(other)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This PR changes the way that binary operations are performed between columns. Instead of directly invoking the `_binaryop` method Frame binary operations now invoke operators directly using the `operator` module. Each `Column` subclass now only defines operations that are well-defined, relying on Python to handle raising `TypeError`s for all others. Binary operations return `NotImplemented` instead of raising a `TypeError` _except_ in specific cases where a meaningful error should be raised, allowing us to take advantage of reflected operations to prevent duplicate logic on how to handle binary operations between distinct types. Finally, various edge cases that were previously handled by Frames are now handled in Column so that different dtype columns are the sole source of truth on what operands are supported. These changes move us towards fully functional Column classes that do not rely on preprocessed inputs coming from the Frame layer. 

This PR has a large changeset, but a large chunk of the changes lines are simply because some changes to the pipeline result in operations having their dunder names instead of having the dunders stripped, e.g. `__add__` instead of `add`. 