### PR TITLE
Support for ZLIB compression in ORC writer

### DIFF
--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -162,6 +162,7 @@ auto batched_compress_temp_size(compression_type compression,
 #else
       CUDF_FAIL("Unsupported compression type");
 #endif
+    case compression_type::ZSTD: [[fallthrough]];
     default: CUDF_FAIL("Unsupported compression type");
   }
 
@@ -240,7 +241,7 @@ static void batched_compress_async(compression_type compression,
 #else
       CUDF_FAIL("Unsupported compression type");
 #endif
-    case compression_type::ZSTD:
+    case compression_type::ZSTD: [[fallthrough]];
     default: CUDF_FAIL("Unsupported compression type");
   }
   CUDF_EXPECTS(nvcomp_status == nvcompStatus_t::nvcompSuccess, "Error in compression");

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -46,13 +46,17 @@ auto batched_decompress_get_temp_size(compression_type compression, Args&&... ar
   switch (compression) {
     case compression_type::SNAPPY:
       return nvcompBatchedSnappyDecompressGetTempSize(std::forward<Args>(args)...);
-#if NVCOMP_HAS_ZSTD
     case compression_type::ZSTD:
+#if NVCOMP_HAS_ZSTD
       return nvcompBatchedZstdDecompressGetTempSize(std::forward<Args>(args)...);
+#else
+      CUDF_FAIL("Unsupported compression type");
 #endif
-#if NVCOMP_HAS_DEFLATE
     case compression_type::DEFLATE:
+#if NVCOMP_HAS_DEFLATE
       return nvcompBatchedDeflateDecompressGetTempSize(std::forward<Args>(args)...);
+#else
+      CUDF_FAIL("Unsupported compression type");
 #endif
     default: CUDF_FAIL("Unsupported compression type");
   }
@@ -65,13 +69,17 @@ auto batched_decompress_async(compression_type compression, Args&&... args)
   switch (compression) {
     case compression_type::SNAPPY:
       return nvcompBatchedSnappyDecompressAsync(std::forward<Args>(args)...);
-#if NVCOMP_HAS_ZSTD
     case compression_type::ZSTD:
+#if NVCOMP_HAS_ZSTD
       return nvcompBatchedZstdDecompressAsync(std::forward<Args>(args)...);
+#else
+      CUDF_FAIL("Unsupported compression type");
 #endif
-#if NVCOMP_HAS_DEFLATE
     case compression_type::DEFLATE:
+#if NVCOMP_HAS_DEFLATE
       return nvcompBatchedDeflateDecompressAsync(std::forward<Args>(args)...);
+#else
+      CUDF_FAIL("Unsupported compression type");
 #endif
     default: CUDF_FAIL("Unsupported compression type");
   }
@@ -145,11 +153,14 @@ auto batched_compress_temp_size(compression_type compression,
       nvcomp_status = nvcompBatchedSnappyCompressGetTempSize(
         batch_size, max_uncompressed_chunk_bytes, nvcompBatchedSnappyDefaultOpts, &temp_size);
       break;
-#if NVCOMP_HAS_DEFLATE
+
     case compression_type::DEFLATE:
+#if NVCOMP_HAS_DEFLATE
       nvcomp_status = nvcompBatchedDeflateCompressGetTempSize(
         batch_size, max_uncompressed_chunk_bytes, nvcompBatchedDeflateDefaultOpts, &temp_size);
       break;
+#else
+      CUDF_FAIL("Unsupported compression type");
 #endif
     default: CUDF_FAIL("Unsupported compression type");
   }
@@ -170,12 +181,15 @@ size_t batched_compress_get_max_output_chunk_size(compression_type compression,
       status = nvcompBatchedSnappyCompressGetMaxOutputChunkSize(
         max_uncompressed_chunk_bytes, nvcompBatchedSnappyDefaultOpts, &max_comp_chunk_size);
       break;
-#if NVCOMP_HAS_DEFLATE
     case compression_type::DEFLATE:
+#if NVCOMP_HAS_DEFLATE
       status = nvcompBatchedDeflateCompressGetMaxOutputChunkSize(
         max_uncompressed_chunk_bytes, nvcompBatchedDeflateDefaultOpts, &max_comp_chunk_size);
       break;
+#else
+      CUDF_FAIL("Unsupported compression type");
 #endif
+    case compression_type::ZSTD: [[fallthrough]];
     default: CUDF_FAIL("Unsupported compression type");
   }
 
@@ -210,8 +224,8 @@ static void batched_compress_async(compression_type compression,
                                                        nvcompBatchedSnappyDefaultOpts,
                                                        stream.value());
       break;
-#if NVCOMP_HAS_DEFLATE
     case compression_type::DEFLATE:
+#if NVCOMP_HAS_DEFLATE
       nvcomp_status = nvcompBatchedDeflateCompressAsync(device_uncompressed_ptrs,
                                                         device_uncompressed_bytes,
                                                         max_uncompressed_chunk_bytes,
@@ -223,7 +237,10 @@ static void batched_compress_async(compression_type compression,
                                                         nvcompBatchedDeflateDefaultOpts,
                                                         stream.value());
       break;
+#else
+      CUDF_FAIL("Unsupported compression type");
 #endif
+    case compression_type::ZSTD:
     default: CUDF_FAIL("Unsupported compression type");
   }
   CUDF_EXPECTS(nvcomp_status == nvcompStatus_t::nvcompSuccess, "Error in compression");

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -39,6 +39,7 @@
 
 namespace cudf::io::nvcomp {
 
+// Dispatcher for nvcompBatched<format>DecompressGetTempSize
 template <typename... Args>
 auto batched_decompress_get_temp_size(compression_type compression, Args&&... args)
 {
@@ -55,8 +56,9 @@ auto batched_decompress_get_temp_size(compression_type compression, Args&&... ar
 #endif
     default: CUDF_FAIL("Unsupported compression type");
   }
-};
+}
 
+// Dispatcher for nvcompBatched<format>DecompressAsync
 template <typename... Args>
 auto batched_decompress_async(compression_type compression, Args&&... args)
 {
@@ -73,9 +75,11 @@ auto batched_decompress_async(compression_type compression, Args&&... args)
 #endif
     default: CUDF_FAIL("Unsupported compression type");
   }
-};
+}
 
