### PR TITLE
Re-enable Build Metrics Report

### DIFF
--- a/conda/recipes/libcudf/build.sh
+++ b/conda/recipes/libcudf/build.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 export cudf_ROOT="$(realpath ./cpp/build)"
-./build.sh -n -v libcudf libcudf_kafka benchmarks tests --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+./build.sh -n -v libcudf libcudf_kafka benchmarks tests --build_metrics --incl_cache_stats --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"


### PR DESCRIPTION
The Build Metrics Report was accidentally disabled in #10326. This will add the flags back to the `build.sh` that are required to generate the report during CI.