### PR TITLE
Support octal and hex within regex character class pattern

### DIFF
--- a/cpp/tests/strings/contains_tests.cpp
+++ b/cpp/tests/strings/contains_tests.cpp
@@ -279,6 +279,10 @@ TEST_F(StringsContainsTests, HexTest)
       0, [ch](auto idx) { return ch == static_cast<char>(idx); });
     cudf::test::fixed_width_column_wrapper<bool> expected(true_dat, true_dat + count);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+    // also test hex character appearing in character class brackets
+    pattern = "[" + pattern + "]";
+    results = cudf::strings::contains_re(strings_view, pattern);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
   }
 }
 
@@ -303,6 +307,14 @@ TEST_F(StringsContainsTests, EmbeddedNullCharacter)
 
   results  = cudf::strings::contains_re(strings_view, "J\\0B");
   expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+
+  results  = cudf::strings::contains_re(strings_view, "[G-J][\\0]B");
+  expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 0, 0, 0, 1, 1, 1, 1});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
+
+  results  = cudf::strings::contains_re(strings_view, "[A-D][\\x00]B");
+  expected = cudf::test::fixed_width_column_wrapper<bool>({1, 1, 1, 1, 0, 0, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
 }
 


### PR DESCRIPTION
Closes #11109 

Adds support for `\0` octal and `\x` hex patterns within a regex character class `[ ]` pattern. Refactors the existing octal and hex parsing in non-class expression so it can be reused when building a character class instruction. The refactored code was also simplified as well. 
This change fixes the linked issue by supporting `\0` and `\x00` in the expression which identify embedded null characters.
Additional gtests were added to check for octal and hex within an `[ ]` expression.