### PR TITLE
Converts cudf over to supporting thrust existing in a nested namespace 

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -585,6 +585,7 @@ target_include_directories(
 target_compile_definitions(
   cudf PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_DEFINITIONS}>"
               "$<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_DEFINITIONS}>>"
+       PRIVATE "THRUST_WRAPPED_NAMESPACE=rapids"
 )
 
 # Disable Jitify log printing. See https://github.com/NVIDIA/jitify/issues/79

--- a/cpp/cmake/thirdparty/get_rmm.cmake
+++ b/cpp/cmake/thirdparty/get_rmm.cmake
@@ -15,6 +15,21 @@
 # This function finds rmm and sets any additional necessary environment variables.
 function(find_and_configure_rmm)
   include(${rapids-cmake-dir}/cpm/rmm.cmake)
+  include(${rapids-cmake-dir}/cpm/package_override.cmake)
+
+  file(
+    WRITE "${CMAKE_CURRENT_BINARY_DIR}/rmm_override.json"
+    [=[
+{
+  "packages" : {
+    "rmm" : {
+      "git_url" : "https://github.com/robertmaynard/rmm.git",
+      "git_tag" : "support_custom_thrust_namespaces"
+    }
+  }
+}
+]=])
+  rapids_cpm_package_override("${CMAKE_CURRENT_BINARY_DIR}/rmm_override.json")
 
   # Find or install RMM
   rapids_cpm_rmm(BUILD_EXPORT_SET cudf-exports INSTALL_EXPORT_SET cudf-exports)

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
@@ -23,11 +24,11 @@
 
 #include <cudf/types.hpp>
 
