### PR TITLE
Remove usage of Frame in StringMethods

### DIFF
--- a/python/cudf/cudf/core/column/methods.py
+++ b/python/cudf/cudf/core/column/methods.py
@@ -79,14 +79,12 @@ class ColumnMethods:
                 table = new_col
 
                 if isinstance(self._parent, cudf.BaseIndex):
-                    idx = self._parent._constructor_expanddim._from_data(
-                        table._data, table._index
-                    )
+                    idx = self._parent._constructor_expanddim._from_data(table)
                     idx.names = None
                     return idx
                 else:
                     return self._parent._constructor_expanddim._from_data(
-                        data=table._data, index=self._parent.index
+                        data=table, index=self._parent.index
                     )
             elif isinstance(self._parent, cudf.Series):
                 if retain_index:

--- a/python/cudf/cudf/core/column/methods.py
+++ b/python/cudf/cudf/core/column/methods.py
@@ -73,9 +73,7 @@ class ColumnMethods:
             )
             return None
         else:
-            if expand or isinstance(
-                self._parent, (cudf.DataFrame, cudf.MultiIndex)
-            ):
+            if expand:
                 # This branch indicates the passed as new_col
                 # is a Table
                 table = new_col

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -630,11 +630,11 @@ class StringMethods(ColumnMethods):
                 "unsupported value for `flags` parameter"
             )
 
-        data, index = libstrings.extract(self._column, pat, flags)
+        data, _ = libstrings.extract(self._column, pat, flags)
         if len(data) == 1 and expand is False:
             data = next(iter(data.values()))
         else:
-            data = cudf.core.frame.Frame(data, index)
+            data = data
         return self._return_or_inplace(data, expand=expand)
 
     def contains(
@@ -2448,18 +2448,18 @@ class StringMethods(ColumnMethods):
 
         if expand:
             if self._column.null_count == len(self._column):
-                result_table = cudf.core.frame.Frame({0: self._column.copy()})
+                result_table = {0: self._column.copy()}
             else:
                 if regex is True:
-                    data, index = libstrings.split_re(self._column, pat, n)
+                    data, _ = libstrings.split_re(self._column, pat, n)
                 else:
-                    data, index = libstrings.split(
+                    data, _ = libstrings.split(
                         self._column, cudf.Scalar(pat, "str"), n
                     )
                 if len(data) == 1 and data[0].null_count == len(self._column):
-                    result_table = cudf.core.frame.Frame({})
+                    result_table = {}
                 else:
-                    result_table = cudf.core.frame.Frame(data, index)
+                    result_table = data
         else:
             if regex is True:
                 result_table = libstrings.split_record_re(self._column, pat, n)
@@ -2621,18 +2621,18 @@ class StringMethods(ColumnMethods):
 
         if expand:
             if self._column.null_count == len(self._column):
-                result_table = cudf.core.frame.Frame({0: self._column.copy()})
+                result_table = {0: self._column.copy()}
             else:
                 if regex is True:
-                    data, index = libstrings.rsplit_re(self._column, pat, n)
+                    data, _ = libstrings.rsplit_re(self._column, pat, n)
                 else:
-                    data, index = libstrings.rsplit(
+                    data, _ = libstrings.rsplit(
                         self._column, cudf.Scalar(pat, "str"), n
                     )
                 if len(data) == 1 and data[0].null_count == len(self._column):
-                    result_table = cudf.core.frame.Frame({})
+                    result_table = {}
                 else:
-                    result_table = cudf.core.frame.Frame(data, index)
+                    result_table = data
         else:
             if regex is True:
                 result_table = libstrings.rsplit_record_re(
@@ -2722,9 +2722,7 @@ class StringMethods(ColumnMethods):
             sep = " "
 
         return self._return_or_inplace(
-            cudf.core.frame.Frame(
-                *libstrings.partition(self._column, cudf.Scalar(sep, "str"))
-            ),
+            libstrings.partition(self._column, cudf.Scalar(sep, "str"))[0],
             expand=expand,
         )
 
@@ -2789,9 +2787,7 @@ class StringMethods(ColumnMethods):
             sep = " "
 
         return self._return_or_inplace(
-            cudf.core.frame.Frame(
-                *libstrings.rpartition(self._column, cudf.Scalar(sep, "str"))
-            ),
+            libstrings.rpartition(self._column, cudf.Scalar(sep, "str"))[0],
             expand=expand,
         )
 
@@ -3540,10 +3536,8 @@ class StringMethods(ColumnMethods):
                 "future version. Set expand=False to match future behavior.",
                 FutureWarning,
             )
-            data, index = libstrings.findall(self._column, pat, flags)
-            return self._return_or_inplace(
-                cudf.core.frame.Frame(data, index), expand=expand
-            )
+            data, _ = libstrings.findall(self._column, pat, flags)
+            return self._return_or_inplace(data, expand=expand)
         else:
             data = libstrings.findall_record(self._column, pat, flags)
             return self._return_or_inplace(data, expand=expand)


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->
Various methods of StringMethods create a Frame from a libcudf method and pass that up to `_return_or_inplace`, which handles this as a special case where a method operating on a single column returns multiple columns (e.g. splitting a string column into multiple columns containing substrings). In all such cases, there is no need to pass the index through. When the parent object is an index, the index can simply be discarded, while if the parent is a Series the parent's index is always used for the new object. This removes various unnecessary constructions of the Frame class.