### PR TITLE
JNI: Add generateListOffsets API

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -3475,7 +3475,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
 
   /**
    * Generate list offsets from sizes of each list.
-   * NOTICE: This column should type in INT32. And no null and negative value is allowed.
+   * NOTICE: This API only works for INT32. Otherwise, the behavior is undefined. And no null and negative value is allowed.
    *
    * @return a column of list offsets whose size is N + 1
    */

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -3474,10 +3474,12 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /**
+   * Generate list offsets from sizes of each list.
+   * NOTICE: This column should type in INT32. And no null and negative value is allowed.
    *
+   * @return a column of list offsets whose size is N + 1
    */
   public final ColumnVector generateListOffsets() {
-    assert type.typeId == DType.DTypeEnum.INT32;
     return new ColumnVector(generateListOffsets(getNativeView()));
   }
 

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -3474,6 +3474,14 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /**
+   *
+   */
+  public final ColumnVector generateListOffsets() {
+    assert type.typeId == DType.DTypeEnum.INT32;
+    return new ColumnVector(generateListOffsets(getNativeView()));
+  }
+
+  /**
    * Get a single item from the column at the specified index as a Scalar.
    *
    * Be careful. This is expensive and may involve running a kernel to copy the data out.
@@ -4161,6 +4169,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   static native long getDeviceMemorySize(long viewHandle) throws CudfException;
 
   static native long copyColumnViewToCV(long viewHandle) throws CudfException;
+
+  static native long generateListOffsets(long handle) throws CudfException;
 
   /**
    * A utility class to create column vector like objects without refcounts and other APIs when

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -624,8 +624,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listSortRows(JNIEnv *env,
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_makeListOffsets(JNIEnv *env, jclass,
-                                                                       jlong handle) {
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_generateListOffsets(JNIEnv *env, jclass,
+                                                                           jlong handle) {
   JNI_NULL_CHECK(env, handle, "handle is null", 0)
   try {
     cudf::jni::auto_set_device(env);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -624,6 +624,17 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listSortRows(JNIEnv *env,
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_makeListOffsets(JNIEnv *env, jclass,
+                                                                       jlong handle) {
+  JNI_NULL_CHECK(env, handle, "handle is null", 0)
+  try {
+    cudf::jni::auto_set_device(env);
+    auto const cv = reinterpret_cast<cudf::column_view const *>(handle);
+    return release_as_jlong(cudf::jni::generate_list_offsets(*cv));
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringSplit(JNIEnv *env, jclass,
                                                                         jlong input_handle,
                                                                         jstring pattern_obj,

--- a/java/src/main/native/src/ColumnViewJni.cu
+++ b/java/src/main/native/src/ColumnViewJni.cu
@@ -18,9 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/valid_if.cuh>
-
 #include <rmm/exec_policy.hpp>
-
 #include <thrust/scan.h>
 
 #include "ColumnViewJni.hpp"

--- a/java/src/main/native/src/ColumnViewJni.cu
+++ b/java/src/main/native/src/ColumnViewJni.cu
@@ -19,8 +19,9 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/valid_if.cuh>
 
-#include "ColumnViewJni.hpp"
 #include "rmm/exec_policy.hpp"
+
+#include "ColumnViewJni.hpp"
 
 namespace cudf::jni {
 

--- a/java/src/main/native/src/ColumnViewJni.cu
+++ b/java/src/main/native/src/ColumnViewJni.cu
@@ -54,17 +54,15 @@ new_column_with_boolean_column_as_validity(cudf::column_view const &exemplar,
   return deep_copy;
 }
 
-std::unique_ptr<cudf::column>
-generate_list_offsets(cudf::column_view const &list_length, rmm::cuda_stream_view stream) {
+std::unique_ptr<cudf::column> generate_list_offsets(cudf::column_view const &list_length,
+                                                    rmm::cuda_stream_view stream) {
   CUDF_EXPECTS(list_length.type().id() == cudf::type_id::INT32,
                "Input column does not have type INT32.");
 
   auto offsets = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
-                                           list_length.size() + 1,
-                                           cudf::mask_state::UNALLOCATED);
+                                           list_length.size() + 1, cudf::mask_state::UNALLOCATED);
   auto output_view = offsets->mutable_view();
-  thrust::inclusive_scan(rmm::exec_policy(stream),
-                         list_length.template begin<offset_type>(),
+  thrust::inclusive_scan(rmm::exec_policy(stream), list_length.template begin<offset_type>(),
                          list_length.template end<offset_type>(),
                          output_view.template begin<offset_type>() + 1);
 

--- a/java/src/main/native/src/ColumnViewJni.cu
+++ b/java/src/main/native/src/ColumnViewJni.cu
@@ -19,9 +19,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/strings/detail/utilities.cuh>
-
 #include <rmm/exec_policy.hpp>
-
 #include <thrust/scan.h>
 
 #include "ColumnViewJni.hpp"
@@ -57,8 +55,8 @@ new_column_with_boolean_column_as_validity(cudf::column_view const &exemplar,
   return deep_copy;
 }
 
-std::unique_ptr<cudf::column>
-generate_list_offsets(cudf::column_view const &list_length, rmm::cuda_stream_view stream) {
+std::unique_ptr<cudf::column> generate_list_offsets(cudf::column_view const &list_length,
+                                                    rmm::cuda_stream_view stream) {
   CUDF_EXPECTS(list_length.type().id() == cudf::type_id::INT32,
                "Input column does not have type INT32.");
 

--- a/java/src/main/native/src/ColumnViewJni.cu
+++ b/java/src/main/native/src/ColumnViewJni.cu
@@ -19,7 +19,9 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/valid_if.cuh>
 
-#include "rmm/exec_policy.hpp"
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/scan.h>
 
 #include "ColumnViewJni.hpp"
 

--- a/java/src/main/native/src/ColumnViewJni.cu
+++ b/java/src/main/native/src/ColumnViewJni.cu
@@ -15,8 +15,11 @@
  */
 
 #include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/valid_if.cuh>
