### PR TITLE
Exclude CudaFatalTest when selecting all Java tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -169,7 +169,7 @@ function buildLibCudfJniInDocker {
                 -DUSE_GDS=ON \
                 -DGPU_ARCHS=${CUDF_CMAKE_CUDA_ARCHITECTURES} \
                 -DCUDF_JNI_LIBCUDF_STATIC=ON \
-                -Dtest=*,!CuFileTest"
+                -Dtest=*,!CuFileTest,!CudaFatalTest"
 }
 
 if hasArg -h || hasArg --h || hasArg --help; then

--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -78,7 +78,7 @@ BUILD_ARG="-Dmaven.repo.local=\"$WORKSPACE/.m2\"\
  -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=$ENABLE_PTDS\
  -DCUDA_STATIC_RUNTIME=$ENABLE_CUDA_STATIC_RUNTIME\
  -DCUDF_JNI_LIBCUDF_STATIC=ON\
- -DUSE_GDS=$ENABLE_GDS -Dtest=*,!CuFileTest"
+ -DUSE_GDS=$ENABLE_GDS -Dtest=*,!CuFileTest,!CudaFatalTest"
 
 if [ "$SIGN_FILE" == true ]; then
     # Build javadoc and sources only when SIGN_FILE is true


### PR DESCRIPTION
#10884 added a test that generates a CUDA fatal error, requiring a separate JVM process to avoid the error leaking into subsequent tests.  There are some CI scripts that are selecting all tests and then deselecting some, and this new test needs to be also excluded to avoid running it in the same JVM as other tests.