### PR TITLE
Convert byte_array_view to use std::byte

### DIFF
--- a/cpp/include/cudf/utilities/traits.hpp
+++ b/cpp/include/cudf/utilities/traits.hpp
@@ -374,6 +374,19 @@ constexpr inline bool is_floating_point(data_type type)
 }
 
 /**
+ * @brief Indicates whether `T` is a std::byte type.
+ *
+ * @param type The `data_type` to verify
+ * @return true `type` is std::byte
+ * @return false `type` is not std::byte
+ */
+template <typename T>
+constexpr inline bool is_byte()
+{
+  return std::is_same_v<std::remove_const_t<T>, std::byte>;
+}
+
+/**
  * @brief Indicates whether `T` is a Boolean type.
  *
  * @param type The `data_type` to verify
@@ -561,7 +574,8 @@ constexpr inline bool is_chrono(data_type type)
 template <typename T>
 constexpr bool is_rep_layout_compatible()
 {
-  return cudf::is_numeric<T>() or cudf::is_chrono<T>() or cudf::is_boolean<T>();
+  return cudf::is_numeric<T>() or cudf::is_chrono<T>() or cudf::is_boolean<T>() or
+         cudf::is_byte<T>();
 }
 
 /**

--- a/cpp/include/cudf/utilities/traits.hpp
+++ b/cpp/include/cudf/utilities/traits.hpp
@@ -383,7 +383,7 @@ constexpr inline bool is_floating_point(data_type type)
 template <typename T>
 constexpr inline bool is_byte()
 {
-  return std::is_same_v<std::remove_const_t<T>, std::byte>;
+  return std::is_same_v<std::remove_cv_t<T>, std::byte>;
 }
 
 /**

--- a/cpp/src/io/statistics/byte_array_view.cuh
+++ b/cpp/src/io/statistics/byte_array_view.cuh
@@ -28,7 +28,7 @@ namespace cudf::io::statistics {
  */
 class byte_array_view {
  public:
-  using element_type = uint8_t const;  ///< The type of the elements in the byte array
+  using element_type = std::byte const;  ///< The type of the elements in the byte array
 
   constexpr byte_array_view() noexcept {}
   /**

--- a/cpp/src/io/statistics/statistics.cuh
+++ b/cpp/src/io/statistics/statistics.cuh
@@ -85,7 +85,8 @@ struct t_array_stats {
   __host__ __device__ __forceinline__ operator ReturnType() { return ReturnType(ptr, length); }
 };
 using string_stats     = t_array_stats<string_view, char>;
-using byte_array_stats = t_array_stats<statistics::byte_array_view, uint8_t>;
+using byte_array_view  = statistics::byte_array_view;
+using byte_array_stats = t_array_stats<byte_array_view, byte_array_view::element_type>;
 
 union statistics_val {
   string_stats str_val;       //!< string columns
@@ -129,10 +130,10 @@ template <typename T, std::enable_if_t<std::is_same_v<T, statistics::byte_array_
 __device__ T get_element(column_device_view const& col, uint32_t row)
 {
   using et              = typename T::element_type;
-  size_type index       = row + col.offset();  // account for this view's _offset
+  size_type const index = row + col.offset();  // account for this view's _offset
   auto const* d_offsets = col.child(lists_column_view::offsets_column_index).data<offset_type>();
   auto const* d_data    = col.child(lists_column_view::child_column_index).data<et>();
-  offset_type offset    = d_offsets[index];
+  auto const offset     = d_offsets[index];
   return T(d_data + offset, d_offsets[index + 1] - offset);
 }
 


### PR DESCRIPTION
## Description
When reviewing PR #11322 it was noted that it would be preferable to use `std::byte` for the data type, but at the time that didn't work out, so the plan was to address it later and issue #11362 was created to track it.

Fixes #11362 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
