### PR TITLE
Add support for non-numeric types in Series.diff and DataFrame.diff

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1768,7 +1768,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             upper_right = self.head(upper_rows).iloc[:, right_cols:]
             lower_left = self.tail(lower_rows).iloc[:, :left_cols]
             lower_right = self.tail(lower_rows).iloc[:, right_cols:]
-
             upper = cudf.concat([upper_left, upper_right], axis=1)
             lower = cudf.concat([lower_left, lower_right], axis=1)
             output = cudf.concat([upper, lower])
@@ -2665,11 +2664,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         axis = self._get_axis_from_axis_arg(axis)
         if axis != 0:
             raise NotImplementedError("Only axis=0 is supported.")
-
-        if not all(is_numeric_dtype(i) for i in self.dtypes):
-            raise NotImplementedError(
-                "DataFrame.diff only supports numeric dtypes"
-            )
 
         if abs(periods) > len(self):
             df = cudf.DataFrame._from_data(

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1768,7 +1768,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             upper_right = self.head(upper_rows).iloc[:, right_cols:]
             lower_left = self.tail(lower_rows).iloc[:, :left_cols]
             lower_right = self.tail(lower_rows).iloc[:, right_cols:]
-            
+
             upper = cudf.concat([upper_left, upper_right], axis=1)
             lower = cudf.concat([lower_left, lower_right], axis=1)
             output = cudf.concat([upper, lower])

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1768,6 +1768,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             upper_right = self.head(upper_rows).iloc[:, right_cols:]
             lower_left = self.tail(lower_rows).iloc[:, :left_cols]
             lower_right = self.tail(lower_rows).iloc[:, right_cols:]
+            
             upper = cudf.concat([upper_left, upper_right], axis=1)
             lower = cudf.concat([lower_left, lower_right], axis=1)
             output = cudf.concat([upper, lower])

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -3045,27 +3045,6 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
                 "Diff currently requires columns with no null values"
             )
 
-        # if not np.issubdtype(self.dtype, np.number):
-        #     raise NotImplementedError(
-        #         "Diff currently only supports numeric dtypes"
-        #     )
-
-        # TODO: move this libcudf
-        # input_col = self._column
-        # output_col = column_empty_like(input_col)
-        # output_mask = column_empty_like(input_col, dtype="bool")
-        # if output_col.size > 0:
-        #     cudautils.gpu_diff.forall(output_col.size)(
-        #         input_col, output_col, output_mask, periods
-        #     )
-
-        # output_col = column.build_column(
-        #     data=output_col.data,
-        #     dtype=output_col.dtype,
-        #     mask=bools_to_mask(output_mask),
-        # )
-
-        # return Series(output_col, name=self.name, index=self.index)
         return self - self.shift(periods=periods)
 
     @copy_docstring(SeriesGroupBy)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -3045,27 +3045,28 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
                 "Diff currently requires columns with no null values"
             )
 
-        if not np.issubdtype(self.dtype, np.number):
-            raise NotImplementedError(
-                "Diff currently only supports numeric dtypes"
-            )
+        # if not np.issubdtype(self.dtype, np.number):
+        #     raise NotImplementedError(
+        #         "Diff currently only supports numeric dtypes"
+        #     )
 
         # TODO: move this libcudf
-        input_col = self._column
-        output_col = column_empty_like(input_col)
-        output_mask = column_empty_like(input_col, dtype="bool")
-        if output_col.size > 0:
-            cudautils.gpu_diff.forall(output_col.size)(
-                input_col, output_col, output_mask, periods
-            )
+        # input_col = self._column
+        # output_col = column_empty_like(input_col)
+        # output_mask = column_empty_like(input_col, dtype="bool")
+        # if output_col.size > 0:
+        #     cudautils.gpu_diff.forall(output_col.size)(
+        #         input_col, output_col, output_mask, periods
+        #     )
 
-        output_col = column.build_column(
-            data=output_col.data,
-            dtype=output_col.dtype,
-            mask=bools_to_mask(output_mask),
-        )
+        # output_col = column.build_column(
+        #     data=output_col.data,
+        #     dtype=output_col.dtype,
+        #     mask=bools_to_mask(output_mask),
+        # )
 
-        return Series(output_col, name=self.name, index=self.index)
+        # return Series(output_col, name=self.name, index=self.index)
+        return self - self.shift(periods=periods)
 
     @copy_docstring(SeriesGroupBy)
     @_cudf_nvtx_annotate


### PR DESCRIPTION
This PR supports non-numeric data types (timestamp and ranges) in `Series.diff` and `DataFrame.diff`. In `DataFrame.diff`, datetime ranges are already supported because `DataFrame.shift` works. But `Series.diff` doesn't use the `Series.shift` implementation, so there wasn't support for datetime ranges. 
```python
import datetime
dti = pd.to_datetime(
    ["1/1/2018", np.datetime64("2018-01-01"), datetime.datetime(2018, 1, 1), datetime.datetime(2020, 1, 1)]
)
df = DataFrame({"dates": dti})
df.diff(periods=periods, axis=axis)
```
closes #10212. 