### PR TITLE
Remove cudf::strings::string namespace

### DIFF
--- a/cpp/include/cudf/strings/string.cuh
+++ b/cpp/include/cudf/strings/string.cuh
@@ -23,7 +23,6 @@
 
 namespace cudf {
 namespace strings {
-namespace string {
 /**
  * @addtogroup strings_classes
  * @{
@@ -150,6 +149,5 @@ inline __device__ bool is_float(string_view const& d_str)
 }
 
 /** @} */  // end of group
-}  // namespace string
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -67,8 +67,8 @@ __device__ inline double stod(string_view const& d_str)
   // special strings: NaN, Inf
   if ((in_ptr < end) && *in_ptr > '9') {
     auto const inf_nan = string_view(in_ptr, static_cast<size_type>(thrust::distance(in_ptr, end)));
-    if (string::is_nan_str(inf_nan)) return std::numeric_limits<double>::quiet_NaN();
-    if (string::is_inf_str(inf_nan)) return sign * std::numeric_limits<double>::infinity();
+    if (is_nan_str(inf_nan)) return std::numeric_limits<double>::quiet_NaN();
+    if (is_inf_str(inf_nan)) return sign * std::numeric_limits<double>::infinity();
   }
 
   // Parse and store the mantissa as much as we can,
@@ -567,7 +567,7 @@ std::unique_ptr<column> is_float(
                     d_results,
                     [d_column] __device__(size_type idx) {
                       if (d_column.is_null(idx)) return false;
-                      return string::is_float(d_column.element<string_view>(idx));
+                      return strings::is_float(d_column.element<string_view>(idx));
                     });
   results->set_null_count(strings.null_count());
   return results;

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -150,14 +150,13 @@ std::unique_ptr<column> is_integer(
       d_column->pair_begin<string_view, true>(),
       d_column->pair_end<string_view, true>(),
       d_results,
-      [] __device__(auto const& p) { return p.second ? string::is_integer(p.first) : false; });
+      [] __device__(auto const& p) { return p.second ? strings::is_integer(p.first) : false; });
   } else {
-    thrust::transform(
-      rmm::exec_policy(stream),
-      d_column->pair_begin<string_view, false>(),
-      d_column->pair_end<string_view, false>(),
-      d_results,
-      [] __device__(auto const& p) { return p.second ? string::is_integer(p.first) : false; });
+    thrust::transform(rmm::exec_policy(stream),
+                      d_column->pair_begin<string_view, false>(),
+                      d_column->pair_end<string_view, false>(),
+                      d_results,
+                      [] __device__(auto const& p) { return strings::is_integer(p.first); });
   }
 
   // Calling mutable_view() on a column invalidates it's null count so we need to set it back


### PR DESCRIPTION
Minor change to change the unnecessary `cudf::strings::string` namespace in the `string.cuh` functions' declarations/definitions to just `cudf::strings`. The extra `string` namespace is confusing an not needed. Calling functions have been updated appropriately.

