### PR TITLE
Fix reverse binary operators acting on a host value and cudf.Scalar

### DIFF
--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -417,7 +417,7 @@ _reflected_ops = [
 @pytest.mark.parametrize(
     "func, dtype", list(product(_reflected_ops, utils.NUMERIC_TYPES))
 )
-def test_reflected_ops_scalar(func, dtype, obj_class):
+def test_series_reflected_ops_scalar(func, dtype, obj_class):
     # create random series
     np.random.seed(12)
     random_series = utils.gen_rand(dtype, 100, low=10)
@@ -440,6 +440,19 @@ def test_reflected_ops_scalar(func, dtype, obj_class):
 
     # verify
     np.testing.assert_allclose(ps_result, gs_result.to_numpy())
+
+
+@pytest.mark.parametrize(
+    "func, dtype", list(product(_reflected_ops, utils.NUMERIC_TYPES))
+)
+def test_cudf_scalar_reflected_ops_scalar(func, dtype):
+    value = 42
+    scalar = cudf.Scalar(42)
+
+    expected = func(value)
+    actual = func(scalar).value
+
+    assert np.isclose(expected, actual)
 
 
 _cudf_scalar_reflected_ops = [
@@ -483,7 +496,7 @@ _cudf_scalar_reflected_ops = [
         )
     ),
 )
-def test_reflected_ops_cudf_scalar(funcs, dtype, obj_class):
+def test_series_reflected_ops_cudf_scalar(funcs, dtype, obj_class):
     cpu_func, gpu_func = funcs
 
     # create random series

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -3052,7 +3052,6 @@ def test_binop_integer_power_int_series():
     utils.assert_eq(expected, got)
 
 
-@pytest.mark.xfail(reason="Reverse binops fail for scalar. See GH: #11225.")
 def test_binop_integer_power_int_scalar():
     # GH: #10178
     base = 3

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -469,12 +469,19 @@ def get_allowed_combinations_for_operator(dtype_l, dtype_r, op):
 
     to_numpy_ops = {
         "__add__": _ADD_TYPES,
+        "__radd__": _ADD_TYPES,
         "__sub__": _SUB_TYPES,
+        "__rsub__": _SUB_TYPES,
         "__mul__": _MUL_TYPES,
+        "__rmul__": _MUL_TYPES,
         "__floordiv__": _FLOORDIV_TYPES,
+        "__rfloordiv__": _FLOORDIV_TYPES,
         "__truediv__": _TRUEDIV_TYPES,
+        "__rtruediv__": _TRUEDIV_TYPES,
         "__mod__": _MOD_TYPES,
+        "__rmod__": _MOD_TYPES,
         "__pow__": _POW_TYPES,
+        "__rpow__": _POW_TYPES,
     }
     allowed = to_numpy_ops.get(op, op)
 


### PR DESCRIPTION
## Description
This PR resolves #11225. It fixes binary operator dispatch for reverse ops like `__radd__` acting on host scalars and `cudf.Scalar` objects in expressions like `1 + cudf.Scalar(3)`, which previously threw an error.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
