### PR TITLE
copy_range ballot_syncs to have no execution dependency

### DIFF
--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -86,7 +86,7 @@ __global__ void copy_range_kernel(SourceValueIterator source_value_begin,
 
       cudf::bitmask_type old_mask = target.get_mask_word(mask_idx);
       if (lane_id == leader_lane) {
-        cudf::bitmask_type new_mask = (old_mask & ~active_mask) | (warp_mask);
+        cudf::bitmask_type new_mask = (old_mask & ~active_mask) | warp_mask;
         target.set_mask_word(mask_idx, new_mask);
         warp_null_change += __popc(active_mask & old_mask) - __popc(active_mask & new_mask);
       }

--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -79,18 +79,15 @@ __global__ void copy_range_kernel(SourceValueIterator source_value_begin,
     if (in_range) target.element<T>(index) = *(source_value_begin + source_idx);
 
     if (has_validity) {  // update bitmask
-      int active_mask = __ballot_sync(0xFFFFFFFF, in_range);
-
-      bool valid    = in_range && *(source_validity_begin + source_idx);
-      int warp_mask = __ballot_sync(active_mask, valid);
+      const bool valid    = in_range && *(source_validity_begin + source_idx);
+      const int active_mask = __ballot_sync(0xFFFFFFFF, in_range);
+      const int valid_mask  = __ballot_sync(0xFFFFFFFF, valid);
+      const int warp_mask = active_mask & valid_mask;
 
       cudf::bitmask_type old_mask = target.get_mask_word(mask_idx);
-
       if (lane_id == leader_lane) {
-        cudf::bitmask_type new_mask = (old_mask & ~active_mask) | (warp_mask & active_mask);
+        cudf::bitmask_type new_mask = (old_mask & ~active_mask) | (warp_mask);
         target.set_mask_word(mask_idx, new_mask);
-        // null_diff =
-        //   (warp_size - __popc(new_mask)) - (warp_size - __popc(old_mask))
         warp_null_change += __popc(active_mask & old_mask) - __popc(active_mask & new_mask);
       }
     }

--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -79,10 +79,10 @@ __global__ void copy_range_kernel(SourceValueIterator source_value_begin,
     if (in_range) target.element<T>(index) = *(source_value_begin + source_idx);
 
     if (has_validity) {  // update bitmask
-      const bool valid    = in_range && *(source_validity_begin + source_idx);
+      const bool valid      = in_range && *(source_validity_begin + source_idx);
       const int active_mask = __ballot_sync(0xFFFFFFFF, in_range);
       const int valid_mask  = __ballot_sync(0xFFFFFFFF, valid);
-      const int warp_mask = active_mask & valid_mask;
+      const int warp_mask   = active_mask & valid_mask;
 
       cudf::bitmask_type old_mask = target.get_mask_word(mask_idx);
       if (lane_id == leader_lane) {


### PR DESCRIPTION
## Description
We can simplify the logic around determining the warp_mask by having both queries issued without a dependency

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
