### PR TITLE
Revise 10 minutes notebook.

### DIFF
--- a/docs/cudf/source/user_guide/10min.ipynb
+++ b/docs/cudf/source/user_guide/10min.ipynb
@@ -2485,14 +2485,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mmccarty/miniconda3/envs/cudf_dev/lib/python3.8/site-packages/cudf/core/series.py:2223: FutureWarning: Series.applymap is deprecated and will be removed in a future cuDF release. Use Series.apply instead.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
        "0     10\n",
@@ -2527,7 +2519,7 @@
     "def add_ten(num):\n",
     "    return num + 10\n",
     "\n",
-    "df['a'].applymap(add_ten)"
+    "df['a'].apply(add_ten)"
    ]
   },
   {
@@ -3013,88 +3005,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Append"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Appending values from another `Series` or array-like object."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mmccarty/miniconda3/envs/cudf_dev/lib/python3.8/site-packages/cudf/core/indexed_frame.py:2329: FutureWarning: append is deprecated and will be removed in a future version. Use concat instead.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "0       1\n",
-       "1       2\n",
-       "2       3\n",
-       "3    <NA>\n",
-       "4       5\n",
-       "0       1\n",
-       "1       2\n",
-       "2       3\n",
-       "3    <NA>\n",
-       "4       5\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "s.append(s)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0       1\n",
-       "1       2\n",
-       "2       3\n",
-       "3    <NA>\n",
-       "4       5\n",
-       "0       1\n",
-       "1       2\n",
-       "2       3\n",
-       "3    <NA>\n",
-       "4       5\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ds2.append(ds2).compute()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Grouping"
    ]
   },
@@ -3107,7 +3017,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3122,6 +3032,161 @@
    "metadata": {},
    "source": [
     "Grouping and then applying the `sum` function to the grouped data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "      <th>c</th>\n",
+       "      <th>agg_col2</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>agg_col1</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>90</td>\n",
+       "      <td>100</td>\n",
+       "      <td>90</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>100</td>\n",
+       "      <td>90</td>\n",
+       "      <td>100</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            a    b    c  agg_col2\n",
+       "agg_col1                         \n",
+       "1          90  100   90         4\n",
+       "0         100   90  100         3"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.groupby('agg_col1').sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "      <th>c</th>\n",
+       "      <th>agg_col2</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>agg_col1</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>90</td>\n",
+       "      <td>100</td>\n",
+       "      <td>90</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>100</td>\n",
+       "      <td>90</td>\n",
+       "      <td>100</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            a    b    c  agg_col2\n",
+       "agg_col1                         \n",
+       "1          90  100   90         4\n",
+       "0         100   90  100         3"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ddf.groupby('agg_col1').sum().compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Grouping hierarchically then applying the `sum` function to grouped data."
    ]
   },
   {
@@ -3150,14 +3215,14 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th></th>\n",
        "      <th>a</th>\n",
        "      <th>b</th>\n",
        "      <th>c</th>\n",
-       "      <th>agg_col2</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>agg_col1</th>\n",
-       "      <th></th>\n",
+       "      <th>agg_col2</th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
@@ -3166,27 +3231,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>90</td>\n",
-       "      <td>100</td>\n",
-       "      <td>90</td>\n",
-       "      <td>4</td>\n",
+       "      <th>0</th>\n",
+       "      <td>54</td>\n",
+       "      <td>60</td>\n",
+       "      <td>54</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>100</td>\n",
-       "      <td>90</td>\n",
-       "      <td>100</td>\n",
-       "      <td>3</td>\n",
+       "      <th>0</th>\n",
+       "      <td>73</td>\n",
+       "      <td>60</td>\n",
+       "      <td>73</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <th>1</th>\n",
+       "      <td>36</td>\n",
+       "      <td>40</td>\n",
+       "      <td>36</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <td>27</td>\n",
+       "      <td>30</td>\n",
+       "      <td>27</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "            a    b    c  agg_col2\n",
-       "agg_col1                         \n",
-       "1          90  100   90         4\n",
-       "0         100   90  100         3"
+       "                    a   b   c\n",
+       "agg_col1 agg_col2            \n",
+       "1        0         54  60  54\n",
+       "0        0         73  60  73\n",
+       "1        1         36  40  36\n",
+       "0        1         27  30  27"
       ]
      },
      "execution_count": 48,
