### PR TITLE
Enable pydocstyle for all packages.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,11 +65,7 @@ repos:
                     conda|
                     docs|
                     java|
-                    notebooks|
-                    python/dask_cudf|
-                    python/cudf_kafka|
-                    python/custreamz|
-                    python/cudf/cudf/tests
+                    notebooks
                     )
       - repo: https://github.com/pre-commit/mirrors-clang-format
         rev: v11.1.0

--- a/python/.flake8
+++ b/python/.flake8
@@ -15,7 +15,7 @@ ignore =
 # unlike the match option above this match-dir will have no effect when
 # pydocstyle is invoked from pre-commit. Therefore this exclusion list must
 # also be maintained in the pre-commit config file.
-match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks|dask_cudf|cudf_kafka|custreamz|tests)).*$
+match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select = 

--- a/python/custreamz/custreamz/kafka.py
+++ b/python/custreamz/custreamz/kafka.py
@@ -95,7 +95,7 @@ class Consumer(CudfKafkaClient):
         message_format="json",
     ):
 
-        """
+        r"""
         Read messages from the underlying KafkaDatasource connection and create
         a cudf Dataframe
 


### PR DESCRIPTION
Follow-up to #10748 to enable the base pydocstyle rules on all Python packages (`dask_cudf`, `cudf_kafka`, `custreamz`) and test files. Contributes to #10711, #10758.