### PR TITLE
[REVIEW] Fix `distributed` error related to `loop_in_thread`

### DIFF
--- a/python/dask_cudf/dask_cudf/tests/test_distributed.py
+++ b/python/dask_cudf/dask_cudf/tests/test_distributed.py
@@ -6,7 +6,7 @@ import pytest
 import dask
 from dask import dataframe as dd
 from dask.distributed import Client
-from distributed.utils_test import cleanup, loop  # noqa: F401
+from distributed.utils_test import cleanup, loop, loop_in_thread  # noqa: F401
 
 import cudf
 from cudf.testing._utils import assert_eq


### PR DESCRIPTION
## Description
This PR resolves the following error showing up in latest `distributed`:

```python

python/dask_cudf/dask_cudf/tests/test_distributed.py EE                                                                                                                                [100%]

=========================================================================================== ERRORS ===========================================================================================
_____________________________________________________________________________ ERROR at setup of test_basic[True] _____________________________________________________________________________
file /nvme/0/pgali/cudf/python/dask_cudf/dask_cudf/tests/test_distributed.py, line 24
  @pytest.mark.parametrize("delayed", [True, False])
  def test_basic(loop, delayed):  # noqa: F811
file /nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/distributed/utils_test.py, line 145
  @pytest.fixture
  def loop(loop_in_thread):
E       fixture 'loop_in_thread' not found
>       available fixtures: benchmark, benchmark_weave, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, cleanup, current_cases, doctest_namespace, loop, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, testrun_uid, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, worker_id
>       use 'pytest --fixtures [testpath]' for help on them.

/nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/distributed/utils_test.py:145
____________________________________________________________________________ ERROR at setup of test_basic[False] _____________________________________________________________________________
file /nvme/0/pgali/cudf/python/dask_cudf/dask_cudf/tests/test_distributed.py, line 24
  @pytest.mark.parametrize("delayed", [True, False])
  def test_basic(loop, delayed):  # noqa: F811
file /nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/distributed/utils_test.py, line 145
  @pytest.fixture
  def loop(loop_in_thread):
E       fixture 'loop_in_thread' not found
>       available fixtures: benchmark, benchmark_weave, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, cleanup, current_cases, doctest_namespace, loop, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, testrun_uid, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, worker_id
>       use 'pytest --fixtures [testpath]' for help on them.

```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
