### PR TITLE
Improve multibyte_split performance

### DIFF
--- a/cpp/benchmarks/io/text/multibyte_split.cpp
+++ b/cpp/benchmarks/io/text/multibyte_split.cpp
@@ -151,12 +151,12 @@ class MultibyteSplitBenchmark : public cudf::benchmark {
     BM_multibyte_split(state);                                                  \
   }                                                                             \
   BENCHMARK_REGISTER_F(MultibyteSplitBenchmark, name)                           \
-    ->ArgsProduct({{data_chunk_source_type::file},                              \
-                   {                                                            \
-                     1,                                                         \
-                   },                                                           \
-                   {3},                                                         \
-                   {1 << 30}})                                                  \
+    ->ArgsProduct({{data_chunk_source_type::device,                             \
+                    data_chunk_source_type::file,                               \
+                    data_chunk_source_type::host},                              \
+                   {1, 4, 7},                                                   \
+                   {1, 25},                                                     \
+                   {1 << 15, 1 << 30}})                                         \
     ->UseManualTime()                                                           \
     ->Unit(::benchmark::kMillisecond);
 

--- a/cpp/benchmarks/io/text/multibyte_split.cpp
+++ b/cpp/benchmarks/io/text/multibyte_split.cpp
@@ -151,12 +151,12 @@ class MultibyteSplitBenchmark : public cudf::benchmark {
     BM_multibyte_split(state);                                                  \
   }                                                                             \
   BENCHMARK_REGISTER_F(MultibyteSplitBenchmark, name)                           \
-    ->ArgsProduct({{data_chunk_source_type::device,                             \
-                    data_chunk_source_type::file,                               \
-                    data_chunk_source_type::host},                              \
-                   {1, 4, 7},                                                   \
-                   {1, 25},                                                     \
-                   {1 << 15, 1 << 30}})                                         \
+    ->ArgsProduct({{data_chunk_source_type::file},                              \
+                   {                                                            \
+                     1,                                                         \
+                   },                                                           \
+                   {3},                                                         \
+                   {1 << 30}})                                                  \
     ->UseManualTime()                                                           \
     ->Unit(::benchmark::kMillisecond);
 

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -418,15 +418,14 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
   auto reader = source.create_reader();
   reader->skip_bytes(relevant_offset_first);
 
-  for (int32_t i = 0; i < string_chars_size; i += ITEMS_PER_CHUNK)
-  {
-      auto read_size = std::min(static_cast<int64_t>(ITEMS_PER_CHUNK), string_chars_size - i);
-      auto relevant_bytes = reader->get_next_chunk(read_size, stream);
+  for (int32_t i = 0; i < string_chars_size; i += ITEMS_PER_CHUNK) {
+    auto read_size = std::min(static_cast<int64_t>(ITEMS_PER_CHUNK), string_chars_size - i);
+    auto relevant_bytes = reader->get_next_chunk(read_size, stream);
 
-      thrust::copy(rmm::exec_policy(stream),
-          relevant_bytes->data(),  //
-          relevant_bytes->data() + relevant_bytes->size(),
-          string_chars.begin() + i);
+    thrust::copy(rmm::exec_policy(stream),
+                 relevant_bytes->data(),  //
+                 relevant_bytes->data() + relevant_bytes->size(),
+                 string_chars.begin() + i);
   }
 
   auto string_count = string_offsets_out.size() - 1;

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -418,12 +418,16 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
   auto reader = source.create_reader();
   reader->skip_bytes(relevant_offset_first);
 
-  auto relevant_bytes = reader->get_next_chunk(string_chars_size, stream);
+  for (int32_t i = 0; i < string_chars_size; i += ITEMS_PER_CHUNK)
+  {
+      auto read_size = std::min(static_cast<int64_t>(ITEMS_PER_CHUNK), string_chars_size - i);
+      auto relevant_bytes = reader->get_next_chunk(read_size, stream);
 
-  thrust::copy(rmm::exec_policy(stream),
-               relevant_bytes->data(),  //
-               relevant_bytes->data() + relevant_bytes->size(),
-               string_chars.begin());
+      thrust::copy(rmm::exec_policy(stream),
+          relevant_bytes->data(),  //
+          relevant_bytes->data() + relevant_bytes->size(),
+          string_chars.begin() + i);
+  }
 
   auto string_count = string_offsets_out.size() - 1;
 

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -419,12 +419,12 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
   reader->skip_bytes(relevant_offset_first);
 
   for (int32_t i = 0; i < string_chars_size; i += ITEMS_PER_CHUNK) {
-    auto read_size = std::min(static_cast<int64_t>(ITEMS_PER_CHUNK), string_chars_size - i);
-    auto relevant_bytes = reader->get_next_chunk(read_size, stream);
+    auto const read_size   = std::min<int64_t>(ITEMS_PER_CHUNK, string_chars_size - i);
+    auto const chunk_bytes = reader->get_next_chunk(read_size, stream);
 
     thrust::copy(rmm::exec_policy(stream),
-                 relevant_bytes->data(),  //
-                 relevant_bytes->data() + relevant_bytes->size(),
+                 chunk_bytes->data(),
+                 chunk_bytes->data() + chunk_bytes->size(),
                  string_chars.begin() + i);
   }
 


### PR DESCRIPTION
Improve's the performance of `multibyte_split` by converting one giant `get_next_chunk` read in to multiple smaller `get_next_chunk` reads, preventing the pinned host memory buffer from resizing, which was taking a very long time.

before:
![before](https://user-images.githubusercontent.com/1445368/180912597-98225d00-be9d-464f-94da-c9d03ef2a164.png)
after:
![after](https://user-images.githubusercontent.com/1445368/180912603-7fb0c6f9-33bd-4dc6-902c-0a82fb69a3ce.png)

