### PR TITLE
Remove ColumnBase.__getitem__

### DIFF
--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -1067,7 +1067,13 @@ class CategoricalColumn(column.ColumnBase):
         df = df.drop_duplicates(subset=["old"], keep="last", ignore_index=True)
         if df._data["old"].null_count == 1:
             fill_value = df._data["new"][df._data["old"].isnull()][0]
-            if fill_value in self.categories:
+            # TODO: This line of code does not work because we cannot use the
+            # `in` operator on self.categories (which is a column). mypy
+            # realizes that this is wrong because __iter__ is not implemented.
+            # However, it seems that this functionality has been broken for a
+            # long time so for now we're just having mypy ignore and we'll come
+            # back to this.
+            if fill_value in self.categories:  # type: ignore
                 replaced = self.fillna(fill_value)
             else:
                 new_categories = self.categories.append(

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -1083,9 +1083,9 @@ class CategoricalColumn(column.ColumnBase):
         if df._data["new"].null_count > 0:
             drop_values = df._data["old"][df._data["new"].isnull()]
             cur_categories = replaced.categories
-            new_categories = cur_categories[
+            new_categories = cur_categories.apply_boolean_mask(
                 ~cudf.Series(cur_categories.isin(drop_values))
-            ]
+            )
             replaced = replaced._set_categories(new_categories)
             df = df.dropna(subset=["new"])
             to_replace_col = df._data["old"]

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -77,7 +77,7 @@ from cudf.utils.dtypes import (
     pandas_dtypes_alias_to_cudf_alias,
     pandas_dtypes_to_np_dtypes,
 )
-from cudf.utils.utils import NotIterable, _array_ufunc, mask_dtype
+from cudf.utils.utils import _array_ufunc, mask_dtype
 
 T = TypeVar("T", bound="ColumnBase")
 # TODO: This workaround allows type hints for `slice`, since `slice` is a
@@ -85,7 +85,7 @@ T = TypeVar("T", bound="ColumnBase")
 Slice = TypeVar("Slice", bound=slice)
 
 
-class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
+class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
     _VALID_REDUCTIONS = {
         "any",
         "all",
@@ -1009,13 +1009,6 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
             "Implicit conversion to a host PyArrow Array via __arrow_array__ "
             "is not allowed, To explicitly construct a PyArrow Array, "
             "consider using .to_arrow()"
-        )
-
-    def __array__(self, dtype=None):
-        raise TypeError(
-            "Implicit conversion to a host NumPy array via __array__ is not "
-            "allowed. To explicitly construct a host array, consider using "
-            ".to_numpy()"
         )
 
     @property

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -44,7 +44,6 @@ from cudf._lib.transform import bools_to_mask
 from cudf._typing import ColumnLike, Dtype, ScalarLike
 from cudf.api.types import (
     _is_non_decimal_numeric_dtype,
-    _is_scalar_or_zero_d_array,
     infer_dtype,
     is_bool_dtype,
     is_categorical_dtype,
@@ -479,22 +478,6 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible, NotIterable):
                 dtype=cudf.dtype(np.int32),
             )
             return self.take(gather_map)
-
-    def __getitem__(self, arg) -> Union[ScalarLike, ColumnBase]:
-        if _is_scalar_or_zero_d_array(arg):
-            return self.element_indexing(int(arg))
-        elif isinstance(arg, slice):
-            start, stop, stride = arg.indices(len(self))
-            return self.slice(start, stop, stride)
-        else:
-            arg = as_column(arg)
-            if len(arg) == 0:
-                arg = as_column([], dtype="int32")
-            if is_integer_dtype(arg.dtype):
-                return self.take(arg)
-            if is_bool_dtype(arg.dtype):
-                return self.apply_boolean_mask(arg)
-            raise NotImplementedError(type(arg))
 
     def __setitem__(self, key: Any, value: Any):
         """

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -473,7 +473,9 @@ class DatetimeColumn(column.ColumnBase):
         Returns offset of first value that matches
         """
         value = pd.to_datetime(value)
-        value = column.as_column(value, dtype=self.dtype).as_numerical[0]
+        value = column.as_column(
+            value, dtype=self.dtype
+        ).as_numerical.element_indexing(0)
         return self.as_numerical.find_first_value(value, closest=closest)
 
     def find_last_value(self, value: ScalarLike, closest: bool = False) -> int:
