### PR TITLE
Fix grouped covariance to require both values to be convertible to double.

### DIFF
--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -133,7 +133,7 @@ std::unique_ptr<column> group_covariance(column_view const& values_0,
       .type();
   };
   bool const is_convertible =
-    type_dispatcher(get_base_type(values_0), is_double_convertible_impl{}) or
+    type_dispatcher(get_base_type(values_0), is_double_convertible_impl{}) and
     type_dispatcher(get_base_type(values_1), is_double_convertible_impl{});
 
   CUDF_EXPECTS(is_convertible,
@@ -186,7 +186,7 @@ std::unique_ptr<column> group_correlation(column_view const& covariance,
 {
   using result_type = id_to_type<type_id::FLOAT64>;
   CUDF_EXPECTS(covariance.type().id() == type_id::FLOAT64,
-               "Covariance result as FLOAT64 is supported");
+               "Covariance result must be FLOAT64");
   auto stddev0_ptr = stddev_0.begin<result_type>();
   auto stddev1_ptr = stddev_1.begin<result_type>();
   auto stddev_iter = thrust::make_zip_iterator(thrust::make_tuple(stddev0_ptr, stddev1_ptr));

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -185,8 +185,7 @@ std::unique_ptr<column> group_correlation(column_view const& covariance,
                                           rmm::mr::device_memory_resource* mr)
 {
   using result_type = id_to_type<type_id::FLOAT64>;
-  CUDF_EXPECTS(covariance.type().id() == type_id::FLOAT64,
-               "Covariance result must be FLOAT64");
+  CUDF_EXPECTS(covariance.type().id() == type_id::FLOAT64, "Covariance result must be FLOAT64");
   auto stddev0_ptr = stddev_0.begin<result_type>();
   auto stddev1_ptr = stddev_1.begin<result_type>();
   auto stddev_iter = thrust::make_zip_iterator(thrust::make_tuple(stddev0_ptr, stddev1_ptr));

--- a/cpp/tests/groupby/covariance_tests.cpp
+++ b/cpp/tests/groupby/covariance_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,22 @@ using supported_types = RemoveIf<ContainedIn<Types<bool>>, cudf::test::NumericTy
 
 TYPED_TEST_SUITE(groupby_covariance_test, supported_types);
 using K = int32_t;
+
+TYPED_TEST(groupby_covariance_test, invalid_types)
+{
+  using V = TypeParam;
+
+  auto keys     = fixed_width_column_wrapper<K>{{1, 2, 2, 1}};
+  auto member_0 = fixed_width_column_wrapper<V>{{1, 1, 1, 2}};
+  // Covariance aggregations require all types are convertible to double, but
+  // timestamp_D cannot be converted to double.
+  auto member_1 =
+    fixed_width_column_wrapper<cudf::timestamp_D, cudf::timestamp_D::rep>{{0, 0, 1, 1}};
+  auto vals = structs{{member_0, member_1}};
+
+  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  test_single_agg(keys, vals, keys, vals, std::move(agg), force_use_sort_impl::YES);
+}
 
 TYPED_TEST(groupby_covariance_test, basic)
 {

--- a/cpp/tests/groupby/covariance_tests.cpp
+++ b/cpp/tests/groupby/covariance_tests.cpp
@@ -51,9 +51,8 @@ TYPED_TEST(groupby_covariance_test, invalid_types)
   auto member_0 = fixed_width_column_wrapper<V>{{1, 1, 1, 2}};
   // Covariance aggregations require all types are convertible to double, but
   // timestamp_D cannot be converted to double.
-  auto member_1 =
-    fixed_width_column_wrapper<cudf::timestamp_D, cudf::timestamp_D::rep>{{0, 0, 1, 1}};
-  auto vals = structs{{member_0, member_1}};
+  auto member_1 = fixed_width_column_wrapper<cudf::duration_D, cudf::duration::rep>{{0, 0, 1, 1}};
+  auto vals     = structs{{member_0, member_1}};
 
   auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
   test_single_agg(keys, vals, keys, vals, std::move(agg), force_use_sort_impl::YES);

--- a/cpp/tests/groupby/covariance_tests.cpp
+++ b/cpp/tests/groupby/covariance_tests.cpp
@@ -50,12 +50,13 @@ TYPED_TEST(groupby_covariance_test, invalid_types)
   auto keys     = fixed_width_column_wrapper<K>{{1, 2, 2, 1}};
   auto member_0 = fixed_width_column_wrapper<V>{{1, 1, 1, 2}};
   // Covariance aggregations require all types are convertible to double, but
-  // timestamp_D cannot be converted to double.
-  auto member_1 = fixed_width_column_wrapper<cudf::duration_D, cudf::duration::rep>{{0, 0, 1, 1}};
+  // duration_D cannot be converted to double.
+  auto member_1 = fixed_width_column_wrapper<cudf::duration_D, cudf::duration_D::rep>{{0, 0, 1, 1}};
   auto vals     = structs{{member_0, member_1}};
 
   auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
-  test_single_agg(keys, vals, keys, vals, std::move(agg), force_use_sort_impl::YES);
+  EXPECT_THROW(test_single_agg(keys, vals, keys, vals, std::move(agg), force_use_sort_impl::YES),
+               cudf::logic_error);
 }
 
 TYPED_TEST(groupby_covariance_test, basic)


### PR DESCRIPTION
This PR changes a requirement to ensure that both value inputs to a sort-groupby covariance computation are convertible to double.