### PR TITLE
Update contributing doc to include links to the developer guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,6 +380,13 @@ Now code linters and formatters will be run each time you commit changes.
 
 You can skip these checks with `git commit --no-verify` or with the short version `git commit -n`.
 
+## Developer Guidelines
+
+The [C++ Developer Guide](cpp/docs/DEVELOPER_GUIDE.md) includes details on contributing to libcudf C++ code.
+
+The [Python Developer Guide](https://docs.rapids.ai/api/cudf/stable/developer_guide/index.html) includes details on contributing to cuDF Python code.
+
+
 ## Attribution
 
 Portions adopted from https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md

--- a/docs/cudf/README.md
+++ b/docs/cudf/README.md
@@ -3,4 +3,4 @@
 This directory contains the documentation of cuDF Python.
 For more information on how to write, build, and read the documentation,
 see 
-[the developer documentation](https://github.com/rapidsai/cudf/blob/main/docs/cudf/source/developer_guide/documentation.md).
+[the developer documentation](https://github.com/rapidsai/cudf/blob/HEAD/docs/cudf/source/developer_guide/documentation.md).


### PR DESCRIPTION
## Description
Adds links to the developer guides to the contributing.md

Closes #11348 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
