### PR TITLE
Generate Doxygen Tag File for Libcudf

### DIFF
--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -2174,7 +2174,7 @@ TAGFILES               = rmm.tag=https://docs.rapids.ai/api/librmm/22.06
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = html/libcudf.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
A [doxygen tag file](https://www.doxygen.nl/manual/external.html) is a compact representation of entries in the doxygen documentation. Doxygen can generate tag files and read tag files from external sources. Local test shows that including tag file for libcudf does not have visible impact on build time and the tag file size is manageable (~126KB).

This is similar to rmm tag file: 
https://github.com/rapidsai/rmm/blob/c49493dea6caf7e8c840b1c83f20caa50de92d5f/doxygen/Doxyfile#L2084
