### PR TITLE
Provides a method for the user to remove the hook and re-register the hook in a custom shutdown hook manager

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -145,10 +145,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- Depend on `org.apache.hadoop.util.ShutdownHookManager` in `MemoryCleaner` -->
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>3.2.3</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -149,7 +149,7 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>3.2.3</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -145,11 +145,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <!-- Depend on `org.apache.hadoop.util.ShutdownHookManager` in `MemoryCleaner` -->
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>3.2.3</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -229,7 +229,7 @@ public final class MemoryCleaner {
       // priority. The priority parameter will guarantee the execution order.
       //
       // Here also use `Hadoop ShutdownHookManager` to add a lower priority hook.
-      // 20 priority is small enough, will run after Spark hooks
+      // 20 priority is small enough, will run after Spark hooks.
       // Note: `ShutdownHookManager.get()` is a singleton, Spark and JNI both use the same singleton
       org.apache.hadoop.util.ShutdownHookManager.get().addShutdownHook(hook, 20);
     }


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/5854

###  Problem
Prints `RapidsHostMemoryStore.pool` leaked error log when running Rapids Accelerator test cases.
```
All tests passed.

22/06/27 17:45:57.298 Thread-7 ERROR HostMemoryBuffer: A HOST BUFFER WAS LEAKED (ID: 1 7f8557fff010)
22/06/27 17:45:57.303 Thread-7 ERROR MemoryCleaner: Leaked host buffer (ID: 1): 2022-06-27 09:45:16.0171 UTC: INC
java.lang.Thread.getStackTrace(Thread.java:1559)
ai.rapids.cudf.MemoryCleaner$RefCountDebugItem.<init>(MemoryCleaner.java:301)
ai.rapids.cudf.MemoryCleaner$Cleaner.addRef(MemoryCleaner.java:82)
ai.rapids.cudf.MemoryBuffer.incRefCount(MemoryBuffer.java:232)
ai.rapids.cudf.MemoryBuffer.<init>(MemoryBuffer.java:98)
ai.rapids.cudf.HostMemoryBuffer.<init>(HostMemoryBuffer.java:196)
ai.rapids.cudf.HostMemoryBuffer.<init>(HostMemoryBuffer.java:192)
ai.rapids.cudf.HostMemoryBuffer.allocate(HostMemoryBuffer.java:144)
com.nvidia.spark.rapids.RapidsHostMemoryStore.<init>(RapidsHostMemoryStore.scala:38)

```
### Root cause
`RapidsHostMemoryStore.pool` is not closed before `MemoryCleaner` checking the leaks.
It's actually not a leak, it's caused by hooks execution order.
`RapidsHostMemoryStore.pool` is closed in the [Spark executor plugin hook](https://github.com/apache/spark/blob/v3.3.0/core/src/main/scala/org/apache/spark/executor/Executor.scala#L351toL381).
```
plugins.foreach(_.shutdown())  // this line will eventually close the RapidsHostMemoryStore.pool
```
The close path is:
```
  The close path is: 
    Spark executor plugin hook ->
      RapidsExecutorPlugin.shutdown ->
        GpuDeviceManager.shutdown ->
          RapidsBufferCatalog.close() ->
            RapidsHostMemoryStore.close ->
              RapidsHostMemoryStore.pool.close ->
```

Rapids Accelerator JNI also checks leaks in a shutdown hook.
Shutdown hooks are executed concurrently, there is no execution order guarantee.

### solution 1 - Not recommanded
Just wait one second before checking the leak in the `MemoryCleaner`.
It's modifying debug code, it's modifying closing code, and has no impact on production code.

### solution 2 - Not recommanded
Spark has a util class `ShutdownHookManager` which is a  ShutdownHook wrapper.
It can [addShutdownHook with priority](https://github.com/apache/spark/blob/v3.3.0/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala#L152) via `Hadoop ShutdownHookManager`
```
def addShutdownHook(priority: Int)(hook: () => Unit): AnyRef = {
```

Leveraging Hadoop ShutdownHookManager as Spark does is feasible.

###  Solution 3 Recommanded
Provides a method for the user to remove the hook and re-register the hook in a custom shutdown hook manager.

Signed-off-by: Chong Gao <res_life@163.com>