### PR TITLE
Use stod in cuio floating point parsing

### DIFF
--- a/cpp/include/cudf/strings/string.cuh
+++ b/cpp/include/cudf/strings/string.cuh
@@ -141,6 +141,7 @@ constexpr inline bool is_float(const char* data,
   return result;
 }
 // @endcond
+
 /**
  * @brief Returns `true` if all characters in the string
  * are valid for conversion to a float type.
@@ -157,7 +158,7 @@ constexpr inline bool is_float(const char* data,
  * The following strings are also allowed and will return true:
  *  "NaN", "NAN", "Inf", "INF", "INFINITY"
  *
- * @param d_str String to check.
+ * @param d_str String to check
  * @return true if string has valid float characters
  */
 inline __device__ bool is_float(string_view const& d_str)

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -138,8 +138,10 @@ constexpr uint8_t decode_digit(char c, bool* valid_flag)
  * This will also map strings containing "NaN", "Inf", etc. to the appropriate float values.
  *
  * This function will also handle scientific notation format.
+ 
  * @tparam is_check_validity If true, the function return `error_result` if the input string is
  * not a valid floating point number
+ 
  * @param begin Beginning of the string to convert
  * @param end End of the string to convert
  * @param error_result Value to return if the input string is not a valid floating point number

--- a/cpp/src/io/utilities/parsing_utils.cuh
+++ b/cpp/src/io/utilities/parsing_utils.cuh
@@ -358,6 +358,26 @@ constexpr T parse_numeric(const char* begin,
   return value * sign;
 }
 
+// Specialization for float
+template <>
+constexpr float parse_numeric<float, 10>(const char* begin,
+                                         const char* end,
+                                         parse_options_view const& opts,
+                                         float error_result)
+{
+  return stod<true>(begin, end, error_result, opts.decimal, opts.thousands);
+}
+
+// Specialization for double
+template <>
+constexpr double parse_numeric<double, 10>(const char* begin,
+                                           const char* end,
+                                           parse_options_view const& opts,
+                                           double error_result)
+{
+  return stod<true>(begin, end, error_result, opts.decimal, opts.thousands);
+}
+
 namespace gpu {
 /**
  * @brief CUDA kernel iterates over the data until the end of the current field

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <io/utilities/parsing_utils.cuh>
+
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/null_mask.hpp>
@@ -56,97 +58,9 @@ namespace {
  */
 __device__ inline double stod(string_view const& d_str)
 {
-  const char* in_ptr = d_str.data();
-  const char* end    = in_ptr + d_str.size_bytes();
-  if (end == in_ptr) return 0.0;
-  double sign{1.0};
-  if (*in_ptr == '-' || *in_ptr == '+') {
-    sign = (*in_ptr == '-' ? -1 : 1);
-    ++in_ptr;
-  }
-
-  // special strings: NaN, Inf
-  if ((in_ptr < end) && *in_ptr > '9') {
-    auto const inf_nan = string_view(in_ptr, static_cast<size_type>(thrust::distance(in_ptr, end)));
-    if (is_nan_str(inf_nan)) return std::numeric_limits<double>::quiet_NaN();
-    if (is_inf_str(inf_nan)) return sign * std::numeric_limits<double>::infinity();
-  }
-
-  // Parse and store the mantissa as much as we can,
-  // until we are about to exceed the limit of uint64_t
-  constexpr uint64_t max_holding = (std::numeric_limits<uint64_t>::max() - 9L) / 10L;
-  uint64_t digits                = 0;
-  int exp_off                    = 0;
-  bool decimal                   = false;
-  while (in_ptr < end) {
-    char ch = *in_ptr;
-    if (ch == '.') {
-      decimal = true;
-      ++in_ptr;
-      continue;
-    }
-    if (ch < '0' || ch > '9') break;
-    if (digits > max_holding)
-      exp_off += (int)!decimal;
-    else {
-      digits = (digits * 10L) + static_cast<uint64_t>(ch - '0');
-      if (digits > max_holding) {
-        digits = digits / 10L;
-        exp_off += (int)!decimal;
-      } else
-        exp_off -= (int)decimal;
-    }
-    ++in_ptr;
-  }
-  if (digits == 0) return sign * static_cast<double>(0);
-
-  // check for exponent char
-  int exp_ten  = 0;
-  int exp_sign = 1;
-  if (in_ptr < end) {
-    char ch = *in_ptr++;
-    if (ch == 'e' || ch == 'E') {
-      if (in_ptr < end) {
-        ch = *in_ptr;
-        if (ch == '-' || ch == '+') {
-          exp_sign = (ch == '-' ? -1 : 1);
-          ++in_ptr;
-        }
-        while (in_ptr < end) {
-          ch = *in_ptr++;
-          if (ch < '0' || ch > '9') break;
-          exp_ten = (exp_ten * 10) + (int)(ch - '0');
-        }
-      }
-    }
-  }
-
-  int const num_digits = static_cast<int>(log10(digits)) + 1;
-  exp_ten *= exp_sign;
-  exp_ten += exp_off;
-  exp_ten += num_digits - 1;
-  if (exp_ten > std::numeric_limits<double>::max_exponent10) {
-    return sign > 0 ? std::numeric_limits<double>::infinity()
-                    : -std::numeric_limits<double>::infinity();
-  }
-
-  double base = sign * static_cast<double>(digits);
-
-  exp_ten += 1 - num_digits;
-  // If 10^exp_ten would result in a subnormal value, the base and
-  // exponent should be adjusted so that 10^exp_ten is a normal value
-  auto const subnormal_shift = std::numeric_limits<double>::min_exponent10 - exp_ten;
-  if (subnormal_shift > 0) {
-    // Handle subnormal values. Ensure that both base and exponent are
-    // normal values before computing their product.
-    base = base / exp10(static_cast<double>(num_digits - 1 + subnormal_shift));
-    exp_ten += num_digits - 1;  // adjust exponent
-    auto const exponent = exp10(static_cast<double>(exp_ten + subnormal_shift));
-    return base * exponent;
-  }
-
-  double const exponent = exp10(static_cast<double>(std::abs(exp_ten)));
-  return exp_ten < 0 ? base / exponent : base * exponent;
+  const char* begin = d_str.data();
+  const char* end   = begin + d_str.size_bytes();
+  return io::stod<false>(begin, end);
 }
 
 /**


### PR DESCRIPTION
Fixes #10599
Parsing string to float is inconsistent between CSV reader and to_numeric. This is because cuio parsing and cudf.to_numeric uses different algorithms.
- cuio parsing uses `parse_numeric`. This is written such that it works on both integrals and floating point numbers.
- to_numeric in convert_floats.cu uses `stod`. This can return partial result if parsing encounters invalid float format.

`stod` is very close to the C++ STL `stod` function implementation.

This PR updated the parsing code to use modified version of `stod`.  
`stod` can take optional parameters such as error_result, decimal_char, thousands_char (documented).
