### PR TITLE
Use `cudf::distinct` in Java binding

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -708,8 +708,7 @@ public final class Table implements AutoCloseable {
   private static native long[] filter(long input, long mask);
 
   private static native long[] dropDuplicates(long nativeHandle, int[] keyColumns,
-                                              boolean keepFirst, boolean nullsEqual,
-                                              boolean nullsBefore) throws CudfException;
+                                              int keepValue, boolean nullsEqual) throws CudfException;
 
   private static native long[] gather(long tableHandle, long gatherView, boolean checkBounds);
 
@@ -2030,27 +2029,36 @@ public final class Table implements AutoCloseable {
   }
 
   /**
+   * Enum to specify which of duplicate rows/elements will be copied to the output.
+   */
+  public enum DuplicateKeepOption {
+    KEEP_ANY(0),
+    KEEP_FIRST(1),
+    KEEP_LAST(2),
+    KEEP_NONE(3);
+
+    final int keepValue;
+
+    DuplicateKeepOption(int keepValue) {
+      this.keepValue = keepValue;
+    }
+  }
+
+  /**
    * Copy rows of the current table to an output table such that duplicate rows in the key columns
    * are ignored (i.e., only one row from the duplicate ones will be copied). These keys columns are
    * a subset of the current table columns and their indices are specified by an input array.
    *
-   * Currently, the output table is sorted by key columns, using stable sort. However, this is not
-   * guaranteed in the future.
-   *
    * @param keyColumns Array of indices representing key columns from the current table.
-   * @param keepFirst If it is true, the first row with a duplicated key will be copied. Otherwise,
-   *                  copy the last row with a duplicated key.
+   * @param keep Option specifying to keep any, first, last, or none of the found duplicates.
    * @param nullsEqual Flag to denote whether nulls are treated as equal when comparing rows of the
    *                   key columns to check for uniqueness.
-   * @param nullsBefore Flag to specify whether nulls in the key columns will appear before or
-   *                    after non-null elements when sorting the table.
    *
    * @return Table with unique keys.
    */
-  public Table dropDuplicates(int[] keyColumns, boolean keepFirst, boolean nullsEqual,
-                              boolean nullsBefore) {
+  public Table dropDuplicates(int[] keyColumns, DuplicateKeepOption keep, boolean nullsEqual) {
     assert keyColumns.length >= 1 : "Input keyColumns must contain indices of at least one column";
-    return new Table(dropDuplicates(nativeHandle, keyColumns, keepFirst, nullsEqual, nullsBefore));
+    return new Table(dropDuplicates(nativeHandle, keyColumns, keep.keepValue, nullsEqual));
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -2049,6 +2049,8 @@ public final class Table implements AutoCloseable {
    * are ignored (i.e., only one row from the duplicate ones will be copied). These keys columns are
    * a subset of the current table columns and their indices are specified by an input array.
    *
+   * The order of rows in the output table is not specified.
+   *
    * @param keyColumns Array of indices representing key columns from the current table.
    * @param keep Option specifying to keep any, first, last, or none of the found duplicates.
    * @param nullsEqual Flag to denote whether nulls are treated as equal when comparing rows of the

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -5347,11 +5347,11 @@ public class TableTest extends CudfTestBase {
                ColumnVector expect_first = ColumnVector.fromBoxedInts(7, 7, 5, 3, 7, 7, 9, X, X, X, 0, 4);
                ColumnVector expect_last = ColumnVector.fromBoxedInts(5, 3, 7, 7, 9, X, 4, 4, 0, 4, X, X);
                ColumnVector expect_1th  = ColumnVector.fromBoxedInts(5, 5, 3, 7, 9, 9, X, 4, 0, 0, 4, X);
-               ColumnVector expect_first_skip_null  = 
+               ColumnVector expect_first_skip_null  =
                  ColumnVector.fromBoxedInts(7, 7, 5, 3, 7, 7, 9, 4, 0, 0, 0, 4);
-               ColumnVector expect_last_skip_null  = 
+               ColumnVector expect_last_skip_null  =
                  ColumnVector.fromBoxedInts(5, 3, 7, 7, 9, 9, 4, 4, 0, 4, 4, 4);
-               ColumnVector expect_1th_skip_null  = 
+               ColumnVector expect_1th_skip_null  =
                  ColumnVector.fromBoxedInts(5, 5, 3, 7, 9, 9, 4, X, X, 4, 4, X)) {
             assertColumnsAreEqual(expect_first, windowAggResults.getColumn(0));
             assertColumnsAreEqual(expect_last, windowAggResults.getColumn(1));
@@ -7510,19 +7510,21 @@ public class TableTest extends CudfTestBase {
          Table input = new Table(col1, col2)) {
 
       // Keep the first duplicate element.
-      try (Table result = input.dropDuplicates(keyColumns, true, true, true);
+      try (Table result = input.dropDuplicates(keyColumns, Table.DuplicateKeepOption.KEEP_FIRST, true);
+           Table resultSorted = result.orderBy(OrderByArg.asc(1, true));
            ColumnVector expectedCol1 = ColumnVector.fromBoxedInts(null, 5, 5, 8);
            ColumnVector expectedCol2 = ColumnVector.fromBoxedInts(null, 19, 20, 21);
            Table expected = new Table(expectedCol1, expectedCol2)) {
-        assertTablesAreEqual(expected, result);
+        assertTablesAreEqual(expected, resultSorted);
       }
 
       // Keep the last duplicate element.
-      try (Table result = input.dropDuplicates(keyColumns, false, true, true);
+      try (Table result = input.dropDuplicates(keyColumns, Table.DuplicateKeepOption.KEEP_LAST, true);
+           Table resultSorted = result.orderBy(OrderByArg.asc(1, true));
            ColumnVector expectedCol1 = ColumnVector.fromBoxedInts(3, 1, 5, 8);
            ColumnVector expectedCol2 = ColumnVector.fromBoxedInts(null, 19, 20, 21);
            Table expected = new Table(expectedCol1, expectedCol2)) {
-        assertTablesAreEqual(expected, result);
+        assertTablesAreEqual(expected, resultSorted);
       }
     }
   }


### PR DESCRIPTION
Java binding has `dropDuplicates` API to remove duplicate rows from a table. Previously it has been implemented by sorting the table then calling to `cudf::unique`. This PR changes the implementation to use `cudf::distinct` directly, which can significantly improve performance by avoiding sorting the input table.