@@ -3195,7 +3276,7 @@
     }
    ],
    "source": [
-    "df.groupby('agg_col1').sum()"
+    "df.groupby(['agg_col1', 'agg_col2']).sum()"
    ]
   },
   {
@@ -3224,14 +3305,14 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th></th>\n",
        "      <th>a</th>\n",
        "      <th>b</th>\n",
        "      <th>c</th>\n",
-       "      <th>agg_col2</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>agg_col1</th>\n",
-       "      <th></th>\n",
+       "      <th>agg_col2</th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
@@ -3240,27 +3321,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>90</td>\n",
-       "      <td>100</td>\n",
-       "      <td>90</td>\n",
-       "      <td>4</td>\n",
+       "      <th>1</th>\n",
+       "      <td>36</td>\n",
+       "      <td>40</td>\n",
+       "      <td>36</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>100</td>\n",
-       "      <td>90</td>\n",
-       "      <td>100</td>\n",
-       "      <td>3</td>\n",
+       "      <th>0</th>\n",
+       "      <td>73</td>\n",
+       "      <td>60</td>\n",
+       "      <td>73</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <th>0</th>\n",
+       "      <td>54</td>\n",
+       "      <td>60</td>\n",
+       "      <td>54</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <td>27</td>\n",
+       "      <td>30</td>\n",
+       "      <td>27</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "            a    b    c  agg_col2\n",
-       "agg_col1                         \n",
-       "1          90  100   90         4\n",
-       "0         100   90  100         3"
+       "                    a   b   c\n",
+       "agg_col1 agg_col2            \n",
+       "1        1         36  40  36\n",
+       "0        0         73  60  73\n",
+       "1        0         54  60  54\n",
+       "0        1         27  30  27"
       ]
      },
      "execution_count": 49,
@@ -3269,14 +3366,14 @@
     }
    ],
    "source": [
-    "ddf.groupby('agg_col1').sum().compute()"
+    "ddf.groupby(['agg_col1', 'agg_col2']).sum().compute()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Grouping hierarchically then applying the `sum` function to grouped data."
+    "Grouping and applying statistical functions to specific columns, using `agg`."
    ]
   },
   {
@@ -3305,14 +3402,12 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th></th>\n",
        "      <th>a</th>\n",
        "      <th>b</th>\n",
        "      <th>c</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>agg_col1</th>\n",
-       "      <th>agg_col2</th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
@@ -3321,43 +3416,25 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <th>0</th>\n",
-       "      <td>54</td>\n",
-       "      <td>60</td>\n",
-       "      <td>54</td>\n",
+       "      <td>18</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>90</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <th>0</th>\n",
-       "      <td>73</td>\n",
-       "      <td>60</td>\n",
-       "      <td>73</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <th>1</th>\n",
-       "      <td>36</td>\n",
-       "      <td>40</td>\n",
-       "      <td>36</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <th>1</th>\n",
-       "      <td>27</td>\n",
-       "      <td>30</td>\n",
-       "      <td>27</td>\n",
+       "      <td>19</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>100</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                    a   b   c\n",
-       "agg_col1 agg_col2            \n",
-       "1        0         54  60  54\n",
-       "0        0         73  60  73\n",
-       "1        1         36  40  36\n",
-       "0        1         27  30  27"
+       "           a     b    c\n",
+       "agg_col1               \n",
+       "1         18  10.0   90\n",
+       "0         19   9.0  100"
       ]
      },
      "execution_count": 50,
@@ -3366,7 +3443,7 @@
     }
    ],
    "source": [
-    "df.groupby(['agg_col1', 'agg_col2']).sum()"
+    "df.groupby('agg_col1').agg({'a':'max', 'b':'mean', 'c':'sum'})"
    ]
   },
   {
@@ -3395,14 +3472,12 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th></th>\n",
        "      <th>a</th>\n",
        "      <th>b</th>\n",
        "      <th>c</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>agg_col1</th>\n",
-       "      <th>agg_col2</th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
@@ -3411,193 +3486,28 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <th>1</th>\n",
-       "      <td>36</td>\n",
-       "      <td>40</td>\n",
-       "      <td>36</td>\n",
+       "      <td>18</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>90</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <th>0</th>\n",
-       "      <td>73</td>\n",
-       "      <td>60</td>\n",
-       "      <td>73</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <th>0</th>\n",
-       "      <td>54</td>\n",
-       "      <td>60</td>\n",
-       "      <td>54</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <th>1</th>\n",
-       "      <td>27</td>\n",
-       "      <td>30</td>\n",
-       "      <td>27</td>\n",
+       "      <td>19</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>100</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                    a   b   c\n",
-       "agg_col1 agg_col2            \n",
-       "1        1         36  40  36\n",
-       "0        0         73  60  73\n",
-       "1        0         54  60  54\n",
-       "0        1         27  30  27"
+       "           a     b    c\n",
+       "agg_col1               \n",
+       "1         18  10.0   90\n",
+       "0         19   9.0  100"
       ]
      },
      "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ddf.groupby(['agg_col1', 'agg_col2']).sum().compute()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Grouping and applying statistical functions to specific columns, using `agg`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 52,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "      <th>c</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>agg_col1</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>18</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>90</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>19</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>100</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           a     b    c\n",