-size_t get_temp_size(compression_type compression, size_t num_chunks, size_t max_uncomp_chunk_size)
+size_t batched_decompress_temp_size(compression_type compression,
+                                    size_t num_chunks,
+                                    size_t max_uncomp_chunk_size)
 {
   size_t temp_size = 0;
   nvcompStatus_t nvcomp_status =
@@ -111,20 +115,147 @@ void batched_decompress(compression_type compression,
   rmm::device_uvector<size_t> actual_uncompressed_data_sizes(num_chunks, stream);
   rmm::device_uvector<nvcompStatus_t> nvcomp_statuses(num_chunks, stream);
   // Temporary space required for decompression
-  rmm::device_buffer scratch(get_temp_size(compression, num_chunks, max_uncomp_chunk_size), stream);
+  rmm::device_buffer scratch(
+    batched_decompress_temp_size(compression, num_chunks, max_uncomp_chunk_size), stream);
   auto const nvcomp_status = batched_decompress_async(compression,
-                                                      nvcomp_args.compressed_data_ptrs.data(),
-                                                      nvcomp_args.compressed_data_sizes.data(),
-                                                      nvcomp_args.uncompressed_data_sizes.data(),
+                                                      nvcomp_args.input_data_ptrs.data(),
+                                                      nvcomp_args.input_data_sizes.data(),
+                                                      nvcomp_args.output_data_sizes.data(),
                                                       actual_uncompressed_data_sizes.data(),
                                                       num_chunks,
                                                       scratch.data(),
                                                       scratch.size(),
-                                                      nvcomp_args.uncompressed_data_ptrs.data(),
+                                                      nvcomp_args.output_data_ptrs.data(),
                                                       nvcomp_statuses.data(),
                                                       stream.value());
   CUDF_EXPECTS(nvcomp_status == nvcompStatus_t::nvcompSuccess, "unable to perform decompression");
 
   convert_status(nvcomp_statuses, actual_uncompressed_data_sizes, statuses, stream);
 }
+
+// Dispatcher for nvcompBatched<format>CompressGetTempSize
+auto batched_compress_temp_size(compression_type compression,
+                                size_t batch_size,
+                                size_t max_uncompressed_chunk_bytes)
+{
+  size_t temp_size             = 0;
+  nvcompStatus_t nvcomp_status = nvcompStatus_t::nvcompSuccess;
+  switch (compression) {
+    case compression_type::SNAPPY:
+      nvcomp_status = nvcompBatchedSnappyCompressGetTempSize(
+        batch_size, max_uncompressed_chunk_bytes, nvcompBatchedSnappyDefaultOpts, &temp_size);
+      break;
+#if NVCOMP_HAS_DEFLATE
+    case compression_type::DEFLATE:
+      nvcomp_status = nvcompBatchedDeflateCompressGetTempSize(
+        batch_size, max_uncompressed_chunk_bytes, nvcompBatchedDeflateDefaultOpts, &temp_size);
+      break;
+#endif
+    default: CUDF_FAIL("Unsupported compression type");
+  }
+
+  CUDF_EXPECTS(nvcomp_status == nvcompStatus_t::nvcompSuccess,
+               "Unable to get scratch size for compression");
+  return temp_size;
+}
+
+// Dispatcher for nvcompBatched<format>CompressGetMaxOutputChunkSize
+size_t batched_compress_get_max_output_chunk_size(compression_type compression,
+                                                  uint32_t max_uncompressed_chunk_bytes)
+{
+  size_t max_comp_chunk_size = 0;
+  nvcompStatus_t status      = nvcompStatus_t::nvcompSuccess;
+  switch (compression) {
+    case compression_type::SNAPPY:
+      status = nvcompBatchedSnappyCompressGetMaxOutputChunkSize(
+        max_uncompressed_chunk_bytes, nvcompBatchedSnappyDefaultOpts, &max_comp_chunk_size);
+      break;
+#if NVCOMP_HAS_DEFLATE
+    case compression_type::DEFLATE:
+      status = nvcompBatchedDeflateCompressGetMaxOutputChunkSize(
+        max_uncompressed_chunk_bytes, nvcompBatchedDeflateDefaultOpts, &max_comp_chunk_size);
+      break;
+#endif
+    default: CUDF_FAIL("Unsupported compression type");
+  }
+
+  CUDF_EXPECTS(status == nvcompStatus_t::nvcompSuccess,
+               "failed to get max uncompressed chunk size");
+  return max_comp_chunk_size;
+}
+
+// Dispatcher for nvcompBatched<format>CompressAsync
+static void batched_compress_async(compression_type compression,
+                                   const void* const* device_uncompressed_ptrs,
+                                   const size_t* device_uncompressed_bytes,
+                                   size_t max_uncompressed_chunk_bytes,
+                                   size_t batch_size,
+                                   void* device_temp_ptr,
+                                   size_t temp_bytes,
+                                   void* const* device_compressed_ptrs,
+                                   size_t* device_compressed_bytes,
+                                   rmm::cuda_stream_view stream)
+{
+  nvcompStatus_t nvcomp_status = nvcompStatus_t::nvcompSuccess;
+  switch (compression) {
+    case compression_type::SNAPPY:
+      nvcomp_status = nvcompBatchedSnappyCompressAsync(device_uncompressed_ptrs,
+                                                       device_uncompressed_bytes,
+                                                       max_uncompressed_chunk_bytes,
+                                                       batch_size,
+                                                       device_temp_ptr,
+                                                       temp_bytes,
+                                                       device_compressed_ptrs,
+                                                       device_compressed_bytes,
+                                                       nvcompBatchedSnappyDefaultOpts,
+                                                       stream.value());
+      break;
+#if NVCOMP_HAS_DEFLATE
+    case compression_type::DEFLATE:
+      nvcomp_status = nvcompBatchedDeflateCompressAsync(device_uncompressed_ptrs,
+                                                        device_uncompressed_bytes,
+                                                        max_uncompressed_chunk_bytes,
+                                                        batch_size,
+                                                        device_temp_ptr,
+                                                        temp_bytes,
+                                                        device_compressed_ptrs,
+                                                        device_compressed_bytes,
+                                                        nvcompBatchedDeflateDefaultOpts,
+                                                        stream.value());
+      break;
+#endif
+    default: CUDF_FAIL("Unsupported compression type");
+  }
+  CUDF_EXPECTS(nvcomp_status == nvcompStatus_t::nvcompSuccess, "Error in compression");
+}
+
+void batched_compress(compression_type compression,
+                      device_span<device_span<uint8_t const> const> inputs,
+                      device_span<device_span<uint8_t> const> outputs,
+                      device_span<decompress_status> statuses,
+                      uint32_t max_uncomp_chunk_size,
+                      rmm::cuda_stream_view stream)
+{
+  auto const num_chunks = inputs.size();
+
+  auto const temp_size = batched_compress_temp_size(compression, num_chunks, max_uncomp_chunk_size);
+  rmm::device_buffer scratch(temp_size, stream);
+
+  rmm::device_uvector<size_t> actual_compressed_data_sizes(num_chunks, stream);
+  auto const nvcomp_args = create_batched_nvcomp_args(inputs, outputs, stream);
+
+  batched_compress_async(compression,
+                         nvcomp_args.input_data_ptrs.data(),
+                         nvcomp_args.input_data_sizes.data(),
+                         max_uncomp_chunk_size,
+                         num_chunks,
+                         scratch.data(),
+                         scratch.size(),
+                         nvcomp_args.output_data_ptrs.data(),
+                         actual_compressed_data_sizes.data(),
+                         stream.value());
+
+  convert_status(std::nullopt, actual_compressed_data_sizes, statuses, stream);
+}
+
 }  // namespace cudf::io::nvcomp

--- a/cpp/src/io/comp/nvcomp_adapter.cu
+++ b/cpp/src/io/comp/nvcomp_adapter.cu
@@ -25,7 +25,7 @@ batched_args create_batched_nvcomp_args(device_span<device_span<uint8_t const> c
                                         device_span<device_span<uint8_t> const> outputs,
                                         rmm::cuda_stream_view stream)
 {
-  size_t num_comp_chunks = inputs.size();
+  auto const num_comp_chunks = inputs.size();
   rmm::device_uvector<void const*> input_data_ptrs(num_comp_chunks, stream);
   rmm::device_uvector<size_t> input_data_sizes(num_comp_chunks, stream);
   rmm::device_uvector<void*> output_data_ptrs(num_comp_chunks, stream);

--- a/cpp/src/io/comp/nvcomp_adapter.cu
+++ b/cpp/src/io/comp/nvcomp_adapter.cu
@@ -25,23 +25,21 @@ batched_args create_batched_nvcomp_args(device_span<device_span<uint8_t const> c
                                         device_span<device_span<uint8_t> const> outputs,
                                         rmm::cuda_stream_view stream)
 {
-  size_t num_comp_pages = inputs.size();
-  rmm::device_uvector<void const*> compressed_data_ptrs(num_comp_pages, stream);
-  rmm::device_uvector<size_t> compressed_data_sizes(num_comp_pages, stream);
-  rmm::device_uvector<void*> uncompressed_data_ptrs(num_comp_pages, stream);
-  rmm::device_uvector<size_t> uncompressed_data_sizes(num_comp_pages, stream);
+  size_t num_comp_chunks = inputs.size();
+  rmm::device_uvector<void const*> input_data_ptrs(num_comp_chunks, stream);
+  rmm::device_uvector<size_t> input_data_sizes(num_comp_chunks, stream);
+  rmm::device_uvector<void*> output_data_ptrs(num_comp_chunks, stream);
+  rmm::device_uvector<size_t> output_data_sizes(num_comp_chunks, stream);
 
   // Prepare the input vectors
-  auto ins_it =
-    thrust::make_zip_iterator(compressed_data_ptrs.begin(), compressed_data_sizes.begin());
+  auto ins_it = thrust::make_zip_iterator(input_data_ptrs.begin(), input_data_sizes.begin());
   thrust::transform(
     rmm::exec_policy(stream), inputs.begin(), inputs.end(), ins_it, [] __device__(auto const& in) {
       return thrust::make_tuple(in.data(), in.size());
     });
 
   // Prepare the output vectors
-  auto outs_it =
-    thrust::make_zip_iterator(uncompressed_data_ptrs.begin(), uncompressed_data_sizes.begin());
+  auto outs_it = thrust::make_zip_iterator(output_data_ptrs.begin(), output_data_sizes.begin());
   thrust::transform(
     rmm::exec_policy(stream),
     outputs.begin(),
@@ -49,25 +47,37 @@ batched_args create_batched_nvcomp_args(device_span<device_span<uint8_t const> c
     outs_it,
     [] __device__(auto const& out) { return thrust::make_tuple(out.data(), out.size()); });
 
-  return {std::move(compressed_data_ptrs),
-          std::move(compressed_data_sizes),
-          std::move(uncompressed_data_ptrs),
-          std::move(uncompressed_data_sizes)};
+  return {std::move(input_data_ptrs),
+          std::move(input_data_sizes),
+          std::move(output_data_ptrs),
+          std::move(output_data_sizes)};
 }
 
-void convert_status(device_span<nvcompStatus_t const> nvcomp_stats,
+void convert_status(std::optional<device_span<nvcompStatus_t const>> nvcomp_stats,
                     device_span<size_t const> actual_uncompressed_sizes,
                     device_span<decompress_status> cudf_stats,
                     rmm::cuda_stream_view stream)
 {
-  thrust::transform(
-    rmm::exec_policy(stream),
-    nvcomp_stats.begin(),
-    nvcomp_stats.end(),
-    actual_uncompressed_sizes.begin(),
-    cudf_stats.begin(),
-    [] __device__(auto const& status, auto const& size) {
-      return decompress_status{size, status == nvcompStatus_t::nvcompSuccess ? 0u : 1u};
-    });
+  if (nvcomp_stats.has_value()) {
+    thrust::transform(
+      rmm::exec_policy(stream),
+      nvcomp_stats->begin(),
+      nvcomp_stats->end(),
+      actual_uncompressed_sizes.begin(),
+      cudf_stats.begin(),
+      [] __device__(auto const& status, auto const& size) {
+        return decompress_status{size, status == nvcompStatus_t::nvcompSuccess ? 0u : 1u};
+      });
+  } else {
+    thrust::transform(rmm::exec_policy(stream),
+                      actual_uncompressed_sizes.begin(),
+                      actual_uncompressed_sizes.end(),
+                      cudf_stats.begin(),
+                      [] __device__(size_t size) {
+                        decompress_status status{};
+                        status.bytes_written = size;
+                        return status;
+                      });
+  }
 }
 }  // namespace cudf::io::nvcomp

--- a/cpp/src/io/comp/nvcomp_adapter.cuh
+++ b/cpp/src/io/comp/nvcomp_adapter.cuh
@@ -28,10 +28,10 @@
 namespace cudf::io::nvcomp {
 
 struct batched_args {
-  rmm::device_uvector<void const*> compressed_data_ptrs;
-  rmm::device_uvector<size_t> compressed_data_sizes;
-  rmm::device_uvector<void*> uncompressed_data_ptrs;
-  rmm::device_uvector<size_t> uncompressed_data_sizes;
+  rmm::device_uvector<void const*> input_data_ptrs;
+  rmm::device_uvector<size_t> input_data_sizes;
+  rmm::device_uvector<void*> output_data_ptrs;
+  rmm::device_uvector<size_t> output_data_sizes;
 };
 
 /**
@@ -48,7 +48,7 @@ batched_args create_batched_nvcomp_args(device_span<device_span<uint8_t const> c
 /**
  * @brief Convert nvcomp statuses into cuIO compression statuses.
  */
-void convert_status(device_span<nvcompStatus_t const> nvcomp_stats,
+void convert_status(std::optional<device_span<nvcompStatus_t const>> nvcomp_stats,
                     device_span<size_t const> actual_uncompressed_sizes,
                     device_span<decompress_status> cudf_stats,
                     rmm::cuda_stream_view stream);

--- a/cpp/src/io/comp/nvcomp_adapter.hpp
+++ b/cpp/src/io/comp/nvcomp_adapter.hpp
@@ -29,17 +29,44 @@ enum class compression_type { SNAPPY, ZSTD, DEFLATE };
 /**
  * @brief Device batch decompression of given type.
  *
- * @param[in] type Compression type
+ * @param[in] compression Compression type
  * @param[in] inputs List of input buffers
  * @param[out] outputs List of output buffers
  * @param[out] statuses List of output status structures
- * @param[in] max_uncomp_page_size maximum size of uncompressed block
+ * @param[in] max_uncomp_chunk_size maximum size of uncompressed chunk
  * @param[in] stream CUDA stream to use
  */
 void batched_decompress(compression_type compression,
                         device_span<device_span<uint8_t const> const> inputs,
                         device_span<device_span<uint8_t> const> outputs,
                         device_span<decompress_status> statuses,
-                        size_t max_uncomp_page_size,
+                        size_t max_uncomp_chunk_size,
                         rmm::cuda_stream_view stream);
+
+/**
+ * @brief Gets the maximum size any chunk could compress to in the batch.
+ *
+ * @param compression Compression type
+ * @param max_uncomp_chunk_size Size of the largest uncompressed chunk in the batch
+ */
+size_t batched_compress_get_max_output_chunk_size(compression_type compression,
+                                                  uint32_t max_uncomp_chunk_size);
+
+/**
+ * @brief Device batch compression of given type.
+ *
+ * @param[in] compression Compression type
+ * @param[in] inputs List of input buffers
+ * @param[out] outputs List of output buffers
+ * @param[out] statuses List of output status structures
+ * @param[in] max_uncomp_chunk_size Size of the largest uncompressed chunk in the batch
+ * @param[in] stream CUDA stream to use
+ */
+void batched_compress(compression_type compression,
+                      device_span<device_span<uint8_t const> const> inputs,
+                      device_span<device_span<uint8_t> const> outputs,
+                      device_span<decompress_status> statuses,
+                      uint32_t max_uncomp_chunk_size,
+                      rmm::cuda_stream_view stream);
+
 }  // namespace cudf::io::nvcomp

--- a/cpp/src/io/orc/orc_common.hpp
+++ b/cpp/src/io/orc/orc_common.hpp
@@ -22,7 +22,14 @@ namespace cudf {
 namespace io {
 namespace orc {
 
-static constexpr uint32_t BLOCK_HEADER_SIZE = 3;
+static constexpr uint32_t block_header_size = 3;
+
+constexpr uint32_t compressed_block_size(uint32_t compressed_data_size)
+{
+  return ((compressed_data_size + block_header_size + 0xFF) & ~0xFF);
+}
+
+static constexpr uint32_t padded_block_header_size = compressed_block_size(0);
 
 enum CompressionKind : uint8_t {
   NONE   = 0,

--- a/cpp/src/io/orc/stripe_init.cu
+++ b/cpp/src/io/orc/stripe_init.cu
@@ -60,14 +60,14 @@ __global__ void __launch_bounds__(128, 8) gpuParseCompressedStripeData(
     uint32_t max_uncompressed_block_size = 0;
     uint32_t num_compressed_blocks       = 0;
     uint32_t num_uncompressed_blocks     = 0;
-    while (cur + BLOCK_HEADER_SIZE < end) {
+    while (cur + block_header_size < end) {
       uint32_t block_len = shuffle((lane_id == 0) ? cur[0] | (cur[1] << 8) | (cur[2] << 16) : 0);
       auto const is_uncompressed = static_cast<bool>(block_len & 1);
       uint32_t uncompressed_size;
       device_span<uint8_t const>* init_in_ctl = nullptr;
       device_span<uint8_t>* init_out_ctl      = nullptr;
       block_len >>= 1;
-      cur += BLOCK_HEADER_SIZE;
+      cur += block_header_size;
       if (block_len > block_size || cur + block_len > end) {
         // Fatal
         num_compressed_blocks       = 0;
@@ -161,12 +161,12 @@ __global__ void __launch_bounds__(128, 8)
     uint32_t num_compressed_blocks  = 0;
     uint32_t max_compressed_blocks  = s->info.num_compressed_blocks;
 
-    while (cur + BLOCK_HEADER_SIZE < end) {
+    while (cur + block_header_size < end) {
       uint32_t block_len = shuffle((lane_id == 0) ? cur[0] | (cur[1] << 8) | (cur[2] << 16) : 0);
       auto const is_uncompressed = static_cast<bool>(block_len & 1);
       uint32_t uncompressed_size_est, uncompressed_size_actual;
       block_len >>= 1;
-      cur += BLOCK_HEADER_SIZE;
+      cur += block_header_size;
       if (cur + block_len > end) { break; }
       if (is_uncompressed) {
         uncompressed_size_est    = block_len;
@@ -383,11 +383,11 @@ static __device__ void gpuMapRowIndexToUncompressed(rowindex_state_s* s,
       for (;;) {
         uint32_t block_len;
 
-        if (cur + BLOCK_HEADER_SIZE > end || cur + BLOCK_HEADER_SIZE >= start + compressed_offset) {
+        if (cur + block_header_size > end || cur + block_header_size >= start + compressed_offset) {
           break;
         }
         block_len = cur[0] | (cur[1] << 8) | (cur[2] << 16);
-        cur += BLOCK_HEADER_SIZE;
+        cur += block_header_size;
         auto const is_uncompressed = static_cast<bool>(block_len & 1);
         block_len >>= 1;
         cur += block_len;

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -98,7 +98,7 @@ orc::CompressionKind to_orc_compression(compression_type compression)
  *
  * The nvCOMP ZLIB compression is limited to blocks up to 64KiB.
  */
-size_t compression_block_size(orc::CompressionKind compression)
+constexpr size_t compression_block_size(orc::CompressionKind compression)
 {
   switch (compression) {
     case orc::CompressionKind::NONE: return 0;

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -21,6 +21,7 @@
 
 #include "writer_impl.hpp"
 
+#include <io/comp/nvcomp_adapter.hpp>
 #include <io/statistics/column_statistics.cuh>
 #include <io/utilities/column_utils.cuh>
 
@@ -46,8 +47,6 @@
 #include <thrust/optional.h>
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
-
-#include <nvcomp/snappy.h>
 
 #include <algorithm>
 #include <cstring>
@@ -88,8 +87,23 @@ orc::CompressionKind to_orc_compression(compression_type compression)
   switch (compression) {
     case compression_type::AUTO:
     case compression_type::SNAPPY: return orc::CompressionKind::SNAPPY;
+    case compression_type::ZLIB: return orc::CompressionKind::ZLIB;
     case compression_type::NONE: return orc::CompressionKind::NONE;
     default: CUDF_FAIL("Unsupported compression type"); return orc::CompressionKind::NONE;
+  }
+}
+
+/**
+ * @brief Returns the block size for a given compression kind.
+ *
+ * The nvCOMP ZLIB compression is limited to blocks up to 64KiB.
+ */
+size_t compression_block_size(orc::CompressionKind compression)
+{
+  switch (compression) {
+    case orc::CompressionKind::NONE: return 0;
+    case orc::CompressionKind::ZLIB: return 64 * 1024;
+    default: return 256 * 1024;
   }
 }
 
@@ -1353,10 +1367,10 @@ void writer::impl::write_index_stream(int32_t stripe_id,
       record.pos += stream.lengths[type];
       while ((record.pos >= 0) && (record.blk_pos >= 0) &&
              (static_cast<size_t>(record.pos) >= compression_blocksize_) &&
-             (record.comp_pos + BLOCK_HEADER_SIZE + comp_out[record.blk_pos].bytes_written <
+             (record.comp_pos + block_header_size + comp_out[record.blk_pos].bytes_written <
               static_cast<size_t>(record.comp_size))) {
         record.pos -= compression_blocksize_;
-        record.comp_pos += BLOCK_HEADER_SIZE + comp_out[record.blk_pos].bytes_written;
+        record.comp_pos += block_header_size + comp_out[record.blk_pos].bytes_written;
         record.blk_pos += 1;
       }
     }
@@ -1474,6 +1488,7 @@ writer::impl::impl(std::unique_ptr<data_sink> sink,
     max_stripe_size{options.get_stripe_size_bytes(), options.get_stripe_size_rows()},
     row_index_stride{options.get_row_index_stride()},
     compression_kind_(to_orc_compression(options.get_compression())),
+    compression_blocksize_(compression_block_size(compression_kind_)),
     stats_freq_(options.get_statistics_freq()),
     single_write_mode(mode == SingleWriteMode::YES),
     kv_meta(options.get_key_value_metadata()),
@@ -1495,6 +1510,7 @@ writer::impl::impl(std::unique_ptr<data_sink> sink,
     max_stripe_size{options.get_stripe_size_bytes(), options.get_stripe_size_rows()},
     row_index_stride{options.get_row_index_stride()},
     compression_kind_(to_orc_compression(options.get_compression())),
+    compression_blocksize_(compression_block_size(compression_kind_)),
     stats_freq_(options.get_statistics_freq()),
     single_write_mode(mode == SingleWriteMode::YES),
     kv_meta(options.get_key_value_metadata()),
@@ -1986,6 +2002,22 @@ __global__ void copy_string_data(char* string_pool,
   }
 }
 
+auto to_nvcomp_compression_type(CompressionKind compression_kind)
+{
+  if (compression_kind == SNAPPY) return nvcomp::compression_type::SNAPPY;
+  if (compression_kind == ZLIB) return nvcomp::compression_type::DEFLATE;
+  CUDF_FAIL("Unsupported compression type");
+}
+
+size_t get_compress_max_output_chunk_size(CompressionKind compression_kind,
+                                          uint32_t compression_blocksize)
+{
+  if (compression_kind == NONE) return 0;
+
+  return batched_compress_get_max_output_chunk_size(to_nvcomp_compression_type(compression_kind),
+                                                    compression_blocksize);
+}
+
 void writer::impl::persisted_statistics::persist(int num_table_rows,
                                                  bool single_write_mode,
                                                  intermediate_statistics& intermediate_stats,
@@ -2101,13 +2133,11 @@ void writer::impl::write(table_view const& table)
 
   if (num_rows > 0) {
     // Allocate intermediate output stream buffer
-    size_t compressed_bfr_size       = 0;
-    size_t num_compressed_blocks     = 0;
-    size_t max_compressed_block_size = 0;
-    if (compression_kind_ != NONE) {
-      nvcompBatchedSnappyCompressGetMaxOutputChunkSize(
-        compression_blocksize_, nvcompBatchedSnappyDefaultOpts, &max_compressed_block_size);
-    }
+    size_t compressed_bfr_size   = 0;
+    size_t num_compressed_blocks = 0;
+    auto const max_compressed_block_size =
+      get_compress_max_output_chunk_size(compression_kind_, compression_blocksize_);
+
     auto stream_output = [&]() {
       size_t max_stream_size = 0;
       bool all_device_write  = true;
@@ -2121,9 +2151,9 @@ void writer::impl::write(table_view const& table)
 
           auto num_blocks = std::max<uint32_t>(
             (stream_size + compression_blocksize_ - 1) / compression_blocksize_, 1);
-          stream_size += num_blocks * BLOCK_HEADER_SIZE;
+          stream_size += num_blocks * block_header_size;
           num_compressed_blocks += num_blocks;
-          compressed_bfr_size += (max_compressed_block_size + BLOCK_HEADER_SIZE) * num_blocks;
+          compressed_bfr_size += compressed_block_size(max_compressed_block_size) * num_blocks;
         }
         max_stream_size = std::max(max_stream_size, stream_size);
       }

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -183,9 +183,6 @@ class writer::impl {
   // ORC datasets start with a 3 byte header
   static constexpr const char* MAGIC = "ORC";
 
-  // ORC compresses streams into independent chunks
-  static constexpr uint32_t DEFAULT_COMPRESSION_BLOCKSIZE = 256 * 1024;
-
  public:
   /**
    * @brief Constructor with writer options.
@@ -431,8 +428,8 @@ class writer::impl {
 
   stripe_size_limits max_stripe_size;
   size_type row_index_stride;
-  size_t compression_blocksize_     = DEFAULT_COMPRESSION_BLOCKSIZE;
-  CompressionKind compression_kind_ = CompressionKind::NONE;
+  CompressionKind compression_kind_;
+  size_t compression_blocksize_;
 
   bool enable_dictionary_     = true;
   statistics_freq stats_freq_ = ORC_STATISTICS_ROW_GROUP;

--- a/python/cudf/cudf/_lib/cpp/io/types.pxd
+++ b/python/cudf/cudf/_lib/cpp/io/types.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 
 from libc.stdint cimport uint8_t
 from libcpp cimport bool
@@ -32,6 +32,10 @@ cdef extern from "cudf/io/types.hpp" \
         BROTLI "cudf::io::compression_type::BROTLI"
         ZIP "cudf::io::compression_type::ZIP"
         XZ "cudf::io::compression_type::XZ"
+        ZLIB "cudf::io::compression_type::ZLIB"
+        LZ4 "cudf::io::compression_type::LZ4"
+        LZO "cudf::io::compression_type::LZO"
+        ZSTD "cudf::io::compression_type::ZSTD"
 
     ctypedef enum io_type:
         FILEPATH "cudf::io::io_type::FILEPATH"

--- a/python/cudf/cudf/_lib/orc.pyx
+++ b/python/cudf/cudf/_lib/orc.pyx
@@ -159,6 +159,8 @@ cdef compression_type _get_comp_type(object compression):
         return compression_type.NONE
     elif compression == "snappy":
         return compression_type.SNAPPY
+    elif compression == "ZLIB":
+        return compression_type.ZLIB
     else:
         raise ValueError(f"Unsupported `compression` type {compression}")
 

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -1743,3 +1743,18 @@ def test_writer_protobuf_large_rowindexentry():
 
     got = cudf.read_orc(buff)
     assert_frame_equal(df, got)
+
+
+def test_orc_writer_zlib_compression(list_struct_buff):
+    expected = cudf.read_orc(list_struct_buff)
+    try:
+        # save with ZLIB compression
+        buff = BytesIO()
+        expected.to_orc(buff, compression="ZLIB")
+        got = cudf.read_orc(buff)
+        assert_eq(expected, got)
+    except RuntimeError as e:
+        if "Unsupported compression type" in str(e):
+            pytest.mark.xfail(reason="nvcomp build doesn't have deflate")
+        else:
+            raise e

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -425,7 +425,7 @@ Parameters
 ----------
 fname : str
     File path or object where the ORC dataset will be stored.
-compression : {{ 'snappy', None }}, default None
+compression : {{ 'snappy', 'ZLIB', None }}, default None
     Name of the compression to use. Use None for no compression.
 enable_statistics: boolean, default True
     Enable writing column statistics.


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/11023

Expands the nvcomp adapter to cover compression. Supports SNAPPY and ZLIB.
Moves the ORC writer nvcomp compression from `stripe_enc.cu` to the adapter and add ZLIB support.
Adds padding to compressed blocks in writer to ensure alignment of output pointer alignment that is required for nvcomp ZLIB compression.

Minor changes:
- Make page/block/chunk naming consistent in the nvcomp adapter -> always use chunk (to match nvcomp).
- Rename members of `batched_args` so it also makes sense for compression.