### PR TITLE
Workaround for groupyby-min/max compile-time issue with thrust-1.17

### DIFF
--- a/cpp/include/cudf/detail/utilities/element_argminmax.cuh
+++ b/cpp/include/cudf/detail/utilities/element_argminmax.cuh
@@ -37,6 +37,8 @@ struct element_argminmax_fn {
   bool const has_nulls;
   bool const arg_min;
 
+  // The noinline attribute is due to the aggressive inlining of thrust::reduce_by_key
+  // resulting in very high compile times.
   __noinline__ __device__ auto operator()(size_type const& lhs_idx, size_type const& rhs_idx) const
   {
     // The extra bounds checking is due to issue github.com/rapidsai/cudf/9156 and

--- a/cpp/include/cudf/detail/utilities/element_argminmax.cuh
+++ b/cpp/include/cudf/detail/utilities/element_argminmax.cuh
@@ -37,7 +37,7 @@ struct element_argminmax_fn {
   bool const has_nulls;
   bool const arg_min;
 
-  __device__ inline auto operator()(size_type const& lhs_idx, size_type const& rhs_idx) const
+  __noinline__ __device__ auto operator()(size_type const& lhs_idx, size_type const& rhs_idx) const
   {
     // The extra bounds checking is due to issue github.com/rapidsai/cudf/9156 and
     // github.com/NVIDIA/thrust/issues/1525


### PR DESCRIPTION
## Description
Fixes issue found in #11437 where compile-time for `groupby/sort/group_argmax.cu` and `groupby/sort/group_argmin.cu` more than doubles to over 30 minutes for each file:
https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/prb/job/cudf-cpu-cuda-build/CUDA=11.5/11169/Build_20Metrics_20Report/
Baseline example from a different PR:
https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/prb/job/cudf-cpu-cuda-build/CUDA=11.5/11215/Build_20Metrics_20Report/

The culprit appears to be `thrust::reduce_by_key` and almost all source files using this function appear to have doubled in compile time.
The fix here forces the `element_argminmax_fn` functor's device operator to `noinline`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