-       "agg_col1               \n",
-       "1         18  10.0   90\n",
-       "0         19   9.0  100"
-      ]
-     },
-     "execution_count": 52,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.groupby('agg_col1').agg({'a':'max', 'b':'mean', 'c':'sum'})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "      <th>c</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>agg_col1</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>18</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>90</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>19</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>100</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           a     b    c\n",
-       "agg_col1               \n",
-       "1         18  10.0   90\n",
-       "0         19   9.0  100"
-      ]
-     },
-     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3622,7 +3532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -3677,7 +3587,7 @@
        "2  3  6"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3689,7 +3599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -3741,7 +3651,7 @@
        "b  4  5  6"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3763,6 +3673,173 @@
    "metadata": {},
    "source": [
     "`DataFrames` supports `datetime` typed columns, which allow users to interact with and filter data based on specific timestamps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2018-11-20</td>\n",
+       "      <td>0.986051</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2018-11-21</td>\n",
+       "      <td>0.232034</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2018-11-22</td>\n",
+       "      <td>0.397617</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2018-11-23</td>\n",
+       "      <td>0.103839</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        date     value\n",
+       "0 2018-11-20  0.986051\n",
+       "1 2018-11-21  0.232034\n",
+       "2 2018-11-22  0.397617\n",
+       "3 2018-11-23  0.103839"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import datetime as dt\n",
+    "\n",
+    "date_df = cudf.DataFrame()\n",
+    "date_df['date'] = pd.date_range('11/20/2018', periods=72, freq='D')\n",
+    "date_df['value'] = cp.random.sample(len(date_df))\n",
+    "\n",
+    "search_date = dt.datetime.strptime('2018-11-23', '%Y-%m-%d')\n",
+    "date_df.query('date <= @search_date')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2018-11-20</td>\n",
+       "      <td>0.986051</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2018-11-21</td>\n",
+       "      <td>0.232034</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2018-11-22</td>\n",
+       "      <td>0.397617</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2018-11-23</td>\n",
+       "      <td>0.103839</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        date     value\n",
+       "0 2018-11-20  0.986051\n",
+       "1 2018-11-21  0.232034\n",
+       "2 2018-11-22  0.397617\n",
+       "3 2018-11-23  0.103839"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "date_ddf = dask_cudf.from_cudf(date_df, npartitions=2)\n",
+    "date_ddf.query('date <= @search_date', local_dict={'search_date':search_date}).compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Categoricals\n",
+    "------------"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`DataFrames` support categorical columns."
    ]
   },
   {
@@ -3791,41 +3868,53 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>date</th>\n",
-       "      <th>value</th>\n",
+       "      <th>id</th>\n",
+       "      <th>grade</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>2018-11-20</td>\n",
-       "      <td>0.986051</td>\n",
+       "      <td>1</td>\n",
+       "      <td>a</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2018-11-21</td>\n",
-       "      <td>0.232034</td>\n",
+       "      <td>2</td>\n",
+       "      <td>b</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>2018-11-22</td>\n",
-       "      <td>0.397617</td>\n",
+       "      <td>3</td>\n",
+       "      <td>b</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>2018-11-23</td>\n",
-       "      <td>0.103839</td>\n",
+       "      <td>4</td>\n",
+       "      <td>a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>6</td>\n",
+       "      <td>e</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "        date     value\n",
-       "0 2018-11-20  0.986051\n",
-       "1 2018-11-21  0.232034\n",
-       "2 2018-11-22  0.397617\n",
-       "3 2018-11-23  0.103839"
+       "   id grade\n",
+       "0   1     a\n",
+       "1   2     b\n",
+       "2   3     b\n",
+       "3   4     a\n",
+       "4   5     a\n",
+       "5   6     e"
       ]
      },
      "execution_count": 56,
