### PR TITLE
Set `+/-infinity` as the `identity` values for floating-point numbers in device operators `min` and `max`

### DIFF
--- a/cpp/include/cudf/detail/utilities/device_operators.cuh
+++ b/cpp/include/cudf/detail/utilities/device_operators.cuh
@@ -129,8 +129,13 @@ struct DeviceMin {
   {
     // chrono types do not have std::numeric_limits specializations and should use T::max()
     // https://eel.is/c++draft/numeric.limits.general#6
-    if constexpr (cudf::is_chrono<T>()) return T::max();
-    return cuda::std::numeric_limits<T>::max();
+    if constexpr (cudf::is_chrono<T>()) {
+      return T::max();
+    } else if constexpr (cuda::std::numeric_limits<T>::has_infinity) {
+      return cuda::std::numeric_limits<T>::infinity();
+    } else {
+      return cuda::std::numeric_limits<T>::max();
+    }
   }
 
   template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
@@ -172,8 +177,13 @@ struct DeviceMax {
   {
     // chrono types do not have std::numeric_limits specializations and should use T::min()
     // https://eel.is/c++draft/numeric.limits.general#6
-    if constexpr (cudf::is_chrono<T>()) return T::min();
-    return cuda::std::numeric_limits<T>::lowest();
+    if constexpr (cudf::is_chrono<T>()) {
+      return T::min();
+    } else if constexpr (cuda::std::numeric_limits<T>::has_infinity) {
+      return -cuda::std::numeric_limits<T>::infinity();
+    } else {
+      return cuda::std::numeric_limits<T>::lowest();
+    }
   }
 
   template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>

--- a/cpp/include/cudf/detail/utilities/device_operators.cuh
+++ b/cpp/include/cudf/detail/utilities/device_operators.cuh
@@ -129,13 +129,8 @@ struct DeviceMin {
   {
     // chrono types do not have std::numeric_limits specializations and should use T::max()
     // https://eel.is/c++draft/numeric.limits.general#6
-    if constexpr (cudf::is_chrono<T>()) {
-      return T::max();
-    } else if constexpr (cuda::std::numeric_limits<T>::has_infinity) {
-      return cuda::std::numeric_limits<T>::infinity();
-    } else {
-      return cuda::std::numeric_limits<T>::max();
-    }
+    if constexpr (cudf::is_chrono<T>()) return T::max();
+    return cuda::std::numeric_limits<T>::max();
   }
 
   template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
@@ -177,13 +172,8 @@ struct DeviceMax {
   {
     // chrono types do not have std::numeric_limits specializations and should use T::min()
     // https://eel.is/c++draft/numeric.limits.general#6
-    if constexpr (cudf::is_chrono<T>()) {
-      return T::min();
-    } else if constexpr (cuda::std::numeric_limits<T>::has_infinity) {
-      return -cuda::std::numeric_limits<T>::infinity();
-    } else {
-      return cuda::std::numeric_limits<T>::lowest();
-    }
+    if constexpr (cudf::is_chrono<T>()) return T::min();
+    return cuda::std::numeric_limits<T>::lowest();
   }
 
   template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>

--- a/cpp/tests/groupby/max_tests.cpp
+++ b/cpp/tests/groupby/max_tests.cpp
@@ -24,6 +24,8 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/dictionary/update_keys.hpp>
 
+#include <limits>
+
 using namespace cudf::test::iterators;
 
 namespace cudf {
@@ -428,6 +430,27 @@ TEST_F(groupby_max_struct_test, values_with_null_child)
     auto agg = cudf::make_max_aggregation<groupby_aggregation>();
     test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
   }
+}
+
+struct groupby_max_float_test : public cudf::test::BaseFixture {
+};
+
+TEST_F(groupby_max_float_test, values_with_infinity)
+{
+  using T          = double;
+  using int32s_col = fixed_width_column_wrapper<int32_t>;
+  using floats_col = fixed_width_column_wrapper<T, int32_t>;
+
+  auto constexpr inf = std::numeric_limits<T>::infinity();
+
+  auto const keys = int32s_col{1, 2, 1, 2};
+  auto const vals = floats_col{1., 1., inf, 2.};
+
+  auto const expected_keys = int32s_col{1, 2};
+  auto const expected_vals = floats_col{inf, 2.};
+
+  auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
+  test_single_agg(keys, vals, expected_keys, expected_vals, std::move(agg));
 }
 
 }  // namespace test

--- a/cpp/tests/groupby/max_tests.cpp
+++ b/cpp/tests/groupby/max_tests.cpp
@@ -449,8 +449,11 @@ TEST_F(groupby_max_float_test, values_with_infinity)
   auto const expected_keys = int32s_col{1, 2};
   auto const expected_vals = floats_col{inf, 2.};
 
+  // Related issue: https://github.com/rapidsai/cudf/issues/11352
+  // The issue only occurs in sort-based aggregation.
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
-  test_single_agg(keys, vals, expected_keys, expected_vals, std::move(agg));
+  test_single_agg(
+    keys, vals, expected_keys, expected_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 }  // namespace test

--- a/cpp/tests/groupby/max_tests.cpp
+++ b/cpp/tests/groupby/max_tests.cpp
@@ -447,7 +447,7 @@ TYPED_TEST(groupby_max_floating_point_test, values_with_infinity)
   auto constexpr inf = std::numeric_limits<T>::infinity();
 
   auto const keys = int32s_col{1, 2, 1, 2};
-  auto const vals = floats_col{static_cast<T>(1), static_cast<T>(1), inf, static_cast<T>(1)};
+  auto const vals = floats_col{static_cast<T>(1), static_cast<T>(1), inf, static_cast<T>(2)};
 
   auto const expected_keys = int32s_col{1, 2};
   auto const expected_vals = floats_col{inf, static_cast<T>(2)};

--- a/cpp/tests/groupby/max_tests.cpp
+++ b/cpp/tests/groupby/max_tests.cpp
@@ -432,22 +432,25 @@ TEST_F(groupby_max_struct_test, values_with_null_child)
   }
 }
 
