### PR TITLE
Fix compatibility issues with pandas 1.4.3

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1590,7 +1590,18 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 # include different types that are not comparable.
                 names = sorted(names)
             except TypeError:
-                names = list(names)
+                # For pandas compatibility, we also try to handle the case
+                # where some column names are strings and others are ints. Just
+                # assume that everything that isn't a str is numerical, we
+                # can't sort anything else.
+                try:
+                    str_names = sorted(n for n in names if isinstance(n, str))
+                    non_str_names = sorted(
+                        n for n in names if not isinstance(n, str)
+                    )
+                    names = non_str_names + str_names
+                except TypeError:
+                    names = list(names)
         else:
             names = list(names)
 

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -803,7 +803,10 @@ def test_concat_join_axis_1(objs, ignore_index, sort, join, axis):
         axis=axis,
     )
 
-    assert_eq(expected, actual, check_index_type=True)
+    # TODO: Remove special handling of check_index_type below
+    # after the following bug from pandas is fixed:
+    # https://github.com/pandas-dev/pandas/issues/47501
+    assert_eq(expected, actual, check_index_type=not (axis == 1 and sort))
 
 
 @pytest.mark.parametrize("ignore_index", [True, False])
@@ -870,7 +873,10 @@ def test_concat_join_one_df(ignore_index, sort, join, axis):
         [gdf1], sort=sort, join=join, ignore_index=ignore_index, axis=axis
     )
 
-    assert_eq(expected, actual, check_index_type=True)
+    # TODO: Remove special handling of check_index_type below
+    # after the following bug from pandas is fixed:
+    # https://github.com/pandas-dev/pandas/issues/47501
+    assert_eq(expected, actual, check_index_type=not (axis == 1 and sort))
 
 
 @pytest.mark.parametrize(
@@ -919,7 +925,10 @@ def test_concat_join_no_overlapping_columns(
         axis=axis,
     )
 
-    assert_eq(expected, actual, check_index_type=True)
+    # TODO: Remove special handling of check_index_type below
+    # after the following bug from pandas is fixed:
+    # https://github.com/pandas-dev/pandas/issues/47501
+    assert_eq(expected, actual, check_index_type=not (axis == 1 and sort))
 
 
 @pytest.mark.parametrize("ignore_index", [False, True])
@@ -1107,13 +1116,14 @@ def test_concat_join_series(ignore_index, sort, join, axis):
         axis=axis,
     )
 
-    # TODO: Remove special handling below
-    # after following bug from pandas is fixed:
+    # TODO: Remove special handling of check_index_type below
+    # after the following bugs from pandas are fixed:
     # https://github.com/pandas-dev/pandas/issues/46675
+    # https://github.com/pandas-dev/pandas/issues/47501
     assert_eq(
         expected,
         actual,
-        check_index_type=False if axis == 1 and join == "outer" else True,
+        check_index_type=(axis == 0),
     )
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->
This PR fixes the two main issues that crop up in pandas 1.4.3 relative to 1.4.2, both around `pd.concat`:
- Columns are now sorted such that integer values come before string values. That is a behavior change that we mimic.
- When multiple objects with identical RangeIndexes are concatenated along axis 1 and sorting is requested, pandas now creates an integer index instead of a RangeIndex. This is not what we want since it increases memory pressure, so those tests have been modified to stop checking the index type and a [pandas issue has been raised](https://github.com/pandas-dev/pandas/issues/47501).