### PR TITLE
Expose row-group size options in cudf ParquetWriter

### DIFF
--- a/python/cudf/cudf/_lib/cpp/io/parquet.pxd
+++ b/python/cudf/cudf/_lib/cpp/io/parquet.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 
 from libc.stdint cimport uint8_t
 from libcpp cimport bool
@@ -192,10 +192,10 @@ cdef extern from "cudf/io/parquet.hpp" namespace "cudf::io" nogil:
         chunked_parquet_writer_options_builder& compression(
             cudf_io_types.compression_type compression
         ) except +
-        parquet_writer_options_builder& row_group_size_bytes(
+        chunked_parquet_writer_options_builder& row_group_size_bytes(
             size_t val
         ) except+
-        parquet_writer_options_builder& row_group_size_rows(
+        chunked_parquet_writer_options_builder& row_group_size_rows(
             size_type val
         ) except+
 

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -447,7 +447,7 @@ cdef class ParquetWriter:
 
     def __cinit__(self, object filepath_or_buffer, object index=None,
                   object compression=None, str statistics="ROWGROUP",
-                  int row_group_size_bytes=13369344,
+                  int row_group_size_bytes=134217728,
                   int row_group_size_rows=1000000):
         filepaths_or_buffers = (
             list(filepath_or_buffer)

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -410,6 +410,26 @@ cdef class ParquetWriter:
     ParquetWriter lets you incrementally write out a Parquet file from a series
     of cudf tables
 
+    Parameters
+    ----------
+    filepath_or_buffer : str, io.IOBase, os.PathLike, or list
+        File path or buffer to write to. The argument may also correspond
+        to a list of file paths or buffers.
+    index : bool or None, default None
+        If ``True``, include a dataframe's index(es) in the file output.
+        If ``False``, they will not be written to the file. If ``None``,
+        index(es) other than RangeIndex will be saved as columns.
+    compression : {'snappy', None}, default 'snappy'
+        Name of the compression to use. Use ``None`` for no compression.
+    statistics : {'ROWGROUP', 'PAGE', 'NONE'}, default 'ROWGROUP'
+        Level at which column statistics should be included in file.
+    row_group_size_bytes: int, default 13369344
+        Maximum size of each stripe of the output.
+        By default, 13369344 (128MB) will be used.
+    row_group_size_rows: int, default 1000000
+        Maximum number of rows of each stripe of the output.
+        By default, 1000000 (10^6 rows) will be used.
+
     See Also
     --------
     cudf.io.parquet.write_parquet
@@ -422,25 +442,25 @@ cdef class ParquetWriter:
     cdef cudf_io_types.statistics_freq stat_freq
     cdef cudf_io_types.compression_type comp_type
     cdef object index
-    cdef Py_ssize_t row_group_size_bytes
+    cdef size_type row_group_size_bytes
     cdef size_type row_group_size_rows
 
-    def __cinit__(self, object filepaths_or_buffers, object index=None,
+    def __cinit__(self, object filepath_or_buffer, object index=None,
                   object compression=None, str statistics="ROWGROUP",
-                  object row_group_size_bytes=None,
-                  object row_group_size_rows=None):
+                  int row_group_size_bytes=13369344,
+                  int row_group_size_rows=1000000):
         filepaths_or_buffers = (
-            list(filepaths_or_buffers)
-            if is_list_like(filepaths_or_buffers)
-            else [filepaths_or_buffers]
+            list(filepath_or_buffer)
+            if is_list_like(filepath_or_buffer)
+            else [filepath_or_buffer]
         )
         self.sink = make_sinks_info(filepaths_or_buffers, self._data_sink)
         self.stat_freq = _get_stat_freq(statistics)
         self.comp_type = _get_comp_type(compression)
         self.index = index
         self.initialized = False
-        self.row_group_size_bytes = row_group_size_bytes or 0
-        self.row_group_size_rows = row_group_size_rows or 0
+        self.row_group_size_bytes = row_group_size_bytes
+        self.row_group_size_rows = row_group_size_rows
 
     def write_table(self, table, object partitions_info=None):
         """ Writes a single table to the file """
@@ -555,10 +575,8 @@ cdef class ParquetWriter:
                 .stats_level(self.stat_freq)
                 .build()
             )
-            if self.row_group_size_bytes:
-                args.set_row_group_size_bytes(self.row_group_size_bytes)
-            if self.row_group_size_rows:
-                args.set_row_group_size_rows(self.row_group_size_rows)
+            args.set_row_group_size_bytes(self.row_group_size_bytes)
+            args.set_row_group_size_rows(self.row_group_size_rows)
             self.writer.reset(new cpp_parquet_chunked_writer(args))
         self.initialized = True
 

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -423,9 +423,9 @@ cdef class ParquetWriter:
         Name of the compression to use. Use ``None`` for no compression.
     statistics : {'ROWGROUP', 'PAGE', 'NONE'}, default 'ROWGROUP'
         Level at which column statistics should be included in file.
-    row_group_size_bytes: int, default 13369344
+    row_group_size_bytes: int, default 134217728
         Maximum size of each stripe of the output.
-        By default, 13369344 (128MB) will be used.
+        By default, 134217728 (128MB) will be used.
     row_group_size_rows: int, default 1000000
         Maximum number of rows of each stripe of the output.
         By default, 1000000 (10^6 rows) will be used.
@@ -442,7 +442,7 @@ cdef class ParquetWriter:
     cdef cudf_io_types.statistics_freq stat_freq
     cdef cudf_io_types.compression_type comp_type
     cdef object index
-    cdef size_type row_group_size_bytes
+    cdef size_t row_group_size_bytes
     cdef size_type row_group_size_rows
 
     def __cinit__(self, object filepath_or_buffer, object index=None,

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -427,7 +427,8 @@ cdef class ParquetWriter:
 
     def __cinit__(self, object filepaths_or_buffers, object index=None,
                   object compression=None, str statistics="ROWGROUP",
-                  object row_group_size_bytes=None, object row_group_size_rows=None):
+                  object row_group_size_bytes=None,
+                  object row_group_size_rows=None):
         filepaths_or_buffers = (
             list(filepaths_or_buffers)
             if is_list_like(filepaths_or_buffers)

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -573,10 +573,10 @@ cdef class ParquetWriter:
                 .key_value_metadata(move(user_data))
                 .compression(self.comp_type)
                 .stats_level(self.stat_freq)
+                .row_group_size_bytes(self.row_group_size_bytes)
+                .row_group_size_rows(self.row_group_size_rows)
                 .build()
             )
-            args.set_row_group_size_bytes(self.row_group_size_bytes)
-            args.set_row_group_size_rows(self.row_group_size_rows)
             self.writer.reset(new cpp_parquet_chunked_writer(args))
         self.initialized = True
 

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -1620,16 +1620,18 @@ def test_parquet_writer_bytes_io(simple_gdf):
 
 
 @pytest.mark.parametrize(
-    "row_group_size_kwargs", [
+    "row_group_size_kwargs",
+    [
         {"row_group_size_bytes": 4 * 1024},
         {"row_group_size_rows": 5000},
-    ]
+    ],
 )
 def test_parquet_writer_row_group_size(tmpdir, row_group_size_kwargs):
+    # Check that row_group_size options are exposed in Python
+    # See https://github.com/rapidsai/cudf/issues/10978
+
     size = 20000
-    gdf = cudf.DataFrame(
-        {"a": range(size), "b":[1] * size}
-    )
+    gdf = cudf.DataFrame({"a": range(size), "b": [1] * size})
 
     fname = tmpdir.join("gdf.parquet")
     writer = ParquetWriter(fname, **row_group_size_kwargs)
@@ -1644,7 +1646,9 @@ def test_parquet_writer_row_group_size(tmpdir, row_group_size_kwargs):
 
     # Know the specific row-group count for row_group_size_rows
     if "row_group_size_rows" in row_group_size_kwargs:
-        assert nrow_groups == size // row_group_size_kwargs["row_group_size_rows"]
+        assert (
+            nrow_groups == size // row_group_size_kwargs["row_group_size_rows"]
+        )
 
     assert_eq(cudf.read_parquet(fname), gdf)
 
@@ -2505,7 +2509,7 @@ def test_parquet_reader_one_level_list2(datadir):
 
 @pytest.mark.parametrize("size_bytes", [4_000_000, 1_000_000, 600_000])
 @pytest.mark.parametrize("size_rows", [1_000_000, 100_000, 10_000])
-def test_parquet_writer_row_group_size(
+def test_to_parquet_row_group_size(
     tmpdir, large_int64_gdf, size_bytes, size_rows
 ):
     fname = tmpdir.join("row_group_size.parquet")

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -1634,9 +1634,8 @@ def test_parquet_writer_row_group_size(tmpdir, row_group_size_kwargs):
     gdf = cudf.DataFrame({"a": range(size), "b": [1] * size})
 
     fname = tmpdir.join("gdf.parquet")
-    writer = ParquetWriter(fname, **row_group_size_kwargs)
-    writer.write_table(gdf)
-    writer.close()
+    with ParquetWriter(fname, **row_group_size_kwargs) as writer:
+        writer.write_table(gdf)
 
     # Simple check for multiple row-groups
     nrows, nrow_groups, columns = cudf.io.parquet.read_parquet_metadata(fname)

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -247,7 +247,7 @@ int96_timestamps : bool, default False
     timestamps will not be altered.
 row_group_size_bytes: integer or None, default None
     Maximum size of each stripe of the output.
-    If None, 13369344 (128MB) will be used.
+    If None, 134217728 (128MB) will be used.
 row_group_size_rows: integer or None, default None
     Maximum number of rows of each stripe of the output.
     If None, 1000000 will be used.


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/10978

Minor changes (and test coverage) to add `row_group_size_bytes` and `row_group_size_rows` arguments to `ParquetWriter` API.