### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -62,7 +62,7 @@ dependencies:
   - dask-cuda
   - mimesis<4.1
   - packaging
-  - protobuf
+  - protobuf>=3.20.1,<3.21.0a0
   - nvtx>=0.2.1
   - cachetools
   - transformers<=4.10.3

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - {{ compiler('cxx') }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
-    - protobuf
+    - protobuf>=3.20.1,<3.21.0a0
     - python
     - cython >=0.29,<0.30
     - setuptools
@@ -40,7 +40,7 @@ requirements:
     - rmm {{ minor_version }}
     - cudatoolkit {{ cuda_version }}
   run:
-    - protobuf
+    - protobuf>=3.20.1,<3.21.0a0
     - python
     - typing_extensions
     - pandas >=1.0,<1.5.0dev0

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     "nvtx>=0.2.1",
     "packaging",
     "pandas>=1.0,<1.5.0dev0",
-    "protobuf",
+    "protobuf>=3.20.1,<3.21.0a0",
     "typing_extensions",
 ]
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.