### PR TITLE
Sanitize percentile_approx() output for empty input

### DIFF
--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -358,7 +358,7 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
                          row_size_iter + input.size() + 1,
                          offsets->mutable_view().begin<offset_type>());
 
-  if (percentiles.size() == 0) {
+  if (percentiles.size() == 0 || empty_input) {
     return cudf::make_lists_column(
       input.size(),
       std::move(offsets),
@@ -388,8 +388,7 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
   return cudf::make_lists_column(
     input.size(),
     std::move(offsets),
-    empty_input ? cudf::make_empty_column(type_id::FLOAT64)
-                : tdigest::compute_approx_percentiles(input, percentiles, stream, mr),
+    tdigest::compute_approx_percentiles(input, percentiles, stream, mr),
     null_count,
     std::move(bitmask),
     stream,

--- a/cpp/tests/quantiles/percentile_approx_test.cu
+++ b/cpp/tests/quantiles/percentile_approx_test.cu
@@ -405,8 +405,7 @@ TEST_F(PercentileApproxTest, EmptyInput)
                             3,
                             cudf::test::detail::make_null_mask(nulls.begin(), nulls.end()));
 
-  // TODO: change percentile_approx to produce sanitary list outputs for this case.
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
 }
 
 TEST_F(PercentileApproxTest, EmptyPercentiles)


### PR DESCRIPTION
Closes #10856 

If all of the tdigest inputs to percentile_approx are empty, it will return a column containing null rows, as expected, but they will have unsanitary offsets. This PR checks if all the inputs are empty and returns an empty column as expected. 