### PR TITLE
Support for Zstandard decompression in Parquet reader

### DIFF
--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -19,6 +19,7 @@
 #include <cudf/utilities/error.hpp>
 
 #include <nvcomp/snappy.h>
+#include <nvcomp/zstd.h>
 
 namespace cudf::io::nvcomp {
 
@@ -28,6 +29,8 @@ auto batched_decompress_get_temp_size(compression_type type, Args&&... args)
   switch (type) {
     case compression_type::SNAPPY:
       return nvcompBatchedSnappyDecompressGetTempSize(std::forward<Args>(args)...);
+    case compression_type::ZSTD:
+      return nvcompBatchedZstdDecompressGetTempSize(std::forward<Args>(args)...);
     default: CUDF_FAIL("Unsupported compression type");
   }
 };
@@ -38,6 +41,8 @@ auto batched_decompress_async(compression_type type, Args&&... args)
   switch (type) {
     case compression_type::SNAPPY:
       return nvcompBatchedSnappyDecompressAsync(std::forward<Args>(args)...);
+    case compression_type::ZSTD:
+      return nvcompBatchedZstdDecompressAsync(std::forward<Args>(args)...);
     default: CUDF_FAIL("Unsupported compression type");
   }
 };

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -20,9 +20,9 @@
 
 #include <nvcomp/snappy.h>
 
-#define nvcomp_zstd_header <nvcomp/zstd.h>
-#if __has_include(nvcomp_zstd_header)
-#include nvcomp_zstd_header
+#define NVCOMP_ZSTD_HEADER <nvcomp/zstd.h>
+#if __has_include(NVCOMP_ZSTD_HEADER)
+#include NVCOMP_ZSTD_HEADER
 #define NVCOMP_HAS_ZSTD 1
 #else
 #define NVCOMP_HAS_ZSTD 0

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -23,9 +23,9 @@
 #define nvcomp_zstd_header <nvcomp/zstd.h>
 #if __has_include(nvcomp_zstd_header)
 #include nvcomp_zstd_header
-#define nvcomp_has_zstd 1
+#define NVCOMP_HAS_ZSTD 1
 #else
