### PR TITLE
Simplify and standardize tests that compare against pandas

### DIFF
--- a/python/cudf/benchmarks/common/utils.py
+++ b/python/cudf/benchmarks/common/utils.py
@@ -144,9 +144,6 @@ def benchmark_with_object(
         # to benchmark_with_object.
         parameters = inspect.signature(bm).parameters
 
-        # Note: This logic assumes that any benchmark using this fixture has at
-        # least two parameters since they must be using both the
-        # pytest-benchmark `benchmark` fixture and the cudf object.
         params_str = ", ".join(f"{p}" for p in parameters if p != cls)
         arg_str = ", ".join(f"{p}={p}" for p in parameters if p != cls)
 

--- a/python/cudf/cudf/tests/test_pandas_comparison.py
+++ b/python/cudf/cudf/tests/test_pandas_comparison.py
@@ -288,7 +288,9 @@ def pandas_copy_semantics_comparison_test(cudf_object):
                 cudf_output = test({cudf_arg_str})
                 pandas_output = test({pandas_arg_str})
 
-                # TODO: Make this better
+                # TODO: Generalize this to different data types and make it
+                # robust to the values already contained. It may also need to
+                # be specialized for DataFrame vs. Series ops.
                 cudf_output.iloc[0] = 230849
                 pandas_output.iloc[0] = 230849
 
@@ -318,6 +320,10 @@ def pandas_copy_semantics_comparison_test(cudf_object):
     return deco
 
 
+# TODO: Instead of requiring the user to pass `cudf_object`, we could require
+# the cudf object (fixture or parameter) to be the first argument. The current
+# approach seems more explicit, but perhaps we would prefer the other, less
+# verbose approach?
 @pandas_copy_semantics_comparison_test(cudf_object="df")
 def test_df_head(df):
     return df.head()

--- a/python/cudf/cudf/tests/test_pandas_comparison.py
+++ b/python/cudf/cudf/tests/test_pandas_comparison.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+
+import inspect
+import sys
+import textwrap
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import cudf
+from cudf.testing._utils import assert_eq
+
+
+def _is_cudf(lib):
+    # Is it safe to use `if lib is cudf`? I think there are some cases where
+    # the imports of a package in different modules may not be identical for
+    # that purpose, will have to double-check.
+    return lib.__name__ == "cudf"
+
+
+# The parameter name used for pandas/cudf in test functions.
+_LIB_PARAM_NAME = "lib"
+
+
+def pandas_comparison_test(*args, assert_func=assert_eq):
+    def deco(test):
+        """Run a test function with cudf and pandas and ensure equal results.
+
+        This decorator generates a new function that looks identical to the
+        decorated function but calls the original function twice, once each for
+        pandas and cudf and asserts that the two results are equal.
+        """
+        parameters = inspect.signature(test).parameters
+        params_str = ", ".join(
+            f"{p}" for p in parameters if p != _LIB_PARAM_NAME
+        )
+        arg_str = ", ".join(
+            f"{p}={p}" for p in parameters if p != _LIB_PARAM_NAME
+        )
+
+        if arg_str:
+            arg_str += ", "
+
+        cudf_arg_str = arg_str + f"{_LIB_PARAM_NAME}=cudf"
+        pandas_arg_str = arg_str + f"{_LIB_PARAM_NAME}=pandas"
+
+        src = textwrap.dedent(
+            f"""
+            import pandas
+            import cudf
+            import makefun
+            @makefun.wraps(
+                test,
+                remove_args=("{_LIB_PARAM_NAME}",),
+            )
+            def wrapped_test({params_str}):
+                print()
+                cudf_output = test({cudf_arg_str})
+                pandas_output = test({pandas_arg_str})
+                assert_func(pandas_output, cudf_output)
+            """
+        )
+        globals_ = {
+            "test": test,
+            "assert_func": assert_func,
+        }
+        exec(src, globals_)
+        wrapped_test = globals_["wrapped_test"]
+        # In case marks were applied to the original benchmark, copy them over.
+        if marks := getattr(test, "pytestmark", None):
+            wrapped_test.pytestmark = marks
+        return wrapped_test
+
+    if args:
+        if len(args) == 1:
+            # Was called directly with a test.
+            return deco(args[0])
+        raise ValueError("This decorator only supports keyword arguments.")
+    return deco
+
+
+@pandas_comparison_test
+def test_init(lib):
+    print(f"test1, {cudf}", file=sys.stderr)
+    data = [
+        (5, "cats", "jump", np.nan),
+        (2, "dogs", "dig", 7.5),
+        (3, "cows", "moo", -2.1, "occasionally"),
+    ]
+    return lib.DataFrame(data)
+
+
+@pandas_comparison_test()
+def test_init2(lib):
+    print(f"test2, {cudf}", file=sys.stderr)
+    data = [
+        (5, "cats", "jump", np.nan),
+        (2, "dogs", "dig", 7.5),
+        (3, "cows", "moo", -2.1, "occasionally"),
+    ]
+    return lib.DataFrame(data)
+
+
+@pytest.fixture
+def dt():
+    return [
+        (5, "cats", "jump", np.nan),
+        (2, "dogs", "dig", 7.5),
+        (3, "cows", "moo", -2.1, "occasionally"),
+    ]
+
+
+@pandas_comparison_test
+def test_init4(lib, dt):
+    print(f"test4, {lib}", file=sys.stderr)
+    return lib.DataFrame(dt)
+
+
+@pandas_comparison_test
+@pytest.mark.parametrize(
+    "data",
+    [
+        [
+            (5, "cats", "jump", np.nan),
+            (2, "dogs", "dig", 7.5),
+            (3, "cows", "moo", -2.1, "occasionally"),
+        ]
+    ],
+)
+def test_init5(lib, data):
+    print(f"test5, {lib}", file=sys.stderr)
+    return lib.DataFrame(data)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [
+            (5, "cats", "jump", np.nan),
+            (2, "dogs", "dig", 7.5),
+            (3, "cows", "moo", -2.1, "occasionally"),
+        ]
+    ],
+)
+@pandas_comparison_test
+def test_init6(lib, data):
+    print(f"test6, {lib}", file=sys.stderr)
+    return lib.DataFrame(data)
+
+
+@pytest.mark.parametrize(
+    "df",
+    [
+        pd.DataFrame(
+            [
+                (5, "cats", "jump", np.nan),
+                (2, "dogs", "dig", 7.5),
+                (3, "cows", "moo", -2.1, "occasionally"),
+            ]
+        )
+    ],
+)
+@pandas_comparison_test
+def test_from_pandas(lib, df):
+    print(f"test_from_pandas, {lib}", file=sys.stderr)
+    return lib.from_pandas(df) if _is_cudf(lib) else df
+
+
+def custom_assert(expected, got):
+    cudf.testing.assert_frame_equal(cudf.from_pandas(expected), got)
+
+
+@pytest.mark.parametrize(
+    "df",
+    [
+        pd.DataFrame(
+            [
+                (5, "cats", "jump", np.nan),
+                (2, "dogs", "dig", 7.5),
+                (3, "cows", "moo", -2.1, "occasionally"),
+            ]
+        )
+    ],
+)
+@pandas_comparison_test(assert_func=custom_assert)
+def test_from_pandas_custom_assert(lib, df):
+    print(f"test_from_pandas_custom_assert, {lib}", file=sys.stderr)
+    return lib.from_pandas(df) if _is_cudf(lib) else df

