### PR TITLE
Allow CuPy 11 in cuDF environments

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -12,7 +12,7 @@ dependencies:
   - cxx-compiler
   - clang=11.1.0
   - clang-tools=11.1.0
-  - cupy>=9.5.0,<11.0.0a0
+  - cupy>=9.5.0,<12.0.0a0
   - rmm=22.08.*
   - cmake>=3.20.1,!=3.23.0
   - cmake_setuptools>=0.1.3


### PR DESCRIPTION
## Description

Follow up to comment ( https://github.com/rapidsai/cudf/pull/11393#issuecomment-1199880778 ), allows CuPy 11 in the environment file. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

cc @shwina (for awareness)