### PR TITLE
Make cudf::test::expect_columns_equal() to fail when comparing unsanitary lists.

### DIFF
--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -1454,8 +1454,8 @@ class lists_column_wrapper : public detail::column_wrapper {
       1,
       offsets.release(),
       values.release(),
-      static_cast<int>(!valid),
-      !valid ? cudf::create_null_mask(1, cudf::mask_state::ALL_NULL) : rmm::device_buffer{});
+      valid ? 0 : 1,
+      valid ? rmm::device_buffer{} : cudf::create_null_mask(1, cudf::mask_state::ALL_NULL));
   }
 
  private:

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -1454,7 +1454,7 @@ class lists_column_wrapper : public detail::column_wrapper {
       1,
       offsets.release(),
       values.release(),
-      !valid ? 1 : 0,
+      static_cast<int>(!valid),
       !valid ? cudf::create_null_mask(1, cudf::mask_state::ALL_NULL) : rmm::device_buffer{});
   }
 

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -1441,7 +1441,44 @@ class lists_column_wrapper : public detail::column_wrapper {
     build_from_nested(elements, validity);
   }
 
+  /**
+   * @brief Construct a list column containing a single empty, optionally null row.
+   *
+   * @param valid Whether or not the empty row is also null
+   */
+  static lists_column_wrapper<T> make_one_empty_row_column(bool valid = true)
+  {
+    cudf::test::fixed_width_column_wrapper<cudf::offset_type> offsets{0, 0};
+    cudf::test::fixed_width_column_wrapper<int> values{};
+    return lists_column_wrapper<T>(
+      1,
+      offsets.release(),
+      values.release(),
+      !valid ? 1 : 0,
+      !valid ? cudf::create_null_mask(1, cudf::mask_state::ALL_NULL) : rmm::device_buffer{});
+  }
+
  private:
+  /**
+   * @brief Construct a list column from constituent parts.
+   *
+   * @param num_rows The number of lists the column represents
+   * @param offsets The column of offset values for this column
+   * @param values The column of values bounded by the offsets
+   * @param null_count The number of null list entries
+   * @param null_mask The bits specifying the null lists in device memory
+   */
+  lists_column_wrapper(size_type num_rows,
+                       std::unique_ptr<cudf::column>&& offsets,
+                       std::unique_ptr<cudf::column>&& values,
+                       size_type null_count,
+                       rmm::device_buffer&& null_mask)
+  {
+    // construct the list column
+    wrapped = make_lists_column(
+      num_rows, std::move(offsets), std::move(values), null_count, std::move(null_mask));
+  }
+
   /**
    * @brief Initialize as a nested list column composed of other list columns.
    *

--- a/cpp/tests/quantiles/percentile_approx_test.cu
+++ b/cpp/tests/quantiles/percentile_approx_test.cu
@@ -404,7 +404,8 @@ TEST_F(PercentileApproxTest, EmptyInput)
                             3,
                             cudf::test::detail::make_null_mask(nulls.begin(), nulls.end()));
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+  // TODO: change percentile_approx to produce sanitary list outputs for this case.
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
 }
 
 TEST_F(PercentileApproxTest, EmptyPercentiles)

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -364,6 +364,39 @@ TEST_F(ColumnUtilitiesListsTest, Equivalence)
   }
 }
 
+TEST_F(ColumnUtilitiesListsTest, UnsanitaryLists)
+{
+  // unsanitary
+  //
+  // List<int32_t>:
+  //  Length : 1
+  //  Offsets : 0, 3
+  //  Null count: 1
+  //  0
+  //    0, 1, 2
+  cudf::test::fixed_width_column_wrapper<cudf::offset_type> offsets{0, 3};
+  cudf::test::fixed_width_column_wrapper<int> values{0, 1, 2};
+  auto l0 = cudf::make_lists_column(1,
+                                    offsets.release(),
+                                    values.release(),
+                                    1,
+                                    cudf::create_null_mask(1, cudf::mask_state::ALL_NULL));
+
+  // sanitary
+  //
+  // List<int32_t>:
+  //  Length : 1
+  //  Offsets : 0, 0
+  //  Null count: 1
+  //    0
+  auto l1 = cudf::test::lists_column_wrapper<int>::make_one_empty_row_column(false);
+
+  // equivalent, but not equal
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*l0, l1);
+  EXPECT_EQ(cudf::test::expect_columns_equal(*l0, l1, cudf::test::debug_output_level::QUIET),
+            false);
+}
+
 TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructure)
 {
   // list<int>

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -393,8 +393,7 @@ TEST_F(ColumnUtilitiesListsTest, UnsanitaryLists)
 
   // equivalent, but not equal
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*l0, l1);
-  EXPECT_EQ(cudf::test::expect_columns_equal(*l0, l1, cudf::test::debug_output_level::QUIET),
-            false);
+  EXPECT_FALSE(cudf::test::expect_columns_equal(*l0, l1, cudf::test::debug_output_level::QUIET));
 }
 
 TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructure)


### PR DESCRIPTION

Fixes:  https://github.com/rapidsai/cudf/issues/10855

Unsanitary lists (those with null rows that actually have backing underlying data) should not compare as equal to sanitized lists, but _should_ compare as equivalent.   Only one test in cudf was affected by this change, which I've opened a second issue for:
https://github.com/rapidsai/cudf/issues/10856


This PR also adds a utility function to `cudf::test::lists_column_wrapper`, 

`static lists_column_wrapper<T> make_one_empty_row_column(bool valid = true)`

Due to the way initializer lists and nested class initialization work, it was impossible to create a list column with 1 row that was empty, so I added this explicit function to handle the edge case.