### PR TITLE
Add missing APIs to documentation.

### DIFF
--- a/docs/cudf/source/api_docs/dataframe.rst
+++ b/docs/cudf/source/api_docs/dataframe.rst
@@ -54,7 +54,7 @@ Indexing, iteration
    DataFrame.iloc
    DataFrame.insert
    DataFrame.__iter__
-   DataFrame.iteritems
+   DataFrame.items
    DataFrame.keys
    DataFrame.iterrows
    DataFrame.itertuples
@@ -64,9 +64,6 @@ Indexing, iteration
    DataFrame.where
    DataFrame.mask
    DataFrame.query
-
-For more information on ``.at``, ``.iat``, ``.loc``, and
-``.iloc``,  see the :ref:`indexing documentation <indexing>`.
 
 Binary operator functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -84,6 +81,7 @@ Binary operator functions
    DataFrame.floordiv
    DataFrame.mod
    DataFrame.pow
+   DataFrame.dot
    DataFrame.radd
    DataFrame.rsub
    DataFrame.rmul
@@ -121,6 +119,7 @@ Computations / descriptive stats
 .. autosummary::
    :toctree: api/
 
+   DataFrame.abs
    DataFrame.all
    DataFrame.any
    DataFrame.clip
@@ -132,12 +131,15 @@ Computations / descriptive stats
    DataFrame.cumprod
    DataFrame.cumsum
    DataFrame.describe
+   DataFrame.diff
    DataFrame.kurt
    DataFrame.kurtosis
    DataFrame.max
    DataFrame.mean
+   DataFrame.median
    DataFrame.min
    DataFrame.mode
+   DataFrame.pct_change
    DataFrame.prod
    DataFrame.product
    DataFrame.quantile
@@ -148,6 +150,7 @@ Computations / descriptive stats
    DataFrame.sum
    DataFrame.std
    DataFrame.var
+   DataFrame.nunique
 
 Reindexing / selection / label manipulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -159,7 +162,9 @@ Reindexing / selection / label manipulation
    DataFrame.drop
    DataFrame.drop_duplicates
    DataFrame.equals
+   DataFrame.first
    DataFrame.head
+   DataFrame.last
    DataFrame.reindex
    DataFrame.rename
    DataFrame.reset_index
@@ -180,6 +185,7 @@ Missing data handling
 
    DataFrame.dropna
    DataFrame.fillna
+   DataFrame.interpolate
    DataFrame.isna
    DataFrame.isnull
    DataFrame.nans_to_nulls
@@ -220,27 +226,13 @@ Combining / comparing / joining / merging
    DataFrame.merge
    DataFrame.update
 
-Numerical operations
-~~~~~~~~~~~~~~~~~~~~
-.. autosummary::
-   :toctree: api/
-
-   DataFrame.acos
-   DataFrame.asin
-   DataFrame.atan
-   DataFrame.cos
-   DataFrame.exp
-   DataFrame.log
-   DataFrame.sin
-   DataFrame.sqrt
-   DataFrame.tan
-
 Time Series-related
 ~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: api/
 
    DataFrame.shift
+   DataFrame.resample
 
 Serialization / IO / conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/cudf/source/api_docs/index_objects.rst
+++ b/docs/cudf/source/api_docs/index_objects.rst
@@ -35,7 +35,6 @@ Properties
    Index.size
    Index.values
 
-
 Modifying and computations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
@@ -151,7 +150,6 @@ Numeric Index
    UInt64Index
    Float64Index
 
-
 .. _api.categoricalindex:
 
 CategoricalIndex
@@ -204,7 +202,6 @@ MultiIndex
    :template: autosummary/class_without_autosummary.rst
 
    MultiIndex
-
 
 MultiIndex constructors
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -271,7 +268,6 @@ Time/date components
    DatetimeIndex.quarter
    DatetimeIndex.isocalendar
 
-
 Time-specific operations
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
@@ -315,5 +311,4 @@ Conversion
    :toctree: api/
 
    TimedeltaIndex.to_series
-   TimedeltaIndex.round
    TimedeltaIndex.to_frame

--- a/docs/cudf/source/api_docs/series.rst
+++ b/docs/cudf/source/api_docs/series.rst
@@ -28,6 +28,7 @@ Attributes
    Series.nullmask
    Series.null_count
    Series.size
+   Series.T
    Series.memory_usage
    Series.has_nulls
    Series.empty
@@ -58,9 +59,6 @@ Indexing, iteration
    Series.items
    Series.iteritems
    Series.keys
-
-For more information on ``.at``, ``.iat``, ``.loc``, and
-``.iloc``,  see the :ref:`indexing documentation <indexing>`.
 
 Binary operator functions
 -------------------------
@@ -94,6 +92,7 @@ Binary operator functions
    Series.ne
    Series.eq
    Series.product
+   Series.dot
 
 Function application, GroupBy & window
 --------------------------------------
@@ -118,7 +117,6 @@ Computations / descriptive stats
    Series.all
    Series.any
    Series.autocorr
-   Series.ceil
    Series.clip
    Series.corr
    Series.count
@@ -131,7 +129,6 @@ Computations / descriptive stats
    Series.diff
    Series.digitize
    Series.factorize
-   Series.floor
    Series.kurt
    Series.max
    Series.mean
@@ -140,6 +137,7 @@ Computations / descriptive stats
    Series.mode
    Series.nlargest
    Series.nsmallest
+   Series.pct_change
    Series.prod
    Series.quantile
    Series.rank
@@ -166,8 +164,10 @@ Reindexing / selection / label manipulation
    Series.drop
    Series.drop_duplicates
    Series.equals
+   Series.first
    Series.head
    Series.isin
+   Series.last
    Series.reindex
    Series.rename
    Series.reset_index
@@ -215,27 +215,13 @@ Combining / comparing / joining / merging
    Series.append
    Series.update
 
-Numerical operations
-~~~~~~~~~~~~~~~~~~~~
-.. autosummary::
-   :toctree: api/
-
-   Series.acos
-   Series.asin
-   Series.atan
-   Series.cos
-   Series.exp
-   Series.log
-   Series.sin
-   Series.sqrt
-   Series.tan
-
 Time Series-related
 -------------------
 .. autosummary::
    :toctree: api/
 
    Series.shift
+   Series.resample
 
 Accessors
 ---------

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -259,7 +259,6 @@ row_group_size_rows: integer or None, default None
 See Also
 --------
 cudf.read_parquet
-cudf.read_orc
 """
 doc_to_parquet = docfmt_partial(docstring=_docstring_to_parquet)
 
@@ -413,8 +412,7 @@ Examples
 
 See Also
 --------
-cudf.read_parquet
-cudf.DataFrame.to_parquet
+cudf.DataFrame.to_orc
 """.format(
     remote_data_sources=_docstring_remote_sources
 )


### PR DESCRIPTION
This adds a bunch of missing methods to the documentation and removes methods that no longer exist.

When building, Sphinx issues warnings like this one, which indicates that a method isn't documented:
```
.../cudf/docs/cudf/source/api_docs/api/cudf.Series.pct_change.rst: WARNING: document isn't included in any toctree
```
and this one, which indicates that a documented method no longer exists:
```
WARNING: [autosummary] failed to import cudf.Series.ceil.
Possible hints:
* ModuleNotFoundError: No module named 'cudf.Series'
* AttributeError: type object 'Series' has no attribute 'ceil'
* ImportError:
```

This PR doesn't fix all of the warnings/errors, but it is a good chunk of them.