### PR TITLE
Add `.list.astype()` to cast list leaves to specified dtype

### DIFF
--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -299,16 +299,29 @@ class ListColumn(ColumnBase):
         """
         Create a strings column from a list column
         """
-        # Convert the leaf child column to strings column
+        lc = self._transform_leaves(lambda col: col.as_string_column(dtype))
+
+        # Separator strings to match the Python format
+        separators = as_column([", ", "[", "]"])
+
+        # Call libcudf to format the list column
+        return format_list_column(lc, separators)
+
+    def _transform_leaves(self, func, *args, **kwargs):
+        # return a new list column with the same nested structure
+        # as ``self``, but with the leaf column transformed
+        # by applying ``func`` to it
+
         cc: List[ListColumn] = []
         c: ColumnBase = self
+
         while isinstance(c, ListColumn):
             cc.insert(0, c)
             c = c.children[1]
-        s = c.as_string_column(dtype)
+
+        lc = func(c, *args, **kwargs)
 
         # Rebuild the list column replacing just the leaf child
-        lc = s
         for c in cc:
             o = c.children[0]
             lc = cudf.core.column.ListColumn(  # type: ignore
@@ -319,12 +332,7 @@ class ListColumn(ColumnBase):
                 null_count=c.null_count,
                 children=(o, lc),
             )
-
-        # Separator strings to match the Python format
-        separators = as_column([", ", "[", "]"])
-
-        # Call libcudf to format the list column
-        return format_list_column(lc, separators)
+        return lc
 
 
 class ListMethods(ColumnMethods):
@@ -715,3 +723,30 @@ class ListMethods(ColumnMethods):
                     "of nesting"
                 )
         return self._return_or_inplace(result)
+
+    def astype(self, dtype):
+        """
+        Return a new list Series with the leaf values casted
+        to the specified data type.
+
+        Parameters
+        ----------
+        dtype: data type to cast leaves values to
+
+        Returns
+        -------
+        A new Series of lists
+
+        Examples
+        --------
+        >>> import cudf
+        >>> s = cudf.Series([[1, 2], [3, 4]])
+        >>> s.dtype
+        ListDtype(int64)
+        >>> s2 = s.list.astype("float64")
+        >>> s2.dtype
+        ListDtype(float64)
+        """
+        return self._return_or_inplace(
+            self._column._transform_leaves(lambda col: col.astype(dtype))
+        )

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -739,7 +739,6 @@ class ListMethods(ColumnMethods):
 
         Examples
         --------
-        >>> import cudf
         >>> s = cudf.Series([[1, 2], [3, 4]])
         >>> s.dtype
         ListDtype(int64)

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -299,7 +299,9 @@ class ListColumn(ColumnBase):
         """
         Create a strings column from a list column
         """
-        lc = self._transform_leaves(lambda col: col.as_string_column(dtype))
+        lc = self._transform_leaves(
+            lambda col, dtype: col.as_string_column(dtype), dtype
+        )
 
         # Separator strings to match the Python format
         separators = as_column([", ", "[", "]"])
@@ -747,5 +749,7 @@ class ListMethods(ColumnMethods):
         ListDtype(float64)
         """
         return self._return_or_inplace(
-            self._column._transform_leaves(lambda col: col.astype(dtype))
+            self._column._transform_leaves(
+                lambda col, dtype: col.astype(dtype), dtype
+            )
         )

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -759,3 +759,13 @@ def test_listcol_setitem_retain_dtype():
     # prior to this fix: https://github.com/rapidsai/cudf/pull/10151/
     df2 = df1.copy()
     assert df2["a"].dtype == df["a"].dtype
+
+
+def test_list_astype():
+    s = cudf.Series([[1, 2], [3, 4]])
+    s2 = s.list.astype("float64")
+    assert s2.dtype == cudf.ListDtype("float64")
+
+    s = cudf.Series([[[1, 2], [3]], [[5, 6], None]])
+    s2 = s.list.astype("string")
+    assert s2.dtype == cudf.ListDtype(cudf.ListDtype("string"))

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -765,7 +765,9 @@ def test_list_astype():
     s = cudf.Series([[1, 2], [3, 4]])
     s2 = s.list.astype("float64")
     assert s2.dtype == cudf.ListDtype("float64")
+    assert_eq(s.list.leaves.astype("float64"), s2.list.leaves)
 
     s = cudf.Series([[[1, 2], [3]], [[5, 6], None]])
     s2 = s.list.astype("string")
     assert s2.dtype == cudf.ListDtype(cudf.ListDtype("string"))
+    assert_eq(s.list.leaves.astype("string"), s2.list.leaves)


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/10687.
