### PR TITLE
Clarify append deprecation notice.

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2326,8 +2326,8 @@ class IndexedFrame(Frame):
         self, other, ignore_index=False, verify_integrity=False, sort=None
     ):
         warnings.warn(
-            "append is deprecated and will be removed in a future version. "
-            "Use concat instead.",
+            "The append method is deprecated and will be removed in a future "
+            "version. Use cudf.concat instead.",
             FutureWarning,
         )
         if verify_integrity not in (None, False):


### PR DESCRIPTION
This clarifies that the deprecated `append` method is replaced by a top-level function `cudf.concat`. This has caused some user confusion, because it's not just a name change (`DataFrame.concat` doesn't exist).