### PR TITLE
c++ algorithms consistently specify hex values without separator

### DIFF
--- a/cpp/include/cudf/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/detail/copy_if_else.cuh
@@ -74,7 +74,7 @@ __launch_bounds__(block_size) __global__
     // update validity
     if (has_nulls) {
       // the final validity mask for this warp
-      int warp_mask = __ballot_sync(0xFFFF'FFFF, opt_value.has_value());
+      int warp_mask = __ballot_sync(0xFFFFFFFF, opt_value.has_value());
       // only one guy in the warp needs to update the mask and count
       if (lane_id == 0) {
         out.set_mask_word(warp_cur, warp_mask);

--- a/cpp/include/cudf/detail/valid_if.cuh
+++ b/cpp/include/cudf/detail/valid_if.cuh
@@ -53,7 +53,7 @@ __global__ void valid_if_kernel(
   thread_index_type const stride = blockDim.x * gridDim.x;
   size_type warp_valid_count{0};
 
-  auto active_mask = __ballot_sync(0xFFFF'FFFF, i < size);
+  auto active_mask = __ballot_sync(0xFFFFFFFF, i < size);
   while (i < size) {
     bitmask_type ballot = __ballot_sync(active_mask, p(*(begin + i)));
     if (lane_id == leader_lane) {

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -113,7 +113,7 @@ __global__ void concatenate_masks_kernel(column_device_view const* views,
 {
   size_type mask_index = threadIdx.x + blockIdx.x * blockDim.x;
 
-  auto active_mask = __ballot_sync(0xFFFF'FFFF, mask_index < number_of_mask_bits);
+  auto active_mask = __ballot_sync(0xFFFFFFFF, mask_index < number_of_mask_bits);
 
   while (mask_index < number_of_mask_bits) {
     size_type const source_view_index =
@@ -177,7 +177,7 @@ __global__ void fused_concatenate_kernel(column_device_view const* input_views,
   size_type warp_valid_count = 0;
 
   unsigned active_mask;
-  if (Nullable) { active_mask = __ballot_sync(0xFFFF'FFFF, output_index < output_size); }
+  if (Nullable) { active_mask = __ballot_sync(0xFFFFFFFF, output_index < output_size); }
   while (output_index < output_size) {
     // Lookup input index by searching for output index in offsets
     // thrust::prev isn't in CUDA 10.0, so subtracting 1 here instead

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -124,7 +124,7 @@ __global__ void fused_concatenate_string_offset_kernel(column_device_view const*
   size_type warp_valid_count = 0;
 
   unsigned active_mask;
-  if (Nullable) { active_mask = __ballot_sync(0xFFFF'FFFF, output_index < output_size); }
+  if (Nullable) { active_mask = __ballot_sync(0xFFFFFFFF, output_index < output_size); }
   while (output_index < output_size) {
     // Lookup input index by searching for output index in offsets
     // thrust::prev isn't in CUDA 10.0, so subtracting 1 here instead


### PR DESCRIPTION
## Description
For consistency libcudf should use hex values without separators between the WORDS

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
