### PR TITLE
[FEA] Enable building static libs

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -158,19 +158,20 @@ include(cmake/Modules/FindcuFile.cmake)
 
 # Workaround until https://github.com/rapidsai/rapids-cmake/issues/176 is resolved
 if(NOT BUILD_SHARED_LIBS)
-    include("${rapids-cmake-dir}/export/find_package_file.cmake")
-    file(COPY        "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake"
-         DESTINATION "${CMAKE_BINARY_DIR}/cmake/find_modules")
-    list(APPEND METADATA_KINDS BUILD INSTALL)
-    foreach(METADATA_KIND IN LISTS METADATA_KINDS)
-        rapids_export_find_package_file(${METADATA_KIND}
-                                        "${CMAKE_BINARY_DIR}/cmake/find_modules/FindcuFile.cmake"
-                                        cudf-exports)
-        rapids_export_package(${METADATA_KIND} cuco cudf-exports)
-        rapids_export_package(${METADATA_KIND} ZLIB cudf-exports)
-        rapids_export_package(${METADATA_KIND} cuFile cudf-exports)
-        rapids_export_package(${METADATA_KIND} nvcomp cudf-exports)
-    endforeach()
+  include("${rapids-cmake-dir}/export/find_package_file.cmake")
+  file(COPY "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake"
+       DESTINATION "${CMAKE_BINARY_DIR}/cmake/find_modules"
+  )
+  list(APPEND METADATA_KINDS BUILD INSTALL)
+  foreach(METADATA_KIND IN LISTS METADATA_KINDS)
+    rapids_export_find_package_file(
+      ${METADATA_KIND} "${CMAKE_BINARY_DIR}/cmake/find_modules/FindcuFile.cmake" cudf-exports
+    )
+    rapids_export_package(${METADATA_KIND} cuco cudf-exports)
+    rapids_export_package(${METADATA_KIND} ZLIB cudf-exports)
+    rapids_export_package(${METADATA_KIND} cuFile cudf-exports)
+    rapids_export_package(${METADATA_KIND} nvcomp cudf-exports)
+  endforeach()
 endif()
 
 # ##################################################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -156,6 +156,23 @@ include(cmake/Modules/JitifyPreprocessKernels.cmake)
 # find cuFile
 include(cmake/Modules/FindcuFile.cmake)
 
+# Workaround until https://github.com/rapidsai/rapids-cmake/issues/176 is resolved
+if(NOT BUILD_SHARED_LIBS)
+    include("${rapids-cmake-dir}/export/find_package_file.cmake")
+    file(COPY        "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake"
+         DESTINATION "${CMAKE_BINARY_DIR}/cmake/find_modules")
+    list(APPEND METADATA_KINDS BUILD INSTALL)
+    foreach(METADATA_KIND IN LISTS METADATA_KINDS)
+        rapids_export_find_package_file(${METADATA_KIND}
+                                        "${CMAKE_BINARY_DIR}/cmake/find_modules/FindcuFile.cmake"
+                                        cudf-exports)
+        rapids_export_package(${METADATA_KIND} cuco cudf-exports)
+        rapids_export_package(${METADATA_KIND} ZLIB cudf-exports)
+        rapids_export_package(${METADATA_KIND} cuFile cudf-exports)
+        rapids_export_package(${METADATA_KIND} nvcomp cudf-exports)
+    endforeach()
+endif()
+
 # ##################################################################################################
 # * library targets -------------------------------------------------------------------------------
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -159,13 +159,10 @@ include(cmake/Modules/FindcuFile.cmake)
 # Workaround until https://github.com/rapidsai/rapids-cmake/issues/176 is resolved
 if(NOT BUILD_SHARED_LIBS)
   include("${rapids-cmake-dir}/export/find_package_file.cmake")
-  file(COPY "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake"
-       DESTINATION "${CMAKE_BINARY_DIR}/cmake/find_modules"
-  )
   list(APPEND METADATA_KINDS BUILD INSTALL)
   foreach(METADATA_KIND IN LISTS METADATA_KINDS)
     rapids_export_find_package_file(
-      ${METADATA_KIND} "${CMAKE_BINARY_DIR}/cmake/find_modules/FindcuFile.cmake" cudf-exports
+      ${METADATA_KIND} "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" cudf-exports
     )
     rapids_export_package(${METADATA_KIND} cuco cudf-exports)
     rapids_export_package(${METADATA_KIND} ZLIB cudf-exports)

--- a/cpp/cmake/thirdparty/get_cucollections.cmake
+++ b/cpp/cmake/thirdparty/get_cucollections.cmake
@@ -18,11 +18,18 @@ function(find_and_configure_cucollections)
   # Find or install cuCollections
   rapids_cpm_find(
     # cuCollections doesn't have a version yet
-    cuco 0.0
+    cuco 0.0.1
     GLOBAL_TARGETS cuco::cuco
-    CPM_ARGS GITHUB_REPOSITORY NVIDIA/cuCollections
-    GIT_TAG 6ec8b6dcdeceea07ab4456d32461a05c18864411
-    OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF"
+    BUILD_EXPORT_SET cudf-exports
+    INSTALL_EXPORT_SET cudf-exports
+    CPM_ARGS
+      GITHUB_REPOSITORY NVIDIA/cuCollections
+      GIT_TAG fb58a38701f1c24ecfe07d8f1f208bbe80930da5
+      EXCLUDE_FROM_ALL ${BUILD_SHARED_LIBS}
+      OPTIONS
+        "BUILD_TESTS OFF"
+        "BUILD_BENCHMARKS OFF"
+        "BUILD_EXAMPLES OFF"
   )
 
 endfunction()

--- a/cpp/cmake/thirdparty/get_cucollections.cmake
+++ b/cpp/cmake/thirdparty/get_cucollections.cmake
@@ -22,14 +22,10 @@ function(find_and_configure_cucollections)
     GLOBAL_TARGETS cuco::cuco
     BUILD_EXPORT_SET cudf-exports
     INSTALL_EXPORT_SET cudf-exports
-    CPM_ARGS
-      GITHUB_REPOSITORY NVIDIA/cuCollections
-      GIT_TAG fb58a38701f1c24ecfe07d8f1f208bbe80930da5
-      EXCLUDE_FROM_ALL ${BUILD_SHARED_LIBS}
-      OPTIONS
-        "BUILD_TESTS OFF"
-        "BUILD_BENCHMARKS OFF"
-        "BUILD_EXAMPLES OFF"
+    CPM_ARGS GITHUB_REPOSITORY NVIDIA/cuCollections
+    GIT_TAG fb58a38701f1c24ecfe07d8f1f208bbe80930da5
+    EXCLUDE_FROM_ALL ${BUILD_SHARED_LIBS}
+    OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF"
   )
 
 endfunction()


### PR DESCRIPTION
This PR tracks private dependencies in the build and install export sets when building static libs. This is necessary for consumers to statically link `libcudf.a` via CMake.