### PR TITLE
column: calculate null_count before release()ing the cudf::column

### DIFF
--- a/python/cudf/cudf/_lib/column.pyx
+++ b/python/cudf/cudf/_lib/column.pyx
@@ -449,7 +449,7 @@ cdef class Column:
 
         size = c_col.get()[0].size()
         dtype = dtype_from_column_view(c_col.get()[0].view())
-        has_nulls = c_col.get()[0].has_nulls()
+        null_count = c_col.get()[0].null_count()
 
         # After call to release(), c_col is unusable
         cdef column_contents contents = move(c_col.get()[0].release())
@@ -457,13 +457,11 @@ cdef class Column:
         data = DeviceBuffer.c_from_unique_ptr(move(contents.data))
         data = Buffer(data)
 
-        if has_nulls:
+        if null_count > 0:
             mask = DeviceBuffer.c_from_unique_ptr(move(contents.null_mask))
             mask = Buffer(mask)
-            null_count = c_col.get()[0].null_count()
         else:
             mask = None
-            null_count = 0
 
         cdef vector[unique_ptr[column]] c_children = move(contents.children)
         children = ()


### PR DESCRIPTION
## Description

release() sets the null_count of a column to zero, so previously
asking for the null_count provided an incorrect value. Fortunately
this never exhibited in the final column, since Column.__init__ always
ignores the provided null_count and computes it from the null_mask (if
one is given).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
