### PR TITLE
Fix has_atomic_support check in can_use_hash_groupby()

### DIFF
--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -645,10 +645,14 @@ bool can_use_hash_groupby(table_view const& keys, host_span<aggregation_request 
     // Currently, structs are not supported in any of hash-based aggregations.
     // Therefore, if any request contains structs then we must fallback to sort-based aggregations.
     // TODO: Support structs in hash-based aggregations.
+    auto const v_type = is_dictionary(r.values.type())
+                          ? cudf::dictionary_column_view(r.values).keys().type()
+                          : r.values.type();
+
     return not(r.values.type().id() == type_id::STRUCT) and
-           cudf::has_atomic_support(r.values.type()) and
-           std::all_of(r.aggregations.begin(), r.aggregations.end(), [](auto const& a) {
-             return is_hash_aggregation(a->kind);
+           std::all_of(r.aggregations.begin(), r.aggregations.end(), [v_type](auto const& a) {
+             return cudf::has_atomic_support(cudf::detail::target_type(v_type, a->kind)) and
+                    is_hash_aggregation(a->kind);
            });
   });
 }


### PR DESCRIPTION
Closes #10583.

Change the has_atomic_support check in can_use_hash_groupby() to check the target type for the aggregation instead of the source type.

See discussion in #10583.

I have verified that this fixes the performance regression in our customer queries, and all unit tests still pass.
