### PR TITLE
Struct support for `NULL_EQUALS` binary operation

### DIFF
--- a/cpp/src/binaryop/compiled/binary_ops.cu
+++ b/cpp/src/binaryop/compiled/binary_ops.cu
@@ -405,6 +405,7 @@ void apply_sorting_struct_binary_op(mutable_column_view& out,
   // Struct child column type and structure mismatches are caught within the two_table_comparator
   switch (op) {
     case binary_operator::EQUAL: [[fallthrough]];
+    case binary_operator::NULL_EQUALS: [[fallthrough]];
     case binary_operator::NOT_EQUAL:
       detail::apply_struct_equality_op(
         out,

--- a/cpp/src/binaryop/compiled/struct_binary_ops.cuh
+++ b/cpp/src/binaryop/compiled/struct_binary_ops.cuh
@@ -109,7 +109,8 @@ void apply_struct_equality_op(mutable_column_view& out,
                               PhysicalEqualityComparator comparator = {},
                               rmm::cuda_stream_view stream          = cudf::default_stream_value)
 {
-  CUDF_EXPECTS(op == binary_operator::EQUAL || op == binary_operator::NOT_EQUAL,
+  CUDF_EXPECTS(op == binary_operator::EQUAL || op == binary_operator::NOT_EQUAL ||
+                 op == binary_operator::NULL_EQUALS,
                "Unsupported operator for these types");
 
   auto tlhs = table_view{{lhs}};

--- a/java/src/main/native/src/ScalarJni.cpp
+++ b/java/src/main/native/src/ScalarJni.cpp
@@ -503,9 +503,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_binaryOpSV(JNIEnv *env, jclas
     cudf::binary_operator op = static_cast<cudf::binary_operator>(int_op);
 
     if (lhs->type().id() == cudf::type_id::STRUCT) {
-      auto [new_mask, new_null_count] = cudf::binops::scalar_col_valid_mask_and(*rhs, *lhs);
-      auto out =
-          make_fixed_width_column(n_data_type, rhs->size(), std::move(new_mask), new_null_count);
+      auto out = make_fixed_width_column(n_data_type, rhs->size(), cudf::mask_state::UNALLOCATED);
+
+      if (op == cudf::binary_operator::NULL_EQUALS) {
+        out->set_null_mask(rmm::device_buffer{}, 0);
+      } else {
+        auto [new_mask, new_null_count] = cudf::binops::scalar_col_valid_mask_and(*rhs, *lhs);
+        out->set_null_mask(std::move(new_mask), new_null_count);
+      }
+
       auto lhs_col = cudf::make_column_from_scalar(*lhs, 1);
       auto out_view = out->mutable_view();
       cudf::binops::compiled::detail::apply_sorting_struct_binary_op(out_view, lhs_col->view(),


### PR DESCRIPTION
## Description
Adds support for Spark's null aware equality binop and expands/improves Java testing for struct binops. Properly tests null structs and full operator testing coverage. Utilizes existing Spark struct binop support with JNI changes to force the full null-aware comparison.

Expands on #11153

Partial solution to #8964 -- `NULL_MAX` and `NULL_MIN` still outstanding.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
