### PR TITLE
Improve use of isinstance.

### DIFF
--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -48,16 +48,12 @@ def is_numeric_dtype(obj):
         if issubclass(obj, _BaseDtype):
             return False
     else:
-        if isinstance(obj, cudf.Decimal128Dtype) or isinstance(
-            getattr(obj, "dtype", None), cudf.Decimal128Dtype
-        ):
-            return True
-        if isinstance(obj, cudf.Decimal64Dtype) or isinstance(
-            getattr(obj, "dtype", None), cudf.Decimal64Dtype
-        ):
-            return True
-        if isinstance(obj, cudf.Decimal32Dtype) or isinstance(
-            getattr(obj, "dtype", None), cudf.Decimal32Dtype
+        if isinstance(
+            obj,
+            (cudf.Decimal128Dtype, cudf.Decimal64Dtype, cudf.Decimal32Dtype),
+        ) or isinstance(
+            getattr(obj, "dtype", None),
+            (cudf.Decimal128Dtype, cudf.Decimal64Dtype, cudf.Decimal32Dtype),
         ):
             return True
         if isinstance(obj, _BaseDtype) or isinstance(
@@ -129,12 +125,14 @@ def is_scalar(val):
     bool
         Return True if given object is scalar.
     """
-    return (
-        isinstance(val, cudf._lib.scalar.DeviceScalar)
-        or isinstance(val, cudf.Scalar)
-        or isinstance(val, cudf.core.tools.datetimes.DateOffset)
-        or pd_types.is_scalar(val)
-    )
+    return isinstance(
+        val,
+        (
+            cudf.Scalar,
+            cudf._lib.scalar.DeviceScalar,
+            cudf.core.tools.datetimes.DateOffset,
+        ),
+    ) or pd_types.is_scalar(val)
 
 
 def _is_scalar_or_zero_d_array(val):

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -681,8 +681,13 @@ def is_interval_dtype(obj):
     # TODO: Should there be any branch in this function that calls
     # pd.api.types.is_interval_dtype?
     return (
-        isinstance(obj, cudf.core.dtypes.IntervalDtype)
-        or isinstance(obj, pd.core.dtypes.dtypes.IntervalDtype)
+        isinstance(
+            obj,
+            (
+                cudf.core.dtypes.IntervalDtype,
+                pd.core.dtypes.dtypes.IntervalDtype,
+            ),
+        )
         or obj is cudf.core.dtypes.IntervalDtype
         or (
             isinstance(obj, str) and obj == cudf.core.dtypes.IntervalDtype.name


### PR DESCRIPTION
This PR combines a few `isinstance` checks to reduce the complexity of the logic.

Note: Some of these were identified by https://codereview.doctor/rapidsai/cudf. In some places, the bot correctly identified a problem but its suggestions were invalid or incomplete. I identified steps for improvement beyond what the bot suggested for most of these cases.