### PR TITLE
Adds the JNI call for Cuda.deviceSynchronize

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -596,4 +596,10 @@ public class Cuda {
    * no effect.
    */
   public static native void profilerStop();
+
+  /**
+   * Synchronizes the whole device using cudaDeviceSynchronize.
+   * @note this is very expensive and should almost never be used
+   */
+  public static native void deviceSynchronize();
 }

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -390,4 +390,11 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_profilerStop(JNIEnv *env, jclass
   CATCH_STD(env, );
 }
 
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_deviceSynchronize(JNIEnv *env, jclass clazz) {
+  try {
+    CUDF_CUDA_TRY(cudaDeviceSynchronize());
+  }
+  CATCH_STD(env, );
+}
+
 } // extern "C"

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -392,6 +392,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_profilerStop(JNIEnv *env, jclass
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_deviceSynchronize(JNIEnv *env, jclass clazz) {
   try {
+    cudf::jni::auto_set_device(env);
     CUDF_CUDA_TRY(cudaDeviceSynchronize());
   }
   CATCH_STD(env, );


### PR DESCRIPTION
Running tests locally, but putting this up as WIP for now.

Discussing with @jlowe a solution to https://github.com/NVIDIA/spark-rapids/issues/4818 could involve `cudaDeviceSynchronize.` I noticed that's not in our JNI exposed calls, so I am adding it here.