### PR TITLE
Correct build dir `cudf-config` dependency issues for static builds

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -154,7 +154,7 @@ include(cmake/thirdparty/get_gtest.cmake)
 # preprocess jitify-able kernels
 include(cmake/Modules/JitifyPreprocessKernels.cmake)
 # find cuFile
-include(cmake/Modules/FindcuFile.cmake)
+include(cmake/thirdparty/get_cufile.cmake)
 # find KvikIO
 include(cmake/thirdparty/get_kvikio.cmake)
 
@@ -162,18 +162,15 @@ include(cmake/thirdparty/get_kvikio.cmake)
 if(NOT BUILD_SHARED_LIBS)
   include("${rapids-cmake-dir}/export/find_package_file.cmake")
   list(APPEND METADATA_KINDS BUILD INSTALL)
-  foreach(METADATA_KIND IN LISTS METADATA_KINDS)
-    if(TARGET cufile::cuFile_interface)
-      rapids_export_find_package_file(
-        ${METADATA_KIND} "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" cudf-exports
-      )
-      rapids_export_package(${METADATA_KIND} cuFile cudf-exports)
-    endif()
+  list(APPEND dependencies cuco KvikIO ZLIB nvcomp)
+  if(TARGET cufile::cuFile_interface)
+    list(APPEND dependencies cuFile)
+  endif()
 
-    rapids_export_package(${METADATA_KIND} cuco cudf-exports)
-    rapids_export_package(${METADATA_KIND} KvikIO cudf-exports)
-    rapids_export_package(${METADATA_KIND} ZLIB cudf-exports)
-    rapids_export_package(${METADATA_KIND} nvcomp cudf-exports)
+  foreach(METADATA_KIND IN LISTS METADATA_KINDS)
+    foreach(dep IN LISTS dependencies)
+      rapids_export_package(${METADATA_KIND} ${dep} cudf-exports)
+    endforeach()
   endforeach()
 endif()
 
@@ -592,17 +589,12 @@ add_dependencies(cudf jitify_preprocess_run)
 target_link_libraries(
   cudf
   PUBLIC ${ARROW_LIBRARIES} libcudacxx::libcudacxx cudf::Thrust rmm::rmm
-  PRIVATE cuco::cuco ZLIB::ZLIB nvcomp::nvcomp kvikio::kvikio
+  PRIVATE cuco::cuco ZLIB::ZLIB nvcomp::nvcomp kvikio::kvikio $<TARGET_EXISTS:cuFile_interface>
 )
 
 # Add Conda library, and include paths if specified
 if(TARGET conda_env)
   target_link_libraries(cudf PRIVATE conda_env)
-endif()
-
-# Add cuFile interface if available
-if(TARGET cufile::cuFile_interface)
-  target_link_libraries(cudf PRIVATE cufile::cuFile_interface)
 endif()
 
 if(CUDA_STATIC_RUNTIME)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -172,6 +172,10 @@ if(NOT BUILD_SHARED_LIBS)
       rapids_export_package(${METADATA_KIND} ${dep} cudf-exports)
     endforeach()
   endforeach()
+
+  if(TARGET conda_env)
+    install(TARGETS conda_env EXPORT cudf-exports)
+  endif()
 endif()
 
 # ##################################################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -163,7 +163,7 @@ if(NOT BUILD_SHARED_LIBS)
   include("${rapids-cmake-dir}/export/find_package_file.cmake")
   list(APPEND METADATA_KINDS BUILD INSTALL)
   foreach(METADATA_KIND IN LISTS METADATA_KINDS)
-    if(TARGET cuFile::cuFile_interface)
+    if(TARGET cufile::cuFile_interface)
       rapids_export_find_package_file(
         ${METADATA_KIND} "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" cudf-exports
       )
@@ -601,8 +601,8 @@ if(TARGET conda_env)
 endif()
 
 # Add cuFile interface if available
