### PR TITLE
Refactor inline conditionals.

### DIFF
--- a/python/cudf/cudf/_fuzz_testing/io.py
+++ b/python/cudf/cudf/_fuzz_testing/io.py
@@ -53,7 +53,7 @@ class IOFuzz:
                         "_crash.json"
                     ):
                         self._load_params(file_name)
-        self._regression = True if self._inputs else False
+        self._regression = bool(self._inputs)
         self._idx = 0
         self._current_params = {}
         self._current_buffer = None

--- a/python/cudf/cudf/_lib/sort.pyx
+++ b/python/cudf/cudf/_lib/sort.pyx
@@ -233,7 +233,7 @@ def rank_columns(list source_columns, object method, str na_option,
         if na_option == 'keep'
         else null_policy.INCLUDE
     )
-    cdef bool percentage = True if pct else False
+    cdef bool percentage = bool(pct)
 
     cdef vector[unique_ptr[column]] c_results
     cdef column_view c_view

--- a/python/cudf/cudf/_lib/sort.pyx
+++ b/python/cudf/cudf/_lib/sort.pyx
@@ -233,7 +233,7 @@ def rank_columns(list source_columns, object method, str na_option,
         if na_option == 'keep'
         else null_policy.INCLUDE
     )
-    cdef bool percentage = bool(pct)
+    cdef bool percentage = pct
 
     cdef vector[unique_ptr[column]] c_results
     cdef column_view c_view

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -81,7 +81,7 @@ def _get_combined_index(indexes, intersect: bool = False, sort=None):
     else:
         index = indexes[0]
         if sort is None:
-            sort = False if isinstance(index, cudf.StringIndex) else True
+            sort = not isinstance(index, cudf.StringIndex)
         for other in indexes[1:]:
             index = index.union(other, sort=False)
 

--- a/python/cudf/cudf/tests/test_column.py
+++ b/python/cudf/cudf/tests/test_column.py
@@ -468,7 +468,7 @@ def test_build_df_from_nullable_pandas_dtype(pd_dtype, expect_dtype):
     assert gd_data["a"].dtype == expect_dtype
 
     # check mask
-    expect_mask = [True if x is not pd.NA else False for x in pd_data["a"]]
+    expect_mask = [x is not pd.NA for x in pd_data["a"]]
     got_mask = mask_to_bools(
         gd_data["a"]._column.base_mask, 0, len(gd_data)
     ).values_host
@@ -506,7 +506,7 @@ def test_build_series_from_nullable_pandas_dtype(pd_dtype, expect_dtype):
     assert gd_data.dtype == expect_dtype
 
     # check mask
-    expect_mask = [True if x is not pd.NA else False for x in pd_data]
+    expect_mask = [x is not pd.NA for x in pd_data]
     got_mask = mask_to_bools(
         gd_data._column.base_mask, 0, len(gd_data)
     ).values_host

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -596,9 +596,7 @@ def test_concat_empty_dataframes(df, other, ignore_index):
                 actual[key] = col.fillna(-1)
         assert_eq(expected, actual, check_dtype=False, check_index_type=True)
     else:
-        assert_eq(
-            expected, actual, check_index_type=False if gdf.empty else True
-        )
+        assert_eq(expected, actual, check_index_type=not gdf.empty)
 
 
 @pytest.mark.parametrize("ignore_index", [True, False])
@@ -1113,7 +1111,7 @@ def test_concat_join_series(ignore_index, sort, join, axis):
     assert_eq(
         expected,
         actual,
-        check_index_type=False if axis == 1 and join == "outer" else True,
+        check_index_type=not (axis == 1 and join == "outer"),
     )
 
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -5989,16 +5989,12 @@ def test_dataframe_init_1d_list(data, columns):
     expect = pd.DataFrame(data, columns=columns)
     actual = cudf.DataFrame(data, columns=columns)
 
-    assert_eq(
-        expect, actual, check_index_type=False if len(data) == 0 else True
-    )
+    assert_eq(expect, actual, check_index_type=len(data) != 0)
 
     expect = pd.DataFrame(data, columns=None)
     actual = cudf.DataFrame(data, columns=None)
 