@@ -3834,14 +3923,9 @@
     }
    ],
    "source": [
-    "import datetime as dt\n",
-    "\n",
-    "date_df = cudf.DataFrame()\n",
-    "date_df['date'] = pd.date_range('11/20/2018', periods=72, freq='D')\n",
-    "date_df['value'] = cp.random.sample(len(date_df))\n",
-    "\n",
-    "search_date = dt.datetime.strptime('2018-11-23', '%Y-%m-%d')\n",
-    "date_df.query('date <= @search_date')"
+    "gdf = cudf.DataFrame({\"id\": [1, 2, 3, 4, 5, 6], \"grade\":['a', 'b', 'b', 'a', 'a', 'e']})\n",
+    "gdf['grade'] = gdf['grade'].astype('category')\n",
+    "gdf"
    ]
   },
   {
@@ -3870,230 +3954,56 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>date</th>\n",
-       "      <th>value</th>\n",
+       "      <th>id</th>\n",
+       "      <th>grade</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>2018-11-20</td>\n",
-       "      <td>0.986051</td>\n",
+       "      <td>1</td>\n",
+       "      <td>a</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2018-11-21</td>\n",
-       "      <td>0.232034</td>\n",
+       "      <td>2</td>\n",
+       "      <td>b</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>2018-11-22</td>\n",
-       "      <td>0.397617</td>\n",
+       "      <td>3</td>\n",
+       "      <td>b</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>2018-11-23</td>\n",
-       "      <td>0.103839</td>\n",
+       "      <td>4</td>\n",
+       "      <td>a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>6</td>\n",
+       "      <td>e</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "        date     value\n",
-       "0 2018-11-20  0.986051\n",
-       "1 2018-11-21  0.232034\n",
-       "2 2018-11-22  0.397617\n",
-       "3 2018-11-23  0.103839"
+       "   id grade\n",
+       "0   1     a\n",
+       "1   2     b\n",
+       "2   3     b\n",
+       "3   4     a\n",
+       "4   5     a\n",
+       "5   6     e"
       ]
      },
      "execution_count": 57,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "date_ddf = dask_cudf.from_cudf(date_df, npartitions=2)\n",
-    "date_ddf.query('date <= @search_date', local_dict={'search_date':search_date}).compute()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Categoricals\n",
-    "------------"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`DataFrames` support categorical columns."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 58,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>grade</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>b</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>b</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5</td>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>6</td>\n",
-       "      <td>e</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   id grade\n",
-       "0   1     a\n",
-       "1   2     b\n",
-       "2   3     b\n",
-       "3   4     a\n",
-       "4   5     a\n",
-       "5   6     e"
-      ]
-     },
-     "execution_count": 58,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "gdf = cudf.DataFrame({\"id\": [1, 2, 3, 4, 5, 6], \"grade\":['a', 'b', 'b', 'a', 'a', 'e']})\n",
-    "gdf['grade'] = gdf['grade'].astype('category')\n",
-    "gdf"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 59,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>grade</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>b</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>b</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5</td>\n",
-       "      <td>a</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>6</td>\n",
-       "      <td>e</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   id grade\n",
-       "0   1     a\n",
-       "1   2     b\n",
-       "2   3     b\n",
-       "3   4     a\n",
-       "4   5     a\n",
-       "5   6     e"
-      ]
-     },
-     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4112,7 +4022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -4121,7 +4031,7 @@
        "StringIndex(['a' 'b' 'e'], dtype='object')"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4139,7 +4049,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
@@ -4154,7 +4064,7 @@
        "dtype: uint8"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4165,7 +4075,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
@@ -4180,7 +4090,7 @@
        "dtype: uint8"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4213,7 +4123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
@@ -4298,7 +4208,7 @@
        "4  4  15  4         1         0"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4309,7 +4219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
@@ -4394,7 +4304,7 @@
        "4  4  15  4         1         0"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4419,7 +4329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -4447,7 +4357,7 @@
        "       [19,  0, 19,  0,  0]])"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4458,7 +4368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -4486,7 +4396,7 @@
        "       [19,  0, 19,  0,  0]])"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4504,7 +4414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
@@ -4514,7 +4424,7 @@
        "       17, 18, 19])"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4525,7 +4435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
@@ -4535,7 +4445,7 @@
        "       17, 18, 19])"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4560,7 +4470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
@@ -4580,7 +4490,7 @@
        "agg_col2: [[1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0]]"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4591,7 +4501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -4611,7 +4521,7 @@
        "agg_col2: [[1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0]]"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4644,7 +4554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4656,7 +4566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4672,7 +4582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -4892,7 +4802,7 @@
        "19  19   0  19         0         0"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4904,7 +4814,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -5124,7 +5034,7 @@
        "19  19   0  19         0         0"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5143,7 +5053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
@@ -5543,7 +5453,7 @@
        "19  19   0  19         0         0"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5569,7 +5479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5585,7 +5495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [
     {
@@ -5805,7 +5715,7 @@
        "19  19   0  19         0         0"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5824,7 +5734,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -5833,7 +5743,7 @@
        "(None,)"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5858,32 +5768,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 77,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/home/mmccarty/sandbox/rapids/cudf/python/cudf/cudf/tests/data/orc/TestOrcFile.test1.orc'"
-      ]
-     },
-     "execution_count": 80,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os\n",
     "from pathlib import Path\n",
