### PR TITLE
Pin max version of `cuda-python` to `11.7.0`

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -38,7 +38,7 @@ dependencies:
   - ipython
   - pandoc=<2.0.0
   - cudatoolkit=11.5
-  - cuda-python >=11.5,<12.0
+  - cuda-python >=11.5,<11.7.1
   - pip
   - flake8=3.8.3
   - black=22.3.0

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -63,7 +63,7 @@ requirements:
     - packaging
     - cachetools
     - ptxcompiler  # [linux64]  # CUDA enhanced compatibility. See https://github.com/rapidsai/ptxcompiler
-    - cuda-python >=11.5,<12.0
+    - cuda-python >=11.5,<11.7.1
 test:                                   # [linux64]
   requires:                             # [linux64]
     - cudatoolkit {{ cuda_version }}.*  # [linux64]

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -15,7 +15,7 @@ import versioneer
 
 install_requires = [
     "cachetools",
-    "cuda-python>=11.5,<12.0",
+    "cuda-python>=11.5,<11.7.1",
     "fsspec>=0.6.0",
     "numba>=0.53.1",
     "numpy",


### PR DESCRIPTION
Pin max version of `cuda-python` to `11.7.0`