### PR TITLE
Upgrade Google Benchmark

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -713,9 +713,9 @@ endif()
 if(CUDF_BUILD_BENCHMARKS)
   # Find or install GoogleBench
   rapids_cpm_find(
-    benchmark 1.5.2
+    benchmark 1.6.1
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG v1.5.2
+    GIT_TAG v1.6.1
     GIT_SHALLOW TRUE
     OPTIONS "BENCHMARK_ENABLE_TESTING OFF" "BENCHMARK_ENABLE_INSTALL OFF"
   )


### PR DESCRIPTION
The current version of Google benchmark is 1.5.2, which was released nearly 2 years ago. The latest version has many new useful APIs that we should use. For example, `benchmark::CreateRange` that allows creating ranges which can be used inside the `ArgsProduct()` function. 

This PR update cudf cmake to use the latest Google benchmark version (v1.6.1).

Blocks https://github.com/rapidsai/cudf/pull/11202.