-if(TARGET cuFile::cuFile_interface)
-  target_link_libraries(cudf PRIVATE cuFile::cuFile_interface)
+if(TARGET cufile::cuFile_interface)
+  target_link_libraries(cudf PRIVATE cufile::cuFile_interface)
 endif()
 
 if(CUDA_STATIC_RUNTIME)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -163,12 +163,16 @@ if(NOT BUILD_SHARED_LIBS)
   include("${rapids-cmake-dir}/export/find_package_file.cmake")
   list(APPEND METADATA_KINDS BUILD INSTALL)
   foreach(METADATA_KIND IN LISTS METADATA_KINDS)
-    rapids_export_find_package_file(
-      ${METADATA_KIND} "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" cudf-exports
-    )
+    if(TARGET cuFile::cuFile_interface)
+      rapids_export_find_package_file(
+        ${METADATA_KIND} "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" cudf-exports
+      )
+      rapids_export_package(${METADATA_KIND} cuFile cudf-exports)
+    endif()
+
     rapids_export_package(${METADATA_KIND} cuco cudf-exports)
+    rapids_export_package(${METADATA_KIND} KvikIO cudf-exports)
     rapids_export_package(${METADATA_KIND} ZLIB cudf-exports)
-    rapids_export_package(${METADATA_KIND} cuFile cudf-exports)
     rapids_export_package(${METADATA_KIND} nvcomp cudf-exports)
   endforeach()
 endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -589,7 +589,8 @@ add_dependencies(cudf jitify_preprocess_run)
 target_link_libraries(
   cudf
   PUBLIC ${ARROW_LIBRARIES} libcudacxx::libcudacxx cudf::Thrust rmm::rmm
-  PRIVATE cuco::cuco ZLIB::ZLIB nvcomp::nvcomp kvikio::kvikio $<TARGET_EXISTS:cuFile_interface>
+  PRIVATE cuco::cuco ZLIB::ZLIB nvcomp::nvcomp kvikio::kvikio
+          $<TARGET_NAME_IF_EXISTS:cuFile_interface>
 )
 
 # Add Conda library, and include paths if specified

--- a/cpp/cmake/Modules/FindcuFile.cmake
+++ b/cpp/cmake/Modules/FindcuFile.cmake
@@ -20,9 +20,9 @@ Find cuFile headers and libraries.
 Imported Targets
 ^^^^^^^^^^^^^^^^
 
-``cuFile::cuFile``
+``cufile::cuFile``
   The cuFile library, if found.
-``cuFile::cuFileRDMA``
+``cufile::cuFileRDMA``
   The cuFile RDMA library, if found.
 
 Result Variables
@@ -80,29 +80,29 @@ find_package_handle_standard_args(
   VERSION_VAR cuFile_VERSION
 )
 
-if(cuFile_INCLUDE_DIR AND NOT TARGET cuFile::cuFile_interface)
-  add_library(cuFile::cuFile_interface INTERFACE IMPORTED GLOBAL)
+if(cuFile_INCLUDE_DIR AND NOT TARGET cufile::cuFile_interface)
+  add_library(cufile::cuFile_interface INTERFACE IMPORTED GLOBAL)
   target_include_directories(
-    cuFile::cuFile_interface INTERFACE "$<BUILD_INTERFACE:${cuFile_INCLUDE_DIR}>"
+    cufile::cuFile_interface INTERFACE "$<BUILD_INTERFACE:${cuFile_INCLUDE_DIR}>"
   )
-  target_compile_options(cuFile::cuFile_interface INTERFACE "${cuFile_COMPILE_OPTIONS}")
-  target_compile_definitions(cuFile::cuFile_interface INTERFACE CUFILE_FOUND)
+  target_compile_options(cufile::cuFile_interface INTERFACE "${cuFile_COMPILE_OPTIONS}")
+  target_compile_definitions(cufile::cuFile_interface INTERFACE CUFILE_FOUND)
 endif()
 