-    assert_eq(
-        expect, actual, check_index_type=False if len(data) == 0 else True
-    )
+    assert_eq(expect, actual, check_index_type=len(data) != 0)
 
 
 @pytest.mark.parametrize(
@@ -6818,9 +6814,7 @@ def test_dataframe_append_dataframe(df, other, sort, ignore_index):
     if expected.shape != df.shape:
         assert_eq(expected.fillna(-1), actual.fillna(-1), check_dtype=False)
     else:
-        assert_eq(
-            expected, actual, check_index_type=False if gdf.empty else True
-        )
+        assert_eq(expected, actual, check_index_type=not gdf.empty)
 
 
 @pytest.mark.parametrize(
@@ -6888,9 +6882,7 @@ def test_dataframe_append_series_dict(df, other, sort):
             check_index_type=True,
         )
     else:
-        assert_eq(
-            expected, actual, check_index_type=False if gdf.empty else True
-        )
+        assert_eq(expected, actual, check_index_type=not gdf.empty)
 
 
 def test_dataframe_append_series_mixed_index():
@@ -7044,9 +7036,7 @@ def test_dataframe_append_dataframe_lists(df, other, sort, ignore_index):
     if expected.shape != df.shape:
         assert_eq(expected.fillna(-1), actual.fillna(-1), check_dtype=False)
     else:
-        assert_eq(
-            expected, actual, check_index_type=False if gdf.empty else True
-        )
+        assert_eq(expected, actual, check_index_type=not gdf.empty)
 
 
 @pytest.mark.parametrize(
@@ -7109,12 +7099,10 @@ def test_dataframe_append_lists(df, other, sort, ignore_index):
             expected.fillna(-1),
             actual.fillna(-1),
             check_dtype=False,
-            check_column_type=False if gdf.empty else True,
+            check_column_type=not gdf.empty,
         )
     else:
-        assert_eq(
-            expected, actual, check_index_type=False if gdf.empty else True
-        )
+        assert_eq(expected, actual, check_index_type=not gdf.empty)
 
 
 def test_dataframe_append_error():
@@ -7396,8 +7384,8 @@ def test_dataframe_init_with_columns(data, columns):
     assert_eq(
         pdf,
         gdf,
-        check_index_type=False if len(pdf.index) == 0 else True,
-        check_dtype=False if pdf.empty and len(pdf.columns) else True,
+        check_index_type=len(pdf.index) != 0,
+        check_dtype=not (pdf.empty and len(pdf.columns)),
     )
 
 
@@ -8175,7 +8163,7 @@ def test_dataframe_from_pandas_duplicate_columns():
 @pytest.mark.parametrize("index", [["abc", "def", "ghi"]])
 def test_dataframe_constructor_columns(df, columns, index):
     def assert_local_eq(actual, df, expected, host_columns):
-        check_index_type = False if expected.empty else True
+        check_index_type = not expected.empty
         if host_columns is not None and any(
             col not in df.columns for col in host_columns
         ):
@@ -8651,7 +8639,7 @@ def test_dataframe_init_from_series(data, columns, index):
     assert_eq(
         expected,
         actual,
-        check_index_type=False if len(expected) == 0 else True,
+        check_index_type=len(expected) != 0,
     )
 
 

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -387,7 +387,7 @@ def test_groupby_2keys_agg(nelem, func):
     )
     got_df = make_frame(DataFrame, nelem=nelem).groupby(["x", "y"]).agg(func)
 
-    check_dtype = False if func in _index_type_aggs else True
+    check_dtype = func not in _index_type_aggs
     assert_groupby_results_equal(got_df, expect_df, check_dtype=check_dtype)
 
 
