### PR TITLE
Fix strings strip() to accept only str Scalar for to_strip parameter

### DIFF
--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -2006,7 +2006,9 @@ class StringMethods(ColumnMethods):
             repl = ""
 
         return self._return_or_inplace(
-            libstrings.filter_alphanum(self._column, cudf.Scalar(repl), keep),
+            libstrings.filter_alphanum(
+                self._column, cudf.Scalar(repl, "str"), keep
+            ),
         )
 
     def slice_from(
@@ -2141,7 +2143,7 @@ class StringMethods(ColumnMethods):
 
         return self._return_or_inplace(
             libstrings.slice_replace(
-                self._column, start, stop, cudf.Scalar(repl)
+                self._column, start, stop, cudf.Scalar(repl, "str")
             ),
         )
 
@@ -2192,7 +2194,7 @@ class StringMethods(ColumnMethods):
             repl = ""
 
         return self._return_or_inplace(
-            libstrings.insert(self._column, start, cudf.Scalar(repl)),
+            libstrings.insert(self._column, start, cudf.Scalar(repl, "str")),
         )
 
     def get(self, i: int = 0) -> SeriesOrIndex:
@@ -2643,7 +2645,7 @@ class StringMethods(ColumnMethods):
                 )
             else:
                 result_table = libstrings.rsplit_record(
-                    self._column, cudf.Scalar(pat), n
+                    self._column, cudf.Scalar(pat, "str"), n
                 )
 
         return self._return_or_inplace(result_table, expand=expand)
@@ -2726,7 +2728,7 @@ class StringMethods(ColumnMethods):
 
         return self._return_or_inplace(
             cudf.core.frame.Frame(
-                *libstrings.partition(self._column, cudf.Scalar(sep))
+                *libstrings.partition(self._column, cudf.Scalar(sep, "str"))
             ),
             expand=expand,
         )
@@ -2793,7 +2795,7 @@ class StringMethods(ColumnMethods):
 
         return self._return_or_inplace(
             cudf.core.frame.Frame(
-                *libstrings.rpartition(self._column, cudf.Scalar(sep))
+                *libstrings.rpartition(self._column, cudf.Scalar(sep, "str"))
             ),
             expand=expand,
         )
@@ -3194,7 +3196,7 @@ class StringMethods(ColumnMethods):
             to_strip = ""
 
         return self._return_or_inplace(
-            libstrings.strip(self._column, cudf.Scalar(to_strip))
+            libstrings.strip(self._column, cudf.Scalar(to_strip, "str"))
         )
 
     def lstrip(self, to_strip: str = None) -> SeriesOrIndex:
@@ -3241,7 +3243,7 @@ class StringMethods(ColumnMethods):
             to_strip = ""
 
         return self._return_or_inplace(
-            libstrings.lstrip(self._column, cudf.Scalar(to_strip))
+            libstrings.lstrip(self._column, cudf.Scalar(to_strip, "str"))
         )
 
     def rstrip(self, to_strip: str = None) -> SeriesOrIndex:
@@ -3296,7 +3298,7 @@ class StringMethods(ColumnMethods):
             to_strip = ""
 
         return self._return_or_inplace(
-            libstrings.rstrip(self._column, cudf.Scalar(to_strip))
+            libstrings.rstrip(self._column, cudf.Scalar(to_strip, "str"))
         )
 
     def wrap(self, width: int, **kwargs) -> SeriesOrIndex:
@@ -4245,7 +4247,7 @@ class StringMethods(ColumnMethods):
         table = str.maketrans(table)
         return self._return_or_inplace(
             libstrings.filter_characters(
-                self._column, table, keep, cudf.Scalar(repl)
+                self._column, table, keep, cudf.Scalar(repl, "str")
             ),
         )
 

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -1299,6 +1299,12 @@ def test_string_slice_replace(string, number, diff, repr):
     )
 
 
+def test_string_slice_replace_fail():
+    gs = cudf.Series(["abc", "xyz", ""])
+    with pytest.raises(TypeError):
+        gs.str.slice_replace(0, 1, ["_"])
+
+
 def test_string_insert():
     gs = cudf.Series(["hello world", "holy accéntéd", "batman", None, ""])
 
@@ -1311,6 +1317,9 @@ def test_string_insert():
         gs.str.insert(5, "---"),
         ps.str.slice(stop=5) + "---" + ps.str.slice(start=5),
     )
+
+    with pytest.raises(TypeError):
+        gs.str.insert(0, ["+"])
 
 
 _string_char_types_data = [
@@ -1403,6 +1412,9 @@ def test_string_filter_alphanum():
                 rs = rs + "*"
         expected.append(rs)
     assert_eq(gs.str.filter_alphanum("*", keep=False), cudf.Series(expected))
+
+    with pytest.raises(TypeError):
+        gs.str.filter_alphanum(["a"])
 
 
 @pytest.mark.parametrize(
@@ -1502,6 +1514,14 @@ def test_strings_partition(data):
     assert_eq(pi.str.partition(), gi.str.partition())
     assert_eq(pi.str.partition(","), gi.str.partition(","))
     assert_eq(pi.str.partition("-"), gi.str.partition("-"))
+
+
+def test_string_partition_fail():
+    gs = cudf.Series(["abc", "aa", "cba"])
+    with pytest.raises(TypeError):
+        gs.str.partition(["a"])
+    with pytest.raises(TypeError):
+        gs.str.rpartition(["a"])
 
 
 @pytest.mark.parametrize(
@@ -1638,6 +1658,16 @@ def test_strings_strip_tests(data, to_strip):
     assert_eq(
         pi.str.lstrip(to_strip=to_strip), gi.str.lstrip(to_strip=to_strip)
     )
+
+
+def test_string_strip_fail():
+    gs = cudf.Series(["a", "aa", ""])
+    with pytest.raises(TypeError):
+        gs.str.strip(["a"])
+    with pytest.raises(TypeError):
+        gs.str.lstrip(["a"])
+    with pytest.raises(TypeError):
+        gs.str.rstrip(["a"])
 
 
 @pytest.mark.parametrize(
@@ -2363,6 +2393,9 @@ def test_string_str_filter_characters():
         ["hello world", "A B C D", "           ", "acc nt", None, " 1 50", ""]
     )
     assert_eq(expected, gs.str.filter_characters(filter, True, " "))
+
+    with pytest.raises(TypeError):
+        gs.str.filter_characters(filter, True, ["a"])
 
 
 def test_string_str_code_points():


### PR DESCRIPTION
Closes #10591 

Ensures `to_strip` parameter is a `str` type when converting it to `cudf.Scalar`. It will now through a `TypeError` as follows
```
    libstrings.strip(self._column, cudf.Scalar(to_strip, "str"))
  File "/conda/envs/rapids/lib/python3.8/site-packages/cudf-22.6.0a0+96.g0aef0c1c3e.dirty-py3.8-linux-x86_64.egg/cudf/core/scalar.py", line 78, in __init__
    self._host_value, self._host_dtype = self._preprocess_host_value(
  File "/conda/envs/rapids/lib/python3.8/site-packages/cudf-22.6.0a0+96.g0aef0c1c3e.dirty-py3.8-linux-x86_64.egg/cudf/core/scalar.py", line 128, in _preprocess_host_value
    raise TypeError("Lists may not be cast to a different dtype")
TypeError: Lists may not be cast to a different dtype

```
This will also prevent the _sticky_ CUDA error.

Also, added the `str` parameter to other `cudf.Scalar` calls where only strings are supported as well.