### PR TITLE
Fix unresolved links in markdown

### DIFF
--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -413,7 +413,7 @@ should avoid creating streams (even if it is slightly less efficient). It is a g
 
 ## Memory Allocation
 
-Device [memory resources](#memory_resource) are used in libcudf to abstract and control how device
+Device [memory resources](#rmmdevice_memory_resource) are used in libcudf to abstract and control how device
 memory is allocated.
 
 ### Output Memory
@@ -1169,7 +1169,7 @@ instance of a class object to represent a null string.
 
 The `string_view` contains comparison operators `<,>,==,<=,>=` that can be used in many cudf
 functions like `sort` without string-specific code. The data for a `string_view` instance is
-required to be [UTF-8](#UTF-8) and all operators and methods expect this encoding. Unless documented
+required to be [UTF-8](#utf-8) and all operators and methods expect this encoding. Unless documented
 otherwise, position and length parameters are specified in characters and not bytes. The class also
 includes a `string_view::const_iterator` which can be used to navigate through individual characters
 within the string.

--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -177,7 +177,7 @@ and produce `unique_ptr`s to owning objects as output. For example,
 std::unique_ptr<table> sort(table_view const& input);
 ```
 
-## `rmm::device_memory_resource`<a name="memory_resource"></a>
+## `rmm::device_memory_resource`
 
 libcudf allocates all device memory via RMM memory resources (MR). See the
 [RMM documentation](https://github.com/rapidsai/rmm/blob/main/README.md) for details.

--- a/docs/cudf/source/user_guide/data-types.md
+++ b/docs/cudf/source/user_guide/data-types.md
@@ -133,8 +133,7 @@ dtype: struct
 StructDtype({'a': dtype('int64'), 'b': dtype('int64')})
 ```
 
-Or by reading them from disk, using a [file format that supports
-nested data](io).
+Or by reading them from disk, using a [file format that supports nested data](io).
 
 ```python
 >>> pdf = pd.DataFrame({"a": [[1, 2], [3, 4, 5], [6, 7, 8]]})

--- a/docs/cudf/source/user_guide/pandas-comparison.md
+++ b/docs/cudf/source/user_guide/pandas-comparison.md
@@ -129,7 +129,7 @@ For example, `s.sum()` is not guaranteed to produce identical results
 to Pandas nor produce identical results from run to run, when `s` is a
 Series of floats.  If you need to compare floating point results, you
 should typically do so using the functions provided in the
-[`cudf.testing`](/api_docs/general_utilities.html#testing-functions)
+[`cudf.testing`](/api_docs/general_utilities#testing-functions)
 module, which allow you to compare values up to a desired precision.
 
 ## Column names

--- a/python/custreamz/README.md
+++ b/python/custreamz/README.md
@@ -35,7 +35,7 @@ tips_df['tip_percentage'] = tips_df['tip'] / tips_df['total_bill'] * 100
 print(tips_df.groupby('size').tip_percentage.mean())
 ```
 
-A "hello world" of using cuStreamz with python streamz can be found [here](https://github.com/rapidsai-community/notebooks-contrib/blob/main/getting_started_notebooks/basics/hello_streamz.ipynb)
+A "hello world" of using cuStreamz with python streamz can be found [here](https://github.com/rapidsai-community/notebooks-contrib/blob/main/getting_started_materials/hello_worlds/hello_streamz.ipynb)
 
 A more detailed example of [parsing haproxy logs](https://github.com/rapidsai-community/notebooks-contrib/blob/branch-0.14/intermediate_notebooks/examples/custreamz/parsing_haproxy_logs.ipynb) is also available.
 


### PR DESCRIPTION
Fixes unresolved links in Markdown files
Ran `xrefcheck` and found few issues. 
At this point, It cannot be fully automated using xrefcheck because the .ipynb files are converted to html and their links are reported as errors 