### PR TITLE
Refactor string/numeric conversion utilities

### DIFF
--- a/cpp/include/cudf/strings/detail/convert/int_to_string.cuh
+++ b/cpp/include/cudf/strings/detail/convert/int_to_string.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,34 +21,6 @@
 namespace cudf {
 namespace strings {
 namespace detail {
-
-/**
- * @brief Converts a single string into an integer.
- *
- * The '+' and '-' are allowed but only at the beginning of the string.
- * The string is expected to contain base-10 [0-9] characters only.
- * Any other character will end the parse.
- * Overflow of the int64 type is not detected.
- */
-__device__ inline int64_t string_to_integer(string_view const& d_str)
-{
-  int64_t value   = 0;
-  size_type bytes = d_str.size_bytes();
-  if (bytes == 0) return value;
-  const char* ptr = d_str.data();
-  int sign        = 1;
-  if (*ptr == '-' || *ptr == '+') {
-    sign = (*ptr == '-' ? -1 : 1);
-    ++ptr;
-    --bytes;
-  }
-  for (size_type idx = 0; idx < bytes; ++idx) {
-    char chr = *ptr++;
-    if (chr < '0' || chr > '9') break;
-    value = (value * 10) + static_cast<int64_t>(chr - '0');
-  }
-  return value * static_cast<int64_t>(sign);
-}
 
 /**
  * @brief Converts an integer into string

--- a/cpp/include/cudf/strings/detail/convert/is_float.cuh
+++ b/cpp/include/cudf/strings/detail/convert/is_float.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,42 +17,9 @@
 
 #include <cudf/strings/string_view.cuh>
 
-#include <thrust/distance.h>
-#include <thrust/execution_policy.h>
-#include <thrust/logical.h>
-
 namespace cudf {
 namespace strings {
-/**
- * @addtogroup strings_classes
- * @{
- * @file
- * @brief String functions
- */
-
-/**
- * @brief Returns `true` if all characters in the string
- * are valid for conversion to an integer.
- *
- * Valid characters are in [-+0-9]. The sign character (+/-)
- * is optional but if present must be the first character.
- * An empty string returns `false`.
- * No bounds checking is performed to verify if the integer will fit
- * within a specific integer type.
- *
- * @param d_str String to check.
- * @return true if string has valid integer characters
- */
-inline __device__ bool is_integer(string_view const& d_str)
-{
-  if (d_str.empty()) return false;
-  auto begin = d_str.begin();
-  auto end   = d_str.end();
-  if (*begin == '+' || *begin == '-') ++begin;
-  return (thrust::distance(begin, end) > 0) &&
-         thrust::all_of(
-           thrust::seq, begin, end, [] __device__(auto chr) { return chr >= '0' && chr <= '9'; });
-}
+namespace detail {
 
 /**
  * @brief Returns true if input contains the not-a-number string.
@@ -148,6 +115,6 @@ inline __device__ bool is_float(string_view const& d_str)
   return result;
 }
 
-/** @} */  // end of group
+}  // namespace detail
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/detail/convert/string_to_float.cuh
+++ b/cpp/include/cudf/strings/detail/convert/string_to_float.cuh
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/strings/detail/convert/is_float.cuh>
+#include <cudf/strings/string_view.cuh>
+
+#include <cmath>
+#include <limits>
+
+namespace cudf {
+namespace strings {
+namespace detail {
+
+/**
+ * @brief This function converts the given string into a
+ * floating point double value.
+ *
+ * This will also map strings containing "NaN", "Inf", etc.
+ * to the appropriate float values.
+ *
+ * This function will also handle scientific notation format.
+ */
+__device__ inline double stod(string_view const& d_str)
+{
+  const char* in_ptr = d_str.data();
+  const char* end    = in_ptr + d_str.size_bytes();
+  if (end == in_ptr) return 0.0;
+  double sign{1.0};
+  if (*in_ptr == '-' || *in_ptr == '+') {
+    sign = (*in_ptr == '-' ? -1 : 1);
+    ++in_ptr;
+  }
+
+#ifndef CUDF_JIT_UDF
+  constexpr double infinity      = std::numeric_limits<double>::infinity();
+  constexpr uint64_t max_holding = (std::numeric_limits<uint32_t>::max() - 9L) / 10L;
+#else
+  constexpr double infinity      = (1.0 / 0.0);
+  constexpr uint64_t max_holding = (18446744073709551615UL - 9UL) / 10UL;
+#endif
+
+  // special strings: NaN, Inf
+  if ((in_ptr < end) && *in_ptr > '9') {
+    auto const inf_nan = string_view(in_ptr, static_cast<size_type>(end - in_ptr));
+    if (is_inf_str(inf_nan)) return sign * infinity;
+    if (is_nan_str(inf_nan)) return nan("");
+  }
+
+  // Parse and store the mantissa as much as we can,
+  // until we are about to exceed the limit of uint64_t
+  uint64_t digits = 0;
+  int exp_off     = 0;
+  bool decimal    = false;
+  while (in_ptr < end) {
+    char ch = *in_ptr;
+    if (ch == '.') {
+      decimal = true;
+      ++in_ptr;
+      continue;
+    }
+    if (ch < '0' || ch > '9') break;
+    if (digits > max_holding)
+      exp_off += (int)!decimal;
+    else {
+      digits = (digits * 10L) + static_cast<uint64_t>(ch - '0');
+      if (digits > max_holding) {
+        digits = digits / 10L;
+        exp_off += (int)!decimal;
+      } else
+        exp_off -= (int)decimal;
+    }
+    ++in_ptr;
+  }
+  if (digits == 0) return sign * static_cast<double>(0);
+
+  // check for exponent char
+  int exp_ten  = 0;
+  int exp_sign = 1;
+  if (in_ptr < end) {
+    char ch = *in_ptr++;
+    if (ch == 'e' || ch == 'E') {
+      if (in_ptr < end) {
+        ch = *in_ptr;
+        if (ch == '-' || ch == '+') {
+          exp_sign = (ch == '-' ? -1 : 1);
+          ++in_ptr;
+        }
+        while (in_ptr < end) {
+          ch = *in_ptr++;
+          if (ch < '0' || ch > '9') break;
+          exp_ten = (exp_ten * 10) + (int)(ch - '0');
+        }
+      }
+    }
+  }
+
+  int const num_digits = static_cast<int>(log10(static_cast<double>(digits))) + 1;
+  exp_ten *= exp_sign;
+  exp_ten += exp_off;
+  exp_ten += num_digits - 1;
+  if (exp_ten > std::numeric_limits<double>::max_exponent10) {
+    return sign > 0 ? infinity : -infinity;
+  }
+
+  double base = sign * static_cast<double>(digits);
+
+  exp_ten += 1 - num_digits;
+  // If 10^exp_ten would result in a subnormal value, the base and
+  // exponent should be adjusted so that 10^exp_ten is a normal value
+  auto const subnormal_shift = std::numeric_limits<double>::min_exponent10 - exp_ten;
+  if (subnormal_shift > 0) {
+    // Handle subnormal values. Ensure that both base and exponent are
+    // normal values before computing their product.
+    base = base / exp10(static_cast<double>(num_digits - 1 + subnormal_shift));
+    exp_ten += num_digits - 1;  // adjust exponent
+    auto const exponent = exp10(static_cast<double>(exp_ten + subnormal_shift));
+    return base * exponent;
+  }
+
+  double const exponent = exp10(static_cast<double>(std::abs(exp_ten)));
+  return exp_ten < 0 ? base / exponent : base * exponent;
+}
+
+}  // namespace detail
+}  // namespace strings
+}  // namespace cudf

--- a/cpp/include/cudf/strings/detail/convert/string_to_int.cuh
+++ b/cpp/include/cudf/strings/detail/convert/string_to_int.cuh
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/strings/string_view.cuh>
+
+namespace cudf {
+namespace strings {
+namespace detail {
+
+/**
+ * @brief Converts a single string into an integer.
+ *
+ * The '+' and '-' are allowed but only at the beginning of the string.
+ * The string is expected to contain base-10 [0-9] characters only.
+ * Any other character will end the parse.
+ * Overflow of the int64 type is not detected.
+ */
+__device__ inline int64_t string_to_integer(string_view const& d_str)
+{
+  int64_t value   = 0;
+  size_type bytes = d_str.size_bytes();
+  if (bytes == 0) return value;
+  const char* ptr = d_str.data();
+  int sign        = 1;
+  if (*ptr == '-' || *ptr == '+') {
+    sign = (*ptr == '-' ? -1 : 1);
+    ++ptr;
+    --bytes;
+  }
+  for (size_type idx = 0; idx < bytes; ++idx) {
+    char chr = *ptr++;
+    if (chr < '0' || chr > '9') break;
+    value = (value * 10) + static_cast<int64_t>(chr - '0');
+  }
+  return value * static_cast<int64_t>(sign);
+}
+
+}  // namespace detail
+}  // namespace strings
+}  // namespace cudf

--- a/cpp/src/io/csv/durations.cu
+++ b/cpp/src/io/csv/durations.cu
@@ -18,13 +18,12 @@
 #include <cudf/detail/get_value.cuh>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/strings/detail/convert/int_to_string.cuh>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/types.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-
-#include <strings/convert/utilities.cuh>
 
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/strings/char_types/char_types.cu
+++ b/cpp/src/strings/char_types/char_types.cu
@@ -24,7 +24,6 @@
 #include <cudf/strings/detail/utf8.hpp>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/detail/utilities.hpp>
-#include <cudf/strings/string.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -17,11 +17,10 @@
 #include <cudf/detail/get_value.cuh>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/strings/detail/convert/int_to_string.cuh>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
-
-#include <strings/convert/utilities.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>

--- a/cpp/src/strings/convert/convert_fixed_point.cu
+++ b/cpp/src/strings/convert/convert_fixed_point.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/convert/convert_fixed_point.hpp>
 #include <cudf/strings/detail/convert/fixed_point.cuh>
+#include <cudf/strings/detail/convert/int_to_string.cuh>
 #include <cudf/strings/detail/converters.hpp>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/detail/utilities.hpp>
@@ -29,8 +30,6 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
-
-#include <strings/convert/utilities.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -19,10 +19,10 @@
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/convert/convert_floats.hpp>
+#include <cudf/strings/detail/convert/string_to_float.cuh>
 #include <cudf/strings/detail/converters.hpp>
 #include <cudf/strings/detail/utilities.cuh>
 #include <cudf/strings/detail/utilities.hpp>
-#include <cudf/strings/string.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -45,109 +45,6 @@ namespace cudf {
 namespace strings {
 namespace detail {
 namespace {
-/**
- * @brief This function converts the given string into a
- * floating point double value.
- *
- * This will also map strings containing "NaN", "Inf", etc.
- * to the appropriate float values.
- *
- * This function will also handle scientific notation format.
- */
-__device__ inline double stod(string_view const& d_str)
-{
-  const char* in_ptr = d_str.data();
-  const char* end    = in_ptr + d_str.size_bytes();
-  if (end == in_ptr) return 0.0;
-  double sign{1.0};
-  if (*in_ptr == '-' || *in_ptr == '+') {
-    sign = (*in_ptr == '-' ? -1 : 1);
-    ++in_ptr;
-  }
-
-  // special strings: NaN, Inf
-  if ((in_ptr < end) && *in_ptr > '9') {
-    auto const inf_nan = string_view(in_ptr, static_cast<size_type>(thrust::distance(in_ptr, end)));
-    if (is_nan_str(inf_nan)) return std::numeric_limits<double>::quiet_NaN();
-    if (is_inf_str(inf_nan)) return sign * std::numeric_limits<double>::infinity();
-  }
-
-  // Parse and store the mantissa as much as we can,
-  // until we are about to exceed the limit of uint64_t
-  constexpr uint64_t max_holding = (std::numeric_limits<uint64_t>::max() - 9L) / 10L;
-  uint64_t digits                = 0;
-  int exp_off                    = 0;
-  bool decimal                   = false;
-  while (in_ptr < end) {
-    char ch = *in_ptr;
-    if (ch == '.') {
-      decimal = true;
-      ++in_ptr;
-      continue;
-    }
-    if (ch < '0' || ch > '9') break;
-    if (digits > max_holding)
-      exp_off += (int)!decimal;
-    else {
-      digits = (digits * 10L) + static_cast<uint64_t>(ch - '0');
-      if (digits > max_holding) {
-        digits = digits / 10L;
-        exp_off += (int)!decimal;
-      } else
-        exp_off -= (int)decimal;
-    }
-    ++in_ptr;
-  }
-  if (digits == 0) return sign * static_cast<double>(0);
-
-  // check for exponent char
-  int exp_ten  = 0;
-  int exp_sign = 1;
-  if (in_ptr < end) {
-    char ch = *in_ptr++;
-    if (ch == 'e' || ch == 'E') {
-      if (in_ptr < end) {
-        ch = *in_ptr;
-        if (ch == '-' || ch == '+') {
-          exp_sign = (ch == '-' ? -1 : 1);
-          ++in_ptr;
-        }
-        while (in_ptr < end) {
-          ch = *in_ptr++;
-          if (ch < '0' || ch > '9') break;
-          exp_ten = (exp_ten * 10) + (int)(ch - '0');
-        }
-      }
-    }
-  }
-
-  int const num_digits = static_cast<int>(log10(digits)) + 1;
-  exp_ten *= exp_sign;
-  exp_ten += exp_off;
-  exp_ten += num_digits - 1;
-  if (exp_ten > std::numeric_limits<double>::max_exponent10) {
-    return sign > 0 ? std::numeric_limits<double>::infinity()
-                    : -std::numeric_limits<double>::infinity();
-  }
-
-  double base = sign * static_cast<double>(digits);
-
-  exp_ten += 1 - num_digits;
-  // If 10^exp_ten would result in a subnormal value, the base and
-  // exponent should be adjusted so that 10^exp_ten is a normal value
-  auto const subnormal_shift = std::numeric_limits<double>::min_exponent10 - exp_ten;
-  if (subnormal_shift > 0) {
-    // Handle subnormal values. Ensure that both base and exponent are
-    // normal values before computing their product.
-    base = base / exp10(static_cast<double>(num_digits - 1 + subnormal_shift));
-    exp_ten += num_digits - 1;  // adjust exponent
-    auto const exponent = exp10(static_cast<double>(exp_ten + subnormal_shift));
-    return base * exponent;
-  }
-
-  double const exponent = exp10(static_cast<double>(std::abs(exp_ten)));
-  return exp_ten < 0 ? base / exponent : base * exponent;
-}
 
 /**
  * @brief Converts strings column entries into floats.
@@ -579,7 +476,7 @@ std::unique_ptr<column> is_float(
                     d_results,
                     [d_column] __device__(size_type idx) {
                       if (d_column.is_null(idx)) return false;
-                      return strings::is_float(d_column.element<string_view>(idx));
+                      return is_float(d_column.element<string_view>(idx));
                     });
   results->set_null_count(strings.null_count());
   return results;


### PR DESCRIPTION
## Description
Move and refactor some internal strings/numeric conversion functions for reuse with strings-udf work #11319 
Some functions needed modification to satisfy the finicky jitify compiler.
Mostly functions have been moved from a `cpp/src/strings/convert/utilities.cuh` and `cpp/include/cudf/strings/string.cuh` files separately into new files in the `cpp/include/cudf/strings/detail/convert` folder.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