-#define nvcomp_has_zstd 0
+#define NVCOMP_HAS_ZSTD 0
 #endif
 
 namespace cudf::io::nvcomp {
@@ -36,7 +36,7 @@ auto batched_decompress_get_temp_size(compression_type type, Args&&... args)
   switch (type) {
     case compression_type::SNAPPY:
       return nvcompBatchedSnappyDecompressGetTempSize(std::forward<Args>(args)...);
-#if nvcomp_has_zstd
+#if NVCOMP_HAS_ZSTD
     case compression_type::ZSTD:
       return nvcompBatchedZstdDecompressGetTempSize(std::forward<Args>(args)...);
 #endif
@@ -50,7 +50,7 @@ auto batched_decompress_async(compression_type type, Args&&... args)
   switch (type) {
     case compression_type::SNAPPY:
       return nvcompBatchedSnappyDecompressAsync(std::forward<Args>(args)...);
-#if nvcomp_has_zstd
+#if NVCOMP_HAS_ZSTD
     case compression_type::ZSTD:
       return nvcompBatchedZstdDecompressAsync(std::forward<Args>(args)...);
 #endif

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -19,7 +19,14 @@
 #include <cudf/utilities/error.hpp>
 
 #include <nvcomp/snappy.h>
-#include <nvcomp/zstd.h>
+
+#define nvcomp_zstd_header <nvcomp/zstd.h>
+#if __has_include(nvcomp_zstd_header)
+#include nvcomp_zstd_header
+#define nvcomp_has_zstd 1
+#else
+#define nvcomp_has_zstd 0
+#endif
 
 namespace cudf::io::nvcomp {
 
@@ -29,8 +36,10 @@ auto batched_decompress_get_temp_size(compression_type type, Args&&... args)
   switch (type) {
     case compression_type::SNAPPY:
       return nvcompBatchedSnappyDecompressGetTempSize(std::forward<Args>(args)...);
+#if nvcomp_has_zstd
     case compression_type::ZSTD:
       return nvcompBatchedZstdDecompressGetTempSize(std::forward<Args>(args)...);
+#endif
     default: CUDF_FAIL("Unsupported compression type");
   }
 };
@@ -41,8 +50,10 @@ auto batched_decompress_async(compression_type type, Args&&... args)
   switch (type) {
     case compression_type::SNAPPY:
       return nvcompBatchedSnappyDecompressAsync(std::forward<Args>(args)...);
+#if nvcomp_has_zstd
     case compression_type::ZSTD:
       return nvcompBatchedZstdDecompressAsync(std::forward<Args>(args)...);
+#endif
     default: CUDF_FAIL("Unsupported compression type");
   }
 };

--- a/cpp/src/io/comp/nvcomp_adapter.hpp
+++ b/cpp/src/io/comp/nvcomp_adapter.hpp
@@ -24,7 +24,7 @@
 
 namespace cudf::io::nvcomp {
 
-enum class compression_type { SNAPPY };
+enum class compression_type { SNAPPY, ZSTD };
 
 /**
  * @brief Device batch decompression of given type.

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -1108,7 +1108,8 @@ rmm::device_buffer reader::impl::decompress_page_data(
 
   std::array codecs{codec_stats{parquet::GZIP, 0, 0},
                     codec_stats{parquet::SNAPPY, 0, 0},
-                    codec_stats{parquet::BROTLI, 0, 0}};
+                    codec_stats{parquet::BROTLI, 0, 0},
+                    codec_stats{parquet::ZSTD, 0, 0}};
 
   auto is_codec_supported = [&codecs](int8_t codec) {
     if (codec == parquet::UNCOMPRESSED) return true;
@@ -1190,6 +1191,14 @@ rmm::device_buffer reader::impl::decompress_page_data(
         } else {
           gpu_unsnap(d_comp_in, d_comp_out, d_comp_stats_view, stream);
         }
+        break;
+      case parquet::ZSTD:
+        nvcomp::batched_decompress(nvcomp::compression_type::ZSTD,
+                                   d_comp_in,
+                                   d_comp_out,
+                                   d_comp_stats_view,
+                                   codec.max_decompressed_size,
+                                   stream);
         break;
       case parquet::BROTLI:
         gpu_debrotli(d_comp_in,

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -2509,8 +2509,14 @@ def test_parquet_reader_decimal_columns():
     assert_eq(actual, expected)
 
 
-def test_parquet_reader_unsupported_compression(datadir):
+def test_parquet_reader_zstd_compression(datadir):
     fname = datadir / "spark_zstd.parquet"
-
-    with pytest.raises(RuntimeError):
-        cudf.read_parquet(fname)
+    try:
+        df = cudf.read_parquet(fname)
+        pdf = pd.read_parquet(fname)
+        assert_eq(df, pdf)
+    except RuntimeError as e:
+        if "Unsupported compression type" in str(e):
+            pytest.mark.xfail(reason="nvcomp build doesn't have zstd")
+        else:
+            raise e

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -189,7 +189,9 @@ def gdf_day_timestamps(pdf_day_timestamps):
     return cudf.DataFrame.from_pandas(pdf_day_timestamps)
 
 
-@pytest.fixture(params=["snappy", "gzip", "brotli", None, np.str_("snappy")])
+@pytest.fixture(
+    params=["snappy", "gzip", "brotli", "zstd", None, np.str_("snappy")]
+)
 def parquet_file(request, tmp_path_factory, pdf):
     fname = tmp_path_factory.mktemp("parquet") / (
         str(request.param) + "_test.parquet"
@@ -2509,8 +2511,10 @@ def test_parquet_reader_decimal_columns():
     assert_eq(actual, expected)
 
 
-def test_parquet_reader_unsupported_compression(datadir):
+def test_parquet_reader_zstd_compression(datadir):
     fname = datadir / "spark_zstd.parquet"
 
-    with pytest.raises(RuntimeError):
-        cudf.read_parquet(fname)
+    actual = cudf.read_parquet(fname)
+    expected = pd.read_parquet(fname)
+
+    assert_eq(actual, expected)

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -189,9 +189,7 @@ def gdf_day_timestamps(pdf_day_timestamps):
     return cudf.DataFrame.from_pandas(pdf_day_timestamps)
 
 
-@pytest.fixture(
-    params=["snappy", "gzip", "brotli", "zstd", None, np.str_("snappy")]
-)
+@pytest.fixture(params=["snappy", "gzip", "brotli", None, np.str_("snappy")])
 def parquet_file(request, tmp_path_factory, pdf):
     fname = tmp_path_factory.mktemp("parquet") / (
         str(request.param) + "_test.parquet"
@@ -2511,10 +2509,8 @@ def test_parquet_reader_decimal_columns():
     assert_eq(actual, expected)
 
 
-def test_parquet_reader_zstd_compression(datadir):
+def test_parquet_reader_unsupported_compression(datadir):
     fname = datadir / "spark_zstd.parquet"
 
-    actual = cudf.read_parquet(fname)
-    expected = pd.read_parquet(fname)
-
-    assert_eq(actual, expected)
+    with pytest.raises(RuntimeError):
+        cudf.read_parquet(fname)


### PR DESCRIPTION
Adds ZSTD compression type to the nvcomp adapter. The zstd header is conditionally included so the code works without nvcomp 2.3.

Test changes:
- nvcomp 2.3 still not used in CI, so almost no test changes;
- Modifies a Python test that assumes the Zstandard is not supported, to also pass if reading is successful.