### PR TITLE
Segmented `apply_boolean_mask` for `LIST` columns

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -359,6 +359,7 @@ add_library(
   src/join/mixed_join_size_kernel_nulls.cu
   src/join/mixed_join_size_kernels_semi.cu
   src/join/semi_join.cu
+  src/lists/apply_boolean_mask.cu
   src/lists/contains.cu
   src/lists/combine/concatenate_list_elements.cu
   src/lists/combine/concatenate_rows.cu

--- a/cpp/include/cudf/lists/detail/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/detail/stream_compaction.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+namespace cudf::lists::detail {
+
+std::unique_ptr<column> apply_boolean_mask(
+  lists_column_view const& input,
+  lists_column_view const& boolean_mask,
+  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+}  // namespace cudf::lists::detail

--- a/cpp/include/cudf/lists/detail/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/detail/stream_compaction.hpp
@@ -31,7 +31,7 @@ namespace cudf::lists::detail {
 std::unique_ptr<column> apply_boolean_mask(
   lists_column_view const& input,
   lists_column_view const& boolean_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cudf::lists::detail

--- a/cpp/include/cudf/lists/detail/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/detail/stream_compaction.hpp
@@ -22,6 +22,12 @@
 
 namespace cudf::lists::detail {
 
+/**
+ * @copydoc cudf::lists::apply_boolean_mask(lists_column_view const&, lists_column_view const&,
+ * rmm::mr::device_memory_resource*)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ */
 std::unique_ptr<column> apply_boolean_mask(
   lists_column_view const& input,
   lists_column_view const& boolean_mask,

--- a/cpp/include/cudf/lists/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/stream_compaction.hpp
@@ -33,15 +33,18 @@ namespace cudf::lists {
  * E.g.
  * @code{.pseudo}
  * auto const input    = lcw<int32_t>{ {0,1,2}, {3,4}, {5,6,7}, {8,9} };
- * auto const selector = lcw<bool>   { {0,1,1}, {1,0}, {1,1,1}, {0,0} };
- * auto const results  = apply_boolean_mask(lists_column_view{input}, lists_column_view{selector});
+ * auto const boolmask = lcw<bool>   { {0,1,1}, {1,0}, {1,1,1}, {0,0} };
+ * auto const results  = apply_boolean_mask(lists_column_view{input}, lists_column_view{boolmask});
  * results             == { {1,2}, {3}, {5,6,7}, {} };
  * @endcode
  *
  * `input` and `boolean_mask` must have the same number of rows.
  * The output column has the same number of rows as the input column.
- * An element is copied to an output row *only* if the corresponding bool selector is `true`.
+ * An element is copied to an output row *only* if the corresponding boolean_mask element is `true`.
  * An output row is invalid only if the input row is invalid.
+ *
+ * @throws cudf::logic_error if `boolean_mask` is not a "lists of bools" column
+ * @throws cudf::logic_error if `input` and `boolean_mask` have different number of rows
  *
  * @param input The input list column view to be filtered
  * @param boolean_mask A nullable list of bools column used to filter `input` elements

--- a/cpp/include/cudf/lists/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/stream_compaction.hpp
@@ -32,10 +32,9 @@ namespace cudf::lists {
  *
  * E.g.
  * @code{.pseudo}
- * auto const input    = lcw<int32_t>{ {0,1,2}, {3,4}, {5,6,7}, {8,9} };
- * auto const boolmask = lcw<bool>   { {0,1,1}, {1,0}, {1,1,1}, {0,0} };
- * auto const results  = apply_boolean_mask(lists_column_view{input}, lists_column_view{boolmask});
- * results             == { {1,2}, {3}, {5,6,7}, {} };
+ * input        = { {0,1,2}, {3,4}, {5,6,7}, {8,9} };
+ * boolean_mask = { {0,1,1}, {1,0}, {1,1,1}, {0,0} };
+ * results      = { {1,2},   {3},   {5,6,7}, {} };
  * @endcode
  *
  * `input` and `boolean_mask` must have the same number of rows.

--- a/cpp/include/cudf/lists/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/stream_compaction.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+namespace cudf::lists {
+
+std::unique_ptr<column> apply_boolean_mask(
+  lists_column_view const& input,
+  lists_column_view const& boolean_mask,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+}  // namespace cudf::lists

--- a/cpp/include/cudf/lists/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/stream_compaction.hpp
@@ -22,6 +22,32 @@
 
 namespace cudf::lists {
 
+/**
+ * @brief Filters elements in each row of `input` LIST column using `boolean_mask`
+ * LIST of booleans as a mask.
+ *
+ * Given an input `LIST` column and a list-of-bools column, the function produces
+ * a new `LIST` column of the same type as `input`, where each element is copied
+ * from the input row *only* if the corresponding `boolean_mask` is non-null and `true`.
+ *
+ * E.g.
+ * @code{.pseudo}
+ * auto const input    = lcw<int32_t>{ {0,1,2}, {3,4}, {5,6,7}, {8,9} };
+ * auto const selector = lcw<bool>   { {0,1,1}, {1,0}, {1,1,1}, {0,0} };
+ * auto const results  = apply_boolean_mask(lists_column_view{input}, lists_column_view{selector});
+ * results             == { {1,2}, {3}, {5,6,7}, {} };
+ * @endcode
+ *
+ * `input` and `boolean_mask` must have the same number of rows.
+ * The output column has the same number of rows as the input column.
+ * An element is copied to an output row *only* if the corresponding bool selector is `true`.
+ * An output row is invalid only if the input row is invalid.
+ *
+ * @param input The input list column view to be filtered
+ * @param boolean_mask A nullable list of bools column used to filter `input` elements
+ * @param mr Device memory resource used to allocate the returned table's device memory
+ * @return List column of the same type as `input`, containing filtered list rows
+ */
 std::unique_ptr<column> apply_boolean_mask(
   lists_column_view const& input,
   lists_column_view const& boolean_mask,

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -89,13 +89,13 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
   auto constexpr offset_data_type = data_type{type_id::INT32};
 
   auto filtered_child = [&] {
-    std::unique_ptr<cudf::table> tbl =
+    auto filtered =
       cudf::detail::apply_boolean_mask(cudf::table_view{{input.get_sliced_child(stream)}},
                                        boolean_mask.get_sliced_child(stream),
                                        stream,
-                                       mr);
-    std::vector<std::unique_ptr<cudf::column>> columns = tbl->release();
-    return std::move(columns.front());
+                                       mr)
+        ->release();
+    return std::move(filtered.front());
   };
 
   auto output_offsets = [&] {

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -84,7 +84,7 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
   assert_same_sizes(input, boolean_mask, stream);
 
   auto constexpr offset_data_type = data_type{type_id::INT32};
-  
+
   auto filtered_child = [&] {
     std::unique_ptr<cudf::table> tbl =
       cudf::detail::apply_boolean_mask(cudf::table_view{{input.get_sliced_child(stream)}},
@@ -96,7 +96,7 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
   };
 
   auto output_offsets = [&] {
-    auto boolean_mask_sliced_offsets = 
+    auto boolean_mask_sliced_offsets =
       cudf::detail::slice(
         boolean_mask.offsets(), {boolean_mask.offset(), boolean_mask.size() + 1}, stream)
         .front();
@@ -115,10 +115,8 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
                            no_null_sizes->view().begin<offset_type>(),
                            no_null_sizes->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>() + 1);
-    CUDF_CUDA_TRY(cudaMemsetAsync(offsets->mutable_view().begin<offset_type>(),
-                                  0,
-                                  sizeof(offset_type),
-                                  stream.value()));
+    CUDF_CUDA_TRY(cudaMemsetAsync(
+      offsets->mutable_view().begin<offset_type>(), 0, sizeof(offset_type), stream.value()));
     return offsets;
   };
 

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -41,6 +41,7 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
                                            rmm::cuda_stream_view stream,
                                            rmm::mr::device_memory_resource* mr)
 {
+  CUDF_EXPECTS(boolean_mask.child().type().id() == type_id::BOOL8, "Mask must be of type BOOL8.");
   CUDF_EXPECTS(input.size() == boolean_mask.size(),
                "Boolean masks column must have same number of rows as input.");
   auto const num_rows = input.size();

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/copy.hpp>
+#include <cudf/detail/fill.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/reduction_functions.hpp>
+#include <cudf/detail/replace.hpp>
+#include <cudf/detail/stream_compaction.hpp>
+#include <cudf/lists/detail/stream_compaction.hpp>
+#include <cudf/lists/stream_compaction.hpp>
+#include <cudf/utilities/bit.hpp>
+
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/reduce.h>
+
+namespace cudf {
+namespace detail {
+namespace {
+
+class get_list_size {
+ public:
+  explicit get_list_size(lists_column_view const& lcv)
+    : num_rows{lcv.size()},
+      offsets{lcv.offsets().begin<offset_type>() + lcv.offset()},
+      bitmask{lcv.null_mask()}
+  {
+  }
+
+  size_type __device__ operator()(size_type i) const
+  {
+    return bit_value_or(bitmask, i, true) ? (offsets[i + 1] - offsets[i]) : 0;
+  }
+
+ private:
+  size_type num_rows;
+  offset_type const* offsets;
+  bitmask_type const* bitmask;
+};
+
+void assert_same_sizes(lists_column_view const& input,
+                       lists_column_view const& boolean_mask,
+                       rmm::cuda_stream_view stream)
+{
+  CUDF_EXPECTS(input.size() == boolean_mask.size(),
+               "Boolean masks column must have same number of rows as input.");
+
+  auto const begin = make_counting_transform_iterator(
+    0,
+    [get_list_size = get_list_size{input}, get_mask_size = get_list_size{boolean_mask}] __device__(
+      size_type i) -> size_type { return get_list_size(i) != get_mask_size(i); });
+
+  CUDF_EXPECTS(thrust::reduce(rmm::exec_policy(stream), begin, begin + input.size()) == 0,
+               "Each list row must match the corresponding boolean mask row in size.");
+}
+}  // namespace
+
+std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
+                                           lists_column_view const& boolean_mask,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::mr::device_memory_resource* mr)
+{
+  // TODO: Test sliced input. Offsets aren't sliced.
+
+  auto const num_rows = input.size();
+
+  if (num_rows == 0) { return cudf::empty_like(input.child()); }
+  // Note: This assert guarantees that no elements are gathered
+  // from nominally NULL input list rows.
+  assert_same_sizes(input, boolean_mask, stream);
+
+  auto constexpr offset_data_type = data_type{type_id::INT32};
+
+  auto filtered_child = [&] {
+    std::unique_ptr<cudf::table> tbl =
+      cudf::detail::apply_boolean_mask(cudf::table_view{{input.get_sliced_child(stream)}},
+                                       boolean_mask.get_sliced_child(stream),
+                                       stream,
+                                       mr);
+    std::vector<std::unique_ptr<cudf::column>> columns = tbl->release();
+    return std::move(columns.front());
+  };
+
+  auto output_offsets = [&] {
+    auto boolean_mask_sliced_offsets =
+      cudf::detail::slice(
+        boolean_mask.offsets(), {boolean_mask.offset(), boolean_mask.size()}, stream)
+        .front();
+    auto const sizes         = cudf::reduction::segmented_sum(boolean_mask.get_sliced_child(stream),
+                                                      boolean_mask_sliced_offsets,
+                                                      offset_data_type,
+                                                      null_policy::EXCLUDE,
+                                                      stream);
+    auto const scalar_0      = cudf::numeric_scalar<offset_type>{0, true, stream};
+    auto const no_null_sizes = cudf::detail::replace_nulls(*sizes, scalar_0, stream);
+
+    auto offsets = cudf::make_numeric_column(
+      offset_data_type, num_rows + 1, mask_state::UNALLOCATED, stream, mr);
+    thrust::exclusive_scan(rmm::exec_policy(stream),
+                           no_null_sizes->view().begin<offset_type>(),
+                           no_null_sizes->view().end<offset_type>() + 1,
+                           offsets->mutable_view().begin<offset_type>());
+    return offsets;
+  };
+
+  return cudf::make_lists_column(input.size(),
+                                 output_offsets(),
+                                 filtered_child(),
+                                 input.null_count(),
+                                 cudf::detail::copy_bitmask(input.parent(), stream, mr),
+                                 stream,
+                                 mr);
+}
+}  // namespace detail
+
+std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
+                                           lists_column_view const& boolean_mask,
+                                           rmm::mr::device_memory_resource* mr)
+{
+  return detail::apply_boolean_mask(input, boolean_mask, rmm::cuda_stream_default, mr);
+}
+
+}  // namespace cudf

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -119,8 +119,8 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
     // Could have attempted an exclusive_scan(), but it would not compute the last entry.
     // Instead, inclusive_scan(), followed by writing `0` to the head of the offsets column.
     thrust::inclusive_scan(rmm::exec_policy(stream),
-                           sizes_view().begin<offset_type>(),
-                           sizes_view().end<offset_type>(),
+                           sizes_view.begin<offset_type>(),
+                           sizes_view.end<offset_type>(),
                            output_offsets_view.begin<offset_type>() + 1);
     CUDF_CUDA_TRY(cudaMemsetAsync(
       output_offsets_view.begin<offset_type>(), 0, sizeof(offset_type), stream.value()));

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -32,45 +32,10 @@
 
 namespace cudf::lists {
 namespace detail {
-namespace {
 
-class get_list_size {
- public:
-  explicit get_list_size(lists_column_view const& lcv)
-    : offset{lcv.offset()},
-      num_rows{lcv.size()},
-      offsets{lcv.offsets().begin<offset_type>()},
-      bitmask{lcv.null_mask()}
-  {
-  }
-
-  size_type __device__ operator()(size_type i) const
-  {
-    auto const offset_i = i + offset;
-    return bit_value_or(bitmask, offset_i, true) ? (offsets[offset_i + 1] - offsets[offset_i]) : 0;
-  }
-
- private:
-  offset_type offset;
-  size_type num_rows;
-  offset_type const* offsets;
-  bitmask_type const* bitmask;
-};
-
-void assert_same_list_sizes(lists_column_view const& input,
-                            lists_column_view const& boolean_mask,
-                            rmm::cuda_stream_view stream)
-{
-  auto const begin = cudf::detail::make_counting_transform_iterator(
-    0,
-    [get_list_size = get_list_size{input}, get_mask_size = get_list_size{boolean_mask}] __device__(
-      size_type i) -> size_type { return get_list_size(i) != get_mask_size(i); });
-
-  CUDF_EXPECTS(thrust::reduce(rmm::exec_policy(stream), begin, begin + input.size()) == 0,
-               "Each list row must match the corresponding boolean mask row in size.");
-}
-}  // namespace
-
+/**
+ * @copydoc cudf::lists::detail::apply_boolean_mask
+ */
 std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
                                            lists_column_view const& boolean_mask,
                                            rmm::cuda_stream_view stream,
@@ -78,13 +43,9 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
 {
   CUDF_EXPECTS(input.size() == boolean_mask.size(),
                "Boolean masks column must have same number of rows as input.");
-
   auto const num_rows = input.size();
 
   if (num_rows == 0) { return cudf::empty_like(input.parent()); }
-  // Note: This assert guarantees that no elements are gathered
-  // from nominally NULL input list rows.
-  assert_same_list_sizes(input, boolean_mask, stream);
 
   auto constexpr offset_data_type = data_type{type_id::INT32};
 
@@ -103,7 +64,6 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
       cudf::detail::slice(
         boolean_mask.offsets(), {boolean_mask.offset(), boolean_mask.size() + 1}, stream)
         .front();
-
     auto const sizes       = cudf::reduction::segmented_sum(boolean_mask.get_sliced_child(stream),
                                                       boolean_mask_sliced_offsets,
                                                       offset_data_type,
@@ -112,8 +72,7 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
     auto const d_sizes     = column_device_view::create(*sizes, stream);
     auto const sizes_begin = cudf::detail::make_null_replacement_iterator(*d_sizes, offset_type{0});
     auto const sizes_end   = sizes_begin + sizes->size();
-
-    auto output_offsets = cudf::make_numeric_column(
+    auto output_offsets    = cudf::make_numeric_column(
       offset_data_type, num_rows + 1, mask_state::UNALLOCATED, stream, mr);
     auto output_offsets_view = output_offsets->mutable_view();
 
@@ -125,7 +84,6 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
                            output_offsets_view.begin<offset_type>() + 1);
     CUDF_CUDA_TRY(cudaMemsetAsync(
       output_offsets_view.begin<offset_type>(), 0, sizeof(offset_type), stream.value()));
-
     return output_offsets;
   };
 
@@ -139,6 +97,9 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
 }
 }  // namespace detail
 
+/**
+ * @copydoc cudf::lists::apply_boolean_mask
+ */
 std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
                                            lists_column_view const& boolean_mask,
                                            rmm::mr::device_memory_resource* mr)

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -37,18 +37,21 @@ namespace {
 class get_list_size {
  public:
   explicit get_list_size(lists_column_view const& lcv)
-    : num_rows{lcv.size()},
-      offsets{lcv.offsets().begin<offset_type>() + lcv.offset()},
+    : offset{lcv.offset()},
+      num_rows{lcv.size()},
+      offsets{lcv.offsets().begin<offset_type>()},
       bitmask{lcv.null_mask()}
   {
   }
 
   size_type __device__ operator()(size_type i) const
   {
-    return bit_value_or(bitmask, i, true) ? (offsets[i + 1] - offsets[i]) : 0;
+    auto const offset_i = i + offset;
+    return bit_value_or(bitmask, offset_i, true) ? (offsets[offset_i + 1] - offsets[offset_i]) : 0;
   }
 
  private:
+  offset_type offset;
   size_type num_rows;
   offset_type const* offsets;
   bitmask_type const* bitmask;

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -78,7 +78,7 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
 {
   auto const num_rows = input.size();
 
-  if (num_rows == 0) { return cudf::empty_like(input.child()); }
+  if (num_rows == 0) { return cudf::empty_like(input.parent()); }
   // Note: This assert guarantees that no elements are gathered
   // from nominally NULL input list rows.
   assert_same_sizes(input, boolean_mask, stream);

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -478,6 +478,7 @@ ConfigureTest(
   lists/extract_tests.cpp
   lists/sequences_tests.cpp
   lists/sort_lists_tests.cpp
+  lists/segmented_test.cu
 )
 
 # ##################################################################################################

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -469,6 +469,7 @@ ConfigureTest(AST_TEST ast/transform_tests.cpp)
 # * lists tests ----------------------------------------------------------------------------------
 ConfigureTest(
   LISTS_TEST
+  lists/apply_boolean_mask_test.cpp
   lists/combine/concatenate_list_elements_tests.cpp
   lists/combine/concatenate_rows_tests.cpp
   lists/contains_tests.cpp
@@ -478,7 +479,6 @@ ConfigureTest(
   lists/extract_tests.cpp
   lists/sequences_tests.cpp
   lists/sort_lists_tests.cpp
-  lists/segmented_test.cu
 )
 
 # ##################################################################################################

--- a/cpp/tests/lists/apply_boolean_mask_test.cpp
+++ b/cpp/tests/lists/apply_boolean_mask_test.cpp
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cudf/detail/reduction_functions.hpp"
-#include "cudf/detail/stream_compaction.hpp"
-#include "cudf/lists/lists_column_view.hpp"
-#include "cudf/lists/stream_compaction.hpp"
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/lists/extract.hpp>
+#include <cudf/lists/stream_compaction.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -38,8 +35,8 @@
 
 namespace cudf::test {
 
-using cudf::lists::apply_boolean_mask;
 using cudf::lists_column_view;
+using cudf::lists::apply_boolean_mask;
 
 using lists_t  = lists_column_wrapper<int32_t>;
 using filter_t = lists_column_wrapper<bool, int32_t>;
@@ -48,32 +45,32 @@ struct ApplyBooleanMaskTest : public BaseFixture {
 };
 
 template <typename T>
-struct ApplyBooleanMaskTypedTest : ApplyBooleanMaskTest {};
+struct ApplyBooleanMaskTypedTest : ApplyBooleanMaskTest {
+};
 
 using TestTypes = cudf::test::NumericTypes;
 
 TEST_F(ApplyBooleanMaskTest, StraightLine)
 {
-  auto input  = lists_t {{0, 1, 2, 3}, {4, 5}, {6, 7, 8, 9}, {0, 1}, {2, 3, 4, 5}, {6, 7}}.release();
+  auto input  = lists_t{{0, 1, 2, 3}, {4, 5}, {6, 7, 8, 9}, {0, 1}, {2, 3, 4, 5}, {6, 7}}.release();
   auto filter = filter_t{{1, 0, 1, 0}, {1, 0}, {1, 0, 1, 0}, {1, 0}, {1, 0, 1, 0}, {1, 0}};
-  
-  { 
+
+  {
     // Unsliced.
     auto filtered = apply_boolean_mask(lists_column_view{*input}, lists_column_view{filter});
-    auto expected = lists_t{{0,2}, {4}, {6,8}, {0}, {2,4}, {6}};
+    auto expected = lists_t{{0, 2}, {4}, {6, 8}, {0}, {2, 4}, {6}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*filtered, expected);
   }
   {
     // Sliced input: Remove the first row.
     auto sliced = cudf::slice(*input, {1, input->size()}).front();
     //         == lists_t {{4, 5}, {6, 7, 8, 9}, {0, 1}, {2, 3, 4, 5}, {6, 7}};
-    auto filter = filter_t{{0, 1}, {0, 1, 0, 1}, {1, 1}, {0, 1, 0, 1}, {0, 0}};
+    auto filter   = filter_t{{0, 1}, {0, 1, 0, 1}, {1, 1}, {0, 1, 0, 1}, {0, 0}};
     auto filtered = apply_boolean_mask(lists_column_view{sliced}, lists_column_view{filter});
-    auto expected = lists_t{{5},   {7, 9},       {0, 1}, {3, 5},       {}};
+    auto expected = lists_t{{5}, {7, 9}, {0, 1}, {3, 5}, {}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*filtered, expected);
   }
 }
-
 
 /*
 TEST_F(SegmentedFilterTest, TheBasic)

--- a/cpp/tests/lists/apply_boolean_mask_test.cpp
+++ b/cpp/tests/lists/apply_boolean_mask_test.cpp
@@ -150,6 +150,14 @@ TEST_F(ApplyBooleanMaskTest, Trivial)
 TEST_F(ApplyBooleanMaskTest, Failure)
 {
   {
+    // Invalid mask type.
+    auto const input  = lists<int32_t>{{1, 2, 3}, {4, 5, 6}};
+    auto const filter = lists<int32_t>{{0, 0, 0}};
+    CUDF_EXPECT_THROW_MESSAGE(
+      apply_boolean_mask(lists_column_view{input}, lists_column_view{filter}),
+      "Mask must be of type BOOL8.");
+  }
+  {
     // Mismatched number of rows.
     auto const input  = lists<int32_t>{{1, 2, 3}, {4, 5, 6}};
     auto const filter = filter_t{{0, 0, 0}};

--- a/cpp/tests/lists/apply_boolean_mask_test.cpp
+++ b/cpp/tests/lists/apply_boolean_mask_test.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cstdint>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/lists/extract.hpp>
@@ -23,23 +24,18 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
-#include <tests/strings/utilities.h>
-
-#include <rmm/cuda_stream_view.hpp>
-
-#include <thrust/iterator/constant_iterator.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/transform_iterator.h>
-
-#include <vector>
 
 namespace cudf::test {
 
+using namespace iterators;
 using cudf::lists_column_view;
 using cudf::lists::apply_boolean_mask;
 
-using lists_t  = lists_column_wrapper<int32_t>;
+template <typename T>
+using lists    = lists_column_wrapper<T, int32_t>;
 using filter_t = lists_column_wrapper<bool, int32_t>;
+
+auto constexpr X = int32_t{0};  // Placeholder for NULL.
 
 struct ApplyBooleanMaskTest : public BaseFixture {
 };
@@ -48,55 +44,69 @@ template <typename T>
 struct ApplyBooleanMaskTypedTest : ApplyBooleanMaskTest {
 };
 
-using TestTypes = cudf::test::NumericTypes;
+TYPED_TEST_SUITE(ApplyBooleanMaskTypedTest, cudf::test::NumericTypes);
 
-TEST_F(ApplyBooleanMaskTest, StraightLine)
+TYPED_TEST(ApplyBooleanMaskTypedTest, StraightLine)
 {
-  auto input  = lists_t{{0, 1, 2, 3}, {4, 5}, {6, 7, 8, 9}, {0, 1}, {2, 3, 4, 5}, {6, 7}}.release();
+  using T    = TypeParam;
+  auto input = lists<T>{{0, 1, 2, 3}, {4, 5}, {6, 7, 8, 9}, {0, 1}, {2, 3, 4, 5}, {6, 7}}.release();
   auto filter = filter_t{{1, 0, 1, 0}, {1, 0}, {1, 0, 1, 0}, {1, 0}, {1, 0, 1, 0}, {1, 0}};
 
   {
     // Unsliced.
     auto filtered = apply_boolean_mask(lists_column_view{*input}, lists_column_view{filter});
-    auto expected = lists_t{{0, 2}, {4}, {6, 8}, {0}, {2, 4}, {6}};
+    auto expected = lists<T>{{0, 2}, {4}, {6, 8}, {0}, {2, 4}, {6}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*filtered, expected);
   }
   {
     // Sliced input: Remove the first row.
     auto sliced = cudf::slice(*input, {1, input->size()}).front();
-    //         == lists_t {{4, 5}, {6, 7, 8, 9}, {0, 1}, {2, 3, 4, 5}, {6, 7}};
+    //           == lists_t {{4, 5}, {6, 7, 8, 9}, {0, 1}, {2, 3, 4, 5}, {6, 7}};
     auto filter   = filter_t{{0, 1}, {0, 1, 0, 1}, {1, 1}, {0, 1, 0, 1}, {0, 0}};
     auto filtered = apply_boolean_mask(lists_column_view{sliced}, lists_column_view{filter});
-    auto expected = lists_t{{5}, {7, 9}, {0, 1}, {3, 5}, {}};
+    auto expected = lists<T>{{5}, {7, 9}, {0, 1}, {3, 5}, {}};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*filtered, expected);
+  }
+}
+
+TYPED_TEST(ApplyBooleanMaskTypedTest, WithNullElements)
+{
+  using T = TypeParam;
+  auto input =
+    lists<T>{
+      {0, 1, 2, 3},
+      lists<T>{{X, 5}, null_at(0)},
+      {6, 7, 8, 9},
+      {0, 1},
+      lists<T>{{X, 3, 4, X}, nulls_at({0, 3})},
+      lists<T>{{X, X}, nulls_at({0, 1})},
+    }
+      .release();
+  auto filter = filter_t{{1, 0, 1, 0}, {1, 0}, {1, 0, 1, 0}, {1, 0}, {1, 0, 1, 0}, {1, 0}};
+
+  {
+    // Unsliced.
+    auto filtered = apply_boolean_mask(lists_column_view{*input}, lists_column_view{filter});
+    auto expected = lists<T>{{0, 2},
+                             lists<T>{{X}, null_at(0)},
+                             {6, 8},
+                             {0},
+                             lists<T>{{X, 4}, null_at(0)},
+                             lists<T>{{X}, null_at(0)}};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*filtered, expected);
+  }
+  {
+    // Sliced input: Remove the first row.
+    auto sliced = cudf::slice(*input, {1, input->size()}).front();
+    //           == lists_t {{X, 5}, {6, 7, 8, 9}, {0, 1}, {X, 3, 4, X}, {X, X}};
+    auto filter   = filter_t{{0, 1}, {0, 1, 0, 1}, {1, 1}, {0, 1, 0, 1}, {0, 0}};
+    auto filtered = apply_boolean_mask(lists_column_view{sliced}, lists_column_view{filter});
+    auto expected = lists<T>{{5}, {7, 9}, {0, 1}, lists<T>{{3, X}, null_at(1)}, {}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*filtered, expected);
   }
 }
 
 /*
-TEST_F(SegmentedFilterTest, TheBasic)
-{
-  std::cout << "CALEB: SegmentedFilterTest.TheBasic" << std::endl;
-  auto filteree = lists{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 0, 1}, {2, 3, 4}, {5, 6, 7}};
-  auto filterer =
-    filter{{1, 0, 1}, {0, 1, 0}, {1, 0, 1}, {0, 1, 0}, {1, 0, 1}, {0, 1, 0}}.release();
-  // auto filterer   = filter{{1,0,1}, {}, {1,0,1}, {0,1,0}, {1,0,1}, {0,1,0}}.release();
-  auto bools_cv = lists_column_view(*filterer);
-  std::cout << "Filteree: " << std::endl;
-  print(filteree);
-  std::cout << "Filterer: " << std::endl;
-  print(*filterer);
-
-  auto output_offsets = cudf::reduction::segmented_sum(
-    bools_cv.child(), bools_cv.offsets(), data_type{type_id::INT32}, null_policy::EXCLUDE);
-  std::cout << "Output offsets:\n";
-  print(*output_offsets);
-
-  auto filtered_child = cudf::detail::apply_boolean_mask(
-    cudf::table_view{{lists_column_view{filteree}.child()}}, bools_cv.child());
-  std::cout << "Filtered child:\n";
-  print(filtered_child->view().column(0));
-}
-
 TEST_F(SegmentedFilterTest, TheBasicForNestedLists)
 {
   std::cout << "CALEB: SegmentedFilterTest.TheBasicForNestedLists" << std::endl;

--- a/cpp/tests/lists/apply_boolean_mask_test.cpp
+++ b/cpp/tests/lists/apply_boolean_mask_test.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cstdint>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/lists/extract.hpp>
@@ -150,22 +149,11 @@ TEST_F(ApplyBooleanMaskTest, Trivial)
 
 TEST_F(ApplyBooleanMaskTest, Failure)
 {
-  {
-    // Mismatched number of rows.
-    auto const input  = lists<int32_t>{{1, 2, 3}, {4, 5, 6}};
-    auto const filter = filter_t{{0, 0, 0}};
-    CUDF_EXPECT_THROW_MESSAGE(
-      apply_boolean_mask(lists_column_view{input}, lists_column_view{filter}),
-      "Boolean masks column must have same number of rows as input.");
-  }
-  {
-    // Mismatched number of elements.
-    auto const input  = lists<int32_t>{{1, 2, 3}, {4, 5, 6}};
-    auto const filter = filter_t{{0, 0}, {1, 1, 1}};
-    CUDF_EXPECT_THROW_MESSAGE(
-      apply_boolean_mask(lists_column_view{input}, lists_column_view{filter}),
-      "Each list row must match the corresponding boolean mask row in size.");
-  }
+  // Mismatched number of rows.
+  auto const input  = lists<int32_t>{{1, 2, 3}, {4, 5, 6}};
+  auto const filter = filter_t{{0, 0, 0}};
+  CUDF_EXPECT_THROW_MESSAGE(apply_boolean_mask(lists_column_view{input}, lists_column_view{filter}),
+                            "Boolean masks column must have same number of rows as input.");
 }
 
 }  // namespace cudf::test

--- a/cpp/tests/lists/apply_boolean_mask_test.cpp
+++ b/cpp/tests/lists/apply_boolean_mask_test.cpp
@@ -149,11 +149,13 @@ TEST_F(ApplyBooleanMaskTest, Trivial)
 
 TEST_F(ApplyBooleanMaskTest, Failure)
 {
-  // Mismatched number of rows.
-  auto const input  = lists<int32_t>{{1, 2, 3}, {4, 5, 6}};
-  auto const filter = filter_t{{0, 0, 0}};
-  CUDF_EXPECT_THROW_MESSAGE(apply_boolean_mask(lists_column_view{input}, lists_column_view{filter}),
-                            "Boolean masks column must have same number of rows as input.");
+  {
+    // Mismatched number of rows.
+    auto const input  = lists<int32_t>{{1, 2, 3}, {4, 5, 6}};
+    auto const filter = filter_t{{0, 0, 0}};
+    CUDF_EXPECT_THROW_MESSAGE(
+      apply_boolean_mask(lists_column_view{input}, lists_column_view{filter}),
+      "Boolean masks column must have same number of rows as input.");
+  }
 }
-
 }  // namespace cudf::test

--- a/cpp/tests/lists/apply_boolean_mask_test.cpp
+++ b/cpp/tests/lists/apply_boolean_mask_test.cpp
@@ -15,6 +15,8 @@
  */
 #include "cudf/detail/reduction_functions.hpp"
 #include "cudf/detail/stream_compaction.hpp"
+#include "cudf/lists/lists_column_view.hpp"
+#include "cudf/lists/stream_compaction.hpp"
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/lists/extract.hpp>
@@ -36,12 +38,44 @@
 
 namespace cudf::test {
 
-using lists  = lists_column_wrapper<int32_t>;
-using filter = lists_column_wrapper<bool, int32_t>;
+using cudf::lists::apply_boolean_mask;
+using cudf::lists_column_view;
 
-struct SegmentedFilterTest : public BaseFixture {
+using lists_t  = lists_column_wrapper<int32_t>;
+using filter_t = lists_column_wrapper<bool, int32_t>;
+
+struct ApplyBooleanMaskTest : public BaseFixture {
 };
 
+template <typename T>
+struct ApplyBooleanMaskTypedTest : ApplyBooleanMaskTest {};
+
+using TestTypes = cudf::test::NumericTypes;
+
+TEST_F(ApplyBooleanMaskTest, StraightLine)
+{
+  auto input  = lists_t {{0, 1, 2, 3}, {4, 5}, {6, 7, 8, 9}, {0, 1}, {2, 3, 4, 5}, {6, 7}}.release();
+  auto filter = filter_t{{1, 0, 1, 0}, {1, 0}, {1, 0, 1, 0}, {1, 0}, {1, 0, 1, 0}, {1, 0}};
+  
+  { 
+    // Unsliced.
+    auto filtered = apply_boolean_mask(lists_column_view{*input}, lists_column_view{filter});
+    auto expected = lists_t{{0,2}, {4}, {6,8}, {0}, {2,4}, {6}};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*filtered, expected);
+  }
+  {
+    // Sliced input: Remove the first row.
+    auto sliced = cudf::slice(*input, {1, input->size()}).front();
+    //         == lists_t {{4, 5}, {6, 7, 8, 9}, {0, 1}, {2, 3, 4, 5}, {6, 7}};
+    auto filter = filter_t{{0, 1}, {0, 1, 0, 1}, {1, 1}, {0, 1, 0, 1}, {0, 0}};
+    auto filtered = apply_boolean_mask(lists_column_view{sliced}, lists_column_view{filter});
+    auto expected = lists_t{{5},   {7, 9},       {0, 1}, {3, 5},       {}};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*filtered, expected);
+  }
+}
+
+
+/*
 TEST_F(SegmentedFilterTest, TheBasic)
 {
   std::cout << "CALEB: SegmentedFilterTest.TheBasic" << std::endl;
@@ -89,5 +123,6 @@ TEST_F(SegmentedFilterTest, TheBasicForNestedLists)
   std::cout << "Filtered child:\n";
   print(filtered_child->view().column(0));
 }
+*/
 
 }  // namespace cudf::test

--- a/cpp/tests/lists/apply_boolean_mask_test.cpp
+++ b/cpp/tests/lists/apply_boolean_mask_test.cpp
@@ -68,7 +68,7 @@ TYPED_TEST(ApplyBooleanMaskTypedTest, StraightLine)
   }
 }
 
-TYPED_TEST(ApplyBooleanMaskTypedTest, WithNullElements)
+TYPED_TEST(ApplyBooleanMaskTypedTest, NullElementsInTheListRows)
 {
   using T = TypeParam;
   auto input =
@@ -105,7 +105,7 @@ TYPED_TEST(ApplyBooleanMaskTypedTest, WithNullElements)
   }
 }
 
-TYPED_TEST(ApplyBooleanMaskTypedTest, NullInTheInput)
+TYPED_TEST(ApplyBooleanMaskTypedTest, NullListRowsInTheInputColumn)
 {
   using T = TypeParam;
   auto input =

--- a/cpp/tests/lists/apply_boolean_mask_test.cpp
+++ b/cpp/tests/lists/apply_boolean_mask_test.cpp
@@ -34,6 +34,11 @@ template <typename T>
 using lists    = lists_column_wrapper<T, int32_t>;
 using filter_t = lists_column_wrapper<bool, int32_t>;
 
+template <typename T>
+using fwcw    = fixed_width_column_wrapper<T, int32_t>;
+using offsets = fwcw<int32_t>;
+using strings = strings_column_wrapper;
+
 auto constexpr X = int32_t{0};  // Placeholder for NULL.
 
 struct ApplyBooleanMaskTest : public BaseFixture {
@@ -136,6 +141,58 @@ TYPED_TEST(ApplyBooleanMaskTypedTest, NullListRowsInTheInputColumn)
     auto filtered = apply_boolean_mask(lists_column_view{sliced}, lists_column_view{filter});
     auto expected = lists<T>{{{7, 9}, {}, {3, 5}, {}}, null_at(1)};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*filtered, expected);
+  }
+}
+
+TYPED_TEST(ApplyBooleanMaskTypedTest, StructInput)
+{
+  using T    = TypeParam;
+  using fwcw = fwcw<T>;
+
+  auto const input = [] {
+    auto child_num = fwcw{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    auto child_str = strings{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+    return cudf::make_lists_column(7,
+                                   offsets{0, 2, 3, 6, 6, 8, 8, 10}.release(),
+                                   structs_column_wrapper{{child_num, child_str}}.release(),
+                                   0,
+                                   {});
+  }();
+  {
+    // Unsliced.
+    // The input should now look as follows: (String child dropped for brevity.)
+    // Input:                   { [0,1], [2], [3,4,5], [], [6,7], [], [8,9] }
+    auto const filter   = filter_t{{1, 1}, {0}, {0, 1, 0}, {}, {1, 0}, {}, {0, 1}};
+    auto const result   = apply_boolean_mask(lists_column_view{*input}, lists_column_view{filter});
+    auto const expected = [] {
+      auto child_num = fwcw{0, 1, 4, 6, 9};
+      auto child_str = strings{"0", "1", "4", "6", "9"};
+      return cudf::make_lists_column(7,
+                                     offsets{0, 2, 2, 3, 3, 4, 4, 5}.release(),
+                                     structs_column_wrapper{{child_num, child_str}}.release(),
+                                     0,
+                                     {});
+    }();
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+  }
+  {
+    // Sliced. Remove the first row.
+    auto const sliced_input = cudf::slice(*input, {1, input->size()}).front();
+    // The input should now look as follows: (String child dropped for brevity.)
+    // Input:                   { [2], [3,4,5], [], [6,7], [], [8,9] }
+    auto const filter = filter_t{{0}, {0, 1, 0}, {}, {1, 0}, {}, {0, 1}};
+    auto const result =
+      apply_boolean_mask(lists_column_view{sliced_input}, lists_column_view{filter});
+    auto const expected = [] {
+      auto child_num = fwcw{4, 6, 9};
+      auto child_str = strings{"4", "6", "9"};
+      return cudf::make_lists_column(6,
+                                     offsets{0, 0, 1, 1, 2, 2, 3}.release(),
+                                     structs_column_wrapper{{child_num, child_str}}.release(),
+                                     0,
+                                     {});
+    }();
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
   }
 }
 

--- a/cpp/tests/lists/segmented_test.cu
+++ b/cpp/tests/lists/segmented_test.cu
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cudf/detail/reduction_functions.hpp"
+#include "cudf/detail/stream_compaction.hpp"
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/lists/extract.hpp>
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
+#include <tests/strings/utilities.h>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+
+#include <vector>
+
+namespace cudf::test {
+
+using lists  = lists_column_wrapper<int32_t>;
+using filter = lists_column_wrapper<bool, int32_t>;
+
+struct SegmentedFilterTest : public BaseFixture {
+};
+
+TEST_F(SegmentedFilterTest, TheBasic)
+{
+  std::cout << "CALEB: SegmentedFilterTest.TheBasic" << std::endl;
+  auto filteree = lists{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 0, 1}, {2, 3, 4}, {5, 6, 7}};
+  auto filterer =
+    filter{{1, 0, 1}, {0, 1, 0}, {1, 0, 1}, {0, 1, 0}, {1, 0, 1}, {0, 1, 0}}.release();
+  // auto filterer   = filter{{1,0,1}, {}, {1,0,1}, {0,1,0}, {1,0,1}, {0,1,0}}.release();
+  auto bools_cv = lists_column_view(*filterer);
+  std::cout << "Filteree: " << std::endl;
+  print(filteree);
+  std::cout << "Filterer: " << std::endl;
+  print(*filterer);
+
+  auto output_offsets = cudf::reduction::segmented_sum(
+    bools_cv.child(), bools_cv.offsets(), data_type{type_id::INT32}, null_policy::EXCLUDE);
+  std::cout << "Output offsets:\n";
+  print(*output_offsets);
+
+  auto filtered_child = cudf::detail::apply_boolean_mask(
+    cudf::table_view{{lists_column_view{filteree}.child()}}, bools_cv.child());
+  std::cout << "Filtered child:\n";
+  print(filtered_child->view().column(0));
+}
+
+TEST_F(SegmentedFilterTest, TheBasicForNestedLists)
+{
+  std::cout << "CALEB: SegmentedFilterTest.TheBasicForNestedLists" << std::endl;
+  auto filteree =
+    lists{{{0, 1}, {2}}, {{3}, {4, 5}}, {{6, 7}, {8}}, {{9, 0, 1}}, {{2, 3, 4}}, {{5, 6, 7}}};
+  auto filterer = filter{{1, 0}, {0, 1}, {1, 0}, {0}, {1}, {0}}.release();
+  // auto filterer   = filter{{1,0,1}, {}, {1,0,1}, {0,1,0}, {1,0,1}, {0,1,0}}.release();
+  auto bools_cv = lists_column_view(*filterer);
+  std::cout << "Filteree: " << std::endl;
+  print(filteree);
+  std::cout << "Filterer: " << std::endl;
+  print(*filterer);
+
+  auto output_offsets = cudf::reduction::segmented_sum(
+    bools_cv.child(), bools_cv.offsets(), data_type{type_id::INT32}, null_policy::EXCLUDE);
+  std::cout << "Output offsets:\n";
+  print(*output_offsets);
+
+  auto filtered_child = cudf::detail::apply_boolean_mask(
+    cudf::table_view{{lists_column_view{filteree}.child()}}, bools_cv.child());
+  std::cout << "Filtered child:\n";
+  print(filtered_child->view().column(0));
+}
+
+}  // namespace cudf::test


### PR DESCRIPTION
Fixes #10650.

This commit introduces an `apply_boolean_mask()` method that interprets a boolean `LIST` column as a filter, to select elements from an arbitrary `LIST` input column.
E.g.
```c++
auto const input    = lcw<int32_t>{ {0,1,2}, {3,4}, {5,6,7}, {8,9} };
auto const selector = lcw<bool>   { {0,1,1}, {1,0}, {1,1,1}, {0,0} };
auto const results  = apply_boolean_mask( lists_column_view{input}, lists_column_view{selector} );
// results          == { {1,2}, {3}, {5,6,7}, {} };
```

The `input` and the `boolean_mask` should both have the same number of rows, and each row should have the same number of elements. 
Each output row copies the elements from the input where the boolean mask is non-null and true.