### PR TITLE
fix doxygen warnings

### DIFF
--- a/ci/checks/copyright.py
+++ b/ci/checks/copyright.py
@@ -37,7 +37,7 @@ FilesToCheck = [
     re.compile(r"[.]flake8[.]cython$"),
     re.compile(r"meta[.]yaml$")
 ]
-ExemptFiles = []
+ExemptFiles = ["cpp/include/cudf_test/cxxopts.hpp"]
 
 # this will break starting at year 10000, which is probably OK :)
 CheckSimple = re.compile(

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -89,6 +89,7 @@ outputs:
         - test -f $PREFIX/include/cudf/detail/hashing.hpp
         - test -f $PREFIX/include/cudf/detail/interop.hpp
         - test -f $PREFIX/include/cudf/detail/is_element_valid.hpp
+        - test -f $PREFIX/include/cudf/detail/join.hpp
         - test -f $PREFIX/include/cudf/detail/null_mask.hpp
         - test -f $PREFIX/include/cudf/detail/nvtx/nvtx3.hpp
         - test -f $PREFIX/include/cudf/detail/nvtx/ranges.hpp
@@ -168,6 +169,7 @@ outputs:
         - test -f $PREFIX/include/cudf/lists/detail/interleave_columns.hpp
         - test -f $PREFIX/include/cudf/lists/detail/sorting.hpp
         - test -f $PREFIX/include/cudf/lists/detail/scatter_helper.cuh
+        - test -f $PREFIX/include/cudf/lists/detail/stream_compaction.hpp
         - test -f $PREFIX/include/cudf/lists/combine.hpp
         - test -f $PREFIX/include/cudf/lists/count_elements.hpp
         - test -f $PREFIX/include/cudf/lists/explode.hpp
@@ -178,6 +180,7 @@ outputs:
         - test -f $PREFIX/include/cudf/lists/gather.hpp
         - test -f $PREFIX/include/cudf/lists/lists_column_view.hpp
         - test -f $PREFIX/include/cudf/lists/sorting.hpp
+        - test -f $PREFIX/include/cudf/lists/stream_compaction.hpp
         - test -f $PREFIX/include/cudf/merge.hpp
         - test -f $PREFIX/include/cudf/null_mask.hpp
         - test -f $PREFIX/include/cudf/partitioning.hpp

--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -2130,7 +2130,8 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED              = __device__= \
-                          __host__=
+                          __host__= \
+                          DOXYGEN_SHOULD_SKIP_THIS
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -892,7 +892,9 @@ EXCLUDE_PATTERNS       = */nvtx/* */detail/*
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = org::apache
+EXCLUDE_SYMBOLS        = org::apache \
+                         *_impl \
+                         *Impl
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -1198,7 +1198,7 @@ struct optional_accessor {
   /**
    * @brief Constructor
    *
-   * @param col Column on which to iterator over its elements.
+   * @param _col Column on which to iterator over its elements.
    * @param with_nulls Indicates if the `col` should be checked for nulls.
    */
   optional_accessor(column_device_view const& _col, Nullate with_nulls)

--- a/cpp/include/cudf/table/experimental/row_operators.cuh
+++ b/cpp/include/cudf/table/experimental/row_operators.cuh
@@ -420,7 +420,7 @@ class self_comparator {
    * @brief Construct an owning object for performing a lexicographic comparison between two rows of
    * the same table.
    *
-   * @param table The table to compare
+   * @param t The table to compare
    * @param column_order Optional, host array the same length as a row that indicates the desired
    * ascending/descending order of each column in a row. If empty, it is assumed all columns are
    * sorted in ascending order.

--- a/cpp/include/cudf/utilities/type_dispatcher.hpp
+++ b/cpp/include/cudf/utilities/type_dispatcher.hpp
@@ -156,7 +156,7 @@ constexpr bool is_fixed_point(cudf::type_id id)
   template <>                                         \
   struct id_to_type_impl<Id> {                        \
     using type = Type;                                \
-  }
+  };
 #endif
 
 // Defines all of the mappings between C++ types and their corresponding `cudf::type_id` values.

--- a/cpp/include/cudf/utilities/type_dispatcher.hpp
+++ b/cpp/include/cudf/utilities/type_dispatcher.hpp
@@ -159,38 +159,35 @@ constexpr bool is_fixed_point(cudf::type_id id)
   }
 #endif
 
