### PR TITLE
Register `cudf.core.groupby.Grouper` objects to dask `grouper_dispatch` 

### DIFF
--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -13,6 +13,7 @@ from dask.dataframe.dispatch import (
     categorical_dtype_dispatch,
     concat_dispatch,
     group_split_dispatch,
+    grouper_dispatch,
     hash_object_dispatch,
     is_categorical_dtype_dispatch,
     make_meta_dispatch,
@@ -294,6 +295,11 @@ def tolist_cudf(obj):
 @_dask_cudf_nvtx_annotate
 def is_categorical_dtype_cudf(obj):
     return cudf.api.types.is_categorical_dtype(obj)
+
+
+@grouper_dispatch.register((cudf.core.dataframe.DataFrame,))
+def get_grouper_cudf(obj):
+    return cudf.core.groupby.Grouper
 
 
 try:

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -13,7 +13,6 @@ from dask.dataframe.dispatch import (
     categorical_dtype_dispatch,
     concat_dispatch,
     group_split_dispatch,
-    grouper_dispatch,
     hash_object_dispatch,
     is_categorical_dtype_dispatch,
     make_meta_dispatch,
@@ -297,10 +296,15 @@ def is_categorical_dtype_cudf(obj):
     return cudf.api.types.is_categorical_dtype(obj)
 
 
-@grouper_dispatch.register((cudf.Series, cudf.DataFrame))
-def get_grouper_cudf(obj):
-    return cudf.core.groupby.Grouper
+try:
+    from dask.dataframe.dispatch import grouper_dispatch
 
+    @grouper_dispatch.register((cudf.Series, cudf.DataFrame))
+    def get_grouper_cudf(obj):
+        return cudf.core.groupby.Grouper
+
+except ImportError:
+    pass
 
 try:
     try:

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -297,7 +297,7 @@ def is_categorical_dtype_cudf(obj):
     return cudf.api.types.is_categorical_dtype(obj)
 
 
-@grouper_dispatch.register((cudf.core.dataframe.DataFrame,))
+@grouper_dispatch.register((cudf.Series, cudf.DataFrame))
 def get_grouper_cudf(obj):
     return cudf.core.groupby.Grouper
 


### PR DESCRIPTION
This PR registers uses the (presumably shortly merged) dask `Grouper` dispatch to register `cudf.core.groupby.Grouper` objects to `cudf.DataFrame` objects. This should allow our own Grouper objects to be used in critical places in dask rather than pandas objects. 

This solution is favorable IMO rather than changing cuDF to handle pandas grouper objects directly. 

Xref https://github.com/dask/dask/pull/9074