### PR TITLE
Rename tests from multiIndex to multiindex.

### DIFF
--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -646,7 +646,7 @@ def test_concat_two_empty_series(ignore_index, axis):
         ),
     ],
 )
-def test_concat_dataframe_with_multiIndex(df1, df2):
+def test_concat_dataframe_with_multiindex(df1, df2):
     gdf1 = df1
     gdf1 = gdf1.set_index(["k1", "k2"])
 

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -726,7 +726,7 @@ def test_dataframe_take(ntake):
 
 
 @pytest.mark.parametrize("ntake", [1, 2, 8, 9])
-def test_dataframe_take_with_multiIndex(ntake):
+def test_dataframe_take_with_multiindex(ntake):
     np.random.seed(0)
     df = cudf.DataFrame(
         index=cudf.MultiIndex(

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
 
 """
 Test related to MultiIndex
@@ -1131,7 +1131,7 @@ def test_multiindex_values_host():
         ),
     ],
 )
-def test_multiIndex_fillna(gdi, fill_value, expected):
+def test_multiindex_fillna(gdi, fill_value, expected):
     assert_eq(expected, gdi.fillna(fill_value))
 
 
@@ -1173,7 +1173,7 @@ def test_multiIndex_fillna(gdi, fill_value, expected):
         ),
     ],
 )
-def test_multiIndex_empty(pdi):
+def test_multiindex_empty(pdi):
     gdi = cudf.from_pandas(pdi)
 
     assert_eq(pdi.empty, gdi.empty)
@@ -1217,7 +1217,7 @@ def test_multiIndex_empty(pdi):
         ),
     ],
 )
-def test_multiIndex_size(pdi):
+def test_multiindex_size(pdi):
     gdi = cudf.from_pandas(pdi)
 
     assert_eq(pdi.size, gdi.size)
@@ -1375,7 +1375,7 @@ def test_multiindex_sort_values(pmidx, ascending, return_indexer):
     ],
 )
 @pytest.mark.parametrize("ascending", [True, False])
-def test_multiIndex_argsort(pdi, ascending):
+def test_multiindex_argsort(pdi, ascending):
     gdi = cudf.from_pandas(pdi)
 
     if not ascending:
@@ -1562,7 +1562,7 @@ def test_multiindex_indexing(key):
     assert_eq(gi[key], pi[key], exact=False)
 
 
-def test_multiIndex_duplicate_names():
+def test_multiindex_duplicate_names():
     gi = cudf.MultiIndex(
         levels=[["a", "b"], ["b", "a"]],
         codes=[[0, 0], [0, 1]],
@@ -1699,7 +1699,7 @@ def test_intersection_mulitIndex(idx1, idx2, sort):
         None,
     ],
 )
-def test_pickle_roundtrip_multiIndex(names):
+def test_pickle_roundtrip_multiindex(names):
     df = cudf.DataFrame(
         {
             "one": [1, 2, 3],
@@ -1745,7 +1745,7 @@ def test_pickle_roundtrip_multiIndex(names):
         "is_interval",
     ],
 )
-def test_multiIndex_type_methods(pidx, func):
+def test_multiindex_type_methods(pidx, func):
     gidx = cudf.from_pandas(pidx)
 
     expected = getattr(pidx, func)()

--- a/python/cudf/cudf/tests/test_repr.py
+++ b/python/cudf/cudf/tests/test_repr.py
@@ -1132,7 +1132,7 @@ def test_timedelta_index_repr(index, expected_repr):
     ],
 )
 @pytest.mark.parametrize("max_seq_items", [None, 1, 2, 5, 10, 100])
-def test_multiIndex_repr(pmi, max_seq_items):
+def test_multiindex_repr(pmi, max_seq_items):
     pd.set_option("display.max_seq_items", max_seq_items)
     gmi = cudf.from_pandas(pmi)
 
@@ -1377,7 +1377,7 @@ def test_multiIndex_repr(pmi, max_seq_items):
         ),
     ],
 )
-def test_multiIndex_null_repr(gdi, expected_repr):
+def test_multiindex_null_repr(gdi, expected_repr):
     actual_repr = gdi.__repr__()
 
     assert actual_repr.split() == expected_repr.split()


### PR DESCRIPTION
Small PR for improving consistency in cuDF Python test names. Follows up from https://github.com/rapidsai/cudf/pull/10729#discussion_r857972566. cc: @galipremsagar 