### PR TITLE
Fix license families to match all-caps expected by conda-verify.

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -65,8 +65,8 @@ test:                                   # [linux64]
     - cudf                              # [linux64]
 
 about:
-  home: http://rapids.ai/
+  home: https://rapids.ai/
   license: Apache-2.0
-  license_family: Apache
+  license_family: APACHE
   license_file: LICENSE
   summary: cuDF GPU DataFrame core library

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -45,8 +45,8 @@ test:                                   # [linux64]
     - cudf_kafka                        # [linux64]
 
 about:
-  home: http://rapids.ai/
+  home: https://rapids.ai/
   license: Apache-2.0
-  license_family: Apache
+  license_family: APACHE
   license_file: LICENSE
   summary: libcudf_kafka library

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -41,8 +41,8 @@ test:                                   # [linux64]
     - custreamz                         # [linux64]
 
 about:
-  home: http://rapids.ai/
+  home: https://rapids.ai/
   license: Apache-2.0
-  license_family: Apache
+  license_family: APACHE
   license_file: LICENSE
   summary: cuStreamz library

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -42,8 +42,8 @@ test:                                   # [linux64]
 
 
 about:
-  home: http://rapids.ai/
+  home: https://rapids.ai/
   license: Apache-2.0
-  license_family: Apache
+  license_family: APACHE
   license_file: LICENSE
   summary: dask-cudf library

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -279,9 +279,9 @@ outputs:
         - test -f $PREFIX/include/cudf_test/type_list_utilities.hpp
         - test -f $PREFIX/include/cudf_test/type_lists.hpp
     about:
-      home: http://rapids.ai/
+      home: https://rapids.ai/
       license: Apache-2.0
-      license_family: Apache
+      license_family: APACHE
       license_file: LICENSE
       summary: libcudf library
   - name: libcudf_kafka
@@ -302,9 +302,9 @@ outputs:
       commands:
         - test -f $PREFIX/lib/libcudf_kafka.so
     about:
-      home: http://rapids.ai/
+      home: https://rapids.ai/
       license: Apache-2.0
-      license_family: Apache
+      license_family: APACHE
       license_file: LICENSE
       summary: libcudf_kafka library
   - name: libcudf-example
@@ -326,9 +326,9 @@ outputs:
       run:
         - {{ pin_subpackage('libcudf', exact=True) }}
     about:
-      home: http://rapids.ai/
+      home: https://rapids.ai/
       license: Apache-2.0
-      license_family: Apache
+      license_family: APACHE
       license_file: LICENSE
       summary: libcudf_example library
   - name: libcudf-tests

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -349,8 +349,8 @@ outputs:
         - gtest {{ gtest_version }}
         - gmock {{ gtest_version }}
     about:
-      home: http://rapids.ai/
+      home: https://rapids.ai/
       license: Apache-2.0
-      license_family: Apache
+      license_family: APACHE
       license_file: LICENSE
       summary: libcudf test & benchmark executables


### PR DESCRIPTION
This PR fixes warning C1115 from conda-build and conda-verify in the package recipes.

```
tmp/tmpuvqmv1nw/dask-cudf-22.06.00a-cuda_11_py39_g425f2c4930_298.tar.bz2: C1115 Found invalid license "Apache" in info/index.json
```

For context, conda-build does some normalization of the license family (converting it to all caps) but conda-verify does not perform the same normalization.
- https://github.com/conda/conda-build/blob/1ed8da062f123e1fbca604df26b064b267a3d094/conda_build/license_family.py#L108
- https://github.com/conda/conda-verify/blob/f89feaa0d93c6c3f71ce9c2418b28ca5aef53127/conda_verify/checks.py#L248