### PR TITLE
Change build.sh to find C++ library by default and avoid shadowing CMAKE_ARGS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -229,6 +229,11 @@ if hasArg --incl_cache_stats; then
     BUILD_REPORT_INCL_CACHE_STATS=ON
 fi
 
+# Append `-DFIND_CUDF_CPP=ON` to CMAKE_ARGS unless a user specified the option.
+if [[ ${CMAKE_ARGS} != *"DFIND_CUDF_CPP"* ]]; then
+    CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUDF_CPP=ON"
+fi
+
 
 # If clean given, run it prior to any other steps
 if hasArg clean; then

--- a/build.sh
+++ b/build.sh
@@ -230,7 +230,7 @@ if hasArg --incl_cache_stats; then
 fi
 
 # Append `-DFIND_CUDF_CPP=ON` to CMAKE_ARGS unless a user specified the option.
-if [[ ${CMAKE_ARGS} != *"DFIND_CUDF_CPP"* ]]; then
+if [[ "${CMAKE_ARGS}" != *"DFIND_CUDF_CPP"* ]]; then
     CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUDF_CPP=ON"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -92,12 +92,12 @@ function cmakeArgs {
         # There are possible weird edge cases that may cause this regex filter to output nothing and fail silently
         # the true pipe will catch any weird edge cases that may happen and will cause the program to fall back
         # on the invalid option error
-        CMAKE_ARGS=$(echo $ARGS | { grep -Eo "\-\-cmake\-args=\".+\"" || true; })
-        if [[ -n ${CMAKE_ARGS} ]]; then
-            # Remove the full  CMAKE_ARGS argument from list of args so that it passes validArgs function
-            ARGS=${ARGS//$CMAKE_ARGS/}
+        EXTRA_CMAKE_ARGS=$(echo $ARGS | { grep -Eo "\-\-cmake\-args=\".+\"" || true; })
+        if [[ -n ${EXTRA_CMAKE_ARGS} ]]; then
+            # Remove the full  EXTRA_CMAKE_ARGS argument from list of args so that it passes validArgs function
+            ARGS=${ARGS//$EXTRA_CMAKE_ARGS/}
             # Filter the full argument down to just the extra string that will be added to cmake call
-            CMAKE_ARGS=$(echo $CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
+            EXTRA_CMAKE_ARGS=$(echo $EXTRA_CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
         fi
     fi
 }
@@ -229,9 +229,9 @@ if hasArg --incl_cache_stats; then
     BUILD_REPORT_INCL_CACHE_STATS=ON
 fi
 
-# Append `-DFIND_CUDF_CPP=ON` to CMAKE_ARGS unless a user specified the option.
-if [[ "${CMAKE_ARGS}" != *"DFIND_CUDF_CPP"* ]]; then
-    CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUDF_CPP=ON"
+# Append `-DFIND_CUDF_CPP=ON` to EXTRA_CMAKE_ARGS unless a user specified the option.
+if [[ "${EXTRA_CMAKE_ARGS}" != *"DFIND_CUDF_CPP"* ]]; then
+    EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DFIND_CUDF_CPP=ON"
 fi
 
 
@@ -288,7 +288,7 @@ if buildAll || hasArg libcudf; then
           -DDISABLE_DEPRECATION_WARNING=${BUILD_DISABLE_DEPRECATION_WARNING} \
           -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=${BUILD_PER_THREAD_DEFAULT_STREAM} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-          ${CMAKE_ARGS}
+          ${EXTRA_CMAKE_ARGS}
 
     cd ${LIB_BUILD_DIR}
 
@@ -329,9 +329,9 @@ fi
 if buildAll || hasArg cudf; then
 
     cd ${REPODIR}/python/cudf
-    python setup.py build_ext --inplace -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} ${CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
+    python setup.py build_ext --inplace -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} ${EXTRA_CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
     if [[ ${INSTALL_TARGET} != "" ]]; then
-        python setup.py install --single-version-externally-managed --record=record.txt  -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} ${CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
+        python setup.py install --single-version-externally-managed --record=record.txt  -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} ${EXTRA_CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
     fi
 fi
 
@@ -357,7 +357,7 @@ if hasArg libcudf_kafka; then
           -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DBUILD_TESTS=${BUILD_TESTS} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-          ${CMAKE_ARGS}
+          ${EXTRA_CMAKE_ARGS}
 
 
     cd ${KAFKA_LIB_BUILD_DIR}

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -127,7 +127,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     ################################################################################
 
     gpuci_logger "Build from source"
-    "$WORKSPACE/build.sh" clean libcudf cudf dask_cudf libcudf_kafka cudf_kafka benchmarks tests --ptds --cmake-args=\"-DFIND_CUDF_CPP=ON\"
+    "$WORKSPACE/build.sh" clean libcudf cudf dask_cudf libcudf_kafka cudf_kafka benchmarks tests --ptds
 
     ################################################################################
     # TEST - Run GoogleTest

--- a/conda/recipes/cudf/build.sh
+++ b/conda/recipes/cudf/build.sh
@@ -1,4 +1,4 @@
 # Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 # This assumes the script is executed from the root of the repo directory
-./build.sh cudf --cmake-args=\"-DFIND_CUDF_CPP=ON\"
+./build.sh cudf


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->
#10919 changed the Python build system to build its own internal copy of libcudf when invoked directly. It also modified our build.sh script (and associated CI scripts) accordingly so that everywhere that should be reusing a C++ build for a Python build would do so via CMake. This PR makes that behavior the default in build.sh, so any builds of the Python library using build.sh will revert to the prior behavior of searching for a C++ library and failing if one doesn't already exist on the path. Users can still provide the appropriate CMake arguments to the build.sh invocation to make it build libcudf within cuDF Python if they so desire.

Additionally, this PR avoids shadowing the `CMAKE_ARGS` environment variable in build.sh, which is important for conda-forge compatibility.