### PR TITLE
Support equally comparing two different tables in the newly experimental row comparator

### DIFF
--- a/cpp/include/cudf/table/experimental/row_operators.cuh
+++ b/cpp/include/cudf/table/experimental/row_operators.cuh
@@ -558,8 +558,8 @@ class device_row_comparator {
         }
         if (lcol.type().id() == type_id::STRUCT) {
           if (lcol.num_child_columns() == 0) { return true; }
-          lcol = detail::structs_column_device_view(lcol).sliced_child(0);
-          rcol = detail::structs_column_device_view(rcol).sliced_child(0);
+          lcol = lcol.child(0).slice(lhs_element_index, 1);
+          rcol = rcol.child(0).slice(lhs_element_index, 1);
         } else if (lcol.type().id() == type_id::LIST) {
           auto l_list_col = detail::lists_column_device_view(lcol);
           auto r_list_col = detail::lists_column_device_view(rcol);

--- a/cpp/include/cudf/table/experimental/row_operators.cuh
+++ b/cpp/include/cudf/table/experimental/row_operators.cuh
@@ -559,7 +559,7 @@ class device_row_comparator {
         if (lcol.type().id() == type_id::STRUCT) {
           if (lcol.num_child_columns() == 0) { return true; }
           lcol = lcol.child(0).slice(lhs_element_index, 1);
-          rcol = rcol.child(0).slice(lhs_element_index, 1);
+          rcol = rcol.child(0).slice(rhs_element_index, 1);
         } else if (lcol.type().id() == type_id::LIST) {
           auto l_list_col = detail::lists_column_device_view(lcol);
           auto r_list_col = detail::lists_column_device_view(rcol);

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -352,7 +352,8 @@ ConfigureTest(
 # ##################################################################################################
 # * search test -----------------------------------------------------------------------------------
 ConfigureTest(
-  SEARCH_TEST search/search_struct_test.cpp
+  SEARCH_TEST search/search_dictionary_test.cpp search/search_struct_test.cpp
+  search/search_test.cpp
 )
 
 # ##################################################################################################

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -352,8 +352,7 @@ ConfigureTest(
 # ##################################################################################################
 # * search test -----------------------------------------------------------------------------------
 ConfigureTest(
-  SEARCH_TEST search/search_dictionary_test.cpp search/search_struct_test.cpp
-  search/search_test.cpp
+  SEARCH_TEST search/search_struct_test.cpp
 )
 
 # ##################################################################################################

--- a/cpp/tests/search/search_struct_test.cpp
+++ b/cpp/tests/search/search_struct_test.cpp
@@ -449,12 +449,6 @@ TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
       auto child3 = strings_col{"x", "" /*NULL*/, "z"};
       return structs_col{{child1, child2, child3}, null_at(1)};
     }();
-    auto const col2 = [] {
-      auto child1 = col_wrapper{{1, null, 3}, null_at(1)};
-      auto child2 = col_wrapper{{4, null, 6}, null_at(1)};
-      auto child3 = strings_col{{"x", "" /*NULL*/, "z"}, null_at(1)};
-      return structs_col{child1, child2, child3};
-    }();
 
     auto const val1 = [] {
       auto child1 = col_wrapper{1};
@@ -469,16 +463,15 @@ TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
       return cudf::struct_scalar(std::vector<cudf::column_view>{child1, child2, child3});
     }();
     auto const val3 = [] {
-      auto child1 = col_wrapper{std::initializer_list<int32_t>{null}, null_at(0)};
-      auto child2 = col_wrapper{std::initializer_list<int32_t>{null}, null_at(0)};
-      auto child3 = strings_col{std::initializer_list<std::string>{""}, null_at(0)};
+      auto child1 = col_wrapper{{null}, null_at(0)};
+      auto child2 = col_wrapper{{null}, null_at(0)};
+      auto child3 = strings_col{{""}, null_at(0)};
       return cudf::struct_scalar(std::vector<cudf::column_view>{child1, child2, child3});
     }();
 
     EXPECT_EQ(true, cudf::contains(col1, val1));
     EXPECT_EQ(false, cudf::contains(col1, val2));
     EXPECT_EQ(false, cudf::contains(col1, val3));
-    EXPECT_EQ(true, cudf::contains(col2, val3));
   }
 
   // Test with nulls at the children level.
@@ -486,7 +479,7 @@ TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
     auto const col = [] {
       auto child1 = col_wrapper{{1, null, 3}, null_at(1)};
       auto child2 = col_wrapper{{4, null, 6}, null_at(1)};
-      auto child3 = strings_col{{"" /*NULL*/, "y", "z"}, null_at(0)};
+      auto child3 = strings_col{{"" /*NULL*/, "" /*NULL*/, "z"}, nulls_at({0, 1})};
       return structs_col{{child1, child2, child3}};
     }();
 
@@ -502,9 +495,16 @@ TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
       auto child3 = strings_col{""};
       return cudf::struct_scalar(std::vector<cudf::column_view>{child1, child2, child3});
     }();
+    auto const val3 = [] {
+      auto child1 = col_wrapper{{null}, null_at(0)};
+      auto child2 = col_wrapper{{null}, null_at(0)};
+      auto child3 = strings_col{{""}, null_at(0)};
+      return cudf::struct_scalar(std::vector<cudf::column_view>{child1, child2, child3});
+    }();
 
     EXPECT_EQ(true, cudf::contains(col, val1));
     EXPECT_EQ(false, cudf::contains(col, val2));
+    EXPECT_EQ(true, cudf::contains(col, val3));
   }
 
   // Test with nulls in the input scalar.

--- a/cpp/tests/search/search_struct_test.cpp
+++ b/cpp/tests/search/search_struct_test.cpp
@@ -462,9 +462,16 @@ TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
       auto child3 = strings_col{"a"};
       return cudf::struct_scalar(std::vector<cudf::column_view>{child1, child2, child3});
     }();