-struct groupby_max_float_test : public cudf::test::BaseFixture {
+template <typename V>
+struct groupby_max_floating_point_test : public cudf::test::BaseFixture {
 };
 
-TEST_F(groupby_max_float_test, values_with_infinity)
+TYPED_TEST_SUITE(groupby_max_floating_point_test, cudf::test::FloatingPointTypes);
+
+TYPED_TEST(groupby_max_floating_point_test, values_with_infinity)
 {
-  using T          = double;
+  using T          = TypeParam;
   using int32s_col = fixed_width_column_wrapper<int32_t>;
   using floats_col = fixed_width_column_wrapper<T, int32_t>;
 
   auto constexpr inf = std::numeric_limits<T>::infinity();
 
   auto const keys = int32s_col{1, 2, 1, 2};
-  auto const vals = floats_col{1., 1., inf, 2.};
+  auto const vals = floats_col{static_cast<T>(1), static_cast<T>(1), inf, static_cast<T>(1)};
 
   auto const expected_keys = int32s_col{1, 2};
-  auto const expected_vals = floats_col{inf, 2.};
+  auto const expected_vals = floats_col{inf, static_cast<T>(2)};
 
   // Related issue: https://github.com/rapidsai/cudf/issues/11352
   // The issue only occurs in sort-based aggregation.

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -448,8 +448,11 @@ TEST_F(groupby_min_float_test, values_with_infinity)
   auto const expected_keys = int32s_col{1, 2};
   auto const expected_vals = floats_col{-inf, 1.};
 
+  // Related issue: https://github.com/rapidsai/cudf/issues/11352
+  // The issue only occurs in sort-based aggregation.
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
-  test_single_agg(keys, vals, expected_keys, expected_vals, std::move(agg));
+  test_single_agg(
+    keys, vals, expected_keys, expected_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 }  // namespace test

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -431,22 +431,25 @@ TEST_F(groupby_min_struct_test, values_with_null_child)
   }
 }
 
