### PR TITLE
Fix cudf version in README.md install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ For `cudf version == 22.06` :
 ```bash
 # for CUDA 11.0
 conda install -c rapidsai -c nvidia -c numba -c conda-forge \
-    cudf=21.08 python=3.9 cudatoolkit=11.0
+    cudf=22.06 python=3.9 cudatoolkit=11.0
 
 # or, for CUDA 11.2
 conda install -c rapidsai -c nvidia -c numba -c conda-forge \
-    cudf=21.08 python=3.9 cudatoolkit=11.2
+    cudf=22.06 python=3.9 cudatoolkit=11.2
 
 ```
 


### PR DESCRIPTION
Looks like #11029 forgot to update the cudf version in the actual install commands in the readme file. The commands as stated are unsatisfiable, leading to lots of confusion if, like me, you're new to conda and cudf, and just blindly copypaste the install command without noticing the version discrepancy...