### PR TITLE
Add default= kwarg to .list.get() accessor method

### DIFF
--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -384,12 +384,14 @@ class ListMethods(ColumnMethods):
         if not (default is None or default is cudf.NA):
             # determine rows for which `index` is out-of-bounds
             lengths = count_elements(self._column)
-            out_of_bounds_indexes = (-index > lengths) | (index >= lengths)
+            out_of_bounds_mask = (np.negative(index) > lengths) | (
+                index >= lengths
+            )
 
             # replace the value in those rows (should be NA) with `default`
-            if out_of_bounds_indexes.any():
+            if out_of_bounds_mask.any():
                 out = out._scatter_by_column(
-                    out_of_bounds_indexes, cudf.Scalar(default)
+                    out_of_bounds_mask, cudf.Scalar(default)
                 )
 
         return self._return_or_inplace(out)

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -342,8 +342,10 @@ class ListMethods(ColumnMethods):
     ) -> ParentType:
         """
         Extract element at the given index from each list.
+
         If the index is out of bounds for any list,
         return <NA> or, if provided, ``default``.
+        Thus, this method never raises an ``IndexError``.
 
         Parameters
         ----------

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -381,7 +381,7 @@ class ListMethods(ColumnMethods):
         """
         out = extract_element(self._column, index)
 