-struct groupby_min_float_test : public cudf::test::BaseFixture {
+template <typename V>
+struct groupby_min_floating_point_test : public cudf::test::BaseFixture {
 };
 
-TEST_F(groupby_min_float_test, values_with_infinity)
+TYPED_TEST_SUITE(groupby_min_floating_point_test, cudf::test::FloatingPointTypes);
+
+TYPED_TEST(groupby_min_floating_point_test, values_with_infinity)
 {
-  using T          = double;
+  using T          = TypeParam;
   using int32s_col = fixed_width_column_wrapper<int32_t>;
   using floats_col = fixed_width_column_wrapper<T, int32_t>;
 
   auto constexpr inf = std::numeric_limits<T>::infinity();
 
   auto const keys = int32s_col{1, 2, 1, 2};
-  auto const vals = floats_col{1., 1., -inf, 2.};
+  auto const vals = floats_col{static_cast<T>(1), static_cast<T>(1), -inf, static_cast<T>(1)};
 
   auto const expected_keys = int32s_col{1, 2};
-  auto const expected_vals = floats_col{-inf, 1.};
+  auto const expected_vals = floats_col{-inf, static_cast<T>(1)};
 
   // Related issue: https://github.com/rapidsai/cudf/issues/11352
   // The issue only occurs in sort-based aggregation.

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -446,7 +446,7 @@ TYPED_TEST(groupby_min_floating_point_test, values_with_infinity)
   auto constexpr inf = std::numeric_limits<T>::infinity();
 
   auto const keys = int32s_col{1, 2, 1, 2};
-  auto const vals = floats_col{static_cast<T>(1), static_cast<T>(1), -inf, static_cast<T>(1)};
+  auto const vals = floats_col{static_cast<T>(1), static_cast<T>(1), -inf, static_cast<T>(2)};
 
   auto const expected_keys = int32s_col{1, 2};
   auto const expected_vals = floats_col{-inf, static_cast<T>(1)};

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -24,6 +24,8 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/dictionary/update_keys.hpp>
 
+#include <limits>
+
 using namespace cudf::test::iterators;
 
 namespace cudf {
@@ -427,6 +429,27 @@ TEST_F(groupby_min_struct_test, values_with_null_child)
     auto agg = cudf::make_min_aggregation<groupby_aggregation>();
     test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
   }
+}
+
+struct groupby_min_float_test : public cudf::test::BaseFixture {
+};
+
+TEST_F(groupby_min_float_test, values_with_infinity)
+{
+  using T          = double;
+  using int32s_col = fixed_width_column_wrapper<int32_t>;
+  using floats_col = fixed_width_column_wrapper<T, int32_t>;
+
+  auto constexpr inf = std::numeric_limits<T>::infinity();
+
+  auto const keys = int32s_col{1, 2, 1, 2};
+  auto const vals = floats_col{1., 1., -inf, 2.};
+
+  auto const expected_keys = int32s_col{1, 2};
+  auto const expected_vals = floats_col{-inf, 1.};
+
+  auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
+  test_single_agg(keys, vals, expected_keys, expected_vals, std::move(agg));
 }
 
 }  // namespace test

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -135,8 +135,18 @@ struct ScanTest : public BaseScanTest<T> {
       switch (agg->kind) {
         case aggregation::SUM: return HostType{0};
         case aggregation::PRODUCT: return HostType{1};
-        case aggregation::MIN: return std::numeric_limits<HostType>::max();
-        case aggregation::MAX: return std::numeric_limits<HostType>::lowest();
+        case aggregation::MIN:
+          if constexpr (cuda::std::numeric_limits<T>::has_infinity) {
+            return cuda::std::numeric_limits<T>::infinity();
+          } else {
+            return std::numeric_limits<HostType>::max();
+          }
+        case aggregation::MAX:
+          if constexpr (cuda::std::numeric_limits<T>::has_infinity) {
+            return -cuda::std::numeric_limits<T>::infinity();
+          } else {
+            return std::numeric_limits<HostType>::lowest();
+          }
         default: CUDF_FAIL("Unsupported aggregation");
       }
     }

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -136,14 +136,14 @@ struct ScanTest : public BaseScanTest<T> {
         case aggregation::SUM: return HostType{0};
         case aggregation::PRODUCT: return HostType{1};
         case aggregation::MIN:
-          if constexpr (cuda::std::numeric_limits<T>::has_infinity) {
-            return cuda::std::numeric_limits<T>::infinity();
+          if constexpr (cuda::std::numeric_limits<HostType>::has_infinity) {
+            return cuda::std::numeric_limits<HostType>::infinity();
           } else {
             return std::numeric_limits<HostType>::max();
           }
         case aggregation::MAX:
-          if constexpr (cuda::std::numeric_limits<T>::has_infinity) {
-            return -cuda::std::numeric_limits<T>::infinity();
+          if constexpr (cuda::std::numeric_limits<HostType>::has_infinity) {
+            return -cuda::std::numeric_limits<HostType>::infinity();
           } else {
             return std::numeric_limits<HostType>::lowest();
           }

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -136,14 +136,14 @@ struct ScanTest : public BaseScanTest<T> {
         case aggregation::SUM: return HostType{0};
         case aggregation::PRODUCT: return HostType{1};
         case aggregation::MIN:
-          if constexpr (cuda::std::numeric_limits<HostType>::has_infinity) {
-            return cuda::std::numeric_limits<HostType>::infinity();
+          if constexpr (std::numeric_limits<HostType>::has_infinity) {
+            return std::numeric_limits<HostType>::infinity();
           } else {
             return std::numeric_limits<HostType>::max();
           }
         case aggregation::MAX:
-          if constexpr (cuda::std::numeric_limits<HostType>::has_infinity) {
-            return -cuda::std::numeric_limits<HostType>::infinity();
+          if constexpr (std::numeric_limits<HostType>::has_infinity) {
+            return -std::numeric_limits<HostType>::infinity();
           } else {
             return std::numeric_limits<HostType>::lowest();
           }


### PR DESCRIPTION
This fixes a bug of device operators `min` and `max` in generating the `identity` value for floating-point numbers. In particular:
 * `min::identity()` should return `cuda::std::numeric_limits<T>::infinity()` instead of `cuda::std::numeric_limits<T>::max()`, and
 * `max::identity()` should return `-cuda::std::numeric_limits<T>::infinity()` instead of `cuda::std::numeric_limits<T>::lowest()`.

Closes https://github.com/rapidsai/cudf/issues/11352.