### PR TITLE
Fix groupby failures in dask_cudf CI

### DIFF
--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -249,7 +249,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         )
 
     @_dask_cudf_nvtx_annotate
-    def aggregate(self, arg, split_every=None, split_out=1, **kwargs):
+    def aggregate(self, arg, split_every=None, split_out=1, shuffle=None):
         if arg == "size":
             return self.size()
 
@@ -277,7 +277,9 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
             arg,
             split_every=split_every,
             split_out=split_out,
-            **kwargs,
+            # TODO: Change following line to `shuffle=shuffle,`
+            # when dask_cudf is pinned to dask>2022.8.0
+            **({} if shuffle is None else {"shuffle": shuffle}),
         )
 
 
@@ -439,7 +441,7 @@ class CudfSeriesGroupBy(SeriesGroupBy):
         )[self._slice]
 
     @_dask_cudf_nvtx_annotate
-    def aggregate(self, arg, split_every=None, split_out=1, **kwargs):
+    def aggregate(self, arg, split_every=None, split_out=1, shuffle=None):
         if arg == "size":
             return self.size()
 
@@ -465,7 +467,9 @@ class CudfSeriesGroupBy(SeriesGroupBy):
             arg,
             split_every=split_every,
             split_out=split_out,
-            **kwargs,
+            # TODO: Change following line to `shuffle=shuffle,`
+            # when dask_cudf is pinned to dask>2022.8.0
+            **({} if shuffle is None else {"shuffle": shuffle}),
         )
 
 
@@ -896,14 +900,3 @@ def _finalize_gb_agg(
         gb.columns = pd.MultiIndex.from_arrays([col_array, agg_array])
 
     return gb[final_columns]
-
-
-def _check_shuffle_kwarg(shuffle=None, **kwargs):
-    shuffle_kwarg = {}
-    if shuffle is not None:
-        shuffle_kwarg = {"shuffle": shuffle}
-    if kwargs:
-        raise TypeError(
-            f"Unexpected keyword arguments to aggregate: {set(kwargs)}"
-        )
-    return shuffle_kwarg

--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -253,7 +253,6 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
         if arg == "size":
             return self.size()
 
-        maybe_shuffle_kwarg = _check_shuffle_kwarg(**kwargs)
         arg = _redirect_aggs(arg)
 
         if _groupby_supported(self) and _aggs_supported(arg, SUPPORTED_AGGS):
@@ -278,7 +277,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
             arg,
             split_every=split_every,
             split_out=split_out,
-            **maybe_shuffle_kwarg,
+            **kwargs,
         )
 
 
@@ -444,7 +443,6 @@ class CudfSeriesGroupBy(SeriesGroupBy):
         if arg == "size":
             return self.size()
 
-        maybe_shuffle_kwarg = _check_shuffle_kwarg(**kwargs)
         arg = _redirect_aggs(arg)
 
         if not isinstance(arg, dict):
@@ -467,7 +465,7 @@ class CudfSeriesGroupBy(SeriesGroupBy):
             arg,
             split_every=split_every,
             split_out=split_out,
-            **maybe_shuffle_kwarg,
+            **kwargs,
         )
 
 

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -575,14 +575,14 @@ def test_groupby_categorical_key():
     ddf = gddf.to_dask_dataframe()
 
     got = (
-        gddf.groupby("name")
+        gddf.groupby("name", sort=True)
         .agg({"x": ["mean", "max"], "y": ["mean", "count"]})
         .compute()
     )
     expect = (
-        ddf.compute()
-        .groupby("name")
+        ddf.groupby("name", sort=True)
         .agg({"x": ["mean", "max"], "y": ["mean", "count"]})
+        .compute()
     )
     dd.assert_eq(expect, got)
 

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -580,9 +580,9 @@ def test_groupby_categorical_key():
         .compute()
     )
     expect = (
-        ddf.groupby("name")
+        ddf.compute()
+        .groupby("name")
         .agg({"x": ["mean", "max"], "y": ["mean", "count"]})
-        .compute()
     )
     dd.assert_eq(expect, got)
 


### PR DESCRIPTION
## Description

Dask-cudf groupby tests *should* be failing as a result of https://github.com/dask/dask/pull/9302 (see [failures](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/prb/job/cudf-gpu-test/CUDA=11.5,GPU_LABEL=driver-495,LINUX_VER=ubuntu20.04,PYTHON=3.9/9946/) in #11565 is merged - where dask/main is being installed correctly).  This PR updates the dask_cudf groupby code to fix these failures.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
