### PR TITLE
Rename `get_sliced_child` to `sliced_child`.

### DIFF
--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -352,7 +352,7 @@ struct column_gatherer_impl<list_view> {
     // the nesting case.
     if (list.child().type() == cudf::data_type{type_id::LIST}) {
       // gather children
-      auto child = lists::detail::gather_list_nested(list.get_sliced_child(stream), gd, stream, mr);
+      auto child = lists::detail::gather_list_nested(list.sliced_child(stream), gd, stream, mr);
 
       // return the final column
       return make_lists_column(gather_map_size,
@@ -363,7 +363,7 @@ struct column_gatherer_impl<list_view> {
     }
 
     // it's a leaf.  do a regular gather
-    auto child = lists::detail::gather_list_leaf(list.get_sliced_child(stream), gd, stream, mr);
+    auto child = lists::detail::gather_list_leaf(list.sliced_child(stream), gd, stream, mr);
 
     // assemble final column
     return make_lists_column(gather_map_size,
@@ -461,7 +461,7 @@ struct column_gatherer_impl<struct_view> {
                    thrust::make_counting_iterator(column.num_children()),
                    std::back_inserter(sliced_children),
                    [structs_view = structs_column_view{column}](auto const idx) {
-                     return structs_view.get_sliced_child(idx);
+                     return structs_view.sliced_child(idx);
                    });
 
     std::vector<std::unique_ptr<cudf::column>> output_struct_members;

--- a/cpp/include/cudf/lists/lists_column_view.hpp
+++ b/cpp/include/cudf/lists/lists_column_view.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,11 +85,11 @@ class lists_column_view : private column_view {
    * Slice/split offset values are only stored at the root level of a list column.
    * So when doing computations on them, we need to apply that offset to
    * the child columns when recursing.  Most functions operating in a recursive manner
-   * on lists columns should be using `get_sliced_child()` instead of `child()`.
+   * on lists columns should be using `sliced_child()` instead of `child()`.
    *
    * @throw cudf::logic error if this is an empty column
    */
-  [[nodiscard]] column_view get_sliced_child(rmm::cuda_stream_view stream) const;
+  [[nodiscard]] column_view sliced_child(rmm::cuda_stream_view stream) const;
 
   /**
    * @brief Return first offset (accounting for column offset)

--- a/cpp/include/cudf/structs/structs_column_view.hpp
+++ b/cpp/include/cudf/structs/structs_column_view.hpp
@@ -61,11 +61,11 @@ class structs_column_view : public column_view {
    * Slice/split offset values are only stored at the root level of a struct column.
    * So when doing computations on them, we need to apply that offset to
    * the child columns when recursing.  Most functions operating in a recursive manner
-   * on struct columns should be using `get_sliced_child()` instead of `child()`.
+   * on struct columns should be using `sliced_child()` instead of `child()`.
    *
    * @throw cudf::logic error if this is an empty column
    */
-  [[nodiscard]] column_view get_sliced_child(int index) const;
+  [[nodiscard]] column_view sliced_child(int index) const;
 };         // class structs_column_view;
 /** @} */  // end of group
 }  // namespace cudf

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -413,7 +413,7 @@ void traverse_children::operator()<cudf::struct_view>(host_span<column_view cons
                    std::back_inserter(nth_children),
                    [child_index, stream](column_view const& col) {
                      structs_column_view scv(col);
-                     return scv.get_sliced_child(child_index);
+                     return scv.sliced_child(child_index);
                    });
 
     bounds_and_type_check(nth_children, stream);
@@ -434,7 +434,7 @@ void traverse_children::operator()<cudf::list_view>(host_span<column_view const>
   std::transform(
     cols.begin(), cols.end(), std::back_inserter(nth_children), [stream](column_view const& col) {
       lists_column_view lcv(col);
-      return lcv.get_sliced_child(stream);
+      return lcv.sliced_child(stream);
     });
   bounds_and_type_check(nth_children, stream);
 }

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -618,7 +618,7 @@ std::pair<src_buf_info*, size_type> buf_info_functor::operator()<cudf::struct_vi
   std::transform(thrust::make_counting_iterator(0),
                  thrust::make_counting_iterator(scv.num_children()),
                  std::back_inserter(sliced_children),
-                 [&scv](size_type child_index) { return scv.get_sliced_child(child_index); });
+                 [&scv](size_type child_index) { return scv.sliced_child(child_index); });
   return setup_source_buf_info(sliced_children.begin(),
                                sliced_children.end(),
                                head,

--- a/cpp/src/groupby/sort/group_merge_lists.cu
+++ b/cpp/src/groupby/sort/group_merge_lists.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ std::unique_ptr<column> group_merge_lists(column_view const& values,
 
   // The child column of the output lists column is just copied from the input column.
   auto child_column =
-    std::make_unique<column>(lists_column_view(values).get_sliced_child(stream), stream, mr);
+    std::make_unique<column>(lists_column_view(values).sliced_child(stream), stream, mr);
 
   return make_lists_column(num_groups,
                            std::move(offsets_column),

--- a/cpp/src/groupby/sort/group_scan_util.cuh
+++ b/cpp/src/groupby/sort/group_scan_util.cuh
@@ -208,7 +208,7 @@ struct group_scan_functor<K,
     //
     // Gather the children elements of the prefix min/max struct elements first.
     //
-    // Typically, we should use `get_sliced_child` for each child column to properly handle the
+    // Typically, we should use `sliced_child` for each child column to properly handle the
     // input if it is a sliced view. However, since the input to this function is just generated
     // from groupby internal APIs which is never a sliced view, we just use `child_begin` and
     // `child_end` iterators for simplicity.

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -47,12 +47,12 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
 
   auto constexpr offset_data_type = data_type{type_id::INT32};
 
-  auto const boolean_mask_sliced_child = boolean_mask.get_sliced_child(stream);
+  auto const boolean_mask_sliced_child = boolean_mask.sliced_child(stream);
 
   auto const make_filtered_child = [&] {
     auto filtered =
       cudf::detail::apply_boolean_mask(
-        cudf::table_view{{input.get_sliced_child(stream)}}, boolean_mask_sliced_child, stream, mr)
+        cudf::table_view{{input.sliced_child(stream)}}, boolean_mask_sliced_child, stream, mr)
         ->release();
     return std::move(filtered.front());
   };

--- a/cpp/src/lists/combine/concatenate_list_elements.cu
+++ b/cpp/src/lists/combine/concatenate_list_elements.cu
@@ -75,7 +75,7 @@ std::unique_ptr<column> concatenate_lists_ignore_null(column_view const& input,
 
   // The child column of the output lists column is just copied from the input column.
   auto out_entries = std::make_unique<column>(
-    lists_column_view(lists_column_view(input).get_sliced_child(stream)).get_sliced_child(stream),
+    lists_column_view(lists_column_view(input).sliced_child(stream)).sliced_child(stream),
     stream,
     mr);
 

--- a/cpp/src/lists/copying/concatenate.cu
+++ b/cpp/src/lists/copying/concatenate.cu
@@ -78,7 +78,7 @@ std::unique_ptr<column> merge_offsets(host_span<lists_column_view const> columns
         d_merged_offsets.begin<size_type>() + count,
         [local_shift] __device__(size_type offset) { return offset + local_shift; });
 
-      shift += c.get_sliced_child(stream).size();
+      shift += c.sliced_child(stream).size();
       count += c.size();
     }
   });
@@ -112,7 +112,7 @@ std::unique_ptr<column> concatenate(
                 [&total_list_count, &children, stream](lists_column_view const& l) {
                   // count total # of lists
                   total_list_count += l.size();
-                  children.push_back(l.get_sliced_child(stream));
+                  children.push_back(l.sliced_child(stream));
                 });
   auto data = cudf::detail::concatenate(children, stream, mr);
 

--- a/cpp/src/lists/copying/gather.cu
+++ b/cpp/src/lists/copying/gather.cu
@@ -173,7 +173,7 @@ std::unique_ptr<column> gather_list_nested(cudf::lists_column_view const& list,
   // the nesting case.
   if (list.child().type() == cudf::data_type{type_id::LIST}) {
     // gather children.
-    auto child = gather_list_nested(list.get_sliced_child(stream), child_gd, stream, mr);
+    auto child = gather_list_nested(list.sliced_child(stream), child_gd, stream, mr);
 
     // return the nested column
     return make_lists_column(gather_map_size,
@@ -186,7 +186,7 @@ std::unique_ptr<column> gather_list_nested(cudf::lists_column_view const& list,
   }
 
   // it's a leaf.  do a regular gather
-  auto child = gather_list_leaf(list.get_sliced_child(stream), child_gd, stream, mr);
+  auto child = gather_list_leaf(list.sliced_child(stream), child_gd, stream, mr);
 
   // assemble final column
   return make_lists_column(gather_map_size,

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -41,7 +41,7 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
   CUDF_EXPECTS(value_column.size() == gather_map.size(),
                "Gather map and list column should be same size");
 
-  auto const gather_map_sliced_child = gather_map.get_sliced_child(stream);
+  auto const gather_map_sliced_child = gather_map.sliced_child(stream);
   auto const gather_map_size         = gather_map_sliced_child.size();
   auto const gather_index_begin      = gather_map.offsets_begin() + 1;
   auto const gather_index_end        = gather_map.offsets_end();
@@ -80,7 +80,7 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
   auto child_gather_index_begin = cudf::detail::make_counting_transform_iterator(0, transformer);
 
   // Call gather on child of value_column
-  auto child_table = cudf::detail::gather(table_view({value_column.get_sliced_child(stream)}),
+  auto child_table = cudf::detail::gather(table_view({value_column.sliced_child(stream)}),
                                           child_gather_index_begin,
                                           child_gather_index_begin + gather_map_size,
                                           bounds_policy,

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -95,7 +95,7 @@ struct has_negative_nans_dispatch {
     return std::any_of(thrust::make_counting_iterator(0),
                        thrust::make_counting_iterator(input.num_children()),
                        [structs_view = structs_column_view{input}, stream](auto const child_idx) {
-                         auto const col = structs_view.get_sliced_child(child_idx);
+                         auto const col = structs_view.sliced_child(child_idx);
                          return type_dispatcher(
                            col.type(), has_negative_nans_dispatch{}, col, stream);
                        });
@@ -139,7 +139,7 @@ struct replace_negative_nans_dispatch {
                    thrust::make_counting_iterator(input.num_children()),
                    std::back_inserter(output_struct_members),
                    [structs_view = structs_column_view{input}, stream](auto const child_idx) {
-                     auto const col = structs_view.get_sliced_child(child_idx);
+                     auto const col = structs_view.sliced_child(child_idx);
                      return type_dispatcher(
                        col.type(), replace_negative_nans_dispatch{}, col, stream);
                    });
@@ -568,7 +568,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> drop_list_duplicates
   }
 
   // The child column containing list entries.
-  auto const keys_child = keys.get_sliced_child(stream);
+  auto const keys_child = keys.sliced_child(stream);
 
   // Generate a mapping from list entries to their 1-based list indices for the keys column.
   auto const entries_list_indices =
@@ -603,9 +603,8 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> drop_list_duplicates
     }
   }();
 
-  auto const sorting_table = values
-                               ? table_view{{keys_child, values.value().get_sliced_child(stream)}}
-                               : table_view{{keys_child}};
+  auto const sorting_table = values ? table_view{{keys_child, values.value().sliced_child(stream)}}
+                                    : table_view{{keys_child}};
   auto const sorted_table  = cudf::detail::gather(sorting_table,
                                                  sorted_order->view(),
                                                  out_of_bounds_policy::DONT_CHECK,

--- a/cpp/src/lists/explode.cu
+++ b/cpp/src/lists/explode.cu
@@ -114,7 +114,7 @@ std::unique_ptr<table> explode(table_view const& input_table,
                                rmm::mr::device_memory_resource* mr)
 {
   lists_column_view explode_col{input_table.column(explode_column_idx)};
-  auto sliced_child = explode_col.get_sliced_child(stream);
+  auto sliced_child = explode_col.sliced_child(stream);
   rmm::device_uvector<size_type> gather_map(sliced_child.size(), stream);
 
   // Sliced columns may require rebasing of the offsets.
@@ -150,7 +150,7 @@ std::unique_ptr<table> explode_position(table_view const& input_table,
                                         rmm::mr::device_memory_resource* mr)
 {
   lists_column_view explode_col{input_table.column(explode_column_idx)};
-  auto sliced_child = explode_col.get_sliced_child(stream);
+  auto sliced_child = explode_col.sliced_child(stream);
   rmm::device_uvector<size_type> gather_map(sliced_child.size(), stream);
 
   // Sliced columns may require rebasing of the offsets.
@@ -198,7 +198,7 @@ std::unique_ptr<table> explode_outer(table_view const& input_table,
                                      rmm::mr::device_memory_resource* mr)
 {
   lists_column_view explode_col{input_table.column(explode_column_idx)};
-  auto sliced_child  = explode_col.get_sliced_child(stream);
+  auto sliced_child  = explode_col.sliced_child(stream);
   auto counting_iter = thrust::make_counting_iterator(0);
   auto offsets       = explode_col.offsets_begin();
 

--- a/cpp/src/lists/lists_column_view.cu
+++ b/cpp/src/lists/lists_column_view.cu
@@ -43,7 +43,7 @@ column_view lists_column_view::child() const
   return column_view::child(child_column_index);
 }
 
-column_view lists_column_view::get_sliced_child(rmm::cuda_stream_view stream) const
+column_view lists_column_view::sliced_child(rmm::cuda_stream_view stream) const
 {
   // if I have a positive offset, I need to slice my child
   if (offset() > 0) {

--- a/cpp/src/lists/segmented_sort.cu
+++ b/cpp/src/lists/segmented_sort.cu
@@ -254,7 +254,7 @@ std::unique_ptr<column> sort_lists(lists_column_view const& input,
   // for non-numeric columns, calls segmented_sort_by_key.
   auto output_child = type_dispatcher(input.child().type(),
                                       SegmentedSortColumn{},
-                                      input.get_sliced_child(stream),
+                                      input.sliced_child(stream),
                                       output_offset->view(),
                                       column_order,
                                       null_precedence,
@@ -291,7 +291,7 @@ std::unique_ptr<column> stable_sort_lists(lists_column_view const& input,
                       return offset_index - *first;
                     });
 
-  auto const child              = input.get_sliced_child(stream);
+  auto const child              = input.sliced_child(stream);
   auto const sorted_child_table = stable_segmented_sort_by_key(table_view{{child}},
                                                                table_view{{child}},
                                                                output_offset->view(),

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -362,7 +362,7 @@ std::unique_ptr<column> column_merger::operator()<cudf::struct_view>(
   auto it = cudf::detail::make_counting_transform_iterator(
     0, [&, merger = column_merger{row_order_}](size_type i) {
       return cudf::type_dispatcher<dispatch_storage_type>(
-        lhs.child(i).type(), merger, lhs.get_sliced_child(i), rhs.get_sliced_child(i), stream, mr);
+        lhs.child(i).type(), merger, lhs.sliced_child(i), rhs.sliced_child(i), stream, mr);
     });
 
   auto merged_children   = std::vector<std::unique_ptr<column>>(it, it + lhs.num_children());

--- a/cpp/src/reductions/collect_ops.cu
+++ b/cpp/src/reductions/collect_ops.cu
@@ -36,7 +36,7 @@ std::unique_ptr<scalar> drop_duplicates(list_scalar const& scalar,
   auto list_wrapper   = lists::detail::make_lists_column_from_scalar(scalar, 1, stream, mr);
   auto lcw            = lists_column_view(list_wrapper->view());
   auto no_dup_wrapper = lists::drop_list_duplicates(lcw, nulls_equal, nans_equal, mr);
-  auto no_dup         = lists_column_view(no_dup_wrapper->view()).get_sliced_child(stream);
+  auto no_dup         = lists_column_view(no_dup_wrapper->view()).sliced_child(stream);
   return make_list_scalar(no_dup, stream, mr);
 }
 
@@ -61,7 +61,7 @@ std::unique_ptr<scalar> merge_lists(lists_column_view const& col,
                                     rmm::cuda_stream_view stream,
                                     rmm::mr::device_memory_resource* mr)
 {
-  auto flatten_col = col.get_sliced_child(stream);
+  auto flatten_col = col.sliced_child(stream);
   return make_list_scalar(flatten_col, stream, mr);
 }
 
@@ -83,7 +83,7 @@ std::unique_ptr<scalar> merge_sets(lists_column_view const& col,
                                    rmm::cuda_stream_view stream,
                                    rmm::mr::device_memory_resource* mr)
 {
-  auto flatten_col = col.get_sliced_child(stream);
+  auto flatten_col = col.sliced_child(stream);
   auto scalar      = std::make_unique<list_scalar>(flatten_col, true, stream, mr);
   return drop_duplicates(*scalar, nulls_equal, nans_equal, stream, mr);
 }

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -169,12 +169,12 @@ struct scan_functor<Op, cudf::struct_view> {
                            gather_map.begin(),
                            binop_generator.binop());
 
-    // Gather the children columns of the input column. Must use `get_sliced_child` to properly
+    // Gather the children columns of the input column. Must use `sliced_child` to properly
     // handle input in case it is a sliced view.
     auto const input_children = [&] {
       auto const it = cudf::detail::make_counting_transform_iterator(
         0, [structs_view = structs_column_view{input}, stream](auto const child_idx) {
-          return structs_view.get_sliced_child(child_idx);
+          return structs_view.sliced_child(child_idx);
         });
       return std::vector<column_view>(it, it + input.num_children());
     }();

--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -91,10 +91,9 @@ struct interleave_columns_impl<T, std::enable_if_t<std::is_same_v<T, cudf::struc
     std::vector<std::unique_ptr<cudf::column>> output_struct_members;
     for (size_type child_idx = 0; child_idx < num_children; ++child_idx) {
       // Collect children columns from the input structs columns at index `child_idx`.
-      auto const child_iter =
-        thrust::make_transform_iterator(structs_columns.begin(), [child_idx](auto const& col) {
-          return structs_column_view(col).get_sliced_child(child_idx);
-        });
+      auto const child_iter = thrust::make_transform_iterator(
+        structs_columns.begin(),
+        [child_idx](auto const& col) { return structs_column_view(col).sliced_child(child_idx); });
       auto children = std::vector<column_view>(child_iter, child_iter + num_columns);
 
       auto const child_type = children.front().type();

--- a/cpp/src/strings/combine/join_list_elements.cu
+++ b/cpp/src/strings/combine/join_list_elements.cu
@@ -186,7 +186,7 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
   if (num_rows == 0) { return make_empty_column(type_id::STRING); }
 
   // Accessing the child strings column of the lists column must be done by calling `child()` on the
-  // lists column, not `get_sliced_child()`. This is because calling to `offsets_begin()` on the
+  // lists column, not `sliced_child()`. This is because calling to `offsets_begin()` on the
   // lists column returns a pointer to the offsets of the original lists column, which may not start
   // from `0`.
   auto const strings_col     = strings_column_view(lists_strings_column.child());
@@ -260,7 +260,7 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
   if (num_rows == 0) { return make_empty_column(type_id::STRING); }
 
   // Accessing the child strings column of the lists column must be done by calling `child()` on the
-  // lists column, not `get_sliced_child()`. This is because calling to `offsets_begin()` on the
+  // lists column, not `sliced_child()`. This is because calling to `offsets_begin()` on the
   // lists column returns a pointer to the offsets of the original lists column, which may not start
   // from `0`.
   auto const strings_col     = strings_column_view(lists_strings_column.child());

--- a/cpp/src/structs/structs_column_view.cpp
+++ b/cpp/src/structs/structs_column_view.cpp
@@ -27,7 +27,7 @@ structs_column_view::structs_column_view(column_view const& rhs) : column_view{r
 
 column_view structs_column_view::parent() const { return *this; }
 
-column_view structs_column_view::get_sliced_child(int index) const
+column_view structs_column_view::sliced_child(int index) const
 {
   std::vector<column_view> children;
   children.reserve(child(index).num_children());

--- a/cpp/src/structs/utilities.cpp
+++ b/cpp/src/structs/utilities.cpp
@@ -62,7 +62,7 @@ std::vector<std::vector<column_view>> extract_ordered_struct_children(
                    "Mismatch in number of children during struct concatenate");
       CUDF_EXPECTS(struct_cols[0].child(child_index).type() == scv.child(child_index).type(),
                    "Mismatch in child types during struct concatenate");
-      children.push_back(scv.get_sliced_child(child_index));
+      children.push_back(scv.sliced_child(child_index));
     }
 
     result.push_back(std::move(children));
@@ -157,7 +157,7 @@ struct table_flattener {
       if (not null_precedence.empty()) { flat_null_precedence.push_back(col_null_order); }
     }
     for (decltype(col.num_children()) i = 0; i < col.num_children(); ++i) {
-      auto const& child = col.get_sliced_child(i);
+      auto const& child = col.sliced_child(i);
       if (child.type().id() == type_id::STRUCT) {
         flatten_struct_column(structs_column_view{child}, col_order, col_null_order);
       } else {
@@ -365,7 +365,7 @@ std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_paren
 
   // Function to rewrite child null mask.
   auto rewrite_child_mask = [&](auto const& child_idx) {
-    auto child = structs_column.get_sliced_child(child_idx);
+    auto child = structs_column.sliced_child(child_idx);
 
     // If struct is not nullable, child null mask is retained. NOOP.
     if (not structs_column.nullable()) { return child; }

--- a/cpp/src/transform/row_bit_count.cu
+++ b/cpp/src/transform/row_bit_count.cu
@@ -221,7 +221,7 @@ struct flatten_functor {
 
     lists_column_view lcv(col);
     auto iter = cudf::detail::make_counting_transform_iterator(
-      0, [col = lcv.get_sliced_child(stream)](auto) { return col; });
+      0, [col = lcv.sliced_child(stream)](auto) { return col; });
     h_info.complex_type_count++;
 
     flatten_hierarchy(
@@ -246,7 +246,7 @@ struct flatten_functor {
 
     structs_column_view scv(col);
     auto iter = cudf::detail::make_counting_transform_iterator(
-      0, [&scv](auto i) { return scv.get_sliced_child(i); });
+      0, [&scv](auto i) { return scv.sliced_child(i); });
     flatten_hierarchy(iter,
                       iter + scv.num_children(),
                       out,

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -280,12 +280,12 @@ struct column_property_comparator {
     cudf::lists_column_view rhs_l(rhs);
 
     // recurse
-    auto lhs_child = lhs_l.get_sliced_child(rmm::cuda_stream_default);
+    auto lhs_child = lhs_l.sliced_child(rmm::cuda_stream_default);
     // note: if a column is all nulls or otherwise empty, no indices are generated and no recursion
     // happens
     auto lhs_child_indices = generate_child_row_indices(lhs_l, lhs_row_indices);
     if (lhs_child_indices->size() > 0) {
-      auto rhs_child         = rhs_l.get_sliced_child(rmm::cuda_stream_default);
+      auto rhs_child         = rhs_l.sliced_child(rmm::cuda_stream_default);
       auto rhs_child_indices = generate_child_row_indices(rhs_l, rhs_row_indices);
       return cudf::type_dispatcher(lhs_child.type(),
                                    column_property_comparator<check_exact_equality>{},
@@ -311,8 +311,8 @@ struct column_property_comparator {
     structs_column_view r_scv(rhs);
 
     for (size_type i = 0; i < lhs.num_children(); i++) {
-      column_view lhs_child = l_scv.get_sliced_child(i);
-      column_view rhs_child = r_scv.get_sliced_child(i);
+      column_view lhs_child = l_scv.sliced_child(i);
+      column_view rhs_child = r_scv.sliced_child(i);
       if (!cudf::type_dispatcher(lhs_child.type(),
                                  column_property_comparator<check_exact_equality>{},
                                  lhs_child,
@@ -648,12 +648,12 @@ struct column_comparator_impl<list_view, check_exact_equality> {
     }
 
     // recurse.
-    auto lhs_child = lhs_l.get_sliced_child(rmm::cuda_stream_default);
+    auto lhs_child = lhs_l.sliced_child(rmm::cuda_stream_default);
     // note: if a column is all nulls or otherwise empty, no indices are generated and no recursion
     // happens
     auto lhs_child_indices = generate_child_row_indices(lhs_l, lhs_row_indices);
     if (lhs_child_indices->size() > 0) {
-      auto rhs_child         = rhs_l.get_sliced_child(rmm::cuda_stream_default);
+      auto rhs_child         = rhs_l.sliced_child(rmm::cuda_stream_default);
       auto rhs_child_indices = generate_child_row_indices(rhs_l, rhs_row_indices);
       return cudf::type_dispatcher(lhs_child.type(),
                                    column_comparator<check_exact_equality>{},
@@ -684,8 +684,8 @@ struct column_comparator_impl<struct_view, check_exact_equality> {
     structs_column_view r_scv(rhs);
 
     for (size_type i = 0; i < lhs.num_children(); i++) {
-      column_view lhs_child = l_scv.get_sliced_child(i);
-      column_view rhs_child = r_scv.get_sliced_child(i);
+      column_view lhs_child = l_scv.sliced_child(i);
+      column_view rhs_child = r_scv.sliced_child(i);
       if (!cudf::type_dispatcher(lhs_child.type(),
                                  column_comparator<check_exact_equality>{},
                                  lhs_child,
@@ -1070,7 +1070,7 @@ struct column_view_printer {
     lists_column_view lcv(col);
 
     // propagate slicing to the child if necessary
-    column_view child    = lcv.get_sliced_child(rmm::cuda_stream_default);
+    column_view child    = lcv.sliced_child(rmm::cuda_stream_default);
     bool const is_sliced = lcv.offset() > 0 || child.offset() > 0;
 
     std::string tmp =
@@ -1113,7 +1113,7 @@ struct column_view_printer {
       iter + view.num_children(),
       std::ostream_iterator<std::string>(out_stream, "\n"),
       [&](size_type index) {
-        auto child = view.get_sliced_child(index);
+        auto child = view.sliced_child(index);
 
         // non-nested types don't typically display their null masks, so do it here for convenience.
         return (!is_nested(child.type()) && child.nullable()

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -480,7 +480,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicatesWithKey
 
     // Extract list offsets and a column of struct<keys, values> from the input lists column.
     auto const lists_keys_vals = cudf::lists_column_view(*input_cv);
-    auto const keys_vals = lists_keys_vals.get_sliced_child(rmm::cuda_stream_default);
+    auto const keys_vals = lists_keys_vals.sliced_child(rmm::cuda_stream_default);
     CUDF_EXPECTS(keys_vals.type().id() == cudf::type_id::STRUCT,
                  "Input column has child that is not a structs column.");
     CUDF_EXPECTS(keys_vals.num_children() == 2,

--- a/java/src/main/native/src/map_lookup.cu
+++ b/java/src/main/native/src/map_lookup.cu
@@ -135,7 +135,7 @@ void map_input_check(column_view const &map_column, rmm::cuda_stream_view stream
   CUDF_EXPECTS(map_column.type().id() == type_id::LIST, "Expected LIST<STRUCT<key,value>>.");
 
   lists_column_view lcv{map_column};
-  column_view structs_column = lcv.get_sliced_child(stream);
+  column_view structs_column = lcv.sliced_child(stream);
 
   CUDF_EXPECTS(structs_column.type().id() == type_id::STRUCT, "Expected LIST<STRUCT<key,value>>.");
 
@@ -188,7 +188,7 @@ std::unique_ptr<column> map_lookup(column_view const &map_column, string_scalar 
   }
 
   lists_column_view lcv{map_column};
-  column_view structs_column = lcv.get_sliced_child(stream);
+  column_view structs_column = lcv.sliced_child(stream);
   // Two-pass plan: construct gather map, and then gather() on structs_column.child(1). Plan A.
   // (Can do in one pass perhaps, but that's Plan B.)
 


### PR DESCRIPTION
This PR renames the lists/structs methods `get_sliced_child` to `sliced_child`. This resolves some inconsistent naming (like `structs_column_device_view::sliced_child`). Resolves #10666.