### PR TITLE
Fix doxygen Modules page for cudf::lists::sequences

### DIFF
--- a/cpp/include/cudf/lists/combine.hpp
+++ b/cpp/include/cudf/lists/combine.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 #include <cudf/lists/lists_column_view.hpp>
 
 namespace cudf {
+
+//! Lists column APIs
 namespace lists {
 /**
  * @addtogroup lists_combine

--- a/cpp/include/doxygen_groups.h
+++ b/cpp/include/doxygen_groups.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,6 +146,7 @@
  * @{
  *   @defgroup lists_combine Combining
  *   @defgroup lists_extract Extracting
+ *   @defgroup lists_filling Filling
  *   @defgroup lists_contains Searching
  *   @defgroup lists_gather Gathering
  *   @defgroup lists_elements Counting


### PR DESCRIPTION
Corrects the [Modules](https://docs.rapids.ai/api/libcudf/nightly/modules.html) page where the `lists_filling` group appears at the bottom:
![image](https://user-images.githubusercontent.com/45795991/161142554-b78b8c2b-49dd-4958-8d2f-df3aa1720b86.png)

The `lists_filling` group is added to the appropriate section in the [`doxygen_groups.h`](https://github.com/rapidsai/cudf/blob/branch-22.06/cpp/include/doxygen_groups.h) file.

Also added a doxygen description for `namespace lists` so it will appear in the [Namespace List](https://docs.rapids.ai/api/libcudf/nightly/namespaces.html) page. This becomes an easy way to find the documentation fo all the `lists` APIs.