### PR TITLE
Feature/decimal128 stats

### DIFF
--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -1399,8 +1399,8 @@ __global__ void __launch_bounds__(128)
       // Optionally encode page-level statistics
       if (not page_stats.empty()) {
         encoder.field_struct_begin(5);
-        encoder.set_ptr(EncodeStatistics(
-          encoder.get_ptr(), &page_stats[blockIdx.x], col_g.stats_dtype, fp_scratch));
+        encoder.set_ptr(
+          EncodeStatistics(encoder.get_ptr(), &page_stats[blockIdx.x], col_g.stats_dtype, scratch));
         encoder.field_struct_end(5);
       }
       encoder.field_struct_end(5);

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -1263,10 +1263,21 @@ class header_encoder {
   inline __device__ void set_ptr(uint8_t* ptr) { current_header_ptr = ptr; }
 };
 
+// byteswap 128 bit integer into char array in network byte order
+static __device__ void swap128(__int128_t v, void* dst)
+{
+  auto const v_char_ptr = reinterpret_cast<unsigned char const*>(&v);
+  auto d_char_ptr       = reinterpret_cast<unsigned char*>(dst);
+  thrust::copy(thrust::seq,
+               thrust::make_reverse_iterator(v_char_ptr + sizeof(v)),
+               thrust::make_reverse_iterator(v_char_ptr),
+               d_char_ptr);
+}
+
 __device__ uint8_t* EncodeStatistics(uint8_t* start,
                                      const statistics_chunk* s,
                                      uint8_t dtype,
-                                     float* fp_scratch)
+                                     void* scratch)
 {
   uint8_t *end, dtype_len;
   switch (dtype) {
@@ -1298,10 +1309,17 @@ __device__ uint8_t* EncodeStatistics(uint8_t* start,
     } else {
       lmin = lmax = dtype_len;
       if (dtype == dtype_float32) {  // Convert from double to float32
-        fp_scratch[0] = s->min_value.fp_val;
-        fp_scratch[1] = s->max_value.fp_val;
-        vmin          = &fp_scratch[0];
-        vmax          = &fp_scratch[1];
+        float* fp_scratch = reinterpret_cast<float*>(scratch);
+        fp_scratch[0]     = s->min_value.fp_val;
+        fp_scratch[1]     = s->max_value.fp_val;
+        vmin              = &fp_scratch[0];
+        vmax              = &fp_scratch[1];
+      } else if (dtype == dtype_decimal128) {
+        uint8_t* d128_scratch = reinterpret_cast<uint8_t*>(scratch);
+        swap128(s->min_value.d128_val, d128_scratch);
+        swap128(s->max_value.d128_val, &d128_scratch[16]);
+        vmin = &d128_scratch[0];
+        vmax = &d128_scratch[16];
       } else {
         vmin = &s->min_value;
         vmax = &s->max_value;
@@ -1325,7 +1343,7 @@ __global__ void __launch_bounds__(128)
   __shared__ __align__(8) parquet_column_device_view col_g;
   __shared__ __align__(8) EncColumnChunk ck_g;
   __shared__ __align__(8) EncPage page_g;
-  __shared__ __align__(8) float fp_scratch[2];
+  __shared__ __align__(8) unsigned char scratch[32];
 
   uint32_t t = threadIdx.x;
 
@@ -1340,7 +1358,7 @@ __global__ void __launch_bounds__(128)
     if (chunk_stats && &pages[blockIdx.x] == ck_g.pages) {  // Is this the first page in a chunk?
       hdr_start = (ck_g.is_compressed) ? ck_g.compressed_bfr : ck_g.uncompressed_bfr;
       hdr_end =
-        EncodeStatistics(hdr_start, &chunk_stats[page_g.chunk_id], col_g.stats_dtype, fp_scratch);
+        EncodeStatistics(hdr_start, &chunk_stats[page_g.chunk_id], col_g.stats_dtype, scratch);
       page_g.chunk->ck_stat_size = static_cast<uint32_t>(hdr_end - hdr_start);
     }
     uncompressed_page_size = page_g.max_data_size;

--- a/cpp/src/io/statistics/statistics.cuh
+++ b/cpp/src/io/statistics/statistics.cuh
@@ -88,6 +88,7 @@ union statistics_val {
   double fp_val;         //!< float columns
   int64_t i_val;         //!< integer columns
   uint64_t u_val;        //!< unsigned integer columns
+  __int128_t d128_val;   //!< decimal128 columns
 };
 
 struct statistics_chunk {

--- a/cpp/src/io/statistics/statistics_type_identification.cuh
+++ b/cpp/src/io/statistics/statistics_type_identification.cuh
@@ -123,13 +123,14 @@ class extrema_type {
 
   using non_arithmetic_extrema_type = typename std::conditional_t<
     cudf::is_fixed_point<T>() or cudf::is_duration<T>() or cudf::is_timestamp<T>(),
-    int64_t,
+    typename std::conditional_t<std::is_same_v<T, numeric::decimal128>, __int128_t, int64_t>,
     typename std::conditional_t<std::is_same_v<T, string_view>, string_view, void>>;
 
   // unsigned int/bool -> uint64_t
   // signed int        -> int64_t
   // float/double      -> double
   // decimal32/64      -> int64_t
+  // decimal128        -> __int128_t
   // duration_[T]      -> int64_t
   // string_view       -> string_view
   // timestamp_[T]     -> int64_t
@@ -174,8 +175,10 @@ class aggregation_type {
   using integral_aggregation_type =
     typename std::conditional_t<std::is_signed_v<T>, int64_t, uint64_t>;
 
-  using arithmetic_aggregation_type =
-    typename std::conditional_t<std::is_integral_v<T>, integral_aggregation_type, double>;
+  using arithmetic_aggregation_type = typename std::conditional_t<
+    std::is_integral_v<T>,
+    std::conditional_t<std::is_same_v<T, __int128_t>, __int128_t, integral_aggregation_type>,
+    double>;
 
   using non_arithmetic_aggregation_type =
     typename std::conditional_t<cudf::is_fixed_point<T>() or cudf::is_duration<T>() or
@@ -208,6 +211,8 @@ class aggregation_type {
   {
     if constexpr (std::is_same_v<T, string_view>) {
       return val.size_bytes();
+    } else if constexpr (std::is_same_v<T, __int128_t>) {
+      return val;
     } else if constexpr (std::is_integral_v<T>) {
       return val;
     } else if constexpr (std::is_floating_point_v<T>) {

--- a/cpp/src/io/statistics/temp_storage_wrapper.cuh
+++ b/cpp/src/io/statistics/temp_storage_wrapper.cuh
@@ -54,6 +54,7 @@ union block_reduce_storage {
   DECLARE_MEMBER(int16_t)
   DECLARE_MEMBER(int32_t)
   DECLARE_MEMBER(int64_t)
+  DECLARE_MEMBER(__int128_t)
   DECLARE_MEMBER(uint8_t)
   DECLARE_MEMBER(uint16_t)
   DECLARE_MEMBER(uint32_t)
@@ -89,6 +90,7 @@ struct storage_wrapper {
   STORAGE_WRAPPER_GET(int16_t);
   STORAGE_WRAPPER_GET(int32_t);
   STORAGE_WRAPPER_GET(int64_t);
+  STORAGE_WRAPPER_GET(__int128_t);
   STORAGE_WRAPPER_GET(uint8_t);
   STORAGE_WRAPPER_GET(uint16_t);
   STORAGE_WRAPPER_GET(uint32_t);

--- a/cpp/src/io/statistics/typed_statistics_chunk.cuh
+++ b/cpp/src/io/statistics/typed_statistics_chunk.cuh
@@ -64,6 +64,12 @@ class union_member {
   }
 
   template <typename T, typename U>
+  __device__ static std::enable_if_t<std::is_same_v<T, __int128_t>, type<T, U>> get(U& val)
+  {
+    return val.d128_val;
+  }
+
+  template <typename T, typename U>
   __device__ static std::enable_if_t<std::is_floating_point_v<T>, type<T, U>> get(U& val)
   {
     return val.fp_val;


### PR DESCRIPTION
Fixes an issue with how decimal128 statistics are written to parquet files.  As it stands, the statistics for a decimal128 column will be truncated to 64 bits, in little endian byte order.  This patch will write the full 128 bits in big endian order.

Testing this will require code from #11178, or can be deferred to a subsequent PR (based on #11171)

<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->
