### PR TITLE
Fix docstring section headings.

### DIFF
--- a/python/cudf/cudf/core/algorithms.py
+++ b/python/cudf/cudf/core/algorithms.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 from warnings import warn
 
 import cupy as cp
@@ -21,7 +21,7 @@ def factorize(values, sort=False, na_sentinel=-1, size_hint=None):
         Value to indicate missing category.
 
     Returns
-    --------
+    -------
     (labels, cats) : (cupy.ndarray, cupy.ndarray or Index)
         - *labels* contains the encoded values
         - *cats* contains the categories in order that the N-th

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1980,7 +1980,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         None : method directly changes calling object
 
         Raises
-        -------
+        ------
         ValueError
             - When ``errors`` = 'raise' and there's overlapping non-NA data.
             - When ``errors`` is not either 'ignore' or 'raise'

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -907,7 +907,7 @@ class GroupBy(Serializable, Reducible, Scannable):
             to have a valid result.
 
         Returns
-        ----------
+        -------
         DataFrame
             Correlation matrix.
 

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -206,7 +206,7 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
             ``MultiIndex`` instance
 
         Returns
-        --------
+        -------
         None or MultiIndex
 
         Examples
@@ -591,7 +591,7 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
             CuPy array of boolean values.
 
         Notes
-        -------
+        -----
         When `level` is None, `values` can only be MultiIndex, or a
         set/list-like tuples.
         When `level` is provided, `values` can be Index or MultiIndex,

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2485,7 +2485,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
             Series of booleans indicating if each element is in values.
 
         Raises
-        -------
+        ------
         TypeError
             If values is a string
 

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -273,7 +273,7 @@ class SingleColumnFrame(Frame, NotIterable):
             Value to indicate missing category.
 
         Returns
-        --------
+        -------
         (labels, cats) : (cupy.ndarray, cupy.ndarray or Index)
             - *labels* contains the encoded values
             - *cats* contains the categories in order that the N-th

--- a/python/cudf/cudf/utils/cudautils.py
+++ b/python/cudf/cudf/utils/cudautils.py
@@ -249,7 +249,7 @@ def compile_udf(udf, type_signature):
       numpy types with `numba.numpy_support.from_dtype(...)`.
 
     Returns
-    --------
+    -------
     ptx_code:
       The compiled CUDA PTX
 

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -387,7 +387,7 @@ def search_range(start, stop, x, step=1, side="left"):
         See description for usage.
 
     Returns
-    --------
+    -------
     int
         Insertion position of n.
 


### PR DESCRIPTION
Standardizes docstring section headings to reduce parsing warnings in Sphinx output. (I have a few other incoming PRs to fix documentation issues, this one is split into its own PR since it touches a lot of files.)