### PR TITLE
xfail custreamz display test for now

### DIFF
--- a/python/custreamz/custreamz/tests/test_dataframes.py
+++ b/python/custreamz/custreamz/tests/test_dataframes.py
@@ -502,6 +502,10 @@ def test_cumulative_aggregations(op, getter, stream):
     assert_eq(cudf.concat(L), expected)
 
 
+@pytest.mark.xfail(
+    reason="IPyWidgets 8.0 broke streamz 0.6.4."
+    "We should remove this xfail when this is fixed in streamz"
+)
 def test_display(stream):
     pytest.importorskip("ipywidgets")
     pytest.importorskip("IPython")

--- a/python/custreamz/custreamz/tests/test_dataframes.py
+++ b/python/custreamz/custreamz/tests/test_dataframes.py
@@ -503,8 +503,8 @@ def test_cumulative_aggregations(op, getter, stream):
 
 
 @pytest.mark.xfail(
-    reason="IPyWidgets 8.0 broke streamz 0.6.4."
-    "We should remove this xfail when this is fixed in streamz"
+    reason="IPyWidgets 8.0 broke streamz 0.6.4. "
+    "We should remove this xfail when this is fixed in streamz."
 )
 def test_display(stream):
     pytest.importorskip("ipywidgets")


### PR DESCRIPTION
## Description
Should unblock CI that is now failing due to upstream breakage. It appears that ipywidgets 8.0.0 is incompatible with streamz 0.6.4.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
