### PR TITLE
Use cudf.read_json as documented API name.

### DIFF
--- a/docs/cudf/source/api_docs/io.rst
+++ b/docs/cudf/source/api_docs/io.rst
@@ -14,17 +14,13 @@ CSV
    DataFrame.to_csv
 
 
-.. currentmodule:: cudf.io.json
-
 JSON
 ~~~~
 .. autosummary::
    :toctree: api/
 
    read_json
-   to_json
-
-.. currentmodule:: cudf
+   DataFrame.to_json
 
 Parquet
 ~~~~~~~

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -566,7 +566,7 @@ result : Series or DataFrame, depending on the value of `typ`.
 
 See Also
 --------
-.cudf.io.json.to_json
+cudf.DataFrame.to_json
 """
 doc_read_json = docfmt_partial(docstring=_docstring_read_json)
 
@@ -633,7 +633,7 @@ index : bool, default True
 
 See Also
 --------
-.cudf.io.json.read_json
+cudf.read_json
 """
 doc_to_json = docfmt_partial(docstring=_docstring_to_json)
 


### PR DESCRIPTION
Changes documented API name from `cudf.io.json.read_json` to `cudf.read_json`. This aligns with Pandas' documentation and eliminates an awkward switch of the `.. currentmodule` in Sphinx. See thread: https://github.com/rapidsai/cudf/pull/10638#discussion_r847838662