--- a/python/cudf/cudf/tests/test_pandas_comparison.py
+++ b/python/cudf/cudf/tests/test_pandas_comparison.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 import inspect
-import sys
 import textwrap
 
 import numpy as np
@@ -82,7 +81,6 @@ def pandas_comparison_test(*args, assert_func=assert_eq):
 
 @pandas_comparison_test
 def test_init(lib):
-    print(f"test1, {cudf}", file=sys.stderr)
     data = [
         (5, "cats", "jump", np.nan),
         (2, "dogs", "dig", 7.5),
@@ -93,7 +91,6 @@ def test_init(lib):
 
 @pandas_comparison_test()
 def test_init2(lib):
-    print(f"test2, {cudf}", file=sys.stderr)
     data = [
         (5, "cats", "jump", np.nan),
         (2, "dogs", "dig", 7.5),
@@ -113,7 +110,11 @@ def dt():
 
 @pandas_comparison_test
 def test_init4(lib, dt):
-    print(f"test4, {lib}", file=sys.stderr)
+    return lib.DataFrame(dt)
+
+
+@pandas_comparison_test
+def test_init7(dt, lib):
     return lib.DataFrame(dt)
 
 
@@ -129,7 +130,6 @@ def test_init4(lib, dt):
     ],
 )
 def test_init5(lib, data):
