### PR TITLE
Make Index Join Tests on Default Precisions Deterministic

### DIFF
--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -2674,7 +2674,7 @@ def test_rangeindex_join_user_option(default_integer_bitwidth):
     idx1 = cudf.RangeIndex(0, 10)
     idx2 = cudf.RangeIndex(5, 15)
 
-    actual = idx1.join(idx2, how="inner")
+    actual = idx1.join(idx2, how="inner", sort=True)
     expected = cudf.Index(
         [5, 6, 7, 8, 9], dtype=f"int{default_integer_bitwidth}", name=0
     )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR fixes a flaky test introduced by #11272, cudf joins by default does not guarantee return orders and may lead to occasional test regression. This PR adds `sort` argument to make sure result is deterministic.

Note that `index.union` and `index.intersection` may also include random output ordering, but by default these methods sorts the result before returning so `sort` argument does not need to be modified.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
