### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - python
     - typing_extensions
     - pandas >=1.0,<1.5.0dev0
-    - cupy >=9.5.0,<11.0.0a0
+    - cupy >=9.5.0,<12.0.0a0
     - numba >=0.54
     - numpy
     - {{ pin_compatible('pyarrow', max_pin='x.x.x') }} *cuda

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -81,7 +81,7 @@ cuda_include_dir = os.path.join(CUDA_HOME, "include")
 install_requires.append(
     "cupy-cuda"
     + get_cuda_version_from_header(cuda_include_dir)
-    + ">=9.5.0,<11.0.0a0"
+    + ">=9.5.0,<12.0.0a0"
 )
 
 

--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -68,7 +68,7 @@ cuda_include_dir = os.path.join(CUDA_HOME, "include")
 install_requires.append(
     "cupy-cuda"
     + get_cuda_version_from_header(cuda_include_dir)
-    + ">=9.5.0,<11.0.0a0"
+    + ">=9.5.0,<12.0.0a0"
 )
 
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.