### PR TITLE
Include <optional> for GCC 11 compatibility.

### DIFF
--- a/cpp/benchmarks/common/generate_input.hpp
+++ b/cpp/benchmarks/common/generate_input.hpp
@@ -16,10 +16,11 @@
 
 #pragma once
 
-#include <map>
-
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/traits.hpp>
+
+#include <map>
+#include <optional>
 
 /**
  * @file generate_input.hpp


### PR DESCRIPTION
This PR fixes a missing include in `generate_input.hpp` that prevents benchmarks from building with GCC 11.