### PR TITLE
Remove unused is_struct trait.

### DIFF
--- a/cpp/include/cudf/utilities/traits.hpp
+++ b/cpp/include/cudf/utilities/traits.hpp
@@ -722,37 +722,6 @@ constexpr inline bool is_nested(data_type type)
   return cudf::type_dispatcher(type, is_nested_impl{});
 }
 
-/**
- * @brief Indicates whether `T` is a struct type.
- *
- * @param T The type to verify
- * @return A boolean indicating if T is a struct type
- */
-template <typename T>
-constexpr inline bool is_struct()
-{
-  return std::is_same_v<T, cudf::struct_view>;
-}
-
-struct is_struct_impl {
-  template <typename T>
-  constexpr bool operator()()
-  {
-    return is_struct<T>();
-  }
-};
-
-/**
- * @brief Indicates whether `type` is a struct type.
- *
- * @param type The `data_type` to verify
- * @return A boolean indicating if `type` is a struct type
- */
-constexpr inline bool is_struct(data_type type)
-{
-  return cudf::type_dispatcher(type, is_struct_impl{});
-}
-
 template <typename FromType>
 struct is_bit_castable_to_impl {
   template <typename ToType, std::enable_if_t<is_compound<ToType>()>* = nullptr>


### PR DESCRIPTION
## Description
This PR removes the unused `is_struct` trait. Users should instead check the column `data_type` id, like `col->type().id() == cudf::type_id::STRUCT`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
