### PR TITLE
Conform "bench_isin" to match generator column names

### DIFF
--- a/python/cudf/benchmarks/API/bench_dataframe.py
+++ b/python/cudf/benchmarks/API/bench_dataframe.py
@@ -43,7 +43,9 @@ def bench_merge(benchmark, dataframe, num_key_cols):
     [
         lambda: range(50),
         lambda: {f"{string.ascii_lowercase[i]}": range(50) for i in range(10)},
-        lambda: cudf.DataFrame({f"{string.ascii_lowercase[i]}": range(50) for i in range(10)}),
+        lambda: cudf.DataFrame(
+            {f"{string.ascii_lowercase[i]}": range(50) for i in range(10)}
+        ),
         lambda: cudf.Series(range(50)),
     ],
 )

--- a/python/cudf/benchmarks/API/bench_dataframe.py
+++ b/python/cudf/benchmarks/API/bench_dataframe.py
@@ -41,10 +41,10 @@ def bench_merge(benchmark, dataframe, num_key_cols):
 @pytest.mark.parametrize(
     "values",
     [
-        range(1000),
-        {f"key{i}": range(1000) for i in range(10)},
-        cudf.DataFrame({f"key{i}": range(1000) for i in range(10)}),
-        cudf.Series(range(1000)),
+        range(50),
+        {f"{string.ascii_lowercase[i]}": range(50) for i in range(10)},
+        cudf.DataFrame({f"{string.ascii_lowercase[i]}": range(50) for i in range(10)}),
+        cudf.Series(range(50)),
     ],
 )
 def bench_isin(benchmark, dataframe, values):

--- a/python/cudf/benchmarks/API/bench_dataframe.py
+++ b/python/cudf/benchmarks/API/bench_dataframe.py
@@ -41,14 +41,14 @@ def bench_merge(benchmark, dataframe, num_key_cols):
 @pytest.mark.parametrize(
     "values",
     [
-        range(50),
-        {f"{string.ascii_lowercase[i]}": range(50) for i in range(10)},
-        cudf.DataFrame({f"{string.ascii_lowercase[i]}": range(50) for i in range(10)}),
-        cudf.Series(range(50)),
+        lambda: range(50),
+        lambda: {f"{string.ascii_lowercase[i]}": range(50) for i in range(10)},
+        lambda: cudf.DataFrame({f"{string.ascii_lowercase[i]}": range(50) for i in range(10)}),
+        lambda: cudf.Series(range(50)),
     ],
 )
 def bench_isin(benchmark, dataframe, values):
-    benchmark(dataframe.isin, values)
+    benchmark(dataframe.isin, values())
 
 
 @pytest.fixture(


### PR DESCRIPTION
## Description
The version of `bench_isin` merged in #11125 used key and column names of the format `f"key{i}"` rather than the format `f"{string.ascii_lowercase[i]}"` as is used in the dataframe generator. As a result the `isin` benchmark using a dictionary argument short-circuits with no matching keys, and the `isin` benchmark using a dataframe argument finds no matches.

This PR also adjusts the `isin` arguments from `range(1000)` to `range(50)` to better match the input dataframe cardinality of 100. With `range(1000)`, every element matches but with `range(50)` only 50% of the elements match.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
