### PR TITLE
Fixing crash when writing binary nested data in parquet

### DIFF
--- a/cpp/src/io/utilities/column_utils.cuh
+++ b/cpp/src/io/utilities/column_utils.cuh
@@ -67,13 +67,17 @@ rmm::device_uvector<column_device_view> create_leaf_column_device_views(
       size_type index) mutable {
       col_desc[index].parent_column = parent_col_view.begin() + index;
       column_device_view col        = parent_col_view.column(index);
-      if (col_desc[index].stats_dtype != dtype_byte_array) {
-        // traverse till leaf column
-        while (col.type().id() == type_id::LIST or col.type().id() == type_id::STRUCT) {
-          col = (col.type().id() == type_id::LIST)
-                  ? col.child(lists_column_view::child_column_index)
-                  : col.child(0);
+      // traverse till leaf column
+      while (col.type().id() == type_id::LIST or col.type().id() == type_id::STRUCT) {
+        auto child = (col.type().id() == type_id::LIST)
+                       ? col.child(lists_column_view::child_column_index)
+                       : col.child(0);
+        // stop early if writing a byte array, it needs to be a list<int8> not the int8 column
+        if (col_desc[index].stats_dtype == dtype_byte_array &&
+            (child.type().id() == type_id::INT8 || child.type().id() == type_id::UINT8)) {
+          break;
         }
+        col = child;
       }
       // Store leaf_column to device storage
       column_device_view* leaf_col_ptr = leaf_columns.begin() + index;

--- a/cpp/src/io/utilities/column_utils.cuh
+++ b/cpp/src/io/utilities/column_utils.cuh
@@ -68,11 +68,11 @@ rmm::device_uvector<column_device_view> create_leaf_column_device_views(
       col_desc[index].parent_column = parent_col_view.begin() + index;
       column_device_view col        = parent_col_view.column(index);
       // traverse till leaf column
-      while (col.type().id() == type_id::LIST or col.type().id() == type_id::STRUCT) {
-        auto child = (col.type().id() == type_id::LIST)
-                       ? col.child(lists_column_view::child_column_index)
-                       : col.child(0);
-        // stop early if writing a byte array, it needs to be a list<int8> not the int8 column
+      while (cudf::is_nested(col.type())) {
+        auto const child = (col.type().id() == type_id::LIST)
+                             ? col.child(lists_column_view::child_column_index)
+                             : col.child(0);
+        // stop early if writing a byte array
         if (col_desc[index].stats_dtype == dtype_byte_array &&
             (child.type().id() == type_id::INT8 || child.type().id() == type_id::UINT8)) {
           break;

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -4250,6 +4250,9 @@ TEST_F(ParquetWriterTest, ByteArrayStats)
 
   read_footer(source, &fmd);
 
+  EXPECT_EQ(fmd.schema[1].type, cudf::io::parquet::Type::BYTE_ARRAY);
+  EXPECT_EQ(fmd.schema[2].type, cudf::io::parquet::Type::BYTE_ARRAY);
+
   auto const stats0 = parse_statistics(fmd.row_groups[0].columns[0]);
   auto const stats1 = parse_statistics(fmd.row_groups[0].columns[1]);
 


### PR DESCRIPTION
## Description
This fixes the crash described in the bug related to writing nested data in parquet with the binary flag set to write binary data as byte_arrays. We were incorrectly selecting the top-most node instead of the list<int8>, which resulted in a crash down in the kernels when the data pointer was null for those upper list columns.

closes #11506

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
