### PR TITLE
Change std::string parameters in cudf::strings APIs to std::string_view

### DIFF
--- a/cpp/include/cudf/strings/convert/convert_datetime.hpp
+++ b/cpp/include/cudf/strings/convert/convert_datetime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ namespace strings {
 std::unique_ptr<column> to_timestamps(
   strings_column_view const& strings,
   data_type timestamp_type,
-  std::string const& format,
+  std::string_view format,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -115,7 +115,7 @@ std::unique_ptr<column> to_timestamps(
  */
 std::unique_ptr<column> is_timestamp(
   strings_column_view const& strings,
-  std::string const& format,
+  std::string_view format,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -225,7 +225,7 @@ std::unique_ptr<column> is_timestamp(
  */
 std::unique_ptr<column> from_timestamps(
   column_view const& timestamps,
-  std::string const& format           = "%Y-%m-%dT%H:%M:%SZ",
+  std::string_view format             = "%Y-%m-%dT%H:%M:%SZ",
   strings_column_view const& names    = strings_column_view(column_view{
     data_type{type_id::STRING}, 0, nullptr}),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());

--- a/cpp/include/cudf/strings/convert/convert_durations.hpp
+++ b/cpp/include/cudf/strings/convert/convert_durations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ namespace strings {
 std::unique_ptr<column> to_durations(
   strings_column_view const& strings,
   data_type duration_type,
-  std::string const& format,
+  std::string_view format,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -121,7 +121,7 @@ std::unique_ptr<column> to_durations(
  */
 std::unique_ptr<column> from_durations(
   column_view const& durations,
-  std::string const& format           = "%D days %H:%M:%S",
+  std::string_view format             = "%D days %H:%M:%S",
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of doxygen group

--- a/cpp/include/cudf/strings/detail/converters.hpp
+++ b/cpp/include/cudf/strings/detail/converters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,49 +87,49 @@ std::unique_ptr<column> from_booleans(column_view const& booleans,
                                       rmm::mr::device_memory_resource* mr);
 
 /**
- * @copydoc to_timestamps(strings_column_view const&,data_type,std::string
- * const&,rmm::mr::device_memory_resource*)
+ * @copydoc to_timestamps(strings_column_view const&,data_type,std::string_view,
+ * rmm::mr::device_memory_resource*)
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& strings,
                                             data_type timestamp_type,
-                                            std::string const& format,
+                                            std::string_view format,
                                             rmm::cuda_stream_view stream,
                                             rmm::mr::device_memory_resource* mr);
 
 /**
- * @copydoc from_timestamps(strings_column_view const&,std::string
- * const&,strings_column_view const&,rmm::mr::device_memory_resource*)
+ * @copydoc from_timestamps(strings_column_view const&,std::string_view,
+ * strings_column_view const&,rmm::mr::device_memory_resource*)
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<column> from_timestamps(column_view const& timestamps,
-                                        std::string const& format,
+                                        std::string_view format,
                                         strings_column_view const& names,
                                         rmm::cuda_stream_view stream,
                                         rmm::mr::device_memory_resource* mr);
 
 /**
- * @copydoc to_durations(strings_column_view const&,data_type,std::string
- * const&,rmm::mr::device_memory_resource*)
+ * @copydoc to_durations(strings_column_view const&,data_type,std::string_view,
+ * rmm::mr::device_memory_resource*)
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<column> to_durations(strings_column_view const& strings,
                                      data_type duration_type,
-                                     std::string const& format,
+                                     std::string_view format,
                                      rmm::cuda_stream_view stream,
                                      rmm::mr::device_memory_resource* mr);
 
 /**
- * @copydoc from_durations(strings_column_view const&,std::string
- * const&,rmm::mr::device_memory_resource*)
+ * @copydoc from_durations(strings_column_view const&,std::string_view.
+ * rmm::mr::device_memory_resource*)
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 std::unique_ptr<column> from_durations(column_view const& durations,
-                                       std::string const& format,
+                                       std::string_view format,
                                        rmm::cuda_stream_view stream,
                                        rmm::mr::device_memory_resource* mr);
 

--- a/cpp/include/cudf/strings/padding.hpp
+++ b/cpp/include/cudf/strings/padding.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ std::unique_ptr<column> pad(
   strings_column_view const& strings,
   size_type width,
   pad_side side                       = cudf::strings::pad_side::RIGHT,
-  std::string const& fill_char        = " ",
+  std::string_view fill_char          = " ",
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -102,7 +102,7 @@ struct alignas(4) format_item {
 using specifier_map = std::map<char, int8_t>;
 
 struct format_compiler {
-  std::string const format;
+  std::string_view const format;
   rmm::device_uvector<format_item> d_items;
 
   // clang-format off
@@ -113,15 +113,15 @@ struct format_compiler {
     {'S', 2}, {'f', 6}, {'z', 5}, {'Z', 3}, {'p', 2}, {'j', 3}};
   // clang-format on
 
-  format_compiler(std::string fmt,
+  format_compiler(std::string_view fmt,
                   rmm::cuda_stream_view stream,
                   specifier_map extra_specifiers = {})
     : format(fmt), d_items(0, stream)
   {
     specifiers.insert(extra_specifiers.begin(), extra_specifiers.end());
     std::vector<format_item> items;
-    const char* str = format.c_str();
-    auto length     = format.length();
+    auto str    = format.data();
+    auto length = format.length();
     while (length > 0) {
       char ch = *str++;
       length--;
@@ -362,7 +362,7 @@ struct parse_datetime {
 struct dispatch_to_timestamps_fn {
   template <typename T, std::enable_if_t<cudf::is_timestamp<T>()>* = nullptr>
   void operator()(column_device_view const& d_strings,
-                  std::string const& format,
+                  std::string_view format,
                   mutable_column_view& results_view,
                   rmm::cuda_stream_view stream) const
   {
@@ -376,7 +376,7 @@ struct dispatch_to_timestamps_fn {
   }
   template <typename T, std::enable_if_t<not cudf::is_timestamp<T>()>* = nullptr>
   void operator()(column_device_view const&,
-                  std::string const&,
+                  std::string_view,
                   mutable_column_view&,
                   rmm::cuda_stream_view) const
   {
@@ -389,7 +389,7 @@ struct dispatch_to_timestamps_fn {
 //
 std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& input,
                                             data_type timestamp_type,
-                                            std::string const& format,
+                                            std::string_view format,
                                             rmm::cuda_stream_view stream,
                                             rmm::mr::device_memory_resource* mr)
 {
@@ -612,7 +612,7 @@ struct check_datetime_format {
 };
 
 std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
-                                           std::string const& format,
+                                           std::string_view const& format,
                                            rmm::cuda_stream_view stream,
                                            rmm::mr::device_memory_resource* mr)
 {
@@ -648,7 +648,7 @@ std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
 
 std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& input,
                                             data_type timestamp_type,
-                                            std::string const& format,
+                                            std::string_view format,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
@@ -656,7 +656,7 @@ std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& input,
 }
 
 std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
-                                           std::string const& format,
+                                           std::string_view format,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
@@ -1100,7 +1100,7 @@ struct dispatch_from_timestamps_fn {
 
 //
 std::unique_ptr<column> from_timestamps(column_view const& timestamps,
-                                        std::string const& format,
+                                        std::string_view format,
                                         strings_column_view const& names,
                                         rmm::cuda_stream_view stream,
                                         rmm::mr::device_memory_resource* mr)
@@ -1143,7 +1143,7 @@ std::unique_ptr<column> from_timestamps(column_view const& timestamps,
 // external API
 
 std::unique_ptr<column> from_timestamps(column_view const& timestamps,
-                                        std::string const& format,
+                                        std::string_view format,
                                         strings_column_view const& names,
                                         rmm::mr::device_memory_resource* mr)
 {

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -84,10 +84,10 @@ struct alignas(4) format_item {
  * components and when formatting a string from duration components.
  */
 struct format_compiler {
-  std::string format;
+  std::string_view const format;
   rmm::device_uvector<format_item> d_items;
-  format_compiler(const char* format_, rmm::cuda_stream_view stream)
-    : format(format_), d_items(0, stream)
+  format_compiler(std::string_view format, rmm::cuda_stream_view stream)
+    : format(format), d_items(0, stream)
   {
     static std::map<char, int8_t> const specifier_lengths = {
       {'-', -1},  // '-' if negative
@@ -102,8 +102,8 @@ struct format_compiler {
       {'r', 11}   // HH:MM:SS AM/PM
     };
     std::vector<format_item> items;
-    const char* str = format.c_str();
-    auto length     = format.length();
+    auto str    = format.data();
+    auto length = format.length();
     bool negative_sign{true};
     while (length > 0) {
       char ch = *str++;
@@ -407,13 +407,13 @@ struct duration_to_string_fn : public duration_to_string_size_fn<T> {
 struct dispatch_from_durations_fn {
   template <typename T, std::enable_if_t<cudf::is_duration<T>()>* = nullptr>
   std::unique_ptr<column> operator()(column_view const& durations,
-                                     std::string const& format,
+                                     std::string_view format,
                                      rmm::cuda_stream_view stream,
                                      rmm::mr::device_memory_resource* mr) const
   {
     CUDF_EXPECTS(!format.empty(), "Format parameter must not be empty.");
 
-    format_compiler compiler(format.c_str(), stream);
+    format_compiler compiler(format, stream);
     auto d_format_items = compiler.compiled_format_items();
 
     size_type strings_count = durations.size();
@@ -675,11 +675,11 @@ struct parse_duration {
 struct dispatch_to_durations_fn {
   template <typename T, std::enable_if_t<cudf::is_duration<T>()>* = nullptr>
   void operator()(column_device_view const& d_strings,
-                  std::string const& format,
+                  std::string_view format,
                   mutable_column_view& results_view,
                   rmm::cuda_stream_view stream) const
   {
-    format_compiler compiler(format.c_str(), stream);
+    format_compiler compiler(format, stream);
     auto d_items   = compiler.compiled_format_items();
     auto d_results = results_view.data<T>();
     parse_duration<T> pfn{d_strings, d_items, compiler.items_count()};
@@ -691,7 +691,7 @@ struct dispatch_to_durations_fn {
   }
   template <typename T, std::enable_if_t<not cudf::is_duration<T>()>* = nullptr>
   void operator()(column_device_view const&,
-                  std::string const&,
+                  std::string_view,
                   mutable_column_view&,
                   rmm::cuda_stream_view) const
   {
@@ -702,7 +702,7 @@ struct dispatch_to_durations_fn {
 }  // namespace
 
 std::unique_ptr<column> from_durations(column_view const& durations,
-                                       std::string const& format,
+                                       std::string_view format,
                                        rmm::cuda_stream_view stream,
                                        rmm::mr::device_memory_resource* mr)
 {
@@ -715,7 +715,7 @@ std::unique_ptr<column> from_durations(column_view const& durations,
 
 std::unique_ptr<column> to_durations(strings_column_view const& strings,
                                      data_type duration_type,
-                                     std::string const& format,
+                                     std::string_view format,
                                      rmm::cuda_stream_view stream,
                                      rmm::mr::device_memory_resource* mr)
 {
@@ -743,7 +743,7 @@ std::unique_ptr<column> to_durations(strings_column_view const& strings,
 }  // namespace detail
 
 std::unique_ptr<column> from_durations(column_view const& durations,
-                                       std::string const& format,
+                                       std::string_view format,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
@@ -752,7 +752,7 @@ std::unique_ptr<column> from_durations(column_view const& durations,
 
 std::unique_ptr<column> to_durations(strings_column_view const& strings,
                                      data_type duration_type,
-                                     std::string const& format,
+                                     std::string_view format,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/strings/padding.cu
+++ b/cpp/src/strings/padding.cu
@@ -60,7 +60,7 @@ std::unique_ptr<column> pad(
   strings_column_view const& strings,
   size_type width,
   pad_side side                       = pad_side::RIGHT,
-  std::string const& fill_char        = " ",
+  std::string_view fill_char          = " ",
   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
@@ -68,7 +68,7 @@ std::unique_ptr<column> pad(
   if (strings_count == 0) return make_empty_column(type_id::STRING);
   CUDF_EXPECTS(!fill_char.empty(), "fill_char parameter must not be empty");
   char_utf8 d_fill_char    = 0;
-  size_type fill_char_size = to_char_utf8(fill_char.c_str(), d_fill_char);
+  size_type fill_char_size = to_char_utf8(fill_char.data(), d_fill_char);
 
   auto strings_column = column_device_view::create(strings.parent(), stream);
   auto d_strings      = *strings_column;
@@ -206,7 +206,7 @@ std::unique_ptr<column> zfill(
 std::unique_ptr<column> pad(strings_column_view const& strings,
                             size_type width,
                             pad_side side,
-                            std::string const& fill_char,
+                            std::string_view fill_char,
                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();


### PR DESCRIPTION
Follow on to #10810. This changes other occurrences of parameter type `std::string` to `std::string_view` in the non-regex APIs. 
This covers `cudf::strings::pad` fill-char and the to/from-timestamp/duration converters that accept format specifiers.