### PR TITLE
Standardize join internals around DataFrame

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pickle
-import warnings
 from functools import cached_property
 from typing import Any, Set
 
@@ -1163,21 +1162,18 @@ class BaseIndex(Serializable):
                     (1, 2)],
                    names=['a', 'b'])
         """
-        warnings.warn(
-            "Index.join is deprecated and will be removed", FutureWarning
-        )
+        self_is_multi = isinstance(self, cudf.MultiIndex)
+        other_is_multi = isinstance(other, cudf.MultiIndex)
+        if level is not None:
+            if self_is_multi and other_is_multi:
+                raise TypeError(
+                    "Join on level between two MultiIndex objects is ambiguous"
+                )
 
-        if isinstance(self, cudf.MultiIndex) and isinstance(
-            other, cudf.MultiIndex
-        ):
-            raise TypeError(
-                "Join on level between two MultiIndex objects is ambiguous"
-            )
+            if not is_scalar(level):
+                raise ValueError("level should be an int or a label only")
 
-        if level is not None and not is_scalar(level):
-            raise ValueError("level should be an int or a label only")
-
-        if isinstance(other, cudf.MultiIndex):
+        if other_is_multi:
             if how == "left":
                 how = "right"
             elif how == "right":
@@ -1188,34 +1184,40 @@ class BaseIndex(Serializable):
             lhs = self.copy(deep=False)
             rhs = other.copy(deep=False)
 
-        on = level
-        # In case of MultiIndex, it will be None as
-        # we don't need to update name
-        left_names = lhs.names
-        right_names = rhs.names
         # There should be no `None` values in Joined indices,
         # so essentially it would be `left/right` or 'inner'
         # in case of MultiIndex
         if isinstance(lhs, cudf.MultiIndex):
-            if level is not None and isinstance(level, int):
-                on = lhs._data.select_by_index(level).names[0]
-            right_names = (on,) if on is not None else right_names
-            on = right_names[0]
+            on = (
+                lhs._data.select_by_index(level).names[0]
+                if isinstance(level, int)
+                else level
+            )
+
+            if on is not None:
+                rhs.names = (on,)
+            on = rhs.names[0]
             if how == "outer":
                 how = "left"
             elif how == "right":
                 how = "inner"
         else:
             # Both are normal indices
-            right_names = left_names
-            on = right_names[0]
+            on = rhs.names[0]
+            rhs.names = lhs.names
 
-        lhs.names = left_names
-        rhs.names = right_names
+        lhs = lhs.to_frame()
+        rhs = rhs.to_frame()
 
         output = lhs._merge(rhs, how=how, on=on, sort=sort)
 
-        return output
+        # If both inputs were MultiIndexes, the output is a MultiIndex.
+        # Otherwise, the output is only a MultiIndex if there are multiple
+        # columns
+        if self_is_multi and other_is_multi:
+            return cudf.MultiIndex._from_data(output._data)
+        else:
+            return cudf.core.index._index_from_data(output._data)
 
     def rename(self, name, inplace=False):
         """