+    auto const val3 = [] {
+      auto child1 = col_wrapper{std::initializer_list<int32_t>{null}, null_at(0)};
+      auto child2 = col_wrapper{std::initializer_list<int32_t>{null}, null_at(0)};
+      auto child3 = strings_col{std::initializer_list<std::string>{""}, null_at(0)};
+      return cudf::struct_scalar(std::vector<cudf::column_view>{child1, child2, child3});
+    }();
 
     EXPECT_EQ(true, cudf::contains(col, val1));
     EXPECT_EQ(false, cudf::contains(col, val2));
+    EXPECT_EQ(false, cudf::contains(col, val3));
   }
 
   // Test with nulls at the children level.

--- a/cpp/tests/search/search_struct_test.cpp
+++ b/cpp/tests/search/search_struct_test.cpp
@@ -404,7 +404,6 @@ TYPED_TEST(TypedScalarStructContainTest, TrivialInputTests)
   EXPECT_EQ(false, cudf::contains(col, val2));
 }
 
-#if 0
 TYPED_TEST(TypedScalarStructContainTest, SlicedColumnInputTests)
 {
   using col_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
@@ -435,7 +434,6 @@ TYPED_TEST(TypedScalarStructContainTest, SlicedColumnInputTests)
   EXPECT_EQ(true, cudf::contains(col, val1));
   EXPECT_EQ(false, cudf::contains(col, val2));
 }
-#endif
 
 TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
 {
@@ -536,7 +534,6 @@ TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
   }
 }
 
-#if 0
 TYPED_TEST(TypedScalarStructContainTest, SlicedInputWithNullsTests)
 {
   using col_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
@@ -601,4 +598,3 @@ TYPED_TEST(TypedScalarStructContainTest, SlicedInputWithNullsTests)
     EXPECT_EQ(false, cudf::contains(col, val2));
   }
 }
-#endif

--- a/cpp/tests/search/search_struct_test.cpp
+++ b/cpp/tests/search/search_struct_test.cpp
@@ -443,11 +443,17 @@ TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
 
   // Test with nulls at the top level.
   {
-    auto const col = [] {
+    auto const col1 = [] {
       auto child1 = col_wrapper{1, null, 3};
       auto child2 = col_wrapper{4, null, 6};
       auto child3 = strings_col{"x", "" /*NULL*/, "z"};
       return structs_col{{child1, child2, child3}, null_at(1)};
+    }();
+    auto const col2 = [] {
+      auto child1 = col_wrapper{{1, null, 3}, null_at(1)};
+      auto child2 = col_wrapper{{4, null, 6}, null_at(1)};
+      auto child3 = strings_col{{"x", "" /*NULL*/, "z"}, null_at(1)};
+      return structs_col{child1, child2, child3};
     }();
 
     auto const val1 = [] {
@@ -469,9 +475,10 @@ TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
       return cudf::struct_scalar(std::vector<cudf::column_view>{child1, child2, child3});
     }();
 
-    EXPECT_EQ(true, cudf::contains(col, val1));
-    EXPECT_EQ(false, cudf::contains(col, val2));
-    EXPECT_EQ(false, cudf::contains(col, val3));
+    EXPECT_EQ(true, cudf::contains(col1, val1));
+    EXPECT_EQ(false, cudf::contains(col1, val2));
+    EXPECT_EQ(false, cudf::contains(col1, val3));
+    EXPECT_EQ(true, cudf::contains(col2, val3));
   }
 
   // Test with nulls at the children level.

--- a/cpp/tests/search/search_struct_test.cpp
+++ b/cpp/tests/search/search_struct_test.cpp
@@ -404,6 +404,7 @@ TYPED_TEST(TypedScalarStructContainTest, TrivialInputTests)
   EXPECT_EQ(false, cudf::contains(col, val2));
 }
 
+#if 0
 TYPED_TEST(TypedScalarStructContainTest, SlicedColumnInputTests)
 {
   using col_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
@@ -434,6 +435,7 @@ TYPED_TEST(TypedScalarStructContainTest, SlicedColumnInputTests)
   EXPECT_EQ(true, cudf::contains(col, val1));
   EXPECT_EQ(false, cudf::contains(col, val2));
 }
+#endif
 
 TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
 {
@@ -534,6 +536,7 @@ TYPED_TEST(TypedScalarStructContainTest, SimpleInputWithNullsTests)
   }
 }
 
+#if 0
 TYPED_TEST(TypedScalarStructContainTest, SlicedInputWithNullsTests)
 {
   using col_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
@@ -598,3 +601,4 @@ TYPED_TEST(TypedScalarStructContainTest, SlicedInputWithNullsTests)
     EXPECT_EQ(false, cudf::contains(col, val2));
   }
 }
+#endif


### PR DESCRIPTION
The new row comparator (https://github.com/rapidsai/cudf/pull/10164) only added a `self_comparator` utility to compare rows of the same table. This PR adds `equality::table_comparator` that allows equally comparing rows from different tables. Immediate usage of such comparator is for linearly searching a struct scalar in a structs column.

In addition, it also fixes the comparator that produces wrong results when the input is sliced.

This PR is required for https://github.com/rapidsai/cudf/pull/10548 and https://github.com/rapidsai/cudf/pull/10656.