### PR TITLE
Fix dask-cudf groupby handling when grouping by all columns

### DIFF
--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -681,10 +681,13 @@ def _groupby_supported(gb):
     )
 
 
-def _make_name(*args, sep="_"):
-    """Combine elements of `args` into a new string"""
-    _args = (arg for arg in args if arg != "")
-    return sep.join(_args)
+def _make_name(col_name, sep="_"):
+    """Combine elements of `col_name` into a single string, or no-op if
+    `col_name` is already a string
+    """
+    if isinstance(col_name, tuple):
+        return sep.join(name for name in col_name if name != "")
+    return col_name
 
 
 @_dask_cudf_nvtx_annotate
@@ -714,14 +717,14 @@ def _groupby_partition_agg(
                 _agg_dict[col].add(agg)
         _agg_dict[col] = list(_agg_dict[col])
         if set(agg_list).intersection({"std", "var"}):
-            pow2_name = _make_name(col, "pow2", sep=sep)
+            pow2_name = _make_name((col, "pow2"), sep=sep)
             df[pow2_name] = df[col].astype("float64").pow(2)
             _agg_dict[pow2_name] = ["sum"]
 
     gb = df.groupby(gb_cols, dropna=dropna, as_index=False, sort=sort).agg(
         _agg_dict
     )
-    gb.columns = [_make_name(*name, sep=sep) for name in gb.columns]
+    gb.columns = [_make_name(name, sep=sep) for name in gb.columns]
 
     if split_out == 1:
         output = {0: gb.copy(deep=False)}
@@ -776,7 +779,10 @@ def _tree_node_agg(dfs, gb_cols, split_out, dropna, sort, sep):
     )
 
     # Don't include the last aggregation in the column names
-    gb.columns = [_make_name(*name[:-1], sep=sep) for name in gb.columns]
+    gb.columns = [
+        _make_name(name[:-1] if isinstance(name, tuple) else name, sep=sep)
+        for name in gb.columns
+    ]
     return gb
 
 
@@ -829,27 +835,27 @@ def _finalize_gb_agg(
         agg_list = aggs.get(col, [])
         agg_set = set(agg_list)
         if agg_set.intersection({"mean", "std", "var"}):
-            count_name = _make_name(col, "count", sep=sep)
-            sum_name = _make_name(col, "sum", sep=sep)
+            count_name = _make_name((col, "count"), sep=sep)
+            sum_name = _make_name((col, "sum"), sep=sep)
             if agg_set.intersection({"std", "var"}):
-                pow2_sum_name = _make_name(col, "pow2", "sum", sep=sep)
+                pow2_sum_name = _make_name((col, "pow2", "sum"), sep=sep)
                 var = _var_agg(gb, col, count_name, sum_name, pow2_sum_name)
                 if "var" in agg_list:
-                    name_var = _make_name(col, "var", sep=sep)
+                    name_var = _make_name((col, "var"), sep=sep)
                     gb[name_var] = var
                 if "std" in agg_list:
-                    name_std = _make_name(col, "std", sep=sep)
+                    name_std = _make_name((col, "std"), sep=sep)
                     gb[name_std] = np.sqrt(var)
                 gb.drop(columns=[pow2_sum_name], inplace=True)
             if "mean" in agg_list:
-                mean_name = _make_name(col, "mean", sep=sep)
+                mean_name = _make_name((col, "mean"), sep=sep)
                 gb[mean_name] = gb[sum_name] / gb[count_name]
             if "sum" not in agg_list:
                 gb.drop(columns=[sum_name], inplace=True)
             if "count" not in agg_list:
                 gb.drop(columns=[count_name], inplace=True)
         if "collect" in agg_list:
-            collect_name = _make_name(col, "collect", sep=sep)
+            collect_name = _make_name((col, "collect"), sep=sep)
             gb[collect_name] = gb[collect_name].list.concat()
 
     # Ensure sorted keys if `sort=True`


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->

Modifies `_make_name` and its various calls throughout the groupby code to address the fact that groupbys can sometimes return an index (i.e. list of strings) rather than a multi-index (i.e. list of tuples); right now the only case I know of where that can occur is when we compute a `GroupBy.agg` with no aggregations, which happens if we attempt to compute a groupby agg grouping by all columns.

Closes #10863
