### PR TITLE
Fix `cudf` recipes syntax

### DIFF
--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -29,14 +29,14 @@ requirements:
   host:
     - python
     - cython >=0.29,<0.30
-    - cudf {{ version }}
-    - libcudf_kafka {{ version }}
+    - cudf ={{ version }}
+    - libcudf_kafka ={{ version }}
     - setuptools
   run:
     - python
-    - libcudf_kafka {{ version }}
+    - libcudf_kafka ={{ version }}
     - python-confluent-kafka >=1.7.0,<1.8.0a0
-    - cudf {{ version }}
+    - cudf ={{ version }}
 
 test:                                   # [linux64]
   requires:                             # [linux64]

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -24,15 +24,15 @@ requirements:
   host:
     - python
     - python-confluent-kafka >=1.7.0,<1.8.0a0
-    - cudf_kafka {{ version }}
+    - cudf_kafka ={{ version }}
   run:
     - python
     - streamz
-    - cudf {{ version }}
+    - cudf ={{ version }}
     - dask>=2022.05.2
     - distributed>=2022.05.2
     - python-confluent-kafka >=1.7.0,<1.8.0a0
-    - cudf_kafka {{ version }}
+    - cudf_kafka ={{ version }}
 
 test:                                   # [linux64]
   requires:                             # [linux64]

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -23,13 +23,13 @@ build:
 requirements:
   host:
     - python
-    - cudf {{ version }}
+    - cudf ={{ version }}
     - dask>=2022.05.2
     - distributed>=2022.05.2
-    - cudatoolkit {{ cuda_version }}
+    - cudatoolkit ={{ cuda_version }}
   run:
     - python
-    - cudf {{ version }}
+    - cudf ={{ version }}
     - dask>=2022.05.2
     - distributed>=2022.05.2
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
#11267 seemed to fix some of the nightly build issues we've been experiencing, but there are other recipes that need to be updated as well.