### PR TITLE
Add cudf JNI docker build github action

### DIFF
--- a/.github/workflows/jni-docker-build.yml
+++ b/.github/workflows/jni-docker-build.yml
@@ -1,3 +1,17 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: JNI Docker Build
 
 on:
@@ -23,18 +37,17 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
+          password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
 
       - name: Set ENVs
         run: |
-          echo "IMAGE_NAME=gpuci/cudf-jni-build" >> $GITHUB_ENV
+          echo "IMAGE_NAME=rapidsai/cudf-jni-build" >> $GITHUB_ENV
           echo "IMAGE_REF=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          echo "IMAGE_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
       - name: Build and Push
         uses: docker/build-push-action@v3
         with:
           push: true
           file: java/ci/Dockerfile.centos7
-          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_REF }},${{ env.IMAGE_NAME }}:${{ env.IMAGE_SHA }}"
+          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_REF }}"

--- a/.github/workflows/jni-docker-build.yml
+++ b/.github/workflows/jni-docker-build.yml
@@ -1,0 +1,40 @@
+name: JNI Docker Build
+
+on:
+  workflow_dispatch: # manual trigger only
+
+concurrency:
+  group: jni-docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build:
+    if: github.repository == 'rapidsai/cudf'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set ENVs
+        run: |
+          echo "IMAGE_NAME=gpuci/cudf-jni-build" >> $GITHUB_ENV
+          echo "IMAGE_REF=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          echo "IMAGE_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+      - name: Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: java/ci/Dockerfile.centos7
+          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_REF }},${{ env.IMAGE_NAME }}:${{ env.IMAGE_SHA }}"


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

related to https://github.com/NVIDIA/spark-rapids-jni/issues/203

I don't know if any restriction of using github actions in rapids org, 
so this PR is just a prototype and waiting for feedback :)

Example in my forked repo,
1. Manual trigger the build
![image](https://user-images.githubusercontent.com/8086184/167101308-b3e4376e-4c42-4603-aca1-2b0f40ace16f.png)
2. example logs https://github.com/pxLi/cudf/runs/6319840419?check_suite_focus=true
3. pushed images https://hub.docker.com/r/pxli/cudf-jni-build/tags
![image](https://user-images.githubusercontent.com/8086184/167102403-a5b49a99-d8de-46d6-b5df-a1ea50254448.png)


Some open questions:
1. Trigger strategy? Manual, crontab, merge trigger, or others?
2. which org in docker hub should we push the image to? gpuci?
3. which account we should use to push?
4. do we want to keep the commit tags or we just overwrite the branch-XY tag only? mostly about space :)

Thanks!
