### PR TITLE
Add handling for string by-columns in dask-cudf groupby

### DIFF
--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -83,22 +83,25 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         g._meta = g._meta[key]
         return g
 
+    def _columns_not_in_by(self):
+        """Generator of the columns contained in the groupby agg result"""
+
+        if isinstance(self.by, list):
+            for c in self.obj.columns:
+                if c not in self.by:
+                    yield c
+        else:
+            for c in self.obj.columns:
+                if c != self.by:
+                    yield c
+
     @_dask_cudf_nvtx_annotate
     @_check_groupby_supported
     def count(self, split_every=None, split_out=1):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "count"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "count" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -113,16 +116,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "mean"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "mean" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -137,16 +131,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "std"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "std" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -161,16 +146,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "var"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "var" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -185,16 +161,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "sum"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "sum" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -209,16 +176,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "min"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "min" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -233,16 +191,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "max"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "max" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -257,16 +206,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "collect"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "collect" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -281,16 +221,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "first"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "first" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -305,16 +236,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {
-                c: "last"
-                for c in self.obj.columns
-                if c
-                not in (
-                    self.by
-                    if isinstance(self.by, (tuple, list))
-                    else [self.by]
-                )
-            },
+            {c: "last" for c in self._columns_not_in_by()},
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -750,6 +672,7 @@ def _aggs_supported(arg, supported: set):
     return False
 
 
+@_dask_cudf_nvtx_annotate
 def _groupby_supported(gb):
     """Check that groupby input is supported by dask-cudf"""
     return isinstance(gb.obj, DaskDataFrame) and (

--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -83,6 +83,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         g._meta = g._meta[key]
         return g
 
+    @_dask_cudf_nvtx_annotate
     def _columns_not_in_by(self):
         """Generator of the columns contained in the groupby agg result"""
 

--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -89,7 +89,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "count" for c in self.obj.columns if c not in self.by},
+            {
+                c: "count"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -104,7 +113,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "mean" for c in self.obj.columns if c not in self.by},
+            {
+                c: "mean"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -119,7 +137,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "std" for c in self.obj.columns if c not in self.by},
+            {
+                c: "std"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -134,7 +161,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "var" for c in self.obj.columns if c not in self.by},
+            {
+                c: "var"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -149,7 +185,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "sum" for c in self.obj.columns if c not in self.by},
+            {
+                c: "sum"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -164,7 +209,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "min" for c in self.obj.columns if c not in self.by},
+            {
+                c: "min"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -179,7 +233,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "max" for c in self.obj.columns if c not in self.by},
+            {
+                c: "max"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -194,7 +257,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "collect" for c in self.obj.columns if c not in self.by},
+            {
+                c: "collect"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -209,7 +281,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "first" for c in self.obj.columns if c not in self.by},
+            {
+                c: "first"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -224,7 +305,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "last" for c in self.obj.columns if c not in self.by},
+            {
+                c: "last"
+                for c in self.obj.columns
+                if c
+                not in (
+                    self.by
+                    if isinstance(self.by, (tuple, list))
+                    else [self.by]
+                )
+            },
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,

--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -84,17 +84,12 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return g
 
     @_dask_cudf_nvtx_annotate
-    def _columns_not_in_by(self):
-        """Generator of the columns contained in the groupby agg result"""
+    def _make_groupby_method_aggs(self, agg_name):
+        """Create aggs dictionary for aggregation methods"""
 
         if isinstance(self.by, list):
-            for c in self.obj.columns:
-                if c not in self.by:
-                    yield c
-        else:
-            for c in self.obj.columns:
-                if c != self.by:
-                    yield c
+            return {c: agg_name for c in self.obj.columns if c not in self.by}
+        return {c: agg_name for c in self.obj.columns if c != self.by}
 
     @_dask_cudf_nvtx_annotate
     @_check_groupby_supported
@@ -102,7 +97,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "count" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("count"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -117,7 +112,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "mean" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("mean"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -132,7 +127,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "std" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("std"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -147,7 +142,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "var" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("var"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -162,7 +157,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "sum" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("sum"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -177,7 +172,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "min" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("min"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -192,7 +187,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "max" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("max"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -207,7 +202,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "collect" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("collect"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -222,7 +217,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "first" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("first"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,
@@ -237,7 +232,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         return groupby_agg(
             self.obj,
             self.by,
-            {c: "last" for c in self._columns_not_in_by()},
+            self._make_groupby_method_aggs("last"),
             split_every=split_every,
             split_out=split_out,
             sep=self.sep,

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -18,6 +18,9 @@ from dask_cudf.groupby import SUPPORTED_AGGS, _aggs_supported
 @pytest.mark.parametrize("series", [False, True])
 def test_groupby_basic(series, aggregation):
     np.random.seed(0)
+
+    # note that column name "x" is a substring of the groupby key;
+    # this gives us coverage for cudf#10829
     pdf = pd.DataFrame(
         {
             "xx": np.random.randint(0, 5, size=10000),

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -20,18 +20,19 @@ def test_groupby_basic(series, aggregation):
     np.random.seed(0)
     pdf = pd.DataFrame(
         {
-            "x": np.random.randint(0, 5, size=10000),
+            "xx": np.random.randint(0, 5, size=10000),
+            "x": np.random.normal(size=10000),
             "y": np.random.normal(size=10000),
         }
     )
 
     gdf = cudf.DataFrame.from_pandas(pdf)
-    gdf_grouped = gdf.groupby("x")
-    ddf_grouped = dask_cudf.from_cudf(gdf, npartitions=5).groupby("x")
+    gdf_grouped = gdf.groupby("xx")
+    ddf_grouped = dask_cudf.from_cudf(gdf, npartitions=5).groupby("xx")
 
     if series:
-        gdf_grouped = gdf_grouped.x
-        ddf_grouped = ddf_grouped.x
+        gdf_grouped = gdf_grouped.xx
+        ddf_grouped = ddf_grouped.xx
 
     a = getattr(gdf_grouped, aggregation)()
     b = getattr(ddf_grouped, aggregation)().compute()
@@ -41,8 +42,8 @@ def test_groupby_basic(series, aggregation):
     else:
         dd.assert_eq(a, b)
 
-    a = gdf_grouped.agg({"x": aggregation})
-    b = ddf_grouped.agg({"x": aggregation}).compute()
+    a = gdf_grouped.agg({"xx": aggregation})
+    b = ddf_grouped.agg({"xx": aggregation}).compute()
 
     if aggregation == "count":
         dd.assert_eq(a, b, check_dtype=False)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->

Converts string `by`-columns to lists when calling aggregation methods, which expect `Groupby.by` to be a list or tuple.

We might be able to do this conversion when initializing the groupby object, just started off with this approach as it seems like upstream Dask is pretty careful not to overwrite the original `by` input if it's a string.

Closes #10829 