### PR TITLE
Add new `_from_data_like_self` factory

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -127,6 +127,10 @@ class Frame(BinaryOperand, Scannable):
         Frame.__init__(obj, data)
         return obj
 
+    @_cudf_nvtx_annotate
+    def _from_data_like_self(cls, data: MutableMapping):
+        return cls._from_data(data)
+
     @classmethod
     @_cudf_nvtx_annotate
     def _from_columns(
@@ -136,7 +140,6 @@ class Frame(BinaryOperand, Scannable):
     ):
         """Construct a `Frame` object from a list of columns."""
         data = {name: columns[i] for i, name in enumerate(column_names)}
-
         return cls._from_data(data)
 
     @_cudf_nvtx_annotate
@@ -1535,9 +1538,7 @@ class Frame(BinaryOperand, Scannable):
         GenericIndex([False, False, True, True, False, False], dtype='bool')
         """
         data_columns = (col.isnull() for col in self._columns)
-        return self.__class__._from_data(
-            zip(self._column_names, data_columns), self._index
-        )
+        return self._from_data_like_self(zip(self._column_names, data_columns))
 
     # Alias for isnull
     isna = isnull
@@ -1617,9 +1618,7 @@ class Frame(BinaryOperand, Scannable):
         GenericIndex([True, True, False, False, True, True], dtype='bool')
         """
         data_columns = (col.notnull() for col in self._columns)
-        return self.__class__._from_data(
-            zip(self._column_names, data_columns), self._index
-        )
+        return self._from_data_like_self(zip(self._column_names, data_columns))
 
     # Alias for notnull
     notna = notnull
@@ -1983,9 +1982,7 @@ class Frame(BinaryOperand, Scannable):
     @_cudf_nvtx_annotate
     def _unaryop(self, op):
         data_columns = (col.unary_operator(op) for col in self._columns)
-        return self.__class__._from_data(
-            zip(self._column_names, data_columns), self._index
-        )
+        return self._from_data_like_self(zip(self._column_names, data_columns))
 
     @classmethod
     @_cudf_nvtx_annotate
@@ -3110,7 +3107,7 @@ class Frame(BinaryOperand, Scannable):
                 result_data[name] = col.nans_to_nulls()
             except AttributeError:
                 result_data[name] = col.copy()
-        return self._from_data(result_data, self._index)
+        return self._from_data_like_self(result_data)
 
     @_cudf_nvtx_annotate
     def __invert__(self):

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -3112,12 +3112,11 @@ class Frame(BinaryOperand, Scannable):
     @_cudf_nvtx_annotate
     def __invert__(self):
         """Bitwise invert (~) for integral dtypes, logical NOT for bools."""
-        return self._from_data(
+        return self._from_data_like_self(
             {
                 name: _apply_inverse_column(col)
                 for name, col in self._data.items()
-            },
-            self._index,
+            }
         )
 
     def nunique(self, dropna: bool = True):

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -128,8 +128,8 @@ class Frame(BinaryOperand, Scannable):
         return obj
 
     @_cudf_nvtx_annotate
-    def _from_data_like_self(cls, data: MutableMapping):
-        return cls._from_data(data)
+    def _from_data_like_self(self, data: MutableMapping):
+        return self._from_data(data)
 
     @classmethod
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -20,6 +20,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 from uuid import uuid4
 
@@ -270,6 +271,10 @@ class IndexedFrame(Frame):
         out._index = RangeIndex(out._data.nrows) if index is None else index
         return out
 
+    @_cudf_nvtx_annotate
+    def _from_data_like_self(self, data: MutableMapping):
+        return self._from_data(data, self._index)
+
     @classmethod
     @_cudf_nvtx_annotate
     def _from_columns(
@@ -283,20 +288,17 @@ class IndexedFrame(Frame):
         If `index_names` is set, the first `len(index_names)` columns are
         used to construct the index of the frame.
         """
-        data_columns = columns
-
         n_index_columns = len(index_names) if index_names else 0
-        index_columns = columns[:n_index_columns]
-        data_columns = columns[n_index_columns:]
+        out = super()._from_columns(columns[n_index_columns:], column_names)
 
-        out = super()._from_columns(data_columns, column_names)
-
-        if index_names is not None:
-            out._index = cudf.core.index._index_from_columns(index_columns)
+        if n_index_columns:
+            out._index = _index_from_columns(columns[:n_index_columns])
             if isinstance(out._index, cudf.MultiIndex):
                 out._index.names = index_names
             else:
-                out._index.name = index_names[0]
+                # TODO: The cast should instead be inferred by already knowing
+                # that index_names is not None.
+                out._index.name = cast(List[str], index_names)[0]
 
         return out
 
@@ -312,6 +314,8 @@ class IndexedFrame(Frame):
         If `index_names` is set, the first `len(index_names)` columns are
         used to construct the index of the frame.
         """
+        if column_names is None:
+            column_names = self._column_names
         frame = self.__class__._from_columns(
             columns, column_names, index_names
         )

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -290,7 +290,7 @@ class IndexedFrame(Frame):
         data_columns = columns
         index = None
 
-        if index_names:
+        if index_names is not None:
             n_index_columns = len(index_names)
             data_columns = columns[n_index_columns:]
             index = _index_from_columns(columns[:n_index_columns])
@@ -300,7 +300,9 @@ class IndexedFrame(Frame):
                 index.name = index_names[0]
 
         out = super()._from_columns(data_columns, column_names)
-        out._index = index
+
+        if index is not None:
+            out._index = index
 
         return out
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->
This PR introduces a small new utility function `_from_data_like_self` to provide an additional hook for `Frame` and `IndexedFrame` to customize `_from_data`. Specifically in instances where the outputs need to share the index of the input for `IndexedFrame` methods, this hook provides the necessary entrypoint. This method is analogous to the already existing `_from_columns_like_self` method.

In the past I made efforts to consolidate our factory methods, and I'm not super happy with proliferating more of them again. However, I think in this case it is worth the tradeoff since this gets us very close to our goal of removing the `_index` attribute from the `Frame` class. Moreover, in the intermediate term I expect both this method and `_from_data` to be subsumed by `_from_columns` when we eventually transition all of our internals (especially the `ColumnAccessor`) to store a list rather than a dict of columns.