### PR TITLE
[REVIEW] Relax arrow version in dev env

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -21,7 +21,7 @@ dependencies:
   - numba>=0.54
   - numpy
   - pandas>=1.0,<1.5.0dev0
-  - pyarrow=8.0.0
+  - pyarrow=8
   - fastavro>=0.22.9
   - python-snappy>=0.6.0
   - notebook>=0.5.0
@@ -51,7 +51,7 @@ dependencies:
   - dask>=2022.05.2
   - distributed>=2022.05.2
   - streamz
-  - arrow-cpp=8.0.0
+  - arrow-cpp=8
   - dlpack>=0.5,<0.6.0a0
   - double-conversion
   - rapidjson


### PR DESCRIPTION
## Description
Arrow version pinnings were relaxed in this commit: https://github.com/rapidsai/cudf/commit/d740c3cd2719c889821153da339dedcb15480103, this PR performs the same change in dev env.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