-    "current_dir = os.path.dirname(os.path.realpath(\"__file__\"))\n",
-    "cudf_root = Path(current_dir).parents[3]\n",
-    "file_path = os.path.join(cudf_root, \"python\", \"cudf\", \"cudf\", \"tests\", \"data\", \"orc\", \"TestOrcFile.test1.orc\")\n",
-    "file_path"
+    "cudf_root = Path(\".\").absolute().parents[3]\n",
+    "orc_file = Path(\"python/cudf/cudf/tests/data/orc/TestOrcFile.test1.orc\")\n",
+    "file_path = cudf_root / orc_file"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
@@ -5974,7 +5871,7 @@
        "1  [{'key': 'chani', 'value': {'int1': 5, 'string...  "
       ]
      },
-     "execution_count": 81,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6007,17 +5904,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-04-21 10:11:07,360 - distributed.diskutils - INFO - Found stale lock file and directory '/home/mmccarty/sandbox/rapids/cudf/docs/cudf/source/user_guide/dask-worker-space/worker-ghcx5g0e', purging\n",
-      "2022-04-21 10:11:07,360 - distributed.diskutils - INFO - Found stale lock file and directory '/home/mmccarty/sandbox/rapids/cudf/docs/cudf/source/user_guide/dask-worker-space/worker-wh16f0h3', purging\n",
-      "2022-04-21 10:11:07,360 - distributed.preloading - INFO - Import preload module: dask_cuda.initialize\n",
-      "2022-04-21 10:11:07,388 - distributed.preloading - INFO - Import preload module: dask_cuda.initialize\n"
+      "2022-04-26 10:47:08,571 - distributed.preloading - INFO - Import preload module: dask_cuda.initialize\n"
      ]
     },
     {
@@ -6027,7 +5921,7 @@
        "    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\"> </div>\n",
        "    <div style=\"margin-left: 48px;\">\n",
        "        <h3 style=\"margin-bottom: 0px;\">Client</h3>\n",
-       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Client-e3492c89-c17c-11ec-813e-fc3497a62adc</p>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Client-2152dbb9-c578-11ec-8606-b04f13036b73</p>\n",
        "        <table style=\"width: 100%; text-align: left;\">\n",
        "\n",
        "        <tr>\n",
@@ -6056,22 +5950,22 @@
        "    </div>\n",
        "    <div style=\"margin-left: 48px;\">\n",
        "        <h3 style=\"margin-bottom: 0px; margin-top: 0px;\">LocalCUDACluster</h3>\n",
-       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">db2501e1</p>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">11b5c3ac</p>\n",
        "        <table style=\"width: 100%; text-align: left;\">\n",
        "            <tr>\n",
        "                <td style=\"text-align: left;\">\n",
        "                    <strong>Dashboard:</strong> <a href=\"http://127.0.0.1:8787/status\" target=\"_blank\">http://127.0.0.1:8787/status</a>\n",
        "                </td>\n",
        "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Workers:</strong> 2\n",
+       "                    <strong>Workers:</strong> 1\n",
        "                </td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Total threads:</strong> 2\n",
+       "                    <strong>Total threads:</strong> 1\n",
        "                </td>\n",
        "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Total memory:</strong> 125.65 GiB\n",
+       "                    <strong>Total memory:</strong> 125.52 GiB\n",
        "                </td>\n",
        "            </tr>\n",
        "            \n",
@@ -6093,14 +5987,14 @@
        "        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n",
        "        <div style=\"margin-left: 48px;\">\n",
        "            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n",
-       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-6f476508-e52f-49e9-8f1f-6a8641e177bd</p>\n",
+       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-1f527f4a-ece1-422c-9702-87f25561cfea</p>\n",
        "            <table style=\"width: 100%; text-align: left;\">\n",
        "                <tr>\n",
        "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Comm:</strong> tcp://127.0.0.1:39755\n",
+       "                        <strong>Comm:</strong> tcp://127.0.0.1:43105\n",
        "                    </td>\n",
        "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Workers:</strong> 2\n",
+       "                        <strong>Workers:</strong> 1\n",
        "                    </td>\n",
        "                </tr>\n",
        "                <tr>\n",
@@ -6108,7 +6002,7 @@
        "                        <strong>Dashboard:</strong> <a href=\"http://127.0.0.1:8787/status\" target=\"_blank\">http://127.0.0.1:8787/status</a>\n",
        "                    </td>\n",
        "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Total threads:</strong> 2\n",
+       "                        <strong>Total threads:</strong> 1\n",
        "                    </td>\n",
        "                </tr>\n",
        "                <tr>\n",
@@ -6116,7 +6010,7 @@
        "                        <strong>Started:</strong> Just now\n",
        "                    </td>\n",
        "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Total memory:</strong> 125.65 GiB\n",
+       "                        <strong>Total memory:</strong> 125.52 GiB\n",
        "                    </td>\n",
        "                </tr>\n",
        "            </table>\n",
@@ -6139,7 +6033,7 @@
        "                <table style=\"width: 100%; text-align: left;\">\n",
        "                    <tr>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Comm: </strong> tcp://127.0.0.1:33491\n",
+       "                            <strong>Comm: </strong> tcp://127.0.0.1:45093\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\">\n",
        "                            <strong>Total threads: </strong> 1\n",
@@ -6147,21 +6041,21 @@
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Dashboard: </strong> <a href=\"http://127.0.0.1:34333/status\" target=\"_blank\">http://127.0.0.1:34333/status</a>\n",
+       "                            <strong>Dashboard: </strong> <a href=\"http://127.0.0.1:44017/status\" target=\"_blank\">http://127.0.0.1:44017/status</a>\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Memory: </strong> 62.82 GiB\n",
+       "                            <strong>Memory: </strong> 125.52 GiB\n",
        "                        </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Nanny: </strong> tcp://127.0.0.1:43093\n",
+       "                            <strong>Nanny: </strong> tcp://127.0.0.1:41841\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\"></td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
-       "                            <strong>Local directory: </strong> /home/mmccarty/sandbox/rapids/cudf/docs/cudf/source/user_guide/dask-worker-space/worker-jsuvfju4\n",
+       "                            <strong>Local directory: </strong> /home/bdice/rapids1/cudf/docs/cudf/source/user_guide/dask-worker-space/worker-8ci7x8v3\n",
        "                        </td>\n",
        "                    </tr>\n",
        "\n",
@@ -6171,61 +6065,7 @@
        "                            <strong>GPU: </strong>NVIDIA RTX A6000\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>GPU memory: </strong> 47.51 GiB\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "                    \n",
-       "\n",
-       "                    \n",
-       "\n",
-       "                </table>\n",
-       "            </details>\n",
-       "            </div>\n",
-       "        </div>\n",
-       "        \n",
-       "        <div style=\"margin-bottom: 20px;\">\n",
-       "            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n",
-       "            <div style=\"margin-left: 48px;\">\n",
-       "            <details>\n",
-       "                <summary>\n",
-       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: 1</h4>\n",
-       "                </summary>\n",
-       "                <table style=\"width: 100%; text-align: left;\">\n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Comm: </strong> tcp://127.0.0.1:44033\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Total threads: </strong> 1\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Dashboard: </strong> <a href=\"http://127.0.0.1:45225/status\" target=\"_blank\">http://127.0.0.1:45225/status</a>\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Memory: </strong> 62.82 GiB\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Nanny: </strong> tcp://127.0.0.1:46529\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\"></td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
-       "                            <strong>Local directory: </strong> /home/mmccarty/sandbox/rapids/cudf/docs/cudf/source/user_guide/dask-worker-space/worker-zlsacw8_\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "\n",
-       "                    \n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>GPU: </strong>NVIDIA RTX A6000\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>GPU memory: </strong> 47.54 GiB\n",
+       "                            <strong>GPU memory: </strong> 47.99 GiB\n",
        "                        </td>\n",
        "                    </tr>\n",
        "                    \n",
@@ -6251,10 +6091,10 @@
        "</div>"
       ],
       "text/plain": [
-       "<Client: 'tcp://127.0.0.1:39755' processes=2 threads=2, memory=125.65 GiB>"
+       "<Client: 'tcp://127.0.0.1:43105' processes=1 threads=1, memory=125.52 GiB>"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6280,7 +6120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
@@ -6356,7 +6196,7 @@
        "<dask_cudf.DataFrame | 20 tasks | 5 npartitions>"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6372,45 +6212,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Thu Apr 21 10:11:07 2022       \n",
-      "+-----------------------------------------------------------------------------+\n",
-      "| NVIDIA-SMI 495.29.05    Driver Version: 495.29.05    CUDA Version: 11.5     |\n",
-      "|-------------------------------+----------------------+----------------------+\n",
-      "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\n",
-      "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\n",
-      "|                               |                      |               MIG M. |\n",
-      "|===============================+======================+======================|\n",
-      "|   0  NVIDIA RTX A6000    On   | 00000000:01:00.0  On |                  Off |\n",
-      "| 30%   48C    P2    83W / 300W |   2970MiB / 48651MiB |      7%      Default |\n",
-      "|                               |                      |                  N/A |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "|   1  NVIDIA RTX A6000    On   | 00000000:02:00.0 Off |                  Off |\n",
-      "| 30%   36C    P2    25W / 300W |    265MiB / 48685MiB |      5%      Default |\n",
-      "|                               |                      |                  N/A |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "                                                                               \n",
-      "+-----------------------------------------------------------------------------+\n",
-      "| Processes:                                                                  |\n",
-      "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\n",
-      "|        ID   ID                                                   Usage      |\n",
-      "|=============================================================================|\n",
-      "|    0   N/A  N/A      2292      G   /usr/lib/xorg/Xorg                871MiB |\n",
-      "|    0   N/A  N/A      2441      G   /usr/bin/gnome-shell              316MiB |\n",
-      "|    0   N/A  N/A   1240494      G   ...AAAAAAAAA= --shared-files       68MiB |\n",
-      "|    0   N/A  N/A   1240525      G   ...RendererForSitePerProcess       41MiB |\n",
-      "|    0   N/A  N/A   1243689      C   .../envs/cudf_dev/bin/python      593MiB |\n",
-      "|    0   N/A  N/A   1245502      C   .../envs/cudf_dev/bin/python      753MiB |\n",
-      "|    0   N/A  N/A   1245751      C   .../envs/cudf_dev/bin/python      257MiB |\n",
-      "|    1   N/A  N/A      2292      G   /usr/lib/xorg/Xorg                  4MiB |\n",
-      "|    1   N/A  N/A   1245748      C   .../envs/cudf_dev/bin/python      257MiB |\n",
-      "+-----------------------------------------------------------------------------+\n"
+      "Tue Apr 26 10:47:09 2022       \r\n",
+      "+-----------------------------------------------------------------------------+\r\n",
+      "| NVIDIA-SMI 510.47.03    Driver Version: 510.47.03    CUDA Version: 11.6     |\r\n",
+      "|-------------------------------+----------------------+----------------------+\r\n",
+      "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\r\n",
+      "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\r\n",
+      "|                               |                      |               MIG M. |\r\n",
+      "|===============================+======================+======================|\r\n",
+      "|   0  NVIDIA RTX A6000    On   | 00000000:65:00.0  On |                  Off |\r\n",
+      "| 30%   43C    P2    76W / 300W |   1703MiB / 49140MiB |      3%      Default |\r\n",
+      "|                               |                      |                  N/A |\r\n",
+      "+-------------------------------+----------------------+----------------------+\r\n",
+      "                                                                               \r\n",
+      "+-----------------------------------------------------------------------------+\r\n",
+      "| Processes:                                                                  |\r\n",
+      "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\r\n",
+      "|        ID   ID                                                   Usage      |\r\n",
+      "|=============================================================================|\r\n",
+      "|    0   N/A  N/A      1657      G                                     204MiB |\r\n",
+      "|    0   N/A  N/A      1940      G                                      70MiB |\r\n",
+      "|    0   N/A  N/A     37085      C                                     257MiB |\r\n",
+      "|    0   N/A  N/A     42594      G                                     158MiB |\r\n",
+      "|    0   N/A  N/A     47497      C                                     751MiB |\r\n",
+      "|    0   N/A  N/A     47555      C                                     257MiB |\r\n",
+      "+-----------------------------------------------------------------------------+\r\n"
      ]
     }
    ],
