### PR TITLE
Fixing deprecation warnings in test_orc.py

### DIFF
--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -310,7 +310,7 @@ def test_orc_read_skiprows(tmpdir):
     writer = pyorc.Writer(buff, pyorc.Struct(a=pyorc.Boolean()))
     tuples = list(
         map(
-            lambda x: (None,) if x[0] is pd.NA else x,
+            lambda x: (None,) if x[0] is pd.NA else (bool(x[0]),),
             list(df.itertuples(index=False, name=None)),
         )
     )
@@ -640,6 +640,12 @@ def test_int_overflow(tmpdir):
 
 
 def normalized_equals(value1, value2):
+    # need naive time object for numpy to convert to datetime64
+    if isinstance(value1, datetime.datetime):
+        value1 = value1.replace(tzinfo=None)
+    if isinstance(value2, datetime.datetime):
+        value2 = value2.replace(tzinfo=None)
+
     if isinstance(value1, (datetime.datetime, np.datetime64)):
         value1 = np.datetime64(value1, "ms")
     if isinstance(value2, (datetime.datetime, np.datetime64)):


### PR DESCRIPTION
This change fixes the deprecation warnings in `test_orc.py`. Fixed warnings:

- parsing timezone aware datetimes is deprecated; this will raise an error in the future
- DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
- FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
- DeprecationWarning: In future, it will be an error for 'np.bool_' scalars to be interpreted as an index
- FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.
