### PR TITLE
Fix a memory aliasing/crash issue in scatter for lists.

### DIFF
--- a/cpp/src/lists/copying/scatter_helper.cu
+++ b/cpp/src/lists/copying/scatter_helper.cu
@@ -418,8 +418,7 @@ struct list_child_constructor {
       });
 
     auto const iter_target_member_as_list = thrust::make_transform_iterator(
-      thrust::make_counting_iterator<cudf::size_type>(0),
-      [&](auto child_idx) {
+      thrust::make_counting_iterator<cudf::size_type>(0), [&](auto child_idx) {
         return project_member_as_list_view(target_structs.child(child_idx),
                                            target_lists_column_view.size(),
                                            target_lists_column_view.offsets(),
@@ -427,21 +426,21 @@ struct list_child_constructor {
                                            target_lists_column_view.null_count());
       });
 
-      std::transform(iter_source_member_as_list,
-                     iter_source_member_as_list + num_struct_members,
-                     iter_target_member_as_list,
-                     std::back_inserter(child_columns),
-                     [&](auto source_struct_member_list_view, auto target_struct_member_list_view) {
-                       return cudf::type_dispatcher<dispatch_storage_type>(
-                         source_struct_member_list_view.child().type(),
-                         list_child_constructor{},
-                         list_vector,
-                         list_offsets,
-                         source_struct_member_list_view,
-                         target_struct_member_list_view,
-                         stream,
-                         mr);
-                     });
+    std::transform(iter_source_member_as_list,
+                   iter_source_member_as_list + num_struct_members,
+                   iter_target_member_as_list,
+                   std::back_inserter(child_columns),
+                   [&](auto source_struct_member_list_view, auto target_struct_member_list_view) {
+                     return cudf::type_dispatcher<dispatch_storage_type>(
+                       source_struct_member_list_view.child().type(),
+                       list_child_constructor{},
+                       list_vector,
+                       list_offsets,
+                       source_struct_member_list_view,
+                       target_struct_member_list_view,
+                       stream,
+                       mr);
+                   });
 
     auto child_null_mask =
       source_lists_column_view.child().nullable() || target_lists_column_view.child().nullable()


### PR DESCRIPTION

Fixes:  https://github.com/rapidsai/cudf/issues/11248

A transform iterator was calling `copy_bitmask()` to create a new `rmm::device_buffer` as a temporary.  The pointer from this was being stored in a `lists_column_view`, but the underlying temporary was being deleted immediately.  

The copy is unnecessary because the backing bitmask is coming from column views that have a safe lifetime for the duration of the operation.  So the fix is to just pass the original pointers along.