-        if default not in {None, cudf.NA}:
+        if not (default is None or default is cudf.NA):
             # determine rows for which `index` is out-of-bounds
             lengths = count_elements(self._column)
             out_of_bounds_mask = (np.negative(index) > lengths) | (

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -386,7 +386,7 @@ class ListMethods(ColumnMethods):
             lengths = count_elements(self._column)
             out_of_bounds_indexes = (-index > lengths) | (index >= lengths)
 
-            # replace the value in those rows (should be NA) with ``default``
+            # replace the value in those rows (should be NA) with `default`
             if out_of_bounds_indexes.any():
                 out = out._scatter_by_column(
                     out_of_bounds_indexes, cudf.Scalar(default)

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -292,10 +292,12 @@ def test_get_nested_lists():
     assert_eq(expect, got)
 
 
-def test_get_nulls():
-    with pytest.raises(IndexError, match="list index out of range"):
-        sr = cudf.Series([[], [], []])
-        sr.list.get(100)
+def test_get_default():
+    sr = cudf.Series([[1, 2], [3, 4, 5], [6, 7, 8, 9]])
+
+    assert_eq(cudf.Series([cudf.NA, 5, 8]), sr.list.get(2))
+    assert_eq(cudf.Series([cudf.NA, 5, 8]), sr.list.get(2, default=cudf.NA))
+    assert_eq(cudf.Series([0, 5, 8]), sr.list.get(2, default=0))
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -298,6 +298,16 @@ def test_get_default():
     assert_eq(cudf.Series([cudf.NA, 5, 8]), sr.list.get(2))
     assert_eq(cudf.Series([cudf.NA, 5, 8]), sr.list.get(2, default=cudf.NA))
     assert_eq(cudf.Series([0, 5, 8]), sr.list.get(2, default=0))
+    assert_eq(cudf.Series([0, 5, 8]), sr.list.get(2, default=0))
+    assert_eq(cudf.Series([2, 5, 9]), sr.list.get(-1))
+
+    string_sr = cudf.Series(
+        [["apple", "banana"], ["carrot", "daffodil", "elephant"]]
+    )
+    assert_eq(
+        cudf.Series(["default", "elephant"]),
+        string_sr.list.get(2, default="default"),
+    )
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -298,7 +298,6 @@ def test_get_default():
     assert_eq(cudf.Series([cudf.NA, 5, 8]), sr.list.get(2))
     assert_eq(cudf.Series([cudf.NA, 5, 8]), sr.list.get(2, default=cudf.NA))
     assert_eq(cudf.Series([0, 5, 8]), sr.list.get(2, default=0))
-    assert_eq(cudf.Series([0, 5, 8]), sr.list.get(2, default=0))
     assert_eq(cudf.Series([0, 3, 7]), sr.list.get(-3, default=0))
     assert_eq(cudf.Series([2, 5, 9]), sr.list.get(-1))
 

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -299,6 +299,7 @@ def test_get_default():
     assert_eq(cudf.Series([cudf.NA, 5, 8]), sr.list.get(2, default=cudf.NA))
     assert_eq(cudf.Series([0, 5, 8]), sr.list.get(2, default=0))
     assert_eq(cudf.Series([0, 5, 8]), sr.list.get(2, default=0))
+    assert_eq(cudf.Series([0, 3, 7]), sr.list.get(-3, default=0))
     assert_eq(cudf.Series([2, 5, 9]), sr.list.get(-1))
 
     string_sr = cudf.Series(
@@ -309,10 +310,8 @@ def test_get_default():
         string_sr.list.get(2, default="default"),
     )
 
-
-def test_get_default_with_null():
-    sr = cudf.Series([[0, cudf.NA], [1]])
-    assert_eq(cudf.Series([cudf.NA, 0]), sr.list.get(1, default=0))
+    sr_with_null = cudf.Series([[0, cudf.NA], [1]])
+    assert_eq(cudf.Series([cudf.NA, 0]), sr_with_null.list.get(1, default=0))
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -310,6 +310,11 @@ def test_get_default():
     )
 
 
+def test_get_default_with_null():
+    sr = cudf.Series([[0, cudf.NA], [1]])
+    assert_eq(cudf.Series([cudf.NA, 0]), sr.list.get(1, default=0))
+
+
 @pytest.mark.parametrize(
     "data, scalar, expect",
     [

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -313,6 +313,13 @@ def test_get_default():
     sr_with_null = cudf.Series([[0, cudf.NA], [1]])
     assert_eq(cudf.Series([cudf.NA, 0]), sr_with_null.list.get(1, default=0))
 
+    sr_nested = cudf.Series([[[1, 2], [3, 4], [5, 6]], [[5, 6], [7, 8]]])
+    assert_eq(cudf.Series([[3, 4], [7, 8]]), sr_nested.list.get(1))
+    assert_eq(cudf.Series([[5, 6], cudf.NA]), sr_nested.list.get(2))
+    assert_eq(
+        cudf.Series([[5, 6], [0, 0]]), sr_nested.list.get(2, default=[0, 0])
+    )
+
 
 @pytest.mark.parametrize(
     "data, scalar, expect",

--- a/python/cudf/cudf/tests/test_text.py
+++ b/python/cudf/cudf/tests/test_text.py
@@ -822,10 +822,10 @@ def test_read_text_byte_range(datadir):
     assert_eq(expected, actual)
 
 
-def test_read_text_byte_range_large(datadir):
-    content = str(("\n" if x % 5 == 0 else "x") for x in range(0, 300000000))
+def test_read_text_byte_range_large(tmpdir):
+    content = str([["\n" if x % 5 == 0 else "x"] for x in range(0, 3000)])
     delimiter = "1."
-    temp_file = str(datadir) + "/temp.txt"
+    temp_file = str(tmpdir) + "/temp.txt"
 
     with open(temp_file, "w") as f:
         f.write(content)

--- a/python/dask_cudf/dask_cudf/tests/test_accessor.py
+++ b/python/dask_cudf/dask_cudf/tests/test_accessor.py
@@ -384,7 +384,7 @@ def test_contains(data, search_key):
     "data, index, expectation",
     [
         (data_test_1(), 1, does_not_raise()),
-        (data_test_2(), 2, pytest.raises(IndexError)),
+        (data_test_2(), 2, does_not_raise()),
     ],
 )
 def test_get(data, index, expectation):


### PR DESCRIPTION
Closes #10540.

As mentioned in the issue, this is a breaking change, although we could introduce this change in a non-breaking way by using a sentinel value for the kwarg if desired.