### PR TITLE
Enable Zstandard decompression only when all nvcomp integrations are enabled

### DIFF
--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -1728,7 +1728,4 @@ def test_orc_reader_zstd_compression(list_struct_buff):
         got = cudf.read_orc(buffer)
         assert_eq(expected, got)
     except RuntimeError as e:
-        if "Unsupported compression type" in str(e):
-            pytest.mark.xfail(reason="nvcomp build doesn't have zstd")
-        else:
-            raise e
+        pytest.mark.xfail(reason="zstd support is not enabled")

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -1727,5 +1727,5 @@ def test_orc_reader_zstd_compression(list_struct_buff):
     try:
         got = cudf.read_orc(buffer)
         assert_eq(expected, got)
-    except RuntimeError as e:
+    except RuntimeError:
         pytest.mark.xfail(reason="zstd support is not enabled")

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -2515,5 +2515,5 @@ def test_parquet_reader_zstd_compression(datadir):
         df = cudf.read_parquet(fname)
         pdf = pd.read_parquet(fname)
         assert_eq(df, pdf)
-    except RuntimeError as e:
+    except RuntimeError:
         pytest.mark.xfail(reason="zstd support is not enabled")

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -2516,7 +2516,4 @@ def test_parquet_reader_zstd_compression(datadir):
         pdf = pd.read_parquet(fname)
         assert_eq(df, pdf)
     except RuntimeError as e:
-        if "Unsupported compression type" in str(e):
-            pytest.mark.xfail(reason="nvcomp build doesn't have zstd")
-        else:
-            raise e
+        pytest.mark.xfail(reason="zstd support is not enabled")


### PR DESCRIPTION
Closes #9055
Limiting due to known nvcomp issues.