### PR TITLE
Rename `sliced_child` to `get_sliced_child`.

### DIFF
--- a/cpp/include/cudf/lists/lists_column_device_view.cuh
+++ b/cpp/include/cudf/lists/lists_column_device_view.cuh
@@ -83,7 +83,7 @@ class lists_column_device_view : private column_device_view {
   /**
    * @brief Fetches the child column of the underlying list column with offset and size applied
    */
-  [[nodiscard]] __device__ inline column_device_view sliced_child() const
+  [[nodiscard]] __device__ inline column_device_view get_sliced_child() const
   {
     auto start = offset_at(0);
     auto end   = offset_at(size());

--- a/cpp/include/cudf/structs/structs_column_device_view.cuh
+++ b/cpp/include/cudf/structs/structs_column_device_view.cuh
@@ -57,7 +57,7 @@ class structs_column_device_view : private column_device_view {
   /**
    * @brief Fetches the child column of the underlying struct column.
    */
-  [[nodiscard]] __device__ inline column_device_view sliced_child(size_type idx) const
+  [[nodiscard]] __device__ inline column_device_view get_sliced_child(size_type idx) const
   {
     return child(idx).slice(offset(), size());
   }

--- a/cpp/include/cudf/table/experimental/row_operators.cuh
+++ b/cpp/include/cudf/table/experimental/row_operators.cuh
@@ -257,8 +257,8 @@ class device_row_comparator {
         }
 
         // Non-empty structs have been modified to only have 1 child when using this.
-        lcol = detail::structs_column_device_view(lcol).sliced_child(0);
-        rcol = detail::structs_column_device_view(rcol).sliced_child(0);
+        lcol = detail::structs_column_device_view(lcol).get_sliced_child(0);
+        rcol = detail::structs_column_device_view(rcol).get_sliced_child(0);
         ++depth;
       }
 
@@ -769,8 +769,8 @@ class device_row_comparator {
         if (lcol.type().id() == type_id::STRUCT) {
           if (lcol.num_child_columns() == 0) { return true; }
           // Non-empty structs are assumed to be decomposed and contain only one child
-          lcol = detail::structs_column_device_view(lcol).sliced_child(0);
-          rcol = detail::structs_column_device_view(rcol).sliced_child(0);
+          lcol = detail::structs_column_device_view(lcol).get_sliced_child(0);
+          rcol = detail::structs_column_device_view(rcol).get_sliced_child(0);
         } else if (lcol.type().id() == type_id::LIST) {
           auto l_list_col = detail::lists_column_device_view(lcol);
           auto r_list_col = detail::lists_column_device_view(rcol);
@@ -781,8 +781,8 @@ class device_row_comparator {
             return false;
           }
 
-          lcol = l_list_col.sliced_child();
-          rcol = r_list_col.sliced_child();
+          lcol = l_list_col.get_sliced_child();
+          rcol = r_list_col.get_sliced_child();
           if (lcol.size() != rcol.size()) { return false; }
         }
       }
@@ -1033,7 +1033,7 @@ class device_row_hasher {
         if (curr_col.type().id() == type_id::STRUCT) {
           if (curr_col.num_child_columns() == 0) { return hash; }
           // Non-empty structs are assumed to be decomposed and contain only one child
-          curr_col = detail::structs_column_device_view(curr_col).sliced_child(0);
+          curr_col = detail::structs_column_device_view(curr_col).get_sliced_child(0);
         } else if (curr_col.type().id() == type_id::LIST) {
           auto list_col   = detail::lists_column_device_view(curr_col);
           auto list_sizes = make_list_size_iterator(list_col);
@@ -1041,7 +1041,7 @@ class device_row_hasher {
             list_sizes, list_sizes + list_col.size(), hash, [](auto hash, auto size) {
               return cudf::detail::hash_combine(hash, hash_fn<size_type>{}(size));
             });
-          curr_col = list_col.sliced_child();
+          curr_col = list_col.get_sliced_child();
         }
       }
       for (int i = 0; i < curr_col.size(); ++i) {


### PR DESCRIPTION
This PR renames the lists/structs device view method `sliced_child` to `get_sliced_child`. This resolves some inconsistent naming (`structs_column_view::get_sliced_child` vs. `structs_column_device_view::sliced_child`). Resolves #10666.