### PR TITLE
Add strong index type adapters for `cudf::experimental::row::` operators

### DIFF
--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -70,9 +70,11 @@ namespace {
 using map_type = concurrent_unordered_map<
   cudf::size_type,
   cudf::size_type,
-  cudf::experimental::row::hash::device_row_hasher<cudf::detail::default_hash,
-                                                   cudf::nullate::DYNAMIC>,
-  cudf::experimental::row::equality::device_row_comparator<cudf::nullate::DYNAMIC>>;
+  cudf::experimental::row::hash::strong_index_hasher_adapter<
+    cudf::experimental::row::hash::device_row_hasher<cudf::detail::default_hash,
+                                                     cudf::nullate::DYNAMIC>>,
+  cudf::experimental::row::equality::strong_index_self_comparator_adapter<
+    cudf::experimental::row::equality::device_row_comparator<cudf::nullate::DYNAMIC>>>;
 
 /**
  * @brief List of aggregation operations that can be computed with a hash-based


### PR DESCRIPTION
Row operators for two tables such as equality comparison require strong index types. As such, the users need to feed into the comparator some input iterators of strong index types for the comparison. However, on each of the comparing tables, we may also want to perform self-comparison or hashing on its rows. Unfortunately, the current implementation of table self comparators and row hasher only accepts `size_type` input for row indices.

This PR adds strong index type adapters for the table self comparators and row hasher.