### PR TITLE
Suppress sizeof-array-div warnings in thrust found by gcc-11

### DIFF
--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wsizeof-array-div"
+
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
@@ -39,6 +43,8 @@
 
 #include <cub/block/block_load.cuh>
 #include <cub/block/block_scan.cuh>
+
+#pragma GCC diagnostic pop
 
 #include <memory>
 #include <optional>

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// Can be removed once we use Thrust 1.16+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wsizeof-array-div"


### PR DESCRIPTION
`sizeof-array-div` is a new warning added in gcc-11 and thrust 1.15 will trigger it when a `T` type is a fixed size array. Nothing is wrong with the thrust logic, so we just suppress the warning while we wait on thrust 1.16

