### PR TITLE
Revert "Allow CuPy 11"

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - python
     - typing_extensions
     - pandas >=1.0,<1.5.0dev0
-    - cupy >=9.5.0,<12.0.0a0
+    - cupy >=9.5.0,<11.0.0a0
     - numba >=0.54
     - numpy
     - {{ pin_compatible('pyarrow', max_pin='x.x.x') }} *cuda

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -81,7 +81,7 @@ cuda_include_dir = os.path.join(CUDA_HOME, "include")
 install_requires.append(
     "cupy-cuda"
     + get_cuda_version_from_header(cuda_include_dir)
-    + ">=9.5.0,<12.0.0a0"
+    + ">=9.5.0,<11.0.0a0"
 )
 
 

--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -68,7 +68,7 @@ cuda_include_dir = os.path.join(CUDA_HOME, "include")
 install_requires.append(
     "cupy-cuda"
     + get_cuda_version_from_header(cuda_include_dir)
-    + ">=9.5.0,<12.0.0a0"
+    + ">=9.5.0,<11.0.0a0"
 )
 
 


### PR DESCRIPTION
## Description

This reverts PR ( https://github.com/rapidsai/cudf/pull/11393 ). Thus constraining this back to CuPy 10.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
