### PR TITLE
Fix Feather test warning.

### DIFF
--- a/python/cudf/cudf/tests/test_feather.py
+++ b/python/cudf/cudf/tests/test_feather.py
@@ -1,7 +1,6 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 import os
-from distutils.version import LooseVersion
 from string import ascii_letters
 
 import numpy as np
@@ -11,15 +10,6 @@ import pytest
 
 import cudf
 from cudf.testing._utils import NUMERIC_TYPES, assert_eq
-
-if LooseVersion(pd.__version__) < LooseVersion("0.24"):
-    try:
-        import feather  # noqa F401
-    except ImportError:
-        pytest.skip(
-            "Feather is not installed and is required for Pandas <" " 0.24",
-            allow_module_level=True,
-        )
 
 
 @pytest.fixture(params=[0, 1, 10, 100])


### PR DESCRIPTION
## Description
This fixes a test warning from `test_feather.py`.

```
cudf/python/cudf/cudf/tests/test_feather.py:15: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```

The code used `distutils` to check the pandas version and import a special `feather` package if it was less than pandas 0.24. However, we no longer need to test against pandas versions that old so we can just remove this check entirely instead of updating it to use `packaging.version`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
