### PR TITLE
[REVIEW] Fix `DatetimeIndex` & `TimedeltaIndex` constructors

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1841,8 +1841,6 @@ def as_column(
                 data = data.fillna(np.nan)
             elif np.issubdtype(data.dtype, np.datetime64):
                 data = data.fillna(np.datetime64("NaT"))
-    # elif isinstance(arbitrary, pd.DatetimeIndex):
-    #     data = as_column(arbitrary.values, dtype=dtype)
     elif hasattr(arbitrary, "__array_interface__"):
         # CUDF assumes values are always contiguous
         desc = arbitrary.__array_interface__

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1841,6 +1841,7 @@ def as_column(
                 data = data.fillna(np.nan)
             elif np.issubdtype(data.dtype, np.datetime64):
                 data = data.fillna(np.datetime64("NaT"))
+
     elif hasattr(arbitrary, "__array_interface__"):
         # CUDF assumes values are always contiguous
         desc = arbitrary.__array_interface__

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1841,7 +1841,8 @@ def as_column(
                 data = data.fillna(np.nan)
             elif np.issubdtype(data.dtype, np.datetime64):
                 data = data.fillna(np.datetime64("NaT"))
-
+    # elif isinstance(arbitrary, pd.DatetimeIndex):
+    #     data = as_column(arbitrary.values, dtype=dtype)
     elif hasattr(arbitrary, "__array_interface__"):
         # CUDF assumes values are always contiguous
         desc = arbitrary.__array_interface__

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -1783,19 +1783,12 @@ class DatetimeIndex(GenericIndex):
         elif dtype not in valid_dtypes:
             raise TypeError("Invalid dtype")
 
-        if copy:
-            data = column.as_column(data, dtype=dtype).copy()
         kwargs = _setdefault_name(data, name=name)
-        if isinstance(data, np.ndarray) and data.dtype.kind == "M":
-            data = column.as_column(data)
-        elif isinstance(data, pd.DatetimeIndex):
-            data = column.as_column(data.values)
-        elif isinstance(data, (list, tuple)):
-            data = column.as_column(np.array(data, dtype=dtype))
-        elif isinstance(data, cudf.Series):
-            data = data._column.astype(dtype)
-        elif isinstance(data, column.ColumnBase):
-            data = data.astype(dtype)
+        data = column.as_column(data, dtype=dtype)
+
+        if copy:
+            data = data.copy()
+
         super().__init__(data, **kwargs)
 
     @property  # type: ignore
@@ -2273,19 +2266,12 @@ class TimedeltaIndex(GenericIndex):
         if dtype not in valid_dtypes:
             raise TypeError("Invalid dtype")
 
-        if copy:
-            data = column.as_column(data, dtype=dtype).copy()
         kwargs = _setdefault_name(data, name=name)
-        if isinstance(data, np.ndarray) and data.dtype.kind == "m":
-            data = column.as_column(data)
-        elif isinstance(data, pd.TimedeltaIndex):
-            data = column.as_column(data.values)
-        elif isinstance(data, (list, tuple)):
-            data = column.as_column(np.array(data, dtype=dtype))
-        elif isinstance(data, cudf.Series):
-            data = data._column.astype(dtype)
-        elif isinstance(data, column.ColumnBase):
-            data = data.astype(dtype)
+        data = column.as_column(data, dtype=dtype)
+
+        if copy:
+            data = data.copy()
+
         super().__init__(data, **kwargs)
 
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -1784,7 +1784,7 @@ class DatetimeIndex(GenericIndex):
             raise TypeError("Invalid dtype")
 
         if copy:
-            data = column.as_column(data).copy()
+            data = column.as_column(data, dtype=dtype).copy()
         kwargs = _setdefault_name(data, name=name)
         if isinstance(data, np.ndarray) and data.dtype.kind == "M":
             data = column.as_column(data)
@@ -1792,6 +1792,10 @@ class DatetimeIndex(GenericIndex):
             data = column.as_column(data.values)
         elif isinstance(data, (list, tuple)):
             data = column.as_column(np.array(data, dtype=dtype))
+        elif isinstance(data, cudf.Series):
+            data = data._column.astype(dtype)
+        elif isinstance(data, column.ColumnBase):
+            data = data.astype(dtype)
         super().__init__(data, **kwargs)
 
     @property  # type: ignore
@@ -2263,8 +2267,14 @@ class TimedeltaIndex(GenericIndex):
                 "dtype parameter is supported"
             )
 
+        valid_dtypes = tuple(
+            f"timedelta64[{res}]" for res in ("s", "ms", "us", "ns")
+        )
+        if dtype not in valid_dtypes:
+            raise TypeError("Invalid dtype")
+
         if copy:
-            data = column.as_column(data).copy()
+            data = column.as_column(data, dtype=dtype).copy()
         kwargs = _setdefault_name(data, name=name)
         if isinstance(data, np.ndarray) and data.dtype.kind == "m":
             data = column.as_column(data)
@@ -2272,6 +2282,10 @@ class TimedeltaIndex(GenericIndex):
             data = column.as_column(data.values)
         elif isinstance(data, (list, tuple)):
             data = column.as_column(np.array(data, dtype=dtype))
+        elif isinstance(data, cudf.Series):
+            data = data._column.astype(dtype)
+        elif isinstance(data, column.ColumnBase):
+            data = data.astype(dtype)
         super().__init__(data, **kwargs)
 
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2007,3 +2007,31 @@ def test_last(idx, offset):
     got = g.last(offset=offset)
 
     assert_eq(expect, got)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [
+            "2020-01-31",
+            "2020-02-15",
+            "2020-02-29",
+            "2020-03-15",
+            "2020-03-31",
+            "2020-04-15",
+            "2020-04-30",
+        ],
+        [43534, 43543, 37897, 2000],
+    ],
+)
+@pytest.mark.parametrize("dtype", [None, "datetime64[ns]"])
+def test_datetime_constructor(data, dtype):
+    expected = pd.DatetimeIndex(data=data, dtype=dtype)
+    actual = cudf.DatetimeIndex(data=data, dtype=dtype)
+
+    assert_eq(expected, actual)
+
+    expected = pd.DatetimeIndex(data=pd.Series(data), dtype=dtype)
+    actual = cudf.DatetimeIndex(data=cudf.Series(data), dtype=dtype)
+
+    assert_eq(expected, actual)

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1389,3 +1389,17 @@ def test_create_TimedeltaIndex(dtype, name):
     )
     pdi = gdi.to_pandas()
     assert_eq(pdi, gdi)
+
+
+@pytest.mark.parametrize("data", [[43534, 43543, 37897, 2000]])
+@pytest.mark.parametrize("dtype", ["timedelta64[ns]"])
+def test_timedelta_constructor(data, dtype):
+    expected = pd.TimedeltaIndex(data=data, dtype=dtype)
+    actual = cudf.TimedeltaIndex(data=data, dtype=dtype)
+
+    assert_eq(expected, actual)
+
+    expected = pd.TimedeltaIndex(data=pd.Series(data), dtype=dtype)
+    actual = cudf.TimedeltaIndex(data=cudf.Series(data), dtype=dtype)
+
+    assert_eq(expected, actual)


### PR DESCRIPTION
## Description
Closes #11335 

This PR fixes an issue with `DatetimeIndex` & `TimedeltaIndex` where the underlying columns would still be of numeric or string types rather than `DatetimeColumn` and `TimedeltaColumn` respectively. This is the actual root cause that leads to errors in some downstream API calls.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