-/**
- * @brief Defines all of the mappings between C++ types and their corresponding
- * `cudf::type_id` values.
- */
-CUDF_TYPE_MAPPING(bool, type_id::BOOL8);
-CUDF_TYPE_MAPPING(int8_t, type_id::INT8);
-CUDF_TYPE_MAPPING(int16_t, type_id::INT16);
-CUDF_TYPE_MAPPING(int32_t, type_id::INT32);
-CUDF_TYPE_MAPPING(int64_t, type_id::INT64);
-CUDF_TYPE_MAPPING(uint8_t, type_id::UINT8);
-CUDF_TYPE_MAPPING(uint16_t, type_id::UINT16);
-CUDF_TYPE_MAPPING(uint32_t, type_id::UINT32);
-CUDF_TYPE_MAPPING(uint64_t, type_id::UINT64);
-CUDF_TYPE_MAPPING(float, type_id::FLOAT32);
-CUDF_TYPE_MAPPING(double, type_id::FLOAT64);
-CUDF_TYPE_MAPPING(cudf::string_view, type_id::STRING);
-CUDF_TYPE_MAPPING(cudf::timestamp_D, type_id::TIMESTAMP_DAYS);
-CUDF_TYPE_MAPPING(cudf::timestamp_s, type_id::TIMESTAMP_SECONDS);
-CUDF_TYPE_MAPPING(cudf::timestamp_ms, type_id::TIMESTAMP_MILLISECONDS);
-CUDF_TYPE_MAPPING(cudf::timestamp_us, type_id::TIMESTAMP_MICROSECONDS);
-CUDF_TYPE_MAPPING(cudf::timestamp_ns, type_id::TIMESTAMP_NANOSECONDS);
-CUDF_TYPE_MAPPING(cudf::duration_D, type_id::DURATION_DAYS);
-CUDF_TYPE_MAPPING(cudf::duration_s, type_id::DURATION_SECONDS);
-CUDF_TYPE_MAPPING(cudf::duration_ms, type_id::DURATION_MILLISECONDS);
-CUDF_TYPE_MAPPING(cudf::duration_us, type_id::DURATION_MICROSECONDS);
-CUDF_TYPE_MAPPING(cudf::duration_ns, type_id::DURATION_NANOSECONDS);
-CUDF_TYPE_MAPPING(dictionary32, type_id::DICTIONARY32);
-CUDF_TYPE_MAPPING(cudf::list_view, type_id::LIST);
-CUDF_TYPE_MAPPING(numeric::decimal32, type_id::DECIMAL32);
-CUDF_TYPE_MAPPING(numeric::decimal64, type_id::DECIMAL64);
-CUDF_TYPE_MAPPING(numeric::decimal128, type_id::DECIMAL128);
-CUDF_TYPE_MAPPING(cudf::struct_view, type_id::STRUCT);
+// Defines all of the mappings between C++ types and their corresponding `cudf::type_id` values.
+CUDF_TYPE_MAPPING(bool, type_id::BOOL8)
+CUDF_TYPE_MAPPING(int8_t, type_id::INT8)
+CUDF_TYPE_MAPPING(int16_t, type_id::INT16)
+CUDF_TYPE_MAPPING(int32_t, type_id::INT32)
+CUDF_TYPE_MAPPING(int64_t, type_id::INT64)
+CUDF_TYPE_MAPPING(uint8_t, type_id::UINT8)
+CUDF_TYPE_MAPPING(uint16_t, type_id::UINT16)
+CUDF_TYPE_MAPPING(uint32_t, type_id::UINT32)
+CUDF_TYPE_MAPPING(uint64_t, type_id::UINT64)
+CUDF_TYPE_MAPPING(float, type_id::FLOAT32)
+CUDF_TYPE_MAPPING(double, type_id::FLOAT64)
+CUDF_TYPE_MAPPING(cudf::string_view, type_id::STRING)
+CUDF_TYPE_MAPPING(cudf::timestamp_D, type_id::TIMESTAMP_DAYS)
+CUDF_TYPE_MAPPING(cudf::timestamp_s, type_id::TIMESTAMP_SECONDS)
+CUDF_TYPE_MAPPING(cudf::timestamp_ms, type_id::TIMESTAMP_MILLISECONDS)
+CUDF_TYPE_MAPPING(cudf::timestamp_us, type_id::TIMESTAMP_MICROSECONDS)
+CUDF_TYPE_MAPPING(cudf::timestamp_ns, type_id::TIMESTAMP_NANOSECONDS)
+CUDF_TYPE_MAPPING(cudf::duration_D, type_id::DURATION_DAYS)
+CUDF_TYPE_MAPPING(cudf::duration_s, type_id::DURATION_SECONDS)
+CUDF_TYPE_MAPPING(cudf::duration_ms, type_id::DURATION_MILLISECONDS)
+CUDF_TYPE_MAPPING(cudf::duration_us, type_id::DURATION_MICROSECONDS)
+CUDF_TYPE_MAPPING(cudf::duration_ns, type_id::DURATION_NANOSECONDS)
+CUDF_TYPE_MAPPING(dictionary32, type_id::DICTIONARY32)
+CUDF_TYPE_MAPPING(cudf::list_view, type_id::LIST)
+CUDF_TYPE_MAPPING(numeric::decimal32, type_id::DECIMAL32)
+CUDF_TYPE_MAPPING(numeric::decimal64, type_id::DECIMAL64)
+CUDF_TYPE_MAPPING(numeric::decimal128, type_id::DECIMAL128)
+CUDF_TYPE_MAPPING(cudf::struct_view, type_id::STRUCT)
 
 /**
  * @brief Use this specialization on `type_dispatcher` whenever you only need to operate on the
@@ -210,6 +207,12 @@ struct type_to_scalar_type_impl {
   using ScalarType = cudf::scalar;
 };
 
+/**
+ * @brief Macro used to define scalar type and scalar device type for
+ * `cudf::numeric_scalar` template class for numeric C++ types.
+ *
+ * @param Type The numeric C++ type
+ */
 #ifndef MAP_NUMERIC_SCALAR
 #define MAP_NUMERIC_SCALAR(Type)                                     \
   template <>                                                        \
