### PR TITLE
Handle RuntimeError thrown by CUDA Python in `validate_setup`

### DIFF
--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -56,7 +56,9 @@ def validate_setup():
         # If there is no GPU detected, set `gpus_count` to -1
         gpus_count = -1
     except RuntimeError as e:
-        # could indicate that `libcuda.so` is missing
+        # getDeviceCount() can raise a RuntimeError
+        # when ``libcuda.so`` is missing.
+        # We don't want this to propagate up to the user.
         warnings.warn(str(e))
         return
 

--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -55,6 +55,10 @@ def validate_setup():
             raise e
         # If there is no GPU detected, set `gpus_count` to -1
         gpus_count = -1
+    except RuntimeError as e:
+        # could indicate that `libcuda.so` is missing
+        warnings.warn(str(e))
+        return
 
     if gpus_count > 0:
         # Cupy throws RunTimeException to get GPU count,


### PR DESCRIPTION
The call to `getDeviceCount()` can raise a `RuntimeError` when `libcuda.so` is missing. We should handle that too in `validate_setup()`.
