### PR TITLE
Fix `cupy` function in notebook

### DIFF
--- a/docs/cudf/source/user_guide/10min-cudf-cupy.ipynb
+++ b/docs/cudf/source/user_guide/10min-cudf-cupy.ipynb
@@ -1067,7 +1067,7 @@
     "    if sparseformat == 'row':\n",
     "        _sparse_constructor = cp.sparse.csr_matrix\n",
     "\n",
-    "    return _sparse_constructor(cp.from_dlpack(data.to_dlpack()))"
+    "    return _sparse_constructor(cupy_from_dlpack(data.to_dlpack()))"
    ]
   },
   {


### PR DESCRIPTION
This PR updates a `from_dlpack` call that was missed in #10631.