### PR TITLE
Returns DataFrame When Concating Along Axis 1

### DIFF
--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -266,7 +266,14 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
                         index=cudf.RangeIndex(len(obj)),
                     )
         else:
-            result = obj.copy()
+            if axis == 0:
+                result = obj.copy()
+            else:
+                data = obj._data.copy(deep=True)
+                if isinstance(obj, cudf.Series) and obj.name is None:
+                    # If the Series has no name, pandas renames it to 0.
+                    data[0] = data.pop(None)
+                result = cudf.DataFrame._from_data(data)
 
         return result.sort_index(axis=axis) if sort else result
 

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -384,17 +384,13 @@ def test_pandas_concat_compatibility_axis1_eq_index():
     )
 
 
-def test_pandas_concat_compatibility_axis1_single_column():
+@pytest.mark.parametrize("name", [None, "a"])
+def test_pandas_concat_compatibility_axis1_single_column(name):
     # Pandas renames series name `None` to 0
-    s = gd.Series([1, 2, 3])
+    # and preserves anything else
+    s = gd.Series([1, 2, 3], name=name)
     got = gd.concat([s], axis=1)
     expected = pd.concat([s.to_pandas()], axis=1)
-    assert_eq(expected, got)
-
-    # Test concat preserves name
-    s2 = gd.Series([1, 2, 3], name="a")
-    got = gd.concat([s2], axis=1)
-    expected = pd.concat([s2.to_pandas()], axis=1)
     assert_eq(expected, got)
 
 

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -384,6 +384,20 @@ def test_pandas_concat_compatibility_axis1_eq_index():
     )
 
 
+def test_pandas_concat_compatibility_axis1_single_column():
+    # Pandas renames series name `None` to 0
+    s = gd.Series([1, 2, 3])
+    got = gd.concat([s], axis=1)
+    expected = pd.concat([s.to_pandas()], axis=1)
+    assert_eq(expected, got)
+
+    # Test concat preserves name
+    s2 = gd.Series([1, 2, 3], name="a")
+    got = gd.concat([s2], axis=1)
+    expected = pd.concat([s2.to_pandas()], axis=1)
+    assert_eq(expected, got)
+
+
 def test_concat_duplicate_columns():
     cdf = gd.DataFrame(
         {


### PR DESCRIPTION
fixes #11244 

When concatenating along axis 1, pandas always return a dataframe even though there are only 1 column involved. This PR conforms cuDF to that behavior.