### PR TITLE
Use nvCOMP for ZLIB decompression in ORC reader

### DIFF
--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -29,6 +29,14 @@
 #define NVCOMP_HAS_ZSTD 0
 #endif
 
+#define NVCOMP_DEFLATE_HEADER <nvcomp/deflate.h>
+#if __has_include(NVCOMP_DEFLATE_HEADER)
+#include NVCOMP_DEFLATE_HEADER
+#define NVCOMP_HAS_DEFLATE 1
+#else
+#define NVCOMP_HAS_DEFLATE 0
+#endif
+
 namespace cudf::io::nvcomp {
 
 template <typename... Args>
@@ -40,6 +48,10 @@ auto batched_decompress_get_temp_size(compression_type compression, Args&&... ar
 #if NVCOMP_HAS_ZSTD
     case compression_type::ZSTD:
       return nvcompBatchedZstdDecompressGetTempSize(std::forward<Args>(args)...);
+#endif
+#if NVCOMP_HAS_DEFLATE
+    case compression_type::DEFLATE:
+      return nvcompBatchedDeflateDecompressGetTempSize(std::forward<Args>(args)...);
 #endif
     default: CUDF_FAIL("Unsupported compression type");
   }
@@ -54,6 +66,10 @@ auto batched_decompress_async(compression_type compression, Args&&... args)
 #if NVCOMP_HAS_ZSTD
     case compression_type::ZSTD:
       return nvcompBatchedZstdDecompressAsync(std::forward<Args>(args)...);
+#endif
+#if NVCOMP_HAS_DEFLATE
+    case compression_type::DEFLATE:
+      return nvcompBatchedDeflateDecompressAsync(std::forward<Args>(args)...);
 #endif
     default: CUDF_FAIL("Unsupported compression type");
   }

--- a/cpp/src/io/comp/nvcomp_adapter.hpp
+++ b/cpp/src/io/comp/nvcomp_adapter.hpp
@@ -24,7 +24,7 @@
 
 namespace cudf::io::nvcomp {
 
-enum class compression_type { SNAPPY, ZSTD };
+enum class compression_type { SNAPPY, ZSTD, DEFLATE };
 
 /**
  * @brief Device batch decompression of given type.


### PR DESCRIPTION
Issue #11023

Adds `DEFLATE` compression type to the nvCOMP adapter.
ORC reader uses the adapter when nvCOMP experimental integrations are enabled (for now). Otherwise behavior is unchanged and the internal implementation is still used.

Pending: Performance impact