### PR TITLE
Use per-page max compressed size estimate for compression

### DIFF
--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -241,7 +241,6 @@ __global__ void __launch_bounds__(128)
                device_span<parquet_column_device_view const> col_desc,
                statistics_merge_group* page_grstats,
                statistics_merge_group* chunk_grstats,
-               size_t max_page_comp_data_size,
                int32_t num_columns,
                size_t max_page_size_bytes,
                size_type max_page_size_rows)
@@ -1999,7 +1998,6 @@ void InitEncoderPages(device_2dspan<EncColumnChunk> chunks,
                       size_type max_page_size_rows,
                       statistics_merge_group* page_grstats,
                       statistics_merge_group* chunk_grstats,
-                      size_t max_page_comp_data_size,
                       rmm::cuda_stream_view stream)
 {
   auto num_rowgroups = chunks.size().first;
@@ -2011,7 +2009,6 @@ void InitEncoderPages(device_2dspan<EncColumnChunk> chunks,
                                                      col_desc,
                                                      page_grstats,
                                                      chunk_grstats,
-                                                     max_page_comp_data_size,
                                                      num_columns,
                                                      max_page_size_bytes,
                                                      max_page_size_rows);

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -308,7 +308,6 @@ __global__ void __launch_bounds__(128)
       __syncwarp();
       if (t == 0) {
         if (not pages.empty()) pages[ck_g.first_page] = page_g;
-        // printf("pagesize %d\n", page_g.max_data_size);
         if (not page_sizes.empty()) page_sizes[ck_g.first_page] = page_g.max_data_size;
         if (page_grstats) page_grstats[ck_g.first_page] = pagestats_g;
       }
@@ -405,8 +404,6 @@ __global__ void __launch_bounds__(128)
         if (t == 0) {
           if (not pages.empty()) { pages[ck_g.first_page + num_pages] = page_g; }
           if (not page_sizes.empty()) {
-            // printf("page no %d pagesize %d\n", ck_g.first_page + num_pages,
-            // page_g.max_data_size);
             page_sizes[ck_g.first_page + num_pages] = page_g.max_data_size;
           }
           if (page_grstats) { page_grstats[ck_g.first_page + num_pages] = pagestats_g; }
@@ -442,7 +439,6 @@ __global__ void __launch_bounds__(128)
       ck_g.page_headers_size  = page_headers_size;
       ck_g.max_page_data_size = max_page_data_size;
       if (not comp_page_sizes.empty()) ck_g.compressed_size = comp_page_offset;
-      // printf("compressed_size %d\n", ck_g.compressed_size);
       pagestats_g.start_chunk = ck_g.first_page + ck_g.use_dictionary;  // Exclude dictionary
       pagestats_g.num_chunks  = num_pages - ck_g.use_dictionary;
     }
@@ -1107,7 +1103,6 @@ __global__ void __launch_bounds__(128, 8)
     if (not comp_in.empty()) {
       comp_in[blockIdx.x]  = {base, actual_data_size};
       comp_out[blockIdx.x] = {s->page.compressed_data + s->page.max_hdr_size, compressed_bfr_size};
-      // printf("compressed_bfr_size: %d\n", compressed_bfr_size);
     }
     pages[blockIdx.x] = s->page;
     if (not comp_stats.empty()) {

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -300,8 +300,9 @@ __global__ void __launch_bounds__(128)
         page_g.num_leaf_values = ck_g.num_dict_entries;
         page_g.num_values      = ck_g.num_dict_entries;  // TODO: shouldn't matter for dict page
         page_offset += page_g.max_hdr_size + page_g.max_data_size;
-        if (not comp_page_sizes.empty())
+        if (not comp_page_sizes.empty()) {
           comp_page_offset += page_g.max_hdr_size + comp_page_sizes[ck_g.first_page];
+        }
         page_headers_size += page_g.max_hdr_size;
         max_page_data_size = max(max_page_data_size, page_g.max_data_size);
       }
@@ -370,8 +371,9 @@ __global__ void __launch_bounds__(128)
             page_g.max_hdr_size += stats_hdr_len;
           }
           page_g.page_data = ck_g.uncompressed_bfr + page_offset;
