### PR TITLE
Add fallback to GenericIndex in `_index_from_data`.

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -110,6 +110,8 @@ def _index_from_data(data: MutableMapping, name: Any = None):
             index_class_type = CategoricalIndex
         elif isinstance(values, IntervalColumn):
             index_class_type = IntervalIndex
+        else:
+            index_class_type = GenericIndex
     else:
         index_class_type = cudf.MultiIndex
     return index_class_type._from_data(data, name)


### PR DESCRIPTION
This PR will resolve the immediate cause of failure in https://github.com/rapidsai/cudf/issues/11148, which is an unbound local variable (`index_from_data` was not being defined in all cases).

Additional investigation is needed for determining the causes of discrepancies with index types and column types returned from `df.pivot`, and to ascertain whether the result of `(df2 == pivot_table).all().index` from that issue can be a `MultiIndex` to match pandas.