### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -8,6 +8,8 @@ channels:
   - dask/label/dev
   - conda-forge
 dependencies:
+  - c-compiler
+  - cxx-compiler
   - clang=11.1.0
   - clang-tools=11.1.0
   - cupy>=9.5.0,<11.0.0a0
@@ -76,3 +78,8 @@ dependencies:
       - git+https://github.com/python-streamz/streamz.git@master
       - pyorc
   - ptxcompiler  # [linux64]
+  - gcc_linux-64=9.3.0 # [linux64]
+  - sysroot_linux-64==2.17 # [linux64]
+  # Un-comment following lines for ARM specific packages.
+  # - gcc_linux-aarch64=9.3.0 # [aarch64]
+  # - sysroot_linux-aarch64==2.17 # [aarch64]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.