### PR TITLE
Fix the behavior of index binary comparison operators with nulls.

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -891,6 +891,9 @@ class GenericIndex(SingleColumnFrame, BaseIndex):
         # explicitly _do not_ use isinstance here: we want only boolean
         # GenericIndexes, not dtype-specific subclasses.
         if type(ret) is GenericIndex and ret.dtype.kind == "b":
+            # In pandas nan != anything, so we must replace the null results of
+            # our operators with the operator-appropriate value.
+            ret._column[ret._column.isnull()] = op == "__ne__"
             return ret.values
         return ret
 

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -2962,3 +2962,24 @@ def test_binops_dot(df, other):
     got = df @ other
 
     utils.assert_eq(expected, got)
+
+
+@pytest.mark.parametrize("binop", _binops_compare)
+def test_index_nulls(binop):
+    gidx = cudf.Index([1.0, 2.0, None, 4.0])
+    pidx = gidx.to_pandas()
+
+    # We have to copy the index here because the following returns True:
+    # idx = pd.Index([np.nan], dtype='float64')
+    # idx > idx  # [ True]
+    # pandas seems to be treating this case specially because lhs[0] is rhs[0]
+    expected = binop(pidx, pidx.copy())
+    got = binop(gidx, gidx)
+    utils.assert_eq(got, expected)
+
+    gidx2 = cudf.Index([1, 2, 3, 4])
+    pidx2 = gidx2.to_pandas()
+
+    expected = binop(pidx, pidx2)
+    got = binop(gidx, gidx2)
+    utils.assert_eq(got, expected)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->
Operations like `Index([None]) == Index([None])` currently fail because the returned value is a cupy array (pandas Index binops return numpy arrays) and those don't support nulls. Since our usual practice of propagating nulls won't work, I've modified these results to match pandas behavior.