### PR TITLE
Fix struct row comparator's exception on empty structs

### DIFF
--- a/cpp/benchmarks/sort/sort_structs.cpp
+++ b/cpp/benchmarks/sort/sort_structs.cpp
@@ -80,5 +80,5 @@ void nvbench_sort_struct(nvbench::state& state)
 NVBENCH_BENCH(nvbench_sort_struct)
   .set_name("sort_struct")
   .add_int64_power_of_two_axis("NumRows", {10, 18, 26})
-  .add_int64_axis("Depth", {1, 8})
+  .add_int64_axis("Depth", {0, 1, 8})
   .add_int64_axis("Nulls", {0, 1});

--- a/cpp/include/cudf/table/experimental/row_operators.cuh
+++ b/cpp/include/cudf/table/experimental/row_operators.cuh
@@ -197,7 +197,11 @@ class device_row_comparator {
           return cuda::std::make_pair(state, depth);
         }
 
-        // Structs have been modified to only have 1 child when using this.
+        if (lcol.num_child_columns() == 0) {
+          return cuda::std::make_pair(weak_ordering::EQUIVALENT, depth);
+        }
+
+        // Non-empty structs have been modified to only have 1 child when using this.
         lcol = lcol.children()[0];
         rcol = rcol.children()[0];
         ++depth;

--- a/cpp/tests/sort/sort_test.cpp
+++ b/cpp/tests/sort/sort_test.cpp
@@ -855,7 +855,7 @@ TEST_F(SortCornerTest, WithEmptyStructColumn)
 
   int_col expected3{{4, 1, 5, 3, 2, 0}};
   auto got3 = sorted_order(input3, {order::ASCENDING});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, got3->view(), debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, got3->view());
 };
 
 }  // namespace test

--- a/cpp/tests/sort/sort_test.cpp
+++ b/cpp/tests/sort/sort_test.cpp
@@ -844,7 +844,7 @@ TEST_F(SortCornerTest, WithEmptyStructColumn)
   std::vector<std::unique_ptr<cudf::column>> child_columns2;
   auto child_col_1 = cudf::make_structs_column(6, {}, UNKNOWN_NULL_COUNT, std::move(null_mask2));
   child_columns2.push_back(std::move(child_col_1));
-  int_col col4{{0, 1, 2, 3, 4, 5}};
+  int_col col4{{5, 4, 3, 2, 1, 0}};
   std::vector<std::unique_ptr<cudf::column>> grand_child;
   grand_child.push_back(std::move(col4.release()));
   auto child_col_2 = cudf::make_structs_column(6, std::move(grand_child), 0, rmm::device_buffer{});
@@ -853,9 +853,9 @@ TEST_F(SortCornerTest, WithEmptyStructColumn)
     cudf::make_structs_column(6, std::move(child_columns2), 0, rmm::device_buffer{});
   table_view input3{{struct_col3->view()}};
 
-  int_col expected3{{1, 4, 0, 2, 3, 5}};
+  int_col expected3{{4, 1, 5, 3, 2, 0}};
   auto got3 = sorted_order(input3, {order::ASCENDING});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, got3->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, got3->view(), debug_output_level::ALL_ERRORS);
 };
 
 }  // namespace test


### PR DESCRIPTION
Fixes #10603

This PR is to fix a bug of the optimized struct row comparator. For now,  the struct row comparator assumes that structs being compared are non-empty, so it fails when comparing empty structs.