### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -21,7 +21,7 @@ dependencies:
   - numba>=0.54
   - numpy
   - pandas>=1.0,<1.5.0dev0
-  - pyarrow=8.0.0
+  - pyarrow=8
   - fastavro>=0.22.9
   - python-snappy>=0.6.0
   - notebook>=0.5.0
@@ -51,7 +51,7 @@ dependencies:
   - dask>=2022.05.2
   - distributed>=2022.05.2
   - streamz
-  - arrow-cpp=8.0.0
+  - arrow-cpp=8
   - dlpack>=0.5,<0.6.0a0
   - double-conversion
   - rapidjson


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.