### PR TITLE
Ensure DeprecationWarnings are not introduced via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,12 @@ repos:
                 args: ['-fallback-style=none', '-style=file', '-i']
       - repo: local
         hooks:
+              - id: no-deprecationwarning
+                name: no-deprecationwarning
+                description: 'Enforce that DeprecationWarning is not introduced (use FutureWarning instead)'
+                entry: '(category=|\s)DeprecationWarning[,)]'
+                language: pygrep
+                types_or: [python, cython]
               - id: cmake-format
                 name: cmake-format
                 entry: ./cpp/scripts/run-cmake-format.sh cmake-format


### PR DESCRIPTION
Deprecated APIs should be announced with FutureWarning, check that
changes don't accidentally introduce DeprecationWarning using a regular
expression that is hopefully specific enough. Closes #11251.