### PR TITLE
Fix memory_usage() for `ListSeries`

### DIFF
--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -70,7 +70,7 @@ class ListColumn(ColumnBase):
             child0_size = (
                 current_base_child.size + 1 - current_offset
             ) * current_base_child.base_children[0].dtype.itemsize
-            current_offset = current_base_child.base_children[0][
+            current_offset = cudf.Series(current_base_child.base_children[0])[
                 current_offset
             ]
             n += child0_size

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -70,9 +70,9 @@ class ListColumn(ColumnBase):
             child0_size = (
                 current_base_child.size + 1 - current_offset
             ) * current_base_child.base_children[0].dtype.itemsize
-            current_offset = cudf.Series(current_base_child.base_children[0])[
-                current_offset
-            ]
+            current_offset = current_base_child.base_children[
+                0
+            ].element_indexing(current_offset)
             n += child0_size
             current_base_child = current_base_child.base_children[1]
 

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -812,3 +812,10 @@ def test_list_astype():
     s2 = s.list.astype("string")
     assert s2.dtype == cudf.ListDtype(cudf.ListDtype("string"))
     assert_eq(s.list.leaves.astype("string"), s2.list.leaves)
+
+
+def test_memory_usage():
+    s1 = cudf.Series([[1, 2], [3, 4]])
+    assert s1.memory_usage() == 44
+    s2 = cudf.Series([[[[1, 2]]], [[[3, 4]]]])
+    assert s2.memory_usage() == 68


### PR DESCRIPTION
## Description
This PR fixes the `memory_usage()` call for `ListSeries`. This is a bugfix. https://www.github.com/rapidsai/cuspatial/pull/585 depends on this. Perhaps it can get into `branch-22.08`?

Fixes #11346.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
