### PR TITLE
Replace `thrust::all_of` with a kernel to avoid a device sync

### DIFF
--- a/cpp/src/io/comp/gpuinflate.hpp
+++ b/cpp/src/io/comp/gpuinflate.hpp
@@ -126,5 +126,16 @@ void gpu_snap(device_span<device_span<uint8_t const> const> inputs,
               device_span<decompress_status> statuses,
               rmm::cuda_stream_view stream);
 
+/**
+ * @brief Checks the vector of decompression status and stores the result in a device scalar.
+ *
+ * @param[in] stats input vector of statuses
+ * @param[out] any_block_failure pointer to device memory where the output status is stored
+ * @param[in] stream CUDA stream to use
+ */
+void decompress_check(device_span<decompress_status> stats,
+                      bool* any_block_failure,
+                      rmm::cuda_stream_view stream);
+
 }  // namespace io
 }  // namespace cudf


### PR DESCRIPTION
Reverts the damage made by #10699.
Also move the kernel definition to a common location so the code is not repeated between ORC and Parquet.