### PR TITLE
Rework `Scalar` imports

### DIFF
--- a/python/cudf/cudf/__init__.py
+++ b/python/cudf/cudf/__init__.py
@@ -17,9 +17,8 @@ from cudf.api.extensions import (
     register_index_accessor,
     register_series_accessor,
 )
-from cudf.core.scalar import (
-    Scalar,
-)
+from cudf.core.scalar import Scalar
+
 from cudf.core.index import (
     BaseIndex,
     CategoricalIndex,

--- a/python/cudf/cudf/__init__.py
+++ b/python/cudf/cudf/__init__.py
@@ -18,7 +18,6 @@ from cudf.api.extensions import (
     register_series_accessor,
 )
 from cudf.core.scalar import (
-    NA,
     Scalar,
 )
 from cudf.core.index import (
@@ -45,6 +44,7 @@ from cudf.core.index import (
 )
 from cudf.core.dataframe import DataFrame, from_pandas, merge, from_dataframe
 from cudf.core.series import Series
+from cudf.core.missing import NA
 from cudf.core.multiindex import MultiIndex
 from cudf.core.cut import cut
 from cudf.core.algorithms import factorize

--- a/python/cudf/cudf/core/missing.py
+++ b/python/cudf/cudf/core/missing.py
@@ -4,4 +4,6 @@
 # Pandas NAType enforces a single instance exists at a time
 # instantiating this class will yield the existing instance
 # of pandas._libs.missing.NAType, id(cudf.NA) == id(pd.NA).
-from pandas import NA  # noqa: F401
+from pandas import NA
+
+__all__ = ["NA"]

--- a/python/cudf/cudf/core/missing.py
+++ b/python/cudf/cudf/core/missing.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+
+
+# Pandas NAType enforces a single instance exists at a time
+# instantiating this class will yield the existing instance
+# of pandas._libs.missing.NAType, id(cudf.NA) == id(pd.NA).
+from pandas import NA  # noqa: F401

--- a/python/cudf/cudf/core/udf/typing.py
+++ b/python/cudf/cudf/core/udf/typing.py
@@ -17,8 +17,8 @@ from numba.core.typing.templates import (
 )
 from numba.core.typing.typeof import typeof
 from numba.cuda.cudadecl import registry as cuda_decl_registry
-from cudf.core.missing import NA
 
+from cudf.core.missing import NA
 from cudf.core.udf import api
 from cudf.core.udf._ops import (
     arith_ops,

--- a/python/cudf/cudf/core/udf/typing.py
+++ b/python/cudf/cudf/core/udf/typing.py
@@ -17,7 +17,7 @@ from numba.core.typing.templates import (
 )
 from numba.core.typing.typeof import typeof
 from numba.cuda.cudadecl import registry as cuda_decl_registry
-from pandas._libs.missing import NAType as _NAType
+from cudf.core.missing import NA
 
 from cudf.core.udf import api
 from cudf.core.udf._ops import (
@@ -214,7 +214,7 @@ class NAType(types.Type):
 na_type = NAType()
 
 
-@typeof_impl.register(_NAType)
+@typeof_impl.register(type(NA))
 def typeof_na(val, c):
     """
     Tie instances of _NAType (cudf.NA) to our NAType.

--- a/python/cudf/cudf/tests/test_udf_masked_ops.py
+++ b/python/cudf/cudf/tests/test_udf_masked_ops.py
@@ -7,7 +7,7 @@ import pytest
 from numba import cuda
 
 import cudf
-from cudf.core.scalar import NA
+from cudf.core.missing import NA
 from cudf.core.udf._ops import (
     arith_ops,
     bitwise_ops,


### PR DESCRIPTION
This PR changes the way things are imported in our scalar code such that it's less prone to circular import issues. For instance before this we can't make `NA` the default value of a kwarg for, say, anything in `column.py`. 