### PR TITLE
Use upstream clang-format pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,9 @@ repos:
         rev: v11.1.0
         hooks:
               - id: clang-format
-                types_or: [c, c++, cuda, header, inl]
+                files: \.(cu|cuh|h|hpp|cpp|inl)$
+                types_or: [file]
+                args: ['-fallback-style=none', '-style=file', '-i']
       - repo: local
         hooks:
               - id: cmake-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,20 +56,13 @@ repos:
         hooks:
               - id: pydocstyle
                 args: ["--config=python/.flake8"]
-      - repo: local
+      - repo: https://github.com/pre-commit/mirrors-clang-format
+        rev: v11.1.0
         hooks:
               - id: clang-format
-                # Using the pre-commit stage to simplify invocation of all
-                # other hooks simultaneously (via any other hook stage).  This
-                # can be removed if we also move to running clang-format
-                # entirely through pre-commit.
-                stages: [commit]
-                name: clang-format
-                description: Format files with ClangFormat.
-                entry: clang-format -i
-                language: system
-                files: \.(cu|cuh|h|hpp|cpp|inl)$
-                args: ['-fallback-style=none']
+                types_or: [c, c++, cuda, header, inl]
+      - repo: local
+        hooks:
               - id: cmake-format
                 name: cmake-format
                 entry: ./cpp/scripts/run-cmake-format.sh cmake-format


### PR DESCRIPTION
This PR improves the use of clang-format in pre-commit and CI by using a hook that is managed and cached by pre-commit. Developers who do not use pre-commit will see no changes to their workflow. Developers using pre-commit will be guaranteed that their code is formatted with the pinned version of clang-format (and will always align with CI's expectations) even if they have a different version of clang-format (or no version of clang-format) installed on their path. Like all pre-commit hooks for linting CMake and Python code, this version pinning will need to be kept in sync with the conda environment if we choose to upgrade clang-format.