### PR TITLE
[REVIEW] Deprecate `skiprows` and `num_rows` in `read_orc`

### DIFF
--- a/python/cudf/cudf/io/orc.py
+++ b/python/cudf/cudf/io/orc.py
@@ -294,6 +294,18 @@ def read_orc(
     """{docstring}"""
     from cudf import DataFrame
 
+    if skiprows is not None:
+        warnings.warn(
+            "skiprows is deprecated and will be removed.",
+            FutureWarning,
+        )
+
+    if num_rows is not None:
+        warnings.warn(
+            "num_rows is deprecated and will be removed.",
+            FutureWarning,
+        )
+
     # Multiple sources are passed as a list. If a single source is passed,
     # wrap it in a list for unified processing downstream.
     if not is_list_like(filepath_or_buffer):

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -378,10 +378,10 @@ stripes: list, default None
     concatenated with index ignored.
 skiprows : int, default None
     If not None, the number of rows to skip from the start of the file.
-    This Parameter is deprecated.
+    This parameter is deprecated.
 num_rows : int, default None
     If not None, the total number of rows to read.
-    This Parameter is deprecated.
+    This parameter is deprecated.
 use_index : bool, default True
     If True, use row index if available for faster seeking.
 use_python_file_object : boolean, default True

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -378,8 +378,10 @@ stripes: list, default None
     concatenated with index ignored.
 skiprows : int, default None
     If not None, the number of rows to skip from the start of the file.
+    This Parameter is deprecated.
 num_rows : int, default None
     If not None, the total number of rows to read.
+    This Parameter is deprecated.
 use_index : bool, default True
     If True, use row index if available for faster seeking.
 use_python_file_object : boolean, default True


### PR DESCRIPTION
## Description
Resolves the first step of #11519 by deprecating `skiprows` and `num_rows` in orc reader.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] The documentation is up to date with these changes.
