### PR TITLE
Mention 2 cpp-reviewer requirement in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,6 +47,10 @@ Here are some guidelines to help the review process go smoothly.
    If conflicts occur against the target branch they should be resolved by
    merging the target branch into the branch used for making the pull request.
 
+8. Pull requests that modify cpp source that are marked ready for review 
+   will automatically be assign two cudf-cpp-codeowners reviewers.
+   Ensure at least two approvals from cudf-cpp-codeowners before merging.
+
 Many thanks in advance for your cooperation!
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,7 @@ Here are some guidelines to help the review process go smoothly.
    merging the target branch into the branch used for making the pull request.
 
 8. Pull requests that modify cpp source that are marked ready for review 
-   will automatically be assign two cudf-cpp-codeowners reviewers.
+   will automatically be assigned two cudf-cpp-codeowners reviewers.
    Ensure at least two approvals from cudf-cpp-codeowners before merging.
 
 Many thanks in advance for your cooperation!


### PR DESCRIPTION
Although 2 cpp reviewers are automatically assigned to a PR, there is no documentation that indicates 2 are required. This PR adds to the list of guidelines in the [Pull Request Template](https://github.com/rapidsai/cudf/blob/branch-22.06/.github/PULL_REQUEST_TEMPLATE.md) that appears when a PR is created through the github web page.