### PR TITLE
Convert thrust::optional usages to std::optional

### DIFF
--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
@@ -23,11 +24,11 @@
 
 #include <cudf/types.hpp>
 
-#include <thrust/optional.h>
-
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // Forward declarations
@@ -383,12 +384,12 @@ class table_input_metadata;
 class column_in_metadata {
   friend table_input_metadata;
   std::string _name = "";
-  thrust::optional<bool> _nullable;
+  std::optional<bool> _nullable;
   bool _list_column_is_map  = false;
   bool _use_int96_timestamp = false;
   bool _output_as_binary    = false;
-  thrust::optional<uint8_t> _decimal_precision;
-  thrust::optional<int32_t> _parquet_field_id;
+  std::optional<uint8_t> _decimal_precision;
+  std::optional<int32_t> _parquet_field_id;
   std::vector<column_in_metadata> children;
 
  public:

--- a/cpp/src/io/parquet/compact_protocol_reader.hpp
+++ b/cpp/src/io/parquet/compact_protocol_reader.hpp
@@ -18,10 +18,9 @@
 
 #include "parquet.hpp"
 
-#include <thrust/optional.h>
-
 #include <algorithm>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -264,10 +263,10 @@ class ParquetFieldInt32 {
  */
 class ParquetFieldOptionalInt32 {
   int field_val;
-  thrust::optional<int32_t>& val;
+  std::optional<int32_t>& val;
 
  public:
-  ParquetFieldOptionalInt32(int f, thrust::optional<int32_t>& v) : field_val(f), val(v) {}
+  ParquetFieldOptionalInt32(int f, std::optional<int32_t>& v) : field_val(f), val(v) {}
 
   inline bool operator()(CompactProtocolReader* cpr, int field_type)
   {

--- a/cpp/src/io/parquet/parquet.hpp
+++ b/cpp/src/io/parquet/parquet.hpp
@@ -18,7 +18,6 @@
 
 #include "parquet_common.hpp"
 
-
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -147,7 +146,7 @@ struct SchemaElement {
   int32_t num_children                = 0;
   int32_t decimal_scale               = 0;
   int32_t decimal_precision           = 0;
-  std::optional<int32_t> field_id  = std::nullopt;
+  std::optional<int32_t> field_id     = std::nullopt;
   bool output_as_byte_array           = false;
 
   // The following fields are filled in later during schema initialization

--- a/cpp/src/io/parquet/parquet.hpp
+++ b/cpp/src/io/parquet/parquet.hpp
@@ -18,9 +18,9 @@
 
 #include "parquet_common.hpp"
 
-#include <thrust/optional.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -147,7 +147,7 @@ struct SchemaElement {
   int32_t num_children                = 0;
   int32_t decimal_scale               = 0;
   int32_t decimal_precision           = 0;
-  thrust::optional<int32_t> field_id  = thrust::nullopt;
+  std::optional<int32_t> field_id  = std::nullopt;
   bool output_as_byte_array           = false;
 
   // The following fields are filled in later during schema initialization


### PR DESCRIPTION
## Description
As noted in https://github.com/rapidsai/cudf/issues/11368 we should strive towards not having thrust types in our 'public' API. 
This removes occurences of using `thrust::optional` from cudf/io host classes in preference of `std::optional`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