-#include <thrust/optional.h>
-
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // Forward declarations
@@ -383,12 +384,12 @@ class table_input_metadata;
 class column_in_metadata {
   friend table_input_metadata;
   std::string _name = "";
-  thrust::optional<bool> _nullable;
+  std::optional<bool> _nullable;
   bool _list_column_is_map  = false;
   bool _use_int96_timestamp = false;
   bool _output_as_binary    = false;
-  thrust::optional<uint8_t> _decimal_precision;
-  thrust::optional<int32_t> _parquet_field_id;
+  std::optional<uint8_t> _decimal_precision;
+  std::optional<int32_t> _parquet_field_id;
   std::vector<column_in_metadata> children;
 
  public:

--- a/cpp/include/cudf/strings/string_view.cuh
+++ b/cpp/include/cudf/strings/string_view.cuh
@@ -51,8 +51,8 @@ __device__ inline size_type characters_in_string(const char* str, size_type byte
   if ((str == nullptr) || (bytes == 0)) return 0;
   auto ptr = reinterpret_cast<uint8_t const*>(str);
 #ifndef CUDF_JIT_UDF
-  return thrust::count_if(
-    thrust::seq, ptr, ptr + bytes, [](uint8_t chr) { return is_begin_utf8_char(chr); });
+  return THRUST_NS_QUALIFIER::count_if(
+    THRUST_NS_QUALIFIER::seq, ptr, ptr + bytes, [](uint8_t chr) { return is_begin_utf8_char(chr); });
 #else
   size_type chars = 0;
   auto const end  = ptr + bytes;

--- a/cpp/src/aggregation/aggregation.cu
+++ b/cpp/src/aggregation/aggregation.cu
@@ -18,6 +18,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 void initialize_with_identity(mutable_table_view& table,

--- a/cpp/src/aggregation/result_cache.cpp
+++ b/cpp/src/aggregation/result_cache.cpp
@@ -16,6 +16,7 @@
 
 #include <cudf/detail/aggregation/result_cache.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/ast/expression_parser.cpp
+++ b/cpp/src/ast/expression_parser.cpp
@@ -29,6 +29,7 @@
 #include <functional>
 #include <iterator>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 namespace ast {

--- a/cpp/src/ast/expressions.cpp
+++ b/cpp/src/ast/expressions.cpp
@@ -22,6 +22,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace ast {
 

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -46,6 +46,7 @@
 
 #include <thrust/optional.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace binops {
 

--- a/cpp/src/binaryop/compiled/binary_ops.cu
+++ b/cpp/src/binaryop/compiled/binary_ops.cu
@@ -33,6 +33,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace binops {
 namespace compiled {

--- a/cpp/src/bitmask/is_element_valid.cpp
+++ b/cpp/src/bitmask/is_element_valid.cpp
@@ -19,6 +19,7 @@
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/error.hpp>
 
+// using namespace THRUST_WRAPPED_NAMESPACE;
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf {

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -45,6 +45,7 @@
 #include <numeric>
 #include <type_traits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 size_type state_null_count(mask_state state, size_type size)
 {

--- a/cpp/src/column/column.cu
+++ b/cpp/src/column/column.cu
@@ -43,6 +43,7 @@
 #include <numeric>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 // Copy ctor w/ optional stream/mr

--- a/cpp/src/column/column_device_view.cu
+++ b/cpp/src/column/column_device_view.cu
@@ -26,6 +26,7 @@
 
 #include <numeric>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 // Trivially copy all members but the children
 column_device_view::column_device_view(column_view source)

--- a/cpp/src/column/column_factories.cpp
+++ b/cpp/src/column/column_factories.cpp
@@ -27,6 +27,7 @@
 
 #include <thrust/iterator/constant_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace {
 struct size_of_helper {

--- a/cpp/src/column/column_factories.cu
+++ b/cpp/src/column/column_factories.cu
@@ -24,6 +24,7 @@
 
 #include <thrust/iterator/constant_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 namespace {

--- a/cpp/src/column/column_view.cpp
+++ b/cpp/src/column/column_view.cpp
@@ -29,6 +29,7 @@
 #include <numeric>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 column_view_base::column_view_base(data_type type,

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -47,6 +47,7 @@
 #include <numeric>
 #include <utility>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -47,6 +47,7 @@
 #include <cstddef>
 #include <numeric>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace {
 

--- a/cpp/src/copying/copy.cpp
+++ b/cpp/src/copying/copy.cpp
@@ -31,6 +31,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -34,6 +34,7 @@
 #include <thrust/distance.h>
 #include <thrust/iterator/counting_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -211,6 +211,7 @@ std::unique_ptr<cudf::column> out_of_place_copy_range_dispatch::operator()<cudf:
 
 }  // namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 void copy_range_in_place(column_view const& source,

--- a/cpp/src/copying/gather.cu
+++ b/cpp/src/copying/gather.cu
@@ -28,6 +28,7 @@
 
 #include <thrust/iterator/transform_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -29,6 +29,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/copying/pack.cpp
+++ b/cpp/src/copying/pack.cpp
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -19,6 +19,7 @@
 
 #include <thrust/iterator/counting_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/copying/reverse.cu
+++ b/cpp/src/copying/reverse.cu
@@ -32,6 +32,7 @@
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::unique_ptr<table> reverse(table_view const& source_table,

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -31,6 +31,7 @@
 #include <thrust/random/uniform_int_distribution.h>
 #include <thrust/shuffle.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -43,6 +43,7 @@
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/copying/segmented_shift.cu
+++ b/cpp/src/copying/segmented_shift.cu
@@ -29,6 +29,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/transform_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -39,6 +39,7 @@
 #include <iterator>
 #include <memory>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace {
 inline bool __device__ out_of_bounds(size_type size, size_type idx)

--- a/cpp/src/copying/slice.cu
+++ b/cpp/src/copying/slice.cu
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::vector<column_view> slice(column_view const& input,

--- a/cpp/src/copying/split.cpp
+++ b/cpp/src/copying/split.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -40,6 +40,7 @@
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace datetime {
 namespace detail {

--- a/cpp/src/dictionary/add_keys.cu
+++ b/cpp/src/dictionary/add_keys.cu
@@ -30,6 +30,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace dictionary {
 namespace detail {

--- a/cpp/src/dictionary/decode.cu
+++ b/cpp/src/dictionary/decode.cu
@@ -27,6 +27,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace dictionary {
 namespace detail {

--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace dictionary {
 namespace detail {

--- a/cpp/src/dictionary/detail/merge.cu
+++ b/cpp/src/dictionary/detail/merge.cu
@@ -28,6 +28,7 @@
 
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace dictionary {
 namespace detail {

--- a/cpp/src/dictionary/dictionary_column_view.cpp
+++ b/cpp/src/dictionary/dictionary_column_view.cpp
@@ -17,6 +17,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/utilities/error.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 //
 dictionary_column_view::dictionary_column_view(column_view const& dictionary_column)

--- a/cpp/src/dictionary/dictionary_factories.cu
+++ b/cpp/src/dictionary/dictionary_factories.cu
@@ -24,6 +24,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace {
 struct dispatch_create_indices {

--- a/cpp/src/dictionary/encode.cu
+++ b/cpp/src/dictionary/encode.cu
@@ -30,6 +30,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace dictionary {
 namespace detail {

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -36,6 +36,7 @@
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace dictionary {
 namespace detail {

--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -27,6 +27,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace dictionary {
 namespace detail {

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -29,6 +29,7 @@
 #include <thrust/distance.h>
 #include <thrust/execution_policy.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace dictionary {
 namespace detail {

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -43,6 +43,7 @@
 #include <algorithm>
 #include <iterator>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace dictionary {
 namespace detail {

--- a/cpp/src/filling/calendrical_month_sequence.cu
+++ b/cpp/src/filling/calendrical_month_sequence.cu
@@ -23,6 +23,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::unique_ptr<cudf::column> calendrical_month_sequence(size_type size,

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -203,6 +203,7 @@ std::unique_ptr<cudf::column> out_of_place_fill_range_dispatch::operator()<cudf:
 
 }  // namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 void fill_in_place(mutable_column_view& destination,

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -99,6 +99,7 @@ struct count_checker {
 
 }  // namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::unique_ptr<table> repeat(table_view const& input_table,

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -30,6 +30,7 @@
 #include <thrust/sequence.h>
 #include <thrust/tabulate.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/groupby/groupby.cu
+++ b/cpp/src/groupby/groupby.cu
@@ -44,6 +44,7 @@
 #include <memory>
 #include <utility>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 // Constructor

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -59,6 +59,7 @@
 
 #include <cuda/std/atomic>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -42,6 +42,7 @@
 #include <unordered_map>
 #include <utility>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_argmax.cu
+++ b/cpp/src/groupby/sort/group_argmax.cu
@@ -23,6 +23,7 @@
 
 #include <thrust/gather.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_argmin.cu
+++ b/cpp/src/groupby/sort/group_argmin.cu
@@ -23,6 +23,7 @@
 
 #include <thrust/gather.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_collect.cu
+++ b/cpp/src/groupby/sort/group_collect.cu
@@ -31,6 +31,7 @@
 
 #include <memory>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -35,6 +35,7 @@
 
 #include <type_traits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_count.cu
+++ b/cpp/src/groupby/sort/group_count.cu
@@ -29,6 +29,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_count_scan.cu
+++ b/cpp/src/groupby/sort/group_count_scan.cu
@@ -25,6 +25,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_m2.cu
+++ b/cpp/src/groupby/sort/group_m2.cu
@@ -30,6 +30,7 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/reduce.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_max.cu
+++ b/cpp/src/groupby/sort/group_max.cu
@@ -18,6 +18,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_max_scan.cu
+++ b/cpp/src/groupby/sort/group_max_scan.cu
@@ -18,6 +18,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_merge_lists.cu
+++ b/cpp/src/groupby/sort/group_merge_lists.cu
@@ -23,6 +23,7 @@
 
 #include <thrust/gather.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -34,6 +34,7 @@
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_min.cu
+++ b/cpp/src/groupby/sort/group_min.cu
@@ -18,6 +18,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_min_scan.cu
+++ b/cpp/src/groupby/sort/group_min_scan.cu
@@ -18,6 +18,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_nth_element.cu
+++ b/cpp/src/groupby/sort/group_nth_element.cu
@@ -37,6 +37,7 @@
 #include <thrust/transform.h>
 #include <thrust/uninitialized_fill.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_nunique.cu
+++ b/cpp/src/groupby/sort/group_nunique.cu
@@ -30,6 +30,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_product.cu
+++ b/cpp/src/groupby/sort/group_product.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_quantiles.cu
+++ b/cpp/src/groupby/sort/group_quantiles.cu
@@ -34,6 +34,7 @@
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_rank_scan.cu
+++ b/cpp/src/groupby/sort/group_rank_scan.cu
@@ -33,6 +33,7 @@
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_replace_nulls.cu
+++ b/cpp/src/groupby/sort/group_replace_nulls.cu
@@ -32,6 +32,7 @@
 
 #include <utility>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_std.cu
+++ b/cpp/src/groupby/sort/group_std.cu
@@ -34,6 +34,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_sum.cu
+++ b/cpp/src/groupby/sort/group_sum.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/group_sum_scan.cu
+++ b/cpp/src/groupby/sort/group_sum_scan.cu
@@ -18,6 +18,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/scan.cpp
+++ b/cpp/src/groupby/sort/scan.cpp
@@ -38,6 +38,7 @@
 
 #include <memory>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -86,6 +86,7 @@ struct permuted_row_equality_comparator {
 
 }  // namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace groupby {
 namespace detail {

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/hash/helper_functions.cuh
+++ b/cpp/src/hash/helper_functions.cuh
@@ -138,7 +138,7 @@ __global__ void init_hashtbl(value_type* __restrict__ const hashtbl_values,
 {
   const size_type idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < n) {
-    store_pair_vectorized(hashtbl_values + idx, thrust::make_pair(key_val, elem_val));
+    store_pair_vectorized(hashtbl_values + idx, THRUST_NS_QUALIFIER::make_pair(key_val, elem_val));
   }
 }
 

--- a/cpp/src/hash/md5_hash.cu
+++ b/cpp/src/hash/md5_hash.cu
@@ -35,6 +35,7 @@
 
 #include <iterator>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 namespace detail {

--- a/cpp/src/hash/murmur_hash.cu
+++ b/cpp/src/hash/murmur_hash.cu
@@ -25,6 +25,7 @@
 
 #include <thrust/tabulate.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/hash/spark_murmur_hash.cu
+++ b/cpp/src/hash/spark_murmur_hash.cu
@@ -25,6 +25,7 @@
 
 #include <thrust/tabulate.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/interop/detail/arrow_allocator.cpp
+++ b/cpp/src/interop/detail/arrow_allocator.cpp
@@ -16,6 +16,7 @@
 
 #include <cudf/detail/interop.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/interop/dlpack.cpp
+++ b/cpp/src/interop/dlpack.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cudf/utilities/traits.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace {
 struct get_column_data_impl {

--- a/cpp/src/interop/from_arrow.cu
+++ b/cpp/src/interop/from_arrow.cu
@@ -36,6 +36,7 @@
 
 #include <thrust/gather.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 namespace detail {

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -38,6 +38,7 @@
 
 #include "detail/arrow_allocator.hpp"
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/io/avro/avro.cpp
+++ b/cpp/src/io/avro/avro.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <unordered_map>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace avro {

--- a/cpp/src/io/avro/avro_gpu.cu
+++ b/cpp/src/io/avro/avro_gpu.cu
@@ -21,6 +21,7 @@
 
 using cudf::device_span;
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace avro {

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -51,6 +51,7 @@
 
 using cudf::device_span;
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/comp/cpu_unbz2.cpp
+++ b/cpp/src/io/comp/cpu_unbz2.cpp
@@ -86,6 +86,7 @@ For more information on these sources, see the manual.
 #include <cstdlib>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 

--- a/cpp/src/io/comp/debrotli.cu
+++ b/cpp/src/io/comp/debrotli.cu
@@ -63,6 +63,7 @@ THE SOFTWARE.
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 constexpr uint32_t huffman_lookup_table_width      = 8;

--- a/cpp/src/io/comp/gpuinflate.cu
+++ b/cpp/src/io/comp/gpuinflate.cu
@@ -50,6 +50,7 @@ Mark Adler    madler@alumni.caltech.edu
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 

--- a/cpp/src/io/comp/snap.cu
+++ b/cpp/src/io/comp/snap.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 constexpr int hash_bits = 12;

--- a/cpp/src/io/comp/uncomp.cpp
+++ b/cpp/src/io/comp/uncomp.cpp
@@ -31,6 +31,7 @@
 
 using cudf::host_span;
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 

--- a/cpp/src/io/comp/unsnap.cu
+++ b/cpp/src/io/comp/unsnap.cu
@@ -22,6 +22,7 @@
 
 #include <cub/cub.cuh>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 constexpr int32_t batch_size    = (1 << 5);

--- a/cpp/src/io/csv/csv_gpu.cu
+++ b/cpp/src/io/csv/csv_gpu.cu
@@ -49,6 +49,7 @@ using namespace ::cudf::io;
 
 using cudf::device_span;
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace csv {

--- a/cpp/src/io/csv/durations.cu
+++ b/cpp/src/io/csv/durations.cu
@@ -30,6 +30,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -63,6 +63,7 @@ using cudf::device_span;
 using cudf::host_span;
 using cudf::detail::make_device_uvector_async;
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -55,6 +55,7 @@
 #include <string>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -34,6 +34,7 @@
 #include <cudf/utilities/error.hpp>
 #include <io/orc/orc.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 // Returns builder for csv_reader_options

--- a/cpp/src/io/json/json_gpu.cu
+++ b/cpp/src/io/json/json_gpu.cu
@@ -47,6 +47,7 @@
 
 using cudf::device_span;
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace json {

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -56,6 +56,7 @@
 
 using cudf::host_span;
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/orc/dict_enc.cu
+++ b/cpp/src/io/orc/dict_enc.cu
@@ -27,6 +27,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/sort.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace orc {

--- a/cpp/src/io/orc/orc.cpp
+++ b/cpp/src/io/orc/orc.cpp
@@ -24,6 +24,7 @@
 
 #include <string>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace orc {

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -55,6 +55,7 @@
 #include <algorithm>
 #include <iterator>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/orc/stats_enc.cu
+++ b/cpp/src/io/orc/stats_enc.cu
@@ -21,6 +21,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace orc {

--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -21,6 +21,7 @@
 #include "orc_common.hpp"
 #include "orc_gpu.hpp"
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace orc {

--- a/cpp/src/io/orc/stripe_enc.cu
+++ b/cpp/src/io/orc/stripe_enc.cu
@@ -34,6 +34,7 @@
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace orc {

--- a/cpp/src/io/orc/stripe_init.cu
+++ b/cpp/src/io/orc/stripe_init.cu
@@ -22,6 +22,7 @@
 #include <cub/cub.cuh>
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace orc {

--- a/cpp/src/io/orc/timezone.cpp
+++ b/cpp/src/io/orc/timezone.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <fstream>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -58,6 +58,7 @@
 
 #include <cuda/std/limits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/parquet/chunk_dict.cu
+++ b/cpp/src/io/parquet/chunk_dict.cu
@@ -24,6 +24,7 @@
 
 #include <cuda/atomic>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace parquet {

--- a/cpp/src/io/parquet/compact_protocol_reader.hpp
+++ b/cpp/src/io/parquet/compact_protocol_reader.hpp
@@ -18,10 +18,9 @@
 
 #include "parquet.hpp"
 
-#include <thrust/optional.h>
-
 #include <algorithm>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -264,10 +263,10 @@ class ParquetFieldInt32 {
  */
 class ParquetFieldOptionalInt32 {
   int field_val;
-  thrust::optional<int32_t>& val;
+  std::optional<int32_t>& val;
 
  public:
-  ParquetFieldOptionalInt32(int f, thrust::optional<int32_t>& v) : field_val(f), val(v) {}
+  ParquetFieldOptionalInt32(int f, std::optional<int32_t>& v) : field_val(f), val(v) {}
 
   inline bool operator()(CompactProtocolReader* cpr, int field_type)
   {

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -45,6 +45,7 @@ inline __device__ uint32_t rotl32(uint32_t x, uint32_t r)
 
 inline __device__ int rolling_index(int index) { return index & (non_zero_buffer_size - 1); }
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace parquet {

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -45,6 +45,7 @@
 #include <thrust/scatter.h>
 #include <thrust/tuple.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace parquet {

--- a/cpp/src/io/parquet/page_hdr.cu
+++ b/cpp/src/io/parquet/page_hdr.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace parquet {

--- a/cpp/src/io/parquet/parquet.hpp
+++ b/cpp/src/io/parquet/parquet.hpp
@@ -18,9 +18,9 @@
 
 #include "parquet_common.hpp"
 
-#include <thrust/optional.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -147,7 +147,7 @@ struct SchemaElement {
   int32_t num_children                = 0;
   int32_t decimal_scale               = 0;
   int32_t decimal_precision           = 0;
-  thrust::optional<int32_t> field_id  = thrust::nullopt;
+  std::optional<int32_t> field_id  = std::nullopt;
   bool output_as_byte_array           = false;
 
   // The following fields are filled in later during schema initialization

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -50,6 +50,7 @@
 #include <numeric>
 #include <regex>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -55,6 +55,7 @@
 #include <numeric>
 #include <utility>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/statistics/orc_column_statistics.cu
+++ b/cpp/src/io/statistics/orc_column_statistics.cu
@@ -21,6 +21,7 @@
 
 #include "column_statistics.cuh"
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/statistics/parquet_column_statistics.cu
+++ b/cpp/src/io/statistics/parquet_column_statistics.cu
@@ -21,6 +21,7 @@
 
 #include "column_statistics.cuh"
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -211,6 +211,7 @@ __global__ void multibyte_split_kernel(
 
 }  // namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace text {

--- a/cpp/src/io/utilities/column_buffer.cpp
+++ b/cpp/src/io/utilities/column_buffer.cpp
@@ -22,6 +22,7 @@
 #include "column_buffer.hpp"
 #include <cudf/detail/utilities/vector_factories.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace detail {

--- a/cpp/src/io/utilities/parsing_utils.cu
+++ b/cpp/src/io/utilities/parsing_utils.cu
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace io {
 namespace {

--- a/cpp/src/io/utilities/trie.cu
+++ b/cpp/src/io/utilities/trie.cu
@@ -30,6 +30,7 @@
 #include <string>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/jit/type.cpp
+++ b/cpp/src/jit/type.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace jit {
 struct get_data_ptr_functor {

--- a/cpp/src/join/conditional_join.cu
+++ b/cpp/src/join/conditional_join.cu
@@ -32,6 +32,7 @@
 
 #include <optional>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -30,6 +30,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 /**

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -39,6 +39,7 @@
 #include <iostream>
 #include <numeric>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -24,6 +24,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/join_utils.cu
+++ b/cpp/src/join/join_utils.cu
@@ -26,6 +26,7 @@
 #include <thrust/sequence.h>
 #include <thrust/uninitialized_fill.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/mixed_join.cu
+++ b/cpp/src/join/mixed_join.cu
@@ -38,6 +38,7 @@
 #include <optional>
 #include <utility>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/mixed_join_kernel.cu
+++ b/cpp/src/join/mixed_join_kernel.cu
@@ -16,6 +16,7 @@
 
 #include "mixed_join_kernel.cuh"
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/mixed_join_kernel_nulls.cu
+++ b/cpp/src/join/mixed_join_kernel_nulls.cu
@@ -16,6 +16,7 @@
 
 #include "mixed_join_kernel.cuh"
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/mixed_join_kernels_semi.cu
+++ b/cpp/src/join/mixed_join_kernels_semi.cu
@@ -26,6 +26,7 @@
 
 #include <cub/cub.cuh>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -41,6 +41,7 @@
 #include <optional>
 #include <utility>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/mixed_join_size_kernel.cu
+++ b/cpp/src/join/mixed_join_size_kernel.cu
@@ -16,6 +16,7 @@
 
 #include "mixed_join_size_kernel.cuh"
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/mixed_join_size_kernel_nulls.cu
+++ b/cpp/src/join/mixed_join_size_kernel_nulls.cu
@@ -16,6 +16,7 @@
 
 #include "mixed_join_size_kernel.cuh"
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/mixed_join_size_kernels_semi.cu
+++ b/cpp/src/join/mixed_join_size_kernels_semi.cu
@@ -26,6 +26,7 @@
 
 #include <cub/cub.cuh>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -36,6 +36,7 @@
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/labeling/label_bins.cu
+++ b/cpp/src/labeling/label_bins.cu
@@ -42,6 +42,7 @@
 
 #include <limits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/lists/combine/concatenate_list_elements.cu
+++ b/cpp/src/lists/combine/concatenate_list_elements.cu
@@ -38,6 +38,7 @@
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/combine/concatenate_rows.cu
+++ b/cpp/src/lists/combine/concatenate_rows.cu
@@ -29,6 +29,7 @@
 
 #include <thrust/iterator/discard_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/copying/concatenate.cu
+++ b/cpp/src/lists/copying/concatenate.cu
@@ -31,6 +31,7 @@
 
 #include <memory>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/copying/copying.cu
+++ b/cpp/src/lists/copying/copying.cu
@@ -28,6 +28,7 @@
 
 #include <iostream>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/copying/gather.cu
+++ b/cpp/src/lists/copying/gather.cu
@@ -25,6 +25,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/copying/scatter_helper.cu
+++ b/cpp/src/lists/copying/scatter_helper.cu
@@ -30,6 +30,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -26,6 +26,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/count_elements.cu
+++ b/cpp/src/lists/count_elements.cu
@@ -32,6 +32,7 @@
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/explode.cu
+++ b/cpp/src/lists/explode.cu
@@ -41,6 +41,7 @@
 #include <memory>
 #include <type_traits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -33,6 +33,7 @@
 
 #include <limits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/interleave_columns.cu
+++ b/cpp/src/lists/interleave_columns.cu
@@ -38,6 +38,7 @@
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/lists_column_factories.cu
+++ b/cpp/src/lists/lists_column_factories.cu
@@ -25,6 +25,7 @@
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/sequence.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/lists/lists_column_view.cu
+++ b/cpp/src/lists/lists_column_view.cu
@@ -22,6 +22,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 lists_column_view::lists_column_view(column_view const& lists_column) : column_view(lists_column)

--- a/cpp/src/lists/segmented_sort.cu
+++ b/cpp/src/lists/segmented_sort.cu
@@ -41,6 +41,7 @@
 
 #include <cub/device/device_segmented_radix_sort.cuh>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace lists {
 namespace detail {

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -43,6 +43,7 @@
 #include <queue>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -35,6 +35,7 @@
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace {
 // Launch configuration for optimized hash partition

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -147,6 +147,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
 }
 }  // namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::pair<std::unique_ptr<table>, std::vector<cudf::size_type>> round_robin_partition(

--- a/cpp/src/quantiles/quantile.cu
+++ b/cpp/src/quantiles/quantile.cu
@@ -42,6 +42,7 @@
 #include <memory>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 template <bool exact, typename SortMapIterator>

--- a/cpp/src/quantiles/quantiles.cu
+++ b/cpp/src/quantiles/quantiles.cu
@@ -34,6 +34,7 @@
 #include <memory>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 template <typename SortMapIterator>

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -40,6 +40,7 @@
 
 using namespace cudf::tdigest;
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace tdigest {

--- a/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
+++ b/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
@@ -50,6 +50,7 @@
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace tdigest {

--- a/cpp/src/quantiles/tdigest/tdigest_column_view.cpp
+++ b/cpp/src/quantiles/tdigest/tdigest_column_view.cpp
@@ -19,6 +19,7 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/tdigest/tdigest_column_view.cuh>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace tdigest {
 

--- a/cpp/src/reductions/all.cu
+++ b/cpp/src/reductions/all.cu
@@ -24,6 +24,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 namespace detail {

--- a/cpp/src/reductions/any.cu
+++ b/cpp/src/reductions/any.cu
@@ -24,6 +24,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 namespace detail {

--- a/cpp/src/reductions/collect_ops.cu
+++ b/cpp/src/reductions/collect_ops.cu
@@ -23,6 +23,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/max.cu
+++ b/cpp/src/reductions/max.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/mean.cu
+++ b/cpp/src/reductions/mean.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/min.cu
+++ b/cpp/src/reductions/min.cu
@@ -18,6 +18,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <reductions/simple.cuh>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/minmax.cu
+++ b/cpp/src/reductions/minmax.cu
@@ -37,6 +37,7 @@
 
 #include <type_traits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/reductions/product.cu
+++ b/cpp/src/reductions/product.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -30,6 +30,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 struct reduce_dispatch_functor {

--- a/cpp/src/reductions/scan/rank_scan.cu
+++ b/cpp/src/reductions/scan/rank_scan.cu
@@ -28,6 +28,7 @@
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -21,6 +21,7 @@
 #include <cudf/reduction.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 std::unique_ptr<column> scan(column_view const& input,

--- a/cpp/src/reductions/scan/scan_exclusive.cu
+++ b/cpp/src/reductions/scan/scan_exclusive.cu
@@ -28,6 +28,7 @@
 
 #include <thrust/scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -36,6 +36,7 @@
 
 #include <type_traits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/reductions/segmented_all.cu
+++ b/cpp/src/reductions/segmented_all.cu
@@ -18,6 +18,7 @@
 
 #include <cudf/detail/reduction_functions.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/segmented_any.cu
+++ b/cpp/src/reductions/segmented_any.cu
@@ -18,6 +18,7 @@
 
 #include <cudf/detail/reduction_functions.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/segmented_max.cu
+++ b/cpp/src/reductions/segmented_max.cu
@@ -18,6 +18,7 @@
 
 #include <cudf/detail/reduction_functions.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/segmented_min.cu
+++ b/cpp/src/reductions/segmented_min.cu
@@ -18,6 +18,7 @@
 
 #include <cudf/detail/reduction_functions.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/segmented_product.cu
+++ b/cpp/src/reductions/segmented_product.cu
@@ -18,6 +18,7 @@
 
 #include <cudf/detail/reduction_functions.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/segmented_reductions.cpp
+++ b/cpp/src/reductions/segmented_reductions.cpp
@@ -25,6 +25,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 struct segmented_reduce_dispatch_functor {

--- a/cpp/src/reductions/segmented_sum.cu
+++ b/cpp/src/reductions/segmented_sum.cu
@@ -18,6 +18,7 @@
 
 #include <cudf/detail/reduction_functions.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/std.cu
+++ b/cpp/src/reductions/std.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/sum.cu
+++ b/cpp/src/reductions/sum.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/sum_of_squares.cu
+++ b/cpp/src/reductions/sum_of_squares.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/reductions/var.cu
+++ b/cpp/src/reductions/var.cu
@@ -20,6 +20,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace reduction {
 

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -44,6 +44,7 @@
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -33,6 +33,7 @@
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {
@@ -169,6 +170,7 @@ struct normalize_nans_and_zeros_kernel_forwarder {
 
 }  // end anonymous namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 void normalize_nans_and_zeros(mutable_column_view in_out, rmm::cuda_stream_view stream)

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -403,6 +403,7 @@ std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const&
 
 }  // end anonymous namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -483,6 +483,7 @@ std::unique_ptr<cudf::column> replace_kernel_forwarder::operator()<cudf::diction
 
 }  // end anonymous namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::unique_ptr<cudf::column> find_and_replace_all(cudf::column_view const& input_col,

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -31,6 +31,7 @@
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -34,6 +34,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/reshape/tile.cu
+++ b/cpp/src/reshape/tile.cu
@@ -31,6 +31,7 @@
 
 #include <memory>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace {
 struct tile_functor {

--- a/cpp/src/rolling/detail/rolling_collect_list.cu
+++ b/cpp/src/rolling/detail/rolling_collect_list.cu
@@ -32,6 +32,7 @@
 #include <thrust/scatter.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -34,6 +34,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/partition.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
                                                column_view const& input,

--- a/cpp/src/rolling/range_window_bounds.cpp
+++ b/cpp/src/rolling/range_window_bounds.cpp
@@ -20,6 +20,9 @@
 #include <cudf/types.hpp>
 #include <cudf/wrappers/durations.hpp>
 
+#ifdef THRUST_WRAPPED_NAMESPACE
+using namespace THRUST_WRAPPED_NAMESPACE;
+#endif
 namespace cudf {
 namespace {
 

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -21,6 +21,7 @@
 
 #include <thrust/iterator/constant_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 // Applies a fixed-size rolling window function to the values in a column, with default output

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -39,6 +39,7 @@
 #include <thrust/uninitialized_fill.h>
 #include <type_traits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {  // anonymous

--- a/cpp/src/scalar/scalar.cpp
+++ b/cpp/src/scalar/scalar.cpp
@@ -29,6 +29,7 @@
 
 #include <string>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 scalar::scalar(data_type type,

--- a/cpp/src/scalar/scalar_factories.cpp
+++ b/cpp/src/scalar/scalar_factories.cpp
@@ -24,6 +24,7 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace {
 struct scalar_construction_helper {

--- a/cpp/src/search/contains_column.cu
+++ b/cpp/src/search/contains_column.cu
@@ -36,6 +36,7 @@
 #include <thrust/transform.h>
 #include <thrust/uninitialized_fill.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -29,6 +29,7 @@
 
 #include <thrust/binary_search.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -31,6 +31,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/sort.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -43,6 +43,7 @@
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/sort/segmented_sort.cu
+++ b/cpp/src/sort/segmented_sort.cu
@@ -26,6 +26,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -27,6 +27,7 @@
 
 #include <thrust/functional.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::unique_ptr<column> sorted_order(table_view const& input,

--- a/cpp/src/sort/sort_column.cu
+++ b/cpp/src/sort/sort_column.cu
@@ -20,6 +20,7 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -25,6 +25,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::unique_ptr<column> stable_sorted_order(table_view const& input,

--- a/cpp/src/sort/stable_sort_column.cu
+++ b/cpp/src/sort/stable_sort_column.cu
@@ -19,6 +19,7 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/stream_compaction/apply_boolean_mask.cu
+++ b/cpp/src/stream_compaction/apply_boolean_mask.cu
@@ -55,6 +55,7 @@ struct boolean_mask_filter {
 
 }  // namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 /*

--- a/cpp/src/stream_compaction/distinct.cu
+++ b/cpp/src/stream_compaction/distinct.cu
@@ -33,6 +33,7 @@
 #include <utility>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/stream_compaction/distinct_count.cu
+++ b/cpp/src/stream_compaction/distinct_count.cu
@@ -43,6 +43,7 @@
 #include <utility>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/stream_compaction/drop_nans.cu
+++ b/cpp/src/stream_compaction/drop_nans.cu
@@ -79,6 +79,7 @@ struct valid_table_filter {
 
 }  // namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 /*

--- a/cpp/src/stream_compaction/drop_nulls.cu
+++ b/cpp/src/stream_compaction/drop_nulls.cu
@@ -58,6 +58,7 @@ struct valid_table_filter {
 
 }  // namespace
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 /*

--- a/cpp/src/stream_compaction/unique.cu
+++ b/cpp/src/stream_compaction/unique.cu
@@ -45,6 +45,7 @@
 #include <utility>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::unique_ptr<table> unique(table_view const& input,

--- a/cpp/src/stream_compaction/unique_count.cu
+++ b/cpp/src/stream_compaction/unique_count.cu
@@ -43,6 +43,7 @@
 #include <utility>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/strings/attributes.cu
+++ b/cpp/src/strings/attributes.cu
@@ -36,6 +36,7 @@
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/capitalize.cu
+++ b/cpp/src/strings/capitalize.cu
@@ -32,6 +32,7 @@
 #include <thrust/pair.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/case.cu
+++ b/cpp/src/strings/case.cu
@@ -32,6 +32,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/char_types/char_types.cu
+++ b/cpp/src/strings/char_types/char_types.cu
@@ -35,6 +35,7 @@
 #include <thrust/logical.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/combine/concatenate.cu
+++ b/cpp/src/strings/combine/concatenate.cu
@@ -38,6 +38,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/combine/join.cu
+++ b/cpp/src/strings/combine/join.cu
@@ -36,6 +36,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform_scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/combine/join_list_elements.cu
+++ b/cpp/src/strings/combine/join_list_elements.cu
@@ -32,6 +32,7 @@
 
 #include <thrust/iterator/counting_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/contains.cu
+++ b/cpp/src/strings/contains.cu
@@ -29,6 +29,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -36,6 +36,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -48,6 +48,7 @@
 #include <numeric>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -37,6 +37,7 @@
 #include <map>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/convert/convert_fixed_point.cu
+++ b/cpp/src/strings/convert/convert_fixed_point.cu
@@ -44,6 +44,7 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -41,6 +41,7 @@
 #include <cmath>
 #include <limits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/convert/convert_hex.cu
+++ b/cpp/src/strings/convert/convert_hex.cu
@@ -36,6 +36,7 @@
 #include <thrust/logical.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -39,6 +39,7 @@
 #include <thrust/pair.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 

--- a/cpp/src/strings/convert/convert_ipv4.cu
+++ b/cpp/src/strings/convert/convert_ipv4.cu
@@ -33,6 +33,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/convert/convert_lists.cu
+++ b/cpp/src/strings/convert/convert_lists.cu
@@ -23,6 +23,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/convert/convert_urls.cu
+++ b/cpp/src/strings/convert/convert_urls.cu
@@ -44,6 +44,7 @@
 
 using cudf::device_span;
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -36,6 +36,7 @@
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -26,6 +26,7 @@
 
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/count_matches.cu
+++ b/cpp/src/strings/count_matches.cu
@@ -21,6 +21,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/strings/string_view.cuh>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/extract/extract.cu
+++ b/cpp/src/strings/extract/extract.cu
@@ -35,6 +35,7 @@
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/pair.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/extract/extract_all.cu
+++ b/cpp/src/strings/extract/extract_all.cu
@@ -32,6 +32,7 @@
 #include <thrust/functional.h>
 #include <thrust/transform_scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/filling/fill.cu
+++ b/cpp/src/strings/filling/fill.cu
@@ -32,6 +32,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/filter_chars.cu
+++ b/cpp/src/strings/filter_chars.cu
@@ -38,6 +38,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -40,6 +40,7 @@
 #include <thrust/scan.h>
 #include <thrust/tuple.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/padding.cu
+++ b/cpp/src/strings/padding.cu
@@ -34,6 +34,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -30,6 +30,7 @@
 #include <tuple>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/regex/regex.cuh
+++ b/cpp/src/strings/regex/regex.cuh
@@ -36,8 +36,8 @@ namespace detail {
 
 struct relist;
 
-using match_pair   = thrust::pair<cudf::size_type, cudf::size_type>;
-using match_result = thrust::optional<match_pair>;
+using match_pair   = THRUST_NS_QUALIFIER::pair<cudf::size_type, cudf::size_type>;
+using match_result = THRUST_NS_QUALIFIER::optional<match_pair>;
 
 constexpr int32_t MAX_SHARED_MEM      = 2048;  ///< Memory size for storing prog instruction data
 constexpr std::size_t MAX_WORKING_MEM = 0x01FFFFFFFF;  ///< Memory size for state data

--- a/cpp/src/strings/regex/regex.inl
+++ b/cpp/src/strings/regex/regex.inl
@@ -19,6 +19,7 @@
 #include <cudf/strings/detail/utf8.hpp>
 #include <cudf/strings/string_view.cuh>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/regex/regexec.cu
+++ b/cpp/src/strings/regex/regexec.cu
@@ -28,6 +28,7 @@
 #include <functional>
 #include <numeric>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -34,6 +34,7 @@
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/replace/backref_re.cu
+++ b/cpp/src/strings/replace/backref_re.cu
@@ -33,6 +33,7 @@
 
 #include <regex>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/replace/multi_re.cu
+++ b/cpp/src/strings/replace/multi_re.cu
@@ -36,6 +36,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/replace/replace.cu
+++ b/cpp/src/strings/replace/replace.cu
@@ -45,6 +45,7 @@
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/replace/replace_re.cu
+++ b/cpp/src/strings/replace/replace_re.cu
@@ -29,6 +29,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/search/find.cu
+++ b/cpp/src/strings/search/find.cu
@@ -35,6 +35,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/search/find_multiple.cu
+++ b/cpp/src/strings/search/find_multiple.cu
@@ -31,6 +31,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/search/findall.cu
+++ b/cpp/src/strings/search/findall.cu
@@ -35,6 +35,7 @@
 #include <thrust/pair.h>
 #include <thrust/reduce.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/search/findall_record.cu
+++ b/cpp/src/strings/search/findall_record.cu
@@ -34,6 +34,7 @@
 #include <thrust/pair.h>
 #include <thrust/scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/split/partition.cu
+++ b/cpp/src/strings/split/partition.cu
@@ -34,6 +34,7 @@
 
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/split/split.cu
+++ b/cpp/src/strings/split/split.cu
@@ -43,6 +43,7 @@
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/split/split_re.cu
+++ b/cpp/src/strings/split/split_re.cu
@@ -37,6 +37,7 @@
 #include <thrust/transform_reduce.h>
 #include <thrust/transform_scan.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/split/split_record.cu
+++ b/cpp/src/strings/split/split_record.cu
@@ -35,6 +35,7 @@
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/split/split_utils.cuh
+++ b/cpp/src/strings/split/split_utils.cuh
@@ -22,7 +22,7 @@ namespace cudf {
 namespace strings {
 namespace detail {
 
-using position_pair = thrust::pair<size_type, size_type>;
+using position_pair = THRUST_NS_QUALIFIER::pair<size_type, size_type>;
 
 /**
  * @brief Instantiated for each string to manage navigating tokens from

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -29,6 +29,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/pair.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 namespace {

--- a/cpp/src/strings/strings_column_view.cpp
+++ b/cpp/src/strings/strings_column_view.cpp
@@ -17,6 +17,7 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/error.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 //
 strings_column_view::strings_column_view(column_view strings_column) : column_view(strings_column)

--- a/cpp/src/strings/strings_scalar_factories.cpp
+++ b/cpp/src/strings/strings_scalar_factories.cpp
@@ -18,6 +18,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 // Create a strings-type column from array of pointer/size pairs
 std::unique_ptr<scalar> make_string_scalar(std::string const& string,

--- a/cpp/src/strings/strip.cu
+++ b/cpp/src/strings/strip.cu
@@ -32,6 +32,7 @@
 #include <thrust/logical.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/substring.cu
+++ b/cpp/src/strings/substring.cu
@@ -34,6 +34,7 @@
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/translate.cu
+++ b/cpp/src/strings/translate.cu
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/utilities.cu
+++ b/cpp/src/strings/utilities.cu
@@ -30,6 +30,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/strings/wrap.cu
+++ b/cpp/src/strings/wrap.cu
@@ -32,6 +32,7 @@
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace strings {
 namespace detail {

--- a/cpp/src/structs/copying/concatenate.cu
+++ b/cpp/src/structs/copying/concatenate.cu
@@ -30,6 +30,7 @@
 #include <memory>
 #include <numeric>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace structs {
 namespace detail {

--- a/cpp/src/structs/structs_column_factories.cu
+++ b/cpp/src/structs/structs_column_factories.cu
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <memory>
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 /// Column factory that adopts child columns.

--- a/cpp/src/structs/structs_column_view.cpp
+++ b/cpp/src/structs/structs_column_view.cpp
@@ -18,6 +18,7 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/utilities/error.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 structs_column_view::structs_column_view(column_view const& rhs) : column_view{rhs}

--- a/cpp/src/structs/utilities.cpp
+++ b/cpp/src/structs/utilities.cpp
@@ -34,6 +34,7 @@
 #include <bitset>
 #include <iterator>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace structs {
 namespace detail {

--- a/cpp/src/table/row_operators.cu
+++ b/cpp/src/table/row_operators.cu
@@ -26,6 +26,7 @@
 
 #include <jit/type.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace experimental {
 

--- a/cpp/src/table/table.cpp
+++ b/cpp/src/table/table.cpp
@@ -21,6 +21,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 
 // Copy the columns from another table

--- a/cpp/src/table/table_device_view.cu
+++ b/cpp/src/table/table_device_view.cu
@@ -21,6 +21,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 template <typename ColumnDeviceView, typename HostTableView>

--- a/cpp/src/table/table_view.cpp
+++ b/cpp/src/table/table_view.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 template <typename ColumnView>

--- a/cpp/src/transform/bools_to_mask.cu
+++ b/cpp/src/transform/bools_to_mask.cu
@@ -28,6 +28,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(

--- a/cpp/src/transform/compute_column.cu
+++ b/cpp/src/transform/compute_column.cu
@@ -34,6 +34,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/transform/encode.cu
+++ b/cpp/src/transform/encode.cu
@@ -36,6 +36,7 @@
 #include <utility>
 #include <vector>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/transform/mask_to_bools.cu
+++ b/cpp/src/transform/mask_to_bools.cu
@@ -29,6 +29,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::unique_ptr<column> mask_to_bools(bitmask_type const* bitmask,

--- a/cpp/src/transform/nans_to_nulls.cu
+++ b/cpp/src/transform/nans_to_nulls.cu
@@ -29,6 +29,7 @@
 
 #include <thrust/iterator/counting_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 struct dispatch_nan_to_null {

--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/transform/row_bit_count.cu
+++ b/cpp/src/transform/row_bit_count.cu
@@ -32,6 +32,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 

--- a/cpp/src/transform/transform.cpp
+++ b/cpp/src/transform/transform.cpp
@@ -31,6 +31,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace transformation {
 namespace jit {

--- a/cpp/src/transpose/transpose.cu
+++ b/cpp/src/transpose/transpose.cu
@@ -30,6 +30,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 std::pair<std::unique_ptr<column>, table_view> transpose(table_view const& input,

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -32,6 +32,7 @@
 
 #include <thrust/transform.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {  // anonymous namespace

--- a/cpp/src/unary/math_ops.cu
+++ b/cpp/src/unary/math_ops.cu
@@ -31,6 +31,7 @@
 #include <cmath>
 #include <type_traits>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 namespace {

--- a/cpp/src/unary/nan_ops.cu
+++ b/cpp/src/unary/nan_ops.cu
@@ -25,6 +25,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace detail {
 struct nan_dispatcher {

--- a/cpp/src/unary/null_ops.cu
+++ b/cpp/src/unary/null_ops.cu
@@ -24,6 +24,7 @@
 
 #include <thrust/iterator/counting_iterator.h>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 std::unique_ptr<column> is_null(cudf::column_view const& input, rmm::mr::device_memory_resource* mr)
 {

--- a/cpp/src/utilities/type_checks.cpp
+++ b/cpp/src/utilities/type_checks.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 
+using namespace THRUST_WRAPPED_NAMESPACE;
 namespace cudf {
 namespace {
 


### PR DESCRIPTION
## Description
This is one way that cudf can be updated to support a nested version of thrust.
This version requires https://github.com/rapidsai/rmm/pull/1077

## Tasks
- [x] namespaced thrust calls
- [ ] namespace cub calls
- [ ] remove thrust types from public API
- [ ] remove cub types from public API

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
