### PR TITLE
[REVIEW] Fix `moto` timeouts 

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -76,6 +76,7 @@ dependencies:
   - botocore>=1.24.21
   - aiobotocore>=2.2.0
   - s3fs>=2022.3.0
+  - werkzeug<2.2.0 # Temporary transient dependency pinning to avoid URL-LIB3 + moto timeouts
   - pytorch<1.12.0
   - pip:
       - git+https://github.com/python-streamz/streamz.git@master


### PR DESCRIPTION
## Description
This PR fixes timeouts like the following that are happening across all our s3 tests in code-base:
```python
Traceback (most recent call last):
  File "/lib/python3.9/site-packages/urllib3/connectionpool.py", line 426, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/lib/python3.9/site-packages/urllib3/connectionpool.py", line 421, in _make_request
    httplib_response = conn.getresponse()
  File "/..pyenv/versions/3.9.6/lib/python3.9/http/client.py", line 1349, in getresponse
    response.begin()
  File "/..pyenv/versions/3.9.6/lib/python3.9/http/client.py", line 316, in begin
    version, status, reason = self._read_status()
  File "/..pyenv/versions/3.9.6/lib/python3.9/http/client.py", line 277, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/..pyenv/versions/3.9.6/lib/python3.9/socket.py", line 704, in readinto
    return self._sock.recv_into(b)
socket.timeout: timed out
```
This seems to be an issue with `werkzeug` package which was updated 1 day ago. So until there is an upstream fix for it, we will temporarily need to pin this package.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
