### PR TITLE
Add missing cuda-python dependency to cudf

### DIFF
--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -259,6 +259,6 @@ setup(
     ),
     cmdclass=cmdclass,
     install_requires=install_requires,
-    zip_safe=False,
     extras_require=extras_require,
+    zip_safe=False,
 )

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -30,16 +30,16 @@ from setuptools.extension import Extension
 import versioneer
 
 install_requires = [
-    "numba>=0.53.1",
-    "Cython>=0.29,<0.30",
-    "fsspec>=0.6.0",
-    "numpy",
-    "pandas>=1.0,<1.5.0dev0",
-    "typing_extensions",
-    "protobuf",
-    "nvtx>=0.2.1",
     "cachetools",
+    "cuda-python>=11.5,<12.0",
+    "fsspec>=0.6.0",
+    "numba>=0.53.1",
+    "numpy",
+    "nvtx>=0.2.1",
     "packaging",
+    "pandas>=1.0,<1.5.0dev0",
+    "protobuf",
+    "typing_extensions",
 ]
 
 extras_require = {

--- a/python/cudf_kafka/pyproject.toml
+++ b/python/cudf_kafka/pyproject.toml
@@ -5,9 +5,8 @@
 requires = [
     "wheel",
     "setuptools",
-    "Cython>=0.29,<0.30",
+    "cython>=0.29,<0.30",
 ]
-
 
 [tool.black]
 line-length = 79

--- a/python/cudf_kafka/setup.py
+++ b/python/cudf_kafka/setup.py
@@ -13,6 +13,8 @@ import versioneer
 
 install_requires = ["cudf", "cython"]
 
+extras_require = {"test": ["pytest", "pytest-xdist"]}
+
 cython_files = ["cudf_kafka/_lib/*.pyx"]
 
 CUDA_HOME = os.environ.get("CUDA_HOME", False)
@@ -94,7 +96,6 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     # Include the separately-compiled shared library
-    setup_requires=["Cython>=0.29,<0.30"],
     ext_modules=cythonize(
         extensions,
         nthreads=nthreads,
@@ -109,6 +110,6 @@ setup(
     ),
     cmdclass=versioneer.get_cmdclass(),
     install_requires=install_requires,
-    extras_require={"test": ["pytest", "pytest-xdist"]},
+    extras_require=extras_require,
     zip_safe=False,
 )

--- a/python/custreamz/setup.py
+++ b/python/custreamz/setup.py
@@ -6,6 +6,8 @@ import versioneer
 
 install_requires = ["cudf_kafka", "cudf"]
 
+extras_require = {"test": ["pytest", "pytest-xdist"]}
+
 setup(
     name="custreamz",
     version=versioneer.get_version(),
@@ -26,6 +28,6 @@ setup(
     packages=find_packages(include=["custreamz", "custreamz.*"]),
     cmdclass=versioneer.get_cmdclass(),
     install_requires=install_requires,
+    extras_require=extras_require,
     zip_safe=False,
-    extras_require={"test": ["pytest", "pytest-xdist"]},
 )

--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -91,5 +91,4 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     install_requires=install_requires,
     extras_require=extras_require,
-    zip_safe=False,
 )

--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -91,4 +91,5 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     install_requires=install_requires,
     extras_require=extras_require,
+    zip_safe=False,
 )


### PR DESCRIPTION
This PR:
- adds a missing `cuda-python` dependency to cudf's `setup.py`. The package is used here (it is currently being supplied as a transitive dependency of RMM, but we should list all dependencies explicitly): https://github.com/rapidsai/cudf/blob/0cc29a0a0128c5632bd53fd41c0a568929b847ac/python/cudf/cudf/utils/gpu_utils.py#L18
- standardizes declarations of Cython dependencies (it is only a build system dependency in `pyproject.toml`, and never needed at runtime via `install_requires` in `setup.py`)
- standardizes definition of `extras_require` across all included Python packages