### PR TITLE
Remove statically linked CUDA runtime check in Java build

### DIFF
--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -92,9 +92,6 @@ fi
 
 cd "$WORKSPACE/java"
 mvn -B clean package $BUILD_ARG
-
-###### Sanity test: fail if static cudart found ######
-find . -name '*.so' | xargs -I{} readelf -Ws {} | grep cuInit && echo "Found statically linked CUDA runtime, this is currently not tested" && exit 1
 
 ###### Stash Jar files ######
 rm -rf $OUT_PATH


### PR DESCRIPTION
#9873 added static linking of the CUDA runtime by default in Java cudf builds from the `build-in-docker.sh`.  At the end of the script is a sanity check that the CUDA runtime is _not_ statically linked which should have been removed, but it fails to trigger due to an empty `.so` file found during the build that causes an error in `readelf` and prevents the script from exiting early. This PR removes the check since a statically linked CUDA runtime is supported and tested.