### PR TITLE
simplifying skiprows test in test_orc.py

### DIFF
--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -301,27 +301,26 @@ def test_orc_read_rows(datadir, skiprows, num_rows):
     assert_eq(pdf, gdf)
 
 
-def test_orc_read_skiprows(tmpdir):
+def test_orc_read_skiprows():
     buff = BytesIO()
-    df = pd.DataFrame(
-        {"a": [1, 0, 1, 0, None, 1, 1, 1, 0, None, 0, 0, 1, 1, 1, 1]},
-        dtype=pd.BooleanDtype(),
-    )
+    data = [
+        True,
+        None,
+        True,
+        False,
+        None,
+        True,
+        True,
+        False,
+    ]
     writer = pyorc.Writer(buff, pyorc.Struct(a=pyorc.Boolean()))
-    tuples = list(
-        map(
-            lambda x: (None,) if x[0] is pd.NA else (bool(x[0]),),
-            list(df.itertuples(index=False, name=None)),
-        )
-    )
-    writer.writerows(tuples)
+    writer.writerows([(d,) for d in data])
     writer.close()
 
-    skiprows = 10
+    skiprows = 3
 
-    expected = cudf.read_orc(buff)[skiprows::].reset_index(drop=True)
+    expected = cudf.read_orc(buff)[skiprows:].reset_index(drop=True)
     got = cudf.read_orc(buff, skiprows=skiprows)
-
     assert_eq(expected, got)
 
 

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -317,7 +317,9 @@ def test_orc_read_skiprows():
     writer.writerows([(d,) for d in data])
     writer.close()
 
-    skiprows = 3
+    # testing 10 skiprows due to a boolean specific bug fix that didn't
+    # repro for other sizes of data
+    skiprows = 10
 
     expected = cudf.read_orc(buff)[skiprows:].reset_index(drop=True)
     got = cudf.read_orc(buff, skiprows=skiprows)

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -305,13 +305,21 @@ def test_orc_read_skiprows():
     buff = BytesIO()
     data = [
         True,
-        None,
+        False,
         True,
         False,
         None,
         True,
         True,
+        True,
         False,
+        None,
+        False,
+        False,
+        True,
+        True,
+        True,
+        True,
     ]
     writer = pyorc.Writer(buff, pyorc.Struct(a=pyorc.Boolean()))
     writer.writerows([(d,) for d in data])


### PR DESCRIPTION
@bdice helped me look into an issue with deprecated warnings in #10772 and in the process, he pointed out that the skiprows test was unnecessarily complex. We looked into it some and it appeared to be a copy/paste of a more complex test. He asked that I make this PR to simplify this test, but all the credit for noticing and fixing it is his.