### PR TITLE
Document cudf.read_text and cudf.read_avro.

### DIFF
--- a/docs/cudf/source/api_docs/io.rst
+++ b/docs/cudf/source/api_docs/io.rst
@@ -13,6 +13,12 @@ CSV
    read_csv
    DataFrame.to_csv
 
+Text
+~~~~
+.. autosummary::
+   :toctree: api/
+
+   read_text
 
 .. currentmodule:: cudf.io.json
 
@@ -43,8 +49,6 @@ ORC
    read_orc
    DataFrame.to_orc
 
-.. currentmodule:: cudf
-
 HDFStore: PyTables (HDF5)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
@@ -71,3 +75,9 @@ Feather
    Feather reader and writers are not GPU accelerated. These currently use CPU via Pandas.
    This may be GPU accelerated in the future.
 
+Avro
+~~~~
+.. autosummary::
+   :toctree: api/
+
+   read_avro

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -81,7 +81,7 @@ Examples
 See Also
 --------
 cudf.read_csv
-cudf.read_json
+cudf.io.json.read_json
 """.format(
     remote_data_sources=_docstring_remote_sources
 )


### PR DESCRIPTION
This adds documentation for `cudf.read_text` and `cudf.read_avro`.