-          if (not comp_page_sizes.empty())
+          if (not comp_page_sizes.empty()) {
             page_g.compressed_data = ck_g.compressed_bfr + comp_page_offset;
+          }
           page_g.start_row        = cur_row;
           page_g.num_rows         = rows_in_page;
           page_g.num_leaf_values  = leaf_values_in_page;
@@ -393,8 +395,9 @@ __global__ void __launch_bounds__(128)
           pagestats_g.start_chunk = ck_g.first_fragment + page_start;
           pagestats_g.num_chunks  = page_g.num_fragments;
           page_offset += page_g.max_hdr_size + page_g.max_data_size;
-          if (not comp_page_sizes.empty())
+          if (not comp_page_sizes.empty()) {
             comp_page_offset += page_g.max_hdr_size + comp_page_sizes[ck_g.first_page + num_pages];
+          }
           page_headers_size += page_g.max_hdr_size;
           max_page_data_size = max(max_page_data_size, page_g.max_data_size);
           cur_row += rows_in_page;
@@ -438,7 +441,7 @@ __global__ void __launch_bounds__(128)
       ck_g.bfr_size           = page_offset;
       ck_g.page_headers_size  = page_headers_size;
       ck_g.max_page_data_size = max_page_data_size;
-      if (not comp_page_sizes.empty()) ck_g.compressed_size = comp_page_offset;
+      if (not comp_page_sizes.empty()) { ck_g.compressed_size = comp_page_offset; }
       pagestats_g.start_chunk = ck_g.first_page + ck_g.use_dictionary;  // Exclude dictionary
       pagestats_g.num_chunks  = num_pages - ck_g.use_dictionary;
     }

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -573,6 +573,8 @@ void get_dictionary_indices(cudf::detail::device_2dspan<gpu::PageFragment const>
  */
 void InitEncoderPages(cudf::detail::device_2dspan<EncColumnChunk> chunks,
                       device_span<gpu::EncPage> pages,
+                      device_span<size_type> page_sizes,
+                      device_span<size_type> comp_page_sizes,
                       device_span<parquet_column_device_view const> col_desc,
                       int32_t num_columns,
                       size_t max_page_size_bytes,

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -581,7 +581,6 @@ void InitEncoderPages(cudf::detail::device_2dspan<EncColumnChunk> chunks,
                       size_type max_page_size_rows,
                       statistics_merge_group* page_grstats,
                       statistics_merge_group* chunk_grstats,
-                      size_t max_page_comp_data_size,
                       rmm::cuda_stream_view stream);
 
 /**

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -83,17 +83,6 @@ parquet::Compression to_parquet_compression(compression_type compression)
   }
 }
 
-template <typename T>
-void print(rmm::device_uvector<T> const& d_vec, std::string label = "")
-{
-  std::vector<T> h_vec(d_vec.size());
-  cudaMemcpy(h_vec.data(), d_vec.data(), d_vec.size() * sizeof(T), cudaMemcpyDeviceToHost);
-  printf("%s (%lu)\t", label.c_str(), h_vec.size());
-  for (auto&& i : h_vec)
-    std::cout << i << " ";
-  printf("\n");
-}
-
 }  // namespace
 
 struct aggregate_writer_metadata {
@@ -1106,7 +1095,6 @@ void snappy_compress(device_span<device_span<uint8_t const> const> comp_in,
                       comp_out.end(),
                       compressed_data_ptrs.begin(),
                       [] __device__(auto const& out) { return out.data(); });
-    // print(compressed_data_ptrs, "compressed_data_ptrs");
     nvcomp_status = nvcompBatchedSnappyCompressAsync(uncompressed_data_ptrs.data(),
                                                      uncompressed_data_sizes.data(),
                                                      max_page_uncomp_data_size,
@@ -1117,7 +1105,6 @@ void snappy_compress(device_span<device_span<uint8_t const> const> comp_in,
                                                      compressed_bytes_written.data(),
                                                      nvcompBatchedSnappyDefaultOpts,
                                                      stream.value());
-    // print(compressed_bytes_written, "compressed_bytes_written");
     CUDF_EXPECTS(nvcomp_status == nvcompStatus_t::nvcompSuccess, "Error in snappy compression");
 
     // nvcomp also doesn't use comp_out.status . It guarantees that given enough output space,

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -861,7 +861,7 @@ auto init_page_sizes(hostdevice_2dvector<gpu::EncColumnChunk>& chunks,
                      size_type max_page_size_rows,
                      rmm::cuda_stream_view stream)
 {
-  if (chunks.host_view().flat_view().size() == 0) { return hostdevice_vector<size_type>{}; }
+  if (chunks.is_empty()) { return hostdevice_vector<size_type>{}; }
 
   chunks.host_to_device(stream);
   // Calculate number of pages and store in respective chunks

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -902,13 +902,13 @@ auto init_page_sizes(hostdevice_2dvector<gpu::EncColumnChunk>& chunks,
   page_sizes.device_to_host(stream, true);
 
   // Get per-page max compressed size
-  hostdevice_vector<size_type> comp_page_sizes(0, num_pages, stream);
-  for (auto page_size : page_sizes) {
+  hostdevice_vector<size_type> comp_page_sizes(num_pages, stream);
+  std::transform(page_sizes.begin(), page_sizes.end(), comp_page_sizes.begin(), [](auto page_size) {
     size_t page_comp_max_size = 0;
     nvcompBatchedSnappyCompressGetMaxOutputChunkSize(
       page_size, nvcompBatchedSnappyDefaultOpts, &page_comp_max_size);
-    comp_page_sizes.insert(page_comp_max_size);
-  }
+    return page_comp_max_size;
+  });
   comp_page_sizes.host_to_device(stream);
 
   // Use per-page max compressed size to calculate chunk.compressed_size

--- a/cpp/src/io/parquet/writer_impl.hpp
+++ b/cpp/src/io/parquet/writer_impl.hpp
@@ -166,7 +166,6 @@ class writer::impl {
                           hostdevice_vector<size_type>& comp_page_sizes,
                           statistics_chunk* page_stats,
                           statistics_chunk* frag_stats,
-                          size_t max_page_comp_data_size,
                           uint32_t num_columns,
                           uint32_t num_pages,
                           uint32_t num_stats_bfr);

--- a/cpp/src/io/parquet/writer_impl.hpp
+++ b/cpp/src/io/parquet/writer_impl.hpp
@@ -146,16 +146,6 @@ class writer::impl {
                                   device_2dspan<gpu::PageFragment const> frag,
                                   device_span<gpu::parquet_column_device_view const> col_desc,
                                   uint32_t num_fragments);
-  /**
-   * @brief Build per-chunk dictionaries and count data pages
-   *
-   * @param chunks column chunk array
-   * @param col_desc column description array
-   * @param num_columns Total number of columns
-   */
-  void init_page_sizes(hostdevice_2dvector<gpu::EncColumnChunk>& chunks,
-                       device_span<gpu::parquet_column_device_view const> col_desc,
-                       uint32_t num_columns);
 
   /**
    * @brief Initialize encoder pages
@@ -173,6 +163,7 @@ class writer::impl {
   void init_encoder_pages(hostdevice_2dvector<gpu::EncColumnChunk>& chunks,
                           device_span<gpu::parquet_column_device_view const> col_desc,
                           device_span<gpu::EncPage> pages,
+                          hostdevice_vector<size_type>& comp_page_sizes,
                           statistics_chunk* page_stats,
                           statistics_chunk* frag_stats,
                           size_t max_page_comp_data_size,


### PR DESCRIPTION
Closes #10857 

The current behaviour of parquet writer is to get the estimate for maximum page compressed size by first finding the maximum page size and using nvcomp's `nvcompBatchedSnappyCompressGetMaxOutputChunkSize` API once for the largest page. The total output memory is allocated for max_compressed_page_size * num_pages.

This approach is pessimistic and over-allocates output buffer for batched compression.

This PR changes this to call `nvcompBatchedSnappyCompressGetMaxOutputChunkSize` for each page and sum up the result to get the output buffer size. This greatly reduces the peak memory consumption of parquet writer so the compression step is no longer the bottleneck.

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->
