### PR TITLE
Change cmake to allow controlling Arrow version via cmake variable

### DIFF
--- a/cpp/cmake/thirdparty/get_arrow.cmake
+++ b/cpp/cmake/thirdparty/get_arrow.cmake
@@ -273,7 +273,10 @@ function(find_and_configure_arrow VERSION BUILD_STATIC ENABLE_S3 ENABLE_ORC ENAB
 
 endfunction()
 
-set(CUDF_VERSION_Arrow 8.0.0)
+set(CUDF_VERSION_Arrow
+    8.0.0
+    CACHE STRING "The version of Arrow to find (or build)"
+)
 
 find_and_configure_arrow(
   ${CUDF_VERSION_Arrow} ${CUDF_USE_ARROW_STATIC} ${CUDF_ENABLE_ARROW_S3} ${CUDF_ENABLE_ARROW_ORC}

--- a/cpp/cmake/thirdparty/get_arrow.cmake
+++ b/cpp/cmake/thirdparty/get_arrow.cmake
@@ -273,10 +273,12 @@ function(find_and_configure_arrow VERSION BUILD_STATIC ENABLE_S3 ENABLE_ORC ENAB
 
 endfunction()
 
-set(CUDF_VERSION_Arrow
-    8.0.0
-    CACHE STRING "The version of Arrow to find (or build)"
-)
+if(NOT DEFINED CUDF_VERSION_Arrow)
+  set(CUDF_VERSION_Arrow
+      8.0.0
+      CACHE STRING "The version of Arrow to find (or build)"
+  )
+endif()
 
 find_and_configure_arrow(
   ${CUDF_VERSION_Arrow} ${CUDF_USE_ARROW_STATIC} ${CUDF_ENABLE_ARROW_S3} ${CUDF_ENABLE_ARROW_ORC}


### PR DESCRIPTION
## Description
Fixes #11425

Changes the `CUDF_VERSION_Arrow` cmake variable to be a cache entry so that a user can override it by providing `-DCUDF_VERSION_Arrow` at configure time.

Happy to repeat this pattern for other dependencies if desired.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