-if(cuFile_FOUND AND NOT TARGET cuFile::cuFile)
-  add_library(cuFile::cuFile UNKNOWN IMPORTED GLOBAL)
+if(cuFile_FOUND AND NOT TARGET cufile::cuFile)
+  add_library(cufile::cuFile UNKNOWN IMPORTED GLOBAL)
   set_target_properties(
-    cuFile::cuFile
+    cufile::cuFile
     PROPERTIES IMPORTED_LOCATION "${cuFile_LIBRARY}"
                INTERFACE_COMPILE_OPTIONS "${cuFile_COMPILE_OPTIONS}"
                INTERFACE_INCLUDE_DIRECTORIES "${cuFile_INCLUDE_DIR}"
   )
 endif()
 
-if(cuFile_FOUND AND NOT TARGET cuFile::cuFileRDMA)
-  add_library(cuFile::cuFileRDMA UNKNOWN IMPORTED GLOBAL)
+if(cuFile_FOUND AND NOT TARGET cufile::cuFileRDMA)
+  add_library(cufile::cuFileRDMA UNKNOWN IMPORTED GLOBAL)
   set_target_properties(
-    cuFile::cuFileRDMA
+    cufile::cuFileRDMA
     PROPERTIES IMPORTED_LOCATION "${cuFileRDMA_LIBRARY}"
                INTERFACE_COMPILE_OPTIONS "${cuFile_COMPILE_OPTIONS}"
                INTERFACE_INCLUDE_DIRECTORIES "${cuFile_INCLUDE_DIR}"

--- a/cpp/cmake/Modules/FindcuFile.cmake
+++ b/cpp/cmake/Modules/FindcuFile.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/cpp/cmake/Modules/FindcuFile.cmake
+++ b/cpp/cmake/Modules/FindcuFile.cmake
@@ -81,7 +81,7 @@ find_package_handle_standard_args(
 )
 
 if(cuFile_INCLUDE_DIR AND NOT TARGET cuFile::cuFile_interface)
-  add_library(cuFile::cuFile_interface IMPORTED INTERFACE)
+  add_library(cuFile::cuFile_interface IMPORTED GLOBAL INTERFACE)
   target_include_directories(
     cuFile::cuFile_interface INTERFACE "$<BUILD_INTERFACE:${cuFile_INCLUDE_DIR}>"
   )
@@ -90,7 +90,7 @@ if(cuFile_INCLUDE_DIR AND NOT TARGET cuFile::cuFile_interface)
 endif()
 
 if(cuFile_FOUND AND NOT TARGET cuFile::cuFile)
-  add_library(cuFile::cuFile UNKNOWN IMPORTED)
+  add_library(cuFile::cuFile UNKNOWN GLOBAL IMPORTED)
   set_target_properties(
     cuFile::cuFile
     PROPERTIES IMPORTED_LOCATION "${cuFile_LIBRARY}"
@@ -100,7 +100,7 @@ if(cuFile_FOUND AND NOT TARGET cuFile::cuFile)
 endif()
 
 if(cuFile_FOUND AND NOT TARGET cuFile::cuFileRDMA)
-  add_library(cuFile::cuFileRDMA UNKNOWN IMPORTED)
+  add_library(cuFile::cuFileRDMA UNKNOWN GLOBAL IMPORTED)
   set_target_properties(
     cuFile::cuFileRDMA
     PROPERTIES IMPORTED_LOCATION "${cuFileRDMA_LIBRARY}"

--- a/cpp/cmake/Modules/FindcuFile.cmake
+++ b/cpp/cmake/Modules/FindcuFile.cmake
@@ -81,7 +81,7 @@ find_package_handle_standard_args(
 )
 
 if(cuFile_INCLUDE_DIR AND NOT TARGET cuFile::cuFile_interface)
-  add_library(cuFile::cuFile_interface IMPORTED GLOBAL INTERFACE)
+  add_library(cuFile::cuFile_interface INTERFACE IMPORTED GLOBAL)
   target_include_directories(
     cuFile::cuFile_interface INTERFACE "$<BUILD_INTERFACE:${cuFile_INCLUDE_DIR}>"
   )
@@ -90,7 +90,7 @@ if(cuFile_INCLUDE_DIR AND NOT TARGET cuFile::cuFile_interface)
 endif()
 
 if(cuFile_FOUND AND NOT TARGET cuFile::cuFile)
-  add_library(cuFile::cuFile UNKNOWN GLOBAL IMPORTED)
+  add_library(cuFile::cuFile UNKNOWN IMPORTED GLOBAL)
   set_target_properties(
     cuFile::cuFile
     PROPERTIES IMPORTED_LOCATION "${cuFile_LIBRARY}"
@@ -100,7 +100,7 @@ if(cuFile_FOUND AND NOT TARGET cuFile::cuFile)
 endif()
 
 if(cuFile_FOUND AND NOT TARGET cuFile::cuFileRDMA)
-  add_library(cuFile::cuFileRDMA UNKNOWN GLOBAL IMPORTED)
+  add_library(cuFile::cuFileRDMA UNKNOWN IMPORTED GLOBAL)
   set_target_properties(
     cuFile::cuFileRDMA
     PROPERTIES IMPORTED_LOCATION "${cuFileRDMA_LIBRARY}"

--- a/cpp/cmake/thirdparty/get_cufile.cmake
+++ b/cpp/cmake/thirdparty/get_cufile.cmake
@@ -19,6 +19,7 @@ function(find_and_configure_cufile)
   rapids_find_package(cuFile QUIET)
 
   if(cuFile_FOUND AND NOT BUILD_SHARED_LIBS)
+    include("${rapids-cmake-dir}/export/find_package_file.cmake")
     rapids_export_find_package_file(
       BUILD "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" cudf-exports
     )

--- a/cpp/cmake/thirdparty/get_cufile.cmake
+++ b/cpp/cmake/thirdparty/get_cufile.cmake
@@ -1,0 +1,31 @@
+# =============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+# This function finds nvcomp and sets any additional necessary environment variables.
+function(find_and_configure_cufile)
+
+  list(APPEND CMAKE_MODULE_PATH ${CUDF_SOURCE_DIR}/cmake/Modules)
+  rapids_find_package(cuFile QUIET)
+
+  if(cuFile_FOUND AND NOT BUILD_SHARED_LIBS)
+    rapids_export_find_package_file(
+      BUILD "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" cudf-exports
+    )
+    rapids_export_find_package_file(
+      INSTALL "${CUDF_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" cudf-exports
+    )
+  endif()
+endfunction()
+
+find_and_configure_cufile()

--- a/cpp/cmake/thirdparty/get_kvikio.cmake
+++ b/cpp/cmake/thirdparty/get_kvikio.cmake
@@ -25,6 +25,11 @@ function(find_and_configure_kvikio VERSION)
     OPTIONS "KvikIO_BUILD_EXAMPLES OFF"
   )
 
+  if(KvikIO_BINARY_DIR)
+    include("${rapids-cmake-dir}/export/find_package_root.cmake")
+    rapids_export_find_package_root(BUILD KvikIO "${KvikIO_BINARY_DIR}" cudf-exports)
+  endif()
+
 endfunction()
 
 set(KVIKIO_MIN_VERSION_cudf "${CUDF_VERSION_MAJOR}.${CUDF_VERSION_MINOR}")

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -25,6 +25,11 @@ function(find_and_configure_nvcomp VERSION_MIN VERSION_MAX)
     OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF"
   )
 
+  if(nvcomp_BINARY_DIR)
+    include("${rapids-cmake-dir}/export/find_package_root.cmake")
+    rapids_export_find_package_root(BUILD nvcomp "${nvcomp_BINARY_DIR}" cudf-exports)
+  endif()
+
   if(NOT TARGET nvcomp::nvcomp)
     add_library(nvcomp::nvcomp ALIAS nvcomp)
   endif()


### PR DESCRIPTION
When cudf is built statically we had the following three issues that
could cause consumers to fail to find cudf:

  1. kvikio was not setup to be exported properly
  2. Removed cuFile dependency when it isn't found
  3. Hint where to find nvcomp when built by cudf

