### PR TITLE
Add byte_range to multibyte_split benchmark + NVBench refactor

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -297,7 +297,7 @@ ConfigureNVBench(FST_NVBENCH io/fst.cu)
 
 # ##################################################################################################
 # * io benchmark ---------------------------------------------------------------------
-ConfigureBench(MULTIBYTE_SPLIT_BENCHMARK io/text/multibyte_split.cpp)
+ConfigureNVBench(MULTIBYTE_SPLIT_BENCHMARK io/text/multibyte_split.cpp)
 
 add_custom_target(
   run_benchmarks

--- a/cpp/benchmarks/io/text/multibyte_split.cpp
+++ b/cpp/benchmarks/io/text/multibyte_split.cpp
@@ -16,6 +16,7 @@
 
 #include <benchmarks/common/generate_input.hpp>
 #include <benchmarks/fixture/benchmark_fixture.hpp>
+#include <benchmarks/fixture/rmm_pool_raii.hpp>
 #include <benchmarks/io/cuio_common.hpp>
 #include <benchmarks/synchronization/synchronization.hpp>
 
@@ -81,6 +82,8 @@ static cudf::string_scalar create_random_input(int32_t num_chars,
 
 static void bench_multibyte_split(nvbench::state& state)
 {
+  cudf::rmm_pool_raii pool_raii;
+
   auto const source_type      = static_cast<data_chunk_source_type>(state.get_int64("source_type"));
   auto const delim_size       = state.get_int64("delim_size");
   auto const delim_percent    = state.get_int64("delim_percent");

--- a/cpp/benchmarks/io/text/multibyte_split.cpp
+++ b/cpp/benchmarks/io/text/multibyte_split.cpp
@@ -32,11 +32,11 @@
 #include <thrust/host_vector.h>
 #include <thrust/transform.h>
 
+#include <nvbench/nvbench.cuh>
+
 #include <cstdio>
 #include <fstream>
 #include <memory>
-
-#include <nvbench/nvbench.cuh>
 
 temp_directory const temp_dir("cudf_nvbench");
 

--- a/cpp/benchmarks/io/text/multibyte_split.cpp
+++ b/cpp/benchmarks/io/text/multibyte_split.cpp
@@ -135,22 +135,99 @@ static void BM_multibyte_split(benchmark::State& state)
   state.counters["peak_memory_usage"] = mem_stats_logger.peak_memory_usage();
 }
 
+static void BM_multibyte_split_byte_range(benchmark::State& state)
+{
+  auto source_type        = static_cast<data_chunk_source_type>(state.range(0));
+  auto delim_size         = state.range(1);
+  auto delim_percent      = state.range(2);
+  auto file_size_approx   = state.range(3);
+  auto byte_range_percent = state.range(4);
+
+  auto byte_range_factor = static_cast<double>(byte_range_percent) / 100;
+  CUDF_EXPECTS(delim_percent >= 1, "delimiter percent must be at least 1");
+  CUDF_EXPECTS(delim_percent <= 50, "delimiter percent must be at most 50");
+  CUDF_EXPECTS(byte_range_percent >= 1, "byte range percent must be at least 1");
+  CUDF_EXPECTS(byte_range_percent <= 50, "byte range percent must be at most 50");
+
+  auto delim = std::string(":", delim_size);
+
+  auto delim_factor = static_cast<double>(delim_percent) / 100;
+  auto device_input = create_random_input(file_size_approx, delim_factor, 0.05, delim);
+  auto host_input   = thrust::host_vector<char>(device_input.size());
+  auto host_string  = std::string(host_input.data(), host_input.size());
+
+  cudaMemcpyAsync(host_input.data(),
+                  device_input.data(),
+                  device_input.size() * sizeof(char),
+                  cudaMemcpyDeviceToHost,
+                  cudf::default_stream_value);
+
+  auto temp_file_name = random_file_in_dir(temp_dir.path());
+
+  {
+    auto temp_fostream = std::ofstream(temp_file_name, std::ofstream::out);
+    temp_fostream.write(host_input.data(), host_input.size());
+  }
+
+  cudaDeviceSynchronize();
+
+  auto source = std::unique_ptr<cudf::io::text::data_chunk_source>(nullptr);
+
+  switch (source_type) {
+    case data_chunk_source_type::file:  //
+      source = cudf::io::text::make_source_from_file(temp_file_name);
+      break;
+    case data_chunk_source_type::host:  //
+      source = cudf::io::text::make_source(host_string);
+      break;
+    case data_chunk_source_type::device:  //
+      source = cudf::io::text::make_source(device_input);
+      break;
+    default: CUDF_FAIL();
+  }
+
+  auto mem_stats_logger = cudf::memory_stats_logger();
+  auto range_size       = static_cast<int64_t>(file_size_approx * byte_range_factor);
+  auto range_offset     = (file_size_approx - range_size) / 2;
+  cudf::io::text::byte_range_info range{range_offset, range_size};
+  std::unique_ptr<cudf::column> output;
+  for (auto _ : state) {
+    try_drop_l3_cache();
+    cuda_event_timer raii(state, true);
+    output = cudf::io::text::multibyte_split(*source, delim, range);
+  }
+  auto output_size =
+    output->num_children() == 2 ? static_cast<int64_t>(output->child(1).size()) : 0;
+  state.SetBytesProcessed(state.iterations() * std::max(output_size, range_size));
+  state.counters["peak_memory_usage"] = mem_stats_logger.peak_memory_usage();
+}
+
 class MultibyteSplitBenchmark : public cudf::benchmark {
 };
 
-#define TRANSPOSE_BM_BENCHMARK_DEFINE(name)                                     \
-  BENCHMARK_DEFINE_F(MultibyteSplitBenchmark, name)(::benchmark::State & state) \
-  {                                                                             \
-    BM_multibyte_split(state);                                                  \
-  }                                                                             \
-  BENCHMARK_REGISTER_F(MultibyteSplitBenchmark, name)                           \
-    ->ArgsProduct({{data_chunk_source_type::device,                             \
-                    data_chunk_source_type::file,                               \
-                    data_chunk_source_type::host},                              \
-                   {1, 4, 7},                                                   \
-                   {1, 25},                                                     \
-                   {1 << 15, 1 << 30}})                                         \
-    ->UseManualTime()                                                           \
-    ->Unit(::benchmark::kMillisecond);
+BENCHMARK_DEFINE_F(MultibyteSplitBenchmark, multibyte_split_simple)(::benchmark::State& state)
+{
+  BM_multibyte_split(state);
+}
+BENCHMARK_REGISTER_F(MultibyteSplitBenchmark, multibyte_split_simple)
+  ->ArgsProduct(
+    {{data_chunk_source_type::device, data_chunk_source_type::file, data_chunk_source_type::host},
+     {1, 4, 7},
+     {1, 25},
+     {1 << 15, 1 << 30}})
+  ->UseManualTime()
+  ->Unit(::benchmark::kMillisecond);
 
-TRANSPOSE_BM_BENCHMARK_DEFINE(multibyte_split_simple);
+BENCHMARK_DEFINE_F(MultibyteSplitBenchmark, multibyte_split_byte_range)(::benchmark::State& state)
+{
+  BM_multibyte_split_byte_range(state);
+}
+BENCHMARK_REGISTER_F(MultibyteSplitBenchmark, multibyte_split_byte_range)
+  ->ArgsProduct(
+    {{data_chunk_source_type::device, data_chunk_source_type::file, data_chunk_source_type::host},
+     {1, 4, 7},
+     {1, 25},
+     {1 << 15, 1 << 30},
+     {1, 5, 12, 25, 50}})
+  ->UseManualTime()
+  ->Unit(::benchmark::kMillisecond);

--- a/cpp/benchmarks/io/text/multibyte_split.cpp
+++ b/cpp/benchmarks/io/text/multibyte_split.cpp
@@ -87,7 +87,7 @@ static void BM_multibyte_split(benchmark::State& state)
   CUDF_EXPECTS(delim_percent >= 1, "delimiter percent must be at least 1");
   CUDF_EXPECTS(delim_percent <= 50, "delimiter percent must be at most 50");
 
-  auto delim = std::string(":", delim_size);
+  auto delim = std::string(delim_size, ':');
 
   auto delim_factor = static_cast<double>(delim_percent) / 100;
   auto device_input = create_random_input(file_size_approx, delim_factor, 0.05, delim);
@@ -149,7 +149,7 @@ static void BM_multibyte_split_byte_range(benchmark::State& state)
   CUDF_EXPECTS(byte_range_percent >= 1, "byte range percent must be at least 1");
   CUDF_EXPECTS(byte_range_percent <= 50, "byte range percent must be at most 50");
 
-  auto delim = std::string(":", delim_size);
+  auto delim = std::string(delim_size, ':');
 
   auto delim_factor = static_cast<double>(delim_percent) / 100;
   auto device_input = create_random_input(file_size_approx, delim_factor, 0.05, delim);


### PR DESCRIPTION
## Description
This adds a second benchmark testing byte ranges with 1% - 50% of the input size to the multibyte_split benchmarks.

Example output (--run-once):
<details>

```
# Benchmark Results

## multibyte_split

### [0] Tesla T4

| source_type | delim_size | delim_percent |    size_approx    | byte_range_percent | Samples |  CPU Time  | Noise |  GPU Time  | Noise | Peak Memory Usage | Encoded file size |
|-------------|------------|---------------|-------------------|--------------------|---------|------------|-------|------------|-------|-------------------|-------------------|
|           0 |          1 |             1 |      2^15 = 32768 |                  1 |      1x | 683.062 us |  inf% | 677.888 us |  inf% |        86.672 KiB |         315.000 B |
|           1 |          1 |             1 |      2^15 = 32768 |                  1 |      1x |  11.870 ms |  inf% |  11.864 ms |  inf% |       117.055 KiB |         315.000 B |
|           2 |          1 |             1 |      2^15 = 32768 |                  1 |      1x |   8.232 ms |  inf% |   8.226 ms |  inf% |       112.094 KiB |         315.000 B |
|           0 |          4 |             1 |      2^15 = 32768 |                  1 |      1x | 647.178 us |  inf% | 642.464 us |  inf% |        81.938 KiB |         325.000 B |
|           1 |          4 |             1 |      2^15 = 32768 |                  1 |      1x |   8.410 ms |  inf% |   8.405 ms |  inf% |       113.719 KiB |         325.000 B |
|           2 |          4 |             1 |      2^15 = 32768 |                  1 |      1x |   8.194 ms |  inf% |   8.188 ms |  inf% |       113.086 KiB |         325.000 B |
|           0 |          7 |             1 |      2^15 = 32768 |                  1 |      1x | 644.414 us |  inf% | 638.944 us |  inf% |        82.352 KiB |         328.000 B |
|           1 |          7 |             1 |      2^15 = 32768 |                  1 |      1x |   9.467 ms |  inf% |   9.461 ms |  inf% |       113.703 KiB |         328.000 B |
|           2 |          7 |             1 |      2^15 = 32768 |                  1 |      1x |   8.199 ms |  inf% |   8.192 ms |  inf% |       113.344 KiB |         328.000 B |
|           0 |          1 |            25 |      2^15 = 32768 |                  1 |      1x | 661.234 us |  inf% | 656.864 us |  inf% |       146.719 KiB |         243.000 B |
|           1 |          1 |            25 |      2^15 = 32768 |                  1 |      1x |   9.465 ms |  inf% |   9.458 ms |  inf% |       169.945 KiB |         243.000 B |
|           2 |          1 |            25 |      2^15 = 32768 |                  1 |      1x |   8.310 ms |  inf% |   8.304 ms |  inf% |       105.070 KiB |         243.000 B |
|           0 |          4 |            25 |      2^15 = 32768 |                  1 |      1x | 722.079 us |  inf% | 717.024 us |  inf% |        97.547 KiB |         304.000 B |
|           1 |          4 |            25 |      2^15 = 32768 |                  1 |      1x |   9.565 ms |  inf% |   9.558 ms |  inf% |       126.891 KiB |         304.000 B |
|           2 |          4 |            25 |      2^15 = 32768 |                  1 |      1x |   8.242 ms |  inf% |   8.237 ms |  inf% |       111.031 KiB |         304.000 B |
|           0 |          7 |            25 |      2^15 = 32768 |                  1 |      1x | 735.674 us |  inf% | 729.984 us |  inf% |        90.633 KiB |         309.000 B |
|           1 |          7 |            25 |      2^15 = 32768 |                  1 |      1x |   9.623 ms |  inf% |   9.617 ms |  inf% |       120.508 KiB |         309.000 B |
|           2 |          7 |            25 |      2^15 = 32768 |                  1 |      1x |   8.448 ms |  inf% |   8.443 ms |  inf% |       111.547 KiB |         309.000 B |
|           0 |          1 |             1 | 2^30 = 1073741824 |                  1 |      1x | 457.785 ms |  inf% | 457.785 ms |  inf% |       161.148 MiB |        10.066 MiB |
|           1 |          1 |             1 | 2^30 = 1073741824 |                  1 |      1x |    1.283 s |  inf% |    1.283 s |  inf% |       165.148 MiB |        10.066 MiB |
|           2 |          1 |             1 | 2^30 = 1073741824 |                  1 |      1x |    3.676 s |  inf% |    3.676 s |  inf% |         4.079 MiB |        10.066 MiB |
|           0 |          4 |             1 | 2^30 = 1073741824 |                  1 |      1x | 466.860 ms |  inf% | 466.861 ms |  inf% |        30.663 MiB |        10.144 MiB |
|           1 |          4 |             1 | 2^30 = 1073741824 |                  1 |      1x |    1.251 s |  inf% |    1.251 s |  inf% |        34.663 MiB |        10.144 MiB |
|           2 |          4 |             1 | 2^30 = 1073741824 |                  1 |      1x |    3.517 s |  inf% |    3.517 s |  inf% |         4.079 MiB |        10.144 MiB |
|           0 |          7 |             1 | 2^30 = 1073741824 |                  1 |      1x | 479.563 ms |  inf% | 479.564 ms |  inf% |        21.915 MiB |        10.156 MiB |
|           1 |          7 |             1 | 2^30 = 1073741824 |                  1 |      1x |    1.207 s |  inf% |    1.207 s |  inf% |        25.915 MiB |        10.156 MiB |
|           2 |          7 |             1 | 2^30 = 1073741824 |                  1 |      1x |    3.218 s |  inf% |    3.218 s |  inf% |         4.079 MiB |        10.156 MiB |
|           0 |          1 |            25 | 2^30 = 1073741824 |                  1 |      1x | 357.260 ms |  inf% | 357.258 ms |  inf% |         2.043 GiB |         7.625 MiB |
|           1 |          1 |            25 | 2^30 = 1073741824 |                  1 |      1x | 948.294 ms |  inf% | 948.298 ms |  inf% |         2.047 GiB |         7.625 MiB |
|           2 |          1 |            25 | 2^30 = 1073741824 |                  1 |      1x |    2.471 s |  inf% |    2.471 s |  inf% |         4.079 MiB |         7.625 MiB |
|           0 |          4 |            25 | 2^30 = 1073741824 |                  1 |      1x | 477.226 ms |  inf% | 477.227 ms |  inf% |       520.458 MiB |         9.531 MiB |
|           1 |          4 |            25 | 2^30 = 1073741824 |                  1 |      1x |    1.180 s |  inf% |    1.180 s |  inf% |       524.458 MiB |         9.531 MiB |
|           2 |          4 |            25 | 2^30 = 1073741824 |                  1 |      1x |    3.095 s |  inf% |    3.095 s |  inf% |         4.079 MiB |         9.531 MiB |
|           0 |          7 |            25 | 2^30 = 1073741824 |                  1 |      1x | 481.854 ms |  inf% | 481.854 ms |  inf% |       301.800 MiB |         9.803 MiB |
|           1 |          7 |            25 | 2^30 = 1073741824 |                  1 |      1x |    1.234 s |  inf% |    1.234 s |  inf% |       305.800 MiB |         9.803 MiB |
|           2 |          7 |            25 | 2^30 = 1073741824 |                  1 |      1x |    3.100 s |  inf% |    3.100 s |  inf% |         4.079 MiB |         9.803 MiB |
|           0 |          1 |             1 |      2^15 = 32768 |                  5 |      1x | 580.967 us |  inf% | 577.184 us |  inf% |        87.977 KiB |         1.540 KiB |
|           1 |          1 |             1 |      2^15 = 32768 |                  5 |      1x |  12.855 ms |  inf% |  12.851 ms |  inf% |       117.055 KiB |         1.540 KiB |
|           2 |          1 |             1 |      2^15 = 32768 |                  5 |      1x |   7.830 ms |  inf% |   7.826 ms |  inf% |       112.094 KiB |         1.540 KiB |
|           0 |          4 |             1 |      2^15 = 32768 |                  5 |      1x | 434.534 us |  inf% | 430.720 us |  inf% |        83.531 KiB |         1.589 KiB |
|           1 |          4 |             1 |      2^15 = 32768 |                  5 |      1x |   8.882 ms |  inf% |   8.877 ms |  inf% |       113.719 KiB |         1.589 KiB |
|           2 |          4 |             1 |      2^15 = 32768 |                  5 |      1x |   7.756 ms |  inf% |   7.751 ms |  inf% |       113.086 KiB |         1.589 KiB |
|           0 |          7 |             1 |      2^15 = 32768 |                  5 |      1x | 395.562 us |  inf% | 391.616 us |  inf% |        83.742 KiB |         1.602 KiB |
|           1 |          7 |             1 |      2^15 = 32768 |                  5 |      1x |   8.917 ms |  inf% |   8.911 ms |  inf% |       113.703 KiB |         1.602 KiB |
|           2 |          7 |             1 |      2^15 = 32768 |                  5 |      1x |   7.763 ms |  inf% |   7.758 ms |  inf% |       113.344 KiB |         1.602 KiB |
|           0 |          1 |            25 |      2^15 = 32768 |                  5 |      1x | 445.522 us |  inf% | 441.760 us |  inf% |       149.008 KiB |         1.188 KiB |
|           1 |          1 |            25 |      2^15 = 32768 |                  5 |      1x |   8.994 ms |  inf% |   8.989 ms |  inf% |       169.945 KiB |         1.188 KiB |
|           2 |          1 |            25 |      2^15 = 32768 |                  5 |      1x |   7.975 ms |  inf% |   7.971 ms |  inf% |       105.070 KiB |         1.188 KiB |
|           0 |          4 |            25 |      2^15 = 32768 |                  5 |      1x | 425.132 us |  inf% | 421.248 us |  inf% |        99.031 KiB |         1.486 KiB |
|           1 |          4 |            25 |      2^15 = 32768 |                  5 |      1x |   8.846 ms |  inf% |   8.841 ms |  inf% |       126.891 KiB |         1.486 KiB |
|           2 |          4 |            25 |      2^15 = 32768 |                  5 |      1x |   7.740 ms |  inf% |   7.735 ms |  inf% |       111.031 KiB |         1.486 KiB |
|           0 |          7 |            25 |      2^15 = 32768 |                  5 |      1x | 502.938 us |  inf% | 499.392 us |  inf% |        92.023 KiB |         1.512 KiB |
|           1 |          7 |            25 |      2^15 = 32768 |                  5 |      1x |   8.887 ms |  inf% |   8.882 ms |  inf% |       120.508 KiB |         1.512 KiB |
|           2 |          7 |            25 |      2^15 = 32768 |                  5 |      1x |   7.789 ms |  inf% |   7.784 ms |  inf% |       111.547 KiB |         1.512 KiB |
|           0 |          1 |             1 | 2^30 = 1073741824 |                  5 |      1x | 454.848 ms |  inf% | 454.849 ms |  inf% |       204.424 MiB |        50.332 MiB |
|           1 |          1 |             1 | 2^30 = 1073741824 |                  5 |      1x |    1.203 s |  inf% |    1.203 s |  inf% |       208.424 MiB |        50.332 MiB |
|           2 |          1 |             1 | 2^30 = 1073741824 |                  5 |      1x |    3.307 s |  inf% |    3.307 s |  inf% |         4.079 MiB |        50.332 MiB |
|           0 |          4 |             1 | 2^30 = 1073741824 |                  5 |      1x | 476.083 ms |  inf% | 476.083 ms |  inf% |        71.647 MiB |        50.722 MiB |
|           1 |          4 |             1 | 2^30 = 1073741824 |                  5 |      1x |    1.267 s |  inf% |    1.267 s |  inf% |        75.647 MiB |        50.722 MiB |
|           2 |          4 |             1 | 2^30 = 1073741824 |                  5 |      1x |    3.208 s |  inf% |    3.208 s |  inf% |         4.079 MiB |        50.722 MiB |
|           0 |          7 |             1 | 2^30 = 1073741824 |                  5 |      1x | 473.810 ms |  inf% | 473.810 ms |  inf% |        62.772 MiB |        50.780 MiB |
|           1 |          7 |             1 | 2^30 = 1073741824 |                  5 |      1x |    1.202 s |  inf% |    1.202 s |  inf% |        66.772 MiB |        50.780 MiB |
|           2 |          7 |             1 | 2^30 = 1073741824 |                  5 |      1x |    3.216 s |  inf% |    3.216 s |  inf% |         4.079 MiB |        50.780 MiB |
|           0 |          1 |            25 | 2^30 = 1073741824 |                  5 |      1x | 428.377 ms |  inf% | 428.376 ms |  inf% |         2.113 GiB |        38.123 MiB |
|           1 |          1 |            25 | 2^30 = 1073741824 |                  5 |      1x | 986.342 ms |  inf% | 986.346 ms |  inf% |         2.117 GiB |        38.123 MiB |
|           2 |          1 |            25 | 2^30 = 1073741824 |                  5 |      1x |    2.498 s |  inf% |    2.498 s |  inf% |         4.079 MiB |        38.123 MiB |
|           0 |          4 |            25 | 2^30 = 1073741824 |                  5 |      1x | 446.426 ms |  inf% | 446.427 ms |  inf% |       568.747 MiB |        47.654 MiB |
|           1 |          4 |            25 | 2^30 = 1073741824 |                  5 |      1x |    1.167 s |  inf% |    1.167 s |  inf% |       572.747 MiB |        47.654 MiB |
|           2 |          4 |            25 | 2^30 = 1073741824 |                  5 |      1x |    2.998 s |  inf% |    2.998 s |  inf% |         4.079 MiB |        47.654 MiB |
|           0 |          7 |            25 | 2^30 = 1073741824 |                  5 |      1x | 451.670 ms |  inf% | 451.670 ms |  inf% |       346.822 MiB |        49.016 MiB |
|           1 |          7 |            25 | 2^30 = 1073741824 |                  5 |      1x |    1.184 s |  inf% |    1.184 s |  inf% |       350.822 MiB |        49.016 MiB |
|           2 |          7 |            25 | 2^30 = 1073741824 |                  5 |      1x |    3.174 s |  inf% |    3.174 s |  inf% |         4.079 MiB |        49.016 MiB |
|           0 |          1 |             1 |      2^15 = 32768 |                 25 |      1x | 501.600 us |  inf% | 497.728 us |  inf% |        94.703 KiB |         7.702 KiB |
|           1 |          1 |             1 |      2^15 = 32768 |                 25 |      1x |  12.835 ms |  inf% |  12.831 ms |  inf% |       117.055 KiB |         7.702 KiB |
|           2 |          1 |             1 |      2^15 = 32768 |                 25 |      1x |   7.827 ms |  inf% |   7.822 ms |  inf% |       112.094 KiB |         7.702 KiB |
|           0 |          4 |             1 |      2^15 = 32768 |                 25 |      1x | 400.909 us |  inf% | 396.960 us |  inf% |        89.906 KiB |         7.947 KiB |
|           1 |          4 |             1 |      2^15 = 32768 |                 25 |      1x |   8.860 ms |  inf% |   8.855 ms |  inf% |       113.719 KiB |         7.947 KiB |
|           2 |          4 |             1 |      2^15 = 32768 |                 25 |      1x |   7.785 ms |  inf% |   7.780 ms |  inf% |       113.086 KiB |         7.947 KiB |
|           0 |          7 |             1 |      2^15 = 32768 |                 25 |      1x | 394.719 us |  inf% | 390.816 us |  inf% |        89.344 KiB |         8.010 KiB |
|           1 |          7 |             1 |      2^15 = 32768 |                 25 |      1x |   8.853 ms |  inf% |   8.848 ms |  inf% |       113.703 KiB |         8.010 KiB |
|           2 |          7 |             1 |      2^15 = 32768 |                 25 |      1x |   7.728 ms |  inf% |   7.723 ms |  inf% |       113.344 KiB |         8.010 KiB |
|           0 |          1 |            25 |      2^15 = 32768 |                 25 |      1x | 411.273 us |  inf% | 407.424 us |  inf% |       160.180 KiB |         5.945 KiB |
|           1 |          1 |            25 |      2^15 = 32768 |                 25 |      1x |   8.919 ms |  inf% |   8.913 ms |  inf% |       169.945 KiB |         5.945 KiB |
|           2 |          1 |            25 |      2^15 = 32768 |                 25 |      1x |   7.732 ms |  inf% |   7.728 ms |  inf% |       105.070 KiB |         5.945 KiB |
|           0 |          4 |            25 |      2^15 = 32768 |                 25 |      1x | 413.954 us |  inf% | 409.376 us |  inf% |       106.562 KiB |         7.434 KiB |
|           1 |          4 |            25 |      2^15 = 32768 |                 25 |      1x |   8.895 ms |  inf% |   8.889 ms |  inf% |       126.891 KiB |         7.434 KiB |
|           2 |          4 |            25 |      2^15 = 32768 |                 25 |      1x |   7.756 ms |  inf% |   7.751 ms |  inf% |       111.031 KiB |         7.434 KiB |
|           0 |          7 |            25 |      2^15 = 32768 |                 25 |      1x | 424.539 us |  inf% | 420.160 us |  inf% |        98.930 KiB |         7.561 KiB |
|           1 |          7 |            25 |      2^15 = 32768 |                 25 |      1x |   8.947 ms |  inf% |   8.943 ms |  inf% |       120.508 KiB |         7.561 KiB |
|           2 |          7 |            25 |      2^15 = 32768 |                 25 |      1x |   7.770 ms |  inf% |   7.766 ms |  inf% |       111.547 KiB |         7.561 KiB |
|           0 |          1 |             1 | 2^30 = 1073741824 |                 25 |      1x | 454.401 ms |  inf% | 454.400 ms |  inf% |       420.754 MiB |       251.660 MiB |
|           1 |          1 |             1 | 2^30 = 1073741824 |                 25 |      1x |    1.216 s |  inf% |    1.216 s |  inf% |       424.754 MiB |       251.660 MiB |
|           2 |          1 |             1 | 2^30 = 1073741824 |                 25 |      1x |    3.169 s |  inf% |    3.169 s |  inf% |         4.079 MiB |       251.660 MiB |
|           0 |          4 |             1 | 2^30 = 1073741824 |                 25 |      1x | 473.311 ms |  inf% | 473.311 ms |  inf% |       276.569 MiB |       253.610 MiB |
|           1 |          4 |             1 | 2^30 = 1073741824 |                 25 |      1x |    1.265 s |  inf% |    1.265 s |  inf% |       280.569 MiB |       253.610 MiB |
|           2 |          4 |             1 | 2^30 = 1073741824 |                 25 |      1x |    3.215 s |  inf% |    3.215 s |  inf% |         4.079 MiB |       253.610 MiB |
|           0 |          7 |             1 | 2^30 = 1073741824 |                 25 |      1x | 460.715 ms |  inf% | 460.715 ms |  inf% |       267.056 MiB |       253.902 MiB |
|           1 |          7 |             1 | 2^30 = 1073741824 |                 25 |      1x |    1.294 s |  inf% |    1.294 s |  inf% |       271.056 MiB |       253.902 MiB |
|           2 |          7 |             1 | 2^30 = 1073741824 |                 25 |      1x |    3.179 s |  inf% |    3.179 s |  inf% |         4.079 MiB |       253.902 MiB |
|           0 |          1 |            25 | 2^30 = 1073741824 |                 25 |      1x | 433.565 ms |  inf% | 433.564 ms |  inf% |         2.465 GiB |       190.615 MiB |
|           1 |          1 |            25 | 2^30 = 1073741824 |                 25 |      1x |    1.012 s |  inf% |    1.012 s |  inf% |         2.469 GiB |       190.615 MiB |
|           2 |          1 |            25 | 2^30 = 1073741824 |                 25 |      1x |    2.436 s |  inf% |    2.436 s |  inf% |         4.079 MiB |       190.615 MiB |
|           0 |          4 |            25 | 2^30 = 1073741824 |                 25 |      1x | 473.925 ms |  inf% | 473.927 ms |  inf% |       810.193 MiB |       238.269 MiB |
|           1 |          4 |            25 | 2^30 = 1073741824 |                 25 |      1x |    1.222 s |  inf% |    1.222 s |  inf% |       814.193 MiB |       238.269 MiB |
|           2 |          4 |            25 | 2^30 = 1073741824 |                 25 |      1x |    2.954 s |  inf% |    2.954 s |  inf% |         4.079 MiB |       238.269 MiB |
|           0 |          7 |            25 | 2^30 = 1073741824 |                 25 |      1x | 475.940 ms |  inf% | 475.940 ms |  inf% |       571.933 MiB |       245.080 MiB |
|           1 |          7 |            25 | 2^30 = 1073741824 |                 25 |      1x |    1.216 s |  inf% |    1.216 s |  inf% |       575.933 MiB |       245.080 MiB |
|           2 |          7 |            25 | 2^30 = 1073741824 |                 25 |      1x |    3.035 s |  inf% |    3.035 s |  inf% |         4.079 MiB |       245.080 MiB |
|           0 |          1 |             1 |      2^15 = 32768 |                 50 |      1x | 453.082 us |  inf% | 449.248 us |  inf% |       103.055 KiB |        15.404 KiB |
|           1 |          1 |             1 |      2^15 = 32768 |                 50 |      1x |  12.784 ms |  inf% |  12.778 ms |  inf% |       118.523 KiB |        15.404 KiB |
|           2 |          1 |             1 |      2^15 = 32768 |                 50 |      1x |   8.021 ms |  inf% |   8.017 ms |  inf% |       112.094 KiB |        15.404 KiB |
|           0 |          4 |             1 |      2^15 = 32768 |                 50 |      1x | 450.433 us |  inf% | 445.536 us |  inf% |        97.781 KiB |        15.895 KiB |
|           1 |          4 |             1 |      2^15 = 32768 |                 50 |      1x |   8.740 ms |  inf% |   8.735 ms |  inf% |       113.719 KiB |        15.895 KiB |
|           2 |          4 |             1 |      2^15 = 32768 |                 50 |      1x |   7.715 ms |  inf% |   7.711 ms |  inf% |       113.086 KiB |        15.895 KiB |
|           0 |          7 |             1 |      2^15 = 32768 |                 50 |      1x | 400.055 us |  inf% | 395.264 us |  inf% |        97.750 KiB |        16.020 KiB |
|           1 |          7 |             1 |      2^15 = 32768 |                 50 |      1x |   8.755 ms |  inf% |   8.751 ms |  inf% |       113.750 KiB |        16.020 KiB |
|           2 |          7 |             1 |      2^15 = 32768 |                 50 |      1x |   7.687 ms |  inf% |   7.682 ms |  inf% |       113.344 KiB |        16.020 KiB |
|           0 |          1 |            25 |      2^15 = 32768 |                 50 |      1x | 410.891 us |  inf% | 407.360 us |  inf% |       174.227 KiB |        11.892 KiB |
|           1 |          1 |            25 |      2^15 = 32768 |                 50 |      1x |   8.795 ms |  inf% |   8.790 ms |  inf% |       186.125 KiB |        11.892 KiB |
|           2 |          1 |            25 |      2^15 = 32768 |                 50 |      1x |   7.757 ms |  inf% |   7.753 ms |  inf% |       105.070 KiB |        11.892 KiB |
|           0 |          4 |            25 |      2^15 = 32768 |                 50 |      1x | 414.914 us |  inf% | 411.488 us |  inf% |       115.992 KiB |        14.868 KiB |
|           1 |          4 |            25 |      2^15 = 32768 |                 50 |      1x |   8.790 ms |  inf% |   8.784 ms |  inf% |       130.867 KiB |        14.868 KiB |
|           2 |          4 |            25 |      2^15 = 32768 |                 50 |      1x |   7.702 ms |  inf% |   7.698 ms |  inf% |       111.031 KiB |        14.868 KiB |
|           0 |          7 |            25 |      2^15 = 32768 |                 50 |      1x | 426.890 us |  inf% | 422.528 us |  inf% |       107.648 KiB |        15.121 KiB |
|           1 |          7 |            25 |      2^15 = 32768 |                 50 |      1x |   8.816 ms |  inf% |   8.811 ms |  inf% |       122.789 KiB |        15.121 KiB |
|           2 |          7 |            25 |      2^15 = 32768 |                 50 |      1x |   7.710 ms |  inf% |   7.706 ms |  inf% |       111.547 KiB |        15.121 KiB |
|           0 |          1 |             1 | 2^30 = 1073741824 |                 50 |      1x | 465.599 ms |  inf% | 465.599 ms |  inf% |       691.190 MiB |       503.319 MiB |
|           1 |          1 |             1 | 2^30 = 1073741824 |                 50 |      1x |    1.362 s |  inf% |    1.362 s |  inf% |       695.190 MiB |       503.319 MiB |
|           2 |          1 |             1 | 2^30 = 1073741824 |                 50 |      1x |    3.214 s |  inf% |    3.214 s |  inf% |         4.079 MiB |       503.319 MiB |
|           0 |          4 |             1 | 2^30 = 1073741824 |                 50 |      1x | 494.805 ms |  inf% | 494.807 ms |  inf% |       532.722 MiB |       507.221 MiB |
|           1 |          4 |             1 | 2^30 = 1073741824 |                 50 |      1x |    1.282 s |  inf% |    1.282 s |  inf% |       536.722 MiB |       507.221 MiB |
|           2 |          4 |             1 | 2^30 = 1073741824 |                 50 |      1x |    3.178 s |  inf% |    3.178 s |  inf% |         4.079 MiB |       507.221 MiB |
|           0 |          7 |             1 | 2^30 = 1073741824 |                 50 |      1x | 478.472 ms |  inf% | 478.473 ms |  inf% |       522.410 MiB |       507.803 MiB |
|           1 |          7 |             1 | 2^30 = 1073741824 |                 50 |      1x |    1.287 s |  inf% |    1.287 s |  inf% |       526.410 MiB |       507.803 MiB |
|           2 |          7 |             1 | 2^30 = 1073741824 |                 50 |      1x |    3.229 s |  inf% |    3.229 s |  inf% |         4.079 MiB |       507.803 MiB |
|           0 |          1 |            25 | 2^30 = 1073741824 |                 50 |      1x | 451.871 ms |  inf% | 451.872 ms |  inf% |         2.904 GiB |       381.231 MiB |
|           1 |          1 |            25 | 2^30 = 1073741824 |                 50 |      1x |    1.029 s |  inf% |    1.029 s |  inf% |         2.908 GiB |       381.231 MiB |
|           2 |          1 |            25 | 2^30 = 1073741824 |                 50 |      1x |    2.379 s |  inf% |    2.379 s |  inf% |         4.079 MiB |       381.231 MiB |
|           0 |          4 |            25 | 2^30 = 1073741824 |                 50 |      1x | 456.983 ms |  inf% | 456.983 ms |  inf% |         1.086 GiB |       476.537 MiB |
|           1 |          4 |            25 | 2^30 = 1073741824 |                 50 |      1x |    1.245 s |  inf% |    1.245 s |  inf% |         1.090 GiB |       476.537 MiB |
|           2 |          4 |            25 | 2^30 = 1073741824 |                 50 |      1x |    2.932 s |  inf% |    2.932 s |  inf% |         4.079 MiB |       476.537 MiB |
|           0 |          7 |            25 | 2^30 = 1073741824 |                 50 |      1x | 505.587 ms |  inf% | 505.586 ms |  inf% |       853.321 MiB |       490.160 MiB |
|           1 |          7 |            25 | 2^30 = 1073741824 |                 50 |      1x |    1.264 s |  inf% |    1.264 s |  inf% |       857.321 MiB |       490.160 MiB |
|           2 |          7 |            25 | 2^30 = 1073741824 |                 50 |      1x |    2.991 s |  inf% |    2.991 s |  inf% |         4.079 MiB |       490.160 MiB |
|           0 |          1 |             1 |      2^15 = 32768 |                100 |      1x | 452.555 us |  inf% | 448.512 us |  inf% |       119.547 KiB |        30.809 KiB |
|           1 |          1 |             1 |      2^15 = 32768 |                100 |      1x |  12.755 ms |  inf% |  12.750 ms |  inf% |       150.359 KiB |        30.809 KiB |
|           2 |          1 |             1 |      2^15 = 32768 |                100 |      1x |   8.670 ms |  inf% |   8.666 ms |  inf% |       142.914 KiB |        30.809 KiB |
|           0 |          4 |             1 |      2^15 = 32768 |                100 |      1x | 402.123 us |  inf% | 398.688 us |  inf% |       114.047 KiB |        31.790 KiB |
|           1 |          4 |             1 |      2^15 = 32768 |                100 |      1x |   8.997 ms |  inf% |   8.993 ms |  inf% |       145.844 KiB |        31.790 KiB |
|           2 |          4 |             1 |      2^15 = 32768 |                100 |      1x |   8.703 ms |  inf% |   8.698 ms |  inf% |       144.891 KiB |        31.790 KiB |
|           0 |          7 |             1 |      2^15 = 32768 |                100 |      1x | 396.810 us |  inf% | 393.184 us |  inf% |       113.891 KiB |        32.040 KiB |
|           1 |          7 |             1 |      2^15 = 32768 |                100 |      1x |   8.775 ms |  inf% |   8.770 ms |  inf% |       145.938 KiB |        32.040 KiB |
|           2 |          7 |             1 |      2^15 = 32768 |                100 |      1x |   8.561 ms |  inf% |   8.555 ms |  inf% |       145.398 KiB |        32.040 KiB |
|           0 |          1 |            25 |      2^15 = 32768 |                100 |      1x | 410.632 us |  inf% | 407.136 us |  inf% |       202.391 KiB |        23.783 KiB |
|           1 |          1 |            25 |      2^15 = 32768 |                100 |      1x |   8.663 ms |  inf% |   8.658 ms |  inf% |       226.180 KiB |        23.783 KiB |
|           2 |          1 |            25 |      2^15 = 32768 |                100 |      1x |   8.569 ms |  inf% |   8.564 ms |  inf% |       128.867 KiB |        23.783 KiB |
|           0 |          4 |            25 |      2^15 = 32768 |                100 |      1x | 420.616 us |  inf% | 416.288 us |  inf% |       134.828 KiB |        29.736 KiB |
|           1 |          4 |            25 |      2^15 = 32768 |                100 |      1x |   8.701 ms |  inf% |   8.697 ms |  inf% |       164.570 KiB |        29.736 KiB |
|           2 |          4 |            25 |      2^15 = 32768 |                100 |      1x |   8.700 ms |  inf% |   8.696 ms |  inf% |       140.781 KiB |        29.736 KiB |
|           0 |          7 |            25 |      2^15 = 32768 |                100 |      1x | 420.545 us |  inf% | 417.184 us |  inf% |       125.000 KiB |        30.243 KiB |
|           1 |          7 |            25 |      2^15 = 32768 |                100 |      1x |   8.689 ms |  inf% |   8.684 ms |  inf% |       155.250 KiB |        30.243 KiB |
|           2 |          7 |            25 |      2^15 = 32768 |                100 |      1x |   8.651 ms |  inf% |   8.646 ms |  inf% |       141.805 KiB |        30.243 KiB |
|           0 |          1 |             1 | 2^30 = 1073741824 |                100 |      1x | 473.237 ms |  inf% | 473.238 ms |  inf% |         1.203 GiB |      1006.638 MiB |
|           1 |          1 |             1 | 2^30 = 1073741824 |                100 |      1x |    1.388 s |  inf% |    1.388 s |  inf% |         1.207 GiB |      1006.638 MiB |
|           2 |          1 |             1 | 2^30 = 1073741824 |                100 |      1x |    3.482 s |  inf% |    3.483 s |  inf% |      1010.718 MiB |      1006.638 MiB |
|           0 |          4 |             1 | 2^30 = 1073741824 |                100 |      1x | 475.645 ms |  inf% | 475.645 ms |  inf% |         1.021 GiB |      1014.442 MiB |
|           1 |          4 |             1 | 2^30 = 1073741824 |                100 |      1x |    1.384 s |  inf% |    1.384 s |  inf% |         1.024 GiB |      1014.442 MiB |
|           2 |          4 |             1 | 2^30 = 1073741824 |                100 |      1x |    3.432 s |  inf% |    3.432 s |  inf% |      1018.521 MiB |      1014.442 MiB |
|           0 |          7 |             1 | 2^30 = 1073741824 |                100 |      1x | 488.596 ms |  inf% | 488.597 ms |  inf% |         1.009 GiB |      1015.606 MiB |
|           1 |          7 |             1 | 2^30 = 1073741824 |                100 |      1x |    1.404 s |  inf% |    1.404 s |  inf% |         1.013 GiB |      1015.606 MiB |
|           2 |          7 |             1 | 2^30 = 1073741824 |                100 |      1x |    3.407 s |  inf% |    3.407 s |  inf% |      1019.686 MiB |      1015.606 MiB |
|           0 |          1 |            25 | 2^30 = 1073741824 |                100 |      1x | 444.580 ms |  inf% | 444.580 ms |  inf% |         3.783 GiB |       762.462 MiB |
|           1 |          1 |            25 | 2^30 = 1073741824 |                100 |      1x |    1.086 s |  inf% |    1.086 s |  inf% |         3.787 GiB |       762.462 MiB |
|           2 |          1 |            25 | 2^30 = 1073741824 |                100 |      1x |    2.761 s |  inf% |    2.761 s |  inf% |       766.541 MiB |       762.462 MiB |
|           0 |          4 |            25 | 2^30 = 1073741824 |                100 |      1x | 517.450 ms |  inf% | 517.450 ms |  inf% |         1.675 GiB |       953.075 MiB |
|           1 |          4 |            25 | 2^30 = 1073741824 |                100 |      1x |    1.627 s |  inf% |    1.627 s |  inf% |         1.679 GiB |       953.075 MiB |
|           2 |          4 |            25 | 2^30 = 1073741824 |                100 |      1x |    4.586 s |  inf% |    4.586 s |  inf% |       957.154 MiB |       953.075 MiB |
|           0 |          7 |            25 | 2^30 = 1073741824 |                100 |      1x | 527.723 ms |  inf% | 527.723 ms |  inf% |         1.383 GiB |       980.321 MiB |
|           1 |          7 |            25 | 2^30 = 1073741824 |                100 |      1x |    1.584 s |  inf% |    1.584 s |  inf% |         1.387 GiB |       980.321 MiB |
|           2 |          7 |            25 | 2^30 = 1073741824 |                100 |      1x |    4.653 s |  inf% |    4.653 s |  inf% |       984.400 MiB |       980.321 MiB |
```

</details>

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