@@ -6427,7 +6260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [
     {
@@ -6503,7 +6336,7 @@
        "<dask_cudf.DataFrame | 5 tasks | 5 npartitions>"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6515,45 +6348,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Thu Apr 21 10:11:08 2022       \n",
-      "+-----------------------------------------------------------------------------+\n",
-      "| NVIDIA-SMI 495.29.05    Driver Version: 495.29.05    CUDA Version: 11.5     |\n",
-      "|-------------------------------+----------------------+----------------------+\n",
-      "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\n",
-      "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\n",
-      "|                               |                      |               MIG M. |\n",
-      "|===============================+======================+======================|\n",
-      "|   0  NVIDIA RTX A6000    On   | 00000000:01:00.0  On |                  Off |\n",
-      "| 30%   48C    P2    84W / 300W |   2970MiB / 48651MiB |      3%      Default |\n",
-      "|                               |                      |                  N/A |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "|   1  NVIDIA RTX A6000    On   | 00000000:02:00.0 Off |                  Off |\n",
-      "| 30%   36C    P2    37W / 300W |    265MiB / 48685MiB |      0%      Default |\n",
-      "|                               |                      |                  N/A |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "                                                                               \n",
-      "+-----------------------------------------------------------------------------+\n",
-      "| Processes:                                                                  |\n",
-      "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\n",
-      "|        ID   ID                                                   Usage      |\n",
-      "|=============================================================================|\n",
-      "|    0   N/A  N/A      2292      G   /usr/lib/xorg/Xorg                871MiB |\n",
-      "|    0   N/A  N/A      2441      G   /usr/bin/gnome-shell              316MiB |\n",
-      "|    0   N/A  N/A   1240494      G   ...AAAAAAAAA= --shared-files       68MiB |\n",
-      "|    0   N/A  N/A   1240525      G   ...RendererForSitePerProcess       41MiB |\n",
-      "|    0   N/A  N/A   1243689      C   .../envs/cudf_dev/bin/python      593MiB |\n",
-      "|    0   N/A  N/A   1245502      C   .../envs/cudf_dev/bin/python      753MiB |\n",
-      "|    0   N/A  N/A   1245751      C   .../envs/cudf_dev/bin/python      257MiB |\n",
-      "|    1   N/A  N/A      2292      G   /usr/lib/xorg/Xorg                  4MiB |\n",
-      "|    1   N/A  N/A   1245748      C   .../envs/cudf_dev/bin/python      257MiB |\n",
-      "+-----------------------------------------------------------------------------+\n"
+      "Tue Apr 26 10:47:09 2022       \r\n",
+      "+-----------------------------------------------------------------------------+\r\n",
+      "| NVIDIA-SMI 510.47.03    Driver Version: 510.47.03    CUDA Version: 11.6     |\r\n",
+      "|-------------------------------+----------------------+----------------------+\r\n",
+      "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\r\n",
+      "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\r\n",
+      "|                               |                      |               MIG M. |\r\n",
+      "|===============================+======================+======================|\r\n",
+      "|   0  NVIDIA RTX A6000    On   | 00000000:65:00.0  On |                  Off |\r\n",
+      "| 30%   43C    P2    76W / 300W |   1703MiB / 49140MiB |      2%      Default |\r\n",
+      "|                               |                      |                  N/A |\r\n",
+      "+-------------------------------+----------------------+----------------------+\r\n",
+      "                                                                               \r\n",
+      "+-----------------------------------------------------------------------------+\r\n",
+      "| Processes:                                                                  |\r\n",
+      "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\r\n",
+      "|        ID   ID                                                   Usage      |\r\n",
+      "|=============================================================================|\r\n",
+      "|    0   N/A  N/A      1657      G                                     204MiB |\r\n",
+      "|    0   N/A  N/A      1940      G                                      70MiB |\r\n",
+      "|    0   N/A  N/A     37085      C                                     257MiB |\r\n",
+      "|    0   N/A  N/A     42594      G                                     158MiB |\r\n",
+      "|    0   N/A  N/A     47497      C                                     751MiB |\r\n",
+      "|    0   N/A  N/A     47555      C                                     257MiB |\r\n",
+      "+-----------------------------------------------------------------------------+\r\n"
      ]
     }
    ],