@@ -481,7 +483,9 @@ class DatetimeColumn(column.ColumnBase):
         Returns offset of last value that matches
         """
         value = pd.to_datetime(value)
-        value = column.as_column(value, dtype=self.dtype).as_numerical[0]
+        value = column.as_column(
+            value, dtype=self.dtype
+        ).as_numerical.element_indexing(0)
         return self.as_numerical.find_last_value(value, closest=closest)
 
     @property

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -453,7 +453,9 @@ class NumericalColumn(NumericalBaseColumn):
         df = df.drop_duplicates(subset=["old"], keep="last", ignore_index=True)
         if df._data["old"].null_count == 1:
             replaced = replaced.fillna(
-                df._data["new"][df._data["old"].isnull()][0]
+                df._data["new"]
+                .apply_boolean_mask(df._data["old"].isnull())
+                .element_indexing(0)
             )
             df = df.dropna(subset=["old"])
 

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5205,7 +5205,7 @@ class StringColumn(column.ColumnBase):
                 result_col,
                 sep=cudf.Scalar(""),
                 na_rep=cudf.Scalar(None, "str"),
-            )[0]
+            ).element_indexing(0)
         else:
             return result_col
 

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5432,7 +5432,11 @@ class StringColumn(column.ColumnBase):
         )
         df = df.drop_duplicates(subset=["old"], keep="last", ignore_index=True)
         if df._data["old"].null_count == 1:
-            res = self.fillna(df._data["new"][df._data["old"].isnull()][0])
+            res = self.fillna(
+                df._data["new"]
+                .apply_boolean_mask(df._data["old"].isnull())
+                .element_indexing(0)
+            )
             df = df.dropna(subset=["old"])
         else:
             res = self

--- a/python/cudf/cudf/core/column/struct.py
+++ b/python/cudf/cudf/core/column/struct.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 from __future__ import annotations
 
 import pandas as pd
@@ -91,14 +91,12 @@ class StructColumn(ColumnBase):
             pd_series.index = index
         return pd_series
 
-    def __getitem__(self, args):
-        result = super().__getitem__(args)
-        if isinstance(result, dict):
-            return {
-                field: value
-                for field, value in zip(self.dtype.fields, result.values())
-            }
-        return result
+    def element_indexing(self, index: int):
+        result = super().element_indexing(index)
+        return {
+            field: value
+            for field, value in zip(self.dtype.fields, result.values())
+        }
 
     def __setitem__(self, key, value):
         if isinstance(value, dict):

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2457,8 +2457,8 @@ def interval_range(
                 init=start.device_value,
                 step=freq_step.device_value,
             )
-            left_col = bin_edges[:-1]
-            right_col = bin_edges[1:]
+            left_col = bin_edges.slice(0, len(bin_edges) - 1)
+            right_col = bin_edges.slice(1, len(bin_edges))
     elif freq and periods:
         if end:
             start = end - (freq * periods)

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -30,7 +30,6 @@ from cudf._lib.filling import sequence
 from cudf._lib.search import search_sorted
 from cudf.api.types import (
     _is_non_decimal_numeric_dtype,
-    _is_scalar_or_zero_d_array,
     is_categorical_dtype,
     is_dtype_equal,
     is_interval_dtype,
@@ -342,9 +341,8 @@ class RangeIndex(BaseIndex, BinaryOperand):
 
     @_cudf_nvtx_annotate
     def __getitem__(self, index):
-        len_self = len(self)
         if isinstance(index, slice):
-            sl_start, sl_stop, sl_step = index.indices(len_self)
+            sl_start, sl_stop, sl_step = index.indices(len(self))
 
             lo = self._start + sl_start * self._step
             hi = self._start + sl_stop * self._step
@@ -352,19 +350,13 @@ class RangeIndex(BaseIndex, BinaryOperand):
             return RangeIndex(start=lo, stop=hi, step=st, name=self._name)
 
         elif isinstance(index, Number):
+            len_self = len(self)
             if index < 0:
-                index = len_self + index
+                index += len_self
             if not (0 <= index < len_self):
-                raise IndexError("out-of-bound")
-            index = min(index, len_self)
-            index = self._start + index * self._step
-            return index
-        else:
-            if _is_scalar_or_zero_d_array(index):
-                index = np.min_scalar_type(index).type(index)
-            index = column.as_column(index)
-
-        return as_index(self._values[index], name=self.name)
+                raise IndexError("Index out of bounds")
+            return self._start + index * self._step
+        return self._as_int64()[index]
 
     @_cudf_nvtx_annotate
     def equals(self, other):
@@ -1183,11 +1175,7 @@ class GenericIndex(SingleColumnFrame, BaseIndex):
 
     @_cudf_nvtx_annotate
     def __getitem__(self, index):
-        if type(self) == IntervalIndex:
-            raise NotImplementedError(
-                "Getting a scalar from an IntervalIndex is not yet supported"
-            )
-        res = self._values[index]
+        res = self._get_from_column(index)
         if not isinstance(index, int):
             res = as_index(res)
             res.name = self.name
@@ -2613,6 +2601,11 @@ class IntervalIndex(GenericIndex):
         )
 
         return IntervalIndex(interval_col, name=name)
+
+    def __getitem__(self, index):
+        raise NotImplementedError(
+            "Getting a scalar from an IntervalIndex is not yet supported"
+        )
 
     def is_interval(self):
         return True

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -1175,7 +1175,7 @@ class GenericIndex(SingleColumnFrame, BaseIndex):
 
     @_cudf_nvtx_annotate
     def __getitem__(self, index):
-        res = self._get_from_column(index)
+        res = self._get_elements_from_column(index)
         if not isinstance(index, int):
             res = as_index(res)
             res.name = self.name

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1808,7 +1808,9 @@ class IndexedFrame(Frame):
             return self.copy()
 
         pd_offset = pd.tseries.frequencies.to_offset(offset)
-        to_search = op(pd.Timestamp(self._index._column[idx]), pd_offset)
+        to_search = op(
+            pd.Timestamp(self._index._column.element_indexing(idx)), pd_offset
+        )
         if (
             idx == 0
             and not isinstance(pd_offset, pd.tseries.offsets.Tick)

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1173,9 +1173,9 @@ class IndexedFrame(Frame):
 
             # argsort the `by` column
             return self._gather(
-                self._get_columns_by_label(columns)._get_sorted_inds(
-                    ascending=not largest
-                )[:n],
+                self._get_columns_by_label(columns)
+                ._get_sorted_inds(ascending=not largest)
+                .slice(*slice(None, n).indices(len(self))),
                 keep_index=True,
                 check_bounds=False,
             )
@@ -1186,9 +1186,11 @@ class IndexedFrame(Frame):
 
             if n <= 0:
                 # Empty slice.
-                indices = indices[0:0]
+                indices = indices.slice(0, 0)
             else:
-                indices = indices[: -n - 1 : -1]
+                indices = indices.slice(
+                    *slice(None, -n - 1, -1).indices(len(self))
+                )
             return self._gather(indices, keep_index=True, check_bounds=False)
         else:
             raise ValueError('keep must be either "first", "last"')

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -98,7 +98,11 @@ class _SeriesIlocIndexer(_FrameIndexer):
             arg = list(arg)
         data = self._frame._get_from_column(arg)
 
-        if _is_scalar_or_zero_d_array(data) or _is_null_host_scalar(data):
+        if (
+            isinstance(data, (dict, list))
+            or _is_scalar_or_zero_d_array(data)
+            or _is_null_host_scalar(data)
+        ):
             return data
         return self._frame._from_data(
             {self._frame.name: data},

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -96,7 +96,7 @@ class _SeriesIlocIndexer(_FrameIndexer):
     def __getitem__(self, arg):
         if isinstance(arg, tuple):
             arg = list(arg)
-        data = self._frame._get_from_column(arg)
+        data = self._frame._get_elements_from_column(arg)
 
         if (
             isinstance(data, (dict, list))

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -96,13 +96,9 @@ class _SeriesIlocIndexer(_FrameIndexer):
     def __getitem__(self, arg):
         if isinstance(arg, tuple):
             arg = list(arg)
-        data = self._frame._column[arg]
+        data = self._frame._get_from_column(arg)
 
-        if (
-            isinstance(data, (dict, list))
-            or _is_scalar_or_zero_d_array(data)
-            or _is_null_host_scalar(data)
-        ):
+        if _is_scalar_or_zero_d_array(data) or _is_null_host_scalar(data):
             return data
         return self._frame._from_data(
             {self._frame.name: data},

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -10,8 +10,12 @@ import numpy as np
 import pandas as pd
 
 import cudf
-from cudf._typing import Dtype
-from cudf.api.types import _is_scalar_or_zero_d_array
+from cudf._typing import Dtype, ScalarLike
+from cudf.api.types import (
+    _is_scalar_or_zero_d_array,
+    is_bool_dtype,
+    is_integer_dtype,
+)
 from cudf.core.column import ColumnBase, as_column
 from cudf.core.frame import Frame
 from cudf.utils.utils import NotIterable, _cudf_nvtx_annotate
@@ -359,3 +363,23 @@ class SingleColumnFrame(Frame, NotIterable):
         if self._column.null_count == len(self):
             return 0
         return self._column.distinct_count(dropna=dropna)
+
+    def _get_from_column(self, arg) -> Union[ScalarLike, ColumnBase]:
+        # A generic method for getting elements from a column that supports a
+        # wide range of different inputs. This method should only used where
+        # _absolutely_ necessary, since in almost all cases a more specific
+        # method can be used e.g. element_indexing or slice.
+        if _is_scalar_or_zero_d_array(arg):
+            return self._column.element_indexing(int(arg))
+        elif isinstance(arg, slice):
+            start, stop, stride = arg.indices(len(self))
+            return self._column.slice(start, stop, stride)
+        else:
+            arg = as_column(arg)
+            if len(arg) == 0:
+                arg = as_column([], dtype="int32")
+            if is_integer_dtype(arg.dtype):
+                return self._column.take(arg)
+            if is_bool_dtype(arg.dtype):
+                return self._column.apply_boolean_mask(arg)
+            raise NotImplementedError(f"Unknown indexer {type(arg)}")

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -364,7 +364,7 @@ class SingleColumnFrame(Frame, NotIterable):
             return 0
         return self._column.distinct_count(dropna=dropna)
 
-    def _get_from_column(self, arg) -> Union[ScalarLike, ColumnBase]:
+    def _get_elements_from_column(self, arg) -> Union[ScalarLike, ColumnBase]:
         # A generic method for getting elements from a column that supports a
         # wide range of different inputs. This method should only used where
         # _absolutely_ necessary, since in almost all cases a more specific

--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -262,7 +262,7 @@ def to_datetime(
             )
 
             if is_scalar(arg):
-                return col[0]
+                return col.element_indexing(0)
             else:
                 return as_index(col)
     except Exception as e:
@@ -346,11 +346,13 @@ def _process_col(col, unit, dayfirst, infer_datetime_format, format):
         else:
             if infer_datetime_format and format is None:
                 format = column.datetime.infer_format(
-                    element=col[0],
+                    element=col.element_indexing(0),
                     dayfirst=dayfirst,
                 )
             elif format is None:
-                format = column.datetime.infer_format(element=col[0])
+                format = column.datetime.infer_format(
+                    element=col.element_indexing(0)
+                )
             col = col.as_datetime_column(
                 dtype=_unit_dtype_map[unit],
                 format=format,
@@ -909,9 +911,9 @@ def date_range(
             # As mentioned in [1], this is a post processing step to trim extra
             # elements when `periods` is an estimated value. Only offset
             # specified with non fixed frequencies requires trimming.
-            res = res[
+            res = res.apply_boolean_mask(
                 (res <= end) if _is_increment_sequence else (res <= start)
-            ]
+            )
     else:
         # If `offset` is fixed frequency, we generate a range of
         # treating `start`, `stop` and `step` as ints:

--- a/python/cudf/cudf/testing/testing.py
+++ b/python/cudf/cudf/testing/testing.py
@@ -247,8 +247,12 @@ def assert_column_equal(
             if columns_equal and not check_exact and is_numeric_dtype(left):
                 # non-null values must be the same
                 columns_equal = cp.allclose(
-                    left[left.isnull().unary_operator("not")].values,
-                    right[right.isnull().unary_operator("not")].values,
+                    left.apply_boolean_mask(
+                        left.isnull().unary_operator("not")
+                    ).values,
+                    right.apply_boolean_mask(
+                        right.isnull().unary_operator("not")
+                    ).values,
                 )
                 if columns_equal and (
                     left.dtype.kind == right.dtype.kind == "f"

--- a/python/cudf/cudf/tests/test_df_protocol.py
+++ b/python/cudf/cudf/tests/test_df_protocol.py
@@ -33,7 +33,10 @@ def assert_buffer_equal(buffer_and_dtype: Tuple[_CuDFBuffer, Any], cudfcol):
     # currently only non-null values are compared, null positions are
     # unchecked.
     non_null_idxs = ~cudf.Series(cudfcol).isna()
-    assert_eq(col_from_buf[non_null_idxs], cudfcol[non_null_idxs])
+    assert_eq(
+        col_from_buf.apply_boolean_mask(non_null_idxs),
+        cudfcol.apply_boolean_mask(non_null_idxs),
+    )
 
     if dtype[0] != _DtypeKind.BOOL:
         array_from_dlpack = cp.fromDlpack(buf.__dlpack__()).get()

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -341,14 +341,7 @@ def test_series_column_iter_error():
     ):
         gs.iteritems()
 
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            f"{gs._column.__class__.__name__} object is not iterable. "
-            f"Consider using `.to_arrow()`, `.to_pandas()` or `.values_host` "
-            f"if you wish to iterate over the values."
-        ),
-    ):
+    with pytest.raises(TypeError):
         iter(gs._column)
 
 

--- a/python/cudf/cudf/tests/test_testing.py
+++ b/python/cudf/cudf/tests/test_testing.py
@@ -170,8 +170,8 @@ def test_assert_column_equal_dtype_edge_cases(other):
         assert_column_equal(base, other, check_dtype=False)
 
     # the exceptions are the empty and all null cases
-    assert_column_equal(base[:0], other[:0], check_dtype=False)
-    assert_column_equal(other[:0], base[:0], check_dtype=False)
+    assert_column_equal(base.slice(0, 0), other.slice(0, 0), check_dtype=False)
+    assert_column_equal(other.slice(0, 0), base.slice(0, 0), check_dtype=False)
 
     base = full(len(base), fill_value=cudf.NA, dtype=base.dtype)
     other = full(len(other), fill_value=cudf.NA, dtype=other.dtype)
@@ -411,8 +411,8 @@ def test_assert_column_memory_basic(arrow_arrays):
 
 def test_assert_column_memory_slice(arrow_arrays):
     col = cudf.core.column.ColumnBase.from_arrow(arrow_arrays)
-    left = col[0:1]
-    right = col[1:2]
+    left = col.slice(0, 1)
+    right = col.slice(1, 2)
 
     with pytest.raises(AssertionError):
         assert_column_memory_eq(left, right)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This PR removes the `ColumnBase.__getitem__` method, which is heavily overloaded and easy to abuse, and changes everywhere that called it to use the appropriate method. There turn out to be exactly two places in the code that actually require the current implementation of this method, Series and Index indexing, so this functionality has been moved into `SingleColumnFrame`. Removing `__getitem__` also means that we no longer need to explicitly fail on `__iter__` and `__array__` since there is no longer an implicit fallback.

The one downside to this now is that it _is_ possible to create a numpy array from a column. However, it won't make a numpy array from the data, it will create an object dtype 0-D array _containing_ the column. This is how `np.array` and `np.asarray` behave for normal objects, so I think this behavior is fine for us too. ColumnBase is (for now) an internal object, so we don't need to provide super helpful error messages, and for developers it should be fairly obvious what is wrong if they try to do this conversion:
```
>>> import cudf
>>> import numpy as np
>>> s = cudf.Series([1])
>>> arr = np.array(s._column)
>>> arr.ndim
0
>>> arr[0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: too many indices for array: array is 0-dimensional, but 1 were indexed
>>> arr
array(<cudf.core.column.numerical.NumericalColumn object at 0x7efeddf634c0>
[
  1
]
dtype: int64, dtype=object)
```

That being said, I can put back the `__array__` implementation if people feel strongly about it.