### PR TITLE
Fix sphinx/jupyter heading issue in UDF notebook

### DIFF
--- a/docs/cudf/source/user_guide/guide-to-udfs.ipynb
+++ b/docs/cudf/source/user_guide/guide-to-udfs.ipynb
@@ -4,7 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Overview of User Defined Functions with cuDF"
+    "Overview of User Defined Functions with cuDF\n",
+    "===================================="
    ]
   },
   {
@@ -40,7 +41,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Series UDFs\n",
+    "Series UDFs\n",
+    "--------------\n",
     "\n",
     "You can execute UDFs on Series in two ways:\n",
     "\n",
@@ -54,7 +56,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#  `cudf.Series.apply`"
+    "`cudf.Series.apply`\n",
+    "---------------------"
    ]
   },
   {
@@ -126,7 +129,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Functions with Additional Scalar Arguments"
+    "Functions with Additional Scalar Arguments\n",
+    "---------------------------------------------------"
    ]
   },
   {
@@ -181,7 +185,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Nullable Data"
+    "Nullable Data\n",
+    "----------------"
    ]
   },
   {
@@ -307,7 +312,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Lower level control with custom `numba` kernels"
+    "Lower level control with custom `numba` kernels\n",
+    "---------------------------------------------------------"
    ]
   },
   {
@@ -472,7 +478,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## DataFrame UDFs\n",
+    "DataFrame UDFs\n",
+    "--------------------\n",
     "\n",
     "Like `cudf.Series`, there are multiple ways of using UDFs on dataframes, which essentially amount to UDFs that expect multiple columns as input:\n",
     "\n",
@@ -485,7 +492,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# `cudf.DataFrame.apply`"
+    "`cudf.DataFrame.apply`\n",
+    "---------------------------"
    ]
   },
   {
@@ -1197,7 +1205,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Numba kernels for DataFrames"
+    "Numba kernels for DataFrames\n",
+    "------------------------------------"
    ]
   },
   {
@@ -1546,7 +1555,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Rolling Window UDFs\n",
+    "Rolling Window UDFs\n",
+    "-------------------------\n",
     "\n",
     "For time-series data, we may need to operate on a small \\\"window\\\" of our column at a time, processing each portion independently. We could slide (\\\"roll\\\") this window over the entire column to answer questions like \\\"What is the 3-day moving average of a stock price over the past year?\"\n",
     "\n",
@@ -1859,7 +1869,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## GroupBy DataFrame UDFs\n",
+    "GroupBy DataFrame UDFs\n",
+    "-------------------------------\n",
     "\n",
     "We can also apply UDFs to grouped DataFrames using `apply_grouped`. This example is also drawn and adapted from the RAPIDS [API documentation]().\n",
     "\n",
@@ -2155,7 +2166,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Numba Kernels on CuPy Arrays\n",
+    "Numba Kernels on CuPy Arrays\n",
+    "-------------------------------------\n",
     "\n",
     "We can also execute Numba kernels on CuPy NDArrays, again thanks to the `__cuda_array_interface__`. We can even run the same UDF on the Series and the CuPy array. First, we define a Series and then create a CuPy array from that Series."
    ]
@@ -2257,7 +2269,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Caveats"
+    "Caveats\n",
+    "---------"
    ]
   },
   {
@@ -2272,7 +2285,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Summary\n",
+    "Summary\n",
+    "-----------\n",
     "\n",
     "This guide has covered a lot of content. At this point, you should hopefully feel comfortable writing UDFs (with or without null values) that operate on\n",
     "\n",
@@ -2305,7 +2319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes an issue where sphinx was reading the `#`'s in the UDF guide markdown cells as section headings causing strange effects in the docs main index page.