### PR TITLE
Python API for the future experimental JSON reader

### DIFF
--- a/cpp/tests/io/json_test.cpp
+++ b/cpp/tests/io/json_test.cpp
@@ -915,4 +915,13 @@ TEST_F(JsonReaderTest, BadDtypeParams)
   EXPECT_THROW(cudf_io::read_json(options_map), cudf::logic_error);
 }
 
+TEST_F(JsonReaderTest, ExperimentalParam)
+{
+  cudf_io::json_reader_options const options =
+    cudf_io::json_reader_options::builder(cudf_io::source_info{nullptr, 0}).experimental(true);
+
+  // should throw for now
+  EXPECT_THROW(cudf_io::read_json(options), cudf::logic_error);
+}
+
 CUDF_TEST_PROGRAM_MAIN()

--- a/python/cudf/cudf/_lib/cpp/io/json.pxd
+++ b/python/cudf/cudf/_lib/cpp/io/json.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 
 from libc.stdint cimport uint8_t
 from libcpp cimport bool

--- a/python/cudf/cudf/_lib/cpp/io/json.pxd
+++ b/python/cudf/cudf/_lib/cpp/io/json.pxd
@@ -24,6 +24,7 @@ cdef extern from "cudf/io/json.hpp" \
         size_type get_byte_range_size() except+
         bool is_enabled_lines() except+
         bool is_enabled_dayfirst() except+
+        bool is_enabled_experimental() except+
 
         # setter
         void set_dtypes(vector[data_type] types) except+
@@ -35,6 +36,7 @@ cdef extern from "cudf/io/json.hpp" \
         void set_byte_range_size(size_type size) except+
         void enable_lines(bool val) except+
         void enable_dayfirst(bool val) except+
+        void enable_experimental(bool val) except+
 
         @staticmethod
         json_reader_options_builder builder(
@@ -68,6 +70,9 @@ cdef extern from "cudf/io/json.hpp" \
             bool val
         ) except+
         json_reader_options_builder& dayfirst(
+            bool val
+        ) except+
+        json_reader_options_builder& experimental(
             bool val
         ) except+
 

--- a/python/cudf/cudf/_lib/json.pyx
+++ b/python/cudf/cudf/_lib/json.pyx
@@ -31,7 +31,8 @@ cpdef read_json(object filepaths_or_buffers,
                 object dtype,
                 bool lines,
                 object compression,
-                object byte_range):
+                object byte_range,
+                bool experimental):
     """
     Cython function to call into libcudf API, see `read_json`.
 
@@ -98,6 +99,7 @@ cpdef read_json(object filepaths_or_buffers,
         .lines(c_lines)
         .byte_range_offset(c_range_offset)
         .byte_range_size(c_range_size)
+        .experimental(experimental)
         .build()
     )
     if is_list_like_dtypes:

--- a/python/cudf/cudf/io/json.py
+++ b/python/cudf/cudf/io/json.py
@@ -30,7 +30,7 @@ def read_json(
         raise ValueError("cudf engine only supports JSON Lines format")
     if engine == "auto":
         engine = "cudf" if lines else "pandas"
-    if engine == "cudf":
+    if engine == "cudf" or engine == "cudf_experimental":
         # Multiple sources are passed as a list. If a single source is passed,
         # wrap it in a list for unified processing downstream.
         if not is_list_like(path_or_buf):
@@ -58,7 +58,12 @@ def read_json(
                 filepaths_or_buffers.append(tmp_source)
 
         df = libjson.read_json(
-            filepaths_or_buffers, dtype, lines, compression, byte_range
+            filepaths_or_buffers,
+            dtype,
+            lines,
+            compression,
+            byte_range,
+            engine == "cudf_experimental",
         )
     else:
         warnings.warn(

--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -573,3 +573,9 @@ def test_default_float_bitwidth(default_float_bitwidth):
     )
     assert df["a"].dtype == np.dtype(f"f{default_float_bitwidth//8}")
     assert df["b"].dtype == np.dtype(f"f{default_float_bitwidth//8}")
+
+
+def test_json_experimental():
+    # should raise an exception, for now
+    with pytest.raises(RuntimeError):
+        cudf.read_json("", engine="cudf_experimental")

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -463,7 +463,7 @@ path_or_buf : list, str, path object, or file-like object
     function or `StringIO`). Multiple inputs may be provided as a list. If a
     list is specified each list entry may be of a different input type as long
     as each input is of a valid type and all input JSON schema(s) match.
-engine : {{ 'auto', 'cudf', 'pandas' }}, default 'auto'
+engine : {{ 'auto', 'cudf', 'cudf_experimental', 'pandas' }}, default 'auto'
     Parser engine to use. If 'auto' is passed, the engine will be
     automatically selected based on the other parameters.
 orient : string,


### PR DESCRIPTION
## Description
Add Python API to expose the future experimental JSON reader implementation.
Add tests for C++ and Python experimental APIs.

Issue https://github.com/rapidsai/cudf/issues/8827

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
