### PR TITLE
Fix for pivot: error when 'values' is a multicharacter string

### DIFF
--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -616,6 +616,7 @@ class ColumnAccessor(abc.MutableMapping):
             len(self._level_names) == 1
         ):  # can't use nlevels, as it depends on multiindex
             self.multiindex = False
+        self._clear_cache()
 
 
 def _compare_keys(target: Any, key: Any) -> bool:

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -951,6 +951,7 @@ def pivot(data, index=None, columns=None, values=None):
 
     """
     df = data
+    values_is_list = True
     if values is None:
         values = df._columns_view(
             col for col in df._column_names if col not in (index, columns)
@@ -958,6 +959,7 @@ def pivot(data, index=None, columns=None, values=None):
     else:
         if not isinstance(values, (list, tuple)):
             values = [values]
+            values_is_list = False
         values = df._columns_view(values)
     if index is None:
         index = df.index
@@ -980,7 +982,10 @@ def pivot(data, index=None, columns=None, values=None):
     if len(columns_index) != len(columns_index.drop_duplicates()):
         raise ValueError("Duplicate index-column pairs found. Cannot reshape.")
 
-    return _pivot(values, index, columns)
+    result = _pivot(values, index, columns)
+    if not values_is_list:
+        result.columns = result.columns.droplevel(0)
+    return result
 
 
 def unstack(df, level, fill_value=None):

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -986,9 +986,7 @@ def pivot(data, index=None, columns=None, values=None):
 
     # MultiIndex to Index
     if not values_is_list:
-        column_name = result._data.level_names[1]
-        table_columns = [multi_col[1] for multi_col in result._data.names]
-        result.columns = cudf.Index(data=table_columns, name=column_name)
+        result._data.droplevel(0)
 
     return result
 

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -956,6 +956,8 @@ def pivot(data, index=None, columns=None, values=None):
             col for col in df._column_names if col not in (index, columns)
         )
     else:
+        if not isinstance(values, (list, tuple)):
+            values = [values]
         values = df._columns_view(values)
     if index is None:
         index = df.index

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -983,8 +983,13 @@ def pivot(data, index=None, columns=None, values=None):
         raise ValueError("Duplicate index-column pairs found. Cannot reshape.")
 
     result = _pivot(values, index, columns)
+
+    # MultiIndex to Index
     if not values_is_list:
-        result.columns = result.columns.droplevel(0)
+        column_name = result._data.level_names[1]
+        table_columns = [multi_col[1] for multi_col in result._data.names]
+        result.columns = cudf.Index(data=table_columns, name=column_name)
+
     return result
 
 

--- a/python/cudf/cudf/tests/test_reshape.py
+++ b/python/cudf/cudf/tests/test_reshape.py
@@ -621,3 +621,32 @@ def test_crosstab_simple():
     expected = pd.crosstab(a, [b, c], rownames=["a"], colnames=["b", "c"])
     actual = cudf.crosstab(a, [b, c], rownames=["a"], colnames=["b", "c"])
     assert_eq(expected, actual, check_dtype=False)
+
+
+@pytest.mark.parametrize(
+    "values", ["z", "z123", ["z123"], ["z", "z123", "123z"]]
+)
+def test_pivot_values(values):
+    data = [
+        ["A", "a", 0, 0, 0],
+        ["A", "b", 1, 1, 1],
+        ["A", "c", 2, 2, 2],
+        ["B", "a", 0, 0, 0],
+        ["B", "b", 1, 1, 1],
+        ["B", "c", 2, 2, 2],
+        ["C", "a", 0, 0, 0],
+        ["C", "b", 1, 1, 1],
+        ["C", "c", 2, 2, 2],
+    ]
+    columns = ["x", "y", "z", "z123", "123z"]
+    pdf = pd.DataFrame(data, columns=columns)
+    cdf = cudf.DataFrame(data, columns=columns)
+    expected = pd.pivot(pdf, index="x", columns="y", values=values)
+    actual = cudf.pivot(cdf, index="x", columns="y", values=values)
+    if not isinstance(values, (list, tuple)):
+        actual.columns = actual.columns.droplevel(0)
+    assert_eq(
+        expected,
+        actual,
+        check_dtype=False,
+    )

--- a/python/cudf/cudf/tests/test_reshape.py
+++ b/python/cudf/cudf/tests/test_reshape.py
@@ -409,6 +409,33 @@ def test_pivot_multi_values():
 
 
 @pytest.mark.parametrize(
+    "values", ["z", "z123", ["z123"], ["z", "z123", "123z"]]
+)
+def test_pivot_values(values):
+    data = [
+        ["A", "a", 0, 0, 0],
+        ["A", "b", 1, 1, 1],
+        ["A", "c", 2, 2, 2],
+        ["B", "a", 0, 0, 0],
+        ["B", "b", 1, 1, 1],
+        ["B", "c", 2, 2, 2],
+        ["C", "a", 0, 0, 0],
+        ["C", "b", 1, 1, 1],
+        ["C", "c", 2, 2, 2],
+    ]
+    columns = ["x", "y", "z", "z123", "123z"]
+    pdf = pd.DataFrame(data, columns=columns)
+    cdf = cudf.DataFrame(data, columns=columns)
+    expected = pd.pivot(pdf, index="x", columns="y", values=values)
+    actual = cudf.pivot(cdf, index="x", columns="y", values=values)
+    assert_eq(
+        expected,
+        actual,
+        check_dtype=False,
+    )
+
+
+@pytest.mark.parametrize(
     "level",
     [
         0,
@@ -621,32 +648,3 @@ def test_crosstab_simple():
     expected = pd.crosstab(a, [b, c], rownames=["a"], colnames=["b", "c"])
     actual = cudf.crosstab(a, [b, c], rownames=["a"], colnames=["b", "c"])
     assert_eq(expected, actual, check_dtype=False)
-
-
-@pytest.mark.parametrize(
-    "values", ["z", "z123", ["z123"], ["z", "z123", "123z"]]
-)
-def test_pivot_values(values):
-    data = [
-        ["A", "a", 0, 0, 0],
-        ["A", "b", 1, 1, 1],
-        ["A", "c", 2, 2, 2],
-        ["B", "a", 0, 0, 0],
-        ["B", "b", 1, 1, 1],
-        ["B", "c", 2, 2, 2],
-        ["C", "a", 0, 0, 0],
-        ["C", "b", 1, 1, 1],
-        ["C", "c", 2, 2, 2],
-    ]
-    columns = ["x", "y", "z", "z123", "123z"]
-    pdf = pd.DataFrame(data, columns=columns)
-    cdf = cudf.DataFrame(data, columns=columns)
-    expected = pd.pivot(pdf, index="x", columns="y", values=values)
-    actual = cudf.pivot(cdf, index="x", columns="y", values=values)
-    if not isinstance(values, (list, tuple)):
-        actual.columns = actual.columns.droplevel(0)
-    assert_eq(
-        expected,
-        actual,
-        check_dtype=False,
-    )


### PR DESCRIPTION
## Description
Resolves: https://github.com/rapidsai/cudf/issues/10529

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