+#include <rmm/exec_policy.hpp>
+#include <thrust/scan.h>
 
 #include "ColumnViewJni.hpp"
 
@@ -51,18 +54,18 @@ new_column_with_boolean_column_as_validity(cudf::column_view const &exemplar,
   return deep_copy;
 }
 
-std::unique_ptr<cudf::column> generate_list_offsets(cudf::column_view const &index,
-                                                    rmm::cuda_stream_view stream) {
-  CUDF_EXPECTS(index.type().id() == cudf::type_id::INT32,
+std::unique_ptr<cudf::column>
+generate_list_offsets(cudf::column_view const &list_length, rmm::cuda_stream_view stream) {
+  CUDF_EXPECTS(list_length.type().id() == cudf::type_id::INT32,
                "Input column does not have type INT32.");
 
   auto offsets = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
-                                           index.size() + 1,
+                                           list_length.size() + 1,
                                            cudf::mask_state::UNALLOCATED);
-  auto output_view = offsets->mutable_column_view();
+  auto output_view = offsets->mutable_view();
   thrust::inclusive_scan(rmm::exec_policy(stream),
-                         index.template begin<offset_type>(),
-                         index.template end<offset_type>(),
+                         list_length.template begin<offset_type>(),
+                         list_length.template end<offset_type>(),
                          output_view.template begin<offset_type>() + 1);
 
   return offsets;

--- a/java/src/main/native/src/ColumnViewJni.cu
+++ b/java/src/main/native/src/ColumnViewJni.cu
@@ -19,8 +19,6 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/strings/detail/utilities.cuh>
-#include <rmm/exec_policy.hpp>
-#include <thrust/scan.h>
 
 #include "ColumnViewJni.hpp"
 

--- a/java/src/main/native/src/ColumnViewJni.hpp
+++ b/java/src/main/native/src/ColumnViewJni.hpp
@@ -40,9 +40,9 @@ new_column_with_boolean_column_as_validity(cudf::column_view const &exemplar,
  * @brief Generates list offsets with lengths of each list.
  *
  * For example,
- * Here is a list column: [[1,2,3], [4,5], [6], [], [7,8]]
- * The list lengths: [3, 2, 1, 0, 2]
- * The list offsets: [0, 3, 5, 6, 6, 8]
+ * Given a list column: [[1,2,3], [4,5], [6], [], [7,8]]
+ * The list lengths of it: [3, 2, 1, 0, 2]
+ * The list offsets of it: [0, 3, 5, 6, 6, 8]
  *
  * @param list_length The column represents list lengths.
  * @return The column represents list offsets.

--- a/java/src/main/native/src/ColumnViewJni.hpp
+++ b/java/src/main/native/src/ColumnViewJni.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,5 +34,9 @@ namespace cudf::jni {
 std::unique_ptr<cudf::column>
 new_column_with_boolean_column_as_validity(cudf::column_view const &exemplar,
                                            cudf::column_view const &bool_column);
+
+std::unique_ptr<cudf::column>
+generate_list_offsets(cudf::column_view const &index,
+                      rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 } // namespace cudf::jni

--- a/java/src/main/native/src/ColumnViewJni.hpp
+++ b/java/src/main/native/src/ColumnViewJni.hpp
@@ -15,6 +15,7 @@
  */
 
 #include <cudf/column/column.hpp>
+#include <rmm/cuda_stream_view.hpp>
 
 namespace cudf::jni {
 
@@ -35,8 +36,19 @@ std::unique_ptr<cudf::column>
 new_column_with_boolean_column_as_validity(cudf::column_view const &exemplar,
                                            cudf::column_view const &bool_column);
 
+/**
+ * @brief Generates list offsets with lengths of each list.
+ *
+ * For example,
+ * Here is a list column: [[1,2,3], [4,5], [6], [], [7,8]]
+ * The list lengths: [3, 2, 1, 0, 2]
+ * The list offsets: [0, 3, 5, 6, 6, 8]
+ *
+ * @param list_length The column represents list lengths.
+ * @return The column represents list offsets.
+ */
 std::unique_ptr<cudf::column>
-generate_list_offsets(cudf::column_view const &index,
+generate_list_offsets(cudf::column_view const &list_length,
                       rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 } // namespace cudf::jni

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -6284,4 +6284,19 @@ public class ColumnVectorTest extends CudfTestBase {
       assertColumnsAreEqual(expected, actual);
     }
   }
+
+  @Test
+  void testGenerateListOffsets() {
+    try (ColumnVector index = ColumnVector.fromInts(1, 3, 3, 0, 2, 0, 0, 5, 10, 25);
+         ColumnVector actual = index.generateListOffsets();
+         ColumnVector expected = ColumnVector.fromInts(0, 1, 4, 7, 7, 9, 9, 9, 14, 24, 49)) {
+      assertColumnsAreEqual(expected, actual);
+    }
+
+    try (ColumnVector index = ColumnVector.fromInts(0, 0, 1, 0, 0);
+         ColumnVector actual = index.generateListOffsets();
+         ColumnVector expected = ColumnVector.fromInts(0, 0, 0, 1, 1, 1)) {
+      assertColumnsAreEqual(expected, actual);
+    }
+  }
 }


### PR DESCRIPTION
Add generateListOffsets API, converting list lengths to list offsets, which is useful in the development of spark-rapids.

For example, the support of [array_repeat](https://github.com/NVIDIA/spark-rapids/issues/5226) and [arrays_zip](https://github.com/NVIDIA/spark-rapids/issues/5229) relies on this API.