### PR TITLE
Relax arrow pinning to just 8.x and remove cuda build dependency from cudf recipe

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - setuptools
     - numba >=0.54
     - dlpack>=0.5,<0.6.0a0
-    - pyarrow =8.0.0
+    - pyarrow =8
     - libcudf ={{ version }}
     - rmm ={{ minor_version }}
     - cudatoolkit ={{ cuda_version }}
@@ -53,7 +53,7 @@ requirements:
     - cupy >=9.5.0,<12.0.0a0
     - numba >=0.54
     - numpy
-    - {{ pin_compatible('pyarrow', max_pin='x.x.x') }} *cuda
+    - {{ pin_compatible('pyarrow', max_pin='x.x.x') }}
     - libcudf {{ version }}
     - fastavro >=0.22.0
     - {{ pin_compatible('rmm', max_pin='x.x') }}

--- a/conda/recipes/libcudf/conda_build_config.yaml
+++ b/conda/recipes/libcudf/conda_build_config.yaml
@@ -17,7 +17,7 @@ gtest_version:
   - "=1.10.0"
 
 arrow_cpp_version:
-  - "=8.0.0"
+  - "=8"
 
 dlpack_version:
   - ">=0.5,<0.6.0a0"


### PR DESCRIPTION
## Description
Arrow 8.0.1 just got built and uploaded to conda-forge and there's an associated PR to update the pinning to 8.0.1. Currently the recipes pin to 8.0.0 explicitly which will cause solving issues. Instead of just changing to 8.0.1, this PR relaxes the pinning to allow minor and patch versions to get pulled as there hasn't been any nvcc compiler issues in a while and Arrow strives to not introduce API / ABI breakages in minor and patch versions. Additionally, the cudf recipe seems to be unnecessarily setting requiring a cuda build of pyarrow which should no longer be needed after #10995.

Would really like this in for 21.08 if possible, but happy to change to just pin 8.0.1 if preferred.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
