### PR TITLE
[REVIEW] Update parquet fuzz tests to drop support for `skiprows` & `num_rows`

### DIFF
--- a/python/cudf/cudf/_fuzz_testing/parquet.py
+++ b/python/cudf/cudf/_fuzz_testing/parquet.py
@@ -102,10 +102,6 @@ class ParquetReader(IOFuzz):
                 params_dict[param] = list(
                     np.unique(np.random.choice(self._df.columns, col_size))
                 )
-            elif param in ("skiprows", "num_rows"):
-                params_dict[param] = np.random.choice(
-                    [None, self._rand(len(self._df))]
-                )
             else:
                 params_dict[param] = np.random.choice(values)
         self._current_params["test_kwargs"] = self.process_kwargs(params_dict)

--- a/python/cudf/cudf/_fuzz_testing/tests/fuzz_test_parquet.py
+++ b/python/cudf/cudf/_fuzz_testing/tests/fuzz_test_parquet.py
@@ -28,29 +28,19 @@ def parquet_reader_test(parquet_buffer):
     params={
         "columns": ALL_POSSIBLE_VALUES,
         "use_pandas_metadata": [True, False],
-        "skiprows": ALL_POSSIBLE_VALUES,
-        "num_rows": ALL_POSSIBLE_VALUES,
     },
 )
-def parquet_reader_columns(
-    parquet_buffer, columns, use_pandas_metadata, skiprows, num_rows
-):
+def parquet_reader_columns(parquet_buffer, columns, use_pandas_metadata):
     pdf = pd.read_parquet(
         parquet_buffer,
         columns=columns,
         use_pandas_metadata=use_pandas_metadata,
     )
 
-    pdf = pdf.iloc[skiprows:]
-    if num_rows is not None:
-        pdf = pdf.head(num_rows)
-
     gdf = cudf.read_parquet(
         parquet_buffer,
         columns=columns,
         use_pandas_metadata=use_pandas_metadata,
-        skiprows=skiprows,
-        num_rows=num_rows,
     )
 
     compare_dataframe(gdf, pdf)


### PR DESCRIPTION
## Description
In a previous PR https://github.com/rapidsai/cudf/pull/11480/, `skiprows` & `num_rows` were removed from `cudf.read_parquet`, this PR updates the corresponding parquet reader fuzz tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
