### PR TITLE
Add docs to rolling var, std, count.

### DIFF
--- a/docs/cudf/source/api_docs/window.rst
+++ b/docs/cudf/source/api_docs/window.rst
@@ -18,6 +18,8 @@ Rolling window functions
    Rolling.count
    Rolling.sum
    Rolling.mean
+   Rolling.var
+   Rolling.std
    Rolling.min
    Rolling.max
    Rolling.apply

--- a/python/cudf/cudf/_lib/rolling.pyx
+++ b/python/cudf/cudf/_lib/rolling.pyx
@@ -35,8 +35,7 @@ def rolling(Column source_column,
     min_periods : Minimum number of observations in window required to have
                   a value (otherwise result is null)
     center : Set the labels at the center of the window
-    op : operation to be executed, as of now it supports MIN, MAX, COUNT, SUM,
-         MEAN and UDF
+    op : operation to be executed
     agg_params : dict, parameter for the aggregation (e.g. ddof for VAR/STD)
 
     Returns

--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -288,14 +288,49 @@ class Rolling(GetAttrGetItemMixin, Reducible):
         return self._apply_agg(op)
 
     def var(self, ddof=1):
+        """Calculate the rolling variance.
+
+        Parameters
+        ----------
+        ddof : int, default 1
+            Delta Degrees of Freedom.  The divisor used in calculations
+            is ``N - ddof``, where ``N`` represents the number of
+            elements.
+
+        Returns
+        -------
+        Series or DataFrame
+            Return type is the same as the original object.
+        """
         self.agg_params["ddof"] = ddof
         return self._apply_agg("var")
 
     def std(self, ddof=1):
+        """Calculate the rolling standard deviation.
+
+        Parameters
+        ----------
+        ddof : int, default 1
+            Delta Degrees of Freedom.  The divisor used in calculations
+            is ``N - ddof``, where ``N`` represents the number of
+            elements.
+
+        Returns
+        -------
+        Series or DataFrame
+            Return type is the same as the original object.
+        """
         self.agg_params["ddof"] = ddof
         return self._apply_agg("std")
 
     def count(self):
+        """Calculate the rolling count of non NaN observations.
+
+        Returns
+        -------
+        Series or DataFrame
+            Return type is the same as the original object.
+        """
         return self._apply_agg("count")
 
     def apply(self, func, *args, **kwargs):


### PR DESCRIPTION
This PR adds missing documentation for rolling var, std, count. Resolves #10665.