-    print(f"test5, {lib}", file=sys.stderr)
     return lib.DataFrame(data)
 
 
@@ -145,7 +145,6 @@ def test_init5(lib, data):
 )
 @pandas_comparison_test
 def test_init6(lib, data):
-    print(f"test6, {lib}", file=sys.stderr)
     return lib.DataFrame(data)
 
 
@@ -163,7 +162,6 @@ def test_init6(lib, data):
 )
 @pandas_comparison_test
 def test_from_pandas(lib, df):
-    print(f"test_from_pandas, {lib}", file=sys.stderr)
     return lib.from_pandas(df) if _is_cudf(lib) else df
 
 
@@ -185,5 +183,4 @@ def custom_assert(expected, got):
 )
 @pandas_comparison_test(assert_func=custom_assert)
 def test_from_pandas_custom_assert(lib, df):
-    print(f"test_from_pandas_custom_assert, {lib}", file=sys.stderr)
     return lib.from_pandas(df) if _is_cudf(lib) else df

--- a/python/cudf/cudf/tests/test_pandas_comparison.py
+++ b/python/cudf/cudf/tests/test_pandas_comparison.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 
 import inspect
 import textwrap


### PR DESCRIPTION
<!--

Thank you for contributing to cuDF :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. There are CI checks in place to enforce that committed code follows our style
   and syntax standards. Please see our contribution guide in `CONTRIBUTING.MD`
   in the project root for more information about the checks we perform and how
   you can run them locally.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   C/C++ code of a feature is complete but Python bindings are still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on the target branch, force push, or rewrite history.
   Doing any of these causes the context of any comments made by reviewers to be lost.
   If conflicts occur against the target branch they should be resolved by
   merging the target branch into the branch used for making the pull request.

8. Pull requests that modify cpp source that are marked ready for review 
   will automatically be assigned two cudf-cpp-codeowners reviewers.
   Ensure at least two approvals from cudf-cpp-codeowners before merging.

Many thanks in advance for your cooperation!

-->
A large number of cudf's current tests are about twice as long as they need to be because they contain two copies of the same set of commands, once for cudf and once for pandas. Aside from the fact that this unnecessarily doubles the number of lines of code, it also introduces additional room for divergence. For instance, different tests may be initialized with cudf or pandas objects, potentially leading to a doubling of parametrization or fixtures. Furthermore, it forces developers to read the entire function to find any places where there are expected pandas/cudf divergences that we have to work around.

This PR introduces a new decorator that can be used for tests that perform a pandas/cudf comparison. These tests must accept a parameter `lib` indicating whether to run with `cudf` or `pandas`. The test will then be called twice, once with cudf and once with pandas. It should return results that must be compared. The final assertion may be customized in case we need to do something other than simply `assert_eq`. The rest of the parameters to the test function can be anything normally passed to a pytest test; fixtures and parameters are forwarded transparently to the invocations of the function.