### PR TITLE
Add column constructor from device_uvector&&

### DIFF
--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -89,15 +89,14 @@ class column {
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
   column(rmm::device_uvector<T>&& other,
          rmm::device_buffer&& null_mask = {},
-         size_type null_count           = cudf::UNKNOWN_NULL_COUNT)
-    : _type{cudf::type_to_id<T>()},
-      _size{static_cast<size_type>(other.size())},
-      _data{other.release()},
-      _null_mask{std::forward<rmm::device_buffer>(null_mask)},
-      _null_count{null_count}
+         size_type null_count           = UNKNOWN_NULL_COUNT)
   {
-    CUDF_EXPECTS(_size < std::numeric_limits<size_type>::max(),
-                 "Input vector exceeds maximum column capacity");
+    CUDF_EXPECTS(other.size() <= std::numeric_limits<size_type>::max());
+    _type       = cudf::type_to_id<T>();
+    _size       = static_cast<size_type>(other.size());
+    _data       = other.release();
+    _null_mask  = std::forward<rmm::device_buffer>(null_mask);
+    _null_count = null_count;
   }
 
   /**

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -90,14 +90,17 @@ class column {
   column(rmm::device_uvector<T>&& other,
          rmm::device_buffer&& null_mask = {},
          size_type null_count           = UNKNOWN_NULL_COUNT)
+    : _type{cudf::data_type{cudf::type_to_id<T>()}},
+      _size{[&]() {
+        CUDF_EXPECTS(
+          other.size() <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+          "The device_uvector size exceeds the maximum size_type.");
+        return static_cast<size_type>(other.size());
+      }()},
+      _data{other.release()},
+      _null_mask{std::move(null_mask)},
+      _null_count{null_count}
   {
-    CUDF_EXPECTS(other.size() <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
-                 "The device_uvector size exceeds the maximum size_type.");
-    _type       = cudf::type_to_id<T>();
-    _size       = static_cast<size_type>(other.size());
-    _data       = other.release();
-    _null_mask  = std::forward<rmm::device_buffer>(null_mask);
-    _null_count = null_count;
   }
 
   /**

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -82,10 +82,14 @@ class column {
    * @param other The device_uvector whose contents will be moved into the new column.
    */
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
-  column(rmm::device_uvector<T>&& other)
+  column(rmm::device_uvector<T>&& other,
+         rmm::device_buffer&& null_mask = {},
+         size_type null_count           = cudf::UNKNOWN_NULL_COUNT)
     : _type{cudf::type_to_id<T>()},
-      _size{static_cast<cudf::size_type>(other.size())},
-      _data{other.release()}
+      _size{static_cast<size_type>(other.size())},
+      _data{other.release()},
+      _null_mask{std::forward<rmm::device_buffer>(null_mask)},
+      _null_count{null_count}
   {
     CUDF_EXPECTS(_size < std::numeric_limits<size_type>::max(),
                  "Input vector exceeds maximum column capacity");

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -91,7 +91,7 @@ class column {
          rmm::device_buffer&& null_mask = {},
          size_type null_count           = UNKNOWN_NULL_COUNT)
   {
-    CUDF_EXPECTS(other.size() <= std::numeric_limits<size_type>::max());
+    CUDF_EXPECTS(other.size() <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()));
     _type       = cudf::type_to_id<T>();
     _size       = static_cast<size_type>(other.size());
     _data       = other.release();

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -80,6 +80,11 @@ class column {
    * @brief Construct a new column by taking ownership of the contents of a device_uvector.
    *
    * @param other The device_uvector whose contents will be moved into the new column.
+   * @param[in] null_mask Optional, column's null value indicator bitmask. May
+   * be empty if `null_count` is 0 or `UNKNOWN_NULL_COUNT`.
+   * @param null_count Optional, the count of null elements. If unknown, specify
+   * `UNKNOWN_NULL_COUNT` to indicate that the null count should be computed on
+   * the first invocation of `null_count()`.
    */
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
   column(rmm::device_uvector<T>&& other,

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -23,6 +23,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 
 #include <memory>
@@ -74,6 +75,21 @@ class column {
    * @param other The column whose contents will be moved into the new column
    */
   column(column&& other) noexcept;
+
+  /**
+   * @brief Move the contents from `other` to create a new column.
+   *
+   * After the move, `other.data() == NULL`
+   *
+   * @param other The device_uvector whose contents will be moved into the new column.
+   */
+  template <typename T>
+  column(rmm::device_uvector<T>&& other) noexcept
+    : _type{cudf::type_to_id<T>()},
+      _size{static_cast<cudf::size_type>(other.size())},
+      _data{other.release()}
+  {
+  }
 
   /**
    * @brief Construct a new column from existing device memory.

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -91,7 +91,8 @@ class column {
          rmm::device_buffer&& null_mask = {},
          size_type null_count           = UNKNOWN_NULL_COUNT)
   {
-    CUDF_EXPECTS(other.size() <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()));
+    CUDF_EXPECTS(other.size() <= static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+                 "The device_uvector size exceeds the maximum size_type.");
     _type       = cudf::type_to_id<T>();
     _size       = static_cast<size_type>(other.size());
     _data       = other.release();

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -77,18 +77,18 @@ class column {
   column(column&& other) noexcept;
 
   /**
-   * @brief Move the contents from `other` to create a new column.
-   *
-   * After the move, `other.data() == NULL`
+   * @brief Construct a new column by taking ownership of the contents of a device_uvector.
    *
    * @param other The device_uvector whose contents will be moved into the new column.
    */
-  template <typename T>
-  column(rmm::device_uvector<T>&& other) noexcept
+  template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() or cudf::is_chrono<T>())>
+  column(rmm::device_uvector<T>&& other)
     : _type{cudf::type_to_id<T>()},
       _size{static_cast<cudf::size_type>(other.size())},
       _data{other.release()}
   {
+    CUDF_EXPECTS(_size < std::numeric_limits<size_type>::max(),
+                 "Input vector exceeds maximum column capacity");
   }
 
   /**

--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -345,6 +345,23 @@ TYPED_TEST(TypedColumnTest, MoveConstructorWithMask)
   EXPECT_EQ(original_mask, moved_to_view.null_mask());
 }
 
+TYPED_TEST(TypedColumnTest, DeviceUvectorConstructor)
+{
+  rmm::device_uvector<TypeParam> original{static_cast<std::size_t>(this->num_elements()),
+                                          cudf::default_stream_value};
+  thrust::copy(thrust::device,
+               static_cast<TypeParam*>(this->data.data()),
+               static_cast<TypeParam*>(this->data.data()) + this->num_elements(),
+               original.begin());
+  auto original_data = original.data();
+  cudf::column moved_to{std::move(original)};
+  verify_column_views(moved_to);
+
+  // Verify move
+  cudf::column_view moved_to_view = moved_to;
+  EXPECT_EQ(original_data, moved_to_view.head());
+}
+
 TYPED_TEST(TypedColumnTest, ConstructWithChildren)
 {
   std::vector<std::unique_ptr<cudf::column>> children;


### PR DESCRIPTION
Closes #11115 

This PR adds a `column` constructor to be constructible from a `device_uvector&&` using move semantics. 
