### PR TITLE
Fix compile warning in search.cu

### DIFF
--- a/cpp/src/search/search.cu
+++ b/cpp/src/search/search.cu
@@ -105,21 +105,23 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
                                                  column_order_dv.data(),
                                                  null_precedence_dv.data());
 
-  auto const do_search = [find_first](auto&&... args) {
-    if (find_first) {
-      thrust::lower_bound(std::forward<decltype(args)>(args)...);
-    } else {
-      thrust::upper_bound(std::forward<decltype(args)>(args)...);
-    }
-  };
-  do_search(rmm::exec_policy(stream),
-            count_it,
-            count_it + haystack.num_rows(),
-            count_it,
-            count_it + needles.num_rows(),
-            out_it,
-            comp);
-
+  if (find_first) {
+    thrust::lower_bound(rmm::exec_policy(stream),
+                        count_it,
+                        count_it + haystack.num_rows(),
+                        count_it,
+                        count_it + needles.num_rows(),
+                        out_it,
+                        comp);
+  } else {
+    thrust::upper_bound(rmm::exec_policy(stream),
+                        count_it,
+                        count_it + haystack.num_rows(),
+                        count_it,
+                        count_it + needles.num_rows(),
+                        out_it,
+                        comp);
+  }
   return result;
 }
 


### PR DESCRIPTION
Compile warning introduced with merge of PR #10802 

```
10 warnings like this:
12:43:23 $SRC_DIR/cpp/src/search/search.cu(108): warning #177-D: parameter "args" was declared but never referenced
12:43:23           detected during instantiation of function "lambda [](auto &&...)->auto [with <auto-1>=<rmm::exec_policy, const thrust::counting_iterator<cudf::size_type, thrust::use_default, thrust::use_default, thrust::use_default> &, thrust::counting_iterator<cudf::size_type, thrust::use_default, thrust::use_default, thrust::use_default>, const thrust::counting_iterator<cudf::size_type, thrust::use_default, thrust::use_default, thrust::use_default> &, thrust::counting_iterator<cudf::size_type, thrust::use_default, thrust::use_default, thrust::use_default>, cudf::size_type *const &, const cudf::row_lexicographic_comparator<cudf::nullate::DYNAMIC> &>]" 
12:43:23 (121): here
```

Line 108 has a lambda refactoring that seems to confuse the compiler. 
```
  auto const do_search = [find_first](auto&&... args) {
    if (find_first) {
      thrust::lower_bound(std::forward<decltype(args)>(args)...);
    } else {
      thrust::upper_bound(std::forward<decltype(args)>(args)...);
    }
  };
  do_search(rmm::exec_policy(stream),
            count_it,  count_it + haystack.num_rows(), count_it, count_it + needles.num_rows(),
            out_it, comp);
```
The warning is wrong but generates the correct code.
This PR fixes the warning by replacing the lambda with an if statement.