### PR TITLE
add missed documentation in PR #10870

### DIFF
--- a/cpp/include/cudf/table/experimental/row_operators.cuh
+++ b/cpp/include/cudf/table/experimental/row_operators.cuh
@@ -456,19 +456,36 @@ struct weak_ordering_comparator_impl {
  * @brief Wraps and interprets the result of device_row_comparator, true if the result is
  * weak_ordering::LESS meaning one row is lexicographically *less* than another row.
  *
- * @tparam Nullate A cudf::nullate type describing whether to check for nulls.
+ * @tparam Comparator generic comparator that returns a weak_ordering
  */
 template <typename Comparator>
 struct less_comparator : weak_ordering_comparator_impl<Comparator, weak_ordering::LESS> {
+  /**
+   * @brief Constructs a less_comparator
+   *
+   * @param comparator The comparator to wrap
+   */
   less_comparator(Comparator const& comparator)
     : weak_ordering_comparator_impl<Comparator, weak_ordering::LESS>{comparator}
   {
   }
 };
 
+/**
+ * @brief Wraps and interprets the result of device_row_comparator, true if the result is
+ * weak_ordering::LESS or weak_ordering::EQUIVALENT meaning one row is lexicographically *less* than
+ * or *equivalent* to another row.
+ *
+ * @tparam Comparator generic comparator that returns a weak_ordering
+ */
 template <typename Comparator>
 struct less_equivalent_comparator
   : weak_ordering_comparator_impl<Comparator, weak_ordering::LESS, weak_ordering::EQUIVALENT> {
+  /**
+   * @brief Constructs a less_equivalent_comparator
+   *
+   * @param comparator The comparator to wrap
+   */
   less_equivalent_comparator(Comparator const& comparator)
     : weak_ordering_comparator_impl<Comparator, weak_ordering::LESS, weak_ordering::EQUIVALENT>{
         comparator}
@@ -644,6 +661,7 @@ class self_comparator {
       nullate, *d_t, *d_t, d_t->depths(), d_t->column_order(), d_t->null_precedence(), comparator}};
   }
 
+  /// @copydoc less()
   template <typename Nullate,
             typename PhysicalElementComparator = sorting_physical_element_comparator>
   auto less_equivalent(Nullate nullate                      = {},
@@ -781,6 +799,7 @@ class two_table_comparator {
                                                             comparator}}};
   }
 
+  /// @copydoc less()
   template <typename Nullate,
             typename PhysicalElementComparator = sorting_physical_element_comparator>
   auto less_equivalent(Nullate nullate                      = {},


### PR DESCRIPTION
Fixes parts of https://github.com/rapidsai/cudf/issues/9373
added missing documentation to fix doxygen warnings in table/experimental/row_operators.cuh

<!--

-->
