### PR TITLE
JNI Bindings to fetch CUDA compute capability versions.

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -402,7 +402,7 @@ public class Cuda {
    * @return The Major compute capability version number of the current CUDA device
    * @throws CudaException on any error
    */
-  public static native int getCurrentComputeCapabilityMajor() throws CudaException;  
+  public static native int getComputeCapabilityMajor() throws CudaException;  
 
   /**
    * Gets the minor CUDA compute capability of the current device.
@@ -420,7 +420,7 @@ public class Cuda {
    * @return The Minor compute capability version number of the current CUDA device
    * @throws CudaException on any error
    */
-  public static native int getCurrentComputeCapabilityMinor() throws CudaException;
+  public static native int getComputeCapabilityMinor() throws CudaException;
 
   /**
    * Calls cudaFree(0). This can be used to initialize the GPU after a setDevice()

--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -385,6 +385,42 @@ public class Cuda {
    * @throws CudaException on any error
    */
   static native int getNativeComputeMode() throws CudaException;
+
+  /**
+   * Gets the major CUDA compute capability of the current device.
+   * 
+   * For reference: https://developer.nvidia.com/cuda-gpus
+   * Hardware Generation	Compute Capability
+   *     Ampere	                8.x
+   *     Turing	                7.5
+   *     Volta	                7.0, 7.2
+   *     Pascal	                6.x
+   *     Maxwell                5.x
+   *     Kepler	                3.x
+   *     Fermi	                2.x
+   * 
+   * @return The Major compute capability version number of the current CUDA device
+   * @throws CudaException on any error
+   */
+  public static native int getCurrentComputeCapabilityMajor() throws CudaException;  
+
+  /**
+   * Gets the minor CUDA compute capability of the current device.
+   * 
+   * For reference: https://developer.nvidia.com/cuda-gpus
+   * Hardware Generation	Compute Capability
+   *     Ampere	                8.x
+   *     Turing	                7.5
+   *     Volta	                7.0, 7.2
+   *     Pascal	                6.x
+   *     Maxwell                5.x
+   *     Kepler	                3.x
+   *     Fermi	                2.x
+   * 
+   * @return The Minor compute capability version number of the current CUDA device
+   * @throws CudaException on any error
+   */
+  public static native int getCurrentComputeCapabilityMinor() throws CudaException;
 
   /**
    * Calls cudaFree(0). This can be used to initialize the GPU after a setDevice()

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -195,30 +195,32 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getNativeComputeMode(JNIEnv *env
   CATCH_STD(env, -2);
 }
 
-namespace {
-
-jint cuda_device_get_attribute_impl(JNIEnv *env, cudaDeviceAttr const &attribute_label) {
+JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getComputeCapabilityMajor(JNIEnv *env, jclass) {
   try {
     cudf::jni::auto_set_device(env);
     int device;
     JNI_CUDA_TRY(env, -2, ::cudaGetDevice(&device));
     int attribute_value;
-    JNI_CUDA_TRY(env, -2, ::cudaDeviceGetAttribute(&attribute_value, attribute_label, device));
+    JNI_CUDA_TRY(
+        env, -2,
+        ::cudaDeviceGetAttribute(&attribute_value, ::cudaDevAttrComputeCapabilityMajor, device));
     return attribute_value;
   }
   CATCH_STD(env, -2);
 }
 
-} // namespace
-
-JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getCurrentComputeCapabilityMajor(JNIEnv *env,
-                                                                                 jclass) {
-  return cuda_device_get_attribute_impl(env, ::cudaDevAttrComputeCapabilityMajor);
-}
-
-JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getCurrentComputeCapabilityMinor(JNIEnv *env,
-                                                                                 jclass) {
-  return cuda_device_get_attribute_impl(env, ::cudaDevAttrComputeCapabilityMinor);
+JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getComputeCapabilityMinor(JNIEnv *env, jclass) {
+  try {
+    cudf::jni::auto_set_device(env);
+    int device;
+    JNI_CUDA_TRY(env, -2, ::cudaGetDevice(&device));
+    int attribute_value;
+    JNI_CUDA_TRY(
+        env, -2,
+        ::cudaDeviceGetAttribute(&attribute_value, ::cudaDevAttrComputeCapabilityMinor, device));
+    return attribute_value;
+  }
+  CATCH_STD(env, -2);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_freeZero(JNIEnv *env, jclass) {

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,6 +193,32 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getNativeComputeMode(JNIEnv *env
     return device_prop.computeMode;
   }
   CATCH_STD(env, -2);
+}
+
+namespace {
+
+jint cuda_device_get_attribute_impl(JNIEnv *env, cudaDeviceAttr const &attribute_label) {
+  try {
+    cudf::jni::auto_set_device(env);
+    int device;
+    JNI_CUDA_TRY(env, -2, ::cudaGetDevice(&device));
+    int attribute_value;
+    JNI_CUDA_TRY(env, -2, ::cudaDeviceGetAttribute(&attribute_value, attribute_label, device));
+    return attribute_value;
+  }
+  CATCH_STD(env, -2);
+}
+
+} // namespace
+
+JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getCurrentComputeCapabilityMajor(JNIEnv *env,
+                                                                                 jclass) {
+  return cuda_device_get_attribute_impl(env, ::cudaDevAttrComputeCapabilityMajor);
+}
+
+JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getCurrentComputeCapabilityMinor(JNIEnv *env,
+                                                                                 jclass) {
+  return cuda_device_get_attribute_impl(env, ::cudaDevAttrComputeCapabilityMinor);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_freeZero(JNIEnv *env, jclass) {


### PR DESCRIPTION
This commit introduces JNI bindings to retrieve the major and minor CUDA compute capability versions for the current CUDA device.

This feature enables introspection from `spark-rapids` to detect the GPU architecture, for model-specific behaviour.
This is required from NVIDIA/spark-rapids/pull/5122, to work around the erroneous behaviour of JNI `fixed_width_convert_to_rows()` on Pascal GPUs (#10569), (which in turn produces failures like NVIDIA/spark-rapids/issues/4980).