### PR TITLE
Remove public API of cudf.merge_sorted.

### DIFF
--- a/docs/cudf/source/api_docs/general_functions.rst
+++ b/docs/cudf/source/api_docs/general_functions.rst
@@ -13,7 +13,6 @@ Data manipulations
    cudf.cut
    cudf.get_dummies
    cudf.melt
-   cudf.merge_sorted
    cudf.pivot
    cudf.unstack
 

--- a/python/cudf/cudf/__init__.py
+++ b/python/cudf/cudf/__init__.py
@@ -61,7 +61,6 @@ from cudf.core.reshape import (
     concat,
     get_dummies,
     melt,
-    merge_sorted,
     pivot,
     unstack,
 )
@@ -154,7 +153,6 @@ __all__ = [
     "isclose",
     "melt",
     "merge",
-    "merge_sorted",
     "pivot",
     "read_avro",
     "read_csv",

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 import itertools
-import warnings
 from collections import abc
 from typing import Dict, Optional
 
@@ -756,50 +755,6 @@ def get_dummies(
             dtype=dtype,
         )
         return cudf.DataFrame._from_data(data, index=ser._index)
-
-
-def merge_sorted(
-    objs,
-    keys=None,
-    by_index=False,
-    ignore_index=False,
-    ascending=True,
-    na_position="last",
-):
-    """Merge a list of sorted DataFrame or Series objects.
-
-    Dataframes/Series in objs list MUST be pre-sorted by columns
-    listed in `keys`, or by the index (if `by_index=True`).
-
-    Parameters
-    ----------
-    objs : list of DataFrame or Series
-    keys : list, default None
-        List of Column names to sort by. If None, all columns used
-        (Ignored if `by_index=True`)
-    by_index : bool, default False
-        Use index for sorting. `keys` input will be ignored if True
-    ignore_index : bool, default False
-        Drop and ignore index during merge. Default range index will
-        be used in the output dataframe.
-    ascending : bool, default True
-        Sorting is in ascending order, otherwise it is descending
-    na_position : {‘first’, ‘last’}, default ‘last’
-        'first' nulls at the beginning, 'last' nulls at the end
-
-    Returns
-    -------
-    A new, lexicographically sorted, DataFrame/Series.
-    """
-
-    warnings.warn(
-        "merge_sorted is deprecated and will be removed in a "
-        "future release.",
-        FutureWarning,
-    )
-    return _merge_sorted(
-        objs, keys, by_index, ignore_index, ascending, na_position
-    )
 
 
 def _merge_sorted(

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -765,6 +765,31 @@ def _merge_sorted(
     ascending=True,
     na_position="last",
 ):
+    """Merge a list of sorted DataFrame or Series objects.
+
+    Dataframes/Series in objs list MUST be pre-sorted by columns
+    listed in `keys`, or by the index (if `by_index=True`).
+
+    Parameters
+    ----------
+    objs : list of DataFrame or Series
+    keys : list, default None
+        List of Column names to sort by. If None, all columns used
+        (Ignored if `by_index=True`)
+    by_index : bool, default False
+        Use index for sorting. `keys` input will be ignored if True
+    ignore_index : bool, default False
+        Drop and ignore index during merge. Default range index will
+        be used in the output dataframe.
+    ascending : bool, default True
+        Sorting is in ascending order, otherwise it is descending
+    na_position : {'first', 'last'}, default 'last'
+        'first' nulls at the beginning, 'last' nulls at the end
+
+    Returns
+    -------
+    A new, lexicographically sorted, DataFrame/Series.
+    """
     if not pd.api.types.is_list_like(objs):
         raise TypeError("objs must be a list-like of Frame-like objects")
 

--- a/python/cudf/cudf/tests/test_reshape.py
+++ b/python/cudf/cudf/tests/test_reshape.py
@@ -290,8 +290,9 @@ def test_df_merge_sorted_index(nparts, index, ascending):
     )
 
     expect = df.sort_index(ascending=ascending)
-    with pytest.warns(FutureWarning, match="deprecated and will be removed"):
-        result = cudf.merge_sorted(dfs, by_index=True, ascending=ascending)
+    result = cudf.core.reshape._merge_sorted(
+        dfs, by_index=True, ascending=ascending
+    )
 
     assert_eq(expect.index, result.index)
 


### PR DESCRIPTION
This removes the public API of `cudf.merge_sorted`. This has been replaced by an internal API and does not need to be exposed in the cudf public API. Deprecated in #10713.