### PR TITLE
Add lists filtering APIs to doxygen group.

### DIFF
--- a/cpp/include/cudf/lists/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/stream_compaction.hpp
@@ -24,6 +24,12 @@
 namespace cudf::lists {
 
 /**
+ * @addtogroup lists_filtering
+ * @{
+ * @file
+ */
+
+/**
  * @brief Filters elements in each row of `input` LIST column using `boolean_mask`
  * LIST of booleans as a mask.
  *
@@ -80,5 +86,7 @@ std::unique_ptr<column> distinct(
   null_equality nulls_equal           = null_equality::EQUAL,
   nan_equality nans_equal             = nan_equality::ALL_EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/** @} */ // end of group
 
 }  // namespace cudf::lists

--- a/cpp/include/cudf/lists/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/stream_compaction.hpp
@@ -87,6 +87,6 @@ std::unique_ptr<column> distinct(
   nan_equality nans_equal             = nan_equality::ALL_EQUAL,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
-/** @} */ // end of group
+/** @} */  // end of group
 
 }  // namespace cudf::lists

--- a/cpp/include/doxygen_groups.h
+++ b/cpp/include/doxygen_groups.h
@@ -150,7 +150,7 @@
  *   @defgroup lists_contains Searching
  *   @defgroup lists_gather Gathering
  *   @defgroup lists_elements Counting
- *   @defgroup lists_drop_duplicates Filtering
+ *   @defgroup lists_filtering Filtering
  *   @defgroup lists_sort Sorting
  * @}
  * @defgroup nvtext_apis NVText


### PR DESCRIPTION
## Description
This PR follows up on #11149 to add the lists filtering (stream compaction) APIs to a doxygen group. The previous doxygen group `lists_drop_duplicates` is empty after #11326.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
