### PR TITLE
Fix compile error due to missing header

### DIFF
--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <optional>
 #include <vector>
 
 namespace cudf {

--- a/cpp/include/cudf/detail/reduction_functions.hpp
+++ b/cpp/include/cudf/detail/reduction_functions.hpp
@@ -23,6 +23,8 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <optional>
+
 namespace cudf {
 namespace reduction {
 /**

--- a/cpp/include/cudf/reduction.hpp
+++ b/cpp/include/cudf/reduction.hpp
@@ -21,6 +21,8 @@
 
 #include <rmm/mr/device/per_device_resource.hpp>
 
+#include <optional>
+
 namespace cudf {
 /**
  * @addtogroup aggregation_reduction

--- a/cpp/src/reductions/simple_segmented.cuh
+++ b/cpp/src/reductions/simple_segmented.cuh
@@ -38,6 +38,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 
+#include <optional>
 #include <type_traits>
 
 namespace cudf {


### PR DESCRIPTION
The recently merged PR (https://github.com/rapidsai/cudf/pull/11137) did not include the `<optional>` header which may cause compile error in some systems (in particular, CUDA 11.7 + gcc-11.2):
```
error: ‘std::optional’ has not been declared
error: ‘optional’ in namespace ‘std’ does not name a template type
```

This PR adds that missing header to fix the compile issue.