### PR TITLE
Clean up repo root

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-# Ignore cmake builds from local machine that might have occurred before attempting Docker build. Including these files will cause CMake cache conflict issues
-/cpp/build

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,3 @@ java/              @rapidsai/cudf-java-codeowners
 .github/           @rapidsai/ops-codeowners
 /ci/               @rapidsai/ops-codeowners
 conda/             @rapidsai/ops-codeowners
-/Dockerfile        @rapidsai/ops-codeowners
-/.dockerignore     @rapidsai/ops-codeowners
-/docker/           @rapidsai/ops-codeowners

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include python/versioneer.py
-include python/cudf/_version.py

--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -1,10 +1,10 @@
 ---
-Checks:    
+Checks:
       'modernize-*,
        -modernize-use-equals-default,
        -modernize-concat-nested-namespaces,
        -modernize-use-trailing-return-type'
-      
+
       # -modernize-use-equals-default        # auto-fix is broken (doesn't insert =default correctly)
       # -modernize-concat-nested-namespaces  # auto-fix is broken (can delete code)
       # -modernize-use-trailing-return-type  # just a preference


### PR DESCRIPTION
This PR removes the outdated files `.dockerignore` and `MANIFEST.in`. The Dockerfile was removed in #10069 so we don't need to keep the ignore file around anymore. The `MANIFEST.in` is very old (last updated in 2018, cad899bb9516c173e4b07bd48e8e7b5e10ca412d) and no longer correct for the current package structure.

Finally, I moved `.clang-tidy` into the `cpp/` directory. @codereport said that would be fine to clean up from the root and have no negative effects since clang-tidy isn't being run yet.