### PR TITLE
JNI support for writing binary columns in parquet

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
@@ -32,6 +32,7 @@ public class ColumnWriterOptions {
   private int precision;
   private boolean isNullable;
   private boolean isMap = false;
+  private boolean isBinary = false;
   private String columnName;
   // only for Parquet
   private boolean hasParquetFieldId;
@@ -141,6 +142,22 @@ public class ColumnWriterOptions {
     protected ColumnWriterOptions withTimestamp(String name, boolean isInt96,
                                                 boolean isNullable, int parquetFieldId) {
       return new ColumnWriterOptions(name, isInt96, UNKNOWN_PRECISION, isNullable, parquetFieldId);
+    }
+
+    protected ColumnWriterOptions withBinary(String name, boolean isNullable) {
+      ColumnWriterOptions opt = listBuilder(name, isNullable)
+          .withColumns(false, "BINARY_DATA")
+          .build();
+      opt.isBinary = true;
+      return opt;
+    }
+
+    protected ColumnWriterOptions withBinary(String name, boolean isNullable, int parquetFieldId) {
+      ColumnWriterOptions opt = listBuilder(name, isNullable)
+          .withColumn(false, "BINARY_DATA", parquetFieldId)
+          .build();
+      opt.isBinary = true;
+      return opt;
     }
 
     /**
@@ -255,6 +272,24 @@ public class ColumnWriterOptions {
      */
     public T withDecimalColumn(String name, int precision) {
       withDecimalColumn(name, precision, false);
+      return (T) this;
+    }
+
+    /**
+     * Set a binary child meta data
+     * @return this for chaining.
+     */
+    public T withBinaryColumn(String name, boolean nullable, int parquetFieldId) {
+      children.add(withBinary(name, nullable, parquetFieldId));
+      return (T) this;
+    }
+
+    /**
+     * Set a binary child meta data
+     * @return this for chaining.
+     */
+    public T withBinaryColumn(String name, boolean nullable) {
+      children.add(withBinary(name, nullable));
       return (T) this;
     }
 
@@ -407,6 +442,15 @@ public class ColumnWriterOptions {
     boolean[] ret = {isMap};
     if (childColumnOptions.length > 0) {
       return getFlatBooleans(ret, (opt) -> opt.getFlatIsMap());
+    } else {
+      return ret;
+    }
+  }
+
+  boolean[] getFlatIsBinary() {
+    boolean[] ret = {isBinary};
+    if (childColumnOptions.length > 0) {
+      return getFlatBooleans(ret, (opt) -> opt.getFlatIsBinary());
     } else {
       return ret;
     }

--- a/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
@@ -146,6 +146,8 @@ public class ColumnWriterOptions {
 
     protected ColumnWriterOptions withBinary(String name, boolean isNullable) {
       ColumnWriterOptions opt = listBuilder(name, isNullable)
+          // The name here does not matter. It will not be included in the final file
+          // This is just to get the metadata to line up properly for the C++ APIs
           .withColumns(false, "BINARY_DATA")
           .build();
       opt.isBinary = true;
@@ -154,6 +156,8 @@ public class ColumnWriterOptions {
 
     protected ColumnWriterOptions withBinary(String name, boolean isNullable, int parquetFieldId) {
       ColumnWriterOptions opt = listBuilder(name, isNullable)
+          // The name here does not matter. It will not be included in the final file
+          // This is just to get the metadata to line up properly for the C++ APIs
           .withColumn(false, "BINARY_DATA", parquetFieldId)
           .build();
       opt.isBinary = true;

--- a/java/src/main/java/ai/rapids/cudf/CompressionMetadataWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CompressionMetadataWriterOptions.java
@@ -67,6 +67,11 @@ public class CompressionMetadataWriterOptions extends ColumnWriterOptions.Struct
   }
 
   @Override
+  boolean[] getFlatIsBinary() {
+    return super.getFlatBooleans(new boolean[]{}, (opt) -> opt.getFlatIsBinary());
+  }
+
+  @Override
   String[] getFlatColumnNames() {
     return super.getFlatColumnNames(new String[]{});
   }

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -280,6 +280,7 @@ public final class Table implements AutoCloseable {
    * @param precisions      precision list containing all the precisions of the decimal types in
    *                        the columns
    * @param isMapValues     true if a column is a map
+   * @param isBinaryValues  true if a column is a binary
    * @param filename        local output path
    * @return a handle that is used in later calls to writeParquetChunk and writeParquetEnd.
    */
@@ -294,6 +295,7 @@ public final class Table implements AutoCloseable {
                                                    boolean[] isInt96,
                                                    int[] precisions,
                                                    boolean[] isMapValues,
+                                                   boolean[] isBinaryValues,
                                                    boolean[] hasParquetFieldIds,
                                                    int[] parquetFieldIds,
                                                    String filename) throws CudfException;
@@ -312,6 +314,7 @@ public final class Table implements AutoCloseable {
    * @param precisions      precision list containing all the precisions of the decimal types in
    *                        the columns
    * @param isMapValues     true if a column is a map
+   * @param isBinaryValues  true if a column is a binary
    * @param consumer        consumer of host buffers produced.
    * @return a handle that is used in later calls to writeParquetChunk and writeParquetEnd.
    */
@@ -326,6 +329,7 @@ public final class Table implements AutoCloseable {
                                                      boolean[] isInt96,
                                                      int[] precisions,
                                                      boolean[] isMapValues,
+                                                     boolean[] isBinaryValues,
                                                      boolean[] hasParquetFieldIds,
                                                      int[] parquetFieldIds,
                                                      HostBufferConsumer consumer) throws CudfException;
@@ -1213,6 +1217,7 @@ public final class Table implements AutoCloseable {
       boolean[] columnNullabilities = options.getFlatIsNullable();
       boolean[] timeInt96Values = options.getFlatIsTimeTypeInt96();
       boolean[] isMapValues = options.getFlatIsMap();
+      boolean[] isBinaryValues = options.getFlatIsBinary();
       int[] precisions = options.getFlatPrecision();
       boolean[] hasParquetFieldIds = options.getFlatHasParquetFieldId();
       int[] parquetFieldIds = options.getFlatParquetFieldId();
@@ -1230,6 +1235,7 @@ public final class Table implements AutoCloseable {
           timeInt96Values,
           precisions,
           isMapValues,
+          isBinaryValues,
           hasParquetFieldIds,
           parquetFieldIds,
           outputFile.getAbsolutePath());
@@ -1240,6 +1246,7 @@ public final class Table implements AutoCloseable {
       boolean[] columnNullabilities = options.getFlatIsNullable();
       boolean[] timeInt96Values = options.getFlatIsTimeTypeInt96();
       boolean[] isMapValues = options.getFlatIsMap();
+      boolean[] isBinaryValues = options.getFlatIsBinary();
       int[] precisions = options.getFlatPrecision();
       boolean[] hasParquetFieldIds = options.getFlatHasParquetFieldId();
       int[] parquetFieldIds = options.getFlatParquetFieldId();
@@ -1257,6 +1264,7 @@ public final class Table implements AutoCloseable {
           timeInt96Values,
           precisions,
           isMapValues,
+          isBinaryValues,
           hasParquetFieldIds,
           parquetFieldIds,
           consumer);

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1588,8 +1588,8 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeParquetBufferBegin(
     JNIEnv *env, jclass, jobjectArray j_col_names, jint j_num_children, jintArray j_children,
     jbooleanArray j_col_nullability, jobjectArray j_metadata_keys, jobjectArray j_metadata_values,
     jint j_compression, jint j_stats_freq, jbooleanArray j_isInt96, jintArray j_precisions,
-    jbooleanArray j_is_map, jbooleanArray j_hasParquetFieldIds, jintArray j_parquetFieldIds,
-    jobject consumer) {
+    jbooleanArray j_is_map, jbooleanArray j_is_binary, jbooleanArray j_hasParquetFieldIds,
+    jintArray j_parquetFieldIds, jobject consumer) {
   JNI_NULL_CHECK(env, j_col_names, "null columns", 0);
   JNI_NULL_CHECK(env, j_col_nullability, "null nullability", 0);
   JNI_NULL_CHECK(env, j_metadata_keys, "null metadata keys", 0);
@@ -1598,9 +1598,6 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeParquetBufferBegin(
   try {
     std::unique_ptr<cudf::jni::jni_writer_data_sink> data_sink(
         new cudf::jni::jni_writer_data_sink(env, consumer));
-
-    // temp stub
-    jbooleanArray j_is_binary = NULL;
 
     using namespace cudf::io;
     using namespace cudf::jni;
@@ -1637,8 +1634,8 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeParquetFileBegin(
     JNIEnv *env, jclass, jobjectArray j_col_names, jint j_num_children, jintArray j_children,
     jbooleanArray j_col_nullability, jobjectArray j_metadata_keys, jobjectArray j_metadata_values,
     jint j_compression, jint j_stats_freq, jbooleanArray j_isInt96, jintArray j_precisions,
-    jbooleanArray j_is_map, jbooleanArray j_hasParquetFieldIds, jintArray j_parquetFieldIds,
-    jstring j_output_path) {
+    jbooleanArray j_is_map, jbooleanArray j_is_binary, jbooleanArray j_hasParquetFieldIds,
+    jintArray j_parquetFieldIds, jstring j_output_path) {
   JNI_NULL_CHECK(env, j_col_names, "null columns", 0);
   JNI_NULL_CHECK(env, j_col_nullability, "null nullability", 0);
   JNI_NULL_CHECK(env, j_metadata_keys, "null metadata keys", 0);
@@ -1646,9 +1643,6 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeParquetFileBegin(
   JNI_NULL_CHECK(env, j_output_path, "null output path", 0);
   try {
     cudf::jni::native_jstring output_path(env, j_output_path);
-
-    // temp stub
-    jbooleanArray j_is_binary = NULL;
 
     using namespace cudf::io;
     using namespace cudf::jni;

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -30,6 +30,7 @@ import ai.rapids.cudf.ast.BinaryOperator;
 import ai.rapids.cudf.ast.ColumnReference;
 import ai.rapids.cudf.ast.CompiledExpression;
 import ai.rapids.cudf.ast.TableReference;
+import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
@@ -577,6 +578,52 @@ public class TableTest extends CudfTestBase {
       assertTableTypes(new DType[]{DType.LIST, DType.STRING}, table);
       ColumnView columnView = table.getColumn(0);
       assertEquals(DType.INT8, columnView.getChildColumnView(0).getType());
+    }
+  }
+
+  List<Byte> asList(String str) {
+    byte[] bytes = str.getBytes(Charsets.UTF_8);
+    List<Byte> ret = new ArrayList<>(bytes.length);
+    for(int i = 0; i < bytes.length; i++) {
+      ret.add(bytes[i]);
+    }
+    return ret;
+  }
+
+  @Test
+  void testParquetWriteToBufferChunkedBinary() {
+    // We create a String table and a Binary table with the same data in them to
+    // avoid trying to read the binary data back in the same way. At least until the
+    // API for that is stable
+    String string1 = "ABC";
+    String string2 = "DEF";
+    List<Byte> bin1 = asList(string1);
+    List<Byte> bin2 = asList(string2);
+
+    try (Table binTable = new Table.TestBuilder()
+        .column(new ListType(true, new BasicType(false, DType.INT8)),
+            bin1, bin2)
+        .build();
+         Table stringTable = new Table.TestBuilder()
+             .column(string1, string2)
+             .build();
+         MyBufferConsumer consumer = new MyBufferConsumer()) {
+      ParquetWriterOptions options = ParquetWriterOptions.builder()
+          .withBinaryColumn("_c0", true)
+          .build();
+
+      try (TableWriter writer = Table.writeParquetChunked(options, consumer)) {
+        writer.write(binTable);
+        writer.write(binTable);
+        writer.write(binTable);
+      }
+      ParquetOptions opts = ParquetOptions.builder()
+          .includeColumn("_c0")
+          .build();
+      try (Table table1 = Table.readParquet(opts, consumer.buffer, 0, consumer.offset);
+           Table concat = Table.concatenate(stringTable, stringTable, stringTable)) {
+        assertTablesAreEqual(concat, table1);
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Adds in java APIs to support writing binary columns in parquet.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
