### PR TITLE
Fix Doxygen warnings in multiple headers files

### DIFF
--- a/cpp/include/cudf/io/parquet.hpp
+++ b/cpp/include/cudf/io/parquet.hpp
@@ -491,6 +491,8 @@ class parquet_writer_options {
   /**
    * @brief Returns the maximum uncompressed page size, in bytes. If set larger than the row group
    * size, then this will return the row group size.
+   *
+   * @return Maximum uncompressed page size, in bytes
    */
   auto get_max_page_size_bytes() const
   {
@@ -500,6 +502,8 @@ class parquet_writer_options {
   /**
    * @brief Returns maximum page size, in rows. If set larger than the row group size, then this
    * will return the row group size.
+   *
+   * @return Maximum page size, in rows
    */
   auto get_max_page_size_rows() const
   {
@@ -597,6 +601,7 @@ class parquet_writer_options {
 
   /**
    * @brief Sets the maximum uncompressed page size, in bytes.
+   * @param size_bytes Maximum uncompressed page size, in bytes to set
    */
   void set_max_page_size_bytes(size_t size_bytes)
   {
@@ -606,6 +611,7 @@ class parquet_writer_options {
 
   /**
    * @brief Sets the maximum page size, in rows.
+   * @param size_rows Maximum page size, in rows to set
    */
   void set_max_page_size_rows(size_type size_rows)
   {
@@ -922,6 +928,8 @@ class chunked_parquet_writer_options {
   /**
    * @brief Returns maximum uncompressed page size, in bytes. If set larger than the row group size,
    * then this will return the row group size.
+   *
+   * @return Maximum uncompressed page size, in bytes
    */
   auto get_max_page_size_bytes() const
   {
@@ -931,6 +939,8 @@ class chunked_parquet_writer_options {
   /**
    * @brief Returns maximum page size, in rows. If set larger than the row group size, then this
    * will return the row group size.
+   *
+   * @return Maximum page size, in rows
    */
   auto get_max_page_size_rows() const
   {
@@ -1002,6 +1012,7 @@ class chunked_parquet_writer_options {
 
   /**
    * @brief Sets the maximum uncompressed page size, in bytes.
+   * @param size_bytes Maximum uncompressed page size, in bytes to set
    */
   void set_max_page_size_bytes(size_t size_bytes)
   {
@@ -1011,6 +1022,7 @@ class chunked_parquet_writer_options {
 
   /**
    * @brief Sets the maximum page size, in rows.
+   * @param size_rows The maximum page size, in rows to set
    */
   void set_max_page_size_rows(size_type size_rows)
   {

--- a/cpp/include/cudf/ipc.hpp
+++ b/cpp/include/cudf/ipc.hpp
@@ -3,13 +3,35 @@
 #include <arrow/io/memory.h>
 #include <arrow/ipc/api.h>
 
+/**
+ * @brief Reads Message objects from cuda buffer source
+ *
+ */
 class CudaMessageReader : arrow::ipc::MessageReader {
  public:
+  /**
+   * @brief Construct a new Cuda Message Reader object from a cuda buffer stream
+   *
+   * @param stream The cuda buffer reader stream
+   * @param schema The schema of the stream
+   */
   CudaMessageReader(arrow::cuda::CudaBufferReader* stream, arrow::io::BufferReader* schema);
 
+  /**
+   * @brief Open stream from source.
+   *
+   * @param stream The cuda buffer reader stream
+   * @param schema The schema of the stream
+   * @return arrow::ipc::MessageReader object
+   */
   static std::unique_ptr<arrow::ipc::MessageReader> Open(arrow::cuda::CudaBufferReader* stream,
                                                          arrow::io::BufferReader* schema);
 
+  /**
+   * @brief Read next Message from the stream.
+   *
+   * @return arrow::ipc::Message object
+   */
   arrow::Result<std::unique_ptr<arrow::ipc::Message>> ReadNextMessage() override;
 
  private:

--- a/cpp/include/cudf_test/base_fixture.hpp
+++ b/cpp/include/cudf_test/base_fixture.hpp
@@ -123,7 +123,7 @@ uint64_t random_generator_incrementing_seed();
 template <typename T = cudf::size_type, typename Engine = std::default_random_engine>
 class UniformRandomGenerator {
  public:
-  using uniform_distribution = uniform_distribution_t<T>;
+  using uniform_distribution = uniform_distribution_t<T>;  ///< The uniform distribution type for T.
 
   UniformRandomGenerator() : rng{std::mt19937_64{detail::random_generator_incrementing_seed()}()} {}
 
@@ -144,6 +144,13 @@ class UniformRandomGenerator {
   {
   }
 
+  /**
+   * @brief Construct a new Uniform Random Generator to generate uniformly random booleans
+   *
+   * @param lower ignored
+   * @param upper ignored
+   * @param seed  seed to initialize generator with
+   */
   template <typename TL = T, std::enable_if_t<cudf::is_boolean<TL>()>* = nullptr>
   UniformRandomGenerator(T lower,
                          T upper,
@@ -179,6 +186,10 @@ class UniformRandomGenerator {
     return T{dist(rng)};
   }
 
+  /**
+   * @brief Returns the next random number.
+   * @return generated random number
+   */
   template <typename TL = T, std::enable_if_t<cudf::is_timestamp<TL>()>* = nullptr>
   T generate()
   {

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -94,7 +94,15 @@ class column_wrapper {
  */
 template <typename From, typename To>
 struct fixed_width_type_converter {
-  // Are the types same - simply copy elements from [begin, end) to out
+  /// Are the types same - simply copy elements from [begin, end) to out
+  /**
+   * @brief No conversion necessary
+   *
+   * @tparam FromT Source type
+   * @tparam ToT Target type
+   * @param element Source value
+   * @return The converted target value, same as source value
+   */
   template <typename FromT                                      = From,
             typename ToT                                        = To,
             std::enable_if_t<std::is_same_v<FromT, ToT>, void>* = nullptr>
@@ -103,7 +111,15 @@ struct fixed_width_type_converter {
     return element;
   }
 
-  // Are the types convertible or can target be constructed from source?
+  /// Are the types convertible or can target be constructed from source?
+  /**
+   * @brief  Convert types if possible, otherwise construct target from source.
+   *
+   * @tparam FromT Source type
+   * @tparam ToT Target type
+   * @param element Source value
+   * @return The converted target value
+   */
   template <
     typename FromT          = From,
     typename ToT            = To,
@@ -115,7 +131,14 @@ struct fixed_width_type_converter {
     return static_cast<ToT>(element);
   }
 
-  // Convert integral values to timestamps
+  /**
+   * @brief  Convert integral values to timestamps
+   *
+   * @tparam FromT Source type
+   * @tparam ToT Target type
+   * @param element Source value
+   * @return The converted target `timestamp` value
+   */
   template <
     typename FromT                                                                  = From,
     typename ToT                                                                    = To,
@@ -484,6 +507,11 @@ class fixed_width_column_wrapper : public detail::column_wrapper {
   }
 };
 
+/**
+ * @brief A wrapper for a column of fixed-width elements.
+ *
+ * @tparam Rep The type of the column
+ */
 template <typename Rep>
 class fixed_point_column_wrapper : public detail::column_wrapper {
  public:
@@ -1445,6 +1473,7 @@ class lists_column_wrapper : public detail::column_wrapper {
    * @brief Construct a list column containing a single empty, optionally null row.
    *
    * @param valid Whether or not the empty row is also null
+   * @return A list column containing a single empty row
    */
   static lists_column_wrapper<T> make_one_empty_row_column(bool valid = true)
   {

--- a/cpp/include/cudf_test/cudf_gtest.hpp
+++ b/cpp/include/cudf_test/cudf_gtest.hpp
@@ -34,6 +34,7 @@
  * redefines them properly.
  */
 
+// @cond
 #define Types      Types_NOT_USED
 #define Types0     Types0_NOT_USED
 #define TypeList   TypeList_NOT_USED
@@ -89,15 +90,31 @@ struct TypeList<Types<TYPES...>> {
 
 }  // namespace internal
 }  // namespace testing
+// @endcond
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+/**
+ * @brief test macro to be expected to return cudaSuccess, fails if not
+ * @param expr expression to be tested
+ */
 #define ASSERT_CUDA_SUCCEEDED(expr) ASSERT_EQ(cudaSuccess, expr)
+/**
+ * @brief test macro to be expected to return cudaSuccess
+ * @param expr expression to be tested
+ */
 #define EXPECT_CUDA_SUCCEEDED(expr) EXPECT_EQ(cudaSuccess, expr)
 
-// Utility for testing the expectation that an expression x throws the specified
-// exception whose what() message ends with the msg
+/**
+ * @brief Utility for testing the expectation that an expression x throws the specified
+ * exception whose what() message ends with the msg
+ *
+ * @param x The expression to test
+ * @param exception The exception type to test for
+ * @param startswith The start of the expected message
+ * @param endswith The end of the expected message
+ */
 #define EXPECT_THROW_MESSAGE(x, exception, startswith, endswith)    \
   do {                                                              \
     EXPECT_THROW(                                                   \
@@ -114,12 +131,30 @@ struct TypeList<Types<TYPES...>> {
       exception);                                                   \
   } while (0)
 
+/**
+ * @brief test macro to be expected to throw cudf::logic_error with a message
+ *
+ * @param x The statement to be tested
+ * @param msg The message associated with the exception
+ */
 #define CUDF_EXPECT_THROW_MESSAGE(x, msg) \
   EXPECT_THROW_MESSAGE(x, cudf::logic_error, "cuDF failure at:", msg)
 
+/**
+ * @brief test macro to be expected to throw cudf::cuda_error with a message
+ *
+ * @param x The statement to be tested
+ * @param msg The message associated with the exception
+ */
 #define CUDA_EXPECT_THROW_MESSAGE(x, msg) \
   EXPECT_THROW_MESSAGE(x, cudf::cuda_error, "CUDA error encountered at:", msg)
 
+/**
+ * @brief test macro to be expected to throw cudf::fatal_logic_error with a message
+ *
+ * @param x The statement to be tested
+ * @param msg The message associated with the exception
+ */
 #define FATAL_CUDA_EXPECT_THROW_MESSAGE(x, msg) \
   EXPECT_THROW_MESSAGE(x, cudf::fatal_cuda_error, "Fatal CUDA error encountered at:", msg)
 

--- a/cpp/include/cudf_test/file_utilities.hpp
+++ b/cpp/include/cudf_test/file_utilities.hpp
@@ -33,6 +33,11 @@ class temp_directory {
   std::string _path;
 
  public:
+  /**
+   * @brief Construct a new temp directory object
+   *
+   * @param base_name The base name of the temporary directory
+   */
   temp_directory(const std::string& base_name)
   {
     std::string dir_template{std::filesystem::temp_directory_path().string()};
@@ -47,8 +52,12 @@ class temp_directory {
 
   temp_directory& operator=(temp_directory const&) = delete;
   temp_directory(temp_directory const&)            = delete;
+  /**
+   * @brief Move assignment operator
+   * @return Reference to this object
+   */
   temp_directory& operator=(temp_directory&&) = default;
-  temp_directory(temp_directory&&)            = default;
+  temp_directory(temp_directory&&)            = default;  ///< Move constructor
 
   ~temp_directory() { std::filesystem::remove_all(std::filesystem::path{_path}); }
 

--- a/cpp/include/cudf_test/tdigest_utilities.cuh
+++ b/cpp/include/cudf_test/tdigest_utilities.cuh
@@ -42,16 +42,34 @@ namespace test {
 
 using expected_value = thrust::tuple<size_type, double, double>;
 
+/**
+ * @brief Device functor to compute min of a sequence of values serially.
+ */
 template <typename T>
 struct column_min {
+  /**
+   * @brief Computes the min of a sequence of values serially.
+   *
+   * @param vals The sequence of values to compute the min of
+   * @return The min value
+   */
   __device__ double operator()(device_span<T const> vals)
   {
     return static_cast<double>(*thrust::min_element(thrust::seq, vals.begin(), vals.end()));
   }
 };
 
+/**
+ * @brief Device functor to compute max of a sequence of values serially.
+ */
 template <typename T>
 struct column_max {
+  /**
+   * @brief Computes the max of a sequence of values serially.
+   *
+   * @param vals The sequence of values to compute the max of
+   * @return The max value
+   */
   __device__ double operator()(device_span<T const> vals)
   {
     return static_cast<double>(*thrust::max_element(thrust::seq, vals.begin(), vals.end()));
@@ -62,6 +80,7 @@ struct column_max {
  * @brief Functor to generate a tdigest.
  */
 struct tdigest_gen {
+  // @cond
   template <
     typename T,
     typename Func,
@@ -79,6 +98,7 @@ struct tdigest_gen {
   {
     CUDF_FAIL("Invalid tdigest test type");
   }
+  // @endcond
 };
 
 /**
@@ -120,10 +140,12 @@ void tdigest_minmax_compare(cudf::tdigest::tdigest_column_view const& tdv,
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result_max, *expected_max);
 }
 
+/// Expected values for tdigest tests
 struct expected_tdigest {
-  column_view mean;
-  column_view weight;
-  double min, max;
+  column_view mean;    ///< mean column
+  column_view weight;  ///< weight column
+  double min,          ///< min value
+    max;               ///< max value
 };
 
 /**

--- a/cpp/include/cudf_test/type_list_utilities.hpp
+++ b/cpp/include/cudf_test/type_list_utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,9 @@
  * The test `mytest` will be invoked 3 times, once for each of the types `int,
  * char, float`.
  *
- * Instead of using `::testing::Types` directly, we provide
+ * Instead of using @code ::testing::Types @endcode directly, we provide
  * `cudf::testing::Types`. This is a drop in replacement for GTest's
- * `::testing::Types`. In lieu of including `gtest/gtest.h`, include
+ * @code ::testing::Types @endcode. In lieu of including `gtest/gtest.h`, include
  * `cudf_gtest.hpp` to ensure `cudf::testing::Types` is used.
  *
  * Using the utilities in this file, you can compose complex type lists.
@@ -79,6 +79,7 @@ namespace test {
 // Types -----------------------------------------
 using ::testing::Types;
 
+// @cond
 template <class T, int D>
 struct GetTypeImpl {
   static_assert(D == 0, "Out of bounds");
@@ -98,6 +99,7 @@ struct GetTypeImpl<Types<ARGS...>, 0> {
 
   using type = typename Types<ARGS...>::Head;
 };
+// @endcond
 
 /**
  * @brief Gives the specified type from a type list
@@ -115,6 +117,7 @@ template <class TUPLE, int D>
 using GetType = typename GetTypeImpl<TUPLE, D>::type;
 
 // GetSize -------------------------------
+// @cond
 template <class TUPLE>
 struct GetSizeImpl;
 
@@ -122,6 +125,7 @@ template <class... TYPES>
 struct GetSizeImpl<Types<TYPES...>> {
   static constexpr auto value = sizeof...(TYPES);
 };
+// @endcond
 
 /**
  * @brief Returns the size (number of elements) in a type list
@@ -135,6 +139,7 @@ template <class TUPLE>
 constexpr auto GetSize = GetSizeImpl<TUPLE>::value;
 
 // Concat -----------------------------------------
+// @cond
 namespace detail {
 template <class A, class B>
 struct Concat2;
@@ -167,6 +172,7 @@ template <>
 struct ConcatImpl<> {
   using type = Types<>;
 };
+// @endcond
 
 /**
  * @brief Concatenates compile-time lists of types into a single type list.
@@ -181,6 +187,7 @@ template <class... T>
 using Concat = typename ConcatImpl<T...>::type;
 
 // Flatten -----------------------------------------
+// @cond
 template <class T>
 struct FlattenImpl;
 
@@ -198,6 +205,7 @@ template <class... HEAD, class... TAIL>
 struct FlattenImpl<Types<Types<HEAD...>, TAIL...>> {
   using type = typename FlattenImpl<Types<HEAD..., TAIL...>>::type;
 };
+// @endcond
 
 /**
  * @brief Flattens nested compile-time lists of types into a single list of
@@ -214,6 +222,7 @@ template <class T>
 using Flatten = typename FlattenImpl<T>::type;
 
 // CrossProduct -----------------------------------------
+// @cond
 namespace detail {
 // prepend T in TUPLE
 template <class T, class TUPLE>
@@ -262,6 +271,7 @@ struct CrossProductImpl<Types<AARGS...>, TAIL...> {
 template <class T, class... TAIL>
 struct CrossProductImpl<T, TAIL...> : CrossProductImpl<Types<T>, TAIL...> {
 };
+// @endcond
 
 /**
  * @brief Creates a new type list from the cross product (cartesian product) of
@@ -282,6 +292,7 @@ template <class... ARGS>
 using CrossProduct = typename CrossProductImpl<ARGS...>::type;
 
 // AllSame -----------------------------------------
+// @cond
 namespace detail {
 template <class... ITEMS>
 struct AllSame : std::false_type {
@@ -305,11 +316,12 @@ struct AllSame<Types<ITEMS...>> : AllSame<ITEMS...> {
 };
 
 }  // namespace detail
+// @endcond
 
 /**
  * @brief Indicates if all types in a list are identical.
  *
- * This is useful as a predicate for for `RemoveIf`.
+ * This is useful as a predicate for `RemoveIf`.
  *
  * Example:
  * ```
@@ -323,11 +335,17 @@ struct AllSame<Types<ITEMS...>> : AllSame<ITEMS...> {
  * ```
  */
 struct AllSame {
+  /**
+   * @brief Invoked as predicate for RemoveIf
+   *
+   * @tparam ITEMS The type to check if they are all same
+   */
   template <class... ITEMS>
   using Call = detail::AllSame<ITEMS...>;
 };
 
 // Exists ---------------------------------
+// @cond
 // Do a linear search to find NEEDLE in HAYSACK
 template <class NEEDLE, class HAYSACK>
 struct ExistsImpl;
@@ -346,6 +364,7 @@ struct ExistsImpl<NEEDLE, Types<NEEDLE, TAIL...>> : std::true_type {
 template <class NEEDLE, class HEAD, class... TAIL>
 struct ExistsImpl<NEEDLE, Types<HEAD, TAIL...>> : ExistsImpl<NEEDLE, Types<TAIL...>> {
 };
+// @endcond
 
 /**
  * @brief Indicates if a type exists within a type list.
@@ -394,6 +413,7 @@ struct ContainedIn {
 };
 
 // RemoveIf -----------------------------------------
+// @cond
 template <class PRED, class TUPLE>
 struct RemoveIfImpl;
 
@@ -408,6 +428,7 @@ struct RemoveIfImpl<PRED, Types<HEAD, TAIL...>> {
     Concat<typename std::conditional<PRED::template Call<HEAD>::value, Types<>, Types<HEAD>>::type,
            typename RemoveIfImpl<PRED, Types<TAIL...>>::type>;
 };
+// @endcond
 
 /**
  * @brief Removes types from a type list that satisfy a predicate
@@ -432,7 +453,7 @@ template <class PRED, class TUPLE>
 using RemoveIf = typename RemoveIfImpl<PRED, TUPLE>::type;
 
 // Transform --------------------------------
-
+// @cond
 template <class XFORM, class TYPES>
 struct TransformImpl;
 
@@ -440,6 +461,7 @@ template <class XFORM, class... ITEMS>
 struct TransformImpl<XFORM, Types<ITEMS...>> {
   using type = Types<typename XFORM::template Call<ITEMS>...>;
 };
+// @endcond
 
 /**
  * @brief Applies a transformation to every type in a type list
@@ -460,7 +482,7 @@ template <class XFORM, class TYPES>
 using Transform = typename TransformImpl<XFORM, TYPES>::type;
 
 // Repeat --------------------------------
-
+// @cond
 namespace detail {
 template <class T, int N, class RES>
 struct Repeat;
@@ -475,6 +497,7 @@ struct Repeat<T, 0, Types<ITEMS...>> {
   using type = Types<ITEMS...>;
 };
 }  // namespace detail
+// @endcond
 
 /**
  * @brief Transformation that repeats a type for a specified count.
@@ -492,12 +515,17 @@ struct Repeat<T, 0, Types<ITEMS...>> {
  */
 template <int N>
 struct Repeat {
+  /**
+   * @brief Invoked as predicate for Transform
+   *
+   * @tparam T The type to repeat
+   */
   template <class T>
   using Call = typename detail::Repeat<T, N, Types<>>::type;
 };
 
 // Append --------------------------------
-
+// @cond
 template <class TYPES, class... ITEMS>
 struct AppendImpl;
 
@@ -505,6 +533,7 @@ template <class... HEAD, class... TAIL>
 struct AppendImpl<Types<HEAD...>, TAIL...> {
   using type = Types<HEAD..., TAIL...>;
 };
+// @endcond
 
 /**
  * @brief Appends types to a type list
@@ -523,7 +552,7 @@ using Append = typename AppendImpl<TYPES, ITEMS...>::type;
 
 // Remove -------------------------------------------
 // remove items from tuple given by their indices
-
+// @cond
 namespace detail {
 template <class TUPLE, int CUR, int... IDXs>
 struct Remove;
@@ -556,6 +585,7 @@ template <class TUPLE, int... IDXs>
 struct RemoveImpl {
   using type = typename detail::Remove<TUPLE, 0, IDXs...>::type;
 };
+// @endcond
 
 /**
  * @brief Removes types at specified indices from a type list.
@@ -567,7 +597,7 @@ template <class TUPLE, int... IDXs>
 using Remove = typename RemoveImpl<TUPLE, IDXs...>::type;
 
 // Unique --------------------------------
-
+// @cond
 namespace detail {
 template <class... ITEMS>
 struct Unique;
@@ -591,6 +621,7 @@ template <class... ITEMS>
 struct UniqueImpl<Types<ITEMS...>> {
   using type = typename detail::Unique<ITEMS...>::type;
 };
+// @endcond
 
 /**
  * @brief Removes duplicate types from a type list

--- a/cpp/include/cudf_test/type_lists.hpp
+++ b/cpp/include/cudf_test/type_lists.hpp
@@ -146,6 +146,17 @@ make_type_param_scalar(T const init_value)
   return static_cast<TypeParam>(init_value);
 }
 
+/**
+ * @brief Convert the timestamp value of type T to a fixed width type of type TypeParam.
+ *
+ * This function is necessary because some types (such as timestamp types) are not directly
+ * constructible from timestamp types. This function is offered as a convenience to allow
+ * implicitly constructing such objects from timestamp values.
+ *
+ * @param init_value Value used to initialize the fixed width type
+ * @return A fixed width type - TimeStamp of type TypeParam with the
+ *         value specified
+ */
 template <typename TypeParam, typename T>
 std::enable_if_t<cudf::is_timestamp_t<TypeParam>::value, TypeParam> make_type_param_scalar(
   T const init_value)
@@ -153,6 +164,14 @@ std::enable_if_t<cudf::is_timestamp_t<TypeParam>::value, TypeParam> make_type_pa
   return TypeParam{typename TypeParam::duration(init_value)};
 }
 
+/**
+ * @brief Convert the numeric value of type T to a string type.
+ *
+ * This function converts the numeric value of type T to its string representation.
+ *
+ * @param init_value Value to convert to a string
+ * @return string representation of the value
+ */
 template <typename TypeParam, typename T>
 std::enable_if_t<std::is_same_v<TypeParam, std::string>, TypeParam> make_type_param_scalar(
   T const init_value)

--- a/cpp/include/nvtext/bpe_tokenize.hpp
+++ b/cpp/include/nvtext/bpe_tokenize.hpp
@@ -35,19 +35,43 @@ namespace nvtext {
  */
 struct bpe_merge_pairs {
   struct bpe_merge_pairs_impl;
-  std::unique_ptr<bpe_merge_pairs_impl> impl{};
+  std::unique_ptr<bpe_merge_pairs_impl> impl{};  ///< Implementation of the BPE merge pairs table.
 
+  /**
+   * @brief Construct a new bpe merge pairs object
+   *
+   * @param input The input file containing the BPE merge pairs
+   * @param stream CUDA stream used for device memory operations and kernel launches.
+   * @param mr Device memory resource used to allocate the device memory
+   */
   bpe_merge_pairs(std::unique_ptr<cudf::column>&& input,
                   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+  /**
+   * @brief Construct a new bpe merge pairs object
+   *
+   * @param input The input column of strings
+   * @param stream CUDA stream used for device memory operations and kernel launches.
+   * @param mr Device memory resource used to allocate the device memory
+   */
   bpe_merge_pairs(cudf::strings_column_view const& input,
                   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   ~bpe_merge_pairs();
 
+  /**
+   * @brief  Returns the number of merge pairs in the table.
+   *
+   * @return The number of merge pairs in the table
+   */
   cudf::size_type get_size();
+  /**
+   * @brief  Returns the number of unique merge pairs in the table.
+   *
+   * @return The number of unique merge pairs in the table
+   */
   std::size_t get_map_size();
 };
 
@@ -80,6 +104,7 @@ struct bpe_merge_pairs {
  *
  * @param filename_merges Local file path of pairs encoded in UTF-8.
  * @param mr Memory resource to allocate any returned objects.
+ * @return A nvtext::bpe_merge_pairs object
  */
 std::unique_ptr<bpe_merge_pairs> load_merge_pairs_file(
   std::string const& filename_merges,
@@ -111,6 +136,7 @@ std::unique_ptr<bpe_merge_pairs> load_merge_pairs_file(
  * @param separator String used to build the output after encoding.
  *                  Default is a space.
  * @param mr Memory resource to allocate any returned objects.
+ * @return An encoded column of strings.
  */
 std::unique_ptr<cudf::column> byte_pair_encoding(
   cudf::strings_column_view const& input,

--- a/cpp/include/nvtext/subword_tokenize.hpp
+++ b/cpp/include/nvtext/subword_tokenize.hpp
@@ -31,17 +31,22 @@ namespace nvtext {
  * @brief The vocabulary data for use with the subword_tokenize function.
  */
 struct hashed_vocabulary {
-  uint16_t first_token_id{};
-  uint16_t separator_token_id{};
-  uint16_t unknown_token_id{};
-  uint32_t outer_hash_a{};
-  uint32_t outer_hash_b{};
-  uint16_t num_bins{};
-  std::unique_ptr<cudf::column> table;             // uint64
-  std::unique_ptr<cudf::column> bin_coefficients;  // uint64
-  std::unique_ptr<cudf::column> bin_offsets;       // uint16
-  std::unique_ptr<cudf::column> cp_metadata;       // uint32
-  std::unique_ptr<cudf::column> aux_cp_table;      // uint64
+  uint16_t first_token_id{};            ///< The first token id in the vocabulary
+  uint16_t separator_token_id{};        ///< The separator token id in the vocabulary
+  uint16_t unknown_token_id{};          ///< The unknown token id in the vocabulary
+  uint32_t outer_hash_a{};              ///< The a parameter for the outer hash
+  uint32_t outer_hash_b{};              ///< The b parameter for the outer hash
+  uint16_t num_bins{};                  ///< Number of bins
+  std::unique_ptr<cudf::column> table;  ///< uint64 column, the flattened hash table with key, value
+                                        ///< pairs packed in 64-bits
+  std::unique_ptr<cudf::column> bin_coefficients;  ///< uint64 column, containing the hashing
+                                                   ///< parameters for each hash bin on the GPU
+  std::unique_ptr<cudf::column> bin_offsets;  ///< uint16 column, containing the start index of each
+                                              ///< bin in the flattened hash table
+  std::unique_ptr<cudf::column>
+    cp_metadata;  ///< uint32 column, The code point metadata table to use for normalization
+  std::unique_ptr<cudf::column>
+    aux_cp_table;  ///< uint64 column, The auxiliary code point table to use for normalization
 };
 
 /**

--- a/cpp/libcudf_kafka/include/cudf_kafka/kafka_callback.hpp
+++ b/cpp/libcudf_kafka/include/cudf_kafka/kafka_callback.hpp
@@ -55,9 +55,24 @@ using python_callable_type              = void*;
  */
 class python_oauth_refresh_callback : public RdKafka::OAuthBearerTokenRefreshCb {
  public:
+  /**
+   * @brief Construct a new python oauth refresh callback object
+   *
+   * @param callback_wrapper `kafka_oauth_callback_wrapper_type` Cython wrapper that will
+   *                 be used to invoke the `python_callable`. This wrapper serves the purpose
+   *                 of preventing us from having to link against the Python development library
+   *                 in libcudf_kafka.
+   * @param python_callable `python_callable_type` pointer to a Python functools.partial object
+   */
   python_oauth_refresh_callback(kafka_oauth_callback_wrapper_type callback_wrapper,
                                 python_callable_type python_callable);
 
+  /**
+   * @brief Invoke the Python callback function to get the OAuth token and its expiration time
+   *
+   * @param handle
+   * @param oauthbearer_config pointer to the OAuthBearerConfig object
+   */
   void oauthbearer_token_refresh_cb(RdKafka::Handle* handle, const std::string& oauthbearer_config);
 
  private:

--- a/cpp/libcudf_kafka/include/cudf_kafka/kafka_consumer.hpp
+++ b/cpp/libcudf_kafka/include/cudf_kafka/kafka_consumer.hpp
@@ -141,6 +141,7 @@ class kafka_consumer : public cudf::io::datasource {
    * @param[in] cached If True uses the last retrieved value from the Kafka broker, if False
    *            the latest value will be retrieved from the Kafka broker by making a network
    *            request.
+   * @return The watermark offset value for the specified topic/partition
    */
   std::map<std::string, int64_t> get_watermark_offset(std::string const& topic,
                                                       int partition,
@@ -179,6 +180,7 @@ class kafka_consumer : public cudf::io::datasource {
    * @brief Close the underlying socket connection to Kafka and clean up system resources
    *
    * @throws cudf::logic_error on failure to close the connection
+   * @param timeout Max milliseconds to wait on a response
    */
   void close(int timeout);
 


### PR DESCRIPTION
Fixes parts of https://github.com/rapidsai/cudf/issues/9373
added missing documentation to fix doxygen warnings in multiple headers
cudf_test/, nvtext/, cudf_kafka/
