### PR TITLE
Fix JNI for TableWithMeta to use schema_info instead of column_names

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/TableWithMeta.java
+++ b/java/src/main/java/ai/rapids/cudf/TableWithMeta.java
@@ -52,7 +52,7 @@ public class TableWithMeta implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     if (handle != 0) {
       close(handle);
       handle = 0;

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1357,11 +1357,11 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_TableWithMeta_getColumnNames(
   try {
     cudf::jni::auto_set_device(env);
     auto ptr = reinterpret_cast<cudf::io::table_with_metadata *>(handle);
-    auto length = ptr->metadata.column_names.size();
+    auto length = ptr->metadata.schema_info.size();
     auto ret = static_cast<jobjectArray>(
         env->NewObjectArray(length, env->FindClass("java/lang/String"), nullptr));
     for (size_t i = 0; i < length; i++) {
-      env->SetObjectArrayElement(ret, i, env->NewStringUTF(ptr->metadata.column_names[i].c_str()));
+      env->SetObjectArrayElement(ret, i, env->NewStringUTF(ptr->metadata.schema_info[i].name.c_str()));
     }
 
     return ret;

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1361,7 +1361,8 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_TableWithMeta_getColumnNames(
     auto ret = static_cast<jobjectArray>(
         env->NewObjectArray(length, env->FindClass("java/lang/String"), nullptr));
     for (size_t i = 0; i < length; i++) {
-      env->SetObjectArrayElement(ret, i, env->NewStringUTF(ptr->metadata.schema_info[i].name.c_str()));
+      env->SetObjectArrayElement(ret, i,
+                                 env->NewStringUTF(ptr->metadata.schema_info[i].name.c_str()));
     }
 
     return ret;


### PR DESCRIPTION
## Description
After #11364 `TableWithMeta` no longer returns the column names for a table since it is looking at the old `column_names` field instead of the newer `schema_info` field in the table metadata.  This updates the JNI to use the `schema_info` to get the column names and adds a test for this API which was missing before.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