@@ -230,7 +233,7 @@ MAP_NUMERIC_SCALAR(uint32_t)
 MAP_NUMERIC_SCALAR(uint64_t)
 MAP_NUMERIC_SCALAR(float)
 MAP_NUMERIC_SCALAR(double)
-MAP_NUMERIC_SCALAR(bool);
+MAP_NUMERIC_SCALAR(bool)
 
 template <>
 struct type_to_scalar_type_impl<std::string> {
@@ -281,6 +284,12 @@ struct type_to_scalar_type_impl<cudf::struct_view> {
   // using ScalarDeviceType = cudf::struct_scalar_device_view; // CALEB: TODO!
 };
 
+/**
+ * @brief Macro used to define scalar type and scalar device type for
+ * `cudf::timestamp_scalar` template class for timestamp C++ types.
+ *
+ * @param Type The timestamp C++ type
+ */
 #ifndef MAP_TIMESTAMP_SCALAR
 #define MAP_TIMESTAMP_SCALAR(Type)                                     \
   template <>                                                          \
@@ -296,6 +305,12 @@ MAP_TIMESTAMP_SCALAR(timestamp_ms)
 MAP_TIMESTAMP_SCALAR(timestamp_us)
 MAP_TIMESTAMP_SCALAR(timestamp_ns)
 
+/**
+ * @brief Macro used to define scalar type and scalar device type for
+ * `cudf::duration_scalar` template class for duration C++ types.
+ *
+ * @param Type The duration C++ type
+ */
 #ifndef MAP_DURATION_SCALAR
 #define MAP_DURATION_SCALAR(Type)                                     \
   template <>                                                         \

--- a/cpp/include/cudf_test/cxxopts.hpp
+++ b/cpp/include/cudf_test/cxxopts.hpp
@@ -20,6 +20,8 @@ THE SOFTWARE.
 #ifndef CXXOPTS_HPP_INCLUDED
 #define CXXOPTS_HPP_INCLUDED
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
 #include <cctype>
 #include <cstring>
 #include <exception>
@@ -1498,4 +1500,5 @@ inline const HelpGroupDetails& Options::group_help(const std::string& group) con
 
 }  // namespace cxxopts
 
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
 #endif  // CXXOPTS_HPP_INCLUDED

--- a/cpp/include/nvtext/bpe_tokenize.hpp
+++ b/cpp/include/nvtext/bpe_tokenize.hpp
@@ -107,7 +107,7 @@ std::unique_ptr<bpe_merge_pairs> load_merge_pairs_file(
  * @throw cudf::logic_error if `separator` is invalid
  *
  * @param input Strings to encode.
- * @param merge_pairs Created by a call to @ref nvtext::load_merge_pairs_file.
+ * @param merges_pairs Created by a call to @ref nvtext::load_merge_pairs_file.
  * @param separator String used to build the output after encoding.
  *                  Default is a space.
  * @param mr Memory resource to allocate any returned objects.


### PR DESCRIPTION
 This PR fixes 433 doxygen warnings.

As prerequisite for doxygen CI check https://github.com/rapidsai/cudf/issues/9373, the warnings from doxygen should be minimized as much as possible. 
This is one of the series of PRs to fix doxygen documentation warnings.