@@ -467,7 +467,7 @@ def test_series_groupby(agg):
     gg = g.groupby(g // 2)
     sa = getattr(sg, agg)()
     ga = getattr(gg, agg)()
-    check_dtype = False if agg in _index_type_aggs else True
+    check_dtype = agg not in _index_type_aggs
     assert_groupby_results_equal(sa, ga, check_dtype=check_dtype)
 
 
@@ -479,7 +479,7 @@ def test_series_groupby_agg(agg):
     g = Series([1, 2, 3])
     sg = s.groupby(s // 2).agg(agg)
     gg = g.groupby(g // 2).agg(agg)
-    check_dtype = False if agg in _index_type_aggs else True
+    check_dtype = agg not in _index_type_aggs
     assert_groupby_results_equal(sg, gg, check_dtype=check_dtype)
 
 
@@ -509,7 +509,7 @@ def test_groupby_level_zero(agg):
     gdg = gdf.groupby(level=0)
     pdresult = getattr(pdg, agg)()
     gdresult = getattr(gdg, agg)()
-    check_dtype = False if agg in _index_type_aggs else True
+    check_dtype = agg not in _index_type_aggs
     assert_groupby_results_equal(pdresult, gdresult, check_dtype=check_dtype)
 
 
@@ -539,7 +539,7 @@ def test_groupby_series_level_zero(agg):
     gdg = gdf.groupby(level=0)
     pdresult = getattr(pdg, agg)()
     gdresult = getattr(gdg, agg)()
-    check_dtype = False if agg in _index_type_aggs else True
+    check_dtype = agg not in _index_type_aggs
     assert_groupby_results_equal(pdresult, gdresult, check_dtype=check_dtype)
 
 
@@ -892,7 +892,7 @@ def test_groupby_multi_agg_hash_groupby(agg):
         seed=1,
     ).reset_index(drop=True)
     pdf = gdf.to_pandas()
-    check_dtype = False if "count" in agg else True
+    check_dtype = "count" not in agg
     pdg = pdf.groupby("id").agg(agg)
     gdg = gdf.groupby("id").agg(agg)
     assert_groupby_results_equal(pdg, gdg, check_dtype=check_dtype)
@@ -902,7 +902,7 @@ def test_groupby_multi_agg_hash_groupby(agg):
     "agg", ["min", "max", "idxmax", "idxmax", "sum", "prod", "count", "mean"]
 )
 def test_groupby_nulls_basic(agg):
-    check_dtype = False if agg in _index_type_aggs else True
+    check_dtype = agg not in _index_type_aggs
 
     pdf = pd.DataFrame({"a": [0, 0, 1, 1, 2, 2], "b": [1, 2, 1, 2, 1, None]})
     gdf = cudf.from_pandas(pdf)
@@ -1816,7 +1816,7 @@ def test_groupby_2keys_scan(nelem, func):
     if isinstance(expect_df, pd.Series):
         expect_df = expect_df.to_frame("val")
 
-    check_dtype = False if func in _index_type_aggs else True
+    check_dtype = func not in _index_type_aggs
     assert_groupby_results_equal(got_df, expect_df, check_dtype=check_dtype)
 
 

--- a/python/cudf/cudf/tests/test_interpolate.py
+++ b/python/cudf/cudf/tests/test_interpolate.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+
 import pytest
 
 import cudf
@@ -50,9 +52,7 @@ def test_interpolate_series(data, method, axis):
     expect = psr.interpolate(method=method, axis=axis)
     got = gsr.interpolate(method=method, axis=axis)
 
-    assert_eq(
-        expect, got, check_dtype=False if psr.dtype == "object" else True
-    )
+    assert_eq(expect, got, check_dtype=psr.dtype != "object")
 
 
 @pytest.mark.parametrize(
@@ -90,9 +90,7 @@ def test_interpolate_series_values_or_index(data, index, method):
     expect = psr.interpolate(method=method)
     got = gsr.interpolate(method=method)
 
-    assert_eq(
-        expect, got, check_dtype=False if psr.dtype == "object" else True
-    )
+    assert_eq(expect, got, check_dtype=psr.dtype != "object")
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -84,7 +84,7 @@ def test_leaves(data):
     assert_eq(
         expect,
         got,
-        check_dtype=False if isinstance(pa_array, pa.NullArray) else True,
+        check_dtype=not isinstance(pa_array, pa.NullArray),
     )
 
 
@@ -276,9 +276,7 @@ def test_get(data, index, expect):
     expect = cudf.Series(expect)
     got = sr.list.get(index)
 
-    assert_eq(
-        expect, got, check_dtype=False if expect.isnull().all() else True
-    )
+    assert_eq(expect, got, check_dtype=not expect.isnull().all())
 
 
 def test_get_nested_lists():

--- a/python/cudf/cudf/tests/test_onehot.py
+++ b/python/cudf/cudf/tests/test_onehot.py
@@ -31,14 +31,14 @@ def test_get_dummies(data, index):
     utils.assert_eq(
         encoded_expected,
         encoded_actual,
-        check_dtype=False if len(data) == 0 else True,
+        check_dtype=len(data) != 0,
     )
     encoded_actual = cudf.get_dummies(gdf, prefix="test", dtype=np.uint8)
 
     utils.assert_eq(
         encoded_expected,
         encoded_actual,
-        check_dtype=False if len(data) == 0 else True,
+        check_dtype=len(data) != 0,
     )
 
 

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -354,7 +354,7 @@ def test_parquet_reader_index_col(tmpdir, index_col, columns):
     fname = tmpdir.join("test_pq_reader_index_col.parquet")
 
     # PANDAS' PyArrow backend always writes the index unless disabled
-    df.to_parquet(fname, index=(False if index_col is None else True))
+    df.to_parquet(fname, index=(index_col is not None))
     assert os.path.exists(fname)
 
     pdf = pd.read_parquet(fname, columns=columns)
@@ -1960,7 +1960,7 @@ def test_write_read_cudf(tmpdir, pdf):
     gdf.to_parquet(file_path)
     gdf = cudf.read_parquet(file_path)
 
-    assert_eq(gdf, pdf, check_index_type=False if pdf.empty else True)
+    assert_eq(gdf, pdf, check_index_type=not pdf.empty)
 
 
 def test_write_cudf_read_pandas_pyarrow(tmpdir, pdf):
@@ -1978,7 +1978,7 @@ def test_write_cudf_read_pandas_pyarrow(tmpdir, pdf):
     cudf_res = pd.read_parquet(cudf_path)
     pd_res = pd.read_parquet(pandas_path)
 
-    assert_eq(pd_res, cudf_res, check_index_type=False if pdf.empty else True)
+    assert_eq(pd_res, cudf_res, check_index_type=not pdf.empty)
 
     cudf_res = pa.parquet.read_table(
         cudf_path, use_pandas_metadata=True
@@ -1987,7 +1987,7 @@ def test_write_cudf_read_pandas_pyarrow(tmpdir, pdf):
         pandas_path, use_pandas_metadata=True
     ).to_pandas()
 
-    assert_eq(cudf_res, pd_res, check_index_type=False if pdf.empty else True)
+    assert_eq(cudf_res, pd_res, check_index_type=not pdf.empty)
 
 
 def test_parquet_writer_criteo(tmpdir):
@@ -2430,7 +2430,7 @@ def test_parquet_writer_nulls_pandas_read(tmpdir, pdf):
     assert os.path.exists(fname)
 
     got = pd.read_parquet(fname)
-    nullable = True if num_rows > 0 else False
+    nullable = num_rows > 0
     assert_eq(gdf.to_pandas(nullable=nullable), got)
 
 

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -798,7 +798,7 @@ def test_series_where(data_dtype, fill_value):
         assert_eq(
             expect,
             got,
-            check_dtype=False if expect.dtype.kind in ("f") else True,
+            check_dtype=expect.dtype.kind not in ("f"),
         )
 
     if sr.dtype.type(fill_value) != fill_value:
@@ -811,7 +811,7 @@ def test_series_where(data_dtype, fill_value):
         assert_eq(
             expect,
             got,
-            check_dtype=False if expect.dtype.kind in ("f") else True,
+            check_dtype=expect.dtype.kind not in ("f"),
         )
 
     if sr.dtype.type(fill_value) != fill_value:
@@ -824,7 +824,7 @@ def test_series_where(data_dtype, fill_value):
         assert_eq(
             expect,
             got,
-            check_dtype=False if expect.dtype.kind in ("f") else True,
+            check_dtype=expect.dtype.kind not in ("f"),
         )
 
 

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -212,7 +212,7 @@ def set_allocator(
         Enable logging (default ``False``).
         Enabling this option will introduce performance overhead.
     """
-    use_managed_memory = True if allocator == "managed" else False
+    use_managed_memory = allocator == "managed"
 
     rmm.reinitialize(
         pool_allocator=pool,


### PR DESCRIPTION
This PR refactors a few Python statements like `True if x else False` to just be `x`, (or `bool(x)` if a type conversion is needed).

Similar for `False if x else True` ➡️ `not x` (for these, no explicit type conversion is needed since the unary `not` will convert to bool).