### PR TITLE
Cleanup regex compile optimize functions

### DIFF
--- a/cpp/src/strings/regex/regcomp.h
+++ b/cpp/src/strings/regex/regcomp.h
@@ -114,8 +114,7 @@ class reprog {
   void set_start_inst(int32_t id);
   [[nodiscard]] int32_t get_start_inst() const;
 
-  void optimize1();
-  void optimize2();
+  void finalize();
   void check_for_errors();
 #ifndef NDEBUG
   void print(regex_flags const flags);
@@ -128,6 +127,8 @@ class reprog {
   std::vector<int32_t> _startinst_ids;  // short-cut to speed-up ORs
   int32_t _num_capturing_groups{};
 
+  void collapse_nops();
+  void build_start_ids();
   void check_for_errors(int32_t id, int32_t next_id);
 };
 


### PR DESCRIPTION
Cleans up the internal `regcomp::optimize1()` function by replacing for-loops with STL functions. Hopefully this will make this part of the code a bit easier to understand and maintain.

No external function or behavior has changed.