### PR TITLE
Replace remaining instances of rmm::cuda_stream_default with cudf::default_stream_value

### DIFF
--- a/cpp/benchmarks/column/concatenate.cpp
+++ b/cpp/benchmarks/column/concatenate.cpp
@@ -22,6 +22,7 @@
 
 #include <cudf/concatenate.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -48,7 +49,7 @@ static void BM_concatenate(benchmark::State& state)
   CUDF_CHECK_CUDA(0);
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     auto result = cudf::concatenate(column_views);
   }
 
@@ -90,7 +91,7 @@ static void BM_concatenate_tables(benchmark::State& state)
   CUDF_CHECK_CUDA(0);
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     auto result = cudf::concatenate(table_views);
   }
 
@@ -149,7 +150,7 @@ static void BM_concatenate_strings(benchmark::State& state)
   CUDF_CHECK_CUDA(0);
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     auto result = cudf::concatenate(column_views);
   }
 

--- a/cpp/benchmarks/common/random_distribution_factory.cuh
+++ b/cpp/benchmarks/common/random_distribution_factory.cuh
@@ -18,6 +18,8 @@
 
 #include "generate_input.hpp"
 
+#include <cudf/utilities/default_stream.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/execution_policy.h>
@@ -146,7 +148,7 @@ distribution_fn<T> make_distribution(distribution_id dist_id, T lower_bound, T u
     case distribution_id::NORMAL:
       return [lower_bound, upper_bound, dist = make_normal_dist(lower_bound, upper_bound)](
                thrust::minstd_rand& engine, size_t size) -> rmm::device_uvector<T> {
-        rmm::device_uvector<T> result(size, rmm::cuda_stream_default);
+        rmm::device_uvector<T> result(size, cudf::default_stream_value);
         thrust::tabulate(thrust::device,
                          result.begin(),
                          result.end(),
@@ -156,7 +158,7 @@ distribution_fn<T> make_distribution(distribution_id dist_id, T lower_bound, T u
     case distribution_id::UNIFORM:
       return [lower_bound, upper_bound, dist = make_uniform_dist(lower_bound, upper_bound)](
                thrust::minstd_rand& engine, size_t size) -> rmm::device_uvector<T> {
-        rmm::device_uvector<T> result(size, rmm::cuda_stream_default);
+        rmm::device_uvector<T> result(size, cudf::default_stream_value);
         thrust::tabulate(thrust::device,
                          result.begin(),
                          result.end(),
@@ -167,7 +169,7 @@ distribution_fn<T> make_distribution(distribution_id dist_id, T lower_bound, T u
       // kind of exponential distribution from lower_bound to upper_bound.
       return [lower_bound, upper_bound, dist = geometric_distribution<T>(lower_bound, upper_bound)](
                thrust::minstd_rand& engine, size_t size) -> rmm::device_uvector<T> {
-        rmm::device_uvector<T> result(size, rmm::cuda_stream_default);
+        rmm::device_uvector<T> result(size, cudf::default_stream_value);
         thrust::tabulate(thrust::device,
                          result.begin(),
                          result.end(),

--- a/cpp/benchmarks/copying/copy_if_else.cpp
+++ b/cpp/benchmarks/copying/copy_if_else.cpp
@@ -19,6 +19,7 @@
 #include <benchmarks/synchronization/synchronization.hpp>
 
 #include <cudf/copying.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/device_buffer.hpp>
 
@@ -44,7 +45,7 @@ static void BM_copy_if_else(benchmark::State& state, bool nulls)
   cudf::column_view lhs(input->view().column(0));
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::copy_if_else(lhs, rhs, decision);
   }
 }

--- a/cpp/benchmarks/copying/shift.cu
+++ b/cpp/benchmarks/copying/shift.cu
@@ -19,11 +19,12 @@
 
 #include <cudf/copying.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 template <typename T, typename ScalarType = cudf::scalar_type_t<T>>
 std::unique_ptr<cudf::scalar> make_scalar(
   T value                             = 0,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto s = new ScalarType(value, true, stream, mr);

--- a/cpp/benchmarks/groupby/group_struct_keys.cpp
+++ b/cpp/benchmarks/groupby/group_struct_keys.cpp
@@ -21,6 +21,7 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/groupby.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <nvbench/nvbench.cuh>
 
@@ -87,7 +88,7 @@ void bench_groupby_struct_keys(nvbench::state& state)
   requests[0].aggregations.push_back(cudf::make_min_aggregation<cudf::groupby_aggregation>());
 
   // Set up nvbench default stream
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cudf::default_stream_value;
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
 
   state.exec(nvbench::exec_tag::sync,

--- a/cpp/benchmarks/hashing/hash.cpp
+++ b/cpp/benchmarks/hashing/hash.cpp
@@ -20,6 +20,7 @@
 
 #include <cudf/hashing.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 class HashBenchmark : public cudf::benchmark {
 };
@@ -34,7 +35,7 @@ static void BM_hash(benchmark::State& state, cudf::hash_id hid, contains_nulls h
     data->get_column(0).set_null_mask(rmm::device_buffer{}, 0);
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::hash(data->view(), hid);
   }
 }

--- a/cpp/benchmarks/io/text/multibyte_split.cpp
+++ b/cpp/benchmarks/io/text/multibyte_split.cpp
@@ -27,8 +27,7 @@
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/strings/combine.hpp>
 #include <cudf/types.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/host_vector.h>
 #include <thrust/transform.h>
@@ -106,7 +105,7 @@ static void BM_multibyte_split(benchmark::State& state)
                   device_input.data(),
                   device_input.size() * sizeof(char),
                   cudaMemcpyDeviceToHost,
-                  rmm::cuda_stream_default);
+                  cudf::default_stream_value);
 
   auto temp_file_name = random_file_in_dir(temp_dir.path());
 

--- a/cpp/benchmarks/iterator/iterator.cu
+++ b/cpp/benchmarks/iterator/iterator.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/utilities/device_operators.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/device_uvector.hpp>
 
@@ -54,7 +55,7 @@ inline auto reduce_by_cub(OutputIterator result, InputIterator d_in, int num_ite
     nullptr, temp_storage_bytes, d_in, result, num_items, cudf::DeviceSum{}, init);
 
   // Allocate temporary storage
-  rmm::device_buffer d_temp_storage(temp_storage_bytes, rmm::cuda_stream_default);
+  rmm::device_buffer d_temp_storage(temp_storage_bytes, cudf::default_stream_value);
 
   // Run reduction
   cub::DeviceReduce::Reduce(

--- a/cpp/benchmarks/join/generate_input_tables.cuh
+++ b/cpp/benchmarks/join/generate_input_tables.cuh
@@ -17,9 +17,9 @@
 #pragma once
 
 #include <cudf/detail/utilities/device_atomics.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/distance.h>
@@ -154,7 +154,7 @@ void generate_input_tables(key_type* const build_tbl,
 
   const int num_states =
     num_sms * std::max(num_blocks_init_build_tbl, num_blocks_init_probe_tbl) * block_size;
-  rmm::device_uvector<curandState> devStates(num_states, rmm::cuda_stream_default);
+  rmm::device_uvector<curandState> devStates(num_states, cudf::default_stream_value);
 
   init_curand<<<(num_states - 1) / block_size + 1, block_size>>>(devStates.data(), num_states);
 

--- a/cpp/benchmarks/join/join_common.hpp
+++ b/cpp/benchmarks/join/join_common.hpp
@@ -28,6 +28,7 @@
 #include <cudf/join.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <nvbench/nvbench.cuh>
@@ -125,7 +126,7 @@ static void BM_join(state_type& state, Join JoinFunc)
   // Benchmark the inner join operation
   if constexpr (std::is_same_v<state_type, benchmark::State> and (not is_conditional)) {
     for (auto _ : state) {
-      cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+      cuda_event_timer raii(state, true, cudf::default_stream_value);
 
       auto result = JoinFunc(
         probe_table, build_table, columns_to_join, columns_to_join, cudf::null_equality::UNEQUAL);
@@ -152,7 +153,7 @@ static void BM_join(state_type& state, Join JoinFunc)
       cudf::ast::operation(cudf::ast::ast_operator::EQUAL, col_ref_left_0, col_ref_right_0);
 
     for (auto _ : state) {
-      cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+      cuda_event_timer raii(state, true, cudf::default_stream_value);
 
       auto result =
         JoinFunc(probe_table, build_table, left_zero_eq_right_zero, cudf::null_equality::UNEQUAL);

--- a/cpp/benchmarks/lists/copying/scatter_lists.cu
+++ b/cpp/benchmarks/lists/copying/scatter_lists.cu
@@ -21,8 +21,8 @@
 #include <cudf/copying.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
@@ -40,7 +40,7 @@ class ScatterLists : public cudf::benchmark {
 template <class TypeParam, bool coalesce>
 void BM_lists_scatter(::benchmark::State& state)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cudf::default_stream_value;
   auto mr     = rmm::mr::get_current_device_resource();
 
   const size_type base_size{(size_type)state.range(0)};

--- a/cpp/benchmarks/quantiles/quantiles.cpp
+++ b/cpp/benchmarks/quantiles/quantiles.cpp
@@ -19,6 +19,7 @@
 #include <benchmarks/synchronization/synchronization.hpp>
 
 #include <cudf/quantiles.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/execution_policy.h>
 #include <thrust/tabulate.h>
@@ -50,7 +51,7 @@ static void BM_quantiles(benchmark::State& state, bool nulls)
     thrust::seq, q.begin(), q.end(), [n_quantiles](auto i) { return i * (1.0f / n_quantiles); });
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
 
     auto result = cudf::quantiles(input, q);
     // auto result = (stable) ? cudf::stable_sorted_order(input) : cudf::sorted_order(input);

--- a/cpp/benchmarks/sort/rank.cpp
+++ b/cpp/benchmarks/sort/rank.cpp
@@ -20,6 +20,7 @@
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/sorting.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 class Rank : public cudf::benchmark {
 };
@@ -38,7 +39,7 @@ static void BM_rank(benchmark::State& state, bool nulls)
   cudf::column_view input{keys_table->get_column(0)};
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
 
     auto result = cudf::rank(input,
                              cudf::rank_method::FIRST,

--- a/cpp/benchmarks/sort/sort.cpp
+++ b/cpp/benchmarks/sort/sort.cpp
@@ -19,6 +19,7 @@
 #include <benchmarks/synchronization/synchronization.hpp>
 
 #include <cudf/sorting.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 template <bool stable>
 class Sort : public cudf::benchmark {
@@ -41,7 +42,7 @@ static void BM_sort(benchmark::State& state, bool nulls)
   cudf::table_view input{*input_table};
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
 
     auto result = (stable) ? cudf::stable_sorted_order(input) : cudf::sorted_order(input);
   }

--- a/cpp/benchmarks/sort/sort_strings.cpp
+++ b/cpp/benchmarks/sort/sort_strings.cpp
@@ -20,6 +20,7 @@
 
 #include <cudf/sorting.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 class Sort : public cudf::benchmark {
 };
@@ -31,7 +32,7 @@ static void BM_sort(benchmark::State& state)
   auto const table = create_random_table({cudf::type_id::STRING}, row_count{n_rows});
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::sort(table->view());
   }
 }

--- a/cpp/benchmarks/string/case.cpp
+++ b/cpp/benchmarks/string/case.cpp
@@ -20,6 +20,7 @@
 
 #include <cudf/strings/case.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 class StringCase : public cudf::benchmark {
 };
@@ -31,7 +32,7 @@ static void BM_case(benchmark::State& state)
   cudf::strings_column_view input(table->view().column(0));
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::strings::to_lower(input);
   }
 

--- a/cpp/benchmarks/string/combine.cpp
+++ b/cpp/benchmarks/string/combine.cpp
@@ -23,6 +23,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/combine.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 class StringCombine : public cudf::benchmark {
 };
@@ -41,7 +42,7 @@ static void BM_combine(benchmark::State& state)
   cudf::string_scalar separator("+");
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::strings::concatenate(table->view(), separator);
   }
 

--- a/cpp/benchmarks/string/contains.cpp
+++ b/cpp/benchmarks/string/contains.cpp
@@ -24,6 +24,7 @@
 #include <cudf/strings/contains.hpp>
 #include <cudf/strings/findall.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 class StringContains : public cudf::benchmark {
 };
@@ -86,7 +87,7 @@ static void BM_contains(benchmark::State& state, contains_type ct)
   auto pattern = patterns[pattern_index];
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     switch (ct) {
       case contains_type::contains:  // contains_re and matches_re use the same main logic
         cudf::strings::contains_re(input, pattern);

--- a/cpp/benchmarks/string/copy.cu
+++ b/cpp/benchmarks/string/copy.cu
@@ -23,6 +23,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -58,7 +59,7 @@ static void BM_copy(benchmark::State& state, copy_type ct)
                        thrust::default_random_engine());
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     switch (ct) {
       case gather: cudf::gather(source->view(), index_map); break;
       case scatter: cudf::scatter(source->view(), index_map, target->view()); break;

--- a/cpp/benchmarks/string/factory.cu
+++ b/cpp/benchmarks/string/factory.cu
@@ -24,8 +24,8 @@
 
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/execution_policy.h>
@@ -56,7 +56,7 @@ static void BM_factory(benchmark::State& state)
     cudf::type_id::STRING, distribution_id::NORMAL, 0, max_str_length);
   auto const table = create_random_table({cudf::type_id::STRING}, row_count{n_rows}, table_profile);
   auto d_column    = cudf::column_device_view::create(table->view().column(0));
-  rmm::device_uvector<string_pair> pairs(d_column->size(), rmm::cuda_stream_default);
+  rmm::device_uvector<string_pair> pairs(d_column->size(), cudf::default_stream_value);
   thrust::transform(thrust::device,
                     d_column->pair_begin<cudf::string_view, true>(),
                     d_column->pair_end<cudf::string_view, true>(),
@@ -64,7 +64,7 @@ static void BM_factory(benchmark::State& state)
                     string_view_to_pair{});
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::make_strings_column(pairs);
   }
 

--- a/cpp/benchmarks/string/filter.cpp
+++ b/cpp/benchmarks/string/filter.cpp
@@ -25,6 +25,7 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/strip.hpp>
 #include <cudf/strings/translate.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <limits>
 #include <vector>
@@ -49,7 +50,7 @@ static void BM_filter_chars(benchmark::State& state, FilterAPI api)
     {cudf::char_utf8{'a'}, cudf::char_utf8{'c'}}};
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     switch (api) {
       case filter: cudf::strings::filter_characters_of_type(input, types); break;
       case filter_chars: cudf::strings::filter_characters(input, filter_table); break;

--- a/cpp/benchmarks/string/find.cpp
+++ b/cpp/benchmarks/string/find.cpp
@@ -24,6 +24,7 @@
 #include <cudf/strings/find.hpp>
 #include <cudf/strings/find_multiple.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <limits>
 
@@ -45,7 +46,7 @@ static void BM_find_scalar(benchmark::State& state, FindAPI find_api)
   cudf::test::strings_column_wrapper targets({"+", "-"});
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     switch (find_api) {
       case find: cudf::strings::find(input, target); break;
       case find_multi:

--- a/cpp/benchmarks/string/repeat_strings.cpp
+++ b/cpp/benchmarks/string/repeat_strings.cpp
@@ -22,6 +22,7 @@
 
 #include <cudf/strings/repeat_strings.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 static constexpr cudf::size_type default_repeat_times = 16;
 static constexpr cudf::size_type min_repeat_times     = -16;
@@ -55,7 +56,7 @@ static void BM_repeat_strings_scalar_times(benchmark::State& state)
   auto const strings_col    = cudf::strings_column_view(table->view().column(0));
 
   for ([[maybe_unused]] auto _ : state) {
-    [[maybe_unused]] cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    [[maybe_unused]] cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::strings::repeat_strings(strings_col, default_repeat_times);
   }
 
@@ -71,7 +72,7 @@ static void BM_repeat_strings_column_times(benchmark::State& state)
   auto const repeat_times_col = table->view().column(1);
 
   for ([[maybe_unused]] auto _ : state) {
-    [[maybe_unused]] cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    [[maybe_unused]] cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::strings::repeat_strings(strings_col, repeat_times_col);
   }
 
@@ -88,7 +89,7 @@ static void BM_compute_output_strings_sizes(benchmark::State& state)
   auto const repeat_times_col = table->view().column(1);
 
   for ([[maybe_unused]] auto _ : state) {
-    [[maybe_unused]] cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    [[maybe_unused]] cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::strings::repeat_strings_output_sizes(strings_col, repeat_times_col);
   }
 
@@ -107,7 +108,7 @@ static void BM_repeat_strings_column_times_precomputed_sizes(benchmark::State& s
     cudf::strings::repeat_strings_output_sizes(strings_col, repeat_times_col);
 
   for ([[maybe_unused]] auto _ : state) {
-    [[maybe_unused]] cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    [[maybe_unused]] cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::strings::repeat_strings(strings_col, repeat_times_col, *sizes);
   }
 

--- a/cpp/benchmarks/string/replace.cpp
+++ b/cpp/benchmarks/string/replace.cpp
@@ -25,6 +25,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/replace.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <limits>
 
@@ -48,7 +49,7 @@ static void BM_replace(benchmark::State& state, replace_type rt)
   cudf::test::strings_column_wrapper repls({"", ""});
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     switch (rt) {
       case scalar: cudf::strings::replace(input, target, repl); break;
       case slice: cudf::strings::replace_slice(input, repl, 1, 10); break;

--- a/cpp/benchmarks/string/replace_re.cpp
+++ b/cpp/benchmarks/string/replace_re.cpp
@@ -24,6 +24,7 @@
 
 #include <cudf/strings/replace_re.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 class StringReplace : public cudf::benchmark {
 };
@@ -42,7 +43,7 @@ static void BM_replace(benchmark::State& state, replace_type rt)
   cudf::test::strings_column_wrapper repls({"#", ""});
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     switch (rt) {
       case replace_type::replace_re:  // contains_re and matches_re use the same main logic
         cudf::strings::replace_re(input, "\\d+");

--- a/cpp/benchmarks/string/split.cpp
+++ b/cpp/benchmarks/string/split.cpp
@@ -23,6 +23,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/split/split.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <limits>
 
@@ -43,7 +44,7 @@ static void BM_split(benchmark::State& state, split_type rt)
   cudf::string_scalar target("+");
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     switch (rt) {
       case split: cudf::strings::split(input, target); break;
       case split_ws: cudf::strings::split(input); break;

--- a/cpp/benchmarks/string/substring.cpp
+++ b/cpp/benchmarks/string/substring.cpp
@@ -25,6 +25,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/substring.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 
@@ -52,7 +53,7 @@ static void BM_substring(benchmark::State& state, substring_type rt)
   cudf::test::strings_column_wrapper delimiters(delim_itr, delim_itr + n_rows);
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     switch (rt) {
       case position: cudf::strings::slice_strings(input, 1, max_str_length / 2); break;
       case multi_position: cudf::strings::slice_strings(input, starts, stops); break;

--- a/cpp/benchmarks/string/translate.cpp
+++ b/cpp/benchmarks/string/translate.cpp
@@ -24,6 +24,7 @@
 
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/translate.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 
@@ -53,7 +54,7 @@ static void BM_translate(benchmark::State& state, int entry_count)
                  });
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     cudf::strings::translate(input, entries);
   }
 

--- a/cpp/benchmarks/string/url_decode.cu
+++ b/cpp/benchmarks/string/url_decode.cu
@@ -24,6 +24,7 @@
 #include <cudf/strings/convert/convert_urls.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
@@ -90,7 +91,7 @@ void BM_url_decode(benchmark::State& state, int esc_seq_pct)
   auto strings_view = cudf::strings_column_view(column->view());
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     auto result = cudf::strings::url_decode(strings_view);
   }
 

--- a/cpp/benchmarks/synchronization/synchronization.hpp
+++ b/cpp/benchmarks/synchronization/synchronization.hpp
@@ -63,6 +63,7 @@
 #include <benchmark/benchmark.h>
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -82,7 +83,7 @@ class cuda_event_timer {
    */
   cuda_event_timer(benchmark::State& state,
                    bool flush_l2_cache,
-                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                   rmm::cuda_stream_view stream = cudf::default_stream_value);
 
   // The user must provide a benchmark::State object to set
   // the timer so we disable the default c'tor.

--- a/cpp/benchmarks/text/normalize.cpp
+++ b/cpp/benchmarks/text/normalize.cpp
@@ -20,6 +20,7 @@
 
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <nvtext/normalize.hpp>
 
@@ -37,7 +38,7 @@ static void BM_normalize(benchmark::State& state, bool to_lower)
   cudf::strings_column_view input(table->view().column(0));
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     nvtext::normalize_characters(input, to_lower);
   }
 

--- a/cpp/benchmarks/text/normalize_spaces.cpp
+++ b/cpp/benchmarks/text/normalize_spaces.cpp
@@ -21,6 +21,7 @@
 
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <nvtext/normalize.hpp>
 
@@ -38,7 +39,7 @@ static void BM_normalize(benchmark::State& state)
   cudf::strings_column_view input(table->view().column(0));
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     nvtext::normalize_spaces(input);
   }
 

--- a/cpp/benchmarks/text/tokenize.cpp
+++ b/cpp/benchmarks/text/tokenize.cpp
@@ -23,6 +23,7 @@
 
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <nvtext/ngrams_tokenize.hpp>
 #include <nvtext/tokenize.hpp>
@@ -44,7 +45,7 @@ static void BM_tokenize(benchmark::State& state, tokenize_type tt)
   cudf::test::strings_column_wrapper delimiters({" ", "+", "-"});
 
   for (auto _ : state) {
-    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    cuda_event_timer raii(state, true, cudf::default_stream_value);
     switch (tt) {
       case tokenize_type::single:
         // single whitespace delimiter

--- a/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
+++ b/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
@@ -24,8 +24,8 @@
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <type_traits>
@@ -188,10 +188,10 @@ void type_dispatcher_benchmark(::benchmark::State& state)
   std::vector<rmm::device_buffer> h_vec(n_cols);
   std::vector<TypeParam*> h_vec_p(n_cols);
   std::transform(h_vec.begin(), h_vec.end(), h_vec_p.begin(), [source_size](auto& col) {
-    col.resize(source_size * sizeof(TypeParam), rmm::cuda_stream_default);
+    col.resize(source_size * sizeof(TypeParam), cudf::default_stream_value);
     return static_cast<TypeParam*>(col.data());
   });
-  rmm::device_uvector<TypeParam*> d_vec(n_cols, rmm::cuda_stream_default);
+  rmm::device_uvector<TypeParam*> d_vec(n_cols, cudf::default_stream_value);
 
   if (dispatching_type == NO_DISPATCHING) {
     CUDF_CUDA_TRY(cudaMemcpy(

--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -350,7 +350,7 @@ internal API in the `detail` namespace. The internal `detail` API has the same p
 public API, plus a `rmm::cuda_stream_view` parameter at the end with no default value. If the
 detail API also accepts a memory resource parameter, the stream parameter should be ideally placed
 just *before* the memory resource. The public API will call the detail API and provide
-`rmm::cuda_stream_default`. The implementation should be wholly contained in the `detail` API
+`cudf::default_stream_value`. The implementation should be wholly contained in the `detail` API
 definition and use only asynchronous versions of CUDA APIs with the stream parameter.
 
 In order to make the `detail` API callable from other libcudf functions, it should be exposed in a
@@ -381,7 +381,7 @@ namespace detail{
 
 void external_function(...){
     CUDF_FUNC_RANGE(); // Generates an NVTX range for the lifetime of this function.
-    detail::external_function(..., rmm::cuda_stream_default);
+    detail::external_function(..., cudf::default_stream_value);
 }
 ```
 

--- a/cpp/docs/DOCUMENTATION.md
+++ b/cpp/docs/DOCUMENTATION.md
@@ -235,7 +235,7 @@ Also, `@copydoc` is useful when documenting a `detail` function that differs onl
  */
 std::vector<size_type> segmented_count_set_bits(bitmask_type const* bitmask,
                                                 std::vector<size_type> const& indices,
-                                                rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                                                rmm::cuda_stream_view stream = cudf::default_stream_value);
 ```
 
 Note, you must specify the whole signature of the function, including optional parameters, so that doxygen will be able to locate it.

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -19,6 +19,7 @@
 
 #include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -61,7 +62,7 @@ class column {
    * @param mr Device memory resource to use for all device memory allocations
    */
   column(column const& other,
-         rmm::cuda_stream_view stream        = rmm::cuda_stream_view{},
+         rmm::cuda_stream_view stream        = cudf::default_stream_value,
          rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -116,7 +117,7 @@ class column {
    * @param mr Device memory resource to use for all device memory allocations
    */
   explicit column(column_view view,
-                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                  rmm::cuda_stream_view stream        = cudf::default_stream_value,
                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -24,6 +24,7 @@
 #include <cudf/structs/struct_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -820,7 +821,7 @@ class alignas(16) column_device_view : public detail::column_device_view_base {
    *`source_view` available in device memory.
    */
   static std::unique_ptr<column_device_view, std::function<void(column_device_view*)>> create(
-    column_view source_view, rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+    column_view source_view, rmm::cuda_stream_view stream = cudf::default_stream_value);
 
   /**
    * @brief Destroy the `column_device_view` object.
@@ -972,7 +973,8 @@ class alignas(16) mutable_column_device_view : public detail::column_device_view
    */
   static std::unique_ptr<mutable_column_device_view,
                          std::function<void(mutable_column_device_view*)>>
-  create(mutable_column_view source_view, rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+  create(mutable_column_view source_view,
+         rmm::cuda_stream_view stream = cudf::default_stream_value);
 
   /**
    * @brief Returns pointer to the base device memory allocation casted to

--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -73,7 +74,7 @@ std::unique_ptr<column> make_numeric_column(
   data_type type,
   size_type size,
   mask_state state                    = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -99,7 +100,7 @@ std::unique_ptr<column> make_numeric_column(
   size_type size,
   B&& null_mask,
   size_type null_count                = cudf::UNKNOWN_NULL_COUNT,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(is_numeric(type), "Invalid, non-numeric type.");
@@ -130,7 +131,7 @@ std::unique_ptr<column> make_fixed_point_column(
   data_type type,
   size_type size,
   mask_state state                    = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -155,7 +156,7 @@ std::unique_ptr<column> make_fixed_point_column(
   size_type size,
   B&& null_mask,
   size_type null_count                = cudf::UNKNOWN_NULL_COUNT,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(is_fixed_point(type), "Invalid, non-fixed_point type.");
@@ -187,7 +188,7 @@ std::unique_ptr<column> make_timestamp_column(
   data_type type,
   size_type size,
   mask_state state                    = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -213,7 +214,7 @@ std::unique_ptr<column> make_timestamp_column(
   size_type size,
   B&& null_mask,
   size_type null_count                = cudf::UNKNOWN_NULL_COUNT,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(is_timestamp(type), "Invalid, non-timestamp type.");
@@ -245,7 +246,7 @@ std::unique_ptr<column> make_duration_column(
   data_type type,
   size_type size,
   mask_state state                    = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -271,7 +272,7 @@ std::unique_ptr<column> make_duration_column(
   size_type size,
   B&& null_mask,
   size_type null_count                = cudf::UNKNOWN_NULL_COUNT,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(is_duration(type), "Invalid, non-duration type.");
@@ -303,7 +304,7 @@ std::unique_ptr<column> make_fixed_width_column(
   data_type type,
   size_type size,
   mask_state state                    = mask_state::UNALLOCATED,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -329,7 +330,7 @@ std::unique_ptr<column> make_fixed_width_column(
   size_type size,
   B&& null_mask,
   size_type null_count                = cudf::UNKNOWN_NULL_COUNT,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(is_fixed_width(type), "Invalid, non-fixed-width type.");
@@ -368,7 +369,7 @@ std::unique_ptr<column> make_fixed_width_column(
  */
 std::unique_ptr<column> make_strings_column(
   cudf::device_span<thrust::pair<const char*, size_type> const> strings,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -400,7 +401,7 @@ std::unique_ptr<column> make_strings_column(
 std::unique_ptr<column> make_strings_column(
   cudf::device_span<string_view const> string_views,
   const string_view null_placeholder,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -436,7 +437,7 @@ std::unique_ptr<column> make_strings_column(
   cudf::device_span<size_type const> offsets,
   cudf::device_span<bitmask_type const> null_mask = {},
   size_type null_count                            = cudf::UNKNOWN_NULL_COUNT,
-  rmm::cuda_stream_view stream                    = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                    = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr             = rmm::mr::get_current_device_resource());
 
 /**
@@ -545,7 +546,7 @@ std::unique_ptr<cudf::column> make_lists_column(
   std::unique_ptr<column> child_column,
   size_type null_count,
   rmm::device_buffer&& null_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -576,7 +577,7 @@ std::unique_ptr<cudf::column> make_structs_column(
   std::vector<std::unique_ptr<column>>&& child_columns,
   size_type null_count,
   rmm::device_buffer&& null_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -596,7 +597,7 @@ std::unique_ptr<cudf::column> make_structs_column(
 std::unique_ptr<column> make_column_from_scalar(
   scalar const& s,
   size_type size,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -616,7 +617,7 @@ std::unique_ptr<column> make_column_from_scalar(
 std::unique_ptr<column> make_dictionary_from_scalar(
   scalar const& s,
   size_type size,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/detail/binaryop.hpp
+++ b/cpp/include/cudf/detail/binaryop.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/binaryop.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -34,7 +35,7 @@ std::unique_ptr<column> binary_operation(
   column_view const& rhs,
   std::string const& ptx,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -48,7 +49,7 @@ std::unique_ptr<column> binary_operation(
   column_view const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -62,7 +63,7 @@ std::unique_ptr<column> binary_operation(
   scalar const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -76,7 +77,7 @@ std::unique_ptr<column> binary_operation(
   column_view const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/detail/concatenate.hpp
+++ b/cpp/include/cudf/detail/concatenate.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -34,7 +35,7 @@ namespace detail {
  */
 std::unique_ptr<column> concatenate(
   host_span<column_view const> columns_to_concat,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -44,7 +45,7 @@ std::unique_ptr<column> concatenate(
  */
 std::unique_ptr<table> concatenate(
   host_span<table_view const> tables_to_concat,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/copy.hpp
+++ b/cpp/include/cudf/detail/copy.hpp
@@ -19,6 +19,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -76,7 +77,7 @@ ColumnView slice(ColumnView const& input, cudf::size_type begin, cudf::size_type
  */
 std::vector<column_view> slice(column_view const& input,
                                host_span<size_type const> indices,
-                               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                               rmm::cuda_stream_view stream = cudf::default_stream_value);
 /**
  * @copydoc cudf::slice(column_view const&, std::initializer_list<size_type>)
  *
@@ -84,7 +85,7 @@ std::vector<column_view> slice(column_view const& input,
  */
 std::vector<column_view> slice(column_view const& input,
                                std::initializer_list<size_type> indices,
-                               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                               rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::slice(table_view const&, host_span<size_type const>)
@@ -93,7 +94,7 @@ std::vector<column_view> slice(column_view const& input,
  */
 std::vector<table_view> slice(table_view const& input,
                               host_span<size_type const> indices,
-                              rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                              rmm::cuda_stream_view stream = cudf::default_stream_value);
 /**
  * @copydoc cudf::slice(table_view const&, std::initializer_list<size_type>)
  *
@@ -101,7 +102,7 @@ std::vector<table_view> slice(table_view const& input,
  */
 std::vector<table_view> slice(table_view const& input,
                               std::initializer_list<size_type> indices,
-                              rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                              rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::split(column_view const&, host_span<size_type const>)
@@ -110,7 +111,7 @@ std::vector<table_view> slice(table_view const& input,
  */
 std::vector<column_view> split(column_view const& input,
                                host_span<size_type const> splits,
-                               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                               rmm::cuda_stream_view stream = cudf::default_stream_value);
 /**
  * @copydoc cudf::split(column_view const&, std::initializer_list<size_type>)
  *
@@ -118,7 +119,7 @@ std::vector<column_view> split(column_view const& input,
  */
 std::vector<column_view> split(column_view const& input,
                                std::initializer_list<size_type> splits,
-                               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                               rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::split(table_view const&, host_span<size_type const>)
@@ -127,7 +128,7 @@ std::vector<column_view> split(column_view const& input,
  */
 std::vector<table_view> split(table_view const& input,
                               host_span<size_type const> splits,
-                              rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                              rmm::cuda_stream_view stream = cudf::default_stream_value);
 /**
  * @copydoc cudf::split(table_view const&, std::initializer_list<size_type>)
  *
@@ -135,7 +136,7 @@ std::vector<table_view> split(table_view const& input,
  */
 std::vector<table_view> split(table_view const& input,
                               std::initializer_list<size_type> splits,
-                              rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                              rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::shift(column_view const&,size_type,scalar const&,
@@ -147,7 +148,7 @@ std::unique_ptr<column> shift(
   column_view const& input,
   size_type offset,
   scalar const& fill_value,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -188,7 +189,7 @@ std::unique_ptr<column> segmented_shift(
   device_span<size_type const> segment_offsets,
   size_type offset,
   scalar const& fill_value,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -199,7 +200,7 @@ std::unique_ptr<column> segmented_shift(
 std::vector<packed_table> contiguous_split(
   cudf::table_view const& input,
   std::vector<size_type> const& splits,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -208,7 +209,7 @@ std::vector<packed_table> contiguous_split(
  * @param stream Optional CUDA stream on which to execute kernels
  **/
 packed_columns pack(cudf::table_view const& input,
-                    rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                    rmm::cuda_stream_view stream        = cudf::default_stream_value,
                     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -221,7 +222,7 @@ std::unique_ptr<column> allocate_like(
   column_view const& input,
   size_type size,
   mask_allocation_policy mask_alloc   = mask_allocation_policy::RETAIN,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -234,7 +235,7 @@ std::unique_ptr<column> copy_if_else(
   column_view const& lhs,
   column_view const& rhs,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -247,7 +248,7 @@ std::unique_ptr<column> copy_if_else(
   scalar const& lhs,
   column_view const& rhs,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -260,7 +261,7 @@ std::unique_ptr<column> copy_if_else(
   column_view const& lhs,
   scalar const& rhs,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -273,7 +274,7 @@ std::unique_ptr<column> copy_if_else(
   scalar const& lhs,
   scalar const& rhs,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -286,7 +287,7 @@ std::unique_ptr<table> sample(
   size_type const n,
   sample_with_replacement replacement = sample_with_replacement::FALSE,
   int64_t const seed                  = 0,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -297,7 +298,7 @@ std::unique_ptr<table> sample(
 std::unique_ptr<scalar> get_element(
   column_view const& input,
   size_type index,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -306,7 +307,7 @@ std::unique_ptr<scalar> get_element(
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 bool has_nonempty_nulls(column_view const& input,
-                        rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                        rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::may_have_nonempty_nulls
@@ -314,7 +315,7 @@ bool has_nonempty_nulls(column_view const& input,
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 bool may_have_nonempty_nulls(column_view const& input,
-                             rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                             rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/detail/copy_if.cuh
+++ b/cpp/include/cudf/detail/copy_if.cuh
@@ -28,6 +28,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -322,7 +323,7 @@ template <typename Filter>
 std::unique_ptr<table> copy_if(
   table_view const& input,
   Filter filter,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_FUNC_RANGE();

--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -21,6 +21,7 @@
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -137,7 +138,7 @@ void copy_range(SourceValueIterator source_value_begin,
                 mutable_column_view& target,
                 size_type target_begin,
                 size_type target_end,
-                rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+                rmm::cuda_stream_view stream = cudf::default_stream_value)
 {
   CUDF_EXPECTS((target_begin <= target_end) && (target_begin >= 0) &&
                  (target_begin < target.size()) && (target_end <= target.size()),
@@ -198,7 +199,7 @@ void copy_range_in_place(column_view const& source,
                          size_type source_begin,
                          size_type source_end,
                          size_type target_begin,
-                         rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                         rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::copy_range
@@ -211,7 +212,7 @@ std::unique_ptr<column> copy_range(
   size_type source_begin,
   size_type source_end,
   size_type target_begin,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/datetime.hpp
+++ b/cpp/include/cudf/detail/datetime.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <memory>
 
@@ -30,7 +31,7 @@ namespace detail {
  */
 std::unique_ptr<cudf::column> extract_year(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -40,7 +41,7 @@ std::unique_ptr<cudf::column> extract_year(
  */
 std::unique_ptr<cudf::column> extract_month(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -50,7 +51,7 @@ std::unique_ptr<cudf::column> extract_month(
  */
 std::unique_ptr<cudf::column> extract_day(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -60,7 +61,7 @@ std::unique_ptr<cudf::column> extract_day(
  */
 std::unique_ptr<cudf::column> extract_weekday(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -70,7 +71,7 @@ std::unique_ptr<cudf::column> extract_weekday(
  */
 std::unique_ptr<cudf::column> extract_hour(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -80,7 +81,7 @@ std::unique_ptr<cudf::column> extract_hour(
  */
 std::unique_ptr<cudf::column> extract_minute(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -90,7 +91,7 @@ std::unique_ptr<cudf::column> extract_minute(
  */
 std::unique_ptr<cudf::column> extract_second(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -100,7 +101,7 @@ std::unique_ptr<cudf::column> extract_second(
  */
 std::unique_ptr<cudf::column> last_day_of_month(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -110,7 +111,7 @@ std::unique_ptr<cudf::column> last_day_of_month(
  */
 std::unique_ptr<cudf::column> day_of_year(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -122,7 +123,7 @@ std::unique_ptr<cudf::column> day_of_year(
 std::unique_ptr<cudf::column> add_calendrical_months(
   cudf::column_view const& timestamps,
   cudf::column_view const& months,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -134,7 +135,7 @@ std::unique_ptr<cudf::column> add_calendrical_months(
 std::unique_ptr<cudf::column> add_calendrical_months(
   cudf::column_view const& timestamps,
   cudf::scalar const& months,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -144,12 +145,12 @@ std::unique_ptr<cudf::column> add_calendrical_months(
  */
 std::unique_ptr<cudf::column> is_leap_year(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::column> extract_quarter(
   cudf::column_view const& column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/fill.hpp
+++ b/cpp/include/cudf/detail/fill.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/filling.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -35,7 +36,7 @@ void fill_in_place(mutable_column_view& destination,
                    size_type begin,
                    size_type end,
                    scalar const& value,
-                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                   rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::fill
@@ -47,7 +48,7 @@ std::unique_ptr<column> fill(
   size_type begin,
   size_type end,
   scalar const& value,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -32,6 +32,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -651,7 +652,7 @@ std::unique_ptr<table> gather(
   MapIterator gather_map_begin,
   MapIterator gather_map_end,
   out_of_bounds_policy bounds_policy  = out_of_bounds_policy::DONT_CHECK,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   std::vector<std::unique_ptr<column>> destination_columns;

--- a/cpp/include/cudf/detail/gather.hpp
+++ b/cpp/include/cudf/detail/gather.hpp
@@ -19,6 +19,7 @@
 #include <cudf/copying.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -65,7 +66,7 @@ std::unique_ptr<table> gather(
   column_view const& gather_map,
   out_of_bounds_policy bounds_policy,
   negative_index_policy neg_indices,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -80,7 +81,7 @@ std::unique_ptr<table> gather(
   device_span<size_type const> const gather_map,
   out_of_bounds_policy bounds_policy,
   negative_index_policy neg_indices,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/groupby/group_replace_nulls.hpp
+++ b/cpp/include/cudf/detail/groupby/group_replace_nulls.hpp
@@ -19,6 +19,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/replace.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/exec_policy.hpp>
@@ -39,7 +40,7 @@ std::unique_ptr<column> group_replace_nulls(
   cudf::column_view const& grouped_value,
   device_span<size_type const> group_labels,
   cudf::replace_policy replace_policy,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/hashing.hpp
+++ b/cpp/include/cudf/detail/hashing.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/hashing.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -34,25 +35,25 @@ std::unique_ptr<column> hash(
   table_view const& input,
   hash_id hash_function               = hash_id::HASH_MURMUR3,
   uint32_t seed                       = cudf::DEFAULT_HASH_SEED,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<column> murmur_hash3_32(
   table_view const& input,
   uint32_t seed                       = cudf::DEFAULT_HASH_SEED,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 template <template <typename> class hash_function>
 std::unique_ptr<column> serial_murmur_hash3_32(
   table_view const& input,
   uint32_t seed                       = cudf::DEFAULT_HASH_SEED,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<column> md5_hash(
   table_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /* Copyright 2005-2014 Daniel James.

--- a/cpp/include/cudf/detail/interop.hpp
+++ b/cpp/include/cudf/detail/interop.hpp
@@ -18,6 +18,7 @@
 
 #include <arrow/api.h>
 #include <cudf/interop.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <string>
 
@@ -33,7 +34,7 @@ namespace detail {
  */
 std::unique_ptr<table> from_dlpack(
   DLManagedTensor const* managed_tensor,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -43,7 +44,7 @@ std::unique_ptr<table> from_dlpack(
  */
 DLManagedTensor* to_dlpack(
   table_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 // Creating arrow as per given type_id and buffer arguments
@@ -103,7 +104,7 @@ data_type arrow_to_cudf_type(arrow::DataType const& arrow_type);
  */
 std::shared_ptr<arrow::Table> to_arrow(table_view input,
                                        std::vector<column_metadata> const& metadata = {},
-                                       rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+                                       rmm::cuda_stream_view stream = cudf::default_stream_value,
                                        arrow::MemoryPool* ar_mr     = arrow::default_memory_pool());
 
 /**
@@ -113,7 +114,7 @@ std::shared_ptr<arrow::Table> to_arrow(table_view input,
  */
 std::unique_ptr<table> from_arrow(
   arrow::Table const& input_table,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/is_element_valid.hpp
+++ b/cpp/include/cudf/detail/is_element_valid.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/column/column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -40,7 +41,7 @@ namespace detail {
 
 bool is_element_valid_sync(column_view const& col_view,
                            size_type element_index,
-                           rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                           rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/detail/join.hpp
+++ b/cpp/include/cudf/detail/join.hpp
@@ -20,6 +20,7 @@
 #include <cudf/detail/utilities/hash_functions.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -90,7 +91,7 @@ struct hash_join {
    */
   hash_join(cudf::table_view const& build,
             cudf::null_equality compare_nulls,
-            rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+            rmm::cuda_stream_view stream = cudf::default_stream_value);
 
   /**
    * @copydoc cudf::hash_join::inner_join

--- a/cpp/include/cudf/detail/label_bins.hpp
+++ b/cpp/include/cudf/detail/label_bins.hpp
@@ -21,6 +21,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
@@ -50,7 +51,7 @@ std::unique_ptr<column> label_bins(
   inclusive left_inclusive,
   column_view const& right_edges,
   inclusive right_inclusive,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/detail/null_mask.hpp
+++ b/cpp/include/cudf/detail/null_mask.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -33,7 +34,7 @@ namespace detail {
 rmm::device_buffer create_null_mask(
   size_type size,
   mask_state state,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -45,7 +46,7 @@ void set_null_mask(bitmask_type* bitmask,
                    size_type begin_bit,
                    size_type end_bit,
                    bool valid,
-                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                   rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @brief Given a bitmask, counts the number of set (1) bits in the range

--- a/cpp/include/cudf/detail/quantiles.hpp
+++ b/cpp/include/cudf/detail/quantiles.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/quantiles.hpp>
 #include <cudf/tdigest/tdigest_column_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -34,7 +35,7 @@ std::unique_ptr<column> quantile(
   interpolation interp                = interpolation::LINEAR,
   column_view const& ordered_indices  = {},
   bool exact                          = true,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -49,7 +50,7 @@ std::unique_ptr<table> quantiles(
   cudf::sorted is_input_sorted                   = sorted::NO,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 /**
@@ -61,7 +62,7 @@ std::unique_ptr<table> quantiles(
 std::unique_ptr<column> percentile_approx(
   tdigest::tdigest_column_view const& input,
   column_view const& percentiles,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/reduction_functions.hpp
+++ b/cpp/include/cudf/detail/reduction_functions.hpp
@@ -19,6 +19,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -41,7 +42,7 @@ namespace reduction {
 std::unique_ptr<scalar> sum(
   column_view const& col,
   data_type const output_dtype,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -60,7 +61,7 @@ std::unique_ptr<scalar> sum(
 std::unique_ptr<scalar> min(
   column_view const& col,
   data_type const output_dtype,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -79,7 +80,7 @@ std::unique_ptr<scalar> min(
 std::unique_ptr<scalar> max(
   column_view const& col,
   data_type const output_dtype,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -99,7 +100,7 @@ std::unique_ptr<scalar> max(
 std::unique_ptr<scalar> any(
   column_view const& col,
   data_type const output_dtype,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -119,7 +120,7 @@ std::unique_ptr<scalar> any(
 std::unique_ptr<scalar> all(
   column_view const& col,
   data_type const output_dtype,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -139,7 +140,7 @@ std::unique_ptr<scalar> all(
 std::unique_ptr<scalar> product(
   column_view const& col,
   data_type const output_dtype,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -159,7 +160,7 @@ std::unique_ptr<scalar> product(
 std::unique_ptr<scalar> sum_of_squares(
   column_view const& col,
   data_type const output_dtype,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -179,7 +180,7 @@ std::unique_ptr<scalar> sum_of_squares(
 std::unique_ptr<scalar> mean(
   column_view const& col,
   data_type const output_dtype,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -202,7 +203,7 @@ std::unique_ptr<scalar> variance(
   column_view const& col,
   data_type const output_dtype,
   cudf::size_type ddof,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -225,7 +226,7 @@ std::unique_ptr<scalar> standard_deviation(
   column_view const& col,
   data_type const output_dtype,
   cudf::size_type ddof,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -256,7 +257,7 @@ std::unique_ptr<scalar> nth_element(
   column_view const& col,
   size_type n,
   null_policy null_handling,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -271,7 +272,7 @@ std::unique_ptr<scalar> nth_element(
 std::unique_ptr<scalar> collect_list(
   column_view const& col,
   null_policy null_handling,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -284,7 +285,7 @@ std::unique_ptr<scalar> collect_list(
  */
 std::unique_ptr<scalar> merge_lists(
   lists_column_view const& col,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -303,7 +304,7 @@ std::unique_ptr<scalar> collect_set(
   null_policy null_handling,
   null_equality nulls_equal,
   nan_equality nans_equal,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -320,7 +321,7 @@ std::unique_ptr<scalar> merge_sets(
   lists_column_view const& col,
   null_equality nulls_equal,
   nan_equality nans_equal,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -346,7 +347,7 @@ std::unique_ptr<column> segmented_sum(
   device_span<size_type const> offsets,
   data_type const output_dtype,
   null_policy null_handling,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -372,7 +373,7 @@ std::unique_ptr<column> segmented_product(
   device_span<size_type const> offsets,
   data_type const output_dtype,
   null_policy null_handling,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -397,7 +398,7 @@ std::unique_ptr<column> segmented_min(
   device_span<size_type const> offsets,
   data_type const output_dtype,
   null_policy null_handling,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -422,7 +423,7 @@ std::unique_ptr<column> segmented_max(
   device_span<size_type const> offsets,
   data_type const output_dtype,
   null_policy null_handling,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -448,7 +449,7 @@ std::unique_ptr<column> segmented_any(
   device_span<size_type const> offsets,
   data_type const output_dtype,
   null_policy null_handling,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -474,7 +475,7 @@ std::unique_ptr<column> segmented_all(
   device_span<size_type const> offsets,
   data_type const output_dtype,
   null_policy null_handling,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace reduction

--- a/cpp/include/cudf/detail/repeat.hpp
+++ b/cpp/include/cudf/detail/repeat.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -35,7 +36,7 @@ std::unique_ptr<table> repeat(
   table_view const& input_table,
   column_view const& count,
   bool check_count,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -47,7 +48,7 @@ std::unique_ptr<table> repeat(
 std::unique_ptr<table> repeat(
   table_view const& input_table,
   size_type count,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/replace.hpp
+++ b/cpp/include/cudf/detail/replace.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/replace.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -33,7 +34,7 @@ namespace detail {
 std::unique_ptr<column> replace_nulls(
   column_view const& input,
   cudf::column_view const& replacement,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -45,7 +46,7 @@ std::unique_ptr<column> replace_nulls(
 std::unique_ptr<column> replace_nulls(
   column_view const& input,
   scalar const& replacement,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -57,7 +58,7 @@ std::unique_ptr<column> replace_nulls(
 std::unique_ptr<column> replace_nulls(
   column_view const& input,
   replace_policy const& replace_policy,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -69,7 +70,7 @@ std::unique_ptr<column> replace_nulls(
 std::unique_ptr<column> replace_nans(
   column_view const& input,
   column_view const& replacement,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -81,7 +82,7 @@ std::unique_ptr<column> replace_nans(
 std::unique_ptr<column> replace_nans(
   column_view const& input,
   scalar const& replacement,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -93,7 +94,7 @@ std::unique_ptr<column> find_and_replace_all(
   column_view const& input_col,
   column_view const& values_to_replace,
   column_view const& replacement_values,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -103,7 +104,7 @@ std::unique_ptr<column> find_and_replace_all(
  */
 std::unique_ptr<column> normalize_nans_and_zeros(
   column_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/reshape.hpp
+++ b/cpp/include/cudf/detail/reshape.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -32,7 +33,7 @@ namespace detail {
 std::unique_ptr<table> tile(
   table_view const& input,
   size_type count,
-  rmm::cuda_stream_view               = rmm::cuda_stream_default,
+  rmm::cuda_stream_view               = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -42,7 +43,7 @@ std::unique_ptr<table> tile(
  */
 std::unique_ptr<column> interleave_columns(
   table_view const& input,
-  rmm::cuda_stream_view               = rmm::cuda_stream_default,
+  rmm::cuda_stream_view               = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/rolling.hpp
+++ b/cpp/include/cudf/detail/rolling.hpp
@@ -19,6 +19,7 @@
 #include <cudf/aggregation.hpp>
 #include <cudf/rolling.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -44,7 +45,7 @@ std::unique_ptr<column> rolling_window(
   column_view const& following_window,
   size_type min_periods,
   rolling_aggregation const& agg,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/round.hpp
+++ b/cpp/include/cudf/detail/round.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/round.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -34,7 +35,7 @@ std::unique_ptr<column> round(
   column_view const& input,
   int32_t decimal_places,
   rounding_method method,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -28,6 +28,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/detail/scatter.cuh>
 #include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -390,7 +391,7 @@ std::unique_ptr<table> scatter(
   MapIterator scatter_map_end,
   table_view const& target,
   bool check_bounds                   = false,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_FUNC_RANGE();

--- a/cpp/include/cudf/detail/scatter.hpp
+++ b/cpp/include/cudf/detail/scatter.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -67,7 +68,7 @@ std::unique_ptr<table> scatter(
   column_view const& scatter_map,
   table_view const& target,
   bool check_bounds                   = false,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -81,7 +82,7 @@ std::unique_ptr<table> scatter(
   device_span<size_type const> const scatter_map,
   table_view const& target,
   bool check_bounds                   = false,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -121,7 +122,7 @@ std::unique_ptr<table> scatter(
   column_view const& indices,
   table_view const& target,
   bool check_bounds                   = false,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -136,7 +137,7 @@ std::unique_ptr<table> boolean_mask_scatter(
   table_view const& source,
   table_view const& target,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -152,7 +153,7 @@ std::unique_ptr<table> boolean_mask_scatter(
   std::vector<std::reference_wrapper<const scalar>> const& source,
   table_view const& target,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/sequence.hpp
+++ b/cpp/include/cudf/detail/sequence.hpp
@@ -19,6 +19,7 @@
 #include <cudf/detail/sequence.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -35,7 +36,7 @@ std::unique_ptr<column> sequence(
   size_type size,
   scalar const& init,
   scalar const& step,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -48,7 +49,7 @@ std::unique_ptr<column> sequence(
 std::unique_ptr<column> sequence(
   size_type size,
   scalar const& init,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -63,7 +64,7 @@ std::unique_ptr<cudf::column> calendrical_month_sequence(
   size_type size,
   scalar const& init,
   size_type months,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/sorting.hpp
+++ b/cpp/include/cudf/detail/sorting.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -35,7 +36,7 @@ std::unique_ptr<column> sorted_order(
   table_view const& input,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 /**
@@ -47,7 +48,7 @@ std::unique_ptr<column> stable_sorted_order(
   table_view const& input,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 /**
@@ -60,7 +61,7 @@ std::unique_ptr<table> sort_by_key(
   table_view const& keys,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 /**
@@ -73,7 +74,7 @@ std::unique_ptr<table> stable_sort_by_key(
   table_view const& keys,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 /**
@@ -86,7 +87,7 @@ std::unique_ptr<column> segmented_sorted_order(
   column_view const& segment_offsets,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 /**
@@ -99,7 +100,7 @@ std::unique_ptr<column> stable_segmented_sorted_order(
   column_view const& segment_offsets,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 /**
@@ -113,7 +114,7 @@ std::unique_ptr<table> segmented_sort_by_key(
   column_view const& segment_offsets,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 /**
@@ -127,7 +128,7 @@ std::unique_ptr<table> stable_segmented_sort_by_key(
   column_view const& segment_offsets,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 /**
@@ -139,7 +140,7 @@ std::unique_ptr<table> sort(
   table_view const& values,
   std::vector<order> const& column_order         = {},
   std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream                   = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/stream_compaction.hpp
+++ b/cpp/include/cudf/detail/stream_compaction.hpp
@@ -19,6 +19,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -34,7 +35,7 @@ std::unique_ptr<table> drop_nulls(
   table_view const& input,
   std::vector<size_type> const& keys,
   cudf::size_type keep_threshold,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -47,7 +48,7 @@ std::unique_ptr<table> drop_nans(
   table_view const& input,
   std::vector<size_type> const& keys,
   cudf::size_type keep_threshold,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -58,7 +59,7 @@ std::unique_ptr<table> drop_nans(
 std::unique_ptr<table> apply_boolean_mask(
   table_view const& input,
   column_view const& boolean_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -71,7 +72,7 @@ std::unique_ptr<table> unique(
   std::vector<size_type> const& keys,
   duplicate_keep_option keep,
   null_equality nulls_equal           = null_equality::EQUAL,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -83,7 +84,7 @@ std::unique_ptr<table> distinct(
   table_view const& input,
   std::vector<size_type> const& keys,
   null_equality nulls_equal           = null_equality::EQUAL,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -94,7 +95,7 @@ std::unique_ptr<table> distinct(
 cudf::size_type unique_count(column_view const& input,
                              null_policy null_handling,
                              nan_policy nan_handling,
-                             rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                             rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::unique_count(table_view const&, null_equality)
@@ -103,7 +104,7 @@ cudf::size_type unique_count(column_view const& input,
  */
 cudf::size_type unique_count(table_view const& input,
                              null_equality nulls_equal    = null_equality::EQUAL,
-                             rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                             rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::distinct_count(column_view const&, null_policy, nan_policy)
@@ -113,7 +114,7 @@ cudf::size_type unique_count(table_view const& input,
 cudf::size_type distinct_count(column_view const& input,
                                null_policy null_handling,
                                nan_policy nan_handling,
-                               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                               rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @copydoc cudf::distinct_count(table_view const&, null_equality)
@@ -122,7 +123,7 @@ cudf::size_type distinct_count(column_view const& input,
  */
 cudf::size_type distinct_count(table_view const& input,
                                null_equality nulls_equal    = null_equality::EQUAL,
-                               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                               rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/detail/structs/utilities.hpp
+++ b/cpp/include/cudf/detail/structs/utilities.hpp
@@ -18,6 +18,7 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -217,7 +218,7 @@ void superimpose_parent_nulls(bitmask_type const* parent_null_mask,
  */
 std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_parent_nulls(
   column_view const& parent,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -243,7 +244,7 @@ std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_paren
  */
 std::tuple<cudf::table_view, std::vector<rmm::device_buffer>> superimpose_parent_nulls(
   table_view const& table,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/include/cudf/detail/tdigest/tdigest.hpp
+++ b/cpp/include/cudf/detail/tdigest/tdigest.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -138,7 +139,7 @@ std::unique_ptr<column> make_tdigest_column(
   std::unique_ptr<column>&& tdigest_offsets,
   std::unique_ptr<column>&& min_values,
   std::unique_ptr<column>&& max_values,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -152,7 +153,7 @@ std::unique_ptr<column> make_tdigest_column(
  * @returns An empty tdigest column.
  */
 std::unique_ptr<column> make_empty_tdigest_column(
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -166,7 +167,7 @@ std::unique_ptr<column> make_empty_tdigest_column(
  * @returns An empty tdigest scalar.
  */
 std::unique_ptr<scalar> make_empty_tdigest_scalar(
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/include/cudf/detail/transform.hpp
+++ b/cpp/include/cudf/detail/transform.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/transform.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -33,7 +34,7 @@ std::unique_ptr<column> transform(
   std::string const& unary_udf,
   data_type output_type,
   bool is_ptx,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -44,7 +45,7 @@ std::unique_ptr<column> transform(
 std::unique_ptr<column> compute_column(
   table_view const table,
   ast::operation const& expr,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -54,7 +55,7 @@ std::unique_ptr<column> compute_column(
  */
 std::pair<std::unique_ptr<rmm::device_buffer>, size_type> nans_to_nulls(
   column_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -64,7 +65,7 @@ std::pair<std::unique_ptr<rmm::device_buffer>, size_type> nans_to_nulls(
  */
 std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
   column_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -74,7 +75,7 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
  */
 std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
   cudf::table_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -85,7 +86,7 @@ std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
 std::pair<std::unique_ptr<column>, table_view> one_hot_encode(
   column_view const& input,
   column_view const& categories,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -97,7 +98,7 @@ std::unique_ptr<column> mask_to_bools(
   bitmask_type const* null_mask,
   size_type begin_bit,
   size_type end_bit,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -107,7 +108,7 @@ std::unique_ptr<column> mask_to_bools(
  */
 std::unique_ptr<column> row_bit_count(
   table_view const& t,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/transpose.hpp
+++ b/cpp/include/cudf/detail/transpose.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -29,7 +30,7 @@ namespace detail {
  */
 std::pair<std::unique_ptr<column>, table_view> transpose(
   table_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/unary.hpp
+++ b/cpp/include/cudf/detail/unary.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/unary.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -49,7 +50,7 @@ std::unique_ptr<column> true_if(
   InputIterator end,
   size_type size,
   Predicate p,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto output =
@@ -70,7 +71,7 @@ std::unique_ptr<column> true_if(
 std::unique_ptr<cudf::column> unary_operation(
   cudf::column_view const& input,
   cudf::unary_operator op,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -81,7 +82,7 @@ std::unique_ptr<cudf::column> unary_operation(
 std::unique_ptr<column> cast(
   column_view const& input,
   data_type type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -91,7 +92,7 @@ std::unique_ptr<column> cast(
  */
 std::unique_ptr<column> is_nan(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -101,7 +102,7 @@ std::unique_ptr<column> is_nan(
  */
 std::unique_ptr<column> is_not_nan(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/detail/utilities/cuda.cuh
+++ b/cpp/include/cudf/detail/utilities/cuda.cuh
@@ -19,6 +19,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -169,7 +170,8 @@ __global__ void single_thread_kernel(F f)
  * @param stream CUDA stream used for the kernel launch
  */
 template <class Functor>
-void device_single_thread(Functor functor, rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+void device_single_thread(Functor functor,
+                          rmm::cuda_stream_view stream = cudf::default_stream_value)
 {
   single_thread_kernel<<<1, 1, 0, stream.value()>>>(functor);
 }

--- a/cpp/include/cudf/detail/utilities/vector_factories.hpp
+++ b/cpp/include/cudf/detail/utilities/vector_factories.hpp
@@ -21,6 +21,7 @@
  * @file vector_factories.hpp
  */
 
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
 
@@ -71,7 +72,7 @@ rmm::device_uvector<T> make_zeroed_device_uvector_async(
 template <typename T>
 rmm::device_uvector<T> make_zeroed_device_uvector_sync(
   std::size_t size,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   rmm::device_uvector<T> ret(size, stream, mr);
@@ -147,7 +148,7 @@ rmm::device_uvector<typename Container::value_type> make_device_uvector_async(
 template <typename T>
 rmm::device_uvector<T> make_device_uvector_async(
   device_span<T const> source_data,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   rmm::device_uvector<T> ret(source_data.size(), stream, mr);
@@ -200,7 +201,7 @@ rmm::device_uvector<typename Container::value_type> make_device_uvector_async(
 template <typename T>
 rmm::device_uvector<T> make_device_uvector_sync(
   host_span<T const> source_data,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto ret = make_device_uvector_async(source_data, stream, mr);
@@ -227,7 +228,7 @@ template <
     std::is_convertible_v<Container, host_span<typename Container::value_type const>>>* = nullptr>
 rmm::device_uvector<typename Container::value_type> make_device_uvector_sync(
   Container const& c,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   return make_device_uvector_sync(host_span<typename Container::value_type const>{c}, stream, mr);
@@ -248,7 +249,7 @@ rmm::device_uvector<typename Container::value_type> make_device_uvector_sync(
 template <typename T>
 rmm::device_uvector<T> make_device_uvector_sync(
   device_span<T const> source_data,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto ret = make_device_uvector_async(source_data, stream, mr);
@@ -275,7 +276,7 @@ template <
     std::is_convertible_v<Container, device_span<typename Container::value_type const>>>* = nullptr>
 rmm::device_uvector<typename Container::value_type> make_device_uvector_sync(
   Container const& c,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   return make_device_uvector_sync(device_span<typename Container::value_type const>{c}, stream, mr);
@@ -366,7 +367,7 @@ template <
   std::enable_if_t<
     std::is_convertible_v<Container, device_span<typename Container::value_type const>>>* = nullptr>
 std::vector<typename Container::value_type> make_std_vector_sync(
-  Container const& c, rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+  Container const& c, rmm::cuda_stream_view stream = cudf::default_stream_value)
 {
   return make_std_vector_sync(device_span<typename Container::value_type const>{c}, stream);
 }
@@ -423,7 +424,7 @@ thrust::host_vector<typename Container::value_type> make_host_vector_async(
  */
 template <typename T>
 thrust::host_vector<T> make_host_vector_sync(
-  device_span<T const> v, rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+  device_span<T const> v, rmm::cuda_stream_view stream = cudf::default_stream_value)
 {
   auto result = make_host_vector_async(v, stream);
   stream.synchronize();
@@ -447,7 +448,7 @@ template <
   std::enable_if_t<
     std::is_convertible_v<Container, device_span<typename Container::value_type const>>>* = nullptr>
 thrust::host_vector<typename Container::value_type> make_host_vector_sync(
-  Container const& c, rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+  Container const& c, rmm::cuda_stream_view stream = cudf::default_stream_value)
 {
   return make_host_vector_sync(device_span<typename Container::value_type const>{c}, stream);
 }

--- a/cpp/include/cudf/detail/valid_if.cuh
+++ b/cpp/include/cudf/detail/valid_if.cuh
@@ -20,6 +20,7 @@
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -89,7 +90,7 @@ std::pair<rmm::device_buffer, size_type> valid_if(
   InputIterator begin,
   InputIterator end,
   Predicate p,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(begin <= end, "Invalid range.");

--- a/cpp/include/cudf/dictionary/detail/concatenate.hpp
+++ b/cpp/include/cudf/dictionary/detail/concatenate.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -38,7 +39,7 @@ namespace detail {
  */
 std::unique_ptr<column> concatenate(
   host_span<column_view const> columns,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/dictionary/detail/encode.hpp
+++ b/cpp/include/cudf/dictionary/detail/encode.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -53,7 +54,7 @@ namespace detail {
 std::unique_ptr<column> encode(
   column_view const& column,
   data_type indices_type              = data_type{type_id::UINT32},
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -73,7 +74,7 @@ std::unique_ptr<column> encode(
  */
 std::unique_ptr<column> decode(
   dictionary_column_view const& dictionary_column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/include/cudf/dictionary/detail/replace.hpp
+++ b/cpp/include/cudf/dictionary/detail/replace.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -41,7 +42,7 @@ namespace detail {
 std::unique_ptr<column> replace_nulls(
   dictionary_column_view const& input,
   dictionary_column_view const& replacement,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -59,7 +60,7 @@ std::unique_ptr<column> replace_nulls(
 std::unique_ptr<column> replace_nulls(
   dictionary_column_view const& input,
   scalar const& replacement,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/dictionary/detail/search.hpp
+++ b/cpp/include/cudf/dictionary/detail/search.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -33,7 +34,7 @@ namespace detail {
 std::unique_ptr<scalar> get_index(
   dictionary_column_view const& dictionary,
   scalar const& key,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -58,7 +59,7 @@ std::unique_ptr<scalar> get_index(
 std::unique_ptr<scalar> get_insert_index(
   dictionary_column_view const& dictionary,
   scalar const& key,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/dictionary/detail/update_keys.hpp
+++ b/cpp/include/cudf/dictionary/detail/update_keys.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -34,7 +35,7 @@ namespace detail {
 std::unique_ptr<column> add_keys(
   dictionary_column_view const& dictionary_column,
   column_view const& new_keys,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -46,7 +47,7 @@ std::unique_ptr<column> add_keys(
 std::unique_ptr<column> remove_keys(
   dictionary_column_view const& dictionary_column,
   column_view const& keys_to_remove,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -57,7 +58,7 @@ std::unique_ptr<column> remove_keys(
  */
 std::unique_ptr<column> remove_unused_keys(
   dictionary_column_view const& dictionary_column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -69,7 +70,7 @@ std::unique_ptr<column> remove_unused_keys(
 std::unique_ptr<column> set_keys(
   dictionary_column_view const& dictionary_column,
   column_view const& keys,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -80,7 +81,7 @@ std::unique_ptr<column> set_keys(
  */
 std::vector<std::unique_ptr<column>> match_dictionaries(
   cudf::host_span<dictionary_column_view const> input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -104,7 +105,7 @@ std::vector<std::unique_ptr<column>> match_dictionaries(
  */
 std::pair<std::vector<std::unique_ptr<column>>, std::vector<table_view>> match_dictionaries(
   std::vector<table_view> tables,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/dictionary/dictionary_factories.hpp
+++ b/cpp/include/cudf/dictionary/dictionary_factories.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -63,7 +64,7 @@ namespace cudf {
 std::unique_ptr<column> make_dictionary_column(
   column_view const& keys_column,
   column_view const& indices_column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -115,7 +116,7 @@ std::unique_ptr<column> make_dictionary_column(std::unique_ptr<column> keys_colu
 std::unique_ptr<column> make_dictionary_column(
   std::unique_ptr<column> keys_column,
   std::unique_ptr<column> indices_column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/io/detail/csv.hpp
+++ b/cpp/include/cudf/io/detail/csv.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/io/csv.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -54,7 +55,7 @@ void write_csv(data_sink* sink,
                table_view const& table,
                const table_metadata* metadata,
                csv_writer_options const& options,
-               rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+               rmm::cuda_stream_view stream        = cudf::default_stream_value,
                rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace csv

--- a/cpp/include/cudf/io/detail/json.hpp
+++ b/cpp/include/cudf/io/detail/json.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/io/json.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -38,7 +39,7 @@ namespace json {
 table_with_metadata read_json(
   std::vector<std::unique_ptr<cudf::io::datasource>>& sources,
   json_reader_options const& options,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace json

--- a/cpp/include/cudf/join.hpp
+++ b/cpp/include/cudf/join.hpp
@@ -20,6 +20,7 @@
 #include <cudf/hashing.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -536,7 +537,7 @@ class hash_join {
    */
   hash_join(cudf::table_view const& build,
             null_equality compare_nulls,
-            rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+            rmm::cuda_stream_view stream = cudf::default_stream_value);
 
   /**
    * Returns the row indices that can be used to construct the result of performing
@@ -557,7 +558,7 @@ class hash_join {
             std::unique_ptr<rmm::device_uvector<size_type>>>
   inner_join(cudf::table_view const& probe,
              std::optional<std::size_t> output_size = {},
-             rmm::cuda_stream_view stream           = rmm::cuda_stream_default,
+             rmm::cuda_stream_view stream           = cudf::default_stream_value,
              rmm::mr::device_memory_resource* mr    = rmm::mr::get_current_device_resource()) const;
 
   /**
@@ -579,7 +580,7 @@ class hash_join {
             std::unique_ptr<rmm::device_uvector<size_type>>>
   left_join(cudf::table_view const& probe,
             std::optional<std::size_t> output_size = {},
-            rmm::cuda_stream_view stream           = rmm::cuda_stream_default,
+            rmm::cuda_stream_view stream           = cudf::default_stream_value,
             rmm::mr::device_memory_resource* mr    = rmm::mr::get_current_device_resource()) const;
 
   /**
@@ -601,7 +602,7 @@ class hash_join {
             std::unique_ptr<rmm::device_uvector<size_type>>>
   full_join(cudf::table_view const& probe,
             std::optional<std::size_t> output_size = {},
-            rmm::cuda_stream_view stream           = rmm::cuda_stream_default,
+            rmm::cuda_stream_view stream           = cudf::default_stream_value,
             rmm::mr::device_memory_resource* mr    = rmm::mr::get_current_device_resource()) const;
 
   /**
@@ -615,7 +616,7 @@ class hash_join {
    * `build` and `probe` as the the join keys .
    */
   [[nodiscard]] std::size_t inner_join_size(
-    cudf::table_view const& probe, rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+    cudf::table_view const& probe, rmm::cuda_stream_view stream = cudf::default_stream_value) const;
 
   /**
    * Returns the exact number of matches (rows) when performing a left join with the specified probe
@@ -628,7 +629,7 @@ class hash_join {
    * and `probe` as the the join keys .
    */
   [[nodiscard]] std::size_t left_join_size(
-    cudf::table_view const& probe, rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+    cudf::table_view const& probe, rmm::cuda_stream_view stream = cudf::default_stream_value) const;
 
   /**
    * Returns the exact number of matches (rows) when performing a full join with the specified probe
@@ -644,7 +645,7 @@ class hash_join {
    */
   std::size_t full_join_size(
     cudf::table_view const& probe,
-    rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+    rmm::cuda_stream_view stream        = cudf::default_stream_value,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) const;
 
  private:

--- a/cpp/include/cudf/lists/detail/concatenate.hpp
+++ b/cpp/include/cudf/lists/detail/concatenate.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -44,7 +45,7 @@ namespace detail {
  */
 std::unique_ptr<column> concatenate(
   host_span<column_view const> columns,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/lists/detail/gather.cuh
+++ b/cpp/include/cudf/lists/detail/gather.cuh
@@ -19,6 +19,7 @@
 #include <cudf/detail/get_value.cuh>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
@@ -320,7 +321,7 @@ std::unique_ptr<column> segmented_gather(
   lists_column_view const& source_column,
   lists_column_view const& gather_map_list,
   out_of_bounds_policy bounds_policy  = out_of_bounds_policy::DONT_CHECK,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/lists/detail/scatter.cuh
+++ b/cpp/include/cudf/lists/detail/scatter.cuh
@@ -25,6 +25,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
 #include <rmm/device_uvector.hpp>
@@ -95,7 +96,7 @@ std::unique_ptr<column> scatter_impl(
   MapIterator scatter_map_end,
   column_view const& source,
   column_view const& target,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(column_types_equal(source, target), "Mismatched column types.");
@@ -168,7 +169,7 @@ std::unique_ptr<column> scatter(
   MapIterator scatter_map_begin,
   MapIterator scatter_map_end,
   column_view const& target,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto const num_rows = target.size();
@@ -225,7 +226,7 @@ std::unique_ptr<column> scatter(
   MapIterator scatter_map_begin,
   MapIterator scatter_map_end,
   column_view const& target,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto const num_rows = target.size();

--- a/cpp/include/cudf/lists/lists_column_factories.hpp
+++ b/cpp/include/cudf/lists/lists_column_factories.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 namespace cudf {
 namespace lists {
@@ -35,7 +36,7 @@ namespace detail {
 std::unique_ptr<cudf::column> make_lists_column_from_scalar(
   list_scalar const& value,
   size_type size,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/partitioning.hpp
+++ b/cpp/include/cudf/partitioning.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/hashing.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -96,7 +97,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition(
   int num_partitions,
   hash_id hash_function               = hash_id::HASH_MURMUR3,
   uint32_t seed                       = DEFAULT_HASH_SEED,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -62,7 +63,7 @@ class scalar {
    * @param is_valid true: set the value to valid. false: set it to null.
    * @param stream CUDA stream used for device memory operations.
    */
-  void set_valid_async(bool is_valid, rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+  void set_valid_async(bool is_valid, rmm::cuda_stream_view stream = cudf::default_stream_value);
 
   /**
    * @brief Indicates whether the scalar contains a valid value.
@@ -74,7 +75,7 @@ class scalar {
    * @return true Value is valid
    * @return false Value is invalid/null
    */
-  [[nodiscard]] bool is_valid(rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+  [[nodiscard]] bool is_valid(rmm::cuda_stream_view stream = cudf::default_stream_value) const;
 
   /**
    * @brief Returns a raw pointer to the validity bool in device memory.
@@ -110,7 +111,7 @@ class scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   scalar(scalar const& other,
-         rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+         rmm::cuda_stream_view stream        = cudf::default_stream_value,
          rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -126,7 +127,7 @@ class scalar {
    */
   scalar(data_type type,
          bool is_valid                       = false,
-         rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+         rmm::cuda_stream_view stream        = cudf::default_stream_value,
          rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 };
 
@@ -162,7 +163,7 @@ class fixed_width_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   fixed_width_scalar(fixed_width_scalar const& other,
-                     rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                     rmm::cuda_stream_view stream        = cudf::default_stream_value,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -171,7 +172,7 @@ class fixed_width_scalar : public scalar {
    * @param value New value of scalar.
    * @param stream CUDA stream used for device memory operations.
    */
-  void set_value(T value, rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+  void set_value(T value, rmm::cuda_stream_view stream = cudf::default_stream_value);
 
   /**
    * @brief Explicit conversion operator to get the value of the scalar on the host.
@@ -184,7 +185,7 @@ class fixed_width_scalar : public scalar {
    * @param stream CUDA stream used for device memory operations.
    * @return Value of the scalar
    */
-  T value(rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+  T value(rmm::cuda_stream_view stream = cudf::default_stream_value) const;
 
   /**
    * @brief Returns a raw pointer to the value in device memory.
@@ -213,7 +214,7 @@ class fixed_width_scalar : public scalar {
    */
   fixed_width_scalar(T value,
                      bool is_valid                       = true,
-                     rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                     rmm::cuda_stream_view stream        = cudf::default_stream_value,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -226,7 +227,7 @@ class fixed_width_scalar : public scalar {
    */
   fixed_width_scalar(rmm::device_scalar<T>&& data,
                      bool is_valid                       = true,
-                     rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                     rmm::cuda_stream_view stream        = cudf::default_stream_value,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 };
 
@@ -262,7 +263,7 @@ class numeric_scalar : public detail::fixed_width_scalar<T> {
    * @param mr Device memory resource to use for device memory allocation.
    */
   numeric_scalar(numeric_scalar const& other,
-                 rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                 rmm::cuda_stream_view stream        = cudf::default_stream_value,
                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -275,7 +276,7 @@ class numeric_scalar : public detail::fixed_width_scalar<T> {
    */
   numeric_scalar(T value,
                  bool is_valid                       = true,
-                 rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                 rmm::cuda_stream_view stream        = cudf::default_stream_value,
                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -288,7 +289,7 @@ class numeric_scalar : public detail::fixed_width_scalar<T> {
    */
   numeric_scalar(rmm::device_scalar<T>&& data,
                  bool is_valid                       = true,
-                 rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                 rmm::cuda_stream_view stream        = cudf::default_stream_value,
                  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 };
 
@@ -325,7 +326,7 @@ class fixed_point_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   fixed_point_scalar(fixed_point_scalar const& other,
-                     rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                     rmm::cuda_stream_view stream        = cudf::default_stream_value,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -340,7 +341,7 @@ class fixed_point_scalar : public scalar {
   fixed_point_scalar(rep_type value,
                      numeric::scale_type scale,
                      bool is_valid                       = true,
-                     rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                     rmm::cuda_stream_view stream        = cudf::default_stream_value,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -353,7 +354,7 @@ class fixed_point_scalar : public scalar {
    */
   fixed_point_scalar(rep_type value,
                      bool is_valid                       = true,
-                     rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                     rmm::cuda_stream_view stream        = cudf::default_stream_value,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -366,7 +367,7 @@ class fixed_point_scalar : public scalar {
    */
   fixed_point_scalar(T value,
                      bool is_valid                       = true,
-                     rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                     rmm::cuda_stream_view stream        = cudf::default_stream_value,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -381,7 +382,7 @@ class fixed_point_scalar : public scalar {
   fixed_point_scalar(rmm::device_scalar<rep_type>&& data,
                      numeric::scale_type scale,
                      bool is_valid                       = true,
-                     rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                     rmm::cuda_stream_view stream        = cudf::default_stream_value,
                      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -390,7 +391,7 @@ class fixed_point_scalar : public scalar {
    * @param stream CUDA stream used for device memory operations.
    * @return The value of the scalar
    */
-  rep_type value(rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+  rep_type value(rmm::cuda_stream_view stream = cudf::default_stream_value) const;
 
   /**
    * @brief Get the decimal32, decimal64 or decimal128.
@@ -398,7 +399,7 @@ class fixed_point_scalar : public scalar {
    * @param stream CUDA stream used for device memory operations.
    * @return The decimal32, decimal64 or decimal128 value
    */
-  T fixed_point_value(rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+  T fixed_point_value(rmm::cuda_stream_view stream = cudf::default_stream_value) const;
 
   /**
    * @brief Explicit conversion operator to get the value of the scalar on the host.
@@ -449,7 +450,7 @@ class string_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   string_scalar(string_scalar const& other,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -462,7 +463,7 @@ class string_scalar : public scalar {
    */
   string_scalar(std::string const& string,
                 bool is_valid                       = true,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -477,7 +478,7 @@ class string_scalar : public scalar {
    */
   string_scalar(value_type const& source,
                 bool is_valid                       = true,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -492,7 +493,7 @@ class string_scalar : public scalar {
    */
   string_scalar(rmm::device_scalar<value_type>& data,
                 bool is_valid                       = true,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -508,7 +509,7 @@ class string_scalar : public scalar {
    */
   string_scalar(rmm::device_buffer&& data,
                 bool is_valid                       = true,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -523,7 +524,7 @@ class string_scalar : public scalar {
    * @return The value of the scalar in a host std::string
    */
   [[nodiscard]] std::string to_string(
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+    rmm::cuda_stream_view stream = cudf::default_stream_value) const;
 
   /**
    * @brief Get the value of the scalar as a string_view.
@@ -531,7 +532,7 @@ class string_scalar : public scalar {
    * @param stream CUDA stream used for device memory operations.
    * @return The value of the scalar as a string_view
    */
-  [[nodiscard]] value_type value(rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+  [[nodiscard]] value_type value(rmm::cuda_stream_view stream = cudf::default_stream_value) const;
 
   /**
    * @brief Returns the size of the string in bytes.
@@ -580,7 +581,7 @@ class chrono_scalar : public detail::fixed_width_scalar<T> {
    * @param mr Device memory resource to use for device memory allocation.
    */
   chrono_scalar(chrono_scalar const& other,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -593,7 +594,7 @@ class chrono_scalar : public detail::fixed_width_scalar<T> {
    */
   chrono_scalar(T value,
                 bool is_valid                       = true,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -606,7 +607,7 @@ class chrono_scalar : public detail::fixed_width_scalar<T> {
    */
   chrono_scalar(rmm::device_scalar<T>&& data,
                 bool is_valid                       = true,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 };
 
@@ -639,7 +640,7 @@ class timestamp_scalar : public chrono_scalar<T> {
    * @param mr Device memory resource to use for device memory allocation.
    */
   timestamp_scalar(timestamp_scalar const& other,
-                   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                   rmm::cuda_stream_view stream        = cudf::default_stream_value,
                    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -655,7 +656,7 @@ class timestamp_scalar : public chrono_scalar<T> {
   template <typename Duration2>
   timestamp_scalar(Duration2 const& value,
                    bool is_valid,
-                   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                   rmm::cuda_stream_view stream        = cudf::default_stream_value,
                    rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -694,7 +695,7 @@ class duration_scalar : public chrono_scalar<T> {
    * @param mr Device memory resource to use for device memory allocation.
    */
   duration_scalar(duration_scalar const& other,
-                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                  rmm::cuda_stream_view stream        = cudf::default_stream_value,
                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -707,7 +708,7 @@ class duration_scalar : public chrono_scalar<T> {
    */
   duration_scalar(rep_type value,
                   bool is_valid,
-                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                  rmm::cuda_stream_view stream        = cudf::default_stream_value,
                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -742,7 +743,7 @@ class list_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   list_scalar(list_scalar const& other,
-              rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+              rmm::cuda_stream_view stream        = cudf::default_stream_value,
               rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -757,7 +758,7 @@ class list_scalar : public scalar {
    */
   list_scalar(cudf::column_view const& data,
               bool is_valid                       = true,
-              rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+              rmm::cuda_stream_view stream        = cudf::default_stream_value,
               rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -770,7 +771,7 @@ class list_scalar : public scalar {
    */
   list_scalar(cudf::column&& data,
               bool is_valid                       = true,
-              rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+              rmm::cuda_stream_view stream        = cudf::default_stream_value,
               rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -807,7 +808,7 @@ class struct_scalar : public scalar {
    * @param mr Device memory resource to use for device memory allocation.
    */
   struct_scalar(struct_scalar const& other,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -822,7 +823,7 @@ class struct_scalar : public scalar {
    */
   struct_scalar(table_view const& data,
                 bool is_valid                       = true,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -837,7 +838,7 @@ class struct_scalar : public scalar {
    */
   struct_scalar(host_span<column_view const> data,
                 bool is_valid                       = true,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -853,7 +854,7 @@ class struct_scalar : public scalar {
    */
   struct_scalar(table&& data,
                 bool is_valid                       = true,
-                rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream        = cudf::default_stream_value,
                 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**

--- a/cpp/include/cudf/scalar/scalar_factories.hpp
+++ b/cpp/include/cudf/scalar/scalar_factories.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -41,7 +42,7 @@ namespace cudf {
  */
 std::unique_ptr<scalar> make_numeric_scalar(
   data_type type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -58,7 +59,7 @@ std::unique_ptr<scalar> make_numeric_scalar(
  */
 std::unique_ptr<scalar> make_timestamp_scalar(
   data_type type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -75,7 +76,7 @@ std::unique_ptr<scalar> make_timestamp_scalar(
  */
 std::unique_ptr<scalar> make_duration_scalar(
   data_type type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -92,7 +93,7 @@ std::unique_ptr<scalar> make_duration_scalar(
  */
 std::unique_ptr<scalar> make_fixed_width_scalar(
   data_type type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -109,7 +110,7 @@ std::unique_ptr<scalar> make_fixed_width_scalar(
  */
 std::unique_ptr<scalar> make_string_scalar(
   std::string const& string,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -124,7 +125,7 @@ std::unique_ptr<scalar> make_string_scalar(
  */
 std::unique_ptr<scalar> make_default_constructed_scalar(
   data_type type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -139,7 +140,7 @@ std::unique_ptr<scalar> make_default_constructed_scalar(
  */
 std::unique_ptr<scalar> make_empty_scalar_like(
   column_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -154,7 +155,7 @@ std::unique_ptr<scalar> make_empty_scalar_like(
 template <typename T>
 std::unique_ptr<scalar> make_fixed_width_scalar(
   T value,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   return std::make_unique<scalar_type_t<T>>(value, true, stream, mr);
@@ -174,7 +175,7 @@ template <typename T>
 std::unique_ptr<scalar> make_fixed_point_scalar(
   typename T::rep value,
   numeric::scale_type scale,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   return std::make_unique<scalar_type_t<T>>(value, scale, true, stream, mr);
@@ -190,7 +191,7 @@ std::unique_ptr<scalar> make_fixed_point_scalar(
  */
 std::unique_ptr<scalar> make_list_scalar(
   column_view elements,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -205,7 +206,7 @@ std::unique_ptr<scalar> make_list_scalar(
  */
 std::unique_ptr<scalar> make_struct_scalar(
   table_view const& data,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -220,7 +221,7 @@ std::unique_ptr<scalar> make_struct_scalar(
  */
 std::unique_ptr<scalar> make_struct_scalar(
   host_span<column_view const> data,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group

--- a/cpp/include/cudf/strings/detail/combine.hpp
+++ b/cpp/include/cudf/strings/detail/combine.hpp
@@ -20,6 +20,7 @@
 #include <cudf/strings/combine.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -38,7 +39,7 @@ std::unique_ptr<column> concatenate(
   string_scalar const& separator,
   string_scalar const& narep,
   separator_on_nulls separate_nulls   = separator_on_nulls::YES,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -51,7 +52,7 @@ std::unique_ptr<column> join_strings(
   strings_column_view const& strings,
   string_scalar const& separator,
   string_scalar const& narep,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/include/cudf/strings/detail/concatenate.hpp
+++ b/cpp/include/cudf/strings/detail/concatenate.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -43,7 +44,7 @@ namespace detail {
  */
 std::unique_ptr<column> concatenate(
   host_span<column_view const> columns,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/strings/detail/copying.hpp
+++ b/cpp/include/cudf/strings/detail/copying.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -52,7 +53,7 @@ std::unique_ptr<cudf::column> copy_slice(
   strings_column_view const& strings,
   size_type start,
   size_type end                       = -1,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/include/cudf/strings/detail/fill.hpp
+++ b/cpp/include/cudf/strings/detail/fill.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -46,7 +47,7 @@ std::unique_ptr<column> fill(
   size_type begin,
   size_type end,
   string_scalar const& value,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/strings/detail/json.hpp
+++ b/cpp/include/cudf/strings/detail/json.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -33,7 +34,7 @@ std::unique_ptr<cudf::column> get_json_object(
   cudf::strings_column_view const& col,
   cudf::string_scalar const& json_path,
   get_json_object_options options,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/strings/detail/replace.hpp
+++ b/cpp/include/cudf/strings/detail/replace.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -47,7 +48,7 @@ std::unique_ptr<column> replace(
   string_scalar const& target,
   string_scalar const& repl,
   int32_t maxrepl                     = -1,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -61,7 +62,7 @@ std::unique_ptr<column> replace_slice(
   string_scalar const& repl           = string_scalar(""),
   size_type start                     = 0,
   size_type stop                      = -1,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -74,7 +75,7 @@ std::unique_ptr<column> replace(
   strings_column_view const& strings,
   strings_column_view const& targets,
   strings_column_view const& repls,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -98,7 +99,7 @@ std::unique_ptr<column> replace(
 std::unique_ptr<column> replace_nulls(
   strings_column_view const& strings,
   string_scalar const& repl           = string_scalar(""),
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/strings/detail/scatter.cuh
+++ b/cpp/include/cudf/strings/detail/scatter.cuh
@@ -18,6 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -59,7 +60,7 @@ std::unique_ptr<column> scatter(
   SourceIterator end,
   MapIterator scatter_map,
   strings_column_view const& target,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   if (target.is_empty()) return make_empty_column(type_id::STRING);

--- a/cpp/include/cudf/strings/detail/utilities.cuh
+++ b/cpp/include/cudf/strings/detail/utilities.cuh
@@ -20,6 +20,7 @@
 #include <cudf/detail/get_value.cuh>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -52,7 +53,7 @@ template <typename InputIterator>
 std::unique_ptr<column> make_offsets_child_column(
   InputIterator begin,
   InputIterator end,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(begin < end, "Invalid iterator range");
@@ -120,7 +121,7 @@ auto make_strings_children(
   SizeAndExecuteFunction size_and_exec_fn,
   size_type exec_size,
   size_type strings_count,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto offsets_column = make_numeric_column(
@@ -177,7 +178,7 @@ template <typename SizeAndExecuteFunction>
 auto make_strings_children(
   SizeAndExecuteFunction size_and_exec_fn,
   size_type strings_count,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   return make_strings_children(size_and_exec_fn, strings_count, strings_count, stream, mr);

--- a/cpp/include/cudf/strings/detail/utilities.hpp
+++ b/cpp/include/cudf/strings/detail/utilities.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -37,7 +38,7 @@ namespace detail {
  */
 std::unique_ptr<column> create_chars_child_column(
   size_type bytes,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -50,7 +51,7 @@ std::unique_ptr<column> create_chars_child_column(
  */
 rmm::device_uvector<string_view> create_string_vector_from_column(
   cudf::strings_column_view const strings,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/include/cudf/table/experimental/row_operators.cuh
+++ b/cpp/include/cudf/table/experimental/row_operators.cuh
@@ -28,6 +28,7 @@
 #include <cudf/structs/structs_column_device_view.cuh>
 #include <cudf/table/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -622,7 +623,7 @@ class self_comparator {
   self_comparator(table_view const& t,
                   host_span<order const> column_order         = {},
                   host_span<null_order const> null_precedence = {},
-                  rmm::cuda_stream_view stream                = rmm::cuda_stream_default)
+                  rmm::cuda_stream_view stream                = cudf::default_stream_value)
     : d_t{preprocessed_table::create(t, column_order, null_precedence, stream)}
   {
   }
@@ -744,7 +745,7 @@ class two_table_comparator {
                        table_view const& right,
                        host_span<order const> column_order         = {},
                        host_span<null_order const> null_precedence = {},
-                       rmm::cuda_stream_view stream                = rmm::cuda_stream_default);
+                       rmm::cuda_stream_view stream                = cudf::default_stream_value);
 
   /**
    * @brief Construct an owning object for performing a lexicographic comparison between two rows of

--- a/cpp/include/cudf/table/table.hpp
+++ b/cpp/include/cudf/table/table.hpp
@@ -17,6 +17,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -67,7 +68,7 @@ class table {
    * @param mr Device memory resource used for allocating the device memory for the new columns
    */
   table(table_view view,
-        rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+        rmm::cuda_stream_view stream        = cudf::default_stream_value,
         rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**

--- a/cpp/include/cudf/table/table_device_view.cuh
+++ b/cpp/include/cudf/table/table_device_view.cuh
@@ -18,6 +18,7 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -171,7 +172,7 @@ class table_device_view : public detail::table_device_view_base<column_device_vi
    * available in device memory
    */
   static auto create(table_view source_view,
-                     rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+                     rmm::cuda_stream_view stream = cudf::default_stream_value)
   {
     auto deleter = [](table_device_view* t) { t->destroy(); };
     return std::unique_ptr<table_device_view, decltype(deleter)>{
@@ -208,7 +209,7 @@ class mutable_table_device_view
    * available in device memory
    */
   static auto create(mutable_table_view source_view,
-                     rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+                     rmm::cuda_stream_view stream = cudf::default_stream_value)
   {
     auto deleter = [](mutable_table_device_view* t) { t->destroy(); };
     return std::unique_ptr<mutable_table_device_view, decltype(deleter)>{

--- a/cpp/include/cudf_test/column_utilities.hpp
+++ b/cpp/include/cudf_test/column_utilities.hpp
@@ -22,6 +22,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <thrust/host_vector.h>
@@ -233,11 +234,11 @@ inline std::pair<thrust::host_vector<std::string>, std::vector<bitmask_type>> to
   auto const scv     = strings_column_view(c);
   auto const h_chars = cudf::detail::make_std_vector_sync<char>(
     cudf::device_span<char const>(scv.chars().data<char>(), scv.chars().size()),
-    rmm::cuda_stream_default);
+    cudf::default_stream_value);
   auto const h_offsets = cudf::detail::make_std_vector_sync(
     cudf::device_span<cudf::offset_type const>(
       scv.offsets().data<cudf::offset_type>() + scv.offset(), scv.size() + 1),
-    rmm::cuda_stream_default);
+    cudf::default_stream_value);
 
   // build std::string vector from chars and offsets
   std::vector<std::string> host_data;

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -28,6 +28,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -169,7 +170,7 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
   auto transform_begin = thrust::make_transform_iterator(begin, transformer);
   auto const size      = cudf::distance(begin, end);
   auto const elements  = thrust::host_vector<ElementTo>(transform_begin, transform_begin + size);
-  return rmm::device_buffer{elements.data(), size * sizeof(ElementTo), rmm::cuda_stream_default};
+  return rmm::device_buffer{elements.data(), size * sizeof(ElementTo), cudf::default_stream_value};
 }
 
 /**
@@ -195,7 +196,7 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
   auto transform_begin = thrust::make_transform_iterator(begin, transformer);
   auto const size      = cudf::distance(begin, end);
   auto const elements  = thrust::host_vector<RepType>(transform_begin, transform_begin + size);
-  return rmm::device_buffer{elements.data(), size * sizeof(RepType), rmm::cuda_stream_default};
+  return rmm::device_buffer{elements.data(), size * sizeof(RepType), cudf::default_stream_value};
 }
 
 /**
@@ -222,7 +223,7 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
   auto transformer_begin = thrust::make_transform_iterator(begin, to_rep);
   auto const size        = cudf::distance(begin, end);
   auto const elements = thrust::host_vector<RepType>(transformer_begin, transformer_begin + size);
-  return rmm::device_buffer{elements.data(), size * sizeof(RepType), rmm::cuda_stream_default};
+  return rmm::device_buffer{elements.data(), size * sizeof(RepType), cudf::default_stream_value};
 }
 
 /**
@@ -270,7 +271,7 @@ rmm::device_buffer make_null_mask(ValidityIterator begin, ValidityIterator end)
   auto null_mask = make_null_mask_vector(begin, end);
   return rmm::device_buffer{null_mask.data(),
                             null_mask.size() * sizeof(decltype(null_mask.front())),
-                            rmm::cuda_stream_default};
+                            cudf::default_stream_value};
 }
 
 /**
@@ -546,7 +547,7 @@ class fixed_point_column_wrapper : public detail::column_wrapper {
     wrapped.reset(new cudf::column{
       data_type,
       size,
-      rmm::device_buffer{elements.data(), size * sizeof(Rep), rmm::cuda_stream_default}});
+      rmm::device_buffer{elements.data(), size * sizeof(Rep), cudf::default_stream_value}});
   }
 
   /**
@@ -610,7 +611,7 @@ class fixed_point_column_wrapper : public detail::column_wrapper {
     wrapped.reset(new cudf::column{
       data_type,
       size,
-      rmm::device_buffer{elements.data(), size * sizeof(Rep), rmm::cuda_stream_default},
+      rmm::device_buffer{elements.data(), size * sizeof(Rep), cudf::default_stream_value},
       detail::make_null_mask(v, v + size),
       cudf::UNKNOWN_NULL_COUNT});
   }

--- a/cpp/include/cudf_test/tdigest_utilities.cuh
+++ b/cpp/include/cudf_test/tdigest_utilities.cuh
@@ -20,6 +20,7 @@
 #include <cudf/detail/unary.hpp>
 #include <cudf/groupby.hpp>
 #include <cudf/tdigest/tdigest_column_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <cudf_test/column_wrapper.hpp>
 
@@ -121,7 +122,7 @@ void tdigest_minmax_compare(cudf::tdigest::tdigest_column_view const& tdv,
 
   auto expected_min = cudf::make_fixed_width_column(
     data_type{type_id::FLOAT64}, spans.size(), mask_state::UNALLOCATED);
-  thrust::transform(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     spans.begin(),
                     spans.end(),
                     expected_min->mutable_view().template begin<double>(),
@@ -131,7 +132,7 @@ void tdigest_minmax_compare(cudf::tdigest::tdigest_column_view const& tdv,
 
   auto expected_max = cudf::make_fixed_width_column(
     data_type{type_id::FLOAT64}, spans.size(), mask_state::UNALLOCATED);
-  thrust::transform(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     spans.begin(),
                     spans.end(),
                     expected_max->mutable_view().template begin<double>(),

--- a/cpp/include/nvtext/bpe_tokenize.hpp
+++ b/cpp/include/nvtext/bpe_tokenize.hpp
@@ -19,6 +19,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 namespace nvtext {
 
@@ -45,7 +46,7 @@ struct bpe_merge_pairs {
    * @param mr Device memory resource used to allocate the device memory
    */
   bpe_merge_pairs(std::unique_ptr<cudf::column>&& input,
-                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                  rmm::cuda_stream_view stream        = cudf::default_stream_value,
                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   /**
@@ -56,7 +57,7 @@ struct bpe_merge_pairs {
    * @param mr Device memory resource used to allocate the device memory
    */
   bpe_merge_pairs(cudf::strings_column_view const& input,
-                  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+                  rmm::cuda_stream_view stream        = cudf::default_stream_value,
                   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
   ~bpe_merge_pairs();

--- a/cpp/include/nvtext/detail/tokenize.hpp
+++ b/cpp/include/nvtext/detail/tokenize.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -37,7 +38,7 @@ namespace detail {
 std::unique_ptr<cudf::column> tokenize(
   cudf::strings_column_view const& strings,
   cudf::string_scalar const& delimiter = cudf::string_scalar{""},
-  rmm::cuda_stream_view stream         = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream         = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr  = rmm::mr::get_current_device_resource());
 
 /**
@@ -53,7 +54,7 @@ std::unique_ptr<cudf::column> tokenize(
 std::unique_ptr<cudf::column> tokenize(
   cudf::strings_column_view const& strings,
   cudf::strings_column_view const& delimiters,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -70,7 +71,7 @@ std::unique_ptr<cudf::column> tokenize(
 std::unique_ptr<cudf::column> count_tokens(
   cudf::strings_column_view const& strings,
   cudf::string_scalar const& delimiter = cudf::string_scalar{""},
-  rmm::cuda_stream_view stream         = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream         = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr  = rmm::mr::get_current_device_resource());
 
 /**
@@ -86,7 +87,7 @@ std::unique_ptr<cudf::column> count_tokens(
 std::unique_ptr<cudf::column> count_tokens(
   cudf::strings_column_view const& strings,
   cudf::strings_column_view const& delimiters,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -36,6 +36,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/unary.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -320,7 +321,7 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   return binops::compiled::binary_operation<scalar, column_view>(
-    lhs, rhs, op, output_type, rmm::cuda_stream_default, mr);
+    lhs, rhs, op, output_type, cudf::default_stream_value, mr);
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          scalar const& rhs,
@@ -330,7 +331,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   return binops::compiled::binary_operation<column_view, scalar>(
-    lhs, rhs, op, output_type, rmm::cuda_stream_default, mr);
+    lhs, rhs, op, output_type, cudf::default_stream_value, mr);
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
@@ -340,7 +341,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   return binops::compiled::binary_operation<column_view, column_view>(
-    lhs, rhs, op, output_type, rmm::cuda_stream_default, mr);
+    lhs, rhs, op, output_type, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> binary_operation(column_view const& lhs,
@@ -403,7 +404,7 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::binary_operation(lhs, rhs, op, output_type, rmm::cuda_stream_default, mr);
+  return detail::binary_operation(lhs, rhs, op, output_type, cudf::default_stream_value, mr);
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          scalar const& rhs,
@@ -412,7 +413,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::binary_operation(lhs, rhs, op, output_type, rmm::cuda_stream_default, mr);
+  return detail::binary_operation(lhs, rhs, op, output_type, cudf::default_stream_value, mr);
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
@@ -421,7 +422,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::binary_operation(lhs, rhs, op, output_type, rmm::cuda_stream_default, mr);
+  return detail::binary_operation(lhs, rhs, op, output_type, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> binary_operation(column_view const& lhs,
@@ -431,7 +432,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::binary_operation(lhs, rhs, ptx, output_type, rmm::cuda_stream_default, mr);
+  return detail::binary_operation(lhs, rhs, ptx, output_type, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/binaryop/compiled/binary_ops.hpp
+++ b/cpp/src/binaryop/compiled/binary_ops.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/binaryop.hpp>
 #include <cudf/null_mask.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -36,7 +37,7 @@ std::unique_ptr<column> string_null_min_max(
   column_view const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<column> string_null_min_max(
@@ -44,7 +45,7 @@ std::unique_ptr<column> string_null_min_max(
   scalar const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<column> string_null_min_max(
@@ -52,7 +53,7 @@ std::unique_ptr<column> string_null_min_max(
   column_view const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -79,7 +80,7 @@ std::unique_ptr<column> binary_operation(
   column_view const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -106,7 +107,7 @@ std::unique_ptr<column> binary_operation(
   scalar const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -132,7 +133,7 @@ std::unique_ptr<column> binary_operation(
   column_view const& rhs,
   binary_operator op,
   data_type output_type,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 void binary_operation(mutable_column_view& out,

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -25,6 +25,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
 
@@ -157,7 +158,7 @@ rmm::device_buffer create_null_mask(size_type size,
                                     mask_state state,
                                     rmm::mr::device_memory_resource* mr)
 {
-  return detail::create_null_mask(size, state, rmm::cuda_stream_default, mr);
+  return detail::create_null_mask(size, state, cudf::default_stream_value, mr);
 }
 
 // Set pre-allocated null mask of given bit range [begin_bit, end_bit) to valid, if valid==true,
@@ -509,25 +510,25 @@ rmm::device_buffer copy_bitmask(bitmask_type const* mask,
                                 size_type end_bit,
                                 rmm::mr::device_memory_resource* mr)
 {
-  return detail::copy_bitmask(mask, begin_bit, end_bit, rmm::cuda_stream_default, mr);
+  return detail::copy_bitmask(mask, begin_bit, end_bit, cudf::default_stream_value, mr);
 }
 
 // Create a bitmask from a column view
 rmm::device_buffer copy_bitmask(column_view const& view, rmm::mr::device_memory_resource* mr)
 {
-  return detail::copy_bitmask(view, rmm::cuda_stream_default, mr);
+  return detail::copy_bitmask(view, cudf::default_stream_value, mr);
 }
 
 std::pair<rmm::device_buffer, size_type> bitmask_and(table_view const& view,
                                                      rmm::mr::device_memory_resource* mr)
 {
-  return detail::bitmask_and(view, rmm::cuda_stream_default, mr);
+  return detail::bitmask_and(view, cudf::default_stream_value, mr);
 }
 
 std::pair<rmm::device_buffer, size_type> bitmask_or(table_view const& view,
                                                     rmm::mr::device_memory_resource* mr)
 {
-  return detail::bitmask_or(view, rmm::cuda_stream_default, mr);
+  return detail::bitmask_or(view, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/column/column.cu
+++ b/cpp/src/column/column.cu
@@ -29,6 +29,7 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -143,7 +144,7 @@ size_type column::null_count() const
   CUDF_FUNC_RANGE();
   if (_null_count <= cudf::UNKNOWN_NULL_COUNT) {
     _null_count = cudf::detail::null_count(
-      static_cast<bitmask_type const*>(_null_mask.data()), 0, size(), rmm::cuda_stream_default);
+      static_cast<bitmask_type const*>(_null_mask.data()), 0, size(), cudf::default_stream_value);
   }
   return _null_count;
 }

--- a/cpp/src/column/column_view.cpp
+++ b/cpp/src/column/column_view.cpp
@@ -18,6 +18,7 @@
 #include <cudf/detail/hashing.hpp>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -66,8 +67,8 @@ column_view_base::column_view_base(data_type type,
 size_type column_view_base::null_count() const
 {
   if (_null_count <= cudf::UNKNOWN_NULL_COUNT) {
-    _null_count =
-      cudf::detail::null_count(null_mask(), offset(), offset() + size(), rmm::cuda_stream_default);
+    _null_count = cudf::detail::null_count(
+      null_mask(), offset(), offset() + size(), cudf::default_stream_value);
   }
   return _null_count;
 }
@@ -78,7 +79,7 @@ size_type column_view_base::null_count(size_type begin, size_type end) const
   return (null_count() == 0)
            ? 0
            : cudf::detail::null_count(
-               null_mask(), offset() + begin, offset() + end, rmm::cuda_stream_default);
+               null_mask(), offset() + begin, offset() + end, cudf::default_stream_value);
 }
 
 // Struct to use custom hash combine and fold expression

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -29,6 +29,7 @@
 #include <cudf/structs/detail/concatenate.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_device_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -540,12 +541,12 @@ rmm::device_buffer concatenate_masks(host_span<column_view const> views,
       create_null_mask(total_element_count, mask_state::UNINITIALIZED, mr);
 
     detail::concatenate_masks(
-      views, static_cast<bitmask_type*>(null_mask.data()), rmm::cuda_stream_default);
+      views, static_cast<bitmask_type*>(null_mask.data()), cudf::default_stream_value);
 
     return null_mask;
   }
   // no nulls, so return an empty device buffer
-  return rmm::device_buffer{0, rmm::cuda_stream_default, mr};
+  return rmm::device_buffer{0, cudf::default_stream_value, mr};
 }
 
 // Concatenates the elements from a vector of column_views
@@ -553,14 +554,14 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns_to_conc
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::concatenate(columns_to_concat, rmm::cuda_stream_default, mr);
+  return detail::concatenate(columns_to_concat, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> concatenate(host_span<table_view const> tables_to_concat,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::concatenate(tables_to_concat, rmm::cuda_stream_default, mr);
+  return detail::concatenate(tables_to_concat, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -26,6 +26,7 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -1268,7 +1269,7 @@ std::vector<packed_table> contiguous_split(cudf::table_view const& input,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::contiguous_split(input, splits, rmm::cuda_stream_default, mr);
+  return cudf::detail::contiguous_split(input, splits, cudf::default_stream_value, mr);
 }
 
 };  // namespace cudf

--- a/cpp/src/copying/copy.cpp
+++ b/cpp/src/copying/copy.cpp
@@ -22,6 +22,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -182,7 +183,7 @@ std::unique_ptr<column> allocate_like(column_view const& input,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::allocate_like(input, input.size(), mask_alloc, rmm::cuda_stream_default, mr);
+  return detail::allocate_like(input, input.size(), mask_alloc, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> allocate_like(column_view const& input,
@@ -191,7 +192,7 @@ std::unique_ptr<column> allocate_like(column_view const& input,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::allocate_like(input, size, mask_alloc, rmm::cuda_stream_default, mr);
+  return detail::allocate_like(input, size, mask_alloc, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -24,6 +24,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/detail/copy_if_else.cuh>
 #include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -414,7 +415,7 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_if_else(lhs, rhs, boolean_mask, rmm::cuda_stream_default, mr);
+  return detail::copy_if_else(lhs, rhs, boolean_mask, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
@@ -423,7 +424,7 @@ std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_if_else(lhs, rhs, boolean_mask, rmm::cuda_stream_default, mr);
+  return detail::copy_if_else(lhs, rhs, boolean_mask, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> copy_if_else(column_view const& lhs,
@@ -432,7 +433,7 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_if_else(lhs, rhs, boolean_mask, rmm::cuda_stream_default, mr);
+  return detail::copy_if_else(lhs, rhs, boolean_mask, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
@@ -441,7 +442,7 @@ std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_if_else(lhs, rhs, boolean_mask, rmm::cuda_stream_default, mr);
+  return detail::copy_if_else(lhs, rhs, boolean_mask, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -29,6 +29,7 @@
 #include <cudf/strings/detail/copy_range.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -273,7 +274,7 @@ void copy_range_in_place(column_view const& source,
 {
   CUDF_FUNC_RANGE();
   return detail::copy_range_in_place(
-    source, target, source_begin, source_end, target_begin, rmm::cuda_stream_default);
+    source, target, source_begin, source_end, target_begin, cudf::default_stream_value);
 }
 
 std::unique_ptr<column> copy_range(column_view const& source,
@@ -285,7 +286,7 @@ std::unique_ptr<column> copy_range(column_view const& source,
 {
   CUDF_FUNC_RANGE();
   return detail::copy_range(
-    source, target, source_begin, source_end, target_begin, rmm::cuda_stream_default, mr);
+    source, target, source_begin, source_end, target_begin, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/gather.cu
+++ b/cpp/src/copying/gather.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -84,7 +85,7 @@ std::unique_ptr<table> gather(table_view const& source_table,
                                                      : detail::negative_index_policy::ALLOWED;
 
   return detail::gather(
-    source_table, gather_map, bounds_policy, index_policy, rmm::cuda_stream_default, mr);
+    source_table, gather_map, bounds_policy, index_policy, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -25,6 +25,7 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -207,7 +208,7 @@ std::unique_ptr<scalar> get_element(column_view const& input,
                                     size_type index,
                                     rmm::mr::device_memory_resource* mr)
 {
-  return detail::get_element(input, index, rmm::cuda_stream_default, mr);
+  return detail::get_element(input, index, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/pack.cpp
+++ b/cpp/src/copying/pack.cpp
@@ -16,6 +16,7 @@
 
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -218,7 +219,7 @@ table_view unpack(uint8_t const* metadata, uint8_t const* gpu_data)
 packed_columns pack(cudf::table_view const& input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::pack(input, rmm::cuda_stream_default, mr);
+  return detail::pack(input, cudf::default_stream_value, mr);
 }
 
 /**

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -15,6 +15,7 @@
  */
 #include <cudf/copying.hpp>
 #include <cudf/detail/copy.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 
@@ -110,7 +111,7 @@ bool has_nonempty_nulls(column_view const& input) { return detail::has_nonempty_
 std::unique_ptr<cudf::column> purge_nonempty_nulls(lists_column_view const& input,
                                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::purge_nonempty_nulls(input, rmm::cuda_stream_default, mr);
+  return detail::purge_nonempty_nulls(input, cudf::default_stream_value, mr);
 }
 
 /**
@@ -119,7 +120,7 @@ std::unique_ptr<cudf::column> purge_nonempty_nulls(lists_column_view const& inpu
 std::unique_ptr<cudf::column> purge_nonempty_nulls(structs_column_view const& input,
                                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::purge_nonempty_nulls(input, rmm::cuda_stream_default, mr);
+  return detail::purge_nonempty_nulls(input, cudf::default_stream_value, mr);
 }
 
 /**
@@ -128,7 +129,7 @@ std::unique_ptr<cudf::column> purge_nonempty_nulls(structs_column_view const& in
 std::unique_ptr<cudf::column> purge_nonempty_nulls(strings_column_view const& input,
                                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::purge_nonempty_nulls(input, rmm::cuda_stream_default, mr);
+  return detail::purge_nonempty_nulls(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/reverse.cu
+++ b/cpp/src/copying/reverse.cu
@@ -20,6 +20,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
@@ -56,13 +57,13 @@ std::unique_ptr<column> reverse(column_view const& source_column,
 std::unique_ptr<table> reverse(table_view const& source_table, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::reverse(source_table, rmm::cuda_stream_default, mr);
+  return detail::reverse(source_table, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> reverse(column_view const& source_column,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::reverse(source_column, rmm::cuda_stream_default, mr);
+  return detail::reverse(source_column, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -93,6 +94,6 @@ std::unique_ptr<table> sample(table_view const& input,
 {
   CUDF_FUNC_RANGE();
 
-  return detail::sample(input, n, replacement, seed, rmm::cuda_stream_default, mr);
+  return detail::sample(input, n, replacement, seed, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -31,6 +31,7 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/structs/struct_view.hpp>
 #include <cudf/table/table_device_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -508,7 +509,7 @@ std::unique_ptr<table> scatter(table_view const& source,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::scatter(source, scatter_map, target, check_bounds, rmm::cuda_stream_default, mr);
+  return detail::scatter(source, scatter_map, target, check_bounds, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<const scalar>> const& source,
@@ -518,7 +519,7 @@ std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<const scalar>>
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::scatter(source, indices, target, check_bounds, rmm::cuda_stream_default, mr);
+  return detail::scatter(source, indices, target, check_bounds, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> boolean_mask_scatter(table_view const& input,
@@ -527,7 +528,7 @@ std::unique_ptr<table> boolean_mask_scatter(table_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::boolean_mask_scatter(input, target, boolean_mask, rmm::cuda_stream_default, mr);
+  return detail::boolean_mask_scatter(input, target, boolean_mask, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> boolean_mask_scatter(
@@ -537,7 +538,7 @@ std::unique_ptr<table> boolean_mask_scatter(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::boolean_mask_scatter(input, target, boolean_mask, rmm::cuda_stream_default, mr);
+  return detail::boolean_mask_scatter(input, target, boolean_mask, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -23,6 +23,7 @@
 #include <cudf/strings/detail/copying.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -173,7 +174,7 @@ std::unique_ptr<column> shift(column_view const& input,
                               scalar const& fill_value,
                               rmm::mr::device_memory_resource* mr)
 {
-  return detail::shift(input, offset, fill_value, rmm::cuda_stream_default, mr);
+  return detail::shift(input, offset, fill_value, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/slice.cu
+++ b/cpp/src/copying/slice.cu
@@ -20,6 +20,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -113,25 +114,25 @@ std::vector<table_view> slice(table_view const& input,
 std::vector<column_view> slice(column_view const& input, host_span<size_type const> indices)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice(input, indices, rmm::cuda_stream_default);
+  return detail::slice(input, indices, cudf::default_stream_value);
 }
 
 std::vector<table_view> slice(table_view const& input, host_span<size_type const> indices)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice(input, indices, rmm::cuda_stream_default);
+  return detail::slice(input, indices, cudf::default_stream_value);
 };
 
 std::vector<column_view> slice(column_view const& input, std::initializer_list<size_type> indices)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice(input, indices, rmm::cuda_stream_default);
+  return detail::slice(input, indices, cudf::default_stream_value);
 }
 
 std::vector<table_view> slice(table_view const& input, std::initializer_list<size_type> indices)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice(input, indices, rmm::cuda_stream_default);
+  return detail::slice(input, indices, cudf::default_stream_value);
 };
 
 }  // namespace cudf

--- a/cpp/src/copying/split.cpp
+++ b/cpp/src/copying/split.cpp
@@ -17,6 +17,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -85,26 +86,26 @@ std::vector<cudf::column_view> split(cudf::column_view const& input,
                                      host_span<size_type const> splits)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(input, splits, rmm::cuda_stream_default);
+  return detail::split(input, splits, cudf::default_stream_value);
 }
 
 std::vector<cudf::table_view> split(cudf::table_view const& input,
                                     host_span<size_type const> splits)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(input, splits, rmm::cuda_stream_default);
+  return detail::split(input, splits, cudf::default_stream_value);
 }
 
 std::vector<column_view> split(column_view const& input, std::initializer_list<size_type> splits)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(input, splits, rmm::cuda_stream_default);
+  return detail::split(input, splits, cudf::default_stream_value);
 }
 
 std::vector<table_view> split(table_view const& input, std::initializer_list<size_type> splits)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(input, splits, rmm::cuda_stream_default);
+  return detail::split(input, splits, cudf::default_stream_value);
 }
 
 }  // namespace cudf

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -27,6 +27,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -537,7 +538,7 @@ std::unique_ptr<column> ceil_datetimes(column_view const& column,
 {
   CUDF_FUNC_RANGE();
   return detail::round_general(
-    detail::rounding_function::CEIL, freq, column, rmm::cuda_stream_default, mr);
+    detail::rounding_function::CEIL, freq, column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> floor_datetimes(column_view const& column,
@@ -546,7 +547,7 @@ std::unique_ptr<column> floor_datetimes(column_view const& column,
 {
   CUDF_FUNC_RANGE();
   return detail::round_general(
-    detail::rounding_function::FLOOR, freq, column, rmm::cuda_stream_default, mr);
+    detail::rounding_function::FLOOR, freq, column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> round_datetimes(column_view const& column,
@@ -555,66 +556,66 @@ std::unique_ptr<column> round_datetimes(column_view const& column,
 {
   CUDF_FUNC_RANGE();
   return detail::round_general(
-    detail::rounding_function::ROUND, freq, column, rmm::cuda_stream_default, mr);
+    detail::rounding_function::ROUND, freq, column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> extract_year(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_year(column, rmm::cuda_stream_default, mr);
+  return detail::extract_year(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> extract_month(column_view const& column,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_month(column, rmm::cuda_stream_default, mr);
+  return detail::extract_month(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> extract_day(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_day(column, rmm::cuda_stream_default, mr);
+  return detail::extract_day(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> extract_weekday(column_view const& column,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_weekday(column, rmm::cuda_stream_default, mr);
+  return detail::extract_weekday(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> extract_hour(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_hour(column, rmm::cuda_stream_default, mr);
+  return detail::extract_hour(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> extract_minute(column_view const& column,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_minute(column, rmm::cuda_stream_default, mr);
+  return detail::extract_minute(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> extract_second(column_view const& column,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_second(column, rmm::cuda_stream_default, mr);
+  return detail::extract_second(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> last_day_of_month(column_view const& column,
                                           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::last_day_of_month(column, rmm::cuda_stream_default, mr);
+  return detail::last_day_of_month(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> day_of_year(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::day_of_year(column, rmm::cuda_stream_default, mr);
+  return detail::day_of_year(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> add_calendrical_months(cudf::column_view const& timestamp_column,
@@ -623,7 +624,7 @@ std::unique_ptr<cudf::column> add_calendrical_months(cudf::column_view const& ti
 {
   CUDF_FUNC_RANGE();
   return detail::add_calendrical_months(
-    timestamp_column, months_column, rmm::cuda_stream_default, mr);
+    timestamp_column, months_column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> add_calendrical_months(cudf::column_view const& timestamp_column,
@@ -631,27 +632,27 @@ std::unique_ptr<cudf::column> add_calendrical_months(cudf::column_view const& ti
                                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::add_calendrical_months(timestamp_column, months, rmm::cuda_stream_default, mr);
+  return detail::add_calendrical_months(timestamp_column, months, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> is_leap_year(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_leap_year(column, rmm::cuda_stream_default, mr);
+  return detail::is_leap_year(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> days_in_month(column_view const& column,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::days_in_month(column, rmm::cuda_stream_default, mr);
+  return detail::days_in_month(column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> extract_quarter(column_view const& column,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_quarter(column, rmm::cuda_stream_default, mr);
+  return detail::extract_quarter(column, cudf::default_stream_value, mr);
 }
 
 }  // namespace datetime

--- a/cpp/src/dictionary/add_keys.cu
+++ b/cpp/src/dictionary/add_keys.cu
@@ -28,8 +28,7 @@
 #include <cudf/stream_compaction.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 namespace cudf {
 namespace dictionary {
@@ -131,7 +130,7 @@ std::unique_ptr<column> add_keys(dictionary_column_view const& dictionary_column
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::add_keys(dictionary_column, keys, rmm::cuda_stream_default, mr);
+  return detail::add_keys(dictionary_column, keys, cudf::default_stream_value, mr);
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/decode.cu
+++ b/cpp/src/dictionary/decode.cu
@@ -23,6 +23,7 @@
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -67,7 +68,7 @@ std::unique_ptr<column> decode(dictionary_column_view const& source,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::decode(source, rmm::cuda_stream_default, mr);
+  return detail::decode(source, cudf::default_stream_value, mr);
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/encode.cu
+++ b/cpp/src/dictionary/encode.cu
@@ -26,6 +26,7 @@
 #include <cudf/stream_compaction.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -91,7 +92,7 @@ std::unique_ptr<column> encode(column_view const& input_column,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::encode(input_column, indices_type, rmm::cuda_stream_default, mr);
+  return detail::encode(input_column, indices_type, cudf::default_stream_value, mr);
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -25,6 +25,7 @@
 #include <cudf/dictionary/update_keys.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -58,7 +59,7 @@ template <typename KeysKeeper>
 std::unique_ptr<column> remove_keys_fn(
   dictionary_column_view const& dictionary_column,
   KeysKeeper keys_to_keep_fn,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto const keys_view    = dictionary_column.keys();
@@ -150,7 +151,7 @@ std::unique_ptr<column> remove_keys_fn(
 std::unique_ptr<column> remove_keys(
   dictionary_column_view const& dictionary_column,
   column_view const& keys_to_remove,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(!keys_to_remove.has_nulls(), "keys_to_remove must not have nulls");
@@ -167,7 +168,7 @@ std::unique_ptr<column> remove_keys(
 
 std::unique_ptr<column> remove_unused_keys(
   dictionary_column_view const& dictionary_column,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   // locate the keys to remove
@@ -199,14 +200,14 @@ std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_col
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::remove_keys(dictionary_column, keys_to_remove, rmm::cuda_stream_default, mr);
+  return detail::remove_keys(dictionary_column, keys_to_remove, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& dictionary_column,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::remove_unused_keys(dictionary_column, rmm::cuda_stream_default, mr);
+  return detail::remove_unused_keys(dictionary_column, cudf::default_stream_value, mr);
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -18,6 +18,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/dictionary/detail/search.hpp>
 #include <cudf/dictionary/search.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -179,7 +180,7 @@ std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::get_index(dictionary, key, rmm::cuda_stream_default, mr);
+  return detail::get_index(dictionary, key, cudf::default_stream_value, mr);
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -28,6 +28,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
 #include <cudf/stream_compaction.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -239,14 +240,14 @@ std::unique_ptr<column> set_keys(dictionary_column_view const& dictionary_column
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::set_keys(dictionary_column, keys, rmm::cuda_stream_default, mr);
+  return detail::set_keys(dictionary_column, keys, cudf::default_stream_value, mr);
 }
 
 std::vector<std::unique_ptr<column>> match_dictionaries(
   cudf::host_span<dictionary_column_view const> input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::match_dictionaries(input, rmm::cuda_stream_default, mr);
+  return detail::match_dictionaries(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace dictionary

--- a/cpp/src/filling/calendrical_month_sequence.cu
+++ b/cpp/src/filling/calendrical_month_sequence.cu
@@ -17,6 +17,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/detail/calendrical_month_sequence.cuh>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -40,7 +41,7 @@ std::unique_ptr<cudf::column> calendrical_month_sequence(size_type size,
                                                          size_type months,
                                                          rmm::mr::device_memory_resource* mr)
 {
-  return detail::calendrical_month_sequence(size, init, months, rmm::cuda_stream_default, mr);
+  return detail::calendrical_month_sequence(size, init, months, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -30,6 +30,7 @@
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/strings/detail/fill.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -247,7 +248,7 @@ void fill_in_place(mutable_column_view& destination,
                    scalar const& value)
 {
   CUDF_FUNC_RANGE();
-  return detail::fill_in_place(destination, begin, end, value, rmm::cuda_stream_default);
+  return detail::fill_in_place(destination, begin, end, value, cudf::default_stream_value);
 }
 
 std::unique_ptr<column> fill(column_view const& input,
@@ -257,7 +258,7 @@ std::unique_ptr<column> fill(column_view const& input,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::fill(input, begin, end, value, rmm::cuda_stream_default, mr);
+  return detail::fill(input, begin, end, value, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -26,6 +26,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -165,7 +166,7 @@ std::unique_ptr<table> repeat(table_view const& input_table,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat(input_table, count, check_count, rmm::cuda_stream_default, mr);
+  return detail::repeat(input_table, count, check_count, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> repeat(table_view const& input_table,
@@ -173,7 +174,7 @@ std::unique_ptr<table> repeat(table_view const& input_table,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat(input_table, count, rmm::cuda_stream_default, mr);
+  return detail::repeat(input_table, count, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -21,6 +21,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -151,14 +152,14 @@ std::unique_ptr<column> sequence(size_type size,
                                  scalar const& step,
                                  rmm::mr::device_memory_resource* mr)
 {
-  return detail::sequence(size, init, step, rmm::cuda_stream_default, mr);
+  return detail::sequence(size, init, step, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> sequence(size_type size,
                                  scalar const& init,
                                  rmm::mr::device_memory_resource* mr)
 {
-  return detail::sequence(size, init, rmm::cuda_stream_default, mr);
+  return detail::sequence(size, init, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/hash/concurrent_unordered_map.cuh
+++ b/cpp/src/hash/concurrent_unordered_map.cuh
@@ -23,6 +23,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/device_atomics.cuh>
 #include <cudf/detail/utilities/hash_functions.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -158,7 +159,7 @@ class concurrent_unordered_map {
    * storage
    */
   static auto create(size_type capacity,
-                     rmm::cuda_stream_view stream     = rmm::cuda_stream_default,
+                     rmm::cuda_stream_view stream     = cudf::default_stream_value,
                      const mapped_type unused_element = std::numeric_limits<mapped_type>::max(),
                      const key_type unused_key        = std::numeric_limits<key_type>::max(),
                      const Hasher& hash_function      = hasher(),
@@ -421,7 +422,7 @@ class concurrent_unordered_map {
   }
 
   void assign_async(const concurrent_unordered_map& other,
-                    rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+                    rmm::cuda_stream_view stream = cudf::default_stream_value)
   {
     if (other.m_capacity <= m_capacity) {
       m_capacity = other.m_capacity;
@@ -439,7 +440,7 @@ class concurrent_unordered_map {
                                   stream.value()));
   }
 
-  void clear_async(rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+  void clear_async(rmm::cuda_stream_view stream = cudf::default_stream_value)
   {
     constexpr int block_size = 128;
     init_hashtbl<<<((m_capacity - 1) / block_size) + 1, block_size, 0, stream.value()>>>(
@@ -454,7 +455,7 @@ class concurrent_unordered_map {
     }
   }
 
-  void prefetch(const int dev_id, rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+  void prefetch(const int dev_id, rmm::cuda_stream_view stream = cudf::default_stream_value)
   {
     cudaPointerAttributes hashtbl_values_ptr_attributes;
     cudaError_t status = cudaPointerGetAttributes(&hashtbl_values_ptr_attributes, m_hashtbl_values);
@@ -474,7 +475,7 @@ class concurrent_unordered_map {
    *
    * @param stream CUDA stream used for device memory operations and kernel launches.
    */
-  void destroy(rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+  void destroy(rmm::cuda_stream_view stream = cudf::default_stream_value)
   {
     m_allocator.deallocate(m_hashtbl_values, m_capacity, stream);
     delete this;
@@ -515,7 +516,7 @@ class concurrent_unordered_map {
                            const Hasher& hash_function,
                            const Equality& equal,
                            const allocator_type& allocator,
-                           rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+                           rmm::cuda_stream_view stream = cudf::default_stream_value)
     : m_hf(hash_function),
       m_equal(equal),
       m_allocator(allocator),

--- a/cpp/src/hash/hash_allocator.cuh
+++ b/cpp/src/hash/hash_allocator.cuh
@@ -19,6 +19,8 @@
 
 #include <new>
 
+#include <cudf/utilities/default_stream.hpp>
+
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
@@ -36,14 +38,14 @@ struct managed_allocator {
   {
   }
 
-  T* allocate(std::size_t n, rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
+  T* allocate(std::size_t n, rmm::cuda_stream_view stream = cudf::default_stream_value) const
   {
     return static_cast<T*>(mr->allocate(n * sizeof(T), stream));
   }
 
   void deallocate(T* p,
                   std::size_t n,
-                  rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
+                  rmm::cuda_stream_view stream = cudf::default_stream_value) const
   {
     mr->deallocate(p, n * sizeof(T), stream);
   }
@@ -72,14 +74,14 @@ struct default_allocator {
   {
   }
 
-  T* allocate(std::size_t n, rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
+  T* allocate(std::size_t n, rmm::cuda_stream_view stream = cudf::default_stream_value) const
   {
     return static_cast<T*>(mr->allocate(n * sizeof(T), stream));
   }
 
   void deallocate(T* p,
                   std::size_t n,
-                  rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
+                  rmm::cuda_stream_view stream = cudf::default_stream_value) const
   {
     mr->deallocate(p, n * sizeof(T), stream);
   }

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -20,6 +20,7 @@
 #include <cudf/detail/utilities/hash_functions.cuh>
 #include <cudf/table/experimental/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -113,7 +114,7 @@ std::unique_ptr<column> hash(table_view const& input,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::hash(input, hash_function, seed, rmm::cuda_stream_default, mr);
+  return detail::hash(input, hash_function, seed, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/interop/dlpack.cpp
+++ b/cpp/src/interop/dlpack.cpp
@@ -17,6 +17,7 @@
 #include <cudf/detail/interop.hpp>
 #include <cudf/lists/list_view.hpp>
 #include <cudf/structs/struct_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -292,12 +293,12 @@ DLManagedTensor* to_dlpack(table_view const& input,
 std::unique_ptr<table> from_dlpack(DLManagedTensor const* managed_tensor,
                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::from_dlpack(managed_tensor, rmm::cuda_stream_default, mr);
+  return detail::from_dlpack(managed_tensor, cudf::default_stream_value, mr);
 }
 
 DLManagedTensor* to_dlpack(table_view const& input, rmm::mr::device_memory_resource* mr)
 {
-  return detail::to_dlpack(input, rmm::cuda_stream_default, mr);
+  return detail::to_dlpack(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/interop/from_arrow.cu
+++ b/cpp/src/interop/from_arrow.cu
@@ -28,6 +28,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -449,7 +450,7 @@ std::unique_ptr<table> from_arrow(arrow::Table const& input_table,
 {
   CUDF_FUNC_RANGE();
 
-  return detail::from_arrow(input_table, rmm::cuda_stream_default, mr);
+  return detail::from_arrow(input_table, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -25,6 +25,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -414,7 +415,7 @@ std::shared_ptr<arrow::Table> to_arrow(table_view input,
 {
   CUDF_FUNC_RANGE();
 
-  return detail::to_arrow(input, metadata, rmm::cuda_stream_default, ar_mr);
+  return detail::to_arrow(input, metadata, cudf::default_stream_value, ar_mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -198,7 +198,7 @@ table_with_metadata read_json(json_reader_options options, rmm::mr::device_memor
                                       options.get_byte_range_offset(),
                                       options.get_byte_range_size_with_padding());
 
-  return detail::json::read_json(datasources, options, rmm::cuda_stream_default, mr);
+  return detail::json::read_json(datasources, options, cudf::default_stream_value, mr);
 }
 
 table_with_metadata read_csv(csv_reader_options options, rmm::mr::device_memory_resource* mr)
@@ -216,7 +216,7 @@ table_with_metadata read_csv(csv_reader_options options, rmm::mr::device_memory_
   return cudf::io::detail::csv::read_csv(  //
     std::move(datasources[0]),
     options,
-    rmm::cuda_stream_default,
+    cudf::default_stream_value,
     mr);
 }
 
@@ -233,7 +233,7 @@ void write_csv(csv_writer_options const& options, rmm::mr::device_memory_resourc
     options.get_table(),
     options.get_metadata(),
     options,
-    rmm::cuda_stream_default,
+    cudf::default_stream_value,
     mr);
 }
 
@@ -241,7 +241,7 @@ namespace detail_orc = cudf::io::detail::orc;
 
 raw_orc_statistics read_raw_orc_statistics(source_info const& src_info)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cudf::default_stream_value;
   // Get source to read statistics from
   std::unique_ptr<datasource> source;
   if (src_info.type() == io_type::FILEPATH) {

--- a/cpp/src/io/orc/timezone.cuh
+++ b/cpp/src/io/orc/timezone.cuh
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
 #include <io/utilities/time_utils.cuh>
@@ -114,7 +115,9 @@ class timezone_table {
 
  public:
   // Safe to use the default stream, device_uvectors will not change after they are created empty
-  timezone_table() : ttimes{0, rmm::cuda_stream_default}, offsets{0, rmm::cuda_stream_default} {}
+  timezone_table() : ttimes{0, cudf::default_stream_value}, offsets{0, cudf::default_stream_value}
+  {
+  }
   timezone_table(int32_t gmt_offset,
                  rmm::device_uvector<int64_t>&& ttimes,
                  rmm::device_uvector<int32_t>&& offsets)

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -28,6 +28,7 @@
 #include <cudf/io/text/detail/multistate.hpp>
 #include <cudf/io/text/detail/tile_state.hpp>
 #include <cudf/io/text/detail/trie.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <limits>
@@ -437,7 +438,7 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
                                               std::optional<byte_range_info> byte_range,
                                               rmm::mr::device_memory_resource* mr)
 {
-  auto stream      = rmm::cuda_stream_default;
+  auto stream      = cudf::default_stream_value;
   auto stream_pool = rmm::cuda_stream_pool(2);
 
   auto result = detail::multibyte_split(

--- a/cpp/src/join/conditional_join.cu
+++ b/cpp/src/join/conditional_join.cu
@@ -22,6 +22,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <join/conditional_join.hpp>
 #include <join/conditional_join_kernels.cuh>
 #include <join/join_common_utils.cuh>
@@ -297,7 +298,7 @@ conditional_inner_join(table_view const& left,
                                   binary_predicate,
                                   detail::join_kind::INNER_JOIN,
                                   output_size,
-                                  rmm::cuda_stream_default,
+                                  cudf::default_stream_value,
                                   mr);
 }
 
@@ -315,7 +316,7 @@ conditional_left_join(table_view const& left,
                                   binary_predicate,
                                   detail::join_kind::LEFT_JOIN,
                                   output_size,
-                                  rmm::cuda_stream_default,
+                                  cudf::default_stream_value,
                                   mr);
 }
 
@@ -327,8 +328,13 @@ conditional_full_join(table_view const& left,
                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::conditional_join(
-    left, right, binary_predicate, detail::join_kind::FULL_JOIN, {}, rmm::cuda_stream_default, mr);
+  return detail::conditional_join(left,
+                                  right,
+                                  binary_predicate,
+                                  detail::join_kind::FULL_JOIN,
+                                  {},
+                                  cudf::default_stream_value,
+                                  mr);
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_semi_join(
@@ -344,7 +350,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_semi_join(
                                             binary_predicate,
                                             detail::join_kind::LEFT_SEMI_JOIN,
                                             output_size,
-                                            rmm::cuda_stream_default,
+                                            cudf::default_stream_value,
                                             mr)
                      .first);
 }
@@ -362,7 +368,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_anti_join(
                                             binary_predicate,
                                             detail::join_kind::LEFT_ANTI_JOIN,
                                             output_size,
-                                            rmm::cuda_stream_default,
+                                            cudf::default_stream_value,
                                             mr)
                      .first);
 }
@@ -374,7 +380,7 @@ std::size_t conditional_inner_join_size(table_view const& left,
 {
   CUDF_FUNC_RANGE();
   return detail::compute_conditional_join_output_size(
-    left, right, binary_predicate, detail::join_kind::INNER_JOIN, rmm::cuda_stream_default, mr);
+    left, right, binary_predicate, detail::join_kind::INNER_JOIN, cudf::default_stream_value, mr);
 }
 
 std::size_t conditional_left_join_size(table_view const& left,
@@ -384,7 +390,7 @@ std::size_t conditional_left_join_size(table_view const& left,
 {
   CUDF_FUNC_RANGE();
   return detail::compute_conditional_join_output_size(
-    left, right, binary_predicate, detail::join_kind::LEFT_JOIN, rmm::cuda_stream_default, mr);
+    left, right, binary_predicate, detail::join_kind::LEFT_JOIN, cudf::default_stream_value, mr);
 }
 
 std::size_t conditional_left_semi_join_size(table_view const& left,
@@ -397,7 +403,7 @@ std::size_t conditional_left_semi_join_size(table_view const& left,
                                                                 right,
                                                                 binary_predicate,
                                                                 detail::join_kind::LEFT_SEMI_JOIN,
-                                                                rmm::cuda_stream_default,
+                                                                cudf::default_stream_value,
                                                                 mr));
 }
 
@@ -411,7 +417,7 @@ std::size_t conditional_left_anti_join_size(table_view const& left,
                                                                 right,
                                                                 binary_predicate,
                                                                 detail::join_kind::LEFT_ANTI_JOIN,
-                                                                rmm::cuda_stream_default,
+                                                                cudf::default_stream_value,
                                                                 mr));
 }
 

--- a/cpp/src/join/conditional_join.hpp
+++ b/cpp/src/join/conditional_join.hpp
@@ -19,6 +19,7 @@
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
@@ -47,7 +48,7 @@ conditional_join(table_view const& left,
                  ast::expression const& binary_predicate,
                  join_kind JoinKind,
                  std::optional<std::size_t> output_size = {},
-                 rmm::cuda_stream_view stream           = rmm::cuda_stream_default,
+                 rmm::cuda_stream_view stream           = cudf::default_stream_value,
                  rmm::mr::device_memory_resource* mr    = rmm::mr::get_current_device_resource());
 
 /**
@@ -67,7 +68,7 @@ std::size_t compute_conditional_join_output_size(
   table_view const& right,
   ast::expression const& binary_predicate,
   join_kind JoinKind,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace detail

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -25,6 +25,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -77,7 +78,7 @@ std::unique_ptr<cudf::table> cross_join(cudf::table_view const& left,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::cross_join(left, right, rmm::cuda_stream_default, mr);
+  return detail::cross_join(left, right, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -20,6 +20,7 @@
 #include <cudf/join.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -251,7 +252,7 @@ inner_join(table_view const& left,
            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::inner_join(left, right, compare_nulls, rmm::cuda_stream_default, mr);
+  return detail::inner_join(left, right, compare_nulls, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> inner_join(table_view const& left,
@@ -263,7 +264,7 @@ std::unique_ptr<table> inner_join(table_view const& left,
 {
   CUDF_FUNC_RANGE();
   return detail::inner_join(
-    left, right, left_on, right_on, compare_nulls, rmm::cuda_stream_default, mr);
+    left, right, left_on, right_on, compare_nulls, cudf::default_stream_value, mr);
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -274,7 +275,7 @@ left_join(table_view const& left,
           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::left_join(left, right, compare_nulls, rmm::cuda_stream_default, mr);
+  return detail::left_join(left, right, compare_nulls, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> left_join(table_view const& left,
@@ -286,7 +287,7 @@ std::unique_ptr<table> left_join(table_view const& left,
 {
   CUDF_FUNC_RANGE();
   return detail::left_join(
-    left, right, left_on, right_on, compare_nulls, rmm::cuda_stream_default, mr);
+    left, right, left_on, right_on, compare_nulls, cudf::default_stream_value, mr);
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -297,7 +298,7 @@ full_join(table_view const& left,
           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::full_join(left, right, compare_nulls, rmm::cuda_stream_default, mr);
+  return detail::full_join(left, right, compare_nulls, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> full_join(table_view const& left,
@@ -309,6 +310,6 @@ std::unique_ptr<table> full_join(table_view const& left,
 {
   CUDF_FUNC_RANGE();
   return detail::full_join(
-    left, right, left_on, right_on, compare_nulls, rmm::cuda_stream_default, mr);
+    left, right, left_on, right_on, compare_nulls, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/join/mixed_join.cu
+++ b/cpp/src/join/mixed_join.cu
@@ -26,6 +26,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -457,7 +458,7 @@ mixed_inner_join(
                             compare_nulls,
                             detail::join_kind::INNER_JOIN,
                             output_size_data,
-                            rmm::cuda_stream_default,
+                            cudf::default_stream_value,
                             mr);
 }
 
@@ -478,7 +479,7 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_in
                                                 binary_predicate,
                                                 compare_nulls,
                                                 detail::join_kind::INNER_JOIN,
-                                                rmm::cuda_stream_default,
+                                                cudf::default_stream_value,
                                                 mr);
 }
 
@@ -503,7 +504,7 @@ mixed_left_join(
                             compare_nulls,
                             detail::join_kind::LEFT_JOIN,
                             output_size_data,
-                            rmm::cuda_stream_default,
+                            cudf::default_stream_value,
                             mr);
 }
 
@@ -524,7 +525,7 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_le
                                                 binary_predicate,
                                                 compare_nulls,
                                                 detail::join_kind::LEFT_JOIN,
-                                                rmm::cuda_stream_default,
+                                                cudf::default_stream_value,
                                                 mr);
 }
 
@@ -549,7 +550,7 @@ mixed_full_join(
                             compare_nulls,
                             detail::join_kind::FULL_JOIN,
                             output_size_data,
-                            rmm::cuda_stream_default,
+                            cudf::default_stream_value,
                             mr);
 }
 

--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -28,6 +28,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -502,7 +503,7 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_le
                                                      binary_predicate,
                                                      compare_nulls,
                                                      detail::join_kind::LEFT_SEMI_JOIN,
-                                                     rmm::cuda_stream_default,
+                                                     cudf::default_stream_value,
                                                      mr);
 }
 
@@ -525,7 +526,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_semi_join(
                                  compare_nulls,
                                  detail::join_kind::LEFT_SEMI_JOIN,
                                  output_size_data,
-                                 rmm::cuda_stream_default,
+                                 cudf::default_stream_value,
                                  mr);
 }
 
@@ -546,7 +547,7 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_le
                                                      binary_predicate,
                                                      compare_nulls,
                                                      detail::join_kind::LEFT_ANTI_JOIN,
-                                                     rmm::cuda_stream_default,
+                                                     cudf::default_stream_value,
                                                      mr);
 }
 
@@ -569,7 +570,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_anti_join(
                                  compare_nulls,
                                  detail::join_kind::LEFT_ANTI_JOIN,
                                  output_size_data,
-                                 rmm::cuda_stream_default,
+                                 cudf::default_stream_value,
                                  mr);
 }
 

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -26,6 +26,7 @@
 #include <cudf/dictionary/detail/update_keys.hpp>
 #include <cudf/join.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -266,7 +267,7 @@ std::unique_ptr<cudf::table> left_semi_join(cudf::table_view const& left,
                                      left_on,
                                      right_on,
                                      compare_nulls,
-                                     rmm::cuda_stream_default,
+                                     cudf::default_stream_value,
                                      mr);
 }
 
@@ -278,7 +279,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_join(
 {
   CUDF_FUNC_RANGE();
   return detail::left_semi_anti_join(
-    detail::join_kind::LEFT_SEMI_JOIN, left, right, compare_nulls, rmm::cuda_stream_default, mr);
+    detail::join_kind::LEFT_SEMI_JOIN, left, right, compare_nulls, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::table> left_anti_join(cudf::table_view const& left,
@@ -295,7 +296,7 @@ std::unique_ptr<cudf::table> left_anti_join(cudf::table_view const& left,
                                      left_on,
                                      right_on,
                                      compare_nulls,
-                                     rmm::cuda_stream_default,
+                                     cudf::default_stream_value,
                                      mr);
 }
 
@@ -307,7 +308,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_anti_join(
 {
   CUDF_FUNC_RANGE();
   return detail::left_semi_anti_join(
-    detail::join_kind::LEFT_ANTI_JOIN, left, right, compare_nulls, rmm::cuda_stream_default, mr);
+    detail::join_kind::LEFT_ANTI_JOIN, left, right, compare_nulls, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/labeling/label_bins.cu
+++ b/cpp/src/labeling/label_bins.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/labeling/label_bins.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
@@ -237,7 +238,12 @@ std::unique_ptr<column> label_bins(column_view const& input,
                                    inclusive right_inclusive,
                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::label_bins(
-    input, left_edges, left_inclusive, right_edges, right_inclusive, rmm::cuda_stream_default, mr);
+  return detail::label_bins(input,
+                            left_edges,
+                            left_inclusive,
+                            right_edges,
+                            right_inclusive,
+                            cudf::default_stream_value,
+                            mr);
 }
 }  // namespace cudf

--- a/cpp/src/lists/apply_boolean_mask.cu
+++ b/cpp/src/lists/apply_boolean_mask.cu
@@ -25,6 +25,7 @@
 #include <cudf/lists/detail/stream_compaction.hpp>
 #include <cudf/lists/stream_compaction.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/exec_policy.hpp>
 
@@ -99,7 +100,7 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
                                            lists_column_view const& boolean_mask,
                                            rmm::mr::device_memory_resource* mr)
 {
-  return detail::apply_boolean_mask(input, boolean_mask, rmm::cuda_stream_default, mr);
+  return detail::apply_boolean_mask(input, boolean_mask, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf::lists

--- a/cpp/src/lists/combine/concatenate_list_elements.cu
+++ b/cpp/src/lists/combine/concatenate_list_elements.cu
@@ -24,6 +24,7 @@
 #include <cudf/lists/combine.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -286,7 +287,7 @@ std::unique_ptr<column> concatenate_list_elements(column_view const& input,
                                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::concatenate_list_elements(input, null_policy, rmm::cuda_stream_default, mr);
+  return detail::concatenate_list_elements(input, null_policy, cudf::default_stream_value, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/combine/concatenate_rows.cu
+++ b/cpp/src/lists/combine/concatenate_rows.cu
@@ -21,6 +21,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/lists/combine.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_checks.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -302,7 +303,7 @@ std::unique_ptr<column> concatenate_rows(table_view const& input,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::concatenate_rows(input, null_policy, rmm::cuda_stream_default, mr);
+  return detail::concatenate_rows(input, null_policy, cudf::default_stream_value, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/contains.cu
+++ b/cpp/src/lists/contains.cu
@@ -25,6 +25,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/table/row_operators.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/exec_policy.hpp>
@@ -403,7 +404,7 @@ std::unique_ptr<column> contains(cudf::lists_column_view const& lists,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(lists, search_key, rmm::cuda_stream_default, mr);
+  return detail::contains(lists, search_key, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> contains(cudf::lists_column_view const& lists,
@@ -411,14 +412,14 @@ std::unique_ptr<column> contains(cudf::lists_column_view const& lists,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(lists, search_keys, rmm::cuda_stream_default, mr);
+  return detail::contains(lists, search_keys, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> contains_nulls(cudf::lists_column_view const& input_lists,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains_nulls(input_lists, rmm::cuda_stream_default, mr);
+  return detail::contains_nulls(input_lists, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> index_of(cudf::lists_column_view const& lists,
@@ -427,7 +428,7 @@ std::unique_ptr<column> index_of(cudf::lists_column_view const& lists,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::index_of(lists, search_key, find_option, rmm::cuda_stream_default, mr);
+  return detail::index_of(lists, search_key, find_option, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> index_of(cudf::lists_column_view const& lists,
@@ -436,7 +437,7 @@ std::unique_ptr<column> index_of(cudf::lists_column_view const& lists,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::index_of(lists, search_keys, find_option, rmm::cuda_stream_default, mr);
+  return detail::index_of(lists, search_keys, find_option, cudf::default_stream_value, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -19,6 +19,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/lists/detail/gather.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
@@ -118,7 +119,7 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& source_column,
                                          rmm::mr::device_memory_resource* mr)
 {
   return detail::segmented_gather(
-    source_column, gather_map_list, bounds_policy, rmm::cuda_stream_default, mr);
+    source_column, gather_map_list, bounds_policy, cudf::default_stream_value, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/count_elements.cu
+++ b/cpp/src/lists/count_elements.cu
@@ -22,6 +22,7 @@
 #include <cudf/lists/count_elements.hpp>
 #include <cudf/lists/list_device_view.cuh>
 #include <cudf/lists/lists_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -75,7 +76,7 @@ std::unique_ptr<column> count_elements(lists_column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_elements(input, rmm::cuda_stream_default, mr);
+  return detail::count_elements(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/drop_list_duplicates.cu
+++ b/cpp/src/lists/drop_list_duplicates.cu
@@ -30,6 +30,7 @@
 #include <cudf/structs/struct_view.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -615,7 +616,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> drop_list_duplicates
 {
   CUDF_FUNC_RANGE();
   return detail::drop_list_duplicates(
-    keys, values, nulls_equal, nans_equal, keep_option, rmm::cuda_stream_default, mr);
+    keys, values, nulls_equal, nans_equal, keep_option, cudf::default_stream_value, mr);
 }
 
 /**
@@ -630,7 +631,8 @@ std::unique_ptr<column> drop_list_duplicates(lists_column_view const& input,
                                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::drop_list_duplicates(input, nulls_equal, nans_equal, rmm::cuda_stream_default, mr);
+  return detail::drop_list_duplicates(
+    input, nulls_equal, nans_equal, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf::lists

--- a/cpp/src/lists/explode.cu
+++ b/cpp/src/lists/explode.cu
@@ -20,6 +20,7 @@
 #include <cudf/lists/explode.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -298,7 +299,7 @@ std::unique_ptr<table> explode(table_view const& input_table,
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(input_table.column(explode_column_idx).type().id() == type_id::LIST,
                "Unsupported non-list column");
-  return detail::explode(input_table, explode_column_idx, rmm::cuda_stream_default, mr);
+  return detail::explode(input_table, explode_column_idx, cudf::default_stream_value, mr);
 }
 
 /**
@@ -311,7 +312,7 @@ std::unique_ptr<table> explode_position(table_view const& input_table,
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(input_table.column(explode_column_idx).type().id() == type_id::LIST,
                "Unsupported non-list column");
-  return detail::explode_position(input_table, explode_column_idx, rmm::cuda_stream_default, mr);
+  return detail::explode_position(input_table, explode_column_idx, cudf::default_stream_value, mr);
 }
 
 /**
@@ -325,7 +326,7 @@ std::unique_ptr<table> explode_outer(table_view const& input_table,
   CUDF_EXPECTS(input_table.column(explode_column_idx).type().id() == type_id::LIST,
                "Unsupported non-list column");
   return detail::explode_outer(
-    input_table, explode_column_idx, false, rmm::cuda_stream_default, mr);
+    input_table, explode_column_idx, false, cudf::default_stream_value, mr);
 }
 
 /**
@@ -339,7 +340,8 @@ std::unique_ptr<table> explode_outer_position(table_view const& input_table,
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(input_table.column(explode_column_idx).type().id() == type_id::LIST,
                "Unsupported non-list column");
-  return detail::explode_outer(input_table, explode_column_idx, true, rmm::cuda_stream_default, mr);
+  return detail::explode_outer(
+    input_table, explode_column_idx, true, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -22,6 +22,7 @@
 #include <cudf/lists/detail/gather.cuh>
 #include <cudf/lists/extract.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -168,7 +169,7 @@ std::unique_ptr<column> extract_list_element(lists_column_view const& lists_colu
                                              size_type index,
                                              rmm::mr::device_memory_resource* mr)
 {
-  return detail::extract_list_element_impl(lists_column, index, rmm::cuda_stream_default, mr);
+  return detail::extract_list_element_impl(lists_column, index, cudf::default_stream_value, mr);
 }
 
 /**
@@ -182,7 +183,7 @@ std::unique_ptr<column> extract_list_element(lists_column_view const& lists_colu
 {
   CUDF_EXPECTS(indices.size() == lists_column.size(),
                "Index column must have as many elements as lists column.");
-  return detail::extract_list_element_impl(lists_column, indices, rmm::cuda_stream_default, mr);
+  return detail::extract_list_element_impl(lists_column, indices, cudf::default_stream_value, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/segmented_sort.cu
+++ b/cpp/src/lists/segmented_sort.cu
@@ -26,6 +26,7 @@
 #include <cudf/detail/sorting.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/lists/sorting.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -316,7 +317,7 @@ std::unique_ptr<column> sort_lists(lists_column_view const& input,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sort_lists(input, column_order, null_precedence, rmm::cuda_stream_default, mr);
+  return detail::sort_lists(input, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> stable_sort_lists(lists_column_view const& input,
@@ -326,7 +327,7 @@ std::unique_ptr<column> stable_sort_lists(lists_column_view const& input,
 {
   CUDF_FUNC_RANGE();
   return detail::stable_sort_lists(
-    input, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    input, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/sequences.cu
+++ b/cpp/src/lists/sequences.cu
@@ -21,6 +21,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/lists/filling.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -213,7 +214,7 @@ std::unique_ptr<column> sequences(column_view const& starts,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sequences(starts, sizes, rmm::cuda_stream_default, mr);
+  return detail::sequences(starts, sizes, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> sequences(column_view const& starts,
@@ -222,7 +223,7 @@ std::unique_ptr<column> sequences(column_view const& starts,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sequences(starts, steps, sizes, rmm::cuda_stream_default, mr);
+  return detail::sequences(starts, steps, sizes, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf::lists

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -26,6 +26,7 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_device_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -170,7 +171,7 @@ index_vector generate_merged_indices(table_view const& left_table,
                                      std::vector<order> const& column_order,
                                      std::vector<null_order> const& null_precedence,
                                      bool nullable                = true,
-                                     rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+                                     rmm::cuda_stream_view stream = cudf::default_stream_value)
 {
   const size_type left_size  = left_table.num_rows();
   const size_type right_size = right_table.num_rows();
@@ -539,7 +540,7 @@ std::unique_ptr<cudf::table> merge(std::vector<table_view> const& tables_to_merg
 {
   CUDF_FUNC_RANGE();
   return detail::merge(
-    tables_to_merge, key_cols, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    tables_to_merge, key_cols, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -25,6 +25,7 @@
 #include <cudf/partitioning.hpp>
 #include <cudf/table/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
@@ -795,7 +796,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> partition(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::partition(t, partition_map, num_partitions, rmm::cuda_stream_default, mr);
+  return detail::partition(t, partition_map, num_partitions, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -25,6 +25,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -152,7 +153,7 @@ std::pair<std::unique_ptr<table>, std::vector<cudf::size_type>> round_robin_part
   table_view const& input,
   cudf::size_type num_partitions,
   cudf::size_type start_partition     = 0,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto nrows = input.num_rows();
@@ -267,7 +268,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> round_robi
 {
   CUDF_FUNC_RANGE();
   return cudf::detail::round_robin_partition(
-    input, num_partitions, start_partition, rmm::cuda_stream_default, mr);
+    input, num_partitions, start_partition, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/quantiles/quantile.cu
+++ b/cpp/src/quantiles/quantile.cu
@@ -27,6 +27,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -188,7 +189,7 @@ std::unique_ptr<column> quantile(column_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::quantile(input, q, interp, ordered_indices, exact, rmm::cuda_stream_default, mr);
+  return detail::quantile(input, q, interp, ordered_indices, exact, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/quantiles/quantiles.cu
+++ b/cpp/src/quantiles/quantiles.cu
@@ -23,6 +23,7 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -80,12 +81,16 @@ std::unique_ptr<table> quantiles(table_view const& input,
   CUDF_EXPECTS(input.num_rows() > 0, "multi-column quantiles require at least one input row.");
 
   if (is_input_sorted == sorted::YES) {
-    return detail::quantiles(
-      input, thrust::make_counting_iterator<size_type>(0), q, interp, rmm::cuda_stream_default, mr);
+    return detail::quantiles(input,
+                             thrust::make_counting_iterator<size_type>(0),
+                             q,
+                             interp,
+                             cudf::default_stream_value,
+                             mr);
   } else {
     auto sorted_idx = detail::sorted_order(input, column_order, null_precedence);
     return detail::quantiles(
-      input, sorted_idx->view().data<size_type>(), q, interp, rmm::cuda_stream_default, mr);
+      input, sorted_idx->view().data<size_type>(), q, interp, cudf::default_stream_value, mr);
   }
 }
 

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -22,6 +22,7 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/tdigest/tdigest_column_view.cuh>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -399,7 +400,7 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
                                           column_view const& percentiles,
                                           rmm::mr::device_memory_resource* mr)
 {
-  return percentile_approx(input, percentiles, rmm::cuda_stream_default, mr);
+  return percentile_approx(input, percentiles, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/reductions/minmax.cu
+++ b/cpp/src/reductions/minmax.cu
@@ -23,6 +23,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/reduction.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -275,7 +276,7 @@ std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
 std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
   const column_view& col, rmm::mr::device_memory_resource* mr)
 {
-  return detail::minmax(col, rmm::cuda_stream_default, mr);
+  return detail::minmax(col, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -25,8 +25,9 @@
 #include <cudf/detail/tdigest/tdigest.hpp>
 #include <cudf/reduction.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
-
 #include <cudf/structs/structs_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf {
@@ -140,7 +141,7 @@ std::unique_ptr<scalar> reduce(
   column_view const& col,
   std::unique_ptr<reduce_aggregation> const& agg,
   data_type output_dtype,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   // Returns default scalar if input column is non-valid. In terms of nested columns, we need to
@@ -175,7 +176,7 @@ std::unique_ptr<scalar> reduce(column_view const& col,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::reduce(col, agg, output_dtype, rmm::cuda_stream_default, mr);
+  return detail::reduce(col, agg, output_dtype, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -19,8 +19,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/scan.hpp>
 #include <cudf/reduction.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 namespace cudf {
 
@@ -38,19 +37,19 @@ std::unique_ptr<column> scan(column_view const& input,
     auto const& rank_agg = dynamic_cast<cudf::detail::rank_aggregation const&>(*agg);
     if (rank_agg._method == rank_method::MIN) {
       if (rank_agg._percentage == rank_percentage::NONE) {
-        return inclusive_rank_scan(input, rmm::cuda_stream_default, mr);
+        return inclusive_rank_scan(input, cudf::default_stream_value, mr);
       } else if (rank_agg._percentage == rank_percentage::ONE_NORMALIZED) {
-        return inclusive_one_normalized_percent_rank_scan(input, rmm::cuda_stream_default, mr);
+        return inclusive_one_normalized_percent_rank_scan(input, cudf::default_stream_value, mr);
       }
     } else if (rank_agg._method == rank_method::DENSE) {
-      return inclusive_dense_rank_scan(input, rmm::cuda_stream_default, mr);
+      return inclusive_dense_rank_scan(input, cudf::default_stream_value, mr);
     }
     CUDF_FAIL("Unsupported rank aggregation method for inclusive scan");
   }
 
   return inclusive == scan_type::EXCLUSIVE
-           ? detail::scan_exclusive(input, agg, null_handling, rmm::cuda_stream_default, mr)
-           : detail::scan_inclusive(input, agg, null_handling, rmm::cuda_stream_default, mr);
+           ? detail::scan_exclusive(input, agg, null_handling, cudf::default_stream_value, mr)
+           : detail::scan_inclusive(input, agg, null_handling, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/reductions/segmented_reductions.cpp
+++ b/cpp/src/reductions/segmented_reductions.cpp
@@ -20,6 +20,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/reduction_functions.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -98,7 +99,7 @@ std::unique_ptr<column> segmented_reduce(column_view const& segmented_values,
 {
   CUDF_FUNC_RANGE();
   return detail::segmented_reduce(
-    segmented_values, offsets, agg, output_dtype, null_handling, rmm::cuda_stream_default, mr);
+    segmented_values, offsets, agg, output_dtype, null_handling, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -33,6 +33,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -389,7 +390,7 @@ std::unique_ptr<column> clamp(column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::clamp(input, lo, lo_replace, hi, hi_replace, rmm::cuda_stream_default, mr);
+  return detail::clamp(input, lo, lo_replace, hi, hi_replace, cudf::default_stream_value, mr);
 }
 
 // clamp input at lo and hi
@@ -399,6 +400,6 @@ std::unique_ptr<column> clamp(column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::clamp(input, lo, lo, hi, hi, rmm::cuda_stream_default, mr);
+  return detail::clamp(input, lo, lo, hi, hi, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/replace.hpp>
 #include <cudf/replace.hpp>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -113,7 +114,7 @@ std::unique_ptr<column> replace_nans(column_view const& input,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_nans(input, replacement, rmm::cuda_stream_default, mr);
+  return detail::replace_nans(input, replacement, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> replace_nans(column_view const& input,
@@ -121,7 +122,7 @@ std::unique_ptr<column> replace_nans(column_view const& input,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_nans(input, replacement, rmm::cuda_stream_default, mr);
+  return detail::replace_nans(input, replacement, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf
@@ -222,7 +223,7 @@ std::unique_ptr<column> normalize_nans_and_zeros(column_view const& input,
                                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::normalize_nans_and_zeros(input, rmm::cuda_stream_default, mr);
+  return detail::normalize_nans_and_zeros(input, cudf::default_stream_value, mr);
 }
 
 /**
@@ -238,7 +239,7 @@ std::unique_ptr<column> normalize_nans_and_zeros(column_view const& input,
 void normalize_nans_and_zeros(mutable_column_view& in_out)
 {
   CUDF_FUNC_RANGE();
-  detail::normalize_nans_and_zeros(in_out, rmm::cuda_stream_default);
+  detail::normalize_nans_and_zeros(in_out, cudf::default_stream_value);
 }
 
 }  // namespace cudf

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -36,6 +36,7 @@
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -452,7 +453,7 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::replace_nulls(input, replacement, rmm::cuda_stream_default, mr);
+  return cudf::detail::replace_nulls(input, replacement, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
@@ -460,7 +461,7 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::replace_nulls(input, replacement, rmm::cuda_stream_default, mr);
+  return cudf::detail::replace_nulls(input, replacement, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> replace_nulls(column_view const& input,
@@ -468,7 +469,7 @@ std::unique_ptr<cudf::column> replace_nulls(column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::replace_nulls(input, replace_policy, rmm::cuda_stream_default, mr);
+  return cudf::detail::replace_nulls(input, replace_policy, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -48,6 +48,7 @@
 #include <cudf/replace.hpp>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/detail/utilities.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -530,6 +531,6 @@ std::unique_ptr<cudf::column> find_and_replace_all(cudf::column_view const& inpu
                                                    rmm::mr::device_memory_resource* mr)
 {
   return cudf::detail::find_and_replace_all(
-    input_col, values_to_replace, replacement_values, rmm::cuda_stream_default, mr);
+    input_col, values_to_replace, replacement_values, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -20,6 +20,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/reshape.hpp>
 #include <cudf/strings/detail/utilities.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -136,7 +137,7 @@ std::unique_ptr<column> byte_cast(column_view const& input_column,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::byte_cast(input_column, endian_configuration, rmm::cuda_stream_default, mr);
+  return detail::byte_cast(input_column, endian_configuration, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -24,6 +24,7 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -293,7 +294,7 @@ std::unique_ptr<column> interleave_columns(table_view const& input,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::interleave_columns(input, rmm::cuda_stream_default, mr);
+  return detail::interleave_columns(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/reshape/tile.cu
+++ b/cpp/src/reshape/tile.cu
@@ -21,6 +21,7 @@
 #include <cudf/detail/reshape.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -64,7 +65,7 @@ std::unique_ptr<table> tile(const table_view& in,
                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::tile(in, count, rmm::cuda_stream_default, mr);
+  return detail::tile(in, count, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -24,6 +24,7 @@
 #include <cudf/rolling/range_window_bounds.hpp>
 #include <cudf/types.hpp>
 #include <cudf/unary.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
@@ -210,7 +211,7 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
                                         following_window_bounds,
                                         min_periods,
                                         aggr,
-                                        rmm::cuda_stream_default,
+                                        cudf::default_stream_value,
                                         mr);
 }
 
@@ -1082,7 +1083,7 @@ std::unique_ptr<column> grouped_time_range_rolling_window(table_view const& grou
                                       following,
                                       min_periods,
                                       aggr,
-                                      rmm::cuda_stream_default,
+                                      cudf::default_stream_value,
                                       mr);
 }
 
@@ -1116,7 +1117,7 @@ std::unique_ptr<column> grouped_range_rolling_window(table_view const& group_key
                                               following,
                                               min_periods,
                                               aggr,
-                                              rmm::cuda_stream_default,
+                                              cudf::default_stream_value,
                                               mr);
 }
 

--- a/cpp/src/rolling/range_window_bounds_detail.hpp
+++ b/cpp/src/rolling/range_window_bounds_detail.hpp
@@ -18,6 +18,7 @@
 #include <cudf/rolling/range_window_bounds.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/wrappers/durations.hpp>
 
 namespace cudf {
@@ -119,7 +120,8 @@ RepT range_comparable_value_impl(scalar const& range_scalar, rmm::cuda_stream_vi
  */
 template <typename OrderByType>
 range_rep_type<OrderByType> range_comparable_value(
-  range_window_bounds const& range_bounds, rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+  range_window_bounds const& range_bounds,
+  rmm::cuda_stream_view stream = cudf::default_stream_value)
 {
   auto const& range_scalar = range_bounds.range_scalar();
   using range_type         = cudf::detail::range_type<OrderByType>;

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -17,6 +17,7 @@
 #include "rolling_detail.cuh"
 
 #include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 
@@ -131,7 +132,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                 following_window,
                                 min_periods,
                                 agg,
-                                rmm::cuda_stream_default,
+                                cudf::default_stream_value,
                                 mr);
 }
 
@@ -158,7 +159,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   return detail::rolling_window(
-    input, preceding_window, following_window, min_periods, agg, rmm::cuda_stream_default, mr);
+    input, preceding_window, following_window, min_periods, agg, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -28,6 +28,7 @@
 #include <cudf/round.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -343,7 +344,7 @@ std::unique_ptr<column> round(column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::round(input, decimal_places, method, rmm::cuda_stream_default, mr);
+  return cudf::detail::round(input, decimal_places, method, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/scalar/scalar.cpp
+++ b/cpp/src/scalar/scalar.cpp
@@ -20,6 +20,7 @@
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/string_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -108,7 +109,7 @@ size_type string_scalar::size() const { return _data.size(); }
 
 const char* string_scalar::data() const { return static_cast<const char*>(_data.data()); }
 
-string_scalar::operator std::string() const { return this->to_string(rmm::cuda_stream_default); }
+string_scalar::operator std::string() const { return this->to_string(cudf::default_stream_value); }
 
 std::string string_scalar::to_string(rmm::cuda_stream_view stream) const
 {
@@ -185,7 +186,7 @@ T fixed_point_scalar<T>::fixed_point_value(rmm::cuda_stream_view stream) const
 template <typename T>
 fixed_point_scalar<T>::operator value_type() const
 {
-  return this->fixed_point_value(rmm::cuda_stream_default);
+  return this->fixed_point_value(cudf::default_stream_value);
 }
 
 template <typename T>
@@ -268,7 +269,7 @@ T const* fixed_width_scalar<T>::data() const
 template <typename T>
 fixed_width_scalar<T>::operator value_type() const
 {
-  return this->value(rmm::cuda_stream_default);
+  return this->value(cudf::default_stream_value);
 }
 
 /**

--- a/cpp/src/search/contains.cu
+++ b/cpp/src/search/contains.cu
@@ -24,6 +24,7 @@
 #include <cudf/lists/list_view.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/structs/struct_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -228,7 +229,7 @@ std::unique_ptr<column> contains(column_view const& haystack,
 bool contains(column_view const& haystack, scalar const& needle)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(haystack, needle, rmm::cuda_stream_default);
+  return detail::contains(haystack, needle, cudf::default_stream_value);
 }
 
 std::unique_ptr<column> contains(column_view const& haystack,
@@ -236,7 +237,7 @@ std::unique_ptr<column> contains(column_view const& haystack,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(haystack, needles, rmm::cuda_stream_default, mr);
+  return detail::contains(haystack, needles, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -22,6 +22,7 @@
 #include <cudf/table/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -126,7 +127,7 @@ std::unique_ptr<column> lower_bound(table_view const& haystack,
 {
   CUDF_FUNC_RANGE();
   return detail::lower_bound(
-    haystack, needles, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    haystack, needles, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> upper_bound(table_view const& haystack,
@@ -137,7 +138,7 @@ std::unique_ptr<column> upper_bound(table_view const& haystack,
 {
   CUDF_FUNC_RANGE();
   return detail::upper_bound(
-    haystack, needles, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    haystack, needles, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -21,6 +21,7 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -83,7 +84,7 @@ bool is_sorted(cudf::table_view const& in,
   }
 
   return detail::is_sorted(
-    in, column_order, has_nulls(in), null_precedence, rmm::cuda_stream_default);
+    in, column_order, has_nulls(in), null_precedence, cudf::default_stream_value);
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -24,6 +24,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -349,7 +350,7 @@ std::unique_ptr<column> rank(column_view const& input,
                       null_handling,
                       null_precedence,
                       percentage,
-                      rmm::cuda_stream_default,
+                      cudf::default_stream_value,
                       mr);
 }
 }  // namespace cudf

--- a/cpp/src/sort/segmented_sort.cu
+++ b/cpp/src/sort/segmented_sort.cu
@@ -17,6 +17,7 @@
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/sorting.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -195,7 +196,7 @@ std::unique_ptr<column> segmented_sorted_order(table_view const& keys,
 {
   CUDF_FUNC_RANGE();
   return detail::segmented_sorted_order(
-    keys, segment_offsets, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    keys, segment_offsets, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> stable_segmented_sorted_order(
@@ -207,7 +208,7 @@ std::unique_ptr<column> stable_segmented_sorted_order(
 {
   CUDF_FUNC_RANGE();
   return detail::stable_segmented_sorted_order(
-    keys, segment_offsets, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    keys, segment_offsets, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> segmented_sort_by_key(table_view const& values,
@@ -219,7 +220,7 @@ std::unique_ptr<table> segmented_sort_by_key(table_view const& values,
 {
   CUDF_FUNC_RANGE();
   return detail::segmented_sort_by_key(
-    values, keys, segment_offsets, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    values, keys, segment_offsets, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> stable_segmented_sort_by_key(table_view const& values,
@@ -231,7 +232,7 @@ std::unique_ptr<table> stable_segmented_sort_by_key(table_view const& values,
 {
   CUDF_FUNC_RANGE();
   return detail::stable_segmented_sort_by_key(
-    values, keys, segment_offsets, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    values, keys, segment_offsets, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -19,6 +19,7 @@
 #include <cudf/detail/sorting.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <sort/sort_impl.cuh>
 
@@ -98,7 +99,7 @@ std::unique_ptr<table> sort(table_view const& input,
     return std::make_unique<table>(std::move(columns));
   }
   return detail::sort_by_key(
-    input, input, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    input, input, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 }  // namespace detail
@@ -109,7 +110,7 @@ std::unique_ptr<column> sorted_order(table_view const& input,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sorted_order(input, column_order, null_precedence, rmm::cuda_stream_default, mr);
+  return detail::sorted_order(input, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> sort(table_view const& input,
@@ -118,7 +119,7 @@ std::unique_ptr<table> sort(table_view const& input,
                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sort(input, column_order, null_precedence, rmm::cuda_stream_default, mr);
+  return detail::sort(input, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> sort_by_key(table_view const& values,
@@ -129,7 +130,7 @@ std::unique_ptr<table> sort_by_key(table_view const& values,
 {
   CUDF_FUNC_RANGE();
   return detail::sort_by_key(
-    values, keys, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    values, keys, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -21,6 +21,7 @@
 #include <cudf/detail/sorting.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -63,7 +64,7 @@ std::unique_ptr<column> stable_sorted_order(table_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   return detail::stable_sorted_order(
-    input, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    input, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> stable_sort_by_key(table_view const& values,
@@ -74,7 +75,7 @@ std::unique_ptr<table> stable_sort_by_key(table_view const& values,
 {
   CUDF_FUNC_RANGE();
   return detail::stable_sort_by_key(
-    values, keys, column_order, null_precedence, rmm::cuda_stream_default, mr);
+    values, keys, column_order, null_precedence, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/apply_boolean_mask.cu
+++ b/cpp/src/stream_compaction/apply_boolean_mask.cu
@@ -23,6 +23,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -92,6 +93,6 @@ std::unique_ptr<table> apply_boolean_mask(table_view const& input,
                                           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::apply_boolean_mask(input, boolean_mask, rmm::cuda_stream_default, mr);
+  return detail::apply_boolean_mask(input, boolean_mask, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/stream_compaction/distinct.cu
+++ b/cpp/src/stream_compaction/distinct.cu
@@ -31,6 +31,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -105,7 +106,7 @@ std::unique_ptr<table> distinct(table_view const& input,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::distinct(input, keys, nulls_equal, rmm::cuda_stream_default, mr);
+  return detail::distinct(input, keys, nulls_equal, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/drop_nans.cu
+++ b/cpp/src/stream_compaction/drop_nans.cu
@@ -21,6 +21,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -117,7 +118,7 @@ std::unique_ptr<table> drop_nans(table_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nans(input, keys, keep_threshold, rmm::cuda_stream_default, mr);
+  return cudf::detail::drop_nans(input, keys, keep_threshold, cudf::default_stream_value, mr);
 }
 /*
  * Filters a table to remove nan null elements.
@@ -127,7 +128,7 @@ std::unique_ptr<table> drop_nans(table_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nans(input, keys, keys.size(), rmm::cuda_stream_default, mr);
+  return cudf::detail::drop_nans(input, keys, keys.size(), cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/drop_nulls.cu
+++ b/cpp/src/stream_compaction/drop_nulls.cu
@@ -21,6 +21,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -90,7 +91,7 @@ std::unique_ptr<table> drop_nulls(table_view const& input,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nulls(input, keys, keep_threshold, rmm::cuda_stream_default, mr);
+  return cudf::detail::drop_nulls(input, keys, keep_threshold, cudf::default_stream_value, mr);
 }
 /*
  * Filters a table to remove null elements.
@@ -100,7 +101,7 @@ std::unique_ptr<table> drop_nulls(table_view const& input,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nulls(input, keys, keys.size(), rmm::cuda_stream_default, mr);
+  return cudf::detail::drop_nulls(input, keys, keys.size(), cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/unique.cu
+++ b/cpp/src/stream_compaction/unique.cu
@@ -31,6 +31,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -95,7 +96,7 @@ std::unique_ptr<table> unique(table_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::unique(input, keys, keep, nulls_equal, rmm::cuda_stream_default, mr);
+  return detail::unique(input, keys, keep, nulls_equal, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/strings/attributes.cu
+++ b/cpp/src/strings/attributes.cu
@@ -22,6 +22,7 @@
 #include <cudf/strings/attributes.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -183,21 +184,21 @@ std::unique_ptr<column> count_characters(strings_column_view const& strings,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_characters(strings, rmm::cuda_stream_default, mr);
+  return detail::count_characters(strings, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> count_bytes(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_bytes(strings, rmm::cuda_stream_default, mr);
+  return detail::count_bytes(strings, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> code_points(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::code_points(strings, rmm::cuda_stream_default, mr);
+  return detail::code_points(strings, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/capitalize.cu
+++ b/cpp/src/strings/capitalize.cu
@@ -27,6 +27,7 @@
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -290,7 +291,7 @@ std::unique_ptr<column> capitalize(strings_column_view const& input,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::capitalize(input, delimiter, rmm::cuda_stream_default, mr);
+  return detail::capitalize(input, delimiter, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> title(strings_column_view const& input,
@@ -298,14 +299,14 @@ std::unique_ptr<column> title(strings_column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::title(input, sequence_type, rmm::cuda_stream_default, mr);
+  return detail::title(input, sequence_type, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> is_title(strings_column_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_title(input, rmm::cuda_stream_default, mr);
+  return detail::is_title(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/case.cu
+++ b/cpp/src/strings/case.cu
@@ -24,6 +24,7 @@
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <strings/char_types/char_cases.h>
 #include <strings/char_types/is_flags.h>
@@ -187,21 +188,21 @@ std::unique_ptr<column> to_lower(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_lower(strings, rmm::cuda_stream_default, mr);
+  return detail::to_lower(strings, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> to_upper(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_upper(strings, rmm::cuda_stream_default, mr);
+  return detail::to_upper(strings, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> swapcase(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::swapcase(strings, rmm::cuda_stream_default, mr);
+  return detail::swapcase(strings, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/char_types/char_types.cu
+++ b/cpp/src/strings/char_types/char_types.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/string.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <strings/utf8.cuh>
 #include <strings/utilities.hpp>
@@ -212,7 +213,8 @@ std::unique_ptr<column> all_characters_of_type(strings_column_view const& string
                                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::all_characters_of_type(strings, types, verify_types, rmm::cuda_stream_default, mr);
+  return detail::all_characters_of_type(
+    strings, types, verify_types, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> filter_characters_of_type(strings_column_view const& strings,
@@ -223,7 +225,7 @@ std::unique_ptr<column> filter_characters_of_type(strings_column_view const& str
 {
   CUDF_FUNC_RANGE();
   return detail::filter_characters_of_type(
-    strings, types_to_remove, replacement, types_to_keep, rmm::cuda_stream_default, mr);
+    strings, types_to_remove, replacement, types_to_keep, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/combine/concatenate.cu
+++ b/cpp/src/strings/combine/concatenate.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table_device_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -269,7 +270,7 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
 {
   CUDF_FUNC_RANGE();
   return detail::concatenate(
-    strings_columns, separator, narep, separate_nulls, rmm::cuda_stream_default, mr);
+    strings_columns, separator, narep, separate_nulls, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> concatenate(table_view const& strings_columns,
@@ -285,7 +286,7 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
                              separator_narep,
                              col_narep,
                              separate_nulls,
-                             rmm::cuda_stream_default,
+                             cudf::default_stream_value,
                              mr);
 }
 

--- a/cpp/src/strings/combine/join.cu
+++ b/cpp/src/strings/combine/join.cu
@@ -24,6 +24,7 @@
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -134,7 +135,7 @@ std::unique_ptr<column> join_strings(strings_column_view const& strings,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::join_strings(strings, separator, narep, rmm::cuda_stream_default, mr);
+  return detail::join_strings(strings, separator, narep, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/combine/join_list_elements.cu
+++ b/cpp/src/strings/combine/join_list_elements.cu
@@ -24,6 +24,7 @@
 #include <cudf/strings/combine.hpp>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -307,7 +308,7 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
                                     narep,
                                     separate_nulls,
                                     empty_list_policy,
-                                    rmm::cuda_stream_default,
+                                    cudf::default_stream_value,
                                     mr);
 }
 
@@ -326,7 +327,7 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
                                     string_narep,
                                     separate_nulls,
                                     empty_list_policy,
-                                    rmm::cuda_stream_default,
+                                    cudf::default_stream_value,
                                     mr);
 }
 

--- a/cpp/src/strings/contains.cu
+++ b/cpp/src/strings/contains.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/contains.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -133,7 +134,7 @@ std::unique_ptr<column> contains_re(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains_re(strings, pattern, flags, rmm::cuda_stream_default, mr);
+  return detail::contains_re(strings, pattern, flags, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> matches_re(strings_column_view const& strings,
@@ -142,7 +143,7 @@ std::unique_ptr<column> matches_re(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::matches_re(strings, pattern, flags, rmm::cuda_stream_default, mr);
+  return detail::matches_re(strings, pattern, flags, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> count_re(strings_column_view const& strings,
@@ -151,7 +152,7 @@ std::unique_ptr<column> count_re(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_re(strings, pattern, flags, rmm::cuda_stream_default, mr);
+  return detail::count_re(strings, pattern, flags, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -85,7 +86,7 @@ std::unique_ptr<column> to_booleans(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_booleans(strings, true_string, rmm::cuda_stream_default, mr);
+  return detail::to_booleans(strings, true_string, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -154,7 +155,7 @@ std::unique_ptr<column> from_booleans(column_view const& booleans,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_booleans(booleans, true_string, false_string, rmm::cuda_stream_default, mr);
+  return detail::from_booleans(booleans, true_string, false_string, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -652,7 +653,7 @@ std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_timestamps(input, timestamp_type, format, rmm::cuda_stream_default, mr);
+  return detail::to_timestamps(input, timestamp_type, format, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
@@ -660,7 +661,7 @@ std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_timestamp(input, format, rmm::cuda_stream_default, mr);
+  return detail::is_timestamp(input, format, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -1148,7 +1149,7 @@ std::unique_ptr<column> from_timestamps(column_view const& timestamps,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_timestamps(timestamps, format, names, rmm::cuda_stream_default, mr);
+  return detail::from_timestamps(timestamps, format, names, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -19,6 +19,8 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
 #include <strings/convert/utilities.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -747,7 +749,7 @@ std::unique_ptr<column> from_durations(column_view const& durations,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_durations(durations, format, rmm::cuda_stream_default, mr);
+  return detail::from_durations(durations, format, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> to_durations(strings_column_view const& strings,
@@ -756,7 +758,7 @@ std::unique_ptr<column> to_durations(strings_column_view const& strings,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_durations(strings, duration_type, format, rmm::cuda_stream_default, mr);
+  return detail::to_durations(strings, duration_type, format, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_fixed_point.cu
+++ b/cpp/src/strings/convert/convert_fixed_point.cu
@@ -27,6 +27,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <strings/convert/utilities.cuh>
@@ -189,7 +190,7 @@ std::unique_ptr<column> to_fixed_point(strings_column_view const& strings,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_fixed_point(strings, output_type, rmm::cuda_stream_default, mr);
+  return detail::to_fixed_point(strings, output_type, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -332,7 +333,7 @@ std::unique_ptr<column> from_fixed_point(column_view const& input,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_fixed_point(input, rmm::cuda_stream_default, mr);
+  return detail::from_fixed_point(input, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -396,7 +397,7 @@ std::unique_ptr<column> is_fixed_point(strings_column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_fixed_point(input, decimal_type, rmm::cuda_stream_default, mr);
+  return detail::is_fixed_point(input, decimal_type, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/string.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -227,7 +228,7 @@ std::unique_ptr<column> to_floats(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_floats(strings, output_type, rmm::cuda_stream_default, mr);
+  return detail::to_floats(strings, output_type, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -552,7 +553,7 @@ std::unique_ptr<column> from_floats(column_view const& floats,
 std::unique_ptr<column> from_floats(column_view const& floats, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_floats(floats, rmm::cuda_stream_default, mr);
+  return detail::from_floats(floats, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -591,7 +592,7 @@ std::unique_ptr<column> is_float(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_float(strings, rmm::cuda_stream_default, mr);
+  return detail::is_float(strings, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_hex.cu
+++ b/cpp/src/strings/convert/convert_hex.cu
@@ -23,6 +23,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -281,21 +282,21 @@ std::unique_ptr<column> hex_to_integers(strings_column_view const& strings,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::hex_to_integers(strings, output_type, rmm::cuda_stream_default, mr);
+  return detail::hex_to_integers(strings, output_type, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> is_hex(strings_column_view const& strings,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_hex(strings, rmm::cuda_stream_default, mr);
+  return detail::is_hex(strings, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> integers_to_hex(column_view const& input,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::integers_to_hex(input, rmm::cuda_stream_default, mr);
+  return detail::integers_to_hex(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/string.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <strings/convert/utilities.cuh>
 
@@ -182,7 +183,7 @@ std::unique_ptr<column> is_integer(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_integer(strings, rmm::cuda_stream_default, mr);
+  return detail::is_integer(strings, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> is_integer(strings_column_view const& strings,
@@ -190,7 +191,7 @@ std::unique_ptr<column> is_integer(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_integer(strings, int_type, rmm::cuda_stream_default, mr);
+  return detail::is_integer(strings, int_type, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -283,7 +284,7 @@ std::unique_ptr<column> to_integers(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_integers(strings, output_type, rmm::cuda_stream_default, mr);
+  return detail::to_integers(strings, output_type, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -404,7 +405,7 @@ std::unique_ptr<column> from_integers(column_view const& integers,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_integers(integers, rmm::cuda_stream_default, mr);
+  return detail::from_integers(integers, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_ipv4.cu
+++ b/cpp/src/strings/convert/convert_ipv4.cu
@@ -23,6 +23,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -109,7 +110,7 @@ std::unique_ptr<column> ipv4_to_integers(strings_column_view const& strings,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::ipv4_to_integers(strings, rmm::cuda_stream_default, mr);
+  return detail::ipv4_to_integers(strings, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -263,14 +264,14 @@ std::unique_ptr<column> integers_to_ipv4(column_view const& integers,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::integers_to_ipv4(integers, rmm::cuda_stream_default, mr);
+  return detail::integers_to_ipv4(integers, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> is_ipv4(strings_column_view const& strings,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_ipv4(strings, rmm::cuda_stream_default, mr);
+  return detail::is_ipv4(strings, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_lists.cu
+++ b/cpp/src/strings/convert/convert_lists.cu
@@ -19,6 +19,7 @@
 #include <cudf/strings/convert/convert_lists.hpp>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -234,7 +235,7 @@ std::unique_ptr<column> format_list_column(lists_column_view const& input,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::format_list_column(input, na_rep, separators, rmm::cuda_stream_default, mr);
+  return detail::format_list_column(input, na_rep, separators, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_urls.cu
+++ b/cpp/src/strings/convert/convert_urls.cu
@@ -27,6 +27,7 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -171,7 +172,7 @@ std::unique_ptr<column> url_encode(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::url_encode(strings, rmm::cuda_stream_default, mr);
+  return detail::url_encode(strings, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -453,7 +454,7 @@ std::unique_ptr<column> url_decode(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::url_decode(strings, rmm::cuda_stream_default, mr);
+  return detail::url_decode(strings, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/extract/extract.cu
+++ b/cpp/src/strings/extract/extract.cu
@@ -24,6 +24,7 @@
 #include <cudf/strings/extract.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -135,7 +136,7 @@ std::unique_ptr<table> extract(strings_column_view const& strings,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract(strings, pattern, flags, rmm::cuda_stream_default, mr);
+  return detail::extract(strings, pattern, flags, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/extract/extract_all.cu
+++ b/cpp/src/strings/extract/extract_all.cu
@@ -24,6 +24,7 @@
 #include <cudf/strings/detail/strings_column_factories.cuh>
 #include <cudf/strings/extract.hpp>
 #include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -170,7 +171,7 @@ std::unique_ptr<column> extract_all_record(strings_column_view const& strings,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_all_record(strings, pattern, flags, rmm::cuda_stream_default, mr);
+  return detail::extract_all_record(strings, pattern, flags, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/filter_chars.cu
+++ b/cpp/src/strings/filter_chars.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/translate.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -159,7 +160,7 @@ std::unique_ptr<column> filter_characters(
 {
   CUDF_FUNC_RANGE();
   return detail::filter_characters(
-    strings, characters_to_filter, keep_characters, replacement, rmm::cuda_stream_default, mr);
+    strings, characters_to_filter, keep_characters, replacement, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -27,6 +27,7 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <io/utilities/parsing_utils.cuh>
@@ -1043,7 +1044,7 @@ std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& c
                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::get_json_object(col, json_path, options, rmm::cuda_stream_default, mr);
+  return detail::get_json_object(col, json_path, options, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/padding.cu
+++ b/cpp/src/strings/padding.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/padding.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -61,7 +62,7 @@ std::unique_ptr<column> pad(
   size_type width,
   pad_side side                       = pad_side::RIGHT,
   std::string_view fill_char          = " ",
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   size_type strings_count = strings.size();
@@ -210,7 +211,7 @@ std::unique_ptr<column> pad(strings_column_view const& strings,
                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::pad(strings, width, side, fill_char, rmm::cuda_stream_default, mr);
+  return detail::pad(strings, width, side, fill_char, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> zfill(strings_column_view const& strings,
@@ -218,7 +219,7 @@ std::unique_ptr<column> zfill(strings_column_view const& strings,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::zfill(strings, width, rmm::cuda_stream_default, mr);
+  return detail::zfill(strings, width, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -22,6 +22,7 @@
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/repeat_strings.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -384,7 +385,7 @@ std::unique_ptr<string_scalar> repeat_string(string_scalar const& input,
                                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat_string(input, repeat_times, rmm::cuda_stream_default, mr);
+  return detail::repeat_string(input, repeat_times, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> repeat_strings(strings_column_view const& input,
@@ -392,7 +393,7 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat_strings(input, repeat_times, rmm::cuda_stream_default, mr);
+  return detail::repeat_strings(input, repeat_times, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> repeat_strings(strings_column_view const& input,
@@ -402,7 +403,7 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
 {
   CUDF_FUNC_RANGE();
   return detail::repeat_strings(
-    input, repeat_times, output_strings_sizes, rmm::cuda_stream_default, mr);
+    input, repeat_times, output_strings_sizes, cudf::default_stream_value, mr);
 }
 
 std::pair<std::unique_ptr<column>, int64_t> repeat_strings_output_sizes(
@@ -411,7 +412,7 @@ std::pair<std::unique_ptr<column>, int64_t> repeat_strings_output_sizes(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat_strings_output_sizes(input, repeat_times, rmm::cuda_stream_default, mr);
+  return detail::repeat_strings_output_sizes(input, repeat_times, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/replace/backref_re.cu
+++ b/cpp/src/strings/replace/backref_re.cu
@@ -27,6 +27,7 @@
 #include <cudf/strings/replace_re.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -152,7 +153,7 @@ std::unique_ptr<column> replace_with_backrefs(strings_column_view const& strings
 {
   CUDF_FUNC_RANGE();
   return detail::replace_with_backrefs(
-    strings, pattern, replacement, flags, rmm::cuda_stream_default, mr);
+    strings, pattern, replacement, flags, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/replace/multi_re.cu
+++ b/cpp/src/strings/replace/multi_re.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/replace_re.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -196,7 +197,7 @@ std::unique_ptr<column> replace_re(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_re(strings, patterns, replacements, flags, rmm::cuda_stream_default, mr);
+  return detail::replace_re(strings, patterns, replacements, flags, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/replace/replace.cu
+++ b/cpp/src/strings/replace/replace.cu
@@ -27,6 +27,7 @@
 #include <cudf/strings/replace.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -843,7 +844,7 @@ std::unique_ptr<column> replace(strings_column_view const& strings,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace(strings, target, repl, maxrepl, rmm::cuda_stream_default, mr);
+  return detail::replace(strings, target, repl, maxrepl, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> replace_slice(strings_column_view const& strings,
@@ -853,7 +854,7 @@ std::unique_ptr<column> replace_slice(strings_column_view const& strings,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_slice(strings, repl, start, stop, rmm::cuda_stream_default, mr);
+  return detail::replace_slice(strings, repl, start, stop, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> replace(strings_column_view const& strings,
@@ -862,7 +863,7 @@ std::unique_ptr<column> replace(strings_column_view const& strings,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace(strings, targets, repls, rmm::cuda_stream_default, mr);
+  return detail::replace(strings, targets, repls, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/replace/replace_re.cu
+++ b/cpp/src/strings/replace/replace_re.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/replace_re.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -105,7 +106,7 @@ std::unique_ptr<column> replace_re(
   string_scalar const& replacement,
   std::optional<size_type> max_replace_count,
   regex_flags const flags,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   if (input.is_empty()) return make_empty_column(type_id::STRING);
@@ -143,7 +144,7 @@ std::unique_ptr<column> replace_re(strings_column_view const& strings,
 {
   CUDF_FUNC_RANGE();
   return detail::replace_re(
-    strings, pattern, replacement, max_replace_count, flags, rmm::cuda_stream_default, mr);
+    strings, pattern, replacement, max_replace_count, flags, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/search/find.cu
+++ b/cpp/src/strings/search/find.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/find.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -104,7 +105,7 @@ std::unique_ptr<column> find(
   string_scalar const& target,
   size_type start                     = 0,
   size_type stop                      = -1,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto pfn = [] __device__(
@@ -124,7 +125,7 @@ std::unique_ptr<column> rfind(
   string_scalar const& target,
   size_type start                     = 0,
   size_type stop                      = -1,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto pfn = [] __device__(
@@ -150,7 +151,7 @@ std::unique_ptr<column> find(strings_column_view const& strings,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::find(strings, target, start, stop, rmm::cuda_stream_default, mr);
+  return detail::find(strings, target, start, stop, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> rfind(strings_column_view const& strings,
@@ -160,7 +161,7 @@ std::unique_ptr<column> rfind(strings_column_view const& strings,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rfind(strings, target, start, stop, rmm::cuda_stream_default, mr);
+  return detail::rfind(strings, target, start, stop, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -460,7 +461,7 @@ std::unique_ptr<column> contains(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(strings, target, rmm::cuda_stream_default, mr);
+  return detail::contains(strings, target, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> contains(strings_column_view const& strings,
@@ -468,7 +469,7 @@ std::unique_ptr<column> contains(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(strings, targets, rmm::cuda_stream_default, mr);
+  return detail::contains(strings, targets, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> starts_with(strings_column_view const& strings,
@@ -476,7 +477,7 @@ std::unique_ptr<column> starts_with(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::starts_with(strings, target, rmm::cuda_stream_default, mr);
+  return detail::starts_with(strings, target, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> starts_with(strings_column_view const& strings,
@@ -484,7 +485,7 @@ std::unique_ptr<column> starts_with(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::starts_with(strings, targets, rmm::cuda_stream_default, mr);
+  return detail::starts_with(strings, targets, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> ends_with(strings_column_view const& strings,
@@ -492,7 +493,7 @@ std::unique_ptr<column> ends_with(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::ends_with(strings, target, rmm::cuda_stream_default, mr);
+  return detail::ends_with(strings, target, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> ends_with(strings_column_view const& strings,
@@ -500,7 +501,7 @@ std::unique_ptr<column> ends_with(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::ends_with(strings, targets, rmm::cuda_stream_default, mr);
+  return detail::ends_with(strings, targets, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/search/find_multiple.cu
+++ b/cpp/src/strings/search/find_multiple.cu
@@ -22,6 +22,7 @@
 #include <cudf/strings/find_multiple.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -91,7 +92,7 @@ std::unique_ptr<column> find_multiple(strings_column_view const& input,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::find_multiple(input, targets, rmm::cuda_stream_default, mr);
+  return detail::find_multiple(input, targets, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/search/findall.cu
+++ b/cpp/src/strings/search/findall.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/detail/strings_column_factories.cuh>
 #include <cudf/strings/findall.hpp>
 #include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -152,7 +153,7 @@ std::unique_ptr<table> findall(strings_column_view const& input,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::findall(input, pattern, flags, rmm::cuda_stream_default, mr);
+  return detail::findall(input, pattern, flags, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/search/findall_record.cu
+++ b/cpp/src/strings/search/findall_record.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/findall.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -138,7 +139,7 @@ std::unique_ptr<column> findall_record(strings_column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::findall_record(input, pattern, flags, rmm::cuda_stream_default, mr);
+  return detail::findall_record(input, pattern, flags, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/split/partition.cu
+++ b/cpp/src/strings/split/partition.cu
@@ -22,6 +22,7 @@
 #include <cudf/strings/split/partition.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -183,7 +184,7 @@ struct rpartition_fn : public partition_fn {
 std::unique_ptr<table> partition(
   strings_column_view const& strings,
   string_scalar const& delimiter      = string_scalar(""),
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(delimiter.is_valid(stream), "Parameter delimiter must be valid");
@@ -211,7 +212,7 @@ std::unique_ptr<table> partition(
 std::unique_ptr<table> rpartition(
   strings_column_view const& strings,
   string_scalar const& delimiter      = string_scalar(""),
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(delimiter.is_valid(stream), "Parameter delimiter must be valid");
@@ -245,7 +246,7 @@ std::unique_ptr<table> partition(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::partition(strings, delimiter, rmm::cuda_stream_default, mr);
+  return detail::partition(strings, delimiter, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> rpartition(strings_column_view const& strings,
@@ -253,7 +254,7 @@ std::unique_ptr<table> rpartition(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rpartition(strings, delimiter, rmm::cuda_stream_default, mr);
+  return detail::rpartition(strings, delimiter, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/split/split.cu
+++ b/cpp/src/strings/split/split.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/split/split.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -795,7 +796,7 @@ std::unique_ptr<table> split(
   strings_column_view const& strings_column,
   string_scalar const& delimiter      = string_scalar(""),
   size_type maxsplit                  = -1,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(delimiter.is_valid(stream), "Parameter delimiter must be valid");
@@ -820,7 +821,7 @@ std::unique_ptr<table> rsplit(
   strings_column_view const& strings_column,
   string_scalar const& delimiter      = string_scalar(""),
   size_type maxsplit                  = -1,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(delimiter.is_valid(stream), "Parameter delimiter must be valid");
@@ -851,7 +852,7 @@ std::unique_ptr<table> split(strings_column_view const& strings_column,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(strings_column, delimiter, maxsplit, rmm::cuda_stream_default, mr);
+  return detail::split(strings_column, delimiter, maxsplit, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> rsplit(strings_column_view const& strings_column,
@@ -860,7 +861,7 @@ std::unique_ptr<table> rsplit(strings_column_view const& strings_column,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rsplit(strings_column, delimiter, maxsplit, rmm::cuda_stream_default, mr);
+  return detail::rsplit(strings_column, delimiter, maxsplit, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/split/split_re.cu
+++ b/cpp/src/strings/split/split_re.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/detail/strings_column_factories.cuh>
 #include <cudf/strings/split/split_re.hpp>
 #include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -334,7 +335,7 @@ std::unique_ptr<table> split_re(strings_column_view const& input,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split_re(input, pattern, maxsplit, rmm::cuda_stream_default, mr);
+  return detail::split_re(input, pattern, maxsplit, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> split_record_re(strings_column_view const& input,
@@ -343,7 +344,7 @@ std::unique_ptr<column> split_record_re(strings_column_view const& input,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split_record_re(input, pattern, maxsplit, rmm::cuda_stream_default, mr);
+  return detail::split_record_re(input, pattern, maxsplit, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<table> rsplit_re(strings_column_view const& input,
@@ -352,7 +353,7 @@ std::unique_ptr<table> rsplit_re(strings_column_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rsplit_re(input, pattern, maxsplit, rmm::cuda_stream_default, mr);
+  return detail::rsplit_re(input, pattern, maxsplit, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> rsplit_record_re(strings_column_view const& input,
@@ -361,7 +362,7 @@ std::unique_ptr<column> rsplit_record_re(strings_column_view const& input,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rsplit_record_re(input, pattern, maxsplit, rmm::cuda_stream_default, mr);
+  return detail::rsplit_record_re(input, pattern, maxsplit, cudf::default_stream_value, mr);
 }
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/src/strings/split/split_record.cu
+++ b/cpp/src/strings/split/split_record.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/split/split.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -268,7 +269,7 @@ std::unique_ptr<column> split_record(
   strings_column_view const& strings,
   string_scalar const& delimiter      = string_scalar(""),
   size_type maxsplit                  = -1,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(delimiter.is_valid(stream), "Parameter delimiter must be valid");
@@ -304,7 +305,7 @@ std::unique_ptr<column> split_record(strings_column_view const& strings,
 {
   CUDF_FUNC_RANGE();
   return detail::split_record<detail::Dir::FORWARD>(
-    strings, delimiter, maxsplit, rmm::cuda_stream_default, mr);
+    strings, delimiter, maxsplit, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> rsplit_record(strings_column_view const& strings,
@@ -314,7 +315,7 @@ std::unique_ptr<column> rsplit_record(strings_column_view const& strings,
 {
   CUDF_FUNC_RANGE();
   return detail::split_record<detail::Dir::BACKWARD>(
-    strings, delimiter, maxsplit, rmm::cuda_stream_default, mr);
+    strings, delimiter, maxsplit, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -19,6 +19,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/detail/strings_column_factories.cuh>
 #include <cudf/strings/detail/utilities.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
 
@@ -60,7 +61,7 @@ std::unique_ptr<column> make_strings_column(
   device_span<size_type> offsets,
   size_type null_count,
   rmm::device_buffer&& null_mask,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_FUNC_RANGE();

--- a/cpp/src/strings/strip.cu
+++ b/cpp/src/strings/strip.cu
@@ -22,6 +22,7 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/strip.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -98,7 +99,7 @@ std::unique_ptr<column> strip(
   strings_column_view const& strings,
   strip_type stype                    = strip_type::BOTH,
   string_scalar const& to_strip       = string_scalar(""),
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   if (strings.is_empty()) return make_empty_column(type_id::STRING);
@@ -129,7 +130,7 @@ std::unique_ptr<column> strip(strings_column_view const& strings,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::strip(strings, stype, to_strip, rmm::cuda_stream_default, mr);
+  return detail::strip(strings, stype, to_strip, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/substring.cu
+++ b/cpp/src/strings/substring.cu
@@ -27,6 +27,7 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/substring.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -109,7 +110,7 @@ std::unique_ptr<column> slice_strings(
   numeric_scalar<size_type> const& start = numeric_scalar<size_type>(0, false),
   numeric_scalar<size_type> const& stop  = numeric_scalar<size_type>(0, false),
   numeric_scalar<size_type> const& step  = numeric_scalar<size_type>(1),
-  rmm::cuda_stream_view stream           = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream           = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr    = rmm::mr::get_current_device_resource())
 {
   if (strings.is_empty()) return make_empty_column(type_id::STRING);
@@ -142,7 +143,7 @@ std::unique_ptr<column> slice_strings(strings_column_view const& strings,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice_strings(strings, start, stop, step, rmm::cuda_stream_default, mr);
+  return detail::slice_strings(strings, start, stop, step, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -371,7 +372,8 @@ std::unique_ptr<column> slice_strings(strings_column_view const& strings,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice_strings(strings, starts_column, stops_column, rmm::cuda_stream_default, mr);
+  return detail::slice_strings(
+    strings, starts_column, stops_column, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> slice_strings(strings_column_view const& strings,
@@ -383,7 +385,7 @@ std::unique_ptr<column> slice_strings(strings_column_view const& strings,
   return detail::slice_strings(strings,
                                cudf::detail::make_pair_iterator<string_view>(delimiter),
                                count,
-                               rmm::cuda_stream_default,
+                               cudf::default_stream_value,
                                mr);
 }
 
@@ -397,20 +399,20 @@ std::unique_ptr<column> slice_strings(strings_column_view const& strings,
 
   CUDF_FUNC_RANGE();
   auto delimiters_dev_view_ptr =
-    cudf::column_device_view::create(delimiters.parent(), rmm::cuda_stream_default);
+    cudf::column_device_view::create(delimiters.parent(), cudf::default_stream_value);
   auto delimiters_dev_view = *delimiters_dev_view_ptr;
   return (delimiters_dev_view.nullable())
            ? detail::slice_strings(
                strings,
                cudf::detail::make_pair_iterator<string_view, true>(delimiters_dev_view),
                count,
-               rmm::cuda_stream_default,
+               cudf::default_stream_value,
                mr)
            : detail::slice_strings(
                strings,
                cudf::detail::make_pair_iterator<string_view, false>(delimiters_dev_view),
                count,
-               rmm::cuda_stream_default,
+               cudf::default_stream_value,
                mr);
 }
 

--- a/cpp/src/strings/translate.cu
+++ b/cpp/src/strings/translate.cu
@@ -24,6 +24,7 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/translate.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -129,7 +130,7 @@ std::unique_ptr<column> translate(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::translate(strings, chars_table, rmm::cuda_stream_default, mr);
+  return detail::translate(strings, chars_table, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/wrap.cu
+++ b/cpp/src/strings/wrap.cu
@@ -25,6 +25,7 @@
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -138,7 +139,7 @@ std::unique_ptr<column> wrap(strings_column_view const& strings,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::wrap<detail::execute_wrap>(strings, width, rmm::cuda_stream_default, mr);
+  return detail::wrap<detail::execute_wrap>(strings, width, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/text/detokenize.cu
+++ b/cpp/src/text/detokenize.cu
@@ -27,6 +27,7 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -200,7 +201,7 @@ std::unique_ptr<cudf::column> detokenize(cudf::strings_column_view const& string
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::detokenize(strings, row_indices, separator, rmm::cuda_stream_default, mr);
+  return detail::detokenize(strings, row_indices, separator, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -23,6 +23,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
@@ -308,7 +309,7 @@ std::unique_ptr<cudf::column> edit_distance(cudf::strings_column_view const& str
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::edit_distance(strings, targets, rmm::cuda_stream_default, mr);
+  return detail::edit_distance(strings, targets, cudf::default_stream_value, mr);
 }
 
 /**
@@ -318,7 +319,7 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
                                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::edit_distance_matrix(strings, rmm::cuda_stream_default, mr);
+  return detail::edit_distance_matrix(strings, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/generate_ngrams.cu
+++ b/cpp/src/text/generate_ngrams.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <nvtext/generate_ngrams.hpp>
@@ -87,7 +88,7 @@ std::unique_ptr<cudf::column> generate_ngrams(
   cudf::strings_column_view const& strings,
   cudf::size_type ngrams               = 2,
   cudf::string_scalar const& separator = cudf::string_scalar{"_"},
-  rmm::cuda_stream_view stream         = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream         = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr  = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(separator.is_valid(stream), "Parameter separator must be valid");
@@ -150,7 +151,7 @@ std::unique_ptr<cudf::column> generate_ngrams(cudf::strings_column_view const& s
                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::generate_ngrams(strings, ngrams, separator, rmm::cuda_stream_default, mr);
+  return detail::generate_ngrams(strings, ngrams, separator, cudf::default_stream_value, mr);
 }
 
 namespace detail {
@@ -260,7 +261,7 @@ std::unique_ptr<cudf::column> generate_character_ngrams(cudf::strings_column_vie
                                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::generate_character_ngrams(strings, ngrams, rmm::cuda_stream_default, mr);
+  return detail::generate_character_ngrams(strings, ngrams, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/ngrams_tokenize.cu
+++ b/cpp/src/text/ngrams_tokenize.cu
@@ -27,6 +27,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -138,7 +139,7 @@ std::unique_ptr<cudf::column> ngrams_tokenize(
   cudf::size_type ngrams               = 2,
   cudf::string_scalar const& delimiter = cudf::string_scalar(""),
   cudf::string_scalar const& separator = cudf::string_scalar{"_"},
-  rmm::cuda_stream_view stream         = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream         = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr  = rmm::mr::get_current_device_resource())
 {
   CUDF_EXPECTS(delimiter.is_valid(stream), "Parameter delimiter must be valid");
@@ -262,7 +263,7 @@ std::unique_ptr<cudf::column> ngrams_tokenize(cudf::strings_column_view const& s
 {
   CUDF_FUNC_RANGE();
   return detail::ngrams_tokenize(
-    strings, ngrams, delimiter, separator, rmm::cuda_stream_default, mr);
+    strings, ngrams, delimiter, separator, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -33,6 +33,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -244,7 +245,7 @@ std::unique_ptr<cudf::column> normalize_spaces(cudf::strings_column_view const& 
                                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::normalize_spaces(strings, rmm::cuda_stream_default, mr);
+  return detail::normalize_spaces(strings, cudf::default_stream_value, mr);
 }
 
 /**
@@ -255,7 +256,7 @@ std::unique_ptr<cudf::column> normalize_characters(cudf::strings_column_view con
                                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::normalize_characters(strings, do_lower_case, rmm::cuda_stream_default, mr);
+  return detail::normalize_characters(strings, do_lower_case, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/replace.cu
+++ b/cpp/src/text/replace.cu
@@ -28,6 +28,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -280,7 +281,7 @@ std::unique_ptr<cudf::column> replace_tokens(cudf::strings_column_view const& st
 {
   CUDF_FUNC_RANGE();
   return detail::replace_tokens(
-    strings, targets, replacements, delimiter, rmm::cuda_stream_default, mr);
+    strings, targets, replacements, delimiter, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> filter_tokens(cudf::strings_column_view const& strings,
@@ -291,7 +292,7 @@ std::unique_ptr<cudf::column> filter_tokens(cudf::strings_column_view const& str
 {
   CUDF_FUNC_RANGE();
   return detail::filter_tokens(
-    strings, min_token_length, replacement, delimiter, rmm::cuda_stream_default, mr);
+    strings, min_token_length, replacement, delimiter, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/stemmer.cu
+++ b/cpp/src/text/stemmer.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -251,7 +252,7 @@ std::unique_ptr<cudf::column> is_letter(cudf::strings_column_view const& strings
   return detail::is_letter(strings,
                            ltype,
                            thrust::make_constant_iterator<cudf::size_type>(character_index),
-                           rmm::cuda_stream_default,
+                           cudf::default_stream_value,
                            mr);
 }
 
@@ -261,7 +262,7 @@ std::unique_ptr<cudf::column> is_letter(cudf::strings_column_view const& strings
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_letter(strings, ltype, indices, rmm::cuda_stream_default, mr);
+  return detail::is_letter(strings, ltype, indices, cudf::default_stream_value, mr);
 }
 
 /**
@@ -271,7 +272,7 @@ std::unique_ptr<cudf::column> porter_stemmer_measure(cudf::strings_column_view c
                                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::porter_stemmer_measure(strings, rmm::cuda_stream_default, mr);
+  return detail::porter_stemmer_measure(strings, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/subword/bpe_tokenizer.cu
+++ b/cpp/src/text/subword/bpe_tokenizer.cu
@@ -26,6 +26,7 @@
 #include <cudf/strings/detail/combine.hpp>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/detail/utilities.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -564,7 +565,7 @@ std::unique_ptr<cudf::column> byte_pair_encoding(cudf::strings_column_view const
                                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::byte_pair_encoding(input, merges_table, separator, rmm::cuda_stream_default, mr);
+  return detail::byte_pair_encoding(input, merges_table, separator, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/subword/load_hash_file.cu
+++ b/cpp/src/text/subword/load_hash_file.cu
@@ -22,6 +22,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/detail/utilities.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -283,7 +284,7 @@ std::unique_ptr<hashed_vocabulary> load_vocabulary_file(
   std::string const& filename_hashed_vocabulary, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::load_vocabulary_file(filename_hashed_vocabulary, rmm::cuda_stream_default, mr);
+  return detail::load_vocabulary_file(filename_hashed_vocabulary, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/subword/load_merges_file.cu
+++ b/cpp/src/text/subword/load_merges_file.cu
@@ -23,6 +23,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/hash_functions.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -158,7 +159,7 @@ std::unique_ptr<bpe_merge_pairs> load_merge_pairs_file(std::string const& filena
                                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::load_merge_pairs_file(filename_merges, rmm::cuda_stream_default, mr);
+  return detail::load_merge_pairs_file(filename_merges, cudf::default_stream_value, mr);
 }
 
 bpe_merge_pairs::bpe_merge_pairs_impl::bpe_merge_pairs_impl(

--- a/cpp/src/text/subword/subword_tokenize.cu
+++ b/cpp/src/text/subword/subword_tokenize.cu
@@ -18,7 +18,9 @@
 #include <cudf/detail/get_value.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
+
 #include <nvtext/detail/load_hash_file.hpp>
 #include <nvtext/subword_tokenize.hpp>
 #include <text/subword/detail/wordpiece_tokenizer.hpp>
@@ -268,7 +270,7 @@ tokenizer_result subword_tokenize(cudf::strings_column_view const& strings,
                                   do_lower_case,
                                   do_truncate,
                                   max_rows_tensor,
-                                  rmm::cuda_stream_default,
+                                  cudf::default_stream_value,
                                   mr);
 }
 

--- a/cpp/src/text/tokenize.cu
+++ b/cpp/src/text/tokenize.cu
@@ -22,6 +22,7 @@
 #include <cudf/strings/detail/strings_column_factories.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <nvtext/detail/tokenize.hpp>
 #include <nvtext/tokenize.hpp>
@@ -231,7 +232,7 @@ std::unique_ptr<cudf::column> tokenize(cudf::strings_column_view const& strings,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::tokenize(strings, delimiter, rmm::cuda_stream_default, mr);
+  return detail::tokenize(strings, delimiter, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> tokenize(cudf::strings_column_view const& strings,
@@ -239,7 +240,7 @@ std::unique_ptr<cudf::column> tokenize(cudf::strings_column_view const& strings,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::tokenize(strings, delimiters, rmm::cuda_stream_default, mr);
+  return detail::tokenize(strings, delimiters, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> count_tokens(cudf::strings_column_view const& strings,
@@ -247,7 +248,7 @@ std::unique_ptr<cudf::column> count_tokens(cudf::strings_column_view const& stri
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_tokens(strings, delimiter, rmm::cuda_stream_default, mr);
+  return detail::count_tokens(strings, delimiter, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> count_tokens(cudf::strings_column_view const& strings,
@@ -255,14 +256,14 @@ std::unique_ptr<cudf::column> count_tokens(cudf::strings_column_view const& stri
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_tokens(strings, delimiters, rmm::cuda_stream_default, mr);
+  return detail::count_tokens(strings, delimiters, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> character_tokenize(cudf::strings_column_view const& strings,
                                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::character_tokenize(strings, rmm::cuda_stream_default, mr);
+  return detail::character_tokenize(strings, cudf::default_stream_value, mr);
 }
 
 }  // namespace nvtext

--- a/cpp/src/transform/bools_to_mask.cu
+++ b/cpp/src/transform/bools_to_mask.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -60,7 +61,7 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
   column_view const& input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::bools_to_mask(input, rmm::cuda_stream_default, mr);
+  return detail::bools_to_mask(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/compute_column.cu
+++ b/cpp/src/transform/compute_column.cu
@@ -27,6 +27,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -136,7 +137,7 @@ std::unique_ptr<column> compute_column(table_view const& table,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::compute_column(table, expr, rmm::cuda_stream_default, mr);
+  return detail::compute_column(table, expr, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/encode.cu
+++ b/cpp/src/transform/encode.cu
@@ -25,6 +25,7 @@
 #include <cudf/detail/transform.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
@@ -65,7 +66,7 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<column>> encode(
 std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
   cudf::table_view const& input, rmm::mr::device_memory_resource* mr)
 {
-  return detail::encode(input, rmm::cuda_stream_default, mr);
+  return detail::encode(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/mask_to_bools.cu
+++ b/cpp/src/transform/mask_to_bools.cu
@@ -20,6 +20,8 @@
 #include <cudf/transform.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
@@ -61,6 +63,6 @@ std::unique_ptr<column> mask_to_bools(bitmask_type const* bitmask,
                                       size_type end_bit,
                                       rmm::mr::device_memory_resource* mr)
 {
-  return detail::mask_to_bools(bitmask, begin_bit, end_bit, rmm::cuda_stream_default, mr);
+  return detail::mask_to_bools(bitmask, begin_bit, end_bit, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/transform/nans_to_nulls.cu
+++ b/cpp/src/transform/nans_to_nulls.cu
@@ -21,6 +21,7 @@
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -94,7 +95,7 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> nans_to_nulls(
   column_view const& input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::nans_to_nulls(input, rmm::cuda_stream_default, mr);
+  return detail::nans_to_nulls(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -21,6 +21,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/table/row_operators.cuh>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -126,6 +127,6 @@ std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const&
                                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::one_hot_encode(input, categories, rmm::cuda_stream_default, mr);
+  return detail::one_hot_encode(input, categories, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/transform/row_bit_count.cu
+++ b/cpp/src/transform/row_bit_count.cu
@@ -23,6 +23,7 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/fill.h>
 #include <thrust/optional.h>
@@ -536,7 +537,7 @@ std::unique_ptr<column> row_bit_count(table_view const& t,
  */
 std::unique_ptr<column> row_bit_count(table_view const& t, rmm::mr::device_memory_resource* mr)
 {
-  return detail::row_bit_count(t, rmm::cuda_stream_default, mr);
+  return detail::row_bit_count(t, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/transform.cpp
+++ b/cpp/src/transform/transform.cpp
@@ -19,6 +19,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/transform.hpp>
 #include <cudf/null_mask.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -98,7 +99,7 @@ std::unique_ptr<column> transform(column_view const& input,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::transform(input, unary_udf, output_type, is_ptx, rmm::cuda_stream_default, mr);
+  return detail::transform(input, unary_udf, output_type, is_ptx, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/transpose/transpose.cu
+++ b/cpp/src/transpose/transpose.cu
@@ -21,6 +21,7 @@
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/transpose.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -62,7 +63,7 @@ std::pair<std::unique_ptr<column>, table_view> transpose(table_view const& input
                                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::transpose(input, rmm::cuda_stream_default, mr);
+  return detail::transpose(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -24,6 +24,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/unary.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -411,7 +412,7 @@ std::unique_ptr<column> cast(column_view const& input,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::cast(input, type, rmm::cuda_stream_default, mr);
+  return detail::cast(input, type, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/math_ops.cu
+++ b/cpp/src/unary/math_ops.cu
@@ -21,6 +21,7 @@
 #include <cudf/detail/unary.hpp>
 #include <cudf/dictionary/detail/encode.hpp>
 #include <cudf/dictionary/detail/iterator.cuh>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -637,7 +638,7 @@ std::unique_ptr<cudf::column> unary_operation(cudf::column_view const& input,
                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::unary_operation(input, op, rmm::cuda_stream_default, mr);
+  return detail::unary_operation(input, op, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/nan_ops.cu
+++ b/cpp/src/unary/nan_ops.cu
@@ -20,6 +20,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/unary.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -93,14 +94,14 @@ std::unique_ptr<column> is_not_nan(cudf::column_view const& input,
 std::unique_ptr<column> is_nan(cudf::column_view const& input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_nan(input, rmm::cuda_stream_default, mr);
+  return detail::is_nan(input, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> is_not_nan(cudf::column_view const& input,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_not_nan(input, rmm::cuda_stream_default, mr);
+  return detail::is_not_nan(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/null_ops.cu
+++ b/cpp/src/unary/null_ops.cu
@@ -19,9 +19,8 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/unary.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 
@@ -36,7 +35,7 @@ std::unique_ptr<column> is_null(cudf::column_view const& input, rmm::mr::device_
                          thrust::make_counting_iterator(input.size()),
                          input.size(),
                          predicate,
-                         rmm::cuda_stream_default,
+                         cudf::default_stream_value,
                          mr);
 }
 
@@ -51,7 +50,7 @@ std::unique_ptr<column> is_valid(cudf::column_view const& input,
                          thrust::make_counting_iterator(input.size()),
                          input.size(),
                          predicate,
-                         rmm::cuda_stream_default,
+                         cudf::default_stream_value,
                          mr);
 }
 

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -19,6 +19,7 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -68,15 +69,15 @@ struct CountBitmaskTest : public cudf::test::BaseFixture {
 
 TEST_F(CountBitmaskTest, NullMask)
 {
-  EXPECT_THROW(cudf::detail::count_set_bits(nullptr, 0, 32, rmm::cuda_stream_default),
+  EXPECT_THROW(cudf::detail::count_set_bits(nullptr, 0, 32, cudf::default_stream_value),
                cudf::logic_error);
-  EXPECT_EQ(32, cudf::detail::valid_count(nullptr, 0, 32, rmm::cuda_stream_default));
+  EXPECT_EQ(32, cudf::detail::valid_count(nullptr, 0, 32, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 32, 7, 25};
-  EXPECT_THROW(cudf::detail::segmented_count_set_bits(nullptr, indices, rmm::cuda_stream_default),
+  EXPECT_THROW(cudf::detail::segmented_count_set_bits(nullptr, indices, cudf::default_stream_value),
                cudf::logic_error);
   auto valid_counts =
-    cudf::detail::segmented_valid_count(nullptr, indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(nullptr, indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{32, 18}));
 }
 
@@ -87,11 +88,11 @@ rmm::device_uvector<cudf::bitmask_type> make_mask(cudf::size_type size, bool fil
   if (!fill_valid) {
     return cudf::detail::make_zeroed_device_uvector_sync<cudf::bitmask_type>(size);
   } else {
-    auto ret = rmm::device_uvector<cudf::bitmask_type>(size, rmm::cuda_stream_default);
+    auto ret = rmm::device_uvector<cudf::bitmask_type>(size, cudf::default_stream_value);
     CUDF_CUDA_TRY(cudaMemsetAsync(ret.data(),
                                   ~cudf::bitmask_type{0},
                                   size * sizeof(cudf::bitmask_type),
-                                  rmm::cuda_stream_default.value()));
+                                  cudf::default_stream_value.value()));
     return ret;
   }
 }
@@ -99,242 +100,244 @@ rmm::device_uvector<cudf::bitmask_type> make_mask(cudf::size_type size, bool fil
 TEST_F(CountBitmaskTest, NegativeStart)
 {
   auto mask = make_mask(1);
-  EXPECT_THROW(cudf::detail::count_set_bits(mask.data(), -1, 32, rmm::cuda_stream_default),
+  EXPECT_THROW(cudf::detail::count_set_bits(mask.data(), -1, 32, cudf::default_stream_value),
                cudf::logic_error);
-  EXPECT_THROW(cudf::detail::valid_count(mask.data(), -1, 32, rmm::cuda_stream_default),
+  EXPECT_THROW(cudf::detail::valid_count(mask.data(), -1, 32, cudf::default_stream_value),
                cudf::logic_error);
 
   std::vector<cudf::size_type> indices = {0, 16, -1, 32};
   EXPECT_THROW(
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default),
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value),
     cudf::logic_error);
-  EXPECT_THROW(cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default),
-               cudf::logic_error);
+  EXPECT_THROW(
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value),
+    cudf::logic_error);
 }
 
 TEST_F(CountBitmaskTest, StartLargerThanStop)
 {
   auto mask = make_mask(1);
-  EXPECT_THROW(cudf::detail::count_set_bits(mask.data(), 32, 31, rmm::cuda_stream_default),
+  EXPECT_THROW(cudf::detail::count_set_bits(mask.data(), 32, 31, cudf::default_stream_value),
                cudf::logic_error);
-  EXPECT_THROW(cudf::detail::valid_count(mask.data(), 32, 31, rmm::cuda_stream_default),
+  EXPECT_THROW(cudf::detail::valid_count(mask.data(), 32, 31, cudf::default_stream_value),
                cudf::logic_error);
 
   std::vector<cudf::size_type> indices = {0, 16, 31, 30};
   EXPECT_THROW(
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default),
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value),
     cudf::logic_error);
-  EXPECT_THROW(cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default),
-               cudf::logic_error);
+  EXPECT_THROW(
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value),
+    cudf::logic_error);
 }
 
 TEST_F(CountBitmaskTest, EmptyRange)
 {
   auto mask = make_mask(1);
-  EXPECT_EQ(0, cudf::detail::count_set_bits(mask.data(), 17, 17, rmm::cuda_stream_default));
-  EXPECT_EQ(0, cudf::detail::valid_count(mask.data(), 17, 17, rmm::cuda_stream_default));
+  EXPECT_EQ(0, cudf::detail::count_set_bits(mask.data(), 17, 17, cudf::default_stream_value));
+  EXPECT_EQ(0, cudf::detail::valid_count(mask.data(), 17, 17, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 0, 17, 17};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{0, 0}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{0, 0}));
 }
 
 TEST_F(CountBitmaskTest, SingleWordAllZero)
 {
   auto mask = make_mask(1);
-  EXPECT_EQ(0, cudf::detail::count_set_bits(mask.data(), 0, 32, rmm::cuda_stream_default));
-  EXPECT_EQ(0, cudf::detail::valid_count(mask.data(), 0, 32, rmm::cuda_stream_default));
+  EXPECT_EQ(0, cudf::detail::count_set_bits(mask.data(), 0, 32, cudf::default_stream_value));
+  EXPECT_EQ(0, cudf::detail::valid_count(mask.data(), 0, 32, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 32, 0, 32};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{0, 0}));
   auto valid_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{0, 0}));
 }
 
 TEST_F(CountBitmaskTest, SingleBitAllZero)
 {
   auto mask = make_mask(1);
-  EXPECT_EQ(0, cudf::detail::count_set_bits(mask.data(), 17, 18, rmm::cuda_stream_default));
-  EXPECT_EQ(0, cudf::detail::valid_count(mask.data(), 17, 18, rmm::cuda_stream_default));
+  EXPECT_EQ(0, cudf::detail::count_set_bits(mask.data(), 17, 18, cudf::default_stream_value));
+  EXPECT_EQ(0, cudf::detail::valid_count(mask.data(), 17, 18, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {17, 18, 7, 8};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{0, 0}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{0, 0}));
 }
 
 TEST_F(CountBitmaskTest, SingleBitAllSet)
 {
   auto mask = make_mask(1, true);
-  EXPECT_EQ(1, cudf::detail::count_set_bits(mask.data(), 13, 14, rmm::cuda_stream_default));
-  EXPECT_EQ(1, cudf::detail::valid_count(mask.data(), 13, 14, rmm::cuda_stream_default));
+  EXPECT_EQ(1, cudf::detail::count_set_bits(mask.data(), 13, 14, cudf::default_stream_value));
+  EXPECT_EQ(1, cudf::detail::valid_count(mask.data(), 13, 14, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {13, 14, 0, 1};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{1, 1}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{1, 1}));
 }
 
 TEST_F(CountBitmaskTest, SingleWordAllBitsSet)
 {
   auto mask = make_mask(1, true);
-  EXPECT_EQ(32, cudf::detail::count_set_bits(mask.data(), 0, 32, rmm::cuda_stream_default));
-  EXPECT_EQ(32, cudf::detail::valid_count(mask.data(), 0, 32, rmm::cuda_stream_default));
+  EXPECT_EQ(32, cudf::detail::count_set_bits(mask.data(), 0, 32, cudf::default_stream_value));
+  EXPECT_EQ(32, cudf::detail::valid_count(mask.data(), 0, 32, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 32, 0, 32};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{32, 32}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{32, 32}));
 }
 
 TEST_F(CountBitmaskTest, SingleWordPreSlack)
 {
   auto mask = make_mask(1, true);
-  EXPECT_EQ(25, cudf::detail::count_set_bits(mask.data(), 7, 32, rmm::cuda_stream_default));
-  EXPECT_EQ(25, cudf::detail::valid_count(mask.data(), 7, 32, rmm::cuda_stream_default));
+  EXPECT_EQ(25, cudf::detail::count_set_bits(mask.data(), 7, 32, cudf::default_stream_value));
+  EXPECT_EQ(25, cudf::detail::valid_count(mask.data(), 7, 32, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {7, 32, 8, 32};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{25, 24}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{25, 24}));
 }
 
 TEST_F(CountBitmaskTest, SingleWordPostSlack)
 {
   auto mask = make_mask(1, true);
-  EXPECT_EQ(17, cudf::detail::count_set_bits(mask.data(), 0, 17, rmm::cuda_stream_default));
-  EXPECT_EQ(17, cudf::detail::valid_count(mask.data(), 0, 17, rmm::cuda_stream_default));
+  EXPECT_EQ(17, cudf::detail::count_set_bits(mask.data(), 0, 17, cudf::default_stream_value));
+  EXPECT_EQ(17, cudf::detail::valid_count(mask.data(), 0, 17, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 17, 0, 18};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{17, 18}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{17, 18}));
 }
 
 TEST_F(CountBitmaskTest, SingleWordSubset)
 {
   auto mask = make_mask(1, true);
-  EXPECT_EQ(30, cudf::detail::count_set_bits(mask.data(), 1, 31, rmm::cuda_stream_default));
-  EXPECT_EQ(30, cudf::detail::valid_count(mask.data(), 1, 31, rmm::cuda_stream_default));
+  EXPECT_EQ(30, cudf::detail::count_set_bits(mask.data(), 1, 31, cudf::default_stream_value));
+  EXPECT_EQ(30, cudf::detail::valid_count(mask.data(), 1, 31, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {1, 31, 7, 17};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{30, 10}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{30, 10}));
 }
 
 TEST_F(CountBitmaskTest, SingleWordSubset2)
 {
   auto mask = make_mask(1, true);
-  EXPECT_EQ(28, cudf::detail::count_set_bits(mask.data(), 2, 30, rmm::cuda_stream_default));
-  EXPECT_EQ(28, cudf::detail::valid_count(mask.data(), 2, 30, rmm::cuda_stream_default));
+  EXPECT_EQ(28, cudf::detail::count_set_bits(mask.data(), 2, 30, cudf::default_stream_value));
+  EXPECT_EQ(28, cudf::detail::valid_count(mask.data(), 2, 30, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {4, 16, 2, 30};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{12, 28}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{12, 28}));
 }
 
 TEST_F(CountBitmaskTest, MultipleWordsAllBits)
 {
   auto mask = make_mask(10, true);
-  EXPECT_EQ(320, cudf::detail::count_set_bits(mask.data(), 0, 320, rmm::cuda_stream_default));
-  EXPECT_EQ(320, cudf::detail::valid_count(mask.data(), 0, 320, rmm::cuda_stream_default));
+  EXPECT_EQ(320, cudf::detail::count_set_bits(mask.data(), 0, 320, cudf::default_stream_value));
+  EXPECT_EQ(320, cudf::detail::valid_count(mask.data(), 0, 320, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 320, 0, 320};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{320, 320}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{320, 320}));
 }
 
 TEST_F(CountBitmaskTest, MultipleWordsSubsetWordBoundary)
 {
   auto mask = make_mask(10, true);
-  EXPECT_EQ(256, cudf::detail::count_set_bits(mask.data(), 32, 288, rmm::cuda_stream_default));
-  EXPECT_EQ(256, cudf::detail::valid_count(mask.data(), 32, 288, rmm::cuda_stream_default));
+  EXPECT_EQ(256, cudf::detail::count_set_bits(mask.data(), 32, 288, cudf::default_stream_value));
+  EXPECT_EQ(256, cudf::detail::valid_count(mask.data(), 32, 288, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {32, 192, 32, 288};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{160, 256}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{160, 256}));
 }
 
 TEST_F(CountBitmaskTest, MultipleWordsSplitWordBoundary)
 {
   auto mask = make_mask(10, true);
-  EXPECT_EQ(2, cudf::detail::count_set_bits(mask.data(), 31, 33, rmm::cuda_stream_default));
-  EXPECT_EQ(2, cudf::detail::valid_count(mask.data(), 31, 33, rmm::cuda_stream_default));
+  EXPECT_EQ(2, cudf::detail::count_set_bits(mask.data(), 31, 33, cudf::default_stream_value));
+  EXPECT_EQ(2, cudf::detail::valid_count(mask.data(), 31, 33, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {31, 33, 60, 67};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{2, 7}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{2, 7}));
 }
 
 TEST_F(CountBitmaskTest, MultipleWordsSubset)
 {
   auto mask = make_mask(10, true);
-  EXPECT_EQ(226, cudf::detail::count_set_bits(mask.data(), 67, 293, rmm::cuda_stream_default));
-  EXPECT_EQ(226, cudf::detail::valid_count(mask.data(), 67, 293, rmm::cuda_stream_default));
+  EXPECT_EQ(226, cudf::detail::count_set_bits(mask.data(), 67, 293, cudf::default_stream_value));
+  EXPECT_EQ(226, cudf::detail::valid_count(mask.data(), 67, 293, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {67, 293, 37, 319};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{226, 282}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{226, 282}));
 }
 
 TEST_F(CountBitmaskTest, MultipleWordsSingleBit)
 {
   auto mask = make_mask(10, true);
-  EXPECT_EQ(1, cudf::detail::count_set_bits(mask.data(), 67, 68, rmm::cuda_stream_default));
-  EXPECT_EQ(1, cudf::detail::valid_count(mask.data(), 67, 68, rmm::cuda_stream_default));
+  EXPECT_EQ(1, cudf::detail::count_set_bits(mask.data(), 67, 68, cudf::default_stream_value));
+  EXPECT_EQ(1, cudf::detail::valid_count(mask.data(), 67, 68, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {67, 68, 31, 32, 192, 193};
   auto set_counts =
-    cudf::detail::segmented_count_set_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_set_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(set_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{1, 1, 1}));
   auto valid_counts =
-    cudf::detail::segmented_valid_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_valid_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(valid_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{1, 1, 1}));
 }
 
@@ -343,178 +346,180 @@ using CountUnsetBitsTest = CountBitmaskTest;
 TEST_F(CountUnsetBitsTest, SingleBitAllSet)
 {
   auto mask = make_mask(1, true);
-  EXPECT_EQ(0, cudf::detail::count_unset_bits(mask.data(), 13, 14, rmm::cuda_stream_default));
-  EXPECT_EQ(0, cudf::detail::null_count(mask.data(), 13, 14, rmm::cuda_stream_default));
+  EXPECT_EQ(0, cudf::detail::count_unset_bits(mask.data(), 13, 14, cudf::default_stream_value));
+  EXPECT_EQ(0, cudf::detail::null_count(mask.data(), 13, 14, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {13, 14, 31, 32};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{0, 0}));
   auto null_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{0, 0}));
 }
 
 TEST_F(CountUnsetBitsTest, NullMask)
 {
-  EXPECT_THROW(cudf::detail::count_unset_bits(nullptr, 0, 32, rmm::cuda_stream_default),
+  EXPECT_THROW(cudf::detail::count_unset_bits(nullptr, 0, 32, cudf::default_stream_value),
                cudf::logic_error);
-  EXPECT_EQ(0, cudf::detail::null_count(nullptr, 0, 32, rmm::cuda_stream_default));
+  EXPECT_EQ(0, cudf::detail::null_count(nullptr, 0, 32, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 32, 7, 25};
-  EXPECT_THROW(cudf::detail::segmented_count_unset_bits(nullptr, indices, rmm::cuda_stream_default),
-               cudf::logic_error);
-  auto null_counts = cudf::detail::segmented_null_count(nullptr, indices, rmm::cuda_stream_default);
+  EXPECT_THROW(
+    cudf::detail::segmented_count_unset_bits(nullptr, indices, cudf::default_stream_value),
+    cudf::logic_error);
+  auto null_counts =
+    cudf::detail::segmented_null_count(nullptr, indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{0, 0}));
 }
 
 TEST_F(CountUnsetBitsTest, SingleWordAllBits)
 {
   auto mask = make_mask(1);
-  EXPECT_EQ(32, cudf::detail::count_unset_bits(mask.data(), 0, 32, rmm::cuda_stream_default));
-  EXPECT_EQ(32, cudf::detail::null_count(mask.data(), 0, 32, rmm::cuda_stream_default));
+  EXPECT_EQ(32, cudf::detail::count_unset_bits(mask.data(), 0, 32, cudf::default_stream_value));
+  EXPECT_EQ(32, cudf::detail::null_count(mask.data(), 0, 32, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 32, 0, 32};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{32, 32}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{32, 32}));
 }
 
 TEST_F(CountUnsetBitsTest, SingleWordPreSlack)
 {
   auto mask = make_mask(1);
-  EXPECT_EQ(25, cudf::detail::count_unset_bits(mask.data(), 7, 32, rmm::cuda_stream_default));
-  EXPECT_EQ(25, cudf::detail::null_count(mask.data(), 7, 32, rmm::cuda_stream_default));
+  EXPECT_EQ(25, cudf::detail::count_unset_bits(mask.data(), 7, 32, cudf::default_stream_value));
+  EXPECT_EQ(25, cudf::detail::null_count(mask.data(), 7, 32, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {7, 32, 8, 32};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{25, 24}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{25, 24}));
 }
 
 TEST_F(CountUnsetBitsTest, SingleWordPostSlack)
 {
   auto mask = make_mask(1);
-  EXPECT_EQ(17, cudf::detail::count_unset_bits(mask.data(), 0, 17, rmm::cuda_stream_default));
-  EXPECT_EQ(17, cudf::detail::null_count(mask.data(), 0, 17, rmm::cuda_stream_default));
+  EXPECT_EQ(17, cudf::detail::count_unset_bits(mask.data(), 0, 17, cudf::default_stream_value));
+  EXPECT_EQ(17, cudf::detail::null_count(mask.data(), 0, 17, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 17, 0, 18};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{17, 18}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{17, 18}));
 }
 
 TEST_F(CountUnsetBitsTest, SingleWordSubset)
 {
   auto mask = make_mask(1);
-  EXPECT_EQ(30, cudf::detail::count_unset_bits(mask.data(), 1, 31, rmm::cuda_stream_default));
-  EXPECT_EQ(30, cudf::detail::null_count(mask.data(), 1, 31, rmm::cuda_stream_default));
+  EXPECT_EQ(30, cudf::detail::count_unset_bits(mask.data(), 1, 31, cudf::default_stream_value));
+  EXPECT_EQ(30, cudf::detail::null_count(mask.data(), 1, 31, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {1, 31, 7, 17};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{30, 10}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{30, 10}));
 }
 
 TEST_F(CountUnsetBitsTest, SingleWordSubset2)
 {
   auto mask = make_mask(1);
-  EXPECT_EQ(28, cudf::detail::count_unset_bits(mask.data(), 2, 30, rmm::cuda_stream_default));
-  EXPECT_EQ(28, cudf::detail::null_count(mask.data(), 2, 30, rmm::cuda_stream_default));
+  EXPECT_EQ(28, cudf::detail::count_unset_bits(mask.data(), 2, 30, cudf::default_stream_value));
+  EXPECT_EQ(28, cudf::detail::null_count(mask.data(), 2, 30, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {4, 16, 2, 30};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{12, 28}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{12, 28}));
 }
 
 TEST_F(CountUnsetBitsTest, MultipleWordsAllBits)
 {
   auto mask = make_mask(10);
-  EXPECT_EQ(320, cudf::detail::count_unset_bits(mask.data(), 0, 320, rmm::cuda_stream_default));
-  EXPECT_EQ(320, cudf::detail::null_count(mask.data(), 0, 320, rmm::cuda_stream_default));
+  EXPECT_EQ(320, cudf::detail::count_unset_bits(mask.data(), 0, 320, cudf::default_stream_value));
+  EXPECT_EQ(320, cudf::detail::null_count(mask.data(), 0, 320, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {0, 320, 0, 320};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{320, 320}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{320, 320}));
 }
 
 TEST_F(CountUnsetBitsTest, MultipleWordsSubsetWordBoundary)
 {
   auto mask = make_mask(10);
-  EXPECT_EQ(256, cudf::detail::count_unset_bits(mask.data(), 32, 288, rmm::cuda_stream_default));
-  EXPECT_EQ(256, cudf::detail::null_count(mask.data(), 32, 288, rmm::cuda_stream_default));
+  EXPECT_EQ(256, cudf::detail::count_unset_bits(mask.data(), 32, 288, cudf::default_stream_value));
+  EXPECT_EQ(256, cudf::detail::null_count(mask.data(), 32, 288, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {32, 192, 32, 288};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{160, 256}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{160, 256}));
 }
 
 TEST_F(CountUnsetBitsTest, MultipleWordsSplitWordBoundary)
 {
   auto mask = make_mask(10);
-  EXPECT_EQ(2, cudf::detail::count_unset_bits(mask.data(), 31, 33, rmm::cuda_stream_default));
-  EXPECT_EQ(2, cudf::detail::null_count(mask.data(), 31, 33, rmm::cuda_stream_default));
+  EXPECT_EQ(2, cudf::detail::count_unset_bits(mask.data(), 31, 33, cudf::default_stream_value));
+  EXPECT_EQ(2, cudf::detail::null_count(mask.data(), 31, 33, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {31, 33, 60, 67};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{2, 7}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{2, 7}));
 }
 
 TEST_F(CountUnsetBitsTest, MultipleWordsSubset)
 {
   auto mask = make_mask(10);
-  EXPECT_EQ(226, cudf::detail::count_unset_bits(mask.data(), 67, 293, rmm::cuda_stream_default));
-  EXPECT_EQ(226, cudf::detail::null_count(mask.data(), 67, 293, rmm::cuda_stream_default));
+  EXPECT_EQ(226, cudf::detail::count_unset_bits(mask.data(), 67, 293, cudf::default_stream_value));
+  EXPECT_EQ(226, cudf::detail::null_count(mask.data(), 67, 293, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {67, 293, 37, 319};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{226, 282}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{226, 282}));
 }
 
 TEST_F(CountUnsetBitsTest, MultipleWordsSingleBit)
 {
   auto mask = make_mask(10);
-  EXPECT_EQ(1, cudf::detail::count_unset_bits(mask.data(), 67, 68, rmm::cuda_stream_default));
-  EXPECT_EQ(1, cudf::detail::null_count(mask.data(), 67, 68, rmm::cuda_stream_default));
+  EXPECT_EQ(1, cudf::detail::count_unset_bits(mask.data(), 67, 68, cudf::default_stream_value));
+  EXPECT_EQ(1, cudf::detail::null_count(mask.data(), 67, 68, cudf::default_stream_value));
 
   std::vector<cudf::size_type> indices = {67, 68, 31, 32, 192, 193};
   auto unset_counts =
-    cudf::detail::segmented_count_unset_bits(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_count_unset_bits(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(unset_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{1, 1, 1}));
   auto null_counts =
-    cudf::detail::segmented_null_count(mask.data(), indices, rmm::cuda_stream_default);
+    cudf::detail::segmented_null_count(mask.data(), indices, cudf::default_stream_value);
   EXPECT_THAT(null_counts, ::testing::ElementsAreArray(std::vector<cudf::size_type>{1, 1, 1}));
 }
 
@@ -617,10 +622,10 @@ TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorContiguous)
   }
   auto gold_mask = cudf::test::detail::make_null_mask(validity_bit.begin(), validity_bit.end());
 
-  rmm::device_buffer copy_mask{gold_mask, rmm::cuda_stream_default};
+  rmm::device_buffer copy_mask{gold_mask, cudf::default_stream_value};
   cudf::column original{t,
                         num_elements,
-                        rmm::device_buffer{num_elements * sizeof(int), rmm::cuda_stream_default},
+                        rmm::device_buffer{num_elements * sizeof(int), cudf::default_stream_value},
                         std::move(copy_mask)};
   std::vector<cudf::size_type> indices{0,
                                        104,
@@ -664,7 +669,7 @@ TEST_F(CopyBitmaskTest, TestCopyColumnViewVectorDiscontiguous)
     cols.emplace_back(
       t,
       split[i + 1] - split[i],
-      rmm::device_buffer{sizeof(int) * (split[i + 1] - split[i]), rmm::cuda_stream_default},
+      rmm::device_buffer{sizeof(int) * (split[i + 1] - split[i]), cudf::default_stream_value},
       cudf::test::detail::make_null_mask(validity_bit.begin() + split[i],
                                          validity_bit.begin() + split[i + 1]));
     views.push_back(cols.back());

--- a/cpp/tests/bitmask/set_nullmask_tests.cu
+++ b/cpp/tests/bitmask/set_nullmask_tests.cu
@@ -21,6 +21,7 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
@@ -49,7 +50,7 @@ struct SetBitmaskTest : public cudf::test::BaseFixture {
   void expect_bitmask_equal(cudf::bitmask_type const* bitmask,  // Device Ptr
                             cudf::size_type start_bit,
                             thrust::host_vector<bool> const& expect,
-                            rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+                            rmm::cuda_stream_view stream = cudf::default_stream_value)
   {
     rmm::device_uvector<bool> result(expect.size(), stream);
     auto counting_iter = thrust::counting_iterator<cudf::size_type>{0};

--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -22,6 +22,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -40,8 +41,8 @@ struct TypedColumnTest : public cudf::test::BaseFixture {
   cudf::data_type type() { return cudf::data_type{cudf::type_to_id<T>()}; }
 
   TypedColumnTest()
-    : data{_num_elements * cudf::size_of(type()), rmm::cuda_stream_default},
-      mask{cudf::bitmask_allocation_size_bytes(_num_elements), rmm::cuda_stream_default}
+    : data{_num_elements * cudf::size_of(type()), cudf::default_stream_value},
+      mask{cudf::bitmask_allocation_size_bytes(_num_elements), cudf::default_stream_value}
   {
     auto typed_data = static_cast<char*>(data.data());
     auto typed_mask = static_cast<char*>(mask.data());
@@ -242,8 +243,8 @@ TYPED_TEST(TypedColumnTest, CopyDataAndMask)
 {
   cudf::column col{this->type(),
                    this->num_elements(),
-                   rmm::device_buffer{this->data, rmm::cuda_stream_default},
-                   rmm::device_buffer{this->all_valid_mask, rmm::cuda_stream_default}};
+                   rmm::device_buffer{this->data, cudf::default_stream_value},
+                   rmm::device_buffer{this->all_valid_mask, cudf::default_stream_value}};
   EXPECT_EQ(this->type(), col.type());
   EXPECT_TRUE(col.nullable());
   EXPECT_EQ(0, col.null_count());
@@ -351,17 +352,17 @@ TYPED_TEST(TypedColumnTest, ConstructWithChildren)
   children.emplace_back(std::make_unique<cudf::column>(
     cudf::data_type{cudf::type_id::INT8},
     42,
-    rmm::device_buffer{this->data, rmm::cuda_stream_default},
-    rmm::device_buffer{this->all_valid_mask, rmm::cuda_stream_default}));
+    rmm::device_buffer{this->data, cudf::default_stream_value},
+    rmm::device_buffer{this->all_valid_mask, cudf::default_stream_value}));
   children.emplace_back(std::make_unique<cudf::column>(
     cudf::data_type{cudf::type_id::FLOAT64},
     314,
-    rmm::device_buffer{this->data, rmm::cuda_stream_default},
-    rmm::device_buffer{this->all_valid_mask, rmm::cuda_stream_default}));
+    rmm::device_buffer{this->data, cudf::default_stream_value},
+    rmm::device_buffer{this->all_valid_mask, cudf::default_stream_value}));
   cudf::column col{this->type(),
                    this->num_elements(),
-                   rmm::device_buffer{this->data, rmm::cuda_stream_default},
-                   rmm::device_buffer{this->all_valid_mask, rmm::cuda_stream_default},
+                   rmm::device_buffer{this->data, cudf::default_stream_value},
+                   rmm::device_buffer{this->all_valid_mask, cudf::default_stream_value},
                    cudf::UNKNOWN_NULL_COUNT,
                    std::move(children)};
 
@@ -396,17 +397,17 @@ TYPED_TEST(TypedColumnTest, ReleaseWithChildren)
   children.emplace_back(std::make_unique<cudf::column>(
     this->type(),
     this->num_elements(),
-    rmm::device_buffer{this->data, rmm::cuda_stream_default},
-    rmm::device_buffer{this->all_valid_mask, rmm::cuda_stream_default}));
+    rmm::device_buffer{this->data, cudf::default_stream_value},
+    rmm::device_buffer{this->all_valid_mask, cudf::default_stream_value}));
   children.emplace_back(std::make_unique<cudf::column>(
     this->type(),
     this->num_elements(),
-    rmm::device_buffer{this->data, rmm::cuda_stream_default},
-    rmm::device_buffer{this->all_valid_mask, rmm::cuda_stream_default}));
+    rmm::device_buffer{this->data, cudf::default_stream_value},
+    rmm::device_buffer{this->all_valid_mask, cudf::default_stream_value}));
   cudf::column col{this->type(),
                    this->num_elements(),
-                   rmm::device_buffer{this->data, rmm::cuda_stream_default},
-                   rmm::device_buffer{this->all_valid_mask, rmm::cuda_stream_default},
+                   rmm::device_buffer{this->data, cudf::default_stream_value},
+                   rmm::device_buffer{this->all_valid_mask, cudf::default_stream_value},
                    cudf::UNKNOWN_NULL_COUNT,
                    std::move(children)};
 

--- a/cpp/tests/column/compound_test.cu
+++ b/cpp/tests/column/compound_test.cu
@@ -18,10 +18,10 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_view.hpp>
 #include <cudf/null_mask.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/cudf_gtest.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
@@ -65,13 +65,13 @@ struct checker_for_level2 {
 
 TEST_F(CompoundColumnTest, ChildrenLevel1)
 {
-  rmm::device_uvector<int32_t> data(1000, rmm::cuda_stream_default);
+  rmm::device_uvector<int32_t> data(1000, cudf::default_stream_value);
   thrust::sequence(rmm::exec_policy(), data.begin(), data.end(), 1);
 
   auto null_mask = cudf::create_null_mask(100, cudf::mask_state::UNALLOCATED);
-  rmm::device_buffer data1{data.data() + 100, 100 * sizeof(int32_t), rmm::cuda_stream_default};
-  rmm::device_buffer data2{data.data() + 200, 100 * sizeof(int32_t), rmm::cuda_stream_default};
-  rmm::device_buffer data3{data.data() + 300, 100 * sizeof(int32_t), rmm::cuda_stream_default};
+  rmm::device_buffer data1{data.data() + 100, 100 * sizeof(int32_t), cudf::default_stream_value};
+  rmm::device_buffer data2{data.data() + 200, 100 * sizeof(int32_t), cudf::default_stream_value};
+  rmm::device_buffer data3{data.data() + 300, 100 * sizeof(int32_t), cudf::default_stream_value};
   auto child1 =
     std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
                                    100,
@@ -121,16 +121,16 @@ TEST_F(CompoundColumnTest, ChildrenLevel1)
 
 TEST_F(CompoundColumnTest, ChildrenLevel2)
 {
-  rmm::device_uvector<int32_t> data(1000, rmm::cuda_stream_default);
+  rmm::device_uvector<int32_t> data(1000, cudf::default_stream_value);
   thrust::sequence(rmm::exec_policy(), data.begin(), data.end(), 1);
 
   auto null_mask = cudf::create_null_mask(100, cudf::mask_state::UNALLOCATED);
-  rmm::device_buffer data11{data.data() + 100, 100 * sizeof(int32_t), rmm::cuda_stream_default};
-  rmm::device_buffer data12{data.data() + 200, 100 * sizeof(int32_t), rmm::cuda_stream_default};
-  rmm::device_buffer data13{data.data() + 300, 100 * sizeof(int32_t), rmm::cuda_stream_default};
-  rmm::device_buffer data21{data.data() + 400, 100 * sizeof(int32_t), rmm::cuda_stream_default};
-  rmm::device_buffer data22{data.data() + 500, 100 * sizeof(int32_t), rmm::cuda_stream_default};
-  rmm::device_buffer data23{data.data() + 600, 100 * sizeof(int32_t), rmm::cuda_stream_default};
+  rmm::device_buffer data11{data.data() + 100, 100 * sizeof(int32_t), cudf::default_stream_value};
+  rmm::device_buffer data12{data.data() + 200, 100 * sizeof(int32_t), cudf::default_stream_value};
+  rmm::device_buffer data13{data.data() + 300, 100 * sizeof(int32_t), cudf::default_stream_value};
+  rmm::device_buffer data21{data.data() + 400, 100 * sizeof(int32_t), cudf::default_stream_value};
+  rmm::device_buffer data22{data.data() + 500, 100 * sizeof(int32_t), cudf::default_stream_value};
+  rmm::device_buffer data23{data.data() + 600, 100 * sizeof(int32_t), cudf::default_stream_value};
   auto gchild11 =
     std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
                                    100,

--- a/cpp/tests/column/factories_test.cpp
+++ b/cpp/tests/column/factories_test.cpp
@@ -24,6 +24,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -35,7 +36,7 @@ class ColumnFactoryTest : public cudf::test::BaseFixture {
 
  public:
   cudf::size_type size() { return _size; }
-  rmm::cuda_stream_view stream() { return rmm::cuda_stream_default; }
+  rmm::cuda_stream_view stream() { return cudf::default_stream_value; }
 };
 
 template <typename T>

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -22,6 +22,7 @@
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -52,7 +53,7 @@ template <typename T>
 struct TypedColumnTest : public cudf::test::BaseFixture {
   cudf::data_type type() { return cudf::data_type{cudf::type_to_id<T>()}; }
 
-  TypedColumnTest(rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+  TypedColumnTest(rmm::cuda_stream_view stream = cudf::default_stream_value)
     : data{_num_elements * cudf::size_of(type()), stream},
       mask{cudf::bitmask_allocation_size_bytes(_num_elements), stream}
   {
@@ -355,7 +356,7 @@ TEST_F(OverflowTest, OverflowTest)
     table_view tbl_last({*many_chars_last});
     std::vector<cudf::table_view> table_views_to_concat({tbl, tbl, tbl, tbl, tbl, tbl_last});
     std::unique_ptr<cudf::table> concatenated_tables = cudf::concatenate(table_views_to_concat);
-    EXPECT_NO_THROW(rmm::cuda_stream_default.synchronize());
+    EXPECT_NO_THROW(cudf::default_stream_value.synchronize());
     ASSERT_EQ(concatenated_tables->num_rows(), std::numeric_limits<size_type>::max());
   }
 

--- a/cpp/tests/copying/detail_gather_tests.cu
+++ b/cpp/tests/copying/detail_gather_tests.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -46,7 +47,7 @@ TYPED_TEST_SUITE(GatherTest, cudf::test::NumericTypes);
 TYPED_TEST(GatherTest, GatherDetailDeviceVectorTest)
 {
   constexpr cudf::size_type source_size{1000};
-  rmm::device_uvector<cudf::size_type> gather_map(source_size, rmm::cuda_stream_default);
+  rmm::device_uvector<cudf::size_type> gather_map(source_size, cudf::default_stream_value);
   thrust::sequence(thrust::device, gather_map.begin(), gather_map.end());
 
   auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });

--- a/cpp/tests/copying/scatter_list_tests.cpp
+++ b/cpp/tests/copying/scatter_list_tests.cpp
@@ -22,6 +22,7 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -68,7 +69,7 @@ TYPED_TEST(TypedScatterListsTest, SlicedInputLists)
   auto src_list_column =
     lists_column_wrapper<T, int32_t>{{0, 0, 0, 0}, {9, 9, 9, 9}, {8, 8, 8}, {7, 7, 7}}.release();
   auto src_sliced =
-    cudf::detail::slice(src_list_column->view(), {1, 3}, rmm::cuda_stream_default).front();
+    cudf::detail::slice(src_list_column->view(), {1, 3}, cudf::default_stream_value).front();
 
   auto target_list_column =
     lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}}
@@ -85,7 +86,7 @@ TYPED_TEST(TypedScatterListsTest, SlicedInputLists)
       {8, 8, 8}, {1, 1}, {9, 9, 9, 9}, {3, 3}, {4, 4}, {5, 5}, {6, 6}});
 
   auto target_sliced =
-    cudf::detail::slice(target_list_column->view(), {1, 6}, rmm::cuda_stream_default);
+    cudf::detail::slice(target_list_column->view(), {1, 6}, cudf::default_stream_value);
 
   auto ret_2 =
     cudf::scatter(cudf::table_view({src_sliced}), scatter_map, cudf::table_view({target_sliced}));

--- a/cpp/tests/copying/shift_tests.cpp
+++ b/cpp/tests/copying/shift_tests.cpp
@@ -22,6 +22,7 @@
 
 #include <cudf/copying.hpp>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -34,7 +35,7 @@ using TestTypes = cudf::test::Types<int32_t>;
 
 template <typename T, typename ScalarType = cudf::scalar_type_t<T>>
 std::unique_ptr<cudf::scalar> make_scalar(
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto s = new ScalarType(cudf::test::make_type_param_scalar<T>(0), false, stream, mr);
@@ -44,7 +45,7 @@ std::unique_ptr<cudf::scalar> make_scalar(
 template <typename T, typename ScalarType = cudf::scalar_type_t<T>>
 std::unique_ptr<cudf::scalar> make_scalar(
   T value,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   auto s = new ScalarType(value, true, stream, mr);

--- a/cpp/tests/device_atomics/device_atomics_test.cu
+++ b/cpp/tests/device_atomics/device_atomics_test.cu
@@ -16,14 +16,13 @@
 
 #include <cudf/detail/utilities/device_atomics.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/wrappers/timestamps.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/timestamp_utilities.cuh>
 #include <cudf_test/type_lists.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
 
 #include <thrust/host_vector.h>
 
@@ -155,7 +154,7 @@ struct AtomicsTest : public cudf::test::BaseFixture {
 
     auto host_result = cudf::detail::make_host_vector_sync(dev_result);
 
-    CUDF_CHECK_CUDA(rmm::cuda_stream_default.value());
+    CUDF_CHECK_CUDA(cudf::default_stream_value.value());
 
     if (!is_timestamp_sum<T, cudf::DeviceSum>()) {
       EXPECT_EQ(host_result[0], exact[0]) << "atomicAdd test failed";
@@ -302,7 +301,7 @@ struct AtomicsBitwiseOpTest : public cudf::test::BaseFixture {
 
     auto host_result = cudf::detail::make_host_vector_sync(dev_result);
 
-    CUDF_CHECK_CUDA(rmm::cuda_stream_default.value());
+    CUDF_CHECK_CUDA(cudf::default_stream_value.value());
 
     // print_exact(exact, "exact");
     // print_exact(host_result.data(), "result");

--- a/cpp/tests/fixed_point/fixed_point_tests.cu
+++ b/cpp/tests/fixed_point/fixed_point_tests.cu
@@ -21,9 +21,9 @@
 
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/reduce.h>
@@ -106,7 +106,7 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
 
   EXPECT_EQ(static_cast<int32_t>(res1), res2);
 
-  rmm::device_uvector<int32_t> d_vec3(1000, rmm::cuda_stream_default);
+  rmm::device_uvector<int32_t> d_vec3(1000, cudf::default_stream_value);
 
   thrust::transform(rmm::exec_policy(),
                     std::cbegin(d_vec1),

--- a/cpp/tests/groupby/lists_tests.cu
+++ b/cpp/tests/groupby/lists_tests.cu
@@ -26,8 +26,7 @@
 #include <cudf/table/experimental/row_operators.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/logical.h>
@@ -113,7 +112,7 @@ inline void test_hash_based_sum_agg(column_view const& keys,
   // resulting table: `t [num_rows, 2 * num_rows - 1]`
   auto combined_table = cudf::concatenate(std::vector{expected_kv, result_kv});
   auto preprocessed_t = cudf::experimental::row::hash::preprocessed_table::create(
-    combined_table->view(), rmm::cuda_stream_default);
+    combined_table->view(), cudf::default_stream_value);
   cudf::experimental::row::equality::self_comparator comparator(preprocessed_t);
 
   auto const null_keys_are_equal =

--- a/cpp/tests/groupby/tdigest_tests.cu
+++ b/cpp/tests/groupby/tdigest_tests.cu
@@ -18,6 +18,7 @@
 #include <cudf/detail/tdigest/tdigest.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/tdigest/tdigest_column_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -73,7 +74,7 @@ struct tdigest_groupby_simple_op {
     // make a simple set of matching keys.
     auto keys = cudf::make_fixed_width_column(
       data_type{type_id::INT32}, values.size(), mask_state::UNALLOCATED);
-    thrust::fill(rmm::exec_policy(rmm::cuda_stream_default),
+    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                  keys->mutable_view().template begin<int>(),
                  keys->mutable_view().template end<int>(),
                  0);
@@ -99,7 +100,7 @@ struct tdigest_groupby_simple_merge_op {
     // make a simple set of matching keys.
     auto merge_keys = cudf::make_fixed_width_column(
       data_type{type_id::INT32}, merge_values.size(), mask_state::UNALLOCATED);
-    thrust::fill(rmm::exec_policy(rmm::cuda_stream_default),
+    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                  merge_keys->mutable_view().template begin<int>(),
                  merge_keys->mutable_view().template end<int>(),
                  0);
@@ -271,7 +272,7 @@ TEST_F(TDigestMergeTest, Grouped)
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
   // 3 groups. 0-250000 in group 0.  250000-500000 in group 1 and 500000-750000 in group 1
   auto key_iter = cudf::detail::make_counting_transform_iterator(0, key_groups{});
-  thrust::copy(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::copy(rmm::exec_policy(cudf::default_stream_value),
                key_iter,
                key_iter + keys->size(),
                keys->mutable_view().template begin<int>());

--- a/cpp/tests/hash_map/map_test.cu
+++ b/cpp/tests/hash_map/map_test.cu
@@ -20,8 +20,8 @@
 #include <hash/concurrent_unordered_map.cuh>
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
@@ -56,13 +56,13 @@ struct InsertTest : public cudf::test::BaseFixture {
     // prevent overflow of small types
     const size_t input_size =
       std::min(static_cast<key_type>(size), std::numeric_limits<key_type>::max());
-    pairs.resize(input_size, rmm::cuda_stream_default);
+    pairs.resize(input_size, cudf::default_stream_value);
     map = std::move(map_type::create(compute_hash_table_size(size)));
-    rmm::cuda_stream_default.synchronize();
+    cudf::default_stream_value.synchronize();
   }
 
   const cudf::size_type size{10000};
-  rmm::device_uvector<pair_type> pairs{static_cast<std::size_t>(size), rmm::cuda_stream_default};
+  rmm::device_uvector<pair_type> pairs{static_cast<std::size_t>(size), cudf::default_stream_value};
   std::unique_ptr<map_type, std::function<void(map_type*)>> map;
 };
 

--- a/cpp/tests/io/comp/decomp_test.cpp
+++ b/cpp/tests/io/comp/decomp_test.cpp
@@ -17,9 +17,10 @@
 #include <io/comp/gpuinflate.hpp>
 #include <io/utilities/hostdevice_vector.hpp>
 
+#include <cudf/utilities/default_stream.hpp>
+
 #include <cudf_test/base_fixture.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -45,7 +46,7 @@ struct DecompressTest : public cudf::test::BaseFixture {
                   const uint8_t* compressed,
                   size_t compressed_size)
   {
-    auto stream = rmm::cuda_stream_default;
+    auto stream = cudf::default_stream_value;
     rmm::device_buffer src{compressed, compressed_size, stream};
     rmm::device_uvector<uint8_t> dst{decompressed->size(), stream};
 
@@ -81,7 +82,7 @@ struct GzipDecompressTest : public DecompressTest<GzipDecompressTest> {
                          d_inf_out,
                          d_inf_stat,
                          cudf::io::gzip_header_included::YES,
-                         rmm::cuda_stream_default);
+                         cudf::default_stream_value);
   }
 };
 
@@ -93,7 +94,7 @@ struct SnappyDecompressTest : public DecompressTest<SnappyDecompressTest> {
                 device_span<device_span<uint8_t>> d_inf_out,
                 device_span<cudf::io::decompress_status> d_inf_stat)
   {
-    cudf::io::gpu_unsnap(d_inf_in, d_inf_out, d_inf_stat, rmm::cuda_stream_default);
+    cudf::io::gpu_unsnap(d_inf_in, d_inf_out, d_inf_stat, cudf::default_stream_value);
   }
 };
 
@@ -106,14 +107,14 @@ struct BrotliDecompressTest : public DecompressTest<BrotliDecompressTest> {
                 device_span<cudf::io::decompress_status> d_inf_stat)
   {
     rmm::device_buffer d_scratch{cudf::io::get_gpu_debrotli_scratch_size(1),
-                                 rmm::cuda_stream_default};
+                                 cudf::default_stream_value};
 
     cudf::io::gpu_debrotli(d_inf_in,
                            d_inf_out,
                            d_inf_stat,
                            d_scratch.data(),
                            d_scratch.size(),
-                           rmm::cuda_stream_default);
+                           cudf::default_stream_value);
   }
 };
 

--- a/cpp/tests/iterator/iterator_tests.cuh
+++ b/cpp/tests/iterator/iterator_tests.cuh
@@ -21,8 +21,8 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/utilities/transform_unary_functions.cuh>  // for meanvar
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
@@ -50,7 +50,7 @@ struct IteratorTest : public cudf::test::BaseFixture {
   void iterator_test_cub(T_output expected, InputIterator d_in, int num_items)
   {
     T_output init = cudf::test::make_type_param_scalar<T_output>(0);
-    rmm::device_uvector<T_output> dev_result(1, rmm::cuda_stream_default);
+    rmm::device_uvector<T_output> dev_result(1, cudf::default_stream_value);
 
     // Get temporary storage size
     size_t temp_storage_bytes = 0;
@@ -58,7 +58,7 @@ struct IteratorTest : public cudf::test::BaseFixture {
       nullptr, temp_storage_bytes, d_in, dev_result.begin(), num_items, thrust::minimum{}, init);
 
     // Allocate temporary storage
-    rmm::device_buffer d_temp_storage(temp_storage_bytes, rmm::cuda_stream_default);
+    rmm::device_buffer d_temp_storage(temp_storage_bytes, cudf::default_stream_value);
 
     // Run reduction
     cub::DeviceReduce::Reduce(d_temp_storage.data(),
@@ -84,7 +84,7 @@ struct IteratorTest : public cudf::test::BaseFixture {
 
     // using a temporary vector and calling transform and all_of separately is
     // equivalent to thrust::equal but compiles ~3x faster
-    auto dev_results = rmm::device_uvector<bool>(num_items, rmm::cuda_stream_default);
+    auto dev_results = rmm::device_uvector<bool>(num_items, cudf::default_stream_value);
     thrust::transform(thrust::device,
                       d_in,
                       d_in_last,

--- a/cpp/tests/iterator/optional_iterator_test_numeric.cu
+++ b/cpp/tests/iterator/optional_iterator_test_numeric.cu
@@ -14,6 +14,8 @@
  */
 #include <tests/iterator/optional_iterator_test.cuh>
 
+#include <cudf/utilities/default_stream.hpp>
+
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/optional.h>
@@ -107,7 +109,7 @@ TYPED_TEST(NumericOptionalIteratorTest, mean_var_output)
 
   // this can be computed with a single reduce and without a temporary output vector
   // but the approach increases the compile time by ~2x
-  auto results = rmm::device_uvector<T_output>(d_col->size(), rmm::cuda_stream_default);
+  auto results = rmm::device_uvector<T_output>(d_col->size(), cudf::default_stream_value);
   thrust::transform(thrust::device,
                     it_dev_squared,
                     it_dev_squared + d_col->size(),

--- a/cpp/tests/join/conditional_join_tests.cu
+++ b/cpp/tests/join/conditional_join_tests.cu
@@ -18,12 +18,11 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/join.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/type_lists.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
 
 #include <thrust/equal.h>
 #include <thrust/execution_policy.h>
@@ -205,8 +204,8 @@ struct ConditionalJoinPairReturnTest : public ConditionalJoinTest<T> {
       // Note: Not trying to be terribly efficient here since these tests are
       // small, otherwise a batch copy to host before constructing the tuples
       // would be important.
-      result_pairs.push_back({result.first->element(i, rmm::cuda_stream_default),
-                              result.second->element(i, rmm::cuda_stream_default)});
+      result_pairs.push_back({result.first->element(i, cudf::default_stream_value),
+                              result.second->element(i, cudf::default_stream_value)});
     }
     std::sort(result_pairs.begin(), result_pairs.end());
     std::sort(expected_outputs.begin(), expected_outputs.end());
@@ -684,7 +683,7 @@ struct ConditionalJoinSingleReturnTest : public ConditionalJoinTest<T> {
       // Note: Not trying to be terribly efficient here since these tests are
       // small, otherwise a batch copy to host before constructing the tuples
       // would be important.
-      resulting_indices.push_back(result->element(i, rmm::cuda_stream_default));
+      resulting_indices.push_back(result->element(i, cudf::default_stream_value));
     }
     std::sort(resulting_indices.begin(), resulting_indices.end());
     std::sort(expected_outputs.begin(), expected_outputs.end());

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -27,6 +27,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <cudf_test/base_fixture.hpp>
@@ -1422,8 +1423,9 @@ TEST_F(JoinTest, HashJoinLargeOutputSize)
 {
   // self-join a table of zeroes to generate an output row count that would overflow int32_t
   std::size_t col_size = 65567;
-  rmm::device_buffer zeroes(col_size * sizeof(int32_t), rmm::cuda_stream_default);
-  CUDF_CUDA_TRY(cudaMemsetAsync(zeroes.data(), 0, zeroes.size(), rmm::cuda_stream_default.value()));
+  rmm::device_buffer zeroes(col_size * sizeof(int32_t), cudf::default_stream_value);
+  CUDF_CUDA_TRY(
+    cudaMemsetAsync(zeroes.data(), 0, zeroes.size(), cudf::default_stream_value.value()));
   cudf::column_view col_zeros(cudf::data_type{cudf::type_id::INT32}, col_size, zeroes.data());
   cudf::table_view tview{{col_zeros}};
   cudf::hash_join hash_join(tview, cudf::null_equality::UNEQUAL);

--- a/cpp/tests/join/mixed_join_tests.cu
+++ b/cpp/tests/join/mixed_join_tests.cu
@@ -18,12 +18,11 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/join.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/type_lists.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
 
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
@@ -229,8 +228,8 @@ struct MixedJoinPairReturnTest : public MixedJoinTest<T> {
       // Note: Not trying to be terribly efficient here since these tests are
       // small, otherwise a batch copy to host before constructing the tuples
       // would be important.
-      result_pairs.push_back({result.first->element(i, rmm::cuda_stream_default),
-                              result.second->element(i, rmm::cuda_stream_default)});
+      result_pairs.push_back({result.first->element(i, cudf::default_stream_value),
+                              result.second->element(i, cudf::default_stream_value)});
     }
     std::sort(result_pairs.begin(), result_pairs.end());
     std::sort(expected_outputs.begin(), expected_outputs.end());
@@ -587,8 +586,8 @@ struct MixedFullJoinTest : public MixedJoinPairReturnTest<T> {
       left_equality, right_equality, left_conditional, right_conditional, predicate, compare_nulls);
     std::vector<std::pair<cudf::size_type, cudf::size_type>> result_pairs;
     for (size_t i = 0; i < result.first->size(); ++i) {
-      result_pairs.push_back({result.first->element(i, rmm::cuda_stream_default),
-                              result.second->element(i, rmm::cuda_stream_default)});
+      result_pairs.push_back({result.first->element(i, cudf::default_stream_value),
+                              result.second->element(i, cudf::default_stream_value)});
     }
     std::sort(result_pairs.begin(), result_pairs.end());
     std::sort(expected_outputs.begin(), expected_outputs.end());
@@ -667,7 +666,7 @@ struct MixedJoinSingleReturnTest : public MixedJoinTest<T> {
       // Note: Not trying to be terribly efficient here since these tests are
       // small, otherwise a batch copy to host before constructing the tuples
       // would be important.
-      resulting_indices.push_back(result->element(i, rmm::cuda_stream_default));
+      resulting_indices.push_back(result->element(i, cudf::default_stream_value));
     }
     std::sort(resulting_indices.begin(), resulting_indices.end());
     std::sort(expected_outputs.begin(), expected_outputs.end());

--- a/cpp/tests/quantiles/percentile_approx_test.cu
+++ b/cpp/tests/quantiles/percentile_approx_test.cu
@@ -23,6 +23,7 @@
 #include <cudf/tdigest/tdigest_column_view.cuh>
 #include <cudf/transform.hpp>
 #include <cudf/unary.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -233,7 +234,7 @@ void simple_test(data_type input_type, std::vector<std::pair<int, int>> params)
   // all in the same group
   auto keys = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
-  thrust::fill(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                keys->mutable_view().template begin<int>(),
                keys->mutable_view().template end<int>(),
                0);
@@ -256,7 +257,7 @@ void grouped_test(data_type input_type, std::vector<std::pair<int, int>> params)
   auto keys = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
   auto i = thrust::make_counting_iterator(0);
-  thrust::transform(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     i,
                     i + values->size(),
                     keys->mutable_view().template begin<int>(),
@@ -281,7 +282,7 @@ void simple_with_nulls_test(data_type input_type, std::vector<std::pair<int, int
   // all in the same group
   auto keys = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
-  thrust::fill(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                keys->mutable_view().template begin<int>(),
                keys->mutable_view().template end<int>(),
                0);
@@ -303,7 +304,7 @@ void grouped_with_nulls_test(data_type input_type, std::vector<std::pair<int, in
   auto keys = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
   auto i = thrust::make_counting_iterator(0);
-  thrust::transform(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     i,
                     i + values->size(),
                     keys->mutable_view().template begin<int>(),

--- a/cpp/tests/quantiles/tdigest_utilities.cu
+++ b/cpp/tests/quantiles/tdigest_utilities.cu
@@ -18,6 +18,7 @@
 #include <cudf/concatenate.hpp>
 #include <cudf/detail/tdigest/tdigest.hpp>
 #include <cudf/tdigest/tdigest_column_view.cuh>
+#include <cudf/utilities/default_stream.hpp>
 
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/cudf_gtest.hpp>
@@ -53,7 +54,7 @@ void tdigest_sample_compare(cudf::tdigest::tdigest_column_view const& tdv,
   rmm::device_vector<expected_value> expected(h_expected.begin(), h_expected.end());
   auto iter = thrust::make_counting_iterator(0);
   thrust::for_each(
-    rmm::exec_policy(rmm::cuda_stream_default),
+    rmm::exec_policy(cudf::default_stream_value),
     iter,
     iter + expected.size(),
     [expected            = expected.data().get(),
@@ -100,13 +101,13 @@ std::unique_ptr<column> make_expected_tdigest_column(std::vector<expected_tdiges
 
     auto min_col =
       cudf::make_fixed_width_column(data_type{type_id::FLOAT64}, 1, mask_state::UNALLOCATED);
-    thrust::fill(rmm::exec_policy(rmm::cuda_stream_default),
+    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                  min_col->mutable_view().begin<double>(),
                  min_col->mutable_view().end<double>(),
                  tdigest.min);
     auto max_col =
       cudf::make_fixed_width_column(data_type{type_id::FLOAT64}, 1, mask_state::UNALLOCATED);
-    thrust::fill(rmm::exec_policy(rmm::cuda_stream_default),
+    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                  max_col->mutable_view().begin<double>(),
                  max_col->mutable_view().end<double>(),
                  tdigest.max);

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -26,6 +26,7 @@
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -175,8 +176,8 @@ TEST_F(ReplaceNullsStringsTest, SimpleReplaceScalar)
   std::vector<std::string> input{"", "", "", "", "", "", "", ""};
   std::vector<cudf::valid_type> input_v{0, 0, 0, 0, 0, 0, 0, 0};
   std::unique_ptr<cudf::scalar> repl =
-    cudf::make_string_scalar("rep", rmm::cuda_stream_default, mr());
-  repl->set_valid_async(true, rmm::cuda_stream_default);
+    cudf::make_string_scalar("rep", cudf::default_stream_value, mr());
+  repl->set_valid_async(true, cudf::default_stream_value);
   std::vector<std::string> expected{"rep", "rep", "rep", "rep", "rep", "rep", "rep", "rep"};
 
   cudf::test::strings_column_wrapper input_w{input.begin(), input.end(), input_v.begin()};

--- a/cpp/tests/scalar/factories_test.cpp
+++ b/cpp/tests/scalar/factories_test.cpp
@@ -21,13 +21,14 @@
 
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
 class ScalarFactoryTest : public cudf::test::BaseFixture {
  public:
-  rmm::cuda_stream_view stream() { return rmm::cuda_stream_default; }
+  rmm::cuda_stream_view stream() { return cudf::default_stream_value; }
 };
 
 template <typename T>

--- a/cpp/tests/scalar/scalar_device_view_test.cu
+++ b/cpp/tests/scalar/scalar_device_view_test.cu
@@ -19,6 +19,7 @@
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/cudf_gtest.hpp>
@@ -26,7 +27,6 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <random>
-#include <rmm/cuda_stream_view.hpp>
 #include <thrust/sequence.h>
 
 template <typename T>
@@ -57,7 +57,7 @@ TYPED_TEST(TypedScalarDeviceViewTest, Value)
 
   auto scalar_device_view  = cudf::get_scalar_device_view(s);
   auto scalar_device_view1 = cudf::get_scalar_device_view(s1);
-  rmm::device_scalar<bool> result{rmm::cuda_stream_default};
+  rmm::device_scalar<bool> result{cudf::default_stream_value};
 
   test_set_value<<<1, 1>>>(scalar_device_view, scalar_device_view1);
   CUDF_CHECK_CUDA(0);
@@ -68,7 +68,7 @@ TYPED_TEST(TypedScalarDeviceViewTest, Value)
   test_value<<<1, 1>>>(scalar_device_view, scalar_device_view1, result.data());
   CUDF_CHECK_CUDA(0);
 
-  EXPECT_TRUE(result.value(rmm::cuda_stream_default));
+  EXPECT_TRUE(result.value(cudf::default_stream_value));
 }
 
 template <typename ScalarDeviceViewType>
@@ -82,12 +82,12 @@ TYPED_TEST(TypedScalarDeviceViewTest, ConstructNull)
   TypeParam value = cudf::test::make_type_param_scalar<TypeParam>(5);
   cudf::scalar_type_t<TypeParam> s(value, false);
   auto scalar_device_view = cudf::get_scalar_device_view(s);
-  rmm::device_scalar<bool> result{rmm::cuda_stream_default};
+  rmm::device_scalar<bool> result{cudf::default_stream_value};
 
   test_null<<<1, 1>>>(scalar_device_view, result.data());
   CUDF_CHECK_CUDA(0);
 
-  EXPECT_FALSE(result.value(rmm::cuda_stream_default));
+  EXPECT_FALSE(result.value(cudf::default_stream_value));
 }
 
 template <typename ScalarDeviceViewType>
@@ -127,11 +127,11 @@ TEST_F(StringScalarDeviceViewTest, Value)
   cudf::string_scalar s(value);
 
   auto scalar_device_view = cudf::get_scalar_device_view(s);
-  rmm::device_scalar<bool> result{rmm::cuda_stream_default};
+  rmm::device_scalar<bool> result{cudf::default_stream_value};
   auto value_v = cudf::detail::make_device_uvector_sync(value);
 
   test_string_value<<<1, 1>>>(scalar_device_view, value_v.data(), value.size(), result.data());
   CUDF_CHECK_CUDA(0);
 
-  EXPECT_TRUE(result.value(rmm::cuda_stream_default));
+  EXPECT_TRUE(result.value(cudf::default_stream_value));
 }

--- a/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
@@ -21,6 +21,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -271,7 +272,7 @@ TEST_F(ApplyBooleanMask, CorrectNullCount)
   auto got     = cudf::apply_boolean_mask(input, boolean_mask);
   auto out_col = got->get_column(0).view();
   auto expected_null_count =
-    cudf::detail::null_count(out_col.null_mask(), 0, out_col.size(), rmm::cuda_stream_default);
+    cudf::detail::null_count(out_col.null_mask(), 0, out_col.size(), cudf::default_stream_value);
 
   ASSERT_EQ(out_col.null_count(), expected_null_count);
 }

--- a/cpp/tests/types/type_dispatcher_test.cu
+++ b/cpp/tests/types/type_dispatcher_test.cu
@@ -16,13 +16,13 @@
 
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 struct DispatcherTest : public cudf::test::BaseFixture {
@@ -72,7 +72,7 @@ TYPED_TEST(TypedDispatcherTest, DeviceDispatch)
   auto result = cudf::detail::make_zeroed_device_uvector_sync<bool>(1);
   dispatch_test_kernel<<<1, 1>>>(cudf::type_to_id<TypeParam>(), result.data());
   CUDF_CUDA_TRY(cudaDeviceSynchronize());
-  EXPECT_EQ(true, result.front_element(rmm::cuda_stream_default));
+  EXPECT_EQ(true, result.front_element(cudf::default_stream_value));
 }
 
 struct IdDispatcherTest : public DispatcherTest, public testing::WithParamInterface<cudf::type_id> {
@@ -133,7 +133,7 @@ TYPED_TEST(TypedDoubleDispatcherTest, DeviceDoubleDispatch)
   double_dispatch_test_kernel<<<1, 1>>>(
     cudf::type_to_id<TypeParam>(), cudf::type_to_id<TypeParam>(), result.data());
   CUDF_CUDA_TRY(cudaDeviceSynchronize());
-  EXPECT_EQ(true, result.front_element(rmm::cuda_stream_default));
+  EXPECT_EQ(true, result.front_element(cudf::default_stream_value));
 }
 
 struct IdDoubleDispatcherTest : public DispatcherTest,

--- a/cpp/tests/unary/cast_tests.cpp
+++ b/cpp/tests/unary/cast_tests.cpp
@@ -24,6 +24,7 @@
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/unary.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/wrappers/timestamps.hpp>
 
 #include <thrust/host_vector.h>
@@ -89,70 +90,70 @@ inline cudf::column make_exp_chrono_column(cudf::type_id type_id)
         test_timestamps_D.size(),
         rmm::device_buffer{test_timestamps_D.data(),
                            test_timestamps_D.size() * sizeof(test_timestamps_D.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     case cudf::type_id::TIMESTAMP_SECONDS:
       return cudf::column(
         cudf::data_type{type_id},
         test_timestamps_s.size(),
         rmm::device_buffer{test_timestamps_s.data(),
                            test_timestamps_s.size() * sizeof(test_timestamps_s.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     case cudf::type_id::TIMESTAMP_MILLISECONDS:
       return cudf::column(
         cudf::data_type{type_id},
         test_timestamps_ms.size(),
         rmm::device_buffer{test_timestamps_ms.data(),
                            test_timestamps_ms.size() * sizeof(test_timestamps_ms.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     case cudf::type_id::TIMESTAMP_MICROSECONDS:
       return cudf::column(
         cudf::data_type{type_id},
         test_timestamps_us.size(),
         rmm::device_buffer{test_timestamps_us.data(),
                            test_timestamps_us.size() * sizeof(test_timestamps_us.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     case cudf::type_id::TIMESTAMP_NANOSECONDS:
       return cudf::column(
         cudf::data_type{type_id},
         test_timestamps_ns.size(),
         rmm::device_buffer{test_timestamps_ns.data(),
                            test_timestamps_ns.size() * sizeof(test_timestamps_ns.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     case cudf::type_id::DURATION_DAYS:
       return cudf::column(
         cudf::data_type{type_id},
         test_durations_D.size(),
         rmm::device_buffer{test_durations_D.data(),
                            test_durations_D.size() * sizeof(test_durations_D.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     case cudf::type_id::DURATION_SECONDS:
       return cudf::column(
         cudf::data_type{type_id},
         test_durations_s.size(),
         rmm::device_buffer{test_durations_s.data(),
                            test_durations_s.size() * sizeof(test_durations_s.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     case cudf::type_id::DURATION_MILLISECONDS:
       return cudf::column(
         cudf::data_type{type_id},
         test_durations_ms.size(),
         rmm::device_buffer{test_durations_ms.data(),
                            test_durations_ms.size() * sizeof(test_durations_ms.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     case cudf::type_id::DURATION_MICROSECONDS:
       return cudf::column(
         cudf::data_type{type_id},
         test_durations_us.size(),
         rmm::device_buffer{test_durations_us.data(),
                            test_durations_us.size() * sizeof(test_durations_us.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     case cudf::type_id::DURATION_NANOSECONDS:
       return cudf::column(
         cudf::data_type{type_id},
         test_durations_ns.size(),
         rmm::device_buffer{test_durations_ns.data(),
                            test_durations_ns.size() * sizeof(test_durations_ns.front()),
-                           rmm::cuda_stream_default});
+                           cudf::default_stream_value});
     default: CUDF_FAIL("Unsupported type_id");
   }
 };

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -27,6 +27,7 @@
 #include <cudf/table/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <cudf_test/column_utilities.hpp>
@@ -36,7 +37,6 @@
 
 #include <jit/type.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/copy.h>
@@ -103,7 +103,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   // if we are checking for exact equality, we should be checking for "unsanitized" data that may
   // be hiding underneath nulls. so check all rows instead of just non-null rows
   if (check_exact_equality) {
-    return generate_all_row_indices(c.get_sliced_child(rmm::cuda_stream_default).size());
+    return generate_all_row_indices(c.get_sliced_child(cudf::default_stream_value).size());
   }
 
   // Example input
@@ -170,7 +170,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
      offsets      = c.offsets().begin<offset_type>(),
      offset       = c.offset(),
      first_offset = cudf::detail::get_value<offset_type>(
-       c.offsets(), c.offset(), rmm::cuda_stream_default)] __device__(int index) {
+       c.offsets(), c.offset(), cudf::default_stream_value)] __device__(int index) {
       auto const true_index = row_indices[index] + offset;
       return offsets[true_index] - first_offset;
     });
@@ -326,8 +326,8 @@ struct column_property_comparator {
     auto lhs_child_indices =
       generate_child_row_indices(lhs_l, lhs_row_indices, check_exact_equality);
     if (lhs_child_indices->size() > 0) {
-      auto lhs_child = lhs_l.get_sliced_child(rmm::cuda_stream_default);
-      auto rhs_child = rhs_l.get_sliced_child(rmm::cuda_stream_default);
+      auto lhs_child = lhs_l.get_sliced_child(cudf::default_stream_value);
+      auto rhs_child = rhs_l.get_sliced_child(cudf::default_stream_value);
       auto rhs_child_indices =
         generate_child_row_indices(rhs_l, rhs_row_indices, check_exact_equality);
       return cudf::type_dispatcher(lhs_child.type(),
@@ -514,9 +514,9 @@ std::string stringify_column_differences(cudf::device_span<int const> difference
     auto const index = h_differences[0];  // only stringify first difference
 
     auto const lhs_index =
-      cudf::detail::get_value<size_type>(lhs_row_indices, index, rmm::cuda_stream_default);
+      cudf::detail::get_value<size_type>(lhs_row_indices, index, cudf::default_stream_value);
     auto const rhs_index =
-      cudf::detail::get_value<size_type>(rhs_row_indices, index, rmm::cuda_stream_default);
+      cudf::detail::get_value<size_type>(rhs_row_indices, index, cudf::default_stream_value);
     auto diff_lhs = cudf::detail::slice(lhs, lhs_index, lhs_index + 1);
     auto diff_rhs = cudf::detail::slice(rhs, rhs_index, rhs_index + 1);
     return depth_str + "first difference: " + "lhs[" + std::to_string(index) +
@@ -547,7 +547,7 @@ struct column_comparator_impl {
                                               corresponding_rows_not_equivalent>;
 
     auto differences = rmm::device_uvector<int>(
-      lhs.size(), rmm::cuda_stream_default);  // worst case: everything different
+      lhs.size(), cudf::default_stream_value);  // worst case: everything different
     auto input_iter = thrust::make_counting_iterator(0);
     auto diff_iter  = thrust::copy_if(
       rmm::exec_policy(),
@@ -557,7 +557,7 @@ struct column_comparator_impl {
       ComparatorType(*d_lhs, *d_rhs, *d_lhs_row_indices, *d_rhs_row_indices, fp_ulps));
 
     differences.resize(thrust::distance(differences.begin(), diff_iter),
-                       rmm::cuda_stream_default);  // shrink back down
+                       cudf::default_stream_value);  // shrink back down
 
     if (not differences.is_empty()) {
       if (verbosity != debug_output_level::QUIET) {
@@ -595,13 +595,13 @@ struct column_comparator_impl<list_view, check_exact_equality> {
     if (lhs_row_indices.is_empty()) { return true; }
 
     // worst case - everything is different
-    rmm::device_uvector<int> differences(lhs_row_indices.size(), rmm::cuda_stream_default);
+    rmm::device_uvector<int> differences(lhs_row_indices.size(), cudf::default_stream_value);
 
     // compare offsets, taking slicing into account
 
     // left side
-    size_type lhs_shift =
-      cudf::detail::get_value<size_type>(lhs_l.offsets(), lhs_l.offset(), rmm::cuda_stream_default);
+    size_type lhs_shift = cudf::detail::get_value<size_type>(
+      lhs_l.offsets(), lhs_l.offset(), cudf::default_stream_value);
     auto lhs_offsets = thrust::make_transform_iterator(
       lhs_l.offsets().begin<size_type>() + lhs_l.offset(),
       [lhs_shift] __device__(size_type offset) { return offset - lhs_shift; });
@@ -612,8 +612,8 @@ struct column_comparator_impl<list_view, check_exact_equality> {
       });
 
     // right side
-    size_type rhs_shift =
-      cudf::detail::get_value<size_type>(rhs_l.offsets(), rhs_l.offset(), rmm::cuda_stream_default);
+    size_type rhs_shift = cudf::detail::get_value<size_type>(
+      rhs_l.offsets(), rhs_l.offset(), cudf::default_stream_value);
     auto rhs_offsets = thrust::make_transform_iterator(
       rhs_l.offsets().begin<size_type>() + rhs_l.offset(),
       [rhs_shift] __device__(size_type offset) { return offset - rhs_shift; });
@@ -677,7 +677,7 @@ struct column_comparator_impl<list_view, check_exact_equality> {
       });
 
     differences.resize(thrust::distance(differences.begin(), diff_iter),
-                       rmm::cuda_stream_default);  // shrink back down
+                       cudf::default_stream_value);  // shrink back down
 
     if (not differences.is_empty()) {
       if (verbosity != debug_output_level::QUIET) {
@@ -696,8 +696,8 @@ struct column_comparator_impl<list_view, check_exact_equality> {
     auto lhs_child_indices =
       generate_child_row_indices(lhs_l, lhs_row_indices, check_exact_equality);
     if (lhs_child_indices->size() > 0) {
-      auto lhs_child = lhs_l.get_sliced_child(rmm::cuda_stream_default);
-      auto rhs_child = rhs_l.get_sliced_child(rmm::cuda_stream_default);
+      auto lhs_child = lhs_l.get_sliced_child(cudf::default_stream_value);
+      auto rhs_child = rhs_l.get_sliced_child(cudf::default_stream_value);
       auto rhs_child_indices =
         generate_child_row_indices(rhs_l, rhs_row_indices, check_exact_equality);
       return cudf::type_dispatcher(lhs_child.type(),
@@ -935,8 +935,8 @@ std::string nested_offsets_to_string(NestedColumnView const& c, std::string cons
 
   // the first offset value to normalize everything against
   size_type first =
-    cudf::detail::get_value<size_type>(offsets, c.offset(), rmm::cuda_stream_default);
-  rmm::device_uvector<size_type> shifted_offsets(output_size, rmm::cuda_stream_default);
+    cudf::detail::get_value<size_type>(offsets, c.offset(), cudf::default_stream_value);
+  rmm::device_uvector<size_type> shifted_offsets(output_size, cudf::default_stream_value);
 
   // normalize the offset values for the column offset
   size_type const* d_offsets = offsets.head<size_type>() + c.offset();
@@ -1104,7 +1104,7 @@ struct column_view_printer {
     lists_column_view lcv(col);
 
     // propagate slicing to the child if necessary
-    column_view child    = lcv.get_sliced_child(rmm::cuda_stream_default);
+    column_view child    = lcv.get_sliced_child(cudf::default_stream_value);
     bool const is_sliced = lcv.offset() > 0 || child.offset() > 0;
 
     std::string tmp =

--- a/cpp/tests/utilities_tests/span_tests.cu
+++ b/cpp/tests/utilities_tests/span_tests.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 #include <io/utilities/hostdevice_vector.hpp>
 
@@ -214,7 +215,7 @@ TEST(SpanTest, CanConstructFromDeviceContainers)
 {
   auto d_thrust_vector = thrust::device_vector<int>(1);
   auto d_vector        = rmm::device_vector<int>(1);
-  auto d_uvector       = rmm::device_uvector<int>(1, rmm::cuda_stream_default);
+  auto d_uvector       = rmm::device_uvector<int>(1, cudf::default_stream_value);
 
   (void)device_span<int>(d_thrust_vector);
   (void)device_span<int>(d_vector);
@@ -251,9 +252,9 @@ class MdSpanTest : public cudf::test::BaseFixture {
 
 TEST(MdSpanTest, CanDetermineEmptiness)
 {
-  auto const vector            = hostdevice_2dvector<int>(1, 2, rmm::cuda_stream_default);
-  auto const no_rows_vector    = hostdevice_2dvector<int>(0, 2, rmm::cuda_stream_default);
-  auto const no_columns_vector = hostdevice_2dvector<int>(1, 0, rmm::cuda_stream_default);
+  auto const vector            = hostdevice_2dvector<int>(1, 2, cudf::default_stream_value);
+  auto const no_rows_vector    = hostdevice_2dvector<int>(0, 2, cudf::default_stream_value);
+  auto const no_columns_vector = hostdevice_2dvector<int>(1, 0, cudf::default_stream_value);
 
   EXPECT_FALSE(host_2dspan<int const>{vector}.is_empty());
   EXPECT_FALSE(device_2dspan<int const>{vector}.is_empty());
@@ -274,17 +275,17 @@ __global__ void readwrite_kernel(device_2dspan<int> result)
 
 TEST(MdSpanTest, DeviceReadWrite)
 {
-  auto vector = hostdevice_2dvector<int>(11, 23, rmm::cuda_stream_default);
+  auto vector = hostdevice_2dvector<int>(11, 23, cudf::default_stream_value);
 
   readwrite_kernel<<<1, 1>>>(vector);
   readwrite_kernel<<<1, 1>>>(vector);
-  vector.device_to_host(rmm::cuda_stream_default, true);
+  vector.device_to_host(cudf::default_stream_value, true);
   EXPECT_EQ(vector[5][6], 30);
 }
 
 TEST(MdSpanTest, HostReadWrite)
 {
-  auto vector = hostdevice_2dvector<int>(11, 23, rmm::cuda_stream_default);
+  auto vector = hostdevice_2dvector<int>(11, 23, cudf::default_stream_value);
   auto span   = host_2dspan<int>{vector};
   span[5][6]  = 5;
   if (span[5][6] == 5) { span[5][6] *= 6; }
@@ -294,7 +295,7 @@ TEST(MdSpanTest, HostReadWrite)
 
 TEST(MdSpanTest, CanGetSize)
 {
-  auto const vector = hostdevice_2dvector<int>(1, 2, rmm::cuda_stream_default);
+  auto const vector = hostdevice_2dvector<int>(1, 2, cudf::default_stream_value);
 
   EXPECT_EQ(host_2dspan<int const>{vector}.size(), vector.size());
   EXPECT_EQ(device_2dspan<int const>{vector}.size(), vector.size());
@@ -302,7 +303,7 @@ TEST(MdSpanTest, CanGetSize)
 
 TEST(MdSpanTest, CanGetCount)
 {
-  auto const vector = hostdevice_2dvector<int>(11, 23, rmm::cuda_stream_default);
+  auto const vector = hostdevice_2dvector<int>(11, 23, cudf::default_stream_value);
 
   EXPECT_EQ(host_2dspan<int const>{vector}.count(), 11ul * 23);
   EXPECT_EQ(device_2dspan<int const>{vector}.count(), 11ul * 23);

--- a/cpp/tests/wrappers/timestamps_test.cu
+++ b/cpp/tests/wrappers/timestamps_test.cu
@@ -25,6 +25,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/wrappers/durations.hpp>
 #include <cudf/wrappers/timestamps.hpp>
 
@@ -37,7 +38,7 @@
 
 template <typename T>
 struct ChronoColumnTest : public cudf::test::BaseFixture {
-  rmm::cuda_stream_view stream() { return rmm::cuda_stream_default; }
+  rmm::cuda_stream_view stream() { return cudf::default_stream_value; }
   cudf::size_type size() { return cudf::size_type(100); }
   cudf::data_type type() { return cudf::data_type{cudf::type_to_id<T>()}; }
 };
@@ -92,7 +93,7 @@ TYPED_TEST(ChronoColumnTest, ChronoDurationsMatchPrimitiveRepresentation)
   auto primitive_col =
     fixed_width_column_wrapper<Rep>(chrono_col_data.begin(), chrono_col_data.end());
 
-  rmm::device_uvector<int32_t> indices(this->size(), rmm::cuda_stream_default);
+  rmm::device_uvector<int32_t> indices(this->size(), cudf::default_stream_value);
   thrust::sequence(rmm::exec_policy(), indices.begin(), indices.end());
   EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
                              indices.begin(),
@@ -146,7 +147,7 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
   auto chrono_rhs_col =
     generate_timestamps<T>(this->size(), time_point_ms(start_rhs), time_point_ms(stop_rhs));
 
-  rmm::device_uvector<int32_t> indices(this->size(), rmm::cuda_stream_default);
+  rmm::device_uvector<int32_t> indices(this->size(), cudf::default_stream_value);
   thrust::sequence(rmm::exec_policy(), indices.begin(), indices.end());
 
   EXPECT_TRUE(thrust::all_of(

--- a/java/src/main/native/include/maps_column_view.hpp
+++ b/java/src/main/native/include/maps_column_view.hpp
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/lists/lists_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf {
@@ -37,7 +38,7 @@ namespace jni {
 class maps_column_view {
 public:
   maps_column_view(lists_column_view const &lists_of_structs,
-                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                   rmm::cuda_stream_view stream = cudf::default_stream_value);
 
   // Rule of 5.
   maps_column_view(maps_column_view const &maps_view) = default;
@@ -81,7 +82,7 @@ public:
    * @return std::unique_ptr<column> Column of values corresponding the value of the lookup key.
    */
   std::unique_ptr<column> get_values_for(
-      column_view const &keys, rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+      column_view const &keys, rmm::cuda_stream_view stream = cudf::default_stream_value,
       rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource()) const;
 
   /**
@@ -99,7 +100,7 @@ public:
    * @return std::unique_ptr<column>
    */
   std::unique_ptr<column> get_values_for(
-      scalar const &key, rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+      scalar const &key, rmm::cuda_stream_view stream = cudf::default_stream_value,
       rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource()) const;
 
   /**
@@ -119,7 +120,7 @@ public:
    * @return std::unique_ptr<column>
    */
   std::unique_ptr<column>
-  contains(scalar const &key, rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+  contains(scalar const &key, rmm::cuda_stream_view stream = cudf::default_stream_value,
            rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource()) const;
 
 private:

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -72,6 +72,7 @@
 #include <cudf/types.hpp>
 #include <cudf/unary.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 #include "cudf_jni_apis.hpp"
 #include "dtype_utils.hpp"
@@ -480,7 +481,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicatesWithKey
 
     // Extract list offsets and a column of struct<keys, values> from the input lists column.
     auto const lists_keys_vals = cudf::lists_column_view(*input_cv);
-    auto const keys_vals = lists_keys_vals.get_sliced_child(rmm::cuda_stream_default);
+    auto const keys_vals = lists_keys_vals.get_sliced_child(cudf::default_stream_value);
     CUDF_EXPECTS(keys_vals.type().id() == cudf::type_id::STRUCT,
                  "Input column has child that is not a structs column.");
     CUDF_EXPECTS(keys_vals.num_children() == 2,

--- a/java/src/main/native/src/ColumnViewJni.hpp
+++ b/java/src/main/native/src/ColumnViewJni.hpp
@@ -15,6 +15,7 @@
  */
 
 #include <cudf/column/column.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf::jni {
@@ -49,6 +50,6 @@ new_column_with_boolean_column_as_validity(cudf::column_view const &exemplar,
  */
 std::unique_ptr<cudf::column>
 generate_list_offsets(cudf::column_view const &list_length,
-                      rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                      rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 } // namespace cudf::jni

--- a/java/src/main/native/src/aggregation128_utils.hpp
+++ b/java/src/main/native/src/aggregation128_utils.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf::jni {
@@ -40,7 +41,7 @@ namespace cudf::jni {
  */
 std::unique_ptr<cudf::column>
 extract_chunk32(cudf::column_view const &col, cudf::data_type dtype, int chunk_idx,
-                rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 /**
  * @brief Reassemble a 128-bit column from four 64-bit integer columns with overflow detection.
@@ -64,6 +65,6 @@ extract_chunk32(cudf::column_view const &col, cudf::data_type dtype, int chunk_i
  */
 std::unique_ptr<cudf::table>
 assemble128_from_sum(cudf::table_view const &chunks_table, cudf::data_type output_type,
-                     rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                     rmm::cuda_stream_view stream = cudf::default_stream_value);
 
 } // namespace cudf::jni

--- a/java/src/main/native/src/map_lookup.hpp
+++ b/java/src/main/native/src/map_lookup.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/column/column.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf {
@@ -48,7 +49,7 @@ namespace jni {
  */
 std::unique_ptr<column>
 map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nulls = true,
-           rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+           rmm::cuda_stream_view stream = cudf::default_stream_value,
            rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -79,7 +80,7 @@ map_lookup(column_view const &map_column, string_scalar lookup_key, bool has_nul
  */
 std::unique_ptr<column>
 map_contains(column_view const &map_column, string_scalar lookup_key, bool has_nulls = true,
-             rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+             rmm::cuda_stream_view stream = cudf::default_stream_value,
              rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 } // namespace jni

--- a/java/src/main/native/src/row_conversion.cu
+++ b/java/src/main/native/src/row_conversion.cu
@@ -27,6 +27,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <rmm/cuda_stream_view.hpp>
@@ -1396,7 +1397,7 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
       input_data.data(), input_nm.data(), data->mutable_view().data<int8_t>());
 
   return make_lists_column(num_rows, std::move(offsets), std::move(data), 0,
-                           rmm::device_buffer{0, rmm::cuda_stream_default, mr}, stream, mr);
+                           rmm::device_buffer{0, cudf::default_stream_value, mr}, stream, mr);
 }
 
 static inline bool are_all_fixed_width(std::vector<data_type> const &schema) {
@@ -2001,7 +2002,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
 
                    return make_lists_column(
                        batch_info.row_batches[batch].row_count, std::move(offsets), std::move(data),
-                       0, rmm::device_buffer{0, rmm::cuda_stream_default, mr}, stream, mr);
+                       0, rmm::device_buffer{0, cudf::default_stream_value, mr}, stream, mr);
                  });
 
   return ret;

--- a/java/src/main/native/src/row_conversion.hpp
+++ b/java/src/main/native/src/row_conversion.hpp
@@ -20,6 +20,7 @@
 
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf {
@@ -28,23 +29,23 @@ namespace jni {
 std::vector<std::unique_ptr<cudf::column>> convert_to_rows_fixed_width_optimized(
     cudf::table_view const &tbl,
     // TODO need something for validity
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+    rmm::cuda_stream_view stream = cudf::default_stream_value,
     rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 std::vector<std::unique_ptr<cudf::column>>
 convert_to_rows(cudf::table_view const &tbl,
                 // TODO need something for validity
-                rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+                rmm::cuda_stream_view stream = cudf::default_stream_value,
                 rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::table> convert_from_rows_fixed_width_optimized(
     cudf::lists_column_view const &input, std::vector<cudf::data_type> const &schema,
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+    rmm::cuda_stream_view stream = cudf::default_stream_value,
     rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::table>
 convert_from_rows(cudf::lists_column_view const &input, std::vector<cudf::data_type> const &schema,
-                  rmm::cuda_stream_view stream = rmm::cuda_stream_default,
+                  rmm::cuda_stream_view stream = cudf::default_stream_value,
                   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 } // namespace jni


### PR DESCRIPTION
Closes #10864.
Also closes #9614.

This PR is a follow-up to #10877.  It replaces all of the remaining instances of `rmm::cuda_stream_default` with `cudf::default_stream_value`.

There are a lot of replacements and addition of includes, along with some reformatting due to clang-format, but like #10877, there should be no noticeable functional change here.
