### PR TITLE
Make CMake hooks verbose

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,8 @@ repos:
                 # of dependencies, so we'll have to update this manually.
                 additional_dependencies:
                   - cmakelang==0.6.13
+                verbose: true
+                require_serial: true
               - id: cmake-lint
                 name: cmake-lint
                 entry: ./cpp/scripts/run-cmake-format.sh cmake-lint
@@ -69,6 +71,8 @@ repos:
                 # of dependencies, so we'll have to update this manually.
                 additional_dependencies:
                   - cmakelang==0.6.13
+                verbose: true
+                require_serial: true
               - id: copyright-check
                 name: copyright-check
                 # This hook's use of Git tools appears to conflict with
@@ -76,6 +80,7 @@ repos:
                 stages: [commit]
                 entry: python ./ci/checks/copyright.py --git-modified-only
                 language: python
+                verbose: true
               - id: doxygen-check
                 name: doxygen-check
                 entry: ./ci/checks/doxygen.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,6 @@ repos:
                 stages: [commit]
                 entry: python ./ci/checks/copyright.py --git-modified-only
                 language: python
-                verbose: true
               - id: doxygen-check
                 name: doxygen-check
                 entry: ./ci/checks/doxygen.sh

--- a/cpp/scripts/run-cmake-format.sh
+++ b/cpp/scripts/run-cmake-format.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+
 # This script is a wrapper for cmakelang that may be used with pre-commit. The
 # wrapping is necessary because RAPIDS libraries split configuration for
 # cmakelang linters between a local config file and a second config file that's
@@ -69,5 +71,14 @@ fi
 if [[ $1 == "cmake-format" ]]; then
   cmake-format -i --config-files cpp/cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2}
 elif [[ $1 == "cmake-lint" ]]; then
-  cmake-lint --config-files cpp/cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2}
+  # Since the pre-commit hook is verbose, we have to be careful to only
+  # present cmake-lint's output (which is quite verbose) if we actually
+  # observe a failure.
+  OUTPUT=$(cmake-lint --config-files cpp/cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2})
+  status=$?
+
+  if ! [ ${status} -eq 0 ]; then
+    echo "${OUTPUT}"
+  fi
+  exit ${status}
 fi


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The hooks for cmake-format and cmake-lint can fail silently if the necessary config files are not available. When creating these hooks we chose this behavior because depending on where and how people build the libraries the location of the format file may not be discoverable. However, this often leads to user confusion where the hooks appear to pass locally when in fact they never ran. This PR changes the hooks to be verbose so that they can provide more useful diagnostic output. In order to leave that output at a maintainable level, it forces these hooks to run serially. On my machine, this results in the cmake-format hook taking ~3.5s instead of ~1.2s to run on all files, which is an acceptable compromise for readable output.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