@@ -6580,7 +6406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6592,7 +6418,7 @@
     "ddf1 = dask_cudf.from_cudf(df1, npartitions=100)\n",
     "\n",
     "def func(df):\n",
-    "    time.sleep(random.randint(1, 60))\n",
+    "    time.sleep(random.randint(1, 10))\n",
     "    return (df + 5) * 3 - 11"
    ]
   },
@@ -6600,12 +6426,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This function will do a basic transformation of every column in the dataframe, but the time spent in the function will vary due to the `time.sleep` statement randomly adding 1-60 seconds of time. We'll run this on every partition of our dataframe using `map_partitions`, which adds the task to our task-graph, and store the result. We can then call `persist` to force execution."
+    "This function will do a basic transformation of every column in the dataframe, but the time spent in the function will vary due to the `time.sleep` statement randomly adding 1-10 seconds of time. We'll run this on every partition of our dataframe using `map_partitions`, which adds the task to our task-graph, and store the result. We can then call `persist` to force execution."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6622,16 +6448,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "DoneAndNotDoneFutures(done={<Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-cec36d97aab9d38423f8023d1b43b6d3', 0)>, <Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-cec36d97aab9d38423f8023d1b43b6d3', 2)>, <Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-cec36d97aab9d38423f8023d1b43b6d3', 3)>, <Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-cec36d97aab9d38423f8023d1b43b6d3', 1)>, <Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-cec36d97aab9d38423f8023d1b43b6d3', 4)>}, not_done=set())"
+       "DoneAndNotDoneFutures(done={<Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-92c447ffc260eb74690c9bdbf10ac39b', 2)>, <Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-92c447ffc260eb74690c9bdbf10ac39b', 4)>, <Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-92c447ffc260eb74690c9bdbf10ac39b', 0)>, <Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-92c447ffc260eb74690c9bdbf10ac39b', 1)>, <Future: finished, type: cudf.core.dataframe.DataFrame, key: ('func-92c447ffc260eb74690c9bdbf10ac39b', 3)>}, not_done=set())"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6646,13 +6472,6 @@
    "source": [
     "## With `wait`, we can safely proceed on in our workflow."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -6672,7 +6491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Follow-up from #10685 to fix deprecation warnings in the 10 minute notebook.

Changes:
- Fixed deprecation warning for `Series.applymap` ➡️  `Series.apply`
- Removed two cells demonstrating `Series.append`. This has also been removed from the Pandas 10 minute notebook because the feature is deprecated.
- Refactored ORC file path logic to be a bit simpler