--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -711,7 +711,7 @@ class BaseIndex(Serializable):
             other.names = self.names
             difference = cudf.core.index._index_from_data(
                 cudf.DataFrame._from_data(self._data)
-                ._merge(
+                .merge(
                     cudf.DataFrame._from_data(other._data),
                     how="leftanti",
                     on=self.name,
@@ -1004,7 +1004,7 @@ class BaseIndex(Serializable):
         other_unique.names = self.names
         intersection_result = cudf.core.index._index_from_data(
             cudf.DataFrame._from_data(self.unique()._data)
-            ._merge(
+            .merge(
                 cudf.DataFrame._from_data(other_unique._data),
                 how="inner",
                 on=self.name,
@@ -1209,7 +1209,7 @@ class BaseIndex(Serializable):
         lhs = lhs.to_frame()
         rhs = rhs.to_frame()
 
-        output = lhs._merge(rhs, how=how, on=on, sort=sort)
+        output = lhs.merge(rhs, how=how, on=on, sort=sort)
 
         # If both inputs were MultiIndexes, the output is a MultiIndex.
         # Otherwise, the output is only a MultiIndex if there are multiple

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -76,6 +76,7 @@ from cudf.core.indexed_frame import (
     _indices_from_labels,
     doc_reset_index_template,
 )
+from cudf.core.join import Merge, MergeSemi
 from cudf.core.missing import NA
 from cudf.core.multiindex import MultiIndex
 from cudf.core.resample import DataFrameResampler
@@ -3559,9 +3560,39 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         - For outer joins, the result will be the union of categories
         from both sides.
         """
-        # Compute merge
-        gdf_result = super()._merge(
-            right,
+        if indicator:
+            raise NotImplementedError(
+                "Only indicator=False is currently supported"
+            )
+
+        if lsuffix or rsuffix:
+            raise ValueError(
+                "The lsuffix and rsuffix keywords have been replaced with the "
+                "``suffixes=`` keyword.  "
+                "Please provide the following instead: \n\n"
+                "    suffixes=('%s', '%s')"
+                % (lsuffix or "_x", rsuffix or "_y")
+            )
+        else:
+            lsuffix, rsuffix = suffixes
+
+        lhs, rhs = self, right
+        merge_cls = Merge
+        if how == "right":
+            # Merge doesn't support right, so just swap
+            how = "left"
+            lhs, rhs = right, self
+            left_on, right_on = right_on, left_on
+            left_index, right_index = right_index, left_index
+            suffixes = (suffixes[1], suffixes[0])
+        elif how in {"leftsemi", "leftanti"}:
+            merge_cls = MergeSemi
+
+        # TODO: the two isinstance checks below indicates that `_merge` should
+        # not be defined in `Frame`, but in `IndexedFrame`.
+        return merge_cls(
+            lhs,
+            rhs,
             on=on,
             left_on=left_on,
             right_on=right_on,
@@ -3571,10 +3602,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             sort=sort,
             indicator=indicator,
             suffixes=suffixes,
-            lsuffix=lsuffix,
-            rsuffix=rsuffix,
-        )
-        return gdf_result
+        ).perform_merge()
 
     @_cudf_nvtx_annotate
     def join(
@@ -6888,7 +6916,9 @@ def from_pandas(obj, nan_as_null=None):
 
 @_cudf_nvtx_annotate
 def merge(left, right, *args, **kwargs):
-    return super(type(left), left)._merge(right, *args, **kwargs)
+    if isinstance(left, Series):
+        left = left.to_frame()
+    return left.merge(right, *args, **kwargs)
 
 
 # a bit of fanciness to inject docstring with left parameter
@@ -6896,7 +6926,11 @@ merge_doc = DataFrame.merge.__doc__
 if merge_doc is not None:
     idx = merge_doc.find("right")
     merge.__doc__ = "".join(
-        [merge_doc[:idx], "\n\tleft : DataFrame\n\t", merge_doc[idx:]]
+        [
+            merge_doc[:idx],
+            "\n\tleft : Series or DataFrame\n\t",
+            merge_doc[idx:],
+        ]
     )
 
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -3588,8 +3588,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         elif how in {"leftsemi", "leftanti"}:
             merge_cls = MergeSemi
 
-        # TODO: the two isinstance checks below indicates that `_merge` should
-        # not be defined in `Frame`, but in `IndexedFrame`.
         return merge_cls(
             lhs,
             rhs,

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -37,7 +37,6 @@ from cudf.core.column import (
     serialize_columns,
 )
 from cudf.core.column_accessor import ColumnAccessor
-from cudf.core.join import Merge, MergeSemi
 from cudf.core.mixins import BinaryOperand, Scannable
 from cudf.core.window import Rolling
 from cudf.utils import ioutils
@@ -1588,68 +1587,6 @@ class Frame(BinaryOperand, Scannable):
         dtype: float64
         """
         return self._unaryop("abs")
-
-    @_cudf_nvtx_annotate
-    def _merge(
-        self,
-        right,
-        on=None,
-        left_on=None,
-        right_on=None,
-        left_index=False,
-        right_index=False,
-        how="inner",
-        sort=False,
-        indicator=False,
-        suffixes=("_x", "_y"),
-        lsuffix=None,
-        rsuffix=None,
-    ):
-        if indicator:
-            raise NotImplementedError(
-                "Only indicator=False is currently supported"
-            )
-
-        if lsuffix or rsuffix:
-            raise ValueError(
-                "The lsuffix and rsuffix keywords have been replaced with the "
-                "``suffixes=`` keyword.  "
-                "Please provide the following instead: \n\n"
-                "    suffixes=('%s', '%s')"
-                % (lsuffix or "_x", rsuffix or "_y")
-            )
-        else:
-            lsuffix, rsuffix = suffixes
-
-        lhs, rhs = self, right
-        merge_cls = Merge
-        if how == "right":
-            # Merge doesn't support right, so just swap
-            how = "left"
-            lhs, rhs = right, self
-            left_on, right_on = right_on, left_on
-            left_index, right_index = right_index, left_index
-            suffixes = (suffixes[1], suffixes[0])
-        elif how in {"leftsemi", "leftanti"}:
-            merge_cls = MergeSemi
-
-        # TODO: the two isinstance checks below indicates that `_merge` should
-        # not be defined in `Frame`, but in `IndexedFrame`.
-        return merge_cls(
-            lhs,
-            rhs,
-            on=on,
-            left_on=left_on,
-            right_on=right_on,
-            left_index=left_index,
-            right_index=right_index,
-            lhs_is_index=isinstance(lhs, cudf.core._base_index.BaseIndex),
-            rhs_is_index=isinstance(rhs, cudf.core._base_index.BaseIndex),
-            how=how,
-            sort=sort,
-            indicator=indicator,
-            suffixes=suffixes,
-        ).perform_merge()
 
     @_cudf_nvtx_annotate
     def _is_sorted(self, ascending=None, null_position=None):

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -776,6 +776,14 @@ class RangeIndex(BaseIndex, BinaryOperand):
     def _binaryop(self, other, op: str):
         return self._as_int64()._binaryop(other, op=op)
 
+    def join(
+        self, other, how="left", level=None, return_indexers=False, sort=False
+    ):
+        # TODO: pandas supports directly merging RangeIndex objects and can
+        # intelligently create RangeIndex outputs depending on the type of
+        # join. We need to implement that for the supported special cases.
+        return self._as_int64().join(other, how, level, return_indexers, sort)
+
 
 # Patch in all binops and unary ops, which bypass __getattr__ on the instance
 # and prevent the above overload from working.

--- a/python/cudf/cudf/core/join/_join_helpers.py
+++ b/python/cudf/cudf/core/join/_join_helpers.py
@@ -15,7 +15,6 @@ from cudf.core.dtypes import CategoricalDtype
 
 if TYPE_CHECKING:
     from cudf.core.column import ColumnBase
-    from cudf.core.frame import Frame
 
 
 class _Indexer:
@@ -35,24 +34,19 @@ class _Indexer:
 
 
 class _ColumnIndexer(_Indexer):
-    def get(self, obj: Frame) -> ColumnBase:
+    def get(self, obj: cudf.DataFrame) -> ColumnBase:
         return obj._data[self.name]
 
-    def set(self, obj: Frame, value: ColumnBase, validate=False):
+    def set(self, obj: cudf.DataFrame, value: ColumnBase, validate=False):
         obj._data.set_by_label(self.name, value, validate=validate)
 
 
 class _IndexIndexer(_Indexer):
-    def get(self, obj: Frame) -> ColumnBase:
-        if obj._index is not None:
-            return obj._index._data[self.name]
-        raise KeyError
+    def get(self, obj: cudf.DataFrame) -> ColumnBase:
+        return obj._index._data[self.name]
 
-    def set(self, obj: Frame, value: ColumnBase, validate=False):
-        if obj._index is not None:
-            obj._index._data.set_by_label(self.name, value, validate=validate)
-        else:
-            raise KeyError
+    def set(self, obj: cudf.DataFrame, value: ColumnBase, validate=False):
+        obj._index._data.set_by_label(self.name, value, validate=validate)
 
 
 def _match_join_keys(

--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020-2022, NVIDIA CORPORATION.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, List, cast
+from typing import Any, ClassVar, List, Optional
 
 import cudf
 from cudf import _lib as libcudf
@@ -11,9 +11,6 @@ from cudf.core.join._join_helpers import (
     _IndexIndexer,
     _match_join_keys,
 )
-
-if TYPE_CHECKING:
-    from cudf.core.frame import Frame
 
 
 class Merge:
@@ -41,8 +38,6 @@ class Merge:
         right_on,
         left_index,
         right_index,
-        lhs_is_index,
-        rhs_is_index,
         how,
         sort,
         indicator,
@@ -53,9 +48,9 @@ class Merge:
 
         Parameters
         ----------
-        lhs : Series or DataFrame
+        lhs : DataFrame
             The left operand of the merge
-        rhs : Series or DataFrame
+        rhs : DataFrame
             The right operand of the merge
         on : string or list like
             A set of key columns in the left and right operands
@@ -72,10 +67,6 @@ class Merge:
         right_index : bool
             Boolean flag indicating the right index column or columns
             are to be used as join keys in order.
-        lhs_is_index : bool
-            ``lhs`` is a ``BaseIndex``
-        rhs_is_index : bool
-            ``rhs`` is a ``BaseIndex``
         how : string
             The type of join. Possible values are
             'inner', 'outer', 'left', 'leftsemi' and 'leftanti'
@@ -100,8 +91,6 @@ class Merge:
 
         self.lhs = lhs.copy(deep=False)
         self.rhs = rhs.copy(deep=False)
-        self.lhs_is_index = lhs_is_index
-        self.rhs_is_index = rhs_is_index
         self.how = how
         self.sort = sort
         self.lsuffix, self.rsuffix = suffixes
@@ -155,15 +144,6 @@ class Merge:
             self._using_left_index = False
             self._using_right_index = False
 
-        if isinstance(lhs, cudf.MultiIndex) or isinstance(
-            rhs, cudf.MultiIndex
-        ):
-            self._out_class = cudf.MultiIndex
-        elif isinstance(lhs, cudf.BaseIndex):
-            self._out_class = lhs.__class__
-        else:
-            self._out_class = cudf.DataFrame
-
         self._key_columns_with_same_name = (
             set(_coerce_to_tuple(on))
             if on
@@ -176,7 +156,7 @@ class Merge:
             }
         )
 
-    def perform_merge(self) -> Frame:
+    def perform_merge(self) -> cudf.DataFrame:
         left_join_cols = []
         right_join_cols = []
 
@@ -206,34 +186,23 @@ class Merge:
             how=self.how,
         )
 
-        gather_index = self._using_left_index or self._using_right_index
-        lkwargs = {
-            "gather_map": left_rows,
+        gather_kwargs = {
             "nullify": True,
             "check_bounds": False,
+            "keep_index": self._using_left_index or self._using_right_index,
         }
-        rkwargs = {
-            "gather_map": right_rows,
-            "nullify": True,
-            "check_bounds": False,
-        }
-        if not self.lhs_is_index:
-            lkwargs["keep_index"] = gather_index
-        if not self.rhs_is_index:
-            rkwargs["keep_index"] = gather_index
-
         left_result = (
-            self.lhs._gather(**lkwargs)
+            self.lhs._gather(gather_map=left_rows, **gather_kwargs)
             if left_rows is not None
-            else cudf.core.frame.Frame()
+            else cudf.DataFrame._from_data({})
         )
         right_result = (
-            self.rhs._gather(**rkwargs)
+            self.rhs._gather(gather_map=right_rows, **gather_kwargs)
             if right_rows is not None
-            else cudf.core.frame.Frame()
+            else cudf.DataFrame._from_data({})
         )
 
-        result = self._out_class._from_data(
+        result = cudf.DataFrame._from_data(
             *self._merge_results(left_result, right_result)
         )
 
@@ -241,9 +210,11 @@ class Merge:
             result = self._sort_result(result)
         return result
 
-    def _merge_results(self, left_result: Frame, right_result: Frame):
-        # Merge the Frames `left_result` and `right_result` into a single
-        # `Frame`, suffixing column names if necessary.
+    def _merge_results(
+        self, left_result: cudf.DataFrame, right_result: cudf.DataFrame
+    ):
+        # Merge the DataFrames `left_result` and `right_result` into a single
+        # `DataFrame`, suffixing column names if necessary.
 
         # If two key columns have the same name, a single output column appears
         # in the result. For all non-outer join types, the key column from the
@@ -298,6 +269,7 @@ class Merge:
         else:
             multiindex_columns = False
 
+        index: Optional[cudf.BaseIndex]
         if self._using_right_index:
             # right_index and left_on
             index = left_result._index
@@ -315,15 +287,14 @@ class Merge:
             index,
         )
 
-    def _sort_result(self, result: Frame) -> Frame:
+    def _sort_result(self, result: cudf.DataFrame) -> cudf.DataFrame:
         # Pandas sorts on the key columns in the
         # same order as given in 'on'. If the indices are used as
         # keys, the index will be sorted. If one index is specified,
         # the key columns on the other side will be used to sort.
         by: List[Any] = []
         if self._using_left_index and self._using_right_index:
-            if result._index is not None:
-                by.extend(result._index._data.columns)
+            by.extend(result._index._data.columns)
         if not self._using_left_index:
             by.extend([result._data[col.name] for col in self._left_keys])
         if not self._using_right_index:
@@ -331,16 +302,11 @@ class Merge:
         if by:
             to_sort = cudf.DataFrame._from_data(dict(enumerate(by)))
             sort_order = to_sort.argsort()
-            if isinstance(result, cudf.core._base_index.BaseIndex):
-                result = result._gather(sort_order, check_bounds=False)
-            else:
-                result = cast(cudf.core.indexed_frame.IndexedFrame, result)
-                result = result._gather(
-                    sort_order,
-                    keep_index=self._using_left_index
-                    or self._using_right_index,
-                    check_bounds=False,
-                )
+            result = result._gather(
+                sort_order,
+                keep_index=self._using_left_index or self._using_right_index,
+                check_bounds=False,
+            )
         return result
 
     @staticmethod
@@ -447,11 +413,6 @@ class Merge:
 class MergeSemi(Merge):
     _joiner: ClassVar[staticmethod] = staticmethod(libcudf.join.semi_join)
 
-    def _merge_results(self, lhs: Frame, rhs: Frame):
+    def _merge_results(self, lhs: cudf.DataFrame, rhs: cudf.DataFrame):
         # semi-join result includes only lhs columns
-        return (
-            lhs._data,
-            lhs._index
-            if not issubclass(self._out_class, cudf.Index)
-            else None,
-        )
+        return lhs._data, lhs._index


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->
This PR un-deprecates the `BaseIndex.join` method, which was erroneously deprecated, but reimplements it by converting the index objects to DataFrames under the hood. This reimplementation allows us to simplify much of the internals around merging, providing a single main code path implemented only for DataFrames. The behavior of `cudf.merge(Series, DataFrame)` is preserved via an explicit upcast as well. These changes allow further simplification of the (currently extremely complex) internals of merging, which hopefully will eventually allow us to extract a fast and simple merge function for internal use from the complexities of the public DataFrame.merge API. This change also removes any vestigial accesses to the Frame._index to enable us to remove that.