### PR TITLE
Fix `cudf` recipe

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
-{% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
+{% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 {% set cuda_version='.'.join(environ.get('CUDA', '11.5').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
@@ -41,10 +41,10 @@ requirements:
     - setuptools
     - numba >=0.54
     - dlpack>=0.5,<0.6.0a0
-    - pyarrow 8.0.0 *cuda
-    - libcudf {{ version }}
-    - rmm {{ minor_version }}
-    - cudatoolkit {{ cuda_version }}
+    - pyarrow =8.0.0 *cuda
+    - libcudf ={{ version }}
+    - rmm ={{ minor_version }}
+    - cudatoolkit ={{ cuda_version }}
   run:
     - protobuf>=3.20.1,<3.21.0a0
     - python


### PR DESCRIPTION
Some of our nightly builds were failing with the error message (i.e. [here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/branches/job/cudf-gpu-build-branch-22.08/63/CUDA=11.5/console)):

```
The reported errors are:
 - Encountered problems while solving:
   - nothing provides requested libcudf 22.08.00a
```

Adding an `=` before `libcudf` in the `cudf/meta.yaml` file seemed to resolve this problem for me locally.