### PR TITLE
[Experimental] Use nosync policy for Thrust calls.

### DIFF
--- a/cpp/benchmarks/lists/copying/scatter_lists.cu
+++ b/cpp/benchmarks/lists/copying/scatter_lists.cu
@@ -51,10 +51,10 @@ void BM_lists_scatter(::benchmark::State& state)
     data_type{type_to_id<TypeParam>()}, base_size, mask_state::UNALLOCATED, stream, mr);
   auto target_base_col = make_fixed_width_column(
     data_type{type_to_id<TypeParam>()}, base_size, mask_state::UNALLOCATED, stream, mr);
-  thrust::sequence(rmm::exec_policy(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream),
                    source_base_col->mutable_view().begin<TypeParam>(),
                    source_base_col->mutable_view().end<TypeParam>());
-  thrust::sequence(rmm::exec_policy(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream),
                    target_base_col->mutable_view().begin<TypeParam>(),
                    target_base_col->mutable_view().end<TypeParam>());
 
@@ -63,12 +63,12 @@ void BM_lists_scatter(::benchmark::State& state)
   auto target_offsets = make_fixed_width_column(
     data_type{type_to_id<offset_type>()}, num_rows + 1, mask_state::UNALLOCATED, stream, mr);
 
-  thrust::sequence(rmm::exec_policy(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream),
                    source_offsets->mutable_view().begin<offset_type>(),
                    source_offsets->mutable_view().end<offset_type>(),
                    0,
                    num_elements_per_row);
-  thrust::sequence(rmm::exec_policy(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream),
                    target_offsets->mutable_view().begin<offset_type>(),
                    target_offsets->mutable_view().end<offset_type>(),
                    0,
@@ -92,7 +92,7 @@ void BM_lists_scatter(::benchmark::State& state)
   auto scatter_map = make_fixed_width_column(
     data_type{type_to_id<size_type>()}, num_rows, mask_state::UNALLOCATED, stream, mr);
   auto m_scatter_map = scatter_map->mutable_view();
-  thrust::sequence(rmm::exec_policy(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream),
                    m_scatter_map.begin<size_type>(),
                    m_scatter_map.end<size_type>(),
                    num_rows - 1,
@@ -100,7 +100,7 @@ void BM_lists_scatter(::benchmark::State& state)
 
   if (not coalesce) {
     thrust::default_random_engine g;
-    thrust::shuffle(rmm::exec_policy(stream),
+    thrust::shuffle(rmm::exec_policy_nosync(stream),
                     m_scatter_map.begin<size_type>(),
                     m_scatter_map.begin<size_type>(),
                     g);

--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -383,7 +383,7 @@ namespace detail{
         rmm::device_buffer buff(...,stream);
         CUDF_CUDA_TRY(cudaMemcpyAsync(...,stream.value()));
         kernel<<<..., stream>>>(...);
-        thrust::algorithm(rmm::exec_policy(stream), ...);
+        thrust::algorithm(rmm::exec_policy_nosync(stream), ...);
     }
 } // namespace detail
 
@@ -695,7 +695,7 @@ Example output iterator usage:
 
 ```c++
 auto result_itr = indexalator_factory::create_output_iterator(indices->mutable_view());
-thrust::lower_bound(rmm::exec_policy(stream),
+thrust::lower_bound(rmm::exec_policy_nosync(stream),
                     input->begin<Element>(),
                     input->end<Element>(),
                     values->begin<Element>(),

--- a/cpp/include/cudf/detail/aggregation/aggregation.cuh
+++ b/cpp/include/cudf/detail/aggregation/aggregation.cuh
@@ -639,7 +639,7 @@ struct identity_initializer {
                                                           rmm::cuda_stream_view stream)
   {
     using DeviceType = device_storage_type_t<T>;
-    thrust::fill(rmm::exec_policy(stream),
+    thrust::fill(rmm::exec_policy_nosync(stream),
                  col.begin<DeviceType>(),
                  col.end<DeviceType>(),
                  get_identity<DeviceType, k>());

--- a/cpp/include/cudf/detail/calendrical_month_sequence.cuh
+++ b/cpp/include/cudf/detail/calendrical_month_sequence.cuh
@@ -49,7 +49,7 @@ struct calendrical_month_sequence_functor {
     auto output             = cudf::make_fixed_width_column(
       output_column_type, n, cudf::mask_state::UNALLOCATED, stream, mr);
 
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(n),
                       output->mutable_view().begin<T>(),

--- a/cpp/include/cudf/detail/copy_if.cuh
+++ b/cpp/include/cudf/detail/copy_if.cuh
@@ -288,7 +288,7 @@ struct scatter_gather_functor {
   {
     rmm::device_uvector<cudf::size_type> indices(output_size, stream);
 
-    thrust::copy_if(rmm::exec_policy(stream),
+    thrust::copy_if(rmm::exec_policy_nosync(stream),
                     thrust::counting_iterator<cudf::size_type>(0),
                     thrust::counting_iterator<cudf::size_type>(input.size()),
                     indices.begin(),

--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -128,7 +128,7 @@ void gather_helper(InputItr source_itr,
 {
   using map_type = typename std::iterator_traits<MapIterator>::value_type;
   if (nullify_out_of_bounds) {
-    thrust::gather_if(rmm::exec_policy(stream),
+    thrust::gather_if(rmm::exec_policy_nosync(stream),
                       gather_map_begin,
                       gather_map_end,
                       gather_map_begin,
@@ -137,7 +137,7 @@ void gather_helper(InputItr source_itr,
                       bounds_checker<map_type>{0, source_size});
   } else {
     thrust::gather(
-      rmm::exec_policy(stream), gather_map_begin, gather_map_end, source_itr, target_itr);
+      rmm::exec_policy_nosync(stream), gather_map_begin, gather_map_end, source_itr, target_itr);
   }
 }
 

--- a/cpp/include/cudf/detail/indexalator.cuh
+++ b/cpp/include/cudf/detail/indexalator.cuh
@@ -319,7 +319,7 @@ struct input_indexalator : base_indexalator<input_indexalator> {
  * Example output iterator usage.
  * @code
  *  auto result_itr = indexalator_factory::create_output_iterator(indices->mutable_view());
- *  thrust::lower_bound(rmm::exec_policy(stream),
+ *  thrust::lower_bound(rmm::exec_policy_nosync(stream),
  *                      input->begin<Element>(),
  *                      input->end<Element>(),
  *                      values->begin<Element>(),

--- a/cpp/include/cudf/detail/labeling/label_segments.cuh
+++ b/cpp/include/cudf/detail/labeling/label_segments.cuh
@@ -78,7 +78,8 @@ void label_segments(InputIterator offsets_begin,
 
   // When the output array is not empty, always fill it with `0` value first.
   using OutputType = typename thrust::iterator_value<OutputIterator>::type;
-  thrust::uninitialized_fill(rmm::exec_policy(stream), label_begin, label_end, OutputType{0});
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream), label_begin, label_end, OutputType{0});
 
   // If the offsets array has no more than 2 offset values, there will be at max 1 segment.
   // In such cases, the output will just be an array of all `0` values (which we already filled).
@@ -88,7 +89,7 @@ void label_segments(InputIterator offsets_begin,
   if (thrust::distance(offsets_begin, offsets_end) <= 2) { return; }
 
   thrust::for_each(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     offsets_begin + 1,  // exclude the first offset value
     offsets_end - 1,    // exclude the last offset value
     [num_labels = static_cast<typename thrust::iterator_value<InputIterator>::type>(num_labels),
@@ -105,7 +106,7 @@ void label_segments(InputIterator offsets_begin,
       // output.
       if (dst_idx < num_labels) { atomicAdd(&output[dst_idx], OutputType{1}); }
     });
-  thrust::inclusive_scan(rmm::exec_policy(stream), label_begin, label_end, label_begin);
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream), label_begin, label_end, label_begin);
 }
 
 /**
@@ -147,7 +148,8 @@ void labels_to_offsets(InputIterator labels_begin,
 {
   // Always fill the entire output array with `0` value regardless of the input.
   using OutputType = typename thrust::iterator_value<OutputIterator>::type;
-  thrust::uninitialized_fill(rmm::exec_policy(stream), offsets_begin, offsets_end, OutputType{0});
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream), offsets_begin, offsets_end, OutputType{0});
 
   // If there is not any label value, we will have zero segment or all empty segments. We should
   // terminate from here because:
@@ -173,7 +175,7 @@ void labels_to_offsets(InputIterator labels_begin,
   auto list_sizes = rmm::device_uvector<OutputType>(num_segments, stream);
 
   // Count the numbers of labels in the each segment.
-  auto const end                    = thrust::reduce_by_key(rmm::exec_policy(stream),
+  auto const end                    = thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                                          labels_begin,  // keys
                                          labels_end,    // keys
                                          thrust::make_constant_iterator<OutputType>(1),
@@ -184,7 +186,7 @@ void labels_to_offsets(InputIterator labels_begin,
   // Scatter segment sizes into the end position of their corresponding segment indices.
   // Given the example above, we scatter [4, 2, 4] by the scatter map [0, 1, 4], resulting
   // output = [4, 2, 0, 0, 4, 0].
-  thrust::scatter(rmm::exec_policy(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream),
                   list_sizes.begin(),
                   list_sizes.begin() + num_non_empty_segments,
                   list_indices.begin(),
@@ -192,7 +194,8 @@ void labels_to_offsets(InputIterator labels_begin,
 
   // Generate offsets from sizes.
   // Given the example above, the final output is [0, 4, 6, 6, 6, 10].
-  thrust::exclusive_scan(rmm::exec_policy(stream), offsets_begin, offsets_end, offsets_begin);
+  thrust::exclusive_scan(
+    rmm::exec_policy_nosync(stream), offsets_begin, offsets_end, offsets_begin);
 }
 
 }  // namespace cudf::detail

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -336,7 +336,7 @@ rmm::device_uvector<size_type> segmented_count_bits(bitmask_type const* bitmask,
         auto const end   = thrust::get<1>(segment);
         return end - begin;
       });
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       segment_length_iterator,
                       segment_length_iterator + num_ranges,
                       d_bit_counts.data(),

--- a/cpp/include/cudf/detail/reduction.cuh
+++ b/cpp/include/cudf/detail/reduction.cuh
@@ -220,7 +220,7 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
   // compute the result value from intermediate value in device
   using ScalarType = cudf::scalar_type_t<OutputType>;
   auto result      = new ScalarType(OutputType{0}, true, stream, mr);
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      intermediate_result.data(),
                      1,
                      [dres = result->data(), op, valid_count, ddof] __device__(auto i) {

--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -79,14 +79,14 @@ auto scatter_to_gather(MapIterator scatter_map_begin,
   // We'll use the `numeric_limits::lowest()` value for this since it should always be outside the
   // valid range.
   auto gather_map = rmm::device_uvector<size_type>(gather_rows, stream);
-  thrust::uninitialized_fill(rmm::exec_policy(stream),
+  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
                              gather_map.begin(),
                              gather_map.end(),
                              std::numeric_limits<size_type>::lowest());
 
   // Convert scatter map to a gather map
   thrust::scatter(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<MapValueType>(0),
     thrust::make_counting_iterator<MapValueType>(std::distance(scatter_map_begin, scatter_map_end)),
     scatter_map_begin,
@@ -114,13 +114,13 @@ auto scatter_to_gather_complement(MapIterator scatter_map_begin,
                                   rmm::cuda_stream_view stream)
 {
   auto gather_map = rmm::device_uvector<size_type>(gather_rows, stream);
-  thrust::sequence(rmm::exec_policy(stream), gather_map.begin(), gather_map.end(), 0);
+  thrust::sequence(rmm::exec_policy_nosync(stream), gather_map.begin(), gather_map.end(), 0);
 
   auto const out_of_bounds_begin =
     thrust::make_constant_iterator(std::numeric_limits<size_type>::lowest());
   auto const out_of_bounds_end =
     out_of_bounds_begin + thrust::distance(scatter_map_begin, scatter_map_end);
-  thrust::scatter(rmm::exec_policy(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream),
                   out_of_bounds_begin,
                   out_of_bounds_end,
                   scatter_map_begin,
@@ -152,7 +152,7 @@ struct column_scatterer_impl<Element, std::enable_if_t<cudf::is_fixed_width<Elem
 
     // NOTE use source.begin + scatter rows rather than source.end in case the
     // scatter map is smaller than the number of source rows
-    thrust::scatter(rmm::exec_policy(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream),
                     source.begin<Element>(),
                     source.begin<Element>() + cudf::distance(scatter_map_begin, scatter_map_end),
                     scatter_map_begin,
@@ -225,7 +225,7 @@ struct column_scatterer_impl<dictionary32> {
     auto source_itr  = indexalator_factory::make_input_iterator(source_view.indices());
     auto new_indices = std::make_unique<column>(target_view.get_indices_annotated(), stream, mr);
     auto target_itr  = indexalator_factory::make_output_iterator(new_indices->mutable_view());
-    thrust::scatter(rmm::exec_policy(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream),
                     source_itr,
                     source_itr + std::distance(scatter_map_begin, scatter_map_end),
                     scatter_map_begin,
@@ -402,10 +402,10 @@ std::unique_ptr<table> scatter(
     auto const begin = -target.num_rows();
     auto const end   = target.num_rows();
     auto bounds      = bounds_checker<MapType>{begin, end};
-    CUDF_EXPECTS(
-      std::distance(scatter_map_begin, scatter_map_end) ==
-        thrust::count_if(rmm::exec_policy(stream), scatter_map_begin, scatter_map_end, bounds),
-      "Scatter map index out of bounds");
+    CUDF_EXPECTS(std::distance(scatter_map_begin, scatter_map_end) ==
+                   thrust::count_if(
+                     rmm::exec_policy_nosync(stream), scatter_map_begin, scatter_map_end, bounds),
+                 "Scatter map index out of bounds");
   }
 
   CUDF_EXPECTS(std::distance(scatter_map_begin, scatter_map_end) <= source.num_rows(),

--- a/cpp/include/cudf/detail/unary.hpp
+++ b/cpp/include/cudf/detail/unary.hpp
@@ -58,7 +58,7 @@ std::unique_ptr<column> true_if(
   auto output_mutable_view = output->mutable_view();
   auto output_data         = output_mutable_view.data<bool>();
 
-  thrust::transform(rmm::exec_policy(stream), begin, end, output_data, p);
+  thrust::transform(rmm::exec_policy_nosync(stream), begin, end, output_data, p);
 
   return output;
 }

--- a/cpp/include/cudf/lists/detail/gather.cuh
+++ b/cpp/include/cudf/lists/detail/gather.cuh
@@ -89,7 +89,7 @@ gather_data make_gather_data(cudf::lists_column_view const& source_column,
   // generate the compacted outgoing offsets.
   auto count_iter = thrust::make_counting_iterator<int32_t>(0);
   thrust::transform_exclusive_scan(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     count_iter,
     count_iter + offset_count,
     dst_offsets_v.begin<int32_t>(),
@@ -125,7 +125,7 @@ gather_data make_gather_data(cudf::lists_column_view const& source_column,
   // generate the base offsets
   rmm::device_uvector<int32_t> base_offsets = rmm::device_uvector<int32_t>(output_count, stream);
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     gather_map,
     gather_map + output_count,
     base_offsets.data(),

--- a/cpp/include/cudf/lists/detail/scatter.cuh
+++ b/cpp/include/cudf/lists/detail/scatter.cuh
@@ -58,7 +58,7 @@ rmm::device_uvector<unbound_list_view> list_vector_from_column(
 
   auto vector = rmm::device_uvector<unbound_list_view>(n_rows, stream, mr);
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     index_begin,
                     index_end,
                     vector.begin(),
@@ -104,7 +104,7 @@ std::unique_ptr<column> scatter_impl(
   auto const child_column_type = lists_column_view(target).child().type();
 
   // Scatter.
-  thrust::scatter(rmm::exec_policy(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream),
                   source_vector.begin(),
                   source_vector.end(),
                   scatter_map_begin,
@@ -239,7 +239,7 @@ std::unique_ptr<column> scatter(
               : cudf::detail::create_null_mask(1, mask_state::ALL_NULL, stream, mr);
   auto offset_column = make_numeric_column(
     data_type{type_to_id<offset_type>()}, 2, mask_state::UNALLOCATED, stream, mr);
-  thrust::sequence(rmm::exec_policy(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream),
                    offset_column->mutable_view().begin<offset_type>(),
                    offset_column->mutable_view().end<offset_type>(),
                    0,

--- a/cpp/include/cudf/strings/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/strings/detail/copy_if_else.cuh
@@ -98,7 +98,7 @@ std::unique_ptr<cudf::column> copy_if_else(
   auto d_chars      = chars_column->mutable_view().template data<char>();
   // fill in chars
   thrust::for_each_n(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     [lhs_begin, rhs_begin, filter_fn, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/include/cudf/strings/detail/copy_range.cuh
+++ b/cpp/include/cudf/strings/detail/copy_range.cuh
@@ -189,7 +189,7 @@ std::unique_ptr<column> copy_range(
     // copy to the chars column
 
     auto p_chars = (p_chars_column->mutable_view()).template data<char>();
-    thrust::for_each(rmm::exec_policy(stream),
+    thrust::for_each(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator(0),
                      thrust::make_counting_iterator(target.size()),
                      [source_value_begin,

--- a/cpp/include/cudf/strings/detail/gather.cuh
+++ b/cpp/include/cudf/strings/detail/gather.cuh
@@ -306,7 +306,7 @@ std::unique_ptr<cudf::column> gather(
   auto const d_in_offsets  = (strings_count > 0) ? strings.offsets_begin() : nullptr;
   auto const d_strings     = column_device_view::create(strings.parent(), stream);
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     begin,
     end,
     d_out_offsets,
@@ -318,7 +318,7 @@ std::unique_ptr<cudf::column> gather(
 
   // check total size is not too large
   size_t const total_bytes = thrust::transform_reduce(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     d_out_offsets,
     d_out_offsets + output_count,
     [] __device__(auto size) { return static_cast<size_t>(size); },
@@ -328,8 +328,10 @@ std::unique_ptr<cudf::column> gather(
                "total size of output strings is too large for a cudf column");
 
   // In-place convert output sizes into offsets
-  thrust::exclusive_scan(
-    rmm::exec_policy(stream), d_out_offsets, d_out_offsets + output_count + 1, d_out_offsets);
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+                         d_out_offsets,
+                         d_out_offsets + output_count + 1,
+                         d_out_offsets);
 
   // build chars column
   cudf::device_span<int32_t const> const d_out_offsets_span(d_out_offsets, output_count + 1);

--- a/cpp/include/cudf/strings/detail/merge.cuh
+++ b/cpp/include/cudf/strings/detail/merge.cuh
@@ -91,7 +91,7 @@ std::unique_ptr<column> merge(strings_column_view const& lhs,
   auto chars_column = strings::detail::create_chars_child_column(bytes, stream, mr);
   // merge the strings
   auto d_chars = chars_column->mutable_view().template data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      [d_lhs, d_rhs, begin, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/include/cudf/strings/detail/scatter.cuh
+++ b/cpp/include/cudf/strings/detail/scatter.cuh
@@ -76,7 +76,8 @@ std::unique_ptr<column> scatter(
     begin, [] __device__(string_view const sv) { return sv.empty() ? string_view{} : sv; });
 
   // do the scatter
-  thrust::scatter(rmm::exec_policy(stream), itr, itr + size, scatter_map, target_vector.begin());
+  thrust::scatter(
+    rmm::exec_policy_nosync(stream), itr, itr + size, scatter_map, target_vector.begin());
 
   // build the output column
   auto sv_span = cudf::device_span<string_view const>(target_vector);

--- a/cpp/include/cudf_test/tdigest_utilities.cuh
+++ b/cpp/include/cudf_test/tdigest_utilities.cuh
@@ -122,7 +122,7 @@ void tdigest_minmax_compare(cudf::tdigest::tdigest_column_view const& tdv,
 
   auto expected_min = cudf::make_fixed_width_column(
     data_type{type_id::FLOAT64}, spans.size(), mask_state::UNALLOCATED);
-  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
+  thrust::transform(rmm::exec_policy_nosync(cudf::default_stream_value),
                     spans.begin(),
                     spans.end(),
                     expected_min->mutable_view().template begin<double>(),
@@ -132,7 +132,7 @@ void tdigest_minmax_compare(cudf::tdigest::tdigest_column_view const& tdv,
 
   auto expected_max = cudf::make_fixed_width_column(
     data_type{type_id::FLOAT64}, spans.size(), mask_state::UNALLOCATED);
-  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
+  thrust::transform(rmm::exec_policy_nosync(cudf::default_stream_value),
                     spans.begin(),
                     spans.end(),
                     expected_max->mutable_view().template begin<double>(),

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -323,7 +323,7 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   return binops::compiled::binary_operation<scalar, column_view>(
-    lhs, rhs, op, output_type, cudf::default_stream_value, mr);
+    lhs, rhs, op, output_type, stream, mr);
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          scalar const& rhs,
@@ -333,7 +333,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   return binops::compiled::binary_operation<column_view, scalar>(
-    lhs, rhs, op, output_type, cudf::default_stream_value, mr);
+    lhs, rhs, op, output_type, stream, mr);
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
@@ -343,7 +343,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   return binops::compiled::binary_operation<column_view, column_view>(
-    lhs, rhs, op, output_type, cudf::default_stream_value, mr);
+    lhs, rhs, op, output_type, stream, mr);
 }
 
 std::unique_ptr<column> binary_operation(column_view const& lhs,
@@ -406,7 +406,10 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::binary_operation(lhs, rhs, op, output_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::binary_operation(lhs, rhs, op, output_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          scalar const& rhs,
@@ -415,7 +418,10 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::binary_operation(lhs, rhs, op, output_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::binary_operation(lhs, rhs, op, output_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
@@ -424,7 +430,10 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::binary_operation(lhs, rhs, op, output_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::binary_operation(lhs, rhs, op, output_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> binary_operation(column_view const& lhs,
@@ -434,7 +443,10 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::binary_operation(lhs, rhs, ptx, output_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::binary_operation(lhs, rhs, ptx, output_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/binaryop/compiled/binary_ops.cu
+++ b/cpp/src/binaryop/compiled/binary_ops.cu
@@ -195,7 +195,7 @@ struct null_considering_binop {
     compare_functor<LhsViewT, RhsViewT, OutT, CompareFunc> binop_func{lhsv, rhsv, cfunc};
 
     // Execute it on every element
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator(0),
                       thrust::make_counting_iterator(col_size),
                       out_col,

--- a/cpp/src/binaryop/compiled/struct_binary_ops.cuh
+++ b/cpp/src/binaryop/compiled/struct_binary_ops.cuh
@@ -88,7 +88,7 @@ void apply_struct_binary_op(mutable_column_view& out,
 
   auto tabulate_device_operator = [&](auto device_comparator) {
     thrust::tabulate(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       out.begin<bool>(),
       out.end<bool>(),
       device_comparison_functor{optional_iter, is_lhs_scalar, is_rhs_scalar, device_comparator});
@@ -125,7 +125,7 @@ void apply_struct_equality_op(mutable_column_view& out,
   auto outd = column_device_view::create(out, stream);
   auto optional_iter =
     cudf::detail::make_optional_iterator<bool>(*outd, nullate::DYNAMIC{out.has_nulls()});
-  thrust::tabulate(rmm::exec_policy(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream),
                    out.begin<bool>(),
                    out.end<bool>(),
                    [optional_iter,

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -158,7 +158,10 @@ rmm::device_buffer create_null_mask(size_type size,
                                     mask_state state,
                                     rmm::mr::device_memory_resource* mr)
 {
-  return detail::create_null_mask(size, state, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::create_null_mask(size, state, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 // Set pre-allocated null mask of given bit range [begin_bit, end_bit) to valid, if valid==true,
@@ -510,25 +513,37 @@ rmm::device_buffer copy_bitmask(bitmask_type const* mask,
                                 size_type end_bit,
                                 rmm::mr::device_memory_resource* mr)
 {
-  return detail::copy_bitmask(mask, begin_bit, end_bit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::copy_bitmask(mask, begin_bit, end_bit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 // Create a bitmask from a column view
 rmm::device_buffer copy_bitmask(column_view const& view, rmm::mr::device_memory_resource* mr)
 {
-  return detail::copy_bitmask(view, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::copy_bitmask(view, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<rmm::device_buffer, size_type> bitmask_and(table_view const& view,
                                                      rmm::mr::device_memory_resource* mr)
 {
-  return detail::bitmask_and(view, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::bitmask_and(view, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<rmm::device_buffer, size_type> bitmask_or(table_view const& view,
                                                     rmm::mr::device_memory_resource* mr)
 {
-  return detail::bitmask_or(view, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::bitmask_or(view, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -278,7 +278,8 @@ std::unique_ptr<column> for_each_concatenate(host_span<column_view const> views,
 
   auto count = 0;
   for (auto& v : views) {
-    thrust::copy(rmm::exec_policy(stream), v.begin<T>(), v.end<T>(), m_view.begin<T>() + count);
+    thrust::copy(
+      rmm::exec_policy_nosync(stream), v.begin<T>(), v.end<T>(), m_view.begin<T>() + count);
     count += v.size();
   }
 

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -1269,7 +1269,10 @@ std::vector<packed_table> contiguous_split(cudf::table_view const& input,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::contiguous_split(input, splits, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::contiguous_split(input, splits, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 };  // namespace cudf

--- a/cpp/src/copying/copy.cpp
+++ b/cpp/src/copying/copy.cpp
@@ -183,7 +183,10 @@ std::unique_ptr<column> allocate_like(column_view const& input,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::allocate_like(input, input.size(), mask_alloc, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::allocate_like(input, input.size(), mask_alloc, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> allocate_like(column_view const& input,
@@ -192,7 +195,10 @@ std::unique_ptr<column> allocate_like(column_view const& input,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::allocate_like(input, size, mask_alloc, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::allocate_like(input, size, mask_alloc, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -415,7 +415,10 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_if_else(lhs, rhs, boolean_mask, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::copy_if_else(lhs, rhs, boolean_mask, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
@@ -424,7 +427,10 @@ std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_if_else(lhs, rhs, boolean_mask, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::copy_if_else(lhs, rhs, boolean_mask, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> copy_if_else(column_view const& lhs,
@@ -433,7 +439,10 @@ std::unique_ptr<column> copy_if_else(column_view const& lhs,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_if_else(lhs, rhs, boolean_mask, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::copy_if_else(lhs, rhs, boolean_mask, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> copy_if_else(scalar const& lhs,
@@ -442,7 +451,10 @@ std::unique_ptr<column> copy_if_else(scalar const& lhs,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_if_else(lhs, rhs, boolean_mask, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::copy_if_else(lhs, rhs, boolean_mask, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/copy.cu
+++ b/cpp/src/copying/copy.cu
@@ -162,7 +162,7 @@ std::unique_ptr<column> scatter_gather_based_if_else(cudf::column_view const& lh
                                                      rmm::mr::device_memory_resource* mr)
 {
   auto gather_map = rmm::device_uvector<size_type>{static_cast<std::size_t>(size), stream};
-  auto const gather_map_end = thrust::copy_if(rmm::exec_policy(stream),
+  auto const gather_map_end = thrust::copy_if(rmm::exec_policy_nosync(stream),
                                               thrust::make_counting_iterator(size_type{0}),
                                               thrust::make_counting_iterator(size_type{size}),
                                               gather_map.begin(),
@@ -196,7 +196,7 @@ std::unique_ptr<column> scatter_gather_based_if_else(cudf::scalar const& lhs,
                                                      rmm::mr::device_memory_resource* mr)
 {
   auto scatter_map = rmm::device_uvector<size_type>{static_cast<std::size_t>(size), stream};
-  auto const scatter_map_end = thrust::copy_if(rmm::exec_policy(stream),
+  auto const scatter_map_end = thrust::copy_if(rmm::exec_policy_nosync(stream),
                                                thrust::make_counting_iterator(size_type{0}),
                                                thrust::make_counting_iterator(size_type{size}),
                                                scatter_map.begin(),

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -273,8 +273,9 @@ void copy_range_in_place(column_view const& source,
                          size_type target_begin)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_range_in_place(
-    source, target, source_begin, source_end, target_begin, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  detail::copy_range_in_place(source, target, source_begin, source_end, target_begin, stream);
+  stream.synchronize();
 }
 
 std::unique_ptr<column> copy_range(column_view const& source,
@@ -285,8 +286,11 @@ std::unique_ptr<column> copy_range(column_view const& source,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::copy_range(
-    source, target, source_begin, source_end, target_begin, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::copy_range(source, target, source_begin, source_end, target_begin, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/gather.cu
+++ b/cpp/src/copying/gather.cu
@@ -84,8 +84,10 @@ std::unique_ptr<table> gather(table_view const& source_table,
   auto index_policy = is_unsigned(gather_map.type()) ? detail::negative_index_policy::NOT_ALLOWED
                                                      : detail::negative_index_policy::ALLOWED;
 
-  return detail::gather(
-    source_table, gather_map, bounds_policy, index_policy, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::gather(source_table, gather_map, bounds_policy, index_policy, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -208,7 +208,10 @@ std::unique_ptr<scalar> get_element(column_view const& input,
                                     size_type index,
                                     rmm::mr::device_memory_resource* mr)
 {
-  return detail::get_element(input, index, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::get_element(input, index, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/pack.cpp
+++ b/cpp/src/copying/pack.cpp
@@ -219,7 +219,10 @@ table_view unpack(uint8_t const* metadata, uint8_t const* gpu_data)
 packed_columns pack(cudf::table_view const& input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::pack(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::pack(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -50,7 +50,7 @@ bool has_nonempty_null_rows(cudf::column_view const& input, rmm::cuda_stream_vie
 
   auto const row_begin = thrust::counting_iterator<cudf::size_type>(0);
   auto const row_end   = row_begin + input.size();
-  return thrust::count_if(rmm::exec_policy(stream), row_begin, row_end, is_dirty_row) > 0;
+  return thrust::count_if(rmm::exec_policy_nosync(stream), row_begin, row_end, is_dirty_row) > 0;
 }
 
 }  // namespace

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -112,7 +112,10 @@ bool has_nonempty_nulls(column_view const& input) { return detail::has_nonempty_
 std::unique_ptr<cudf::column> purge_nonempty_nulls(lists_column_view const& input,
                                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::purge_nonempty_nulls(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::purge_nonempty_nulls(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -121,7 +124,10 @@ std::unique_ptr<cudf::column> purge_nonempty_nulls(lists_column_view const& inpu
 std::unique_ptr<cudf::column> purge_nonempty_nulls(structs_column_view const& input,
                                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::purge_nonempty_nulls(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::purge_nonempty_nulls(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -130,7 +136,10 @@ std::unique_ptr<cudf::column> purge_nonempty_nulls(structs_column_view const& in
 std::unique_ptr<cudf::column> purge_nonempty_nulls(strings_column_view const& input,
                                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::purge_nonempty_nulls(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::purge_nonempty_nulls(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/reverse.cu
+++ b/cpp/src/copying/reverse.cu
@@ -57,13 +57,19 @@ std::unique_ptr<column> reverse(column_view const& source_column,
 std::unique_ptr<table> reverse(table_view const& source_table, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::reverse(source_table, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::reverse(source_table, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> reverse(column_view const& source_column,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::reverse(source_column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::reverse(source_column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -66,7 +66,7 @@ std::unique_ptr<table> sample(table_view const& input,
       make_numeric_column(data_type{type_id::INT32}, num_rows, mask_state::UNALLOCATED, stream);
     auto gather_map_mutable_view = gather_map->mutable_view();
     // Shuffle all the row indices
-    thrust::shuffle_copy(rmm::exec_policy(stream),
+    thrust::shuffle_copy(rmm::exec_policy_nosync(stream),
                          thrust::counting_iterator<size_type>(0),
                          thrust::counting_iterator<size_type>(num_rows),
                          gather_map_mutable_view.begin<size_type>(),

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -93,7 +93,9 @@ std::unique_ptr<table> sample(table_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-
-  return detail::sample(input, n, replacement, seed, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::sample(input, n, replacement, seed, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -119,7 +119,7 @@ struct column_scalar_scatterer_impl {
     auto scalar_iter =
       thrust::make_permutation_iterator(scalar_impl->data(), thrust::make_constant_iterator(0));
 
-    thrust::scatter(rmm::exec_policy(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream),
                     scalar_iter,
                     scalar_iter + scatter_rows,
                     scatter_iter,
@@ -190,8 +190,11 @@ struct column_scalar_scatterer_impl<dictionary32, MapIterator> {
     auto new_indices = std::make_unique<column>(dict_view.get_indices_annotated(), stream, mr);
     auto target_iter = indexalator_factory::make_output_iterator(new_indices->mutable_view());
 
-    thrust::scatter(
-      rmm::exec_policy(stream), scalar_iter, scalar_iter + scatter_rows, scatter_iter, target_iter);
+    thrust::scatter(rmm::exec_policy_nosync(stream),
+                    scalar_iter,
+                    scalar_iter + scatter_rows,
+                    scatter_iter,
+                    target_iter);
 
     // build the dictionary indices column from the result
     auto const indices_type = new_indices->type();
@@ -346,7 +349,7 @@ std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<const scalar>>
   auto const n_rows = target.num_rows();
   if (check_bounds) {
     CUDF_EXPECTS(
-      indices.size() == thrust::count_if(rmm::exec_policy(stream),
+      indices.size() == thrust::count_if(rmm::exec_policy_nosync(stream),
                                          map_begin,
                                          map_end,
                                          [n_rows] __device__(size_type index) {
@@ -396,7 +399,7 @@ std::unique_ptr<column> boolean_mask_scatter(column_view const& input,
     data_type{type_id::INT32}, target.size(), mask_state::UNALLOCATED, stream);
   auto mutable_indices = indices->mutable_view();
 
-  thrust::sequence(rmm::exec_policy(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream),
                    mutable_indices.begin<size_type>(),
                    mutable_indices.end<size_type>(),
                    0);

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -512,7 +512,10 @@ std::unique_ptr<table> scatter(table_view const& source,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::scatter(source, scatter_map, target, check_bounds, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::scatter(source, scatter_map, target, check_bounds, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<const scalar>> const& source,
@@ -522,7 +525,10 @@ std::unique_ptr<table> scatter(std::vector<std::reference_wrapper<const scalar>>
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::scatter(source, indices, target, check_bounds, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::scatter(source, indices, target, check_bounds, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> boolean_mask_scatter(table_view const& input,
@@ -531,7 +537,10 @@ std::unique_ptr<table> boolean_mask_scatter(table_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::boolean_mask_scatter(input, target, boolean_mask, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::boolean_mask_scatter(input, target, boolean_mask, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> boolean_mask_scatter(
@@ -541,7 +550,10 @@ std::unique_ptr<table> boolean_mask_scatter(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::boolean_mask_scatter(input, target, boolean_mask, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::boolean_mask_scatter(input, target, boolean_mask, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -174,7 +174,10 @@ std::unique_ptr<column> shift(column_view const& input,
                               scalar const& fill_value,
                               rmm::mr::device_memory_resource* mr)
 {
-  return detail::shift(input, offset, fill_value, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::shift(input, offset, fill_value, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -141,7 +141,7 @@ struct shift_functor {
         return out_of_bounds(size, src_idx) ? *fill : input.element<T>(src_idx);
       };
 
-    thrust::transform(rmm::exec_policy(stream), index_begin, index_end, data, func_value);
+    thrust::transform(rmm::exec_policy_nosync(stream), index_begin, index_end, data, func_value);
 
     return output;
   }

--- a/cpp/src/copying/slice.cu
+++ b/cpp/src/copying/slice.cu
@@ -114,25 +114,37 @@ std::vector<table_view> slice(table_view const& input,
 std::vector<column_view> slice(column_view const& input, host_span<size_type const> indices)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice(input, indices, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::slice(input, indices, stream);
+  stream.synchronize();
+  return result;
 }
 
 std::vector<table_view> slice(table_view const& input, host_span<size_type const> indices)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice(input, indices, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::slice(input, indices, stream);
+  stream.synchronize();
+  return result;
 };
 
 std::vector<column_view> slice(column_view const& input, std::initializer_list<size_type> indices)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice(input, indices, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::slice(input, indices, stream);
+  stream.synchronize();
+  return result;
 }
 
 std::vector<table_view> slice(table_view const& input, std::initializer_list<size_type> indices)
 {
   CUDF_FUNC_RANGE();
-  return detail::slice(input, indices, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::slice(input, indices, stream);
+  stream.synchronize();
+  return result;
 };
 
 }  // namespace cudf

--- a/cpp/src/copying/split.cpp
+++ b/cpp/src/copying/split.cpp
@@ -86,26 +86,38 @@ std::vector<cudf::column_view> split(cudf::column_view const& input,
                                      host_span<size_type const> splits)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(input, splits, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::split(input, splits, stream);
+  stream.synchronize();
+  return result;
 }
 
 std::vector<cudf::table_view> split(cudf::table_view const& input,
                                     host_span<size_type const> splits)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(input, splits, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::split(input, splits, stream);
+  stream.synchronize();
+  return result;
 }
 
 std::vector<column_view> split(column_view const& input, std::initializer_list<size_type> splits)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(input, splits, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::split(input, splits, stream);
+  stream.synchronize();
+  return result;
 }
 
 std::vector<table_view> split(table_view const& input, std::initializer_list<size_type> splits)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(input, splits, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::split(input, splits, stream);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -537,8 +537,10 @@ std::unique_ptr<column> ceil_datetimes(column_view const& column,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::round_general(
-    detail::rounding_function::CEIL, freq, column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::round_general(detail::rounding_function::CEIL, freq, column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> floor_datetimes(column_view const& column,
@@ -546,8 +548,10 @@ std::unique_ptr<column> floor_datetimes(column_view const& column,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::round_general(
-    detail::rounding_function::FLOOR, freq, column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::round_general(detail::rounding_function::FLOOR, freq, column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> round_datetimes(column_view const& column,
@@ -555,67 +559,96 @@ std::unique_ptr<column> round_datetimes(column_view const& column,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::round_general(
-    detail::rounding_function::ROUND, freq, column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::round_general(detail::rounding_function::ROUND, freq, column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> extract_year(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_year(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_year(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> extract_month(column_view const& column,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_month(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_month(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> extract_day(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_day(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_day(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> extract_weekday(column_view const& column,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_weekday(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_weekday(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> extract_hour(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_hour(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_hour(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> extract_minute(column_view const& column,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_minute(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_minute(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> extract_second(column_view const& column,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_second(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_second(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> last_day_of_month(column_view const& column,
                                           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::last_day_of_month(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::last_day_of_month(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> day_of_year(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::day_of_year(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::day_of_year(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> add_calendrical_months(cudf::column_view const& timestamp_column,
@@ -623,8 +656,10 @@ std::unique_ptr<cudf::column> add_calendrical_months(cudf::column_view const& ti
                                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::add_calendrical_months(
-    timestamp_column, months_column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::add_calendrical_months(timestamp_column, months_column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> add_calendrical_months(cudf::column_view const& timestamp_column,
@@ -632,27 +667,39 @@ std::unique_ptr<cudf::column> add_calendrical_months(cudf::column_view const& ti
                                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::add_calendrical_months(timestamp_column, months, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::add_calendrical_months(timestamp_column, months, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> is_leap_year(column_view const& column, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_leap_year(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_leap_year(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> days_in_month(column_view const& column,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::days_in_month(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::days_in_month(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> extract_quarter(column_view const& column,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_quarter(column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_quarter(column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace datetime

--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -253,7 +253,7 @@ struct dispatch_round {
                                           stream,
                                           mr);
 
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       column.begin<Timestamp>(),
                       column.end<Timestamp>(),
                       output->mutable_view().begin<Timestamp>(),
@@ -289,7 +289,7 @@ struct launch_functor {
   std::enable_if_t<cudf::is_timestamp_t<Timestamp>::value, void> operator()(
     rmm::cuda_stream_view stream) const
   {
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       input.begin<Timestamp>(),
                       input.end<Timestamp>(),
                       output.begin<OutputColT>(),
@@ -353,7 +353,7 @@ struct add_calendrical_months_functor {
       make_fixed_width_column(output_col_type, size, mask_state::UNALLOCATED, stream, mr);
     auto output_mview = output->mutable_view();
 
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       timestamp_column.begin<Timestamp>(),
                       timestamp_column.end<Timestamp>(),
                       months_begin,

--- a/cpp/src/dictionary/add_keys.cu
+++ b/cpp/src/dictionary/add_keys.cu
@@ -132,7 +132,10 @@ std::unique_ptr<column> add_keys(dictionary_column_view const& dictionary_column
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::add_keys(dictionary_column, keys, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::add_keys(dictionary_column, keys, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/decode.cu
+++ b/cpp/src/dictionary/decode.cu
@@ -68,7 +68,10 @@ std::unique_ptr<column> decode(dictionary_column_view const& source,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::decode(source, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::decode(source, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -167,7 +167,7 @@ struct dispatch_compute_indices {
     // new indices values are computed by matching the concatenated keys to the new key set
 
 #ifdef NDEBUG
-    thrust::lower_bound(rmm::exec_policy(stream),
+    thrust::lower_bound(rmm::exec_policy_nosync(stream),
                         begin,
                         end,
                         all_itr,
@@ -178,7 +178,7 @@ struct dispatch_compute_indices {
     // There is a problem with thrust::lower_bound and the output_indexalator.
     // https://github.com/NVIDIA/thrust/issues/1452; thrust team created nvbug 3322776
     // This is a workaround.
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       all_itr,
                       all_itr + all_indices.size(),
                       result_itr,
@@ -257,7 +257,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
     });
   // the indices offsets (pair.second) are for building the map
   thrust::lower_bound(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     children_offsets.begin() + 1,
     children_offsets.end(),
     indices_itr,

--- a/cpp/src/dictionary/detail/merge.cu
+++ b/cpp/src/dictionary/detail/merge.cu
@@ -50,7 +50,7 @@ std::unique_ptr<column> merge(dictionary_column_view const& lcol,
     cudf::detail::indexalator_factory::make_output_iterator(indices_column->mutable_view());
 
   // merge the input indices columns into the output column
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     row_order.begin(),
                     row_order.end(),
                     output_iter,

--- a/cpp/src/dictionary/encode.cu
+++ b/cpp/src/dictionary/encode.cu
@@ -92,7 +92,10 @@ std::unique_ptr<column> encode(column_view const& input_column,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::encode(input_column, indices_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::encode(input_column, indices_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -200,14 +200,20 @@ std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_col
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::remove_keys(dictionary_column, keys_to_remove, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::remove_keys(dictionary_column, keys_to_remove, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& dictionary_column,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::remove_unused_keys(dictionary_column, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::remove_unused_keys(dictionary_column, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -72,7 +72,7 @@ std::unique_ptr<column> remove_keys_fn(
   auto map_itr =
     cudf::detail::indexalator_factory::make_output_iterator(map_indices->mutable_view());
   // init to max to identify new nulls
-  thrust::fill(rmm::exec_policy(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream),
                map_itr,
                map_itr + keys_view.size(),
                max_size);  // all valid indices are less than this value
@@ -84,7 +84,7 @@ std::unique_ptr<column> remove_keys_fn(
       auto positions = make_fixed_width_column(
         indices_type, keys_view.size(), cudf::mask_state::UNALLOCATED, stream);
       auto itr = cudf::detail::indexalator_factory::make_output_iterator(positions->mutable_view());
-      thrust::sequence(rmm::exec_policy(stream), itr, itr + keys_view.size());
+      thrust::sequence(rmm::exec_policy_nosync(stream), itr, itr + keys_view.size());
       return positions;
     }();
     // copy the non-removed keys ( keys_to_keep_fn(idx)==true )
@@ -98,7 +98,7 @@ std::unique_ptr<column> remove_keys_fn(
       cudf::detail::indexalator_factory::make_input_iterator(keys_positions->view());
     // build indices mapper
     // Example scatter([0,1,2][0,2,4][max,max,max,max,max]) => [0,max,1,max,2]
-    thrust::scatter(rmm::exec_policy(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream),
                     positions_itr,
                     positions_itr + filtered_view.size(),
                     filtered_itr,
@@ -179,7 +179,7 @@ std::unique_ptr<column> remove_unused_keys(
   auto const matches = [&] {
     // build keys index to verify against indices values
     rmm::device_uvector<uint32_t> keys_positions(keys_size, stream);
-    thrust::sequence(rmm::exec_policy(stream), keys_positions.begin(), keys_positions.end());
+    thrust::sequence(rmm::exec_policy_nosync(stream), keys_positions.begin(), keys_positions.end());
     // wrap the indices for comparison in contains()
     column_view keys_positions_view(data_type{type_id::UINT32}, keys_size, keys_positions.data());
     return cudf::detail::contains(indices_view, keys_positions_view, stream, mr);

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -124,8 +124,10 @@ struct find_insert_index_fn {
     using ScalarType = cudf::scalar_type_t<Element>;
     auto find_key    = static_cast<ScalarType const&>(key).value(stream);
     auto keys_view   = column_device_view::create(input.keys(), stream);
-    auto iter        = thrust::lower_bound(
-      rmm::exec_policy(stream), keys_view->begin<Element>(), keys_view->end<Element>(), find_key);
+    auto iter        = thrust::lower_bound(rmm::exec_policy_nosync(stream),
+                                    keys_view->begin<Element>(),
+                                    keys_view->end<Element>(),
+                                    find_key);
     return type_dispatcher(input.indices().type(),
                            dispatch_scalar_index{},
                            thrust::distance(keys_view->begin<Element>(), iter),

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -182,7 +182,10 @@ std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::get_index(dictionary, key, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::get_index(dictionary, key, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace dictionary

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -80,7 +80,7 @@ struct dispatch_compute_indices {
       cudf::detail::indexalator_factory::make_output_iterator(result->mutable_view());
 
 #ifdef NDEBUG
-    thrust::lower_bound(rmm::exec_policy(stream),
+    thrust::lower_bound(rmm::exec_policy_nosync(stream),
                         begin,
                         end,
                         dictionary_itr,
@@ -91,7 +91,7 @@ struct dispatch_compute_indices {
     // There is a problem with thrust::lower_bound and the output_indexalator
     // https://github.com/NVIDIA/thrust/issues/1452; thrust team created nvbug 3322776
     // This is a workaround.
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       dictionary_itr,
                       dictionary_itr + input.size(),
                       result_itr,

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -245,14 +245,20 @@ std::unique_ptr<column> set_keys(dictionary_column_view const& dictionary_column
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::set_keys(dictionary_column, keys, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::set_keys(dictionary_column, keys, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::vector<std::unique_ptr<column>> match_dictionaries(
   cudf::host_span<dictionary_column_view const> input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::match_dictionaries(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::match_dictionaries(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace dictionary

--- a/cpp/src/filling/calendrical_month_sequence.cu
+++ b/cpp/src/filling/calendrical_month_sequence.cu
@@ -41,7 +41,10 @@ std::unique_ptr<cudf::column> calendrical_month_sequence(size_type size,
                                                          size_type months,
                                                          rmm::mr::device_memory_resource* mr)
 {
-  return detail::calendrical_month_sequence(size, init, months, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::calendrical_month_sequence(size, init, months, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -248,7 +248,9 @@ void fill_in_place(mutable_column_view& destination,
                    scalar const& value)
 {
   CUDF_FUNC_RANGE();
-  return detail::fill_in_place(destination, begin, end, value, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  detail::fill_in_place(destination, begin, end, value, stream);
+  stream.synchronize();
 }
 
 std::unique_ptr<column> fill(column_view const& input,
@@ -258,7 +260,10 @@ std::unique_ptr<column> fill(column_view const& input,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::fill(input, begin, end, value, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::fill(input, begin, end, value, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/filling/repeat.cu
+++ b/cpp/src/filling/repeat.cu
@@ -166,7 +166,10 @@ std::unique_ptr<table> repeat(table_view const& input_table,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat(input_table, count, check_count, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::repeat(input_table, count, check_count, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> repeat(table_view const& input_table,
@@ -174,7 +177,10 @@ std::unique_ptr<table> repeat(table_view const& input_table,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat(input_table, count, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::repeat(input_table, count, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -17,6 +17,7 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
@@ -152,14 +153,22 @@ std::unique_ptr<column> sequence(size_type size,
                                  scalar const& step,
                                  rmm::mr::device_memory_resource* mr)
 {
-  return detail::sequence(size, init, step, cudf::default_stream_value, mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::sequence(size, init, step, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> sequence(size_type size,
                                  scalar const& init,
                                  rmm::mr::device_memory_resource* mr)
 {
-  return detail::sequence(size, init, cudf::default_stream_value, mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::sequence(size, init, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -78,7 +78,7 @@ struct sequence_functor {
     // not using thrust::sequence because it requires init and step to be passed as
     // constants, not iterators. to do that we would have to retrieve the scalar values off the gpu,
     // which is undesirable from a performance perspective.
-    thrust::tabulate(rmm::exec_policy(stream),
+    thrust::tabulate(rmm::exec_policy_nosync(stream),
                      result_device_view->begin<T>(),
                      result_device_view->end<T>(),
                      tabulator<T>{n_init, n_step});
@@ -102,7 +102,7 @@ struct sequence_functor {
     // not using thrust::sequence because it requires init and step to be passed as
     // constants, not iterators. to do that we would have to retrieve the scalar values off the gpu,
     // which is undesirable from a performance perspective.
-    thrust::tabulate(rmm::exec_policy(stream),
+    thrust::tabulate(rmm::exec_policy_nosync(stream),
                      result_device_view->begin<T>(),
                      result_device_view->end<T>(),
                      const_tabulator<T>{n_init});

--- a/cpp/src/groupby/groupby.cu
+++ b/cpp/src/groupby/groupby.cu
@@ -196,7 +196,10 @@ std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::aggr
 
   if (_keys.num_rows() == 0) { return std::pair(empty_like(_keys), empty_results(requests)); }
 
-  return dispatch_aggregation(requests, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = dispatch_aggregation(requests, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 // Compute scan requests
@@ -214,7 +217,10 @@ std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::scan
 
   if (_keys.num_rows() == 0) { return std::pair(empty_like(_keys), empty_results(requests)); }
 
-  return sort_scan(requests, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = sort_scan(requests, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 groupby::groups groupby::get_groups(table_view values, rmm::mr::device_memory_resource* mr)

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -332,7 +332,7 @@ class hash_compound_agg_finalizer final : public cudf::detail::aggregation_final
     cudf::detail::initialize_with_identity(var_table_view, {agg.kind}, stream);
 
     thrust::for_each_n(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator(0),
       col.size(),
       ::cudf::detail::var_hash_functor<map_type>{
@@ -484,7 +484,7 @@ void compute_single_pass_aggs(table_view const& keys,
     skip_key_rows_with_nulls ? cudf::detail::bitmask_and(keys, stream).first : rmm::device_buffer{};
 
   thrust::for_each_n(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator(0),
     keys.num_rows(),
     hash::compute_single_pass_aggs_fn<map_type>{map,
@@ -516,7 +516,7 @@ rmm::device_uvector<size_type> extract_populated_keys(map_type const& map,
   auto get_key_it = thrust::make_transform_iterator(map.data(), get_key);
   auto key_used   = [unused = map.get_unused_key()] __device__(auto key) { return key != unused; };
 
-  auto end_it = thrust::copy_if(rmm::exec_policy(stream),
+  auto end_it = thrust::copy_if(rmm::exec_policy_nosync(stream),
                                 get_key_it,
                                 get_key_it + map.capacity(),
                                 populated_keys.begin(),

--- a/cpp/src/groupby/sort/group_argmax.cu
+++ b/cpp/src/groupby/sort/group_argmax.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ std::unique_ptr<column> group_argmax(column_view const& values,
   // initialized to ARGMAX_SENTINEL. Using gather_if.
   // This can't use gather because nulls in gathered column will not store ARGMAX_SENTINEL.
   auto indices_view = indices->mutable_view();
-  thrust::gather_if(rmm::exec_policy(stream),
+  thrust::gather_if(rmm::exec_policy_nosync(stream),
                     indices_view.begin<size_type>(),    // map first
                     indices_view.end<size_type>(),      // map last
                     indices_view.begin<size_type>(),    // stencil

--- a/cpp/src/groupby/sort/group_argmin.cu
+++ b/cpp/src/groupby/sort/group_argmin.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ std::unique_ptr<column> group_argmin(column_view const& values,
   // initialized to ARGMIN_SENTINEL. Using gather_if.
   // This can't use gather because nulls in gathered column will not store ARGMIN_SENTINEL.
   auto indices_view = indices->mutable_view();
-  thrust::gather_if(rmm::exec_policy(stream),
+  thrust::gather_if(rmm::exec_policy_nosync(stream),
                     indices_view.begin<size_type>(),    // map first
                     indices_view.end<size_type>(),      // map last
                     indices_view.begin<size_type>(),    // stencil

--- a/cpp/src/groupby/sort/group_collect.cu
+++ b/cpp/src/groupby/sort/group_collect.cu
@@ -69,7 +69,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
   rmm::device_uvector<size_type> null_purged_sizes(num_groups, stream);
 
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(num_groups),
     null_purged_sizes.begin(),
@@ -98,7 +98,7 @@ std::unique_ptr<column> group_collect(column_view const& values,
     auto offsets_column = make_numeric_column(
       data_type(type_to_id<offset_type>()), num_groups + 1, mask_state::UNALLOCATED, stream, mr);
 
-    thrust::copy(rmm::exec_policy(stream),
+    thrust::copy(rmm::exec_policy_nosync(stream),
                  group_offsets.begin(),
                  group_offsets.end(),
                  offsets_column->mutable_view().template begin<offset_type>());

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -161,7 +161,7 @@ std::unique_ptr<column> group_covariance(column_view const& values_0,
   auto corr_iter =
     thrust::make_transform_iterator(thrust::make_counting_iterator(0), covariance_transform_op);
 
-  thrust::reduce_by_key(rmm::exec_policy(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                         group_labels.begin(),
                         group_labels.end(),
                         corr_iter,
@@ -198,7 +198,7 @@ std::unique_ptr<column> group_correlation(column_view const& covariance,
                                     stream,
                                     mr);
   auto d_result    = result->mutable_view().begin<result_type>();
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     covariance.begin<result_type>(),
                     covariance.end<result_type>(),
                     stddev_iter,

--- a/cpp/src/groupby/sort/group_count.cu
+++ b/cpp/src/groupby/sort/group_count.cu
@@ -56,14 +56,14 @@ std::unique_ptr<column> group_count_valid(column_view const& values,
       thrust::make_transform_iterator(cudf::detail::make_validity_iterator(*values_view),
                                       [] __device__(auto b) { return static_cast<size_type>(b); });
 
-    thrust::reduce_by_key(rmm::exec_policy(stream),
+    thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                           group_labels.begin(),
                           group_labels.end(),
                           bitmask_iterator,
                           thrust::make_discard_iterator(),
                           result->mutable_view().begin<size_type>());
   } else {
-    thrust::reduce_by_key(rmm::exec_policy(stream),
+    thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                           group_labels.begin(),
                           group_labels.end(),
                           thrust::make_constant_iterator(1),
@@ -86,7 +86,7 @@ std::unique_ptr<column> group_count_all(cudf::device_span<size_type const> group
 
   if (num_groups == 0) { return result; }
 
-  thrust::adjacent_difference(rmm::exec_policy(stream),
+  thrust::adjacent_difference(rmm::exec_policy_nosync(stream),
                               group_offsets.begin() + 1,
                               group_offsets.end(),
                               result->mutable_view().begin<size_type>());

--- a/cpp/src/groupby/sort/group_count_scan.cu
+++ b/cpp/src/groupby/sort/group_count_scan.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ std::unique_ptr<column> count_scan(cudf::device_span<size_type const> group_labe
 
   auto resultview = result->mutable_view();
   // aggregation::COUNT_ALL
-  thrust::exclusive_scan_by_key(rmm::exec_policy(stream),
+  thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(stream),
                                 group_labels.begin(),
                                 group_labels.end(),
                                 thrust::make_constant_iterator<size_type>(1),

--- a/cpp/src/groupby/sort/group_m2.cu
+++ b/cpp/src/groupby/sort/group_m2.cu
@@ -67,7 +67,7 @@ void compute_m2_fn(column_device_view const& values,
     m2_transform<ResultType, decltype(values_iter)>{
       values, values_iter, d_means, group_labels.data()});
 
-  thrust::reduce_by_key(rmm::exec_policy(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                         group_labels.begin(),
                         group_labels.end(),
                         var_iter,

--- a/cpp/src/groupby/sort/group_merge_lists.cu
+++ b/cpp/src/groupby/sort/group_merge_lists.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ std::unique_ptr<column> group_merge_lists(column_view const& values,
   //
   //   then, the output offsets_column is [0, 5, 8].
   //
-  thrust::gather(rmm::exec_policy(stream),
+  thrust::gather(rmm::exec_policy_nosync(stream),
                  group_offsets.begin(),
                  group_offsets.end(),
                  lists_column_view(values).offsets_begin(),

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -174,7 +174,7 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
                                         count_valid.template begin<size_type>(),
                                         mean_values.template begin<result_type>(),
                                         M2_values.template begin<result_type>()};
-  thrust::transform(rmm::exec_policy(stream), iter, iter + num_groups, out_iter, fn);
+  thrust::transform(rmm::exec_policy_nosync(stream), iter, iter + num_groups, out_iter, fn);
 
   // Generate bitmask for the output.
   // Only mean and M2 values can be nullable. Count column must be non-nullable.

--- a/cpp/src/groupby/sort/group_nth_element.cu
+++ b/cpp/src/groupby/sort/group_nth_element.cu
@@ -58,13 +58,13 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
   auto nth_index = rmm::device_uvector<size_type>(num_groups, stream);
   // TODO: replace with async version
   thrust::uninitialized_fill_n(
-    rmm::exec_policy(stream), nth_index.begin(), num_groups, values.size());
+    rmm::exec_policy_nosync(stream), nth_index.begin(), num_groups, values.size());
 
   // nulls_policy::INCLUDE (equivalent to pandas nth(dropna=None) but return nulls for n
   if (null_handling == null_policy::INCLUDE || !values.has_nulls()) {
     // Returns index of nth value.
     thrust::transform_if(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       group_sizes.begin<size_type>(),
       group_sizes.end<size_type>(),
       group_offsets.begin(),
@@ -84,7 +84,7 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
                                       [] __device__(auto b) { return static_cast<size_type>(b); });
     rmm::device_uvector<size_type> intra_group_index(values.size(), stream);
     // intra group index for valids only.
-    thrust::exclusive_scan_by_key(rmm::exec_policy(stream),
+    thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(stream),
                                   group_labels.begin(),
                                   group_labels.end(),
                                   bitmask_iterator,
@@ -93,7 +93,7 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
     rmm::device_uvector<size_type> group_count = [&] {
       if (n < 0) {
         rmm::device_uvector<size_type> group_count(num_groups, stream);
-        thrust::reduce_by_key(rmm::exec_policy(stream),
+        thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                               group_labels.begin(),
                               group_labels.end(),
                               bitmask_iterator,
@@ -105,7 +105,7 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
       }
     }();
     // gather the valid index == n
-    thrust::scatter_if(rmm::exec_policy(stream),
+    thrust::scatter_if(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        thrust::make_counting_iterator<size_type>(values.size()),
                        group_labels.begin(),                          // map

--- a/cpp/src/groupby/sort/group_nunique.cu
+++ b/cpp/src/groupby/sort/group_nunique.cu
@@ -91,7 +91,7 @@ struct nunique_functor {
                                                  null_handling,
                                                  group_offsets.data(),
                                                  group_labels.data()});
-    thrust::reduce_by_key(rmm::exec_policy(stream),
+    thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                           group_labels.begin(),
                           group_labels.end(),
                           is_unique_iterator,

--- a/cpp/src/groupby/sort/group_quantiles.cu
+++ b/cpp/src/groupby/sort/group_quantiles.cu
@@ -108,7 +108,7 @@ struct quantiles_functor {
     // For each group, calculate quantile
     if (!cudf::is_dictionary(values.type())) {
       auto values_iter = values_view->begin<T>();
-      thrust::for_each_n(rmm::exec_policy(stream),
+      thrust::for_each_n(rmm::exec_policy_nosync(stream),
                          thrust::make_counting_iterator(0),
                          num_groups,
                          calculate_quantile_fn<ResultType, decltype(values_iter)>{
@@ -121,7 +121,7 @@ struct quantiles_functor {
                            interpolation});
     } else {
       auto values_iter = cudf::dictionary::detail::make_dictionary_iterator<T>(*values_view);
-      thrust::for_each_n(rmm::exec_policy(stream),
+      thrust::for_each_n(rmm::exec_policy_nosync(stream),
                          thrust::make_counting_iterator(0),
                          num_groups,
                          calculate_quantile_fn<ResultType, decltype(values_iter)>{

--- a/cpp/src/groupby/sort/group_rank_scan.cu
+++ b/cpp/src/groupby/sort/group_rank_scan.cu
@@ -128,7 +128,7 @@ std::unique_ptr<column> rank_generator(column_view const& grouped_values,
                       row_index - group_start);
     }
   };
-  thrust::tabulate(rmm::exec_policy(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream),
                    mutable_ranks.begin<size_type>(),
                    mutable_ranks.end<size_type>(),
                    unique_identifier);
@@ -141,7 +141,7 @@ std::unique_ptr<column> rank_generator(column_view const& grouped_values,
                           thrust::reverse_iterator(mutable_ranks.end<size_type>())};
     }
   }();
-  thrust::inclusive_scan_by_key(rmm::exec_policy(stream),
+  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
                                 group_labels_begin,
                                 group_labels_begin + group_labels.size(),
                                 mutable_rank_begin,
@@ -204,7 +204,7 @@ std::unique_ptr<column> first_rank_scan(column_view const& grouped_values,
   auto ranks = make_fixed_width_column(
     data_type{type_to_id<size_type>()}, group_labels.size(), mask_state::UNALLOCATED, stream, mr);
   auto mutable_ranks = ranks->mutable_view();
-  thrust::tabulate(rmm::exec_policy(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream),
                    mutable_ranks.begin<size_type>(),
                    mutable_ranks.end<size_type>(),
                    [labels  = group_labels.begin(),
@@ -237,7 +237,7 @@ std::unique_ptr<column> average_rank_scan(column_view const& grouped_values,
   auto ranks    = make_fixed_width_column(
     data_type{type_to_id<double>()}, group_labels.size(), mask_state::UNALLOCATED, stream, mr);
   auto mutable_ranks = ranks->mutable_view();
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     max_rank->view().begin<size_type>(),
                     max_rank->view().end<size_type>(),
                     min_rank->view().begin<size_type>(),
@@ -286,7 +286,7 @@ std::unique_ptr<column> group_rank_to_percentage(rank_method const method,
     return group_size == 1 ? 0.0 : ((rank - 1.0) / (group_size - 1));
   };
   if (method == rank_method::DENSE) {
-    thrust::tabulate(rmm::exec_policy(stream),
+    thrust::tabulate(rmm::exec_policy_nosync(stream),
                      mutable_ranks.begin<double>(),
                      mutable_ranks.end<double>(),
                      [percentage,
@@ -306,7 +306,7 @@ std::unique_ptr<column> group_rank_to_percentage(rank_method const method,
                                 : one_normalized(r, last_rank);
                      });
   } else {
-    thrust::tabulate(rmm::exec_policy(stream),
+    thrust::tabulate(rmm::exec_policy_nosync(stream),
                      mutable_ranks.begin<double>(),
                      mutable_ranks.end<double>(),
                      [percentage,

--- a/cpp/src/groupby/sort/group_replace_nulls.cu
+++ b/cpp/src/groupby/sort/group_replace_nulls.cu
@@ -56,7 +56,7 @@ std::unique_ptr<column> group_replace_nulls(cudf::column_view const& grouped_val
   auto func = cudf::detail::replace_policy_functor();
   thrust::equal_to<cudf::size_type> eq;
   if (replace_policy == cudf::replace_policy::PRECEDING) {
-    thrust::inclusive_scan_by_key(rmm::exec_policy(stream),
+    thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
                                   group_labels.begin(),
                                   group_labels.begin() + size,
                                   in_begin,
@@ -68,7 +68,7 @@ std::unique_ptr<column> group_replace_nulls(cudf::column_view const& grouped_val
     auto in_rbegin = thrust::make_reverse_iterator(in_begin + size);
     auto gm_rbegin = thrust::make_reverse_iterator(gm_begin + size);
     thrust::inclusive_scan_by_key(
-      rmm::exec_policy(stream), gl_rbegin, gl_rbegin + size, in_rbegin, gm_rbegin, eq, func);
+      rmm::exec_policy_nosync(stream), gl_rbegin, gl_rbegin + size, in_rbegin, gm_rbegin, eq, func);
   }
 
   auto output = cudf::detail::gather(cudf::table_view({grouped_value}),

--- a/cpp/src/groupby/sort/group_scan_util.cuh
+++ b/cpp/src/groupby/sort/group_scan_util.cuh
@@ -110,7 +110,7 @@ struct group_scan_functor<K, T, std::enable_if_t<is_group_scan_supported<K, T>()
 
     // Perform segmented scan.
     auto const do_scan = [&](auto const& inp_iter, auto const& out_iter, auto const& binop) {
-      thrust::inclusive_scan_by_key(rmm::exec_policy(stream),
+      thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
                                     group_labels.begin(),
                                     group_labels.end(),
                                     inp_iter,
@@ -155,7 +155,7 @@ struct group_scan_functor<K,
 
     // Perform segmented scan.
     auto const do_scan = [&](auto const& inp_iter, auto const& out_iter, auto const& binop) {
-      thrust::inclusive_scan_by_key(rmm::exec_policy(stream),
+      thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
                                     group_labels.begin(),
                                     group_labels.end(),
                                     inp_iter,
@@ -197,7 +197,7 @@ struct group_scan_functor<K,
 
     auto const binop_generator =
       cudf::reduction::detail::comparison_binop_generator::create<K>(values, stream);
-    thrust::inclusive_scan_by_key(rmm::exec_policy(stream),
+    thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
                                   group_labels.begin(),
                                   group_labels.end(),
                                   thrust::make_counting_iterator<size_type>(0),

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -166,7 +166,7 @@ struct group_reduction_functor<K, T, std::enable_if_t<is_group_reduction_support
 
     // Perform segmented reduction.
     auto const do_reduction = [&](auto const& inp_iter, auto const& out_iter, auto const& binop) {
-      thrust::reduce_by_key(rmm::exec_policy(stream),
+      thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                             group_labels.data(),
                             group_labels.data() + group_labels.size(),
                             inp_iter,
@@ -229,7 +229,7 @@ struct group_reduction_functor<
 
     // Perform segmented reduction to find ARGMIN/ARGMAX.
     auto const do_reduction = [&](auto const& inp_iter, auto const& out_iter, auto const& binop) {
-      thrust::reduce_by_key(rmm::exec_policy(stream),
+      thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                             group_labels.data(),
                             group_labels.data() + group_labels.size(),
                             inp_iter,

--- a/cpp/src/groupby/sort/group_std.cu
+++ b/cpp/src/groupby/sort/group_std.cu
@@ -80,7 +80,7 @@ void reduce_by_key_fn(column_device_view const& values,
     var_transform<ResultType, decltype(values_iter)>{
       values, values_iter, d_means, d_group_sizes, group_labels.data(), ddof});
 
-  thrust::reduce_by_key(rmm::exec_policy(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                         group_labels.begin(),
                         group_labels.end(),
                         var_iter,
@@ -129,7 +129,7 @@ struct var_functor {
 
     // set nulls
     auto result_view = mutable_column_device_view::create(*result, stream);
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator(0),
                        group_sizes.size(),
                        [d_result = *result_view, d_group_sizes, ddof] __device__(size_type i) {

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -149,7 +149,7 @@ column_view sort_groupby_helper::key_sort_order(rmm::cuda_stream_view stream)
 
     auto d_key_sorted_order = _key_sorted_order->mutable_view().data<size_type>();
 
-    thrust::sequence(rmm::exec_policy(stream),
+    thrust::sequence(rmm::exec_policy_nosync(stream),
                      d_key_sorted_order,
                      d_key_sorted_order + _key_sorted_order->size(),
                      0);
@@ -196,7 +196,7 @@ sort_groupby_helper::index_vector const& sort_groupby_helper::group_offsets(
   decltype(_group_offsets->begin()) result_end;
 
   result_end = thrust::unique_copy(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(num_keys(stream)),
     _group_offsets->begin(),
@@ -265,7 +265,7 @@ column_view sort_groupby_helper::keys_bitmask_column(rmm::cuda_stream_view strea
   auto keys_bitmask_view = _keys_bitmask_column->mutable_view();
   using T                = id_to_type<type_id::INT8>;
   thrust::fill(
-    rmm::exec_policy(stream), keys_bitmask_view.begin<T>(), keys_bitmask_view.end<T>(), 0);
+    rmm::exec_policy_nosync(stream), keys_bitmask_view.begin<T>(), keys_bitmask_view.end<T>(), 0);
 
   return _keys_bitmask_column->view();
 }

--- a/cpp/src/hash/hashing.cu
+++ b/cpp/src/hash/hashing.cu
@@ -74,7 +74,10 @@ std::unique_ptr<column> hash(table_view const& input,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::hash(input, hash_function, seed, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::hash(input, hash_function, seed, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/hash/md5_hash.cu
+++ b/cpp/src/hash/md5_hash.cu
@@ -252,7 +252,7 @@ std::unique_ptr<column> md5_hash(table_view const& input,
 
   // Hash each row, hashing each element sequentially left to right
   thrust::for_each(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator(0),
     thrust::make_counting_iterator(input.num_rows()),
     [d_chars, device_input = *device_input] __device__(auto row_index) {

--- a/cpp/src/hash/murmur_hash.cu
+++ b/cpp/src/hash/murmur_hash.cu
@@ -47,7 +47,7 @@ std::unique_ptr<column> murmur_hash3_32(table_view const& input,
   auto output_view      = output->mutable_view();
 
   // Compute the hash value for each row
-  thrust::tabulate(rmm::exec_policy(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream),
                    output_view.begin<hash_value_type>(),
                    output_view.end<hash_value_type>(),
                    row_hasher.device_hasher<MurmurHash3_32>(nullable, seed));

--- a/cpp/src/hash/spark_murmur_hash.cu
+++ b/cpp/src/hash/spark_murmur_hash.cu
@@ -415,7 +415,7 @@ std::unique_ptr<column> spark_murmur_hash3_32(table_view const& input,
 
   // Compute the hash value for each row
   thrust::tabulate(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     output_view.begin<spark_hash_value_type>(),
     output_view.end<spark_hash_value_type>(),
     row_hasher.device_hasher<SparkMurmurHash3_32, spark_murmur_device_row_hasher>(nullable, seed));

--- a/cpp/src/hash/unordered_multiset.cuh
+++ b/cpp/src/hash/unordered_multiset.cuh
@@ -95,7 +95,7 @@ class unordered_multiset {
     size_type* d_hash_bins_end   = hash_bins_end.data();
     Element* d_hash_data         = hash_data.data();
 
-    thrust::for_each(rmm::exec_policy(stream),
+    thrust::for_each(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      thrust::make_counting_iterator<size_type>(col.size()),
                      [d_hash_bins_start, d_col, hasher] __device__(size_t idx) {
@@ -106,17 +106,17 @@ class unordered_multiset {
                        }
                      });
 
-    thrust::exclusive_scan(rmm::exec_policy(stream),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
                            hash_bins_start.begin(),
                            hash_bins_start.end(),
                            hash_bins_end.begin());
 
-    thrust::copy(rmm::exec_policy(stream),
+    thrust::copy(rmm::exec_policy_nosync(stream),
                  hash_bins_end.begin(),
                  hash_bins_end.end(),
                  hash_bins_start.begin());
 
-    thrust::for_each(rmm::exec_policy(stream),
+    thrust::for_each(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      thrust::make_counting_iterator<size_type>(col.size()),
                      [d_hash_bins_end, d_hash_data, d_col, hasher] __device__(size_t idx) {

--- a/cpp/src/interop/dlpack.cpp
+++ b/cpp/src/interop/dlpack.cpp
@@ -293,12 +293,18 @@ DLManagedTensor* to_dlpack(table_view const& input,
 std::unique_ptr<table> from_dlpack(DLManagedTensor const* managed_tensor,
                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::from_dlpack(managed_tensor, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::from_dlpack(managed_tensor, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 DLManagedTensor* to_dlpack(table_view const& input, rmm::mr::device_memory_resource* mr)
 {
-  return detail::to_dlpack(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_dlpack(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/interop/from_arrow.cu
+++ b/cpp/src/interop/from_arrow.cu
@@ -449,8 +449,10 @@ std::unique_ptr<table> from_arrow(arrow::Table const& input_table,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-
-  return detail::from_arrow(input_table, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::from_arrow(input_table, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -190,7 +190,7 @@ std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<numeric::decimal128>
 
   rmm::device_uvector<DeviceType> buf(input.size(), stream);
 
-  thrust::copy(rmm::exec_policy(stream),  //
+  thrust::copy(rmm::exec_policy_nosync(stream),  //
                input.begin<DeviceType>(),
                input.end<DeviceType>(),
                buf.begin());

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -415,7 +415,10 @@ std::shared_ptr<arrow::Table> to_arrow(table_view input,
 {
   CUDF_FUNC_RANGE();
 
-  return detail::to_arrow(input, metadata, cudf::default_stream_value, ar_mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_arrow(input, metadata, stream, ar_mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -287,7 +287,7 @@ rmm::device_buffer decompress_data(datasource& source,
                         0);
     uncompressed_data_offsets.host_to_device(stream);
 
-    thrust::tabulate(rmm::exec_policy(stream),
+    thrust::tabulate(rmm::exec_policy_nosync(stream),
                      uncompressed_data_ptrs.begin(),
                      uncompressed_data_ptrs.end(),
                      [off  = uncompressed_data_offsets.device_ptr(),
@@ -310,12 +310,12 @@ rmm::device_buffer decompress_data(datasource& source,
                                                 stream);
     CUDF_EXPECTS(status == nvcompStatus_t::nvcompSuccess, "unable to perform snappy decompression");
 
-    CUDF_EXPECTS(thrust::equal(rmm::exec_policy(stream),
+    CUDF_EXPECTS(thrust::equal(rmm::exec_policy_nosync(stream),
                                uncompressed_data_sizes.d_begin(),
                                uncompressed_data_sizes.d_end(),
                                actual_uncompressed_data_sizes.begin()),
                  "Mismatch in expected and actual decompressed size during snappy decompression");
-    CUDF_EXPECTS(thrust::equal(rmm::exec_policy(stream),
+    CUDF_EXPECTS(thrust::equal(rmm::exec_policy_nosync(stream),
                                statuses.begin(),
                                statuses.end(),
                                thrust::make_constant_iterator(nvcompStatus_t::nvcompSuccess)),

--- a/cpp/src/io/csv/csv_gpu.cu
+++ b/cpp/src/io/csv/csv_gpu.cu
@@ -947,7 +947,7 @@ size_t __host__ count_blank_rows(const cudf::io::parse_options_view& opts,
   const auto comment  = opts.comment != '\0' ? opts.comment : newline;
   const auto carriage = (opts.skipblanklines && opts.terminator == '\n') ? '\r' : comment;
   return thrust::count_if(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     row_offsets.begin(),
     row_offsets.end(),
     [data = data, newline, comment, carriage] __device__(const uint64_t pos) {
@@ -966,7 +966,7 @@ device_span<uint64_t> __host__ remove_blank_rows(cudf::io::parse_options_view co
   const auto comment  = options.comment != '\0' ? options.comment : newline;
   const auto carriage = (options.skipblanklines && options.terminator == '\n') ? '\r' : comment;
   auto new_end        = thrust::remove_if(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     row_offsets.begin(),
     row_offsets.end(),
     [data = data, d_size, newline, comment, carriage] __device__(const uint64_t pos) {

--- a/cpp/src/io/csv/durations.cu
+++ b/cpp/src/io/csv/durations.cu
@@ -198,7 +198,7 @@ struct dispatch_from_durations_fn {
     auto chars_view   = chars_column->mutable_view();
     auto d_chars      = chars_view.template data<char>();
 
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        strings_count,
                        duration_to_string_fn<T>{d_column, d_new_offsets, d_chars});

--- a/cpp/src/io/fst/logical_stack.cuh
+++ b/cpp/src/io/fst/logical_stack.cuh
@@ -430,7 +430,7 @@ void sparse_stack_op_to_top_of_stack(StackSymbolItT d_symbols,
     stream));
 
   // Fill the output tape with read-symbol
-  thrust::fill(rmm::exec_policy(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream),
                thrust::device_ptr<StackSymbolT>{d_top_of_stack},
                thrust::device_ptr<StackSymbolT>{d_top_of_stack + num_symbols_out},
                read_symbol);
@@ -441,7 +441,7 @@ void sparse_stack_op_to_top_of_stack(StackSymbolItT d_symbols,
 
   // Scatter the stack symbols to the output tape (spots that are not scattered to have been
   // pre-filled with the read-symbol)
-  thrust::scatter(rmm::exec_policy(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream),
                   kv_op_to_stack_sym_it,
                   kv_op_to_stack_sym_it + num_symbols_in,
                   d_symbol_positions_db.Current(),

--- a/cpp/src/io/json/json_gpu.cu
+++ b/cpp/src/io/json/json_gpu.cu
@@ -729,7 +729,7 @@ std::vector<cudf::io::column_type_histogram> detect_data_types(
       rmm::device_uvector<cudf::io::column_type_histogram> d_column_infos(num_columns, stream);
       // Set the null count to the row count (all fields assumes to be null).
       thrust::generate(
-        rmm::exec_policy(stream),
+        rmm::exec_policy_nosync(stream),
         d_column_infos.begin(),
         d_column_infos.end(),
         [num_records = static_cast<cudf::size_type>(row_offsets.size())] __device__() {

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -806,7 +806,7 @@ void get_token_stream(device_span<SymbolT const> json_in,
   // Prepare for PDA transducer pass, merging input symbols with stack symbols
   rmm::device_uvector<PdaSymbolGroupIdT> pda_sgids{json_in.size(), stream};
   auto zip_in = thrust::make_zip_iterator(json_in.data(), stack_op_indices.data());
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     zip_in,
                     zip_in + json_in.size(),
                     pda_sgids.data(),
@@ -1305,7 +1305,7 @@ std::pair<std::unique_ptr<column>, std::vector<column_name_info>> json_column_to
         cudf::detail::make_device_uvector_async(json_col.string_lengths, stream);
       auto offset_length_it =
         thrust::make_zip_iterator(d_string_offsets.begin(), d_string_lengths.begin());
-      thrust::transform(rmm::exec_policy(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream),
                         offset_length_it,
                         offset_length_it + col_size,
                         d_string_data.data(),

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -107,7 +107,7 @@ col_map_ptr_type create_col_names_hash_map(column_view column_name_hashes,
 {
   auto key_col_map       = col_map_type::create(column_name_hashes.size(), stream);
   auto const column_data = column_name_hashes.data<uint32_t>();
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      column_name_hashes.size(),
                      [map = *key_col_map, column_data] __device__(size_type idx) mutable {
@@ -290,7 +290,7 @@ rmm::device_uvector<uint64_t> find_record_starts(json_reader_options const& read
   // Previous call stores the record positions as encountered by all threads
   // Sort the record positions as subsequent processing may require filtering
   // certain rows or other processing on specific records
-  thrust::sort(rmm::exec_policy(stream), rec_starts.begin(), rec_starts.end());
+  thrust::sort(rmm::exec_policy_nosync(stream), rec_starts.begin(), rec_starts.end());
 
   auto filtered_count = prefilter_count;
 
@@ -331,7 +331,7 @@ rmm::device_uvector<char> upload_data_to_device(json_reader_options const& reade
   // Adjust row start positions to account for the data subcopy
   size_t start_offset = h_rec_starts.front();
   rec_starts.resize(h_rec_starts.size(), stream);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     rec_starts.begin(),
                     rec_starts.end(),
                     thrust::make_constant_iterator(start_offset),

--- a/cpp/src/io/orc/dict_enc.cu
+++ b/cpp/src/io/orc/dict_enc.cu
@@ -462,7 +462,7 @@ void BuildStripeDictionaries(device_2dspan<StripeDictionary> d_stripes_dicts,
         auto const dict_data_ptr = thrust::device_pointer_cast(stripe_dict.dict_data);
         auto const string_column = stripe_dict.leaf_column;
         // NOTE: Requires the --expt-extended-lambda nvcc flag
-        thrust::sort(rmm::exec_policy(stream),
+        thrust::sort(rmm::exec_policy_nosync(stream),
                      dict_data_ptr,
                      dict_data_ptr + stripe_dict.num_strings,
                      [string_column] __device__(const uint32_t& lhs, const uint32_t& rhs) {

--- a/cpp/src/io/orc/stripe_enc.cu
+++ b/cpp/src/io/orc/stripe_enc.cu
@@ -1335,7 +1335,7 @@ void CompressOrcDataStreams(uint8_t* compressed_data,
       }
     } catch (...) {
       // There was an error in compressing so set an error status for each block
-      thrust::for_each(rmm::exec_policy(stream),
+      thrust::for_each(rmm::exec_policy_nosync(stream),
                        comp_stat.begin(),
                        comp_stat.end(),
                        [] __device__(decompress_status & stat) { stat.status = 1; });

--- a/cpp/src/io/parquet/reader_impl.cu
+++ b/cpp/src/io/parquet/reader_impl.cu
@@ -250,7 +250,7 @@ std::tuple<int32_t, int32_t, int8_t> conversion_info(type_id column_type_id,
 inline void decompress_check(device_span<decompress_status const> stats,
                              rmm::cuda_stream_view stream)
 {
-  CUDF_EXPECTS(thrust::all_of(rmm::exec_policy(stream),
+  CUDF_EXPECTS(thrust::all_of(rmm::exec_policy_nosync(stream),
                               stats.begin(),
                               stats.end(),
                               [] __device__(auto const& stat) { return stat.status == 0; }),
@@ -1142,7 +1142,7 @@ rmm::device_buffer reader::impl::decompress_page_data(
   comp_out.reserve(num_comp_pages);
 
   rmm::device_uvector<decompress_status> comp_stats(num_comp_pages, _stream);
-  thrust::fill(rmm::exec_policy(_stream),
+  thrust::fill(rmm::exec_policy_nosync(_stream),
                comp_stats.begin(),
                comp_stats.end(),
                decompress_status{0, static_cast<uint32_t>(-1000), 0});

--- a/cpp/src/io/utilities/column_utils.cuh
+++ b/cpp/src/io/utilities/column_utils.cuh
@@ -60,7 +60,7 @@ rmm::device_uvector<column_device_view> create_leaf_column_device_views(
 
   auto iter = thrust::make_counting_iterator<size_type>(0);
   thrust::for_each(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     iter,
     iter + parent_table_device_view.num_columns(),
     [col_desc, parent_col_view = parent_table_device_view, leaf_columns] __device__(

--- a/cpp/src/io/utilities/hostdevice_vector.hpp
+++ b/cpp/src/io/utilities/hostdevice_vector.hpp
@@ -162,7 +162,7 @@ class hostdevice_vector {
     v.h_data       = nullptr;
   }
 
-  rmm::cuda_stream_view stream{cudf::default_stream_value};
+  rmm::cuda_stream_view stream{cudf::default_stream_value};  // TODO: remove stream member?
   size_t max_elements{};
   size_t num_elements{};
   T* h_data{};

--- a/cpp/src/io/utilities/hostdevice_vector.hpp
+++ b/cpp/src/io/utilities/hostdevice_vector.hpp
@@ -162,7 +162,7 @@ class hostdevice_vector {
     v.h_data       = nullptr;
   }
 
-  rmm::cuda_stream_view stream{cudf::default_stream_value};  // TODO: remove stream member?
+  rmm::cuda_stream_view stream{cudf::default_stream_value};
   size_t max_elements{};
   size_t num_elements{};
   T* h_data{};

--- a/cpp/src/join/conditional_join.cu
+++ b/cpp/src/join/conditional_join.cu
@@ -293,13 +293,11 @@ conditional_inner_join(table_view const& left,
                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::conditional_join(left,
-                                  right,
-                                  binary_predicate,
-                                  detail::join_kind::INNER_JOIN,
-                                  output_size,
-                                  cudf::default_stream_value,
-                                  mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::conditional_join(
+    left, right, binary_predicate, detail::join_kind::INNER_JOIN, output_size, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -311,13 +309,11 @@ conditional_left_join(table_view const& left,
                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::conditional_join(left,
-                                  right,
-                                  binary_predicate,
-                                  detail::join_kind::LEFT_JOIN,
-                                  output_size,
-                                  cudf::default_stream_value,
-                                  mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::conditional_join(
+    left, right, binary_predicate, detail::join_kind::LEFT_JOIN, output_size, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -328,13 +324,11 @@ conditional_full_join(table_view const& left,
                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::conditional_join(left,
-                                  right,
-                                  binary_predicate,
-                                  detail::join_kind::FULL_JOIN,
-                                  {},
-                                  cudf::default_stream_value,
-                                  mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::conditional_join(
+    left, right, binary_predicate, detail::join_kind::FULL_JOIN, {}, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_semi_join(
@@ -345,14 +339,13 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_semi_join(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return std::move(detail::conditional_join(left,
-                                            right,
-                                            binary_predicate,
-                                            detail::join_kind::LEFT_SEMI_JOIN,
-                                            output_size,
-                                            cudf::default_stream_value,
-                                            mr)
-                     .first);
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::conditional_join(
+      left, right, binary_predicate, detail::join_kind::LEFT_SEMI_JOIN, output_size, stream, mr)
+      .first;
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_anti_join(
@@ -363,14 +356,13 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_left_anti_join(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return std::move(detail::conditional_join(left,
-                                            right,
-                                            binary_predicate,
-                                            detail::join_kind::LEFT_ANTI_JOIN,
-                                            output_size,
-                                            cudf::default_stream_value,
-                                            mr)
-                     .first);
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::conditional_join(
+      left, right, binary_predicate, detail::join_kind::LEFT_ANTI_JOIN, output_size, stream, mr)
+      .first;
+  stream.synchronize();
+  return result;
 }
 
 std::size_t conditional_inner_join_size(table_view const& left,
@@ -379,8 +371,11 @@ std::size_t conditional_inner_join_size(table_view const& left,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::compute_conditional_join_output_size(
-    left, right, binary_predicate, detail::join_kind::INNER_JOIN, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::compute_conditional_join_output_size(
+    left, right, binary_predicate, detail::join_kind::INNER_JOIN, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::size_t conditional_left_join_size(table_view const& left,
@@ -389,8 +384,11 @@ std::size_t conditional_left_join_size(table_view const& left,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::compute_conditional_join_output_size(
-    left, right, binary_predicate, detail::join_kind::LEFT_JOIN, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::compute_conditional_join_output_size(
+    left, right, binary_predicate, detail::join_kind::LEFT_JOIN, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::size_t conditional_left_semi_join_size(table_view const& left,
@@ -399,12 +397,11 @@ std::size_t conditional_left_semi_join_size(table_view const& left,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return std::move(detail::compute_conditional_join_output_size(left,
-                                                                right,
-                                                                binary_predicate,
-                                                                detail::join_kind::LEFT_SEMI_JOIN,
-                                                                cudf::default_stream_value,
-                                                                mr));
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::compute_conditional_join_output_size(
+    left, right, binary_predicate, detail::join_kind::LEFT_SEMI_JOIN, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::size_t conditional_left_anti_join_size(table_view const& left,
@@ -413,12 +410,11 @@ std::size_t conditional_left_anti_join_size(table_view const& left,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return std::move(detail::compute_conditional_join_output_size(left,
-                                                                right,
-                                                                binary_predicate,
-                                                                detail::join_kind::LEFT_ANTI_JOIN,
-                                                                cudf::default_stream_value,
-                                                                mr));
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::compute_conditional_join_output_size(
+    left, right, binary_predicate, detail::join_kind::LEFT_ANTI_JOIN, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/join/cross_join.cu
+++ b/cpp/src/join/cross_join.cu
@@ -78,7 +78,10 @@ std::unique_ptr<cudf::table> cross_join(cudf::table_view const& left,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::cross_join(left, right, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::cross_join(left, right, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/join/join.cu
+++ b/cpp/src/join/join.cu
@@ -113,7 +113,10 @@ inner_join(table_view const& left,
            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::inner_join(left, right, compare_nulls, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::inner_join(left, right, compare_nulls, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -124,7 +127,10 @@ left_join(table_view const& left,
           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::left_join(left, right, compare_nulls, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::left_join(left, right, compare_nulls, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -135,7 +141,10 @@ full_join(table_view const& left,
           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::full_join(left, right, compare_nulls, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::full_join(left, right, compare_nulls, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/join/join_utils.cu
+++ b/cpp/src/join/join_utils.cu
@@ -56,11 +56,11 @@ get_trivial_left_join_indices(table_view const& left,
                               rmm::mr::device_memory_resource* mr)
 {
   auto left_indices = std::make_unique<rmm::device_uvector<size_type>>(left.num_rows(), stream, mr);
-  thrust::sequence(rmm::exec_policy(stream), left_indices->begin(), left_indices->end(), 0);
+  thrust::sequence(rmm::exec_policy_nosync(stream), left_indices->begin(), left_indices->end(), 0);
   auto right_indices =
     std::make_unique<rmm::device_uvector<size_type>>(left.num_rows(), stream, mr);
   thrust::uninitialized_fill(
-    rmm::exec_policy(stream), right_indices->begin(), right_indices->end(), JoinNoneValue);
+    rmm::exec_policy_nosync(stream), right_indices->begin(), right_indices->end(), JoinNoneValue);
   return std::pair(std::move(left_indices), std::move(right_indices));
 }
 
@@ -78,9 +78,11 @@ VectorPair concatenate_vector_pairs(VectorPair& a, VectorPair& b, rmm::cuda_stre
   auto original_size = a.first->size();
   a.first->resize(a.first->size() + b.first->size(), stream);
   a.second->resize(a.second->size() + b.second->size(), stream);
-  thrust::copy(
-    rmm::exec_policy(stream), b.first->begin(), b.first->end(), a.first->begin() + original_size);
-  thrust::copy(rmm::exec_policy(stream),
+  thrust::copy(rmm::exec_policy_nosync(stream),
+               b.first->begin(),
+               b.first->end(),
+               a.first->begin() + original_size);
+  thrust::copy(rmm::exec_policy_nosync(stream),
                b.second->begin(),
                b.second->end(),
                a.second->begin() + original_size);
@@ -107,7 +109,7 @@ get_left_join_indices_complement(std::unique_ptr<rmm::device_uvector<size_type>>
   // right_indices will be JoinNoneValue, i.e. -1. This if path should
   // produce exactly the same result as the else path but will be faster.
   if (left_table_row_count == 0) {
-    thrust::sequence(rmm::exec_policy(stream),
+    thrust::sequence(rmm::exec_policy_nosync(stream),
                      right_indices_complement->begin(),
                      right_indices_complement->end(),
                      0);
@@ -115,15 +117,17 @@ get_left_join_indices_complement(std::unique_ptr<rmm::device_uvector<size_type>>
     // Assume all the indices in invalid_index_map are invalid
     auto invalid_index_map =
       std::make_unique<rmm::device_uvector<size_type>>(right_table_row_count, stream);
-    thrust::uninitialized_fill(
-      rmm::exec_policy(stream), invalid_index_map->begin(), invalid_index_map->end(), int32_t{1});
+    thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
+                               invalid_index_map->begin(),
+                               invalid_index_map->end(),
+                               int32_t{1});
 
     // Functor to check for index validity since left joins can create invalid indices
     valid_range<size_type> valid(0, right_table_row_count);
 
     // invalid_index_map[index_ptr[i]] = 0 for i = 0 to right_table_row_count
     // Thus specifying that those locations are valid
-    thrust::scatter_if(rmm::exec_policy(stream),
+    thrust::scatter_if(rmm::exec_policy_nosync(stream),
                        thrust::make_constant_iterator(0),
                        thrust::make_constant_iterator(0) + right_indices->size(),
                        right_indices->begin(),      // Index locations
@@ -134,7 +138,7 @@ get_left_join_indices_complement(std::unique_ptr<rmm::device_uvector<size_type>>
     size_type end_counter   = static_cast<size_type>(right_table_row_count);
 
     // Create list of indices that have been marked as invalid
-    size_type indices_count = thrust::copy_if(rmm::exec_policy(stream),
+    size_type indices_count = thrust::copy_if(rmm::exec_policy_nosync(stream),
                                               thrust::make_counting_iterator(begin_counter),
                                               thrust::make_counting_iterator(end_counter),
                                               invalid_index_map->begin(),
@@ -146,7 +150,7 @@ get_left_join_indices_complement(std::unique_ptr<rmm::device_uvector<size_type>>
 
   auto left_invalid_indices =
     std::make_unique<rmm::device_uvector<size_type>>(right_indices_complement->size(), stream);
-  thrust::uninitialized_fill(rmm::exec_policy(stream),
+  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
                              left_invalid_indices->begin(),
                              left_invalid_indices->end(),
                              JoinNoneValue);

--- a/cpp/src/join/mixed_join.cu
+++ b/cpp/src/join/mixed_join.cu
@@ -450,16 +450,19 @@ mixed_inner_join(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::mixed_join(left_equality,
-                            right_equality,
-                            left_conditional,
-                            right_conditional,
-                            binary_predicate,
-                            compare_nulls,
-                            detail::join_kind::INNER_JOIN,
-                            output_size_data,
-                            cudf::default_stream_value,
-                            mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::mixed_join(left_equality,
+                                   right_equality,
+                                   left_conditional,
+                                   right_conditional,
+                                   binary_predicate,
+                                   compare_nulls,
+                                   detail::join_kind::INNER_JOIN,
+                                   output_size_data,
+                                   stream,
+                                   mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_inner_join_size(
@@ -472,15 +475,18 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_in
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::compute_mixed_join_output_size(left_equality,
-                                                right_equality,
-                                                left_conditional,
-                                                right_conditional,
-                                                binary_predicate,
-                                                compare_nulls,
-                                                detail::join_kind::INNER_JOIN,
-                                                cudf::default_stream_value,
-                                                mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::compute_mixed_join_output_size(left_equality,
+                                                       right_equality,
+                                                       left_conditional,
+                                                       right_conditional,
+                                                       binary_predicate,
+                                                       compare_nulls,
+                                                       detail::join_kind::INNER_JOIN,
+                                                       stream,
+                                                       mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -496,16 +502,19 @@ mixed_left_join(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::mixed_join(left_equality,
-                            right_equality,
-                            left_conditional,
-                            right_conditional,
-                            binary_predicate,
-                            compare_nulls,
-                            detail::join_kind::LEFT_JOIN,
-                            output_size_data,
-                            cudf::default_stream_value,
-                            mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::mixed_join(left_equality,
+                                   right_equality,
+                                   left_conditional,
+                                   right_conditional,
+                                   binary_predicate,
+                                   compare_nulls,
+                                   detail::join_kind::LEFT_JOIN,
+                                   output_size_data,
+                                   stream,
+                                   mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_left_join_size(
@@ -518,15 +527,18 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_le
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::compute_mixed_join_output_size(left_equality,
-                                                right_equality,
-                                                left_conditional,
-                                                right_conditional,
-                                                binary_predicate,
-                                                compare_nulls,
-                                                detail::join_kind::LEFT_JOIN,
-                                                cudf::default_stream_value,
-                                                mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::compute_mixed_join_output_size(left_equality,
+                                                       right_equality,
+                                                       left_conditional,
+                                                       right_conditional,
+                                                       binary_predicate,
+                                                       compare_nulls,
+                                                       detail::join_kind::LEFT_JOIN,
+                                                       stream,
+                                                       mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
@@ -542,16 +554,19 @@ mixed_full_join(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::mixed_join(left_equality,
-                            right_equality,
-                            left_conditional,
-                            right_conditional,
-                            binary_predicate,
-                            compare_nulls,
-                            detail::join_kind::FULL_JOIN,
-                            output_size_data,
-                            cudf::default_stream_value,
-                            mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::mixed_join(left_equality,
+                                   right_equality,
+                                   left_conditional,
+                                   right_conditional,
+                                   binary_predicate,
+                                   compare_nulls,
+                                   detail::join_kind::FULL_JOIN,
+                                   output_size_data,
+                                   stream,
+                                   mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -496,15 +496,18 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_le
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::compute_mixed_join_output_size_semi(left_equality,
-                                                     right_equality,
-                                                     left_conditional,
-                                                     right_conditional,
-                                                     binary_predicate,
-                                                     compare_nulls,
-                                                     detail::join_kind::LEFT_SEMI_JOIN,
-                                                     cudf::default_stream_value,
-                                                     mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::compute_mixed_join_output_size_semi(left_equality,
+                                                            right_equality,
+                                                            left_conditional,
+                                                            right_conditional,
+                                                            binary_predicate,
+                                                            compare_nulls,
+                                                            detail::join_kind::LEFT_SEMI_JOIN,
+                                                            stream,
+                                                            mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_semi_join(
@@ -518,16 +521,19 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_semi_join(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::mixed_join_semi(left_equality,
-                                 right_equality,
-                                 left_conditional,
-                                 right_conditional,
-                                 binary_predicate,
-                                 compare_nulls,
-                                 detail::join_kind::LEFT_SEMI_JOIN,
-                                 output_size_data,
-                                 cudf::default_stream_value,
-                                 mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::mixed_join_semi(left_equality,
+                                        right_equality,
+                                        left_conditional,
+                                        right_conditional,
+                                        binary_predicate,
+                                        compare_nulls,
+                                        detail::join_kind::LEFT_SEMI_JOIN,
+                                        output_size_data,
+                                        stream,
+                                        mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_left_anti_join_size(
@@ -540,15 +546,18 @@ std::pair<std::size_t, std::unique_ptr<rmm::device_uvector<size_type>>> mixed_le
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::compute_mixed_join_output_size_semi(left_equality,
-                                                     right_equality,
-                                                     left_conditional,
-                                                     right_conditional,
-                                                     binary_predicate,
-                                                     compare_nulls,
-                                                     detail::join_kind::LEFT_ANTI_JOIN,
-                                                     cudf::default_stream_value,
-                                                     mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::compute_mixed_join_output_size_semi(left_equality,
+                                                            right_equality,
+                                                            left_conditional,
+                                                            right_conditional,
+                                                            binary_predicate,
+                                                            compare_nulls,
+                                                            detail::join_kind::LEFT_ANTI_JOIN,
+                                                            stream,
+                                                            mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_anti_join(
@@ -562,16 +571,19 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_left_anti_join(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::mixed_join_semi(left_equality,
-                                 right_equality,
-                                 left_conditional,
-                                 right_conditional,
-                                 binary_predicate,
-                                 compare_nulls,
-                                 detail::join_kind::LEFT_ANTI_JOIN,
-                                 output_size_data,
-                                 cudf::default_stream_value,
-                                 mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::mixed_join_semi(left_equality,
+                                        right_equality,
+                                        left_conditional,
+                                        right_conditional,
+                                        binary_predicate,
+                                        compare_nulls,
+                                        detail::join_kind::LEFT_ANTI_JOIN,
+                                        output_size_data,
+                                        stream,
+                                        mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -56,7 +56,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_anti_join(
   if ((join_kind::LEFT_ANTI_JOIN == kind) && (0 == right_keys.num_rows())) {
     auto result =
       std::make_unique<rmm::device_uvector<cudf::size_type>>(left_keys.num_rows(), stream, mr);
-    thrust::sequence(rmm::exec_policy(stream), result->begin(), result->end());
+    thrust::sequence(rmm::exec_policy_nosync(stream), result->begin(), result->end());
     return result;
   }
 
@@ -73,7 +73,7 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_anti_join(
 
   // gather_map_end will be the end of valid data in gather_map
   auto gather_map_end =
-    thrust::copy_if(rmm::exec_policy(stream),
+    thrust::copy_if(rmm::exec_policy_nosync(stream),
                     thrust::counting_iterator<size_type>(0),
                     thrust::counting_iterator<size_type>(left_num_rows),
                     gather_map->begin(),

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -94,8 +94,11 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_join(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::left_semi_anti_join(
-    detail::join_kind::LEFT_SEMI_JOIN, left, right, compare_nulls, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::left_semi_anti_join(
+    detail::join_kind::LEFT_SEMI_JOIN, left, right, compare_nulls, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_anti_join(
@@ -105,8 +108,11 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_anti_join(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::left_semi_anti_join(
-    detail::join_kind::LEFT_ANTI_JOIN, left, right, compare_nulls, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::left_semi_anti_join(
+    detail::join_kind::LEFT_ANTI_JOIN, left, right, compare_nulls, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/labeling/label_bins.cu
+++ b/cpp/src/labeling/label_bins.cu
@@ -133,14 +133,14 @@ std::unique_ptr<column> label_bins(column_view const& input,
   using RandomAccessIterator = decltype(left_edges_device_view->begin<T>());
 
   if (input.has_nulls()) {
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       input_device_view->pair_begin<T, true>(),
                       input_device_view->pair_end<T, true>(),
                       output_begin,
                       bin_finder<T, RandomAccessIterator, LeftComparator, RightComparator>(
                         left_begin, left_end, right_begin));
   } else {
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       input_device_view->pair_begin<T, false>(),
                       input_device_view->pair_end<T, false>(),
                       output_begin,

--- a/cpp/src/labeling/label_bins.cu
+++ b/cpp/src/labeling/label_bins.cu
@@ -238,12 +238,11 @@ std::unique_ptr<column> label_bins(column_view const& input,
                                    inclusive right_inclusive,
                                    rmm::mr::device_memory_resource* mr)
 {
-  return detail::label_bins(input,
-                            left_edges,
-                            left_inclusive,
-                            right_edges,
-                            right_inclusive,
-                            cudf::default_stream_value,
-                            mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::label_bins(input, left_edges, left_inclusive, right_edges, right_inclusive, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/lists/combine/concatenate_list_elements.cu
+++ b/cpp/src/lists/combine/concatenate_list_elements.cu
@@ -65,7 +65,7 @@ std::unique_ptr<column> concatenate_lists_ignore_null(column_view const& input,
   // into row offsets of the root column. Those entry offsets are subtracted by the first entry
   // offset to output zero-based offsets.
   auto const iter = thrust::make_counting_iterator<size_type>(0);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     iter,
                     iter + num_rows + 1,
                     d_out_offsets,
@@ -137,7 +137,7 @@ generate_list_offsets_and_validities(column_view const& input,
   // Compute output list sizes and validities.
   auto const iter = thrust::make_counting_iterator<size_type>(0);
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     iter,
     iter + num_rows,
     d_out_offsets,
@@ -166,7 +166,7 @@ generate_list_offsets_and_validities(column_view const& input,
 
   // Compute offsets from sizes.
   thrust::exclusive_scan(
-    rmm::exec_policy(stream), d_out_offsets, d_out_offsets + num_rows + 1, d_out_offsets);
+    rmm::exec_policy_nosync(stream), d_out_offsets, d_out_offsets + num_rows + 1, d_out_offsets);
 
   return {std::move(out_offsets), std::move(validities)};
 }
@@ -191,7 +191,7 @@ std::unique_ptr<column> gather_list_entries(column_view const& input,
 
   // Fill the gather map with indices of the lists from the child column of the input column.
   thrust::for_each_n(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     num_rows,
     [d_row_offsets,

--- a/cpp/src/lists/combine/concatenate_list_elements.cu
+++ b/cpp/src/lists/combine/concatenate_list_elements.cu
@@ -287,7 +287,10 @@ std::unique_ptr<column> concatenate_list_elements(column_view const& input,
                                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::concatenate_list_elements(input, null_policy, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::concatenate_list_elements(input, null_policy, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace lists

--- a/cpp/src/lists/combine/concatenate_rows.cu
+++ b/cpp/src/lists/combine/concatenate_rows.cu
@@ -307,7 +307,10 @@ std::unique_ptr<column> concatenate_rows(table_view const& input,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::concatenate_rows(input, null_policy, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::concatenate_rows(input, null_policy, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace lists

--- a/cpp/src/lists/combine/concatenate_rows.cu
+++ b/cpp/src/lists/combine/concatenate_rows.cu
@@ -110,7 +110,7 @@ generate_regrouped_offsets_and_null_mask(table_device_view const& input,
       return offsets[row_index + 1] - offsets[row_index];
     });
 
-  thrust::reduce_by_key(rmm::exec_policy(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                         keys,
                         keys + (input.num_rows() * input.num_columns()),
                         values,
@@ -118,7 +118,7 @@ generate_regrouped_offsets_and_null_mask(table_device_view const& input,
                         offsets->mutable_view().begin<offset_type>());
 
   // convert to offsets
-  thrust::exclusive_scan(rmm::exec_policy(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
                          offsets->view().begin<offset_type>(),
                          offsets->view().begin<offset_type>() + input.num_rows() + 1,
                          offsets->mutable_view().begin<offset_type>(),
@@ -172,7 +172,7 @@ rmm::device_uvector<size_type> generate_null_counts(table_device_view const& inp
       return col.null_mask() ? (bit_is_set(col.null_mask(), row_index + col.offset()) ? 0 : 1) : 0;
     });
 
-  thrust::reduce_by_key(rmm::exec_policy(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                         keys,
                         keys + (input.num_rows() * input.num_columns()),
                         null_values,

--- a/cpp/src/lists/contains.cu
+++ b/cpp/src/lists/contains.cu
@@ -335,7 +335,10 @@ std::unique_ptr<column> contains(lists_column_view const& lists,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(lists, search_key, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::contains(lists, search_key, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> contains(lists_column_view const& lists,
@@ -343,14 +346,20 @@ std::unique_ptr<column> contains(lists_column_view const& lists,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(lists, search_keys, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::contains(lists, search_keys, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> contains_nulls(lists_column_view const& lists,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains_nulls(lists, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::contains_nulls(lists, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> index_of(lists_column_view const& lists,
@@ -359,7 +368,10 @@ std::unique_ptr<column> index_of(lists_column_view const& lists,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::index_of(lists, search_key, find_option, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::index_of(lists, search_key, find_option, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> index_of(lists_column_view const& lists,
@@ -368,7 +380,10 @@ std::unique_ptr<column> index_of(lists_column_view const& lists,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::index_of(lists, search_keys, find_option, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::index_of(lists, search_keys, find_option, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf::lists

--- a/cpp/src/lists/contains.cu
+++ b/cpp/src/lists/contains.cu
@@ -181,7 +181,7 @@ struct dispatch_index_of {
     auto const out_begin = out_positions->mutable_view().template begin<size_type>();
 
     auto const do_search = [&](auto const keys_iter) {
-      thrust::transform(rmm::exec_policy(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream),
                         input_it,
                         input_it + lists.size(),
                         keys_iter,
@@ -237,7 +237,7 @@ std::unique_ptr<column> to_contains(std::unique_ptr<column>&& key_positions,
   auto const positions_begin = key_positions->view().template begin<size_type>();
   auto result                = make_numeric_column(
     data_type{type_id::BOOL8}, key_positions->size(), mask_state::UNALLOCATED, stream, mr);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     positions_begin,
                     positions_begin + key_positions->size(),
                     result->mutable_view().template begin<bool>(),
@@ -312,7 +312,7 @@ std::unique_ptr<column> contains_nulls(lists_column_view const& lists,
   auto const out_begin     = output->mutable_view().template begin<bool>();
   auto const lists_cdv_ptr = column_device_view::create(lists_cv, stream);
 
-  thrust::tabulate(rmm::exec_policy(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream),
                    out_begin,
                    out_begin + lists.size(),
                    [lists = cudf::detail::lists_column_device_view{*lists_cdv_ptr}] __device__(

--- a/cpp/src/lists/copying/concatenate.cu
+++ b/cpp/src/lists/copying/concatenate.cu
@@ -72,7 +72,7 @@ std::unique_ptr<column> merge_offsets(host_span<lists_column_view const> columns
         (c.offset() > 0 ? cudf::detail::get_value<size_type>(c.offsets(), c.offset(), stream) : 0);
       column_device_view offsets(c.offsets(), nullptr, nullptr);
       thrust::transform(
-        rmm::exec_policy(stream),
+        rmm::exec_policy_nosync(stream),
         offsets.begin<size_type>() + c.offset(),
         offsets.begin<size_type>() + c.offset() + c.size() + 1,
         d_merged_offsets.begin<size_type>() + count,

--- a/cpp/src/lists/copying/copying.cu
+++ b/cpp/src/lists/copying/copying.cu
@@ -58,7 +58,7 @@ std::unique_ptr<cudf::column> copy_slice(lists_column_view const& lists,
 
   // Compute the offsets column of the result:
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     offsets_data + start,
     offsets_data + end + 1,  // size of offsets column is 1 greater than slice length
     out_offsets.data(),

--- a/cpp/src/lists/copying/scatter_helper.cu
+++ b/cpp/src/lists/copying/scatter_helper.cu
@@ -185,7 +185,7 @@ struct list_child_constructor {
                                                       mr);
 
     thrust::transform(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator(0),
       thrust::make_counting_iterator(child_column->size()),
       child_column->mutable_view().begin<T>(),
@@ -235,7 +235,7 @@ struct list_child_constructor {
     auto const null_string_view = string_view{nullptr, 0};  // placeholder for factory function
 
     thrust::transform(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator<size_type>(0),
       thrust::make_counting_iterator<size_type>(string_views.size()),
       string_views.begin(),
@@ -302,7 +302,7 @@ struct list_child_constructor {
     // For instance, if a parent list_device_view has 3 elements, it should have 3 corresponding
     // child list_device_view instances.
     thrust::transform(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator<size_type>(0),
       thrust::make_counting_iterator<size_type>(child_list_views.size()),
       child_list_views.begin(),

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -118,8 +118,10 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& source_column,
                                          out_of_bounds_policy bounds_policy,
                                          rmm::mr::device_memory_resource* mr)
 {
-  return detail::segmented_gather(
-    source_column, gather_map_list, bounds_policy, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::segmented_gather(source_column, gather_map_list, bounds_policy, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace lists

--- a/cpp/src/lists/count_elements.cu
+++ b/cpp/src/lists/count_elements.cu
@@ -76,7 +76,10 @@ std::unique_ptr<column> count_elements(lists_column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_elements(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::count_elements(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace lists

--- a/cpp/src/lists/count_elements.cu
+++ b/cpp/src/lists/count_elements.cu
@@ -58,7 +58,7 @@ std::unique_ptr<column> count_elements(lists_column_view const& input,
                                         mr);
 
   // fill in the sizes
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(input.size()),
                     output->mutable_view().begin<size_type>(),

--- a/cpp/src/lists/dremel.cu
+++ b/cpp/src/lists/dremel.cu
@@ -91,12 +91,12 @@ dremel_data get_dremel_data(column_view h_col,
     auto d_off = lcv.offsets().data<size_type>();
 
     auto empties_idx_end =
-      thrust::copy_if(rmm::exec_policy(stream),
+      thrust::copy_if(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator(start),
                       thrust::make_counting_iterator(end),
                       empties_idx.begin(),
                       [d_off] __device__(auto i) { return d_off[i] == d_off[i + 1]; });
-    auto empties_end = thrust::gather(rmm::exec_policy(stream),
+    auto empties_end = thrust::gather(rmm::exec_policy_nosync(stream),
                                       empties_idx.begin(),
                                       empties_idx_end,
                                       lcv.offsets().begin<size_type>(),
@@ -315,7 +315,7 @@ dremel_data get_dremel_data(column_view h_col,
     auto output_zip_it =
       thrust::make_zip_iterator(thrust::make_tuple(rep_level.begin(), def_level.begin()));
 
-    auto ends = thrust::merge_by_key(rmm::exec_policy(stream),
+    auto ends = thrust::merge_by_key(rmm::exec_policy_nosync(stream),
                                      empties.begin(),
                                      empties.begin() + empties_size,
                                      thrust::make_counting_iterator(column_offsets[level + 1]),
@@ -334,11 +334,11 @@ dremel_data get_dremel_data(column_view h_col,
         auto i) -> int { return (i + 1 < size) && (off[i] == off[i + 1]); });
     rmm::device_uvector<size_type> scan_out(offset_size_at_level, stream);
     thrust::exclusive_scan(
-      rmm::exec_policy(stream), scan_it, scan_it + offset_size_at_level, scan_out.begin());
+      rmm::exec_policy_nosync(stream), scan_it, scan_it + offset_size_at_level, scan_out.begin());
 
     // Add scan output to existing offsets to get new offsets into merged rep level values
     new_offsets = rmm::device_uvector<size_type>(offset_size_at_level, stream);
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator(0),
                        offset_size_at_level,
                        [off      = lcv.offsets().data<size_type>() + column_offsets[level],
@@ -349,7 +349,7 @@ dremel_data get_dremel_data(column_view h_col,
 
     // Set rep level values at level starts to appropriate rep level
     auto scatter_it = thrust::make_constant_iterator(level);
-    thrust::scatter(rmm::exec_policy(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream),
                     scatter_it,
                     scatter_it + new_offsets.size() - 1,
                     new_offsets.begin(),
@@ -398,7 +398,7 @@ dremel_data get_dremel_data(column_view h_col,
     auto output_zip_it =
       thrust::make_zip_iterator(thrust::make_tuple(rep_level.begin(), def_level.begin()));
 
-    auto ends = thrust::merge_by_key(rmm::exec_policy(stream),
+    auto ends = thrust::merge_by_key(rmm::exec_policy_nosync(stream),
                                      transformed_empties,
                                      transformed_empties + empties_size,
                                      thrust::make_counting_iterator(0),
@@ -418,11 +418,11 @@ dremel_data get_dremel_data(column_view h_col,
         auto i) -> int { return (i + 1 < size) && (off[i] == off[i + 1]); });
     rmm::device_uvector<size_type> scan_out(offset_size_at_level, stream);
     thrust::exclusive_scan(
-      rmm::exec_policy(stream), scan_it, scan_it + offset_size_at_level, scan_out.begin());
+      rmm::exec_policy_nosync(stream), scan_it, scan_it + offset_size_at_level, scan_out.begin());
 
     // Add scan output to existing offsets to get new offsets into merged rep level values
     rmm::device_uvector<size_type> temp_new_offsets(offset_size_at_level, stream);
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator(0),
                        offset_size_at_level,
                        [off      = lcv.offsets().data<size_type>() + column_offsets[level],
@@ -435,7 +435,7 @@ dremel_data get_dremel_data(column_view h_col,
 
     // Set rep level values at level starts to appropriate rep level
     auto scatter_it = thrust::make_constant_iterator(level);
-    thrust::scatter(rmm::exec_policy(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream),
                     scatter_it,
                     scatter_it + new_offsets.size() - 1,
                     new_offsets.begin(),

--- a/cpp/src/lists/explode.cu
+++ b/cpp/src/lists/explode.cu
@@ -299,7 +299,10 @@ std::unique_ptr<table> explode(table_view const& input_table,
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(input_table.column(explode_column_idx).type().id() == type_id::LIST,
                "Unsupported non-list column");
-  return detail::explode(input_table, explode_column_idx, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::explode(input_table, explode_column_idx, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -312,7 +315,10 @@ std::unique_ptr<table> explode_position(table_view const& input_table,
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(input_table.column(explode_column_idx).type().id() == type_id::LIST,
                "Unsupported non-list column");
-  return detail::explode_position(input_table, explode_column_idx, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::explode_position(input_table, explode_column_idx, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -325,8 +331,10 @@ std::unique_ptr<table> explode_outer(table_view const& input_table,
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(input_table.column(explode_column_idx).type().id() == type_id::LIST,
                "Unsupported non-list column");
-  return detail::explode_outer(
-    input_table, explode_column_idx, false, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::explode_outer(input_table, explode_column_idx, false, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -340,8 +348,10 @@ std::unique_ptr<table> explode_outer_position(table_view const& input_table,
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(input_table.column(explode_column_idx).type().id() == type_id::LIST,
                "Unsupported non-list column");
-  return detail::explode_outer(
-    input_table, explode_column_idx, true, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::explode_outer(input_table, explode_column_idx, true, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/lists/explode.cu
+++ b/cpp/src/lists/explode.cu
@@ -128,7 +128,7 @@ std::unique_ptr<table> explode(table_view const& input_table,
   // This looks like an off-by-one bug, but what is going on here is that we need to reduce each
   // result from `lower_bound` by 1 to build the correct gather map. This can be accomplished by
   // skipping the first entry and using the result of `lower_bound` directly.
-  thrust::lower_bound(rmm::exec_policy(stream),
+  thrust::lower_bound(rmm::exec_policy_nosync(stream),
                       offsets_minus_one,
                       offsets_minus_one + explode_col.size(),
                       counting_iter,
@@ -167,7 +167,7 @@ std::unique_ptr<table> explode_position(table_view const& input_table,
   // result from `lower_bound` by 1 to build the correct gather map. This can be accomplished by
   // skipping the first entry and using the result of `lower_bound` directly.
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     counting_iter,
     counting_iter + gather_map.size(),
     gather_map.begin(),
@@ -211,7 +211,7 @@ std::unique_ptr<table> explode_outer(table_view const& input_table,
     [offsets, offsets_size = explode_col.size() - 1] __device__(int idx) {
       return (idx > offsets_size || (offsets[idx + 1] != offsets[idx])) ? 0 : 1;
     });
-  thrust::inclusive_scan(rmm::exec_policy(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
                          null_or_empty,
                          null_or_empty + explode_col.size(),
                          null_or_empty_offset.begin());
@@ -274,7 +274,7 @@ std::unique_ptr<table> explode_outer(table_view const& input_table,
 
   // Fill in gather map with all the child column's entries
   thrust::for_each(
-    rmm::exec_policy(stream), counting_iter, counting_iter + loop_count, fill_gather_maps);
+    rmm::exec_policy_nosync(stream), counting_iter, counting_iter + loop_count, fill_gather_maps);
 
   return build_table(
     input_table,

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -171,7 +171,10 @@ std::unique_ptr<column> extract_list_element(lists_column_view const& lists_colu
                                              size_type index,
                                              rmm::mr::device_memory_resource* mr)
 {
-  return detail::extract_list_element_impl(lists_column, index, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_list_element_impl(lists_column, index, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -185,7 +188,10 @@ std::unique_ptr<column> extract_list_element(lists_column_view const& lists_colu
 {
   CUDF_EXPECTS(indices.size() == lists_column.size(),
                "Index column must have as many elements as lists column.");
-  return detail::extract_list_element_impl(lists_column, indices, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_list_element_impl(lists_column, indices, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace lists

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -62,7 +62,7 @@ std::unique_ptr<cudf::column> make_index_child(column_view const& indices,
     cudf::detail::make_null_replacement_iterator(*d_indices, std::numeric_limits<size_type>::max());
   auto index_child =
     make_numeric_column(data_type{type_id::INT32}, indices.size(), mask_state::UNALLOCATED, stream);
-  thrust::copy_n(rmm::exec_policy(stream),
+  thrust::copy_n(rmm::exec_policy_nosync(stream),
                  null_replaced_iter_begin,
                  indices.size(),
                  index_child->mutable_view().begin<size_type>());
@@ -84,8 +84,10 @@ std::unique_ptr<cudf::column> make_index_child(size_type index,
 {
   auto index_child =  // [index, index, index, ..., index]
     make_numeric_column(data_type{type_id::INT32}, num_rows, mask_state::UNALLOCATED, stream);
-  thrust::fill_n(
-    rmm::exec_policy(stream), index_child->mutable_view().begin<size_type>(), num_rows, index);
+  thrust::fill_n(rmm::exec_policy_nosync(stream),
+                 index_child->mutable_view().begin<size_type>(),
+                 num_rows,
+                 index);
   return index_child;
 }
 

--- a/cpp/src/lists/interleave_columns.cu
+++ b/cpp/src/lists/interleave_columns.cu
@@ -69,7 +69,7 @@ generate_list_offsets_and_validities(table_view const& input,
 
   // Compute list sizes and validities.
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(num_output_lists),
     d_offsets,
@@ -89,7 +89,7 @@ generate_list_offsets_and_validities(table_view const& input,
 
   // Compute offsets from sizes.
   thrust::exclusive_scan(
-    rmm::exec_policy(stream), d_offsets, d_offsets + num_output_lists + 1, d_offsets);
+    rmm::exec_policy_nosync(stream), d_offsets, d_offsets + num_output_lists + 1, d_offsets);
 
   return {std::move(list_offsets), std::move(validities)};
 }
@@ -270,7 +270,7 @@ struct interleave_list_entries_impl<T, std::enable_if_t<cudf::is_fixed_width<T>(
       rmm::device_uvector<int8_t>(data_has_null_mask ? num_output_entries : 0, stream);
 
     thrust::for_each_n(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator<size_type>(0),
       num_output_lists,
       [num_cols,

--- a/cpp/src/lists/lists_column_factories.cu
+++ b/cpp/src/lists/lists_column_factories.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ std::unique_ptr<cudf::column> make_lists_column_from_scalar(list_scalar const& v
   auto offsets = make_numeric_column(
     data_type{type_to_id<offset_type>()}, 2, mask_state::UNALLOCATED, stream, mr_final);
   auto m_offsets = offsets->mutable_view();
-  thrust::sequence(rmm::exec_policy(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream),
                    m_offsets.begin<size_type>(),
                    m_offsets.end<size_type>(),
                    0,

--- a/cpp/src/lists/segmented_sort.cu
+++ b/cpp/src/lists/segmented_sort.cu
@@ -317,7 +317,10 @@ std::unique_ptr<column> sort_lists(lists_column_view const& input,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sort_lists(input, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::sort_lists(input, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> stable_sort_lists(lists_column_view const& input,
@@ -326,8 +329,10 @@ std::unique_ptr<column> stable_sort_lists(lists_column_view const& input,
                                           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::stable_sort_lists(
-    input, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::stable_sort_lists(input, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace lists

--- a/cpp/src/lists/segmented_sort.cu
+++ b/cpp/src/lists/segmented_sort.cu
@@ -188,7 +188,7 @@ struct SegmentedSortColumn {
         auto device_child = column_device_view::create(child, stream);
         auto keys_in =
           cudf::detail::make_null_replacement_iterator<T>(*device_child, null_replace_T);
-        thrust::copy_n(rmm::exec_policy(stream), keys_in, child.size(), keys.begin());
+        thrust::copy_n(rmm::exec_policy_nosync(stream), keys_in, child.size(), keys.begin());
         return keys;
       }
       return rmm::device_uvector<T>{0, stream};
@@ -197,7 +197,7 @@ struct SegmentedSortColumn {
     std::unique_ptr<column> sorted_indices = cudf::make_numeric_column(
       data_type(type_to_id<size_type>()), child.size(), mask_state::UNALLOCATED, stream, mr);
     mutable_column_view mutable_indices_view = sorted_indices->mutable_view();
-    thrust::sequence(rmm::exec_policy(stream),
+    thrust::sequence(rmm::exec_policy_nosync(stream),
                      mutable_indices_view.begin<size_type>(),
                      mutable_indices_view.end<size_type>(),
                      0);
@@ -244,7 +244,7 @@ std::unique_ptr<column> sort_lists(lists_column_view const& input,
   if (input.is_empty()) return empty_like(input.parent());
   auto output_offset = make_numeric_column(
     input.offsets().type(), input.size() + 1, mask_state::UNALLOCATED, stream, mr);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     input.offsets_begin(),
                     input.offsets_end(),
                     output_offset->mutable_view().begin<size_type>(),
@@ -284,7 +284,7 @@ std::unique_ptr<column> stable_sort_lists(lists_column_view const& input,
 
   auto output_offset = make_numeric_column(
     input.offsets().type(), input.size() + 1, mask_state::UNALLOCATED, stream, mr);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     input.offsets_begin(),
                     input.offsets_end(),
                     output_offset->mutable_view().template begin<size_type>(),

--- a/cpp/src/lists/sequences.cu
+++ b/cpp/src/lists/sequences.cu
@@ -119,7 +119,7 @@ struct sequences_functor<T, std::enable_if_t<is_supported<T>()>> {
     auto const steps_begin  = steps ? steps.value().template begin<T>() : nullptr;
 
     auto const op = tabulator<T>{n_lists, n_elements, starts_begin, steps_begin, offsets};
-    thrust::tabulate(rmm::exec_policy(stream), result_begin, result_begin + n_elements, op);
+    thrust::tabulate(rmm::exec_policy_nosync(stream), result_begin, result_begin + n_elements, op);
 
     return result;
   }
@@ -166,7 +166,7 @@ std::unique_ptr<column> sequences(column_view const& starts,
   auto const sizes_input_it = cudf::detail::indexalator_factory::make_input_iterator(sizes);
 
   thrust::exclusive_scan(
-    rmm::exec_policy(stream), sizes_input_it, sizes_input_it + n_lists + 1, offsets_begin);
+    rmm::exec_policy_nosync(stream), sizes_input_it, sizes_input_it + n_lists + 1, offsets_begin);
   auto const n_elements = cudf::detail::get_value<size_type>(list_offsets->view(), n_lists, stream);
 
   auto child = type_dispatcher(starts.type(),

--- a/cpp/src/lists/sequences.cu
+++ b/cpp/src/lists/sequences.cu
@@ -214,7 +214,10 @@ std::unique_ptr<column> sequences(column_view const& starts,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sequences(starts, sizes, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::sequences(starts, sizes, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> sequences(column_view const& starts,
@@ -223,7 +226,10 @@ std::unique_ptr<column> sequences(column_view const& starts,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sequences(starts, steps, sizes, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::sequences(starts, steps, sizes, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf::lists

--- a/cpp/src/lists/set_operations.cu
+++ b/cpp/src/lists/set_operations.cu
@@ -93,7 +93,7 @@ std::unique_ptr<column> have_overlap(lists_column_view const& lhs,
   auto overlap_results = rmm::device_uvector<bool>(num_rows, stream);
 
   auto const labels_begin           = rhs_labels->view().begin<size_type>();
-  auto const end                    = thrust::reduce_by_key(rmm::exec_policy(stream),
+  auto const end                    = thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                                          labels_begin,  // keys
                                          labels_begin + rhs_labels->size(),  // keys
                                          contained.begin(),  // values to reduce
@@ -112,8 +112,8 @@ std::unique_ptr<column> have_overlap(lists_column_view const& lhs,
   // `overlap_results` only stores the results of non-empty lists.
   // We need to initialize `false` for the entire output array then scatter these results over.
   thrust::uninitialized_fill(
-    rmm::exec_policy(stream), result_begin, result_begin + num_rows, false);
-  thrust::scatter(rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream), result_begin, result_begin + num_rows, false);
+  thrust::scatter(rmm::exec_policy_nosync(stream),
                   overlap_results.begin(),
                   overlap_results.begin() + num_non_empty_segments,
                   list_indices.begin(),

--- a/cpp/src/lists/set_operations.cu
+++ b/cpp/src/lists/set_operations.cu
@@ -265,7 +265,10 @@ std::unique_ptr<column> have_overlap(lists_column_view const& lhs,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::have_overlap(lhs, rhs, nulls_equal, nans_equal, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::have_overlap(lhs, rhs, nulls_equal, nans_equal, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> intersect_distinct(lists_column_view const& lhs,
@@ -275,8 +278,10 @@ std::unique_ptr<column> intersect_distinct(lists_column_view const& lhs,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::intersect_distinct(
-    lhs, rhs, nulls_equal, nans_equal, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::intersect_distinct(lhs, rhs, nulls_equal, nans_equal, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> union_distinct(lists_column_view const& lhs,
@@ -286,7 +291,10 @@ std::unique_ptr<column> union_distinct(lists_column_view const& lhs,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::union_distinct(lhs, rhs, nulls_equal, nans_equal, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::union_distinct(lhs, rhs, nulls_equal, nans_equal, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> difference_distinct(lists_column_view const& lhs,
@@ -296,8 +304,10 @@ std::unique_ptr<column> difference_distinct(lists_column_view const& lhs,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::difference_distinct(
-    lhs, rhs, nulls_equal, nans_equal, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::difference_distinct(lhs, rhs, nulls_equal, nans_equal, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf::lists

--- a/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
+++ b/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
@@ -79,7 +79,7 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
 
     // Could have attempted an exclusive_scan(), but it would not compute the last entry.
     // Instead, inclusive_scan(), followed by writing `0` to the head of the offsets column.
-    thrust::inclusive_scan(rmm::exec_policy(stream),
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
                            sizes_begin,
                            sizes_end,
                            output_offsets_view.begin<offset_type>() + 1);

--- a/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
+++ b/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
@@ -102,7 +102,10 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
                                            lists_column_view const& boolean_mask,
                                            rmm::mr::device_memory_resource* mr)
 {
-  return detail::apply_boolean_mask(input, boolean_mask, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::apply_boolean_mask(input, boolean_mask, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf::lists

--- a/cpp/src/lists/stream_compaction/distinct.cu
+++ b/cpp/src/lists/stream_compaction/distinct.cu
@@ -78,7 +78,10 @@ std::unique_ptr<column> distinct(lists_column_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::distinct(input, nulls_equal, nans_equal, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::distinct(input, nulls_equal, nans_equal, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf::lists

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -194,7 +194,7 @@ index_vector generate_merged_indices(table_view const& left_table,
 
     auto ineq_op = detail::row_lexicographic_tagged_comparator<true>(
       *lhs_device_view, *rhs_device_view, d_column_order.data(), d_null_precedence.data());
-    thrust::merge(rmm::exec_policy(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream),
                   left_begin,
                   left_begin + left_size,
                   right_begin,
@@ -204,7 +204,7 @@ index_vector generate_merged_indices(table_view const& left_table,
   } else {
     auto ineq_op = detail::row_lexicographic_tagged_comparator<false>(
       *lhs_device_view, *rhs_device_view, d_column_order.data());
-    thrust::merge(rmm::exec_policy(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream),
                   left_begin,
                   left_begin + left_size,
                   right_begin,
@@ -280,7 +280,7 @@ struct column_merger {
     // and "gather" into merged_view.data()[indx_merged]
     // from lcol or rcol, depending on side;
     //
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       row_order_.begin(),
                       row_order_.end(),
                       merged_view.begin<Element>(),

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -539,8 +539,10 @@ std::unique_ptr<cudf::table> merge(std::vector<table_view> const& tables_to_merg
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::merge(
-    tables_to_merge, key_cols, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::merge(tables_to_merge, key_cols, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -796,7 +796,10 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> partition(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::partition(t, partition_map, num_partitions, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::partition(t, partition_map, num_partitions, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -540,7 +540,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
 
   // Compute exclusive scan of all blocks' partition sizes in-place to determine
   // the starting point for each blocks portion of each partition in the output
-  thrust::exclusive_scan(rmm::exec_policy(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
                          block_partition_sizes.begin(),
                          block_partition_sizes.end(),
                          scanned_block_partition_sizes.data());
@@ -548,7 +548,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
   // Compute exclusive scan of size of each partition to determine offset
   // location of each partition in final output.
   // TODO This can be done independently on a separate stream
-  thrust::exclusive_scan(rmm::exec_policy(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
                          global_partition_sizes.begin(),
                          global_partition_sizes.end(),
                          global_partition_sizes.begin());
@@ -677,7 +677,7 @@ struct dispatch_map_type {
     // `histogram` was created with an extra entry at the end such that an
     // exclusive scan will put the total number of rows at the end
     thrust::exclusive_scan(
-      rmm::exec_policy(stream), histogram.begin(), histogram.end(), histogram.begin());
+      rmm::exec_policy_nosync(stream), histogram.begin(), histogram.end(), histogram.begin());
 
     // Copy offsets to host before the transform below modifies the histogram
     auto const partition_offsets = cudf::detail::make_std_vector_sync(histogram, stream);
@@ -688,7 +688,7 @@ struct dispatch_map_type {
 
     // For each `partition_map[i]`, atomically increment the corresponding
     // partition offset to determine `i`s location in the output
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       partition_map.begin<MapType>(),
                       partition_map.end<MapType>(),
                       scatter_map.begin(),

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -268,8 +268,10 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> round_robi
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::round_robin_partition(
-    input, num_partitions, start_partition, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::round_robin_partition(input, num_partitions, start_partition, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -96,7 +96,8 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
 
   if (num_partitions == nrows) {
     rmm::device_uvector<cudf::size_type> partition_offsets(num_partitions, stream);
-    thrust::sequence(rmm::exec_policy(stream), partition_offsets.begin(), partition_offsets.end());
+    thrust::sequence(
+      rmm::exec_policy_nosync(stream), partition_offsets.begin(), partition_offsets.end());
 
     auto uniq_tbl = cudf::detail::gather(input,
                                          rotated_iter_begin,
@@ -113,7 +114,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
     // copy rotated right partition indexes that
     // fall in the interval [0, nrows):
     //(this relies on a _stable_ copy_if())
-    thrust::copy_if(rmm::exec_policy(stream),
+    thrust::copy_if(rmm::exec_policy_nosync(stream),
                     rotated_iter_begin,
                     rotated_iter_begin + num_partitions,
                     d_row_indices.begin(),
@@ -136,7 +137,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
 
     // offsets (part 2: compute partition offsets):
     rmm::device_uvector<cudf::size_type> partition_offsets(num_partitions, stream);
-    thrust::exclusive_scan(rmm::exec_policy(stream),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
                            nedges_iter_begin,
                            nedges_iter_begin + num_partitions,
                            partition_offsets.begin());

--- a/cpp/src/quantiles/quantile.cu
+++ b/cpp/src/quantiles/quantile.cu
@@ -189,7 +189,10 @@ std::unique_ptr<column> quantile(column_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::quantile(input, q, interp, ordered_indices, exact, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::quantile(input, q, interp, ordered_indices, exact, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/quantiles/quantile.cu
+++ b/cpp/src/quantiles/quantile.cu
@@ -90,7 +90,7 @@ struct quantile_functor {
     if (!cudf::is_dictionary(input.type())) {
       auto sorted_data =
         thrust::make_permutation_iterator(input.data<StorageType>(), ordered_indices);
-      thrust::transform(rmm::exec_policy(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream),
                         q_device.begin(),
                         q_device.end(),
                         d_output->template begin<StorageResult>(),
@@ -100,7 +100,7 @@ struct quantile_functor {
     } else {
       auto sorted_data = thrust::make_permutation_iterator(
         dictionary::detail::make_dictionary_iterator<T>(*d_input), ordered_indices);
-      thrust::transform(rmm::exec_policy(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream),
                         q_device.begin(),
                         q_device.end(),
                         d_output->template begin<StorageResult>(),

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -338,7 +338,7 @@ std::unique_ptr<scalar> make_empty_tdigest_scalar(rmm::cuda_stream_view stream,
     std::move(*std::make_unique<table>(std::move(contents.children))), true, stream, mr);
 }
 
-}  // namespace tdigest.
+}  // namespace tdigest
 
 std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
                                           column_view const& percentiles,
@@ -406,7 +406,10 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
                                           column_view const& percentiles,
                                           rmm::mr::device_memory_resource* mr)
 {
-  return percentile_approx(input, percentiles, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::percentile_approx(input, percentiles, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/reductions/all.cu
+++ b/cpp/src/reductions/all.cu
@@ -62,7 +62,7 @@ struct all_fn {
       return thrust::make_transform_iterator(pair_iter, null_iter);
     }();
     auto result = std::make_unique<numeric_scalar<bool>>(true, true, stream, mr);
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        input.size(),
                        all_true_fn<decltype(iter)>{iter, result->data()});

--- a/cpp/src/reductions/any.cu
+++ b/cpp/src/reductions/any.cu
@@ -62,7 +62,7 @@ struct any_fn {
       return thrust::make_transform_iterator(pair_iter, null_iter);
     }();
     auto result = std::make_unique<numeric_scalar<bool>>(false, true, stream, mr);
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        input.size(),
                        any_true_fn<decltype(iter)>{iter, result->data()});

--- a/cpp/src/reductions/minmax.cu
+++ b/cpp/src/reductions/minmax.cu
@@ -276,7 +276,11 @@ std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
 std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
   const column_view& col, rmm::mr::device_memory_resource* mr)
 {
-  return detail::minmax(col, cudf::default_stream_value, mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::minmax(col, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/reductions/nth_element.cu
+++ b/cpp/src/reductions/nth_element.cu
@@ -46,13 +46,13 @@ std::unique_ptr<cudf::scalar> cudf::reduction::nth_element(column_view const& co
                                       [] __device__(auto b) { return static_cast<size_type>(b); });
     rmm::device_uvector<size_type> null_skipped_index(col.size(), stream);
     // null skipped index for valids only.
-    thrust::inclusive_scan(rmm::exec_policy(stream),
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
                            bitmask_iterator,
                            bitmask_iterator + col.size(),
                            null_skipped_index.begin());
 
     auto n_pos = thrust::upper_bound(
-      rmm::exec_policy(stream), null_skipped_index.begin(), null_skipped_index.end(), n);
+      rmm::exec_policy_nosync(stream), null_skipped_index.begin(), null_skipped_index.end(), n);
     auto null_skipped_n = n_pos - null_skipped_index.begin();
     return cudf::detail::get_element(col, null_skipped_n, stream, mr);
   } else {

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -186,7 +186,10 @@ std::unique_ptr<scalar> reduce(column_view const& col,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::reduce(col, agg, output_dtype, std::nullopt, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::reduce(col, agg, output_dtype, std::nullopt, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<scalar> reduce(column_view const& col,
@@ -196,6 +199,9 @@ std::unique_ptr<scalar> reduce(column_view const& col,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::reduce(col, agg, output_dtype, init, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::reduce(col, agg, output_dtype, init, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/reductions/scan/rank_scan.cu
+++ b/cpp/src/reductions/scan/rank_scan.cu
@@ -58,7 +58,7 @@ std::unique_ptr<column> rank_generator(column_view const& order_by,
     data_type{type_to_id<size_type>()}, order_by.size(), mask_state::UNALLOCATED, stream, mr);
   auto mutable_ranks = ranks->mutable_view();
 
-  thrust::tabulate(rmm::exec_policy(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream),
                    mutable_ranks.begin<size_type>(),
                    mutable_ranks.end<size_type>(),
                    [comparator = device_comparator, resolver] __device__(size_type row_index) {
@@ -66,7 +66,7 @@ std::unique_ptr<column> rank_generator(column_view const& order_by,
                                      row_index);
                    });
 
-  thrust::inclusive_scan(rmm::exec_policy(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
                          mutable_ranks.begin<size_type>(),
                          mutable_ranks.end<size_type>(),
                          mutable_ranks.begin<size_type>(),
@@ -114,7 +114,7 @@ std::unique_ptr<column> inclusive_one_normalized_percent_rank_scan(
   auto percent_rank_result = cudf::make_fixed_width_column(
     data_type{type_to_id<result_type>()}, rank_view.size(), mask_state::UNALLOCATED, stream, mr);
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     rank_view.begin<size_type>(),
                     rank_view.end<size_type>(),
                     percent_rank_result->mutable_view().begin<result_type>(),

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -23,6 +23,36 @@
 
 namespace cudf {
 
+namespace detail {
+std::unique_ptr<column> scan(column_view const& input,
+                             std::unique_ptr<scan_aggregation> const& agg,
+                             scan_type inclusive,
+                             null_policy null_handling,
+                             rmm::cuda_stream_view stream,
+                             rmm::mr::device_memory_resource* mr)
+{
+  if (agg->kind == aggregation::RANK) {
+    CUDF_EXPECTS(inclusive == scan_type::INCLUSIVE,
+                 "Rank aggregation operator requires an inclusive scan");
+    auto const& rank_agg = dynamic_cast<cudf::detail::rank_aggregation const&>(*agg);
+    if (rank_agg._method == rank_method::MIN) {
+      if (rank_agg._percentage == rank_percentage::NONE) {
+        return inclusive_rank_scan(input, stream, mr);
+      } else if (rank_agg._percentage == rank_percentage::ONE_NORMALIZED) {
+        return inclusive_one_normalized_percent_rank_scan(input, stream, mr);
+      }
+    } else if (rank_agg._method == rank_method::DENSE) {
+      return inclusive_dense_rank_scan(input, stream, mr);
+    }
+    CUDF_FAIL("Unsupported rank aggregation method for inclusive scan");
+  }
+  return inclusive == scan_type::EXCLUSIVE
+           ? detail::scan_exclusive(input, agg, null_handling, stream, mr)
+           : detail::scan_inclusive(input, agg, null_handling, stream, mr);
+}
+
+}  // namespace detail
+
 std::unique_ptr<column> scan(column_view const& input,
                              std::unique_ptr<scan_aggregation> const& agg,
                              scan_type inclusive,
@@ -30,26 +60,10 @@ std::unique_ptr<column> scan(column_view const& input,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-
-  if (agg->kind == aggregation::RANK) {
-    CUDF_EXPECTS(inclusive == scan_type::INCLUSIVE,
-                 "Rank aggregation operator requires an inclusive scan");
-    auto const& rank_agg = dynamic_cast<cudf::detail::rank_aggregation const&>(*agg);
-    if (rank_agg._method == rank_method::MIN) {
-      if (rank_agg._percentage == rank_percentage::NONE) {
-        return inclusive_rank_scan(input, cudf::default_stream_value, mr);
-      } else if (rank_agg._percentage == rank_percentage::ONE_NORMALIZED) {
-        return inclusive_one_normalized_percent_rank_scan(input, cudf::default_stream_value, mr);
-      }
-    } else if (rank_agg._method == rank_method::DENSE) {
-      return inclusive_dense_rank_scan(input, cudf::default_stream_value, mr);
-    }
-    CUDF_FAIL("Unsupported rank aggregation method for inclusive scan");
-  }
-
-  return inclusive == scan_type::EXCLUSIVE
-           ? detail::scan_exclusive(input, agg, null_handling, cudf::default_stream_value, mr)
-           : detail::scan_inclusive(input, agg, null_handling, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::scan(input, agg, inclusive, null_handling, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/reductions/scan/scan_exclusive.cu
+++ b/cpp/src/reductions/scan/scan_exclusive.cu
@@ -64,8 +64,12 @@ struct scan_dispatcher {
     auto identity = Op::template identity<T>();
 
     auto begin = make_null_replacement_iterator(*d_input, identity, input.has_nulls());
-    thrust::exclusive_scan(
-      rmm::exec_policy(stream), begin, begin + input.size(), output.data<T>(), identity, Op{});
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+                           begin,
+                           begin + input.size(),
+                           output.data<T>(),
+                           identity,
+                           Op{});
 
     CUDF_CHECK_CUDA(stream.value());
     return output_column;

--- a/cpp/src/reductions/segmented_reductions.cpp
+++ b/cpp/src/reductions/segmented_reductions.cpp
@@ -127,14 +127,11 @@ std::unique_ptr<column> segmented_reduce(column_view const& segmented_values,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::segmented_reduce(segmented_values,
-                                  offsets,
-                                  agg,
-                                  output_dtype,
-                                  null_handling,
-                                  std::nullopt,
-                                  cudf::default_stream_value,
-                                  mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::segmented_reduce(
+    segmented_values, offsets, agg, output_dtype, null_handling, std::nullopt, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> segmented_reduce(column_view const& segmented_values,
@@ -146,14 +143,11 @@ std::unique_ptr<column> segmented_reduce(column_view const& segmented_values,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::segmented_reduce(segmented_values,
-                                  offsets,
-                                  agg,
-                                  output_dtype,
-                                  null_handling,
-                                  init,
-                                  cudf::default_stream_value,
-                                  mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::segmented_reduce(
+    segmented_values, offsets, agg, output_dtype, null_handling, init, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/reductions/simple.cuh
+++ b/cpp/src/reductions/simple.cuh
@@ -340,7 +340,7 @@ struct same_element_type_dispatcher {
     // We will do reduction to find the ARGMIN/ARGMAX index, then return the element at that index.
     auto const binop_generator =
       cudf::reduction::detail::comparison_binop_generator::create<Op>(input, stream);
-    auto const minmax_idx = thrust::reduce(rmm::exec_policy(stream),
+    auto const minmax_idx = thrust::reduce(rmm::exec_policy_nosync(stream),
                                            thrust::make_counting_iterator(0),
                                            thrust::make_counting_iterator(input.size()),
                                            size_type{0},

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -140,7 +140,7 @@ std::unique_ptr<cudf::column> clamp_string_column(strings_column_view const& inp
       }
     };
 
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      input.size(),
                      copy_transformer);
@@ -189,7 +189,7 @@ std::enable_if_t<cudf::is_fixed_width<T>(), std::unique_ptr<cudf::column>> clamp
 
   auto input_pair_iterator =
     make_optional_iterator<T>(*input_device_view, nullate::DYNAMIC{input.has_nulls()});
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     input_pair_iterator,
                     input_pair_iterator + input.size(),
                     scalar_zip_itr,

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -391,7 +391,10 @@ std::unique_ptr<column> clamp(column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::clamp(input, lo, lo_replace, hi, hi_replace, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::clamp(input, lo, lo_replace, hi, hi_replace, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 // clamp input at lo and hi
@@ -401,6 +404,9 @@ std::unique_ptr<column> clamp(column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::clamp(input, lo, lo, hi, hi, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::clamp(input, lo, lo, hi, hi, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -114,7 +114,10 @@ std::unique_ptr<column> replace_nans(column_view const& input,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_nans(input, replacement, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace_nans(input, replacement, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> replace_nans(column_view const& input,
@@ -122,7 +125,10 @@ std::unique_ptr<column> replace_nans(column_view const& input,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_nans(input, replacement, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace_nans(input, replacement, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf
@@ -223,7 +229,10 @@ std::unique_ptr<column> normalize_nans_and_zeros(column_view const& input,
                                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::normalize_nans_and_zeros(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::normalize_nans_and_zeros(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -239,7 +248,9 @@ std::unique_ptr<column> normalize_nans_and_zeros(column_view const& input,
 void normalize_nans_and_zeros(mutable_column_view& in_out)
 {
   CUDF_FUNC_RANGE();
-  detail::normalize_nans_and_zeros(in_out, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  detail::normalize_nans_and_zeros(in_out, stream);
+  stream.synchronize();
 }
 
 }  // namespace cudf

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -152,7 +152,7 @@ struct normalize_nans_and_zeros_kernel_forwarder {
                   cudf::mutable_column_device_view out,
                   rmm::cuda_stream_view stream)
   {
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator(0),
                       thrust::make_counting_iterator(in.size()),
                       out.head<T>(),

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -319,7 +319,7 @@ struct replace_nulls_scalar_kernel_forwarder {
     auto device_in   = cudf::column_device_view::create(input, stream);
 
     auto func = replace_nulls_functor<col_type>{s1.data()};
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       input.data<col_type>(),
                       input.data<col_type>() + input.size(),
                       cudf::detail::make_validity_iterator(*device_in),
@@ -383,12 +383,12 @@ std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const&
   auto func = cudf::detail::replace_policy_functor();
   if (replace_policy == cudf::replace_policy::PRECEDING) {
     thrust::inclusive_scan(
-      rmm::exec_policy(stream), in_begin, in_begin + input.size(), gm_begin, func);
+      rmm::exec_policy_nosync(stream), in_begin, in_begin + input.size(), gm_begin, func);
   } else {
     auto in_rbegin = thrust::make_reverse_iterator(in_begin + input.size());
     auto gm_rbegin = thrust::make_reverse_iterator(gm_begin + gather_map.size());
     thrust::inclusive_scan(
-      rmm::exec_policy(stream), in_rbegin, in_rbegin + input.size(), gm_rbegin, func);
+      rmm::exec_policy_nosync(stream), in_rbegin, in_rbegin + input.size(), gm_rbegin, func);
   }
 
   auto output = cudf::detail::gather(cudf::table_view({input}),

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -453,7 +453,10 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::replace_nulls(input, replacement, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace_nulls(input, replacement, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
@@ -461,7 +464,10 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::replace_nulls(input, replacement, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace_nulls(input, replacement, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> replace_nulls(column_view const& input,
@@ -469,7 +475,10 @@ std::unique_ptr<cudf::column> replace_nulls(column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::replace_nulls(input, replace_policy, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace_nulls(input, replace_policy, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -530,7 +530,11 @@ std::unique_ptr<cudf::column> find_and_replace_all(cudf::column_view const& inpu
                                                    cudf::column_view const& replacement_values,
                                                    rmm::mr::device_memory_resource* mr)
 {
-  return cudf::detail::find_and_replace_all(
-    input_col, values_to_replace, replacement_values, cudf::default_stream_value, mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::find_and_replace_all(input_col, values_to_replace, replacement_values, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -64,14 +64,14 @@ struct byte_list_conversion {
     size_type mask     = sizeof(T) - 1;
 
     if (configuration == flip_endianness::YES) {
-      thrust::for_each(rmm::exec_policy(stream),
+      thrust::for_each(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator(0),
                        thrust::make_counting_iterator(num_bytes),
                        [d_chars, d_data, mask] __device__(auto index) {
                          d_chars[index] = d_data[index + mask - ((index & mask) << 1)];
                        });
     } else {
-      thrust::copy_n(rmm::exec_policy(stream), d_data, num_bytes, d_chars);
+      thrust::copy_n(rmm::exec_policy_nosync(stream), d_data, num_bytes, d_chars);
     }
 
     auto begin          = thrust::make_constant_iterator(cudf::size_of(input_column.type()));

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -137,7 +137,10 @@ std::unique_ptr<column> byte_cast(column_view const& input_column,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::byte_cast(input_column, endian_configuration, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::byte_cast(input_column, endian_configuration, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -297,7 +297,10 @@ std::unique_ptr<column> interleave_columns(table_view const& input,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::interleave_columns(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::interleave_columns(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/reshape/tile.cu
+++ b/cpp/src/reshape/tile.cu
@@ -65,7 +65,10 @@ std::unique_ptr<table> tile(const table_view& in,
                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::tile(in, count, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::tile(in, count, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/rolling/detail/lead_lag_nested.cuh
+++ b/cpp/src/rolling/detail/lead_lag_nested.cuh
@@ -136,7 +136,7 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
   auto const input_size = input.size();
   auto const null_index = input.size();
   if (op == aggregation::LEAD) {
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator(size_type{0}),
                       thrust::make_counting_iterator(size_type{input.size()}),
                       gather_map.begin<size_type>(),
@@ -148,7 +148,7 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
                         return (row_offset > _following) ? null_index : (i + row_offset);
                       });
   } else {
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator(size_type{0}),
                       thrust::make_counting_iterator(size_type{input.size()}),
                       gather_map.begin<size_type>(),
@@ -175,7 +175,7 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
 
   // Find all indices at which LEAD/LAG computed nulls previously.
   auto scatter_map_end =
-    thrust::copy_if(rmm::exec_policy(stream),
+    thrust::copy_if(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator(size_type{0}),
                     thrust::make_counting_iterator(size_type{input.size()}),
                     scatter_map.begin(),

--- a/cpp/src/rolling/detail/nth_element.cuh
+++ b/cpp/src/rolling/detail/nth_element.cuh
@@ -159,7 +159,7 @@ std::unique_ptr<column> nth_element(size_type n,
 
   auto gather_map = rmm::device_uvector<offset_type>(input.size(), stream);
   thrust::copy(
-    rmm::exec_policy(stream), gather_iter, gather_iter + input.size(), gather_map.begin());
+    rmm::exec_policy_nosync(stream), gather_iter, gather_iter + input.size(), gather_map.begin());
 
   auto gathered = cudf::detail::gather(table_view{{input}},
                                        gather_map,

--- a/cpp/src/rolling/detail/rolling_collect_list.cu
+++ b/cpp/src/rolling/detail/rolling_collect_list.cu
@@ -57,10 +57,10 @@ std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view con
   auto per_row_mapping = make_fixed_width_column(
     data_type{type_to_id<size_type>()}, num_child_rows, mask_state::UNALLOCATED, stream);
   auto per_row_mapping_begin = per_row_mapping->mutable_view().template begin<size_type>();
-  thrust::fill_n(rmm::exec_policy(stream), per_row_mapping_begin, num_child_rows, 0);
+  thrust::fill_n(rmm::exec_policy_nosync(stream), per_row_mapping_begin, num_child_rows, 0);
 
   auto const begin = thrust::make_counting_iterator<size_type>(0);
-  thrust::scatter_if(rmm::exec_policy(stream),
+  thrust::scatter_if(rmm::exec_policy_nosync(stream),
                      begin,
                      begin + offsets.size() - 1,
                      offsets.begin<size_type>(),
@@ -78,7 +78,7 @@ std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view con
   // For the case with an empty list at index 2:
   //   scatter result == [0, 0, 1, 0, 0, 3, 0, 0, 4, 0, 0, 5, 0]
   //   inclusive_scan == [0, 0, 1, 1, 1, 3, 3, 3, 4, 4, 4, 5, 5]
-  thrust::inclusive_scan(rmm::exec_policy(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
                          per_row_mapping_begin,
                          per_row_mapping_begin + num_child_rows,
                          per_row_mapping_begin,
@@ -99,7 +99,7 @@ size_type count_child_nulls(column_view const& input,
     return d_input.is_null_nocheck(i);
   };
 
-  return thrust::count_if(rmm::exec_policy(stream),
+  return thrust::count_if(rmm::exec_policy_nosync(stream),
                           gather_map->view().begin<size_type>(),
                           gather_map->view().end<size_type>(),
                           input_row_is_null);
@@ -127,7 +127,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
                                                 gather_map.size() - num_child_nulls,
                                                 mask_state::UNALLOCATED,
                                                 stream);
-  thrust::copy_if(rmm::exec_policy(stream),
+  thrust::copy_if(rmm::exec_policy_nosync(stream),
                   gather_map.template begin<size_type>(),
                   gather_map.template end<size_type>(),
                   new_gather_map->mutable_view().template begin<size_type>(),
@@ -137,7 +137,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
   auto new_sizes = make_fixed_width_column(
     data_type{type_to_id<size_type>()}, input.size(), mask_state::UNALLOCATED, stream);
 
-  thrust::tabulate(rmm::exec_policy(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream),
                    new_sizes->mutable_view().template begin<size_type>(),
                    new_sizes->mutable_view().template end<size_type>(),
                    [d_gather_map  = gather_map.template begin<offset_type>(),

--- a/cpp/src/rolling/detail/rolling_collect_list.cuh
+++ b/cpp/src/rolling/detail/rolling_collect_list.cuh
@@ -67,7 +67,7 @@ std::unique_ptr<column> create_collect_offsets(size_type input_size,
   // But if min_periods=3, rows at indices 0 and 4 have too few observations, and must return
   // null. The sizes at these positions must be 0, i.e.
   //  prec + foll = [0,3,3,3,0]
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     preceding_begin,
                     preceding_begin + input_size,
                     following_begin,
@@ -111,7 +111,7 @@ std::unique_ptr<column> create_collect_gather_map(column_view const& child_offse
   auto gather_map = make_fixed_width_column(
     data_type{type_to_id<size_type>()}, per_row_mapping.size(), mask_state::UNALLOCATED, stream);
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(per_row_mapping.size()),
     gather_map->mutable_view().template begin<size_type>(),

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -300,8 +300,10 @@ std::unique_ptr<column> expand_to_column(Calculator const& calc,
 
   auto begin = cudf::detail::make_counting_transform_iterator(0, calc);
 
-  thrust::copy_n(
-    rmm::exec_policy(stream), begin, num_rows, window_column->mutable_view().data<size_type>());
+  thrust::copy_n(rmm::exec_policy_nosync(stream),
+                 begin,
+                 num_rows,
+                 window_column->mutable_view().data<size_type>());
 
   return window_column;
 }
@@ -420,7 +422,7 @@ get_null_bounds_for_orderby_column(column_view const& orderby_column,
 
     // Null timestamps exist. Find null bounds, per group.
     thrust::for_each(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator(static_cast<size_type>(0)),
       thrust::make_counting_iterator(static_cast<size_type>(num_groups)),
       [d_orderby       = *p_orderby_device_view,

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -204,15 +204,18 @@ std::unique_ptr<column> grouped_rolling_window(table_view const& group_keys,
                                                rolling_aggregation const& aggr,
                                                rmm::mr::device_memory_resource* mr)
 {
-  return detail::grouped_rolling_window(group_keys,
-                                        input,
-                                        default_outputs,
-                                        preceding_window_bounds,
-                                        following_window_bounds,
-                                        min_periods,
-                                        aggr,
-                                        cudf::default_stream_value,
-                                        mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::grouped_rolling_window(group_keys,
+                                               input,
+                                               default_outputs,
+                                               preceding_window_bounds,
+                                               following_window_bounds,
+                                               min_periods,
+                                               aggr,
+                                               stream,
+                                               mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace {
@@ -1039,15 +1042,19 @@ std::unique_ptr<column> grouped_time_range_rolling_window(table_view const& grou
   auto preceding = to_range_bounds(preceding_window_in_days, timestamp_column.type());
   auto following = to_range_bounds(following_window_in_days, timestamp_column.type());
 
-  return grouped_range_rolling_window(group_keys,
-                                      timestamp_column,
-                                      timestamp_order,
-                                      input,
-                                      preceding,
-                                      following,
-                                      min_periods,
-                                      aggr,
-                                      mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::grouped_range_rolling_window(group_keys,
+                                                     timestamp_column,
+                                                     timestamp_order,
+                                                     input,
+                                                     preceding,
+                                                     following,
+                                                     min_periods,
+                                                     aggr,
+                                                     stream,
+                                                     mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -1077,16 +1084,19 @@ std::unique_ptr<column> grouped_time_range_rolling_window(table_view const& grou
   range_window_bounds following =
     to_range_bounds(following_window_in_days, timestamp_column.type());
 
-  return grouped_range_rolling_window(group_keys,
-                                      timestamp_column,
-                                      timestamp_order,
-                                      input,
-                                      preceding,
-                                      following,
-                                      min_periods,
-                                      aggr,
-                                      cudf::default_stream_value,
-                                      mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::grouped_range_rolling_window(group_keys,
+                                                     timestamp_column,
+                                                     timestamp_order,
+                                                     input,
+                                                     preceding,
+                                                     following,
+                                                     min_periods,
+                                                     aggr,
+                                                     stream,
+                                                     mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -1111,16 +1121,20 @@ std::unique_ptr<column> grouped_range_rolling_window(table_view const& group_key
                                                      rolling_aggregation const& aggr,
                                                      rmm::mr::device_memory_resource* mr)
 {
-  return detail::grouped_range_rolling_window(group_keys,
-                                              timestamp_column,
-                                              timestamp_order,
-                                              input,
-                                              preceding,
-                                              following,
-                                              min_periods,
-                                              aggr,
-                                              cudf::default_stream_value,
-                                              mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::grouped_range_rolling_window(group_keys,
+                                                     timestamp_column,
+                                                     timestamp_order,
+                                                     input,
+                                                     preceding,
+                                                     following,
+                                                     min_periods,
+                                                     aggr,
+                                                     stream,
+                                                     mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -17,6 +17,7 @@
 #include "detail/rolling.cuh"
 
 #include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
@@ -33,14 +34,12 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        rolling_aggregation const& agg,
                                        rmm::mr::device_memory_resource* mr)
 {
-  return detail::rolling_window(input,
-                                default_outputs,
-                                preceding_window,
-                                following_window,
-                                min_periods,
-                                agg,
-                                cudf::default_stream_value,
-                                mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::rolling_window(
+    input, default_outputs, preceding_window, following_window, min_periods, agg, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 // Applies a fixed-size rolling window function to the values in a column, without default specified
@@ -65,8 +64,12 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        rolling_aggregation const& agg,
                                        rmm::mr::device_memory_resource* mr)
 {
-  return detail::rolling_window(
-    input, preceding_window, following_window, min_periods, agg, cudf::default_stream_value, mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::rolling_window(input, preceding_window, following_window, min_periods, agg, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -347,7 +347,10 @@ std::unique_ptr<column> round(column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::round(input, decimal_places, method, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::round(input, decimal_places, method, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/search/contains_column.cu
+++ b/cpp/src/search/contains_column.cu
@@ -152,7 +152,10 @@ std::unique_ptr<column> contains(column_view const& haystack,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(haystack, needles, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::contains(haystack, needles, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/search/contains_nested.cu
+++ b/cpp/src/search/contains_nested.cu
@@ -47,7 +47,7 @@ bool contains_nested_element(column_view const& haystack,
     auto const haystack_cdv_ptr  = column_device_view::create(haystack, stream);
     auto const haystack_valid_it = cudf::detail::make_validity_iterator<false>(*haystack_cdv_ptr);
 
-    return thrust::count_if(rmm::exec_policy(stream),
+    return thrust::count_if(rmm::exec_policy_nosync(stream),
                             begin,
                             end,
                             [d_comp, haystack_valid_it] __device__(auto const idx) {
@@ -58,7 +58,7 @@ bool contains_nested_element(column_view const& haystack,
   }
 
   return thrust::count_if(
-           rmm::exec_policy(stream), begin, end, [d_comp] __device__(auto const idx) {
+           rmm::exec_policy_nosync(stream), begin, end, [d_comp] __device__(auto const idx) {
              return d_comp(idx, rhs_index_type{0});  // compare haystack[idx] == needle[0].
            }) > 0;
 }

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -172,7 +172,10 @@ bool contains(column_view const& haystack, scalar const& needle, rmm::cuda_strea
 bool contains(column_view const& haystack, scalar const& needle)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(haystack, needle, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::contains(haystack, needle, stream);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -75,7 +75,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
   auto const needles_it  = cudf::experimental::row::rhs_iterator(0);
 
   if (find_first) {
-    thrust::lower_bound(rmm::exec_policy(stream),
+    thrust::lower_bound(rmm::exec_policy_nosync(stream),
                         haystack_it,
                         haystack_it + haystack.num_rows(),
                         needles_it,
@@ -83,7 +83,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
                         out_it,
                         d_comparator);
   } else {
-    thrust::upper_bound(rmm::exec_policy(stream),
+    thrust::upper_bound(rmm::exec_policy_nosync(stream),
                         haystack_it,
                         haystack_it + haystack.num_rows(),
                         needles_it,

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -126,8 +126,10 @@ std::unique_ptr<column> lower_bound(table_view const& haystack,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::lower_bound(
-    haystack, needles, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::lower_bound(haystack, needles, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> upper_bound(table_view const& haystack,
@@ -137,8 +139,10 @@ std::unique_ptr<column> upper_bound(table_view const& haystack,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::upper_bound(
-    haystack, needles, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::upper_bound(haystack, needles, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -55,7 +55,7 @@ auto is_sorted(cudf::table_view const& in,
                                                  d_column_order.data(),
                                                  d_null_precedence.data());
 
-  auto sorted = thrust::is_sorted(rmm::exec_policy(stream),
+  auto sorted = thrust::is_sorted(rmm::exec_policy_nosync(stream),
                                   thrust::make_counting_iterator(0),
                                   thrust::make_counting_iterator(in.num_rows()),
                                   comparator);

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -83,8 +83,10 @@ bool is_sorted(cudf::table_view const& in,
       "Number of columns in the table doesn't match the vector null_precedence's size .\n");
   }
 
-  return detail::is_sorted(
-    in, column_order, has_nulls(in), null_precedence, cudf::default_stream_value);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_sorted(in, column_order, has_nulls(in), null_precedence, stream);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -18,6 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/sorting.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/row_operators.cuh>
@@ -344,13 +345,11 @@ std::unique_ptr<column> rank(column_view const& input,
                              bool percentage,
                              rmm::mr::device_memory_resource* mr)
 {
-  return detail::rank(input,
-                      method,
-                      column_order,
-                      null_handling,
-                      null_precedence,
-                      percentage,
-                      cudf::default_stream_value,
-                      mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::rank(
+    input, method, column_order, null_handling, null_precedence, percentage, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/sort/segmented_sort.cu
+++ b/cpp/src/sort/segmented_sort.cu
@@ -47,7 +47,7 @@ rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
   auto offsets_minus_one = thrust::make_transform_iterator(
     offset_begin, [offset_begin] __device__(auto i) { return i - 1; });
   auto counting_iter = thrust::make_counting_iterator<size_type>(0);
-  thrust::lower_bound(rmm::exec_policy(stream),
+  thrust::lower_bound(rmm::exec_policy_nosync(stream),
                       offsets_minus_one,
                       offsets_minus_one + offsets.size(),
                       counting_iter,

--- a/cpp/src/sort/segmented_sort.cu
+++ b/cpp/src/sort/segmented_sort.cu
@@ -195,8 +195,11 @@ std::unique_ptr<column> segmented_sorted_order(table_view const& keys,
                                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::segmented_sorted_order(
-    keys, segment_offsets, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::segmented_sorted_order(
+    keys, segment_offsets, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> stable_segmented_sorted_order(
@@ -207,8 +210,11 @@ std::unique_ptr<column> stable_segmented_sorted_order(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::stable_segmented_sorted_order(
-    keys, segment_offsets, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::stable_segmented_sorted_order(
+    keys, segment_offsets, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> segmented_sort_by_key(table_view const& values,
@@ -219,8 +225,11 @@ std::unique_ptr<table> segmented_sort_by_key(table_view const& values,
                                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::segmented_sort_by_key(
-    values, keys, segment_offsets, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::segmented_sort_by_key(
+    values, keys, segment_offsets, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> stable_segmented_sort_by_key(table_view const& values,
@@ -231,8 +240,11 @@ std::unique_ptr<table> stable_segmented_sort_by_key(table_view const& values,
                                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::stable_segmented_sort_by_key(
-    values, keys, segment_offsets, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::stable_segmented_sort_by_key(
+    values, keys, segment_offsets, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -101,8 +101,7 @@ std::unique_ptr<table> sort(table_view const& input,
     columns.emplace_back(std::move(output));
     return std::make_unique<table>(std::move(columns));
   }
-  return detail::sort_by_key(
-    input, input, column_order, null_precedence, cudf::default_stream_value, mr);
+  return detail::sort_by_key(input, input, column_order, null_precedence, stream, mr);
 }
 
 }  // namespace detail
@@ -113,7 +112,10 @@ std::unique_ptr<column> sorted_order(table_view const& input,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sorted_order(input, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::sorted_order(input, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> sort(table_view const& input,
@@ -122,7 +124,10 @@ std::unique_ptr<table> sort(table_view const& input,
                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sort(input, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::sort(input, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> sort_by_key(table_view const& values,
@@ -132,8 +137,10 @@ std::unique_ptr<table> sort_by_key(table_view const& values,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::sort_by_key(
-    values, keys, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::sort_by_key(values, keys, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -66,9 +66,11 @@ struct inplace_column_sort_fn {
   {
     CUDF_EXPECTS(!col.has_nulls(), "Nulls not supported for in-place sort");
     if (ascending) {
-      thrust::sort(rmm::exec_policy(stream), col.begin<T>(), col.end<T>(), thrust::less<T>());
+      thrust::sort(
+        rmm::exec_policy_nosync(stream), col.begin<T>(), col.end<T>(), thrust::less<T>());
     } else {
-      thrust::sort(rmm::exec_policy(stream), col.begin<T>(), col.end<T>(), thrust::greater<T>());
+      thrust::sort(
+        rmm::exec_policy_nosync(stream), col.begin<T>(), col.end<T>(), thrust::greater<T>());
     }
   }
 

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -120,7 +120,7 @@ std::unique_ptr<column> sorted_order(table_view input,
   std::unique_ptr<column> sorted_indices = cudf::make_numeric_column(
     data_type(type_to_id<size_type>()), input.num_rows(), mask_state::UNALLOCATED, stream, mr);
   mutable_column_view mutable_indices_view = sorted_indices->mutable_view();
-  thrust::sequence(rmm::exec_policy(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream),
                    mutable_indices_view.begin<size_type>(),
                    mutable_indices_view.end<size_type>(),
                    0);
@@ -130,12 +130,12 @@ std::unique_ptr<column> sorted_order(table_view input,
   auto comparator = comp.less(nullate::DYNAMIC{has_nested_nulls(input)});
 
   if (stable) {
-    thrust::stable_sort(rmm::exec_policy(stream),
+    thrust::stable_sort(rmm::exec_policy_nosync(stream),
                         mutable_indices_view.begin<size_type>(),
                         mutable_indices_view.end<size_type>(),
                         comparator);
   } else {
-    thrust::sort(rmm::exec_policy(stream),
+    thrust::sort(rmm::exec_policy_nosync(stream),
                  mutable_indices_view.begin<size_type>(),
                  mutable_indices_view.end<size_type>(),
                  comparator);

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -63,8 +63,11 @@ std::unique_ptr<column> stable_sorted_order(table_view const& input,
                                             std::vector<null_order> const& null_precedence,
                                             rmm::mr::device_memory_resource* mr)
 {
-  return detail::stable_sorted_order(
-    input, column_order, null_precedence, cudf::default_stream_value, mr);
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::stable_sorted_order(input, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> stable_sort_by_key(table_view const& values,
@@ -74,8 +77,10 @@ std::unique_ptr<table> stable_sort_by_key(table_view const& values,
                                           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::stable_sort_by_key(
-    values, keys, column_order, null_precedence, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::stable_sort_by_key(values, keys, column_order, null_precedence, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/apply_boolean_mask.cu
+++ b/cpp/src/stream_compaction/apply_boolean_mask.cu
@@ -93,6 +93,9 @@ std::unique_ptr<table> apply_boolean_mask(table_view const& input,
                                           rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::apply_boolean_mask(input, boolean_mask, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::apply_boolean_mask(input, boolean_mask, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/stream_compaction/distinct.cu
+++ b/cpp/src/stream_compaction/distinct.cu
@@ -102,7 +102,7 @@ rmm::device_uvector<size_type> get_distinct_indices(table_view const& input,
     if (keep == duplicate_keep_option::KEEP_NONE) {
       // Reduction results with `KEEP_NONE` are either group sizes of equal rows, or `0`.
       // Thus, we only output index of the rows in the groups having group size of `1`.
-      return thrust::copy_if(rmm::exec_policy(stream),
+      return thrust::copy_if(rmm::exec_policy_nosync(stream),
                              thrust::make_counting_iterator(0),
                              thrust::make_counting_iterator(input.num_rows()),
                              output_indices.begin(),
@@ -113,7 +113,7 @@ rmm::device_uvector<size_type> get_distinct_indices(table_view const& input,
     // Reduction results with `KEEP_FIRST` and `KEEP_LAST` are row indices of the first/last row in
     // each group of equal rows (which are the desired output indices), or the value given by
     // `reduction_init_value()`.
-    return thrust::copy_if(rmm::exec_policy(stream),
+    return thrust::copy_if(rmm::exec_policy_nosync(stream),
                            reduction_results.begin(),
                            reduction_results.end(),
                            output_indices.begin(),

--- a/cpp/src/stream_compaction/distinct.cu
+++ b/cpp/src/stream_compaction/distinct.cu
@@ -158,8 +158,10 @@ std::unique_ptr<table> distinct(table_view const& input,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::distinct(
-    input, keys, keep, nulls_equal, nans_equal, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::distinct(input, keys, keep, nulls_equal, nans_equal, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/distinct_count.cu
+++ b/cpp/src/stream_compaction/distinct_count.cu
@@ -95,7 +95,7 @@ struct has_nans {
   {
     auto input_device_view = cudf::column_device_view::create(input, stream);
     auto device_view       = *input_device_view;
-    return thrust::any_of(rmm::exec_policy(stream),
+    return thrust::any_of(rmm::exec_policy_nosync(stream),
                           thrust::counting_iterator<cudf::size_type>(0),
                           thrust::counting_iterator<cudf::size_type>(input.size()),
                           check_for_nan<T>(device_view));

--- a/cpp/src/stream_compaction/distinct_reduce.cu
+++ b/cpp/src/stream_compaction/distinct_reduce.cu
@@ -104,7 +104,7 @@ rmm::device_uvector<size_type> hash_reduce_by_row(
 
   auto reduction_results = rmm::device_uvector<size_type>(num_rows, stream, mr);
 
-  thrust::uninitialized_fill(rmm::exec_policy(stream),
+  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
                              reduction_results.begin(),
                              reduction_results.end(),
                              reduction_init_value(keep));
@@ -117,7 +117,7 @@ rmm::device_uvector<size_type> hash_reduce_by_row(
   auto const reduce_by_row = [&](auto const value_comp) {
     auto const key_equal = row_comp.equal_to(has_nulls, nulls_equal, value_comp);
     thrust::for_each(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator(0),
       thrust::make_counting_iterator(num_rows),
       reduce_by_row_fn{

--- a/cpp/src/stream_compaction/drop_nans.cu
+++ b/cpp/src/stream_compaction/drop_nans.cu
@@ -119,17 +119,24 @@ std::unique_ptr<table> drop_nans(table_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nans(input, keys, keep_threshold, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::drop_nans(input, keys, keep_threshold, stream, mr);
+  stream.synchronize();
+  return result;
 }
+
 /*
- * Filters a table to remove nan null elements.
+ * Filters a table to remove nan elements.
  */
 std::unique_ptr<table> drop_nans(table_view const& input,
                                  std::vector<size_type> const& keys,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nans(input, keys, keys.size(), cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::drop_nans(input, keys, keys.size(), stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/drop_nulls.cu
+++ b/cpp/src/stream_compaction/drop_nulls.cu
@@ -92,8 +92,12 @@ std::unique_ptr<table> drop_nulls(table_view const& input,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nulls(input, keys, keep_threshold, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::drop_nulls(input, keys, keep_threshold, stream, mr);
+  stream.synchronize();
+  return result;
 }
+
 /*
  * Filters a table to remove null elements.
  */
@@ -102,7 +106,10 @@ std::unique_ptr<table> drop_nulls(table_view const& input,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nulls(input, keys, keys.size(), cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::drop_nulls(input, keys, keys.size(), stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/stable_distinct.cu
+++ b/cpp/src/stream_compaction/stable_distinct.cu
@@ -44,9 +44,10 @@ std::unique_ptr<table> stable_distinct(table_view const& input,
   // Markers to denote which rows to be copied to the output.
   auto const output_markers = [&] {
     auto markers = rmm::device_uvector<bool>(input.num_rows(), stream);
-    thrust::uninitialized_fill(rmm::exec_policy(stream), markers.begin(), markers.end(), false);
+    thrust::uninitialized_fill(
+      rmm::exec_policy_nosync(stream), markers.begin(), markers.end(), false);
     thrust::scatter(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::constant_iterator<bool>(true, 0),
       thrust::constant_iterator<bool>(true, static_cast<size_type>(distinct_indices.size())),
       distinct_indices.begin(),

--- a/cpp/src/stream_compaction/stream_compaction_common.cuh
+++ b/cpp/src/stream_compaction/stream_compaction_common.cuh
@@ -142,7 +142,7 @@ OutputIterator unique_copy(InputIterator first,
 {
   size_type const last_index = thrust::distance(first, last) - 1;
   return thrust::copy_if(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     first,
     last,
     thrust::counting_iterator<size_type>(0),

--- a/cpp/src/stream_compaction/unique.cu
+++ b/cpp/src/stream_compaction/unique.cu
@@ -99,7 +99,10 @@ std::unique_ptr<table> unique(table_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::unique(input, keys, keep, nulls_equal, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::unique(input, keys, keep, nulls_equal, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/unique_count.cu
+++ b/cpp/src/stream_compaction/unique_count.cu
@@ -74,7 +74,7 @@ cudf::size_type unique_count(table_view const& keys,
   row_equality_comparator comp(
     nullate::DYNAMIC{cudf::has_nulls(keys)}, *table_ptr, *table_ptr, nulls_equal);
   return thrust::count_if(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::counting_iterator<cudf::size_type>(0),
     thrust::counting_iterator<cudf::size_type>(keys.num_rows()),
     [comp] __device__(cudf::size_type i) { return (i == 0 or not comp(i, i - 1)); });
@@ -102,7 +102,7 @@ cudf::size_type unique_count(column_view const& input,
                                null_equality::EQUAL);
 
   return thrust::count_if(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::counting_iterator<cudf::size_type>(0),
     thrust::counting_iterator<cudf::size_type>(num_rows),
     [count_nulls, nan_is_null, should_check_nan, device_view, comp] __device__(cudf::size_type i) {

--- a/cpp/src/strings/attributes.cu
+++ b/cpp/src/strings/attributes.cu
@@ -72,7 +72,7 @@ std::unique_ptr<column> counts_fn(strings_column_view const& strings,
   auto strings_column = cudf::column_device_view::create(strings.parent(), stream);
   auto d_strings      = *strings_column;
   // fill in the lengths
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(strings.size()),
                     d_lengths,
@@ -146,7 +146,7 @@ std::unique_ptr<column> code_points(
   // create offsets vector to account for each string's character length
   rmm::device_uvector<size_type> offsets(strings.size() + 1, stream);
   thrust::transform_inclusive_scan(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(strings.size()),
     offsets.begin() + 1,
@@ -168,7 +168,7 @@ std::unique_ptr<column> code_points(
   // fill column with character code-point values
   auto d_results = results_view.data<int32_t>();
   // now set the ranges from each strings' character values
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings.size(),
                      code_points_fn{d_column, offsets.data(), d_results});

--- a/cpp/src/strings/attributes.cu
+++ b/cpp/src/strings/attributes.cu
@@ -185,21 +185,30 @@ std::unique_ptr<column> count_characters(strings_column_view const& strings,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_characters(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::count_characters(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> count_bytes(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_bytes(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::count_bytes(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> code_points(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::code_points(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::code_points(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/capitalize.cu
+++ b/cpp/src/strings/capitalize.cu
@@ -273,7 +273,7 @@ std::unique_ptr<column> is_title(strings_column_view const& input,
                                      stream,
                                      mr);
   auto d_column = column_device_view::create(input.parent(), stream);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(input.size()),
                     results->mutable_view().data<bool>(),

--- a/cpp/src/strings/capitalize.cu
+++ b/cpp/src/strings/capitalize.cu
@@ -288,7 +288,10 @@ std::unique_ptr<column> capitalize(strings_column_view const& input,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::capitalize(input, delimiter, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::capitalize(input, delimiter, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> title(strings_column_view const& input,
@@ -296,14 +299,20 @@ std::unique_ptr<column> title(strings_column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::title(input, sequence_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::title(input, sequence_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> is_title(strings_column_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_title(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_title(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/case.cu
+++ b/cpp/src/strings/case.cu
@@ -185,21 +185,30 @@ std::unique_ptr<column> to_lower(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_lower(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_lower(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> to_upper(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_upper(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_upper(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> swapcase(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::swapcase(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::swapcase(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/char_types/char_types.cu
+++ b/cpp/src/strings/char_types/char_types.cu
@@ -197,8 +197,10 @@ std::unique_ptr<column> all_characters_of_type(strings_column_view const& string
                                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::all_characters_of_type(
-    strings, types, verify_types, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::all_characters_of_type(strings, types, verify_types, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> filter_characters_of_type(strings_column_view const& strings,
@@ -208,8 +210,11 @@ std::unique_ptr<column> filter_characters_of_type(strings_column_view const& str
                                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::filter_characters_of_type(
-    strings, types_to_remove, replacement, types_to_keep, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::filter_characters_of_type(
+    strings, types_to_remove, replacement, types_to_keep, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/char_types/char_types.cu
+++ b/cpp/src/strings/char_types/char_types.cu
@@ -62,7 +62,7 @@ std::unique_ptr<column> all_characters_of_type(
   // get the static character types table
   auto d_flags = detail::get_character_flags_table();
   // set the output values by checking the character types for each string
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,

--- a/cpp/src/strings/combine/concatenate.cu
+++ b/cpp/src/strings/combine/concatenate.cu
@@ -269,8 +269,10 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::concatenate(
-    strings_columns, separator, narep, separate_nulls, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::concatenate(strings_columns, separator, narep, separate_nulls, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> concatenate(table_view const& strings_columns,
@@ -281,13 +283,11 @@ std::unique_ptr<column> concatenate(table_view const& strings_columns,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::concatenate(strings_columns,
-                             separators,
-                             separator_narep,
-                             col_narep,
-                             separate_nulls,
-                             cudf::default_stream_value,
-                             mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::concatenate(
+    strings_columns, separators, separator_narep, col_narep, separate_nulls, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/combine/join.cu
+++ b/cpp/src/strings/combine/join.cu
@@ -135,7 +135,10 @@ std::unique_ptr<column> join_strings(strings_column_view const& strings,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::join_strings(strings, separator, narep, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::join_strings(strings, separator, narep, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/combine/join.cu
+++ b/cpp/src/strings/combine/join.cu
@@ -62,7 +62,7 @@ std::unique_ptr<column> join_strings(strings_column_view const& strings,
   auto d_output_offsets = output_offsets.data();
   // using inclusive-scan to compute last entry which is the total size
   thrust::transform_inclusive_scan(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(strings_count),
     d_output_offsets + 1,
@@ -104,7 +104,7 @@ std::unique_ptr<column> join_strings(strings_column_view const& strings,
   auto chars_column = create_chars_child_column(bytes, stream, mr);
   auto d_chars      = chars_column->mutable_view().data<char>();
   thrust::for_each_n(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     [d_strings, d_separator, d_narep, d_output_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/src/strings/combine/join_list_elements.cu
+++ b/cpp/src/strings/combine/join_list_elements.cu
@@ -303,13 +303,11 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::join_list_elements(lists_strings_column,
-                                    separator,
-                                    narep,
-                                    separate_nulls,
-                                    empty_list_policy,
-                                    cudf::default_stream_value,
-                                    mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::join_list_elements(
+    lists_strings_column, separator, narep, separate_nulls, empty_list_policy, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> join_list_elements(lists_column_view const& lists_strings_column,
@@ -321,14 +319,17 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::join_list_elements(lists_strings_column,
-                                    separators,
-                                    separator_narep,
-                                    string_narep,
-                                    separate_nulls,
-                                    empty_list_policy,
-                                    cudf::default_stream_value,
-                                    mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::join_list_elements(lists_strings_column,
+                                           separators,
+                                           separator_narep,
+                                           string_narep,
+                                           separate_nulls,
+                                           empty_list_policy,
+                                           stream,
+                                           mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/contains.cu
+++ b/cpp/src/strings/contains.cu
@@ -134,7 +134,10 @@ std::unique_ptr<column> contains_re(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains_re(strings, pattern, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::contains_re(strings, pattern, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> matches_re(strings_column_view const& strings,
@@ -143,7 +146,10 @@ std::unique_ptr<column> matches_re(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::matches_re(strings, pattern, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::matches_re(strings, pattern, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> count_re(strings_column_view const& strings,
@@ -152,7 +158,10 @@ std::unique_ptr<column> count_re(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_re(strings, pattern, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::count_re(strings, pattern, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -86,7 +86,10 @@ std::unique_ptr<column> to_booleans(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_booleans(strings, true_string, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_booleans(strings, true_string, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -155,7 +158,10 @@ std::unique_ptr<column> from_booleans(column_view const& booleans,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_booleans(booleans, true_string, false_string, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::from_booleans(booleans, true_string, false_string, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -64,7 +64,7 @@ std::unique_ptr<column> to_booleans(strings_column_view const& strings,
   auto results_view = results->mutable_view();
   auto d_results    = results_view.data<bool>();
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -129,7 +129,7 @@ std::unique_ptr<column> from_booleans(column_view const& booleans,
     cudf::detail::get_value<int32_t>(offsets_column->view(), strings_count, stream);
   auto chars_column = create_chars_child_column(bytes, stream, mr);
   auto d_chars      = chars_column->mutable_view().data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      [d_column, d_true, d_false, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -653,7 +653,10 @@ std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_timestamps(input, timestamp_type, format, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_timestamps(input, timestamp_type, format, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
@@ -661,7 +664,10 @@ std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_timestamp(input, format, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_timestamp(input, format, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -1149,7 +1155,10 @@ std::unique_ptr<column> from_timestamps(column_view const& timestamps,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_timestamps(timestamps, format, names, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::from_timestamps(timestamps, format, names, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -369,7 +369,7 @@ struct dispatch_to_timestamps_fn {
   {
     format_compiler compiler(format, stream);
     parse_datetime<T> pfn{d_strings, compiler.format_items(), compiler.subsecond_precision()};
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(results_view.size()),
                       results_view.data<T>(),
@@ -633,7 +633,7 @@ std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
   auto d_results = results->mutable_view().data<bool>();
 
   format_compiler compiler(format, stream);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -1083,7 +1083,7 @@ struct dispatch_from_timestamps_fn {
     auto d_chars      = chars_column->mutable_view().template data<char>();
 
     datetime_formatter<T> pfn{d_timestamps, d_format_names, d_format_items, d_offsets, d_chars};
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<cudf::size_type>(0),
                        d_timestamps.size(),
                        pfn);

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -439,7 +439,7 @@ struct dispatch_from_durations_fn {
     auto chars_column = detail::create_chars_child_column(chars_bytes, stream, mr);
     auto d_chars      = chars_column->mutable_view().template data<char>();
 
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        strings_count,
                        duration_to_string_fn<T>{
@@ -685,7 +685,7 @@ struct dispatch_to_durations_fn {
     auto d_items   = compiler.compiled_format_items();
     auto d_results = results_view.data<T>();
     parse_duration<T> pfn{d_strings, d_items, compiler.items_count()};
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(results_view.size()),
                       d_results,

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -749,7 +749,10 @@ std::unique_ptr<column> from_durations(column_view const& durations,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_durations(durations, format, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::from_durations(durations, format, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> to_durations(strings_column_view const& strings,
@@ -758,7 +761,10 @@ std::unique_ptr<column> to_durations(strings_column_view const& strings,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_durations(strings, duration_type, format, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_durations(strings, duration_type, format, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_fixed_point.cu
+++ b/cpp/src/strings/convert/convert_fixed_point.cu
@@ -152,7 +152,7 @@ struct dispatch_to_fixed_point_fn {
     auto d_results = results->mutable_view().data<DecimalType>();
 
     // convert strings into decimal values
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(input.size()),
                       d_results,
@@ -295,7 +295,7 @@ struct dispatch_from_fixed_point_fn {
       cudf::detail::get_value<int32_t>(offsets_column->view(), input.size(), stream);
     auto chars_column = detail::create_chars_child_column(bytes, stream, mr);
     auto d_chars      = chars_column->mutable_view().template data<char>();
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        input.size(),
                        decimal_to_string_fn<DecimalType>{*d_column, d_offsets, d_chars});
@@ -361,7 +361,7 @@ struct dispatch_is_fixed_point_fn {
     auto d_results = results->mutable_view().data<bool>();
 
     // check strings for valid fixed-point chars
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(input.size()),
                       d_results,

--- a/cpp/src/strings/convert/convert_fixed_point.cu
+++ b/cpp/src/strings/convert/convert_fixed_point.cu
@@ -191,7 +191,10 @@ std::unique_ptr<column> to_fixed_point(strings_column_view const& strings,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_fixed_point(strings, output_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_fixed_point(strings, output_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -334,7 +337,10 @@ std::unique_ptr<column> from_fixed_point(column_view const& input,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_fixed_point(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::from_fixed_point(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -398,7 +404,10 @@ std::unique_ptr<column> is_fixed_point(strings_column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_fixed_point(input, decimal_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_fixed_point(input, decimal_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -228,7 +228,10 @@ std::unique_ptr<column> to_floats(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_floats(strings, output_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_floats(strings, output_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -553,7 +556,10 @@ std::unique_ptr<column> from_floats(column_view const& floats,
 std::unique_ptr<column> from_floats(column_view const& floats, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_floats(floats, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::from_floats(floats, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -592,7 +598,10 @@ std::unique_ptr<column> is_float(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_float(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_float(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -179,7 +179,7 @@ struct dispatch_to_floats_fn {
                   rmm::cuda_stream_view stream) const
   {
     auto d_results = output_column.data<FloatType>();
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_column.size()),
                       d_results,
@@ -512,7 +512,7 @@ struct dispatch_from_floats_fn {
     auto chars_column = detail::create_chars_child_column(bytes, stream, mr);
     auto chars_view   = chars_column->mutable_view();
     auto d_chars      = chars_view.template data<char>();
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        strings_count,
                        float_to_string_fn<FloatType>{d_column, d_offsets, d_chars});
@@ -573,7 +573,7 @@ std::unique_ptr<column> is_float(
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
   // check strings for valid float chars
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings.size()),
                     d_results,

--- a/cpp/src/strings/convert/convert_hex.cu
+++ b/cpp/src/strings/convert/convert_hex.cu
@@ -99,7 +99,7 @@ struct dispatch_hex_to_integers_fn {
                   rmm::cuda_stream_view stream) const
   {
     auto d_results = output_column.data<IntegerType>();
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_column.size()),
                       d_results,
@@ -244,7 +244,7 @@ std::unique_ptr<column> is_hex(strings_column_view const& strings,
                                      stream,
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings.size()),
                     d_results,

--- a/cpp/src/strings/convert/convert_hex.cu
+++ b/cpp/src/strings/convert/convert_hex.cu
@@ -284,21 +284,30 @@ std::unique_ptr<column> hex_to_integers(strings_column_view const& strings,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::hex_to_integers(strings, output_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::hex_to_integers(strings, output_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> is_hex(strings_column_view const& strings,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_hex(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_hex(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> integers_to_hex(column_view const& input,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::integers_to_hex(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::integers_to_hex(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -183,7 +183,10 @@ std::unique_ptr<column> is_integer(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_integer(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_integer(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> is_integer(strings_column_view const& strings,
@@ -191,7 +194,10 @@ std::unique_ptr<column> is_integer(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_integer(strings, int_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_integer(strings, int_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -284,7 +290,10 @@ std::unique_ptr<column> to_integers(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::to_integers(strings, output_type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::to_integers(strings, output_type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -405,7 +414,10 @@ std::unique_ptr<column> from_integers(column_view const& integers,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::from_integers(integers, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::from_integers(integers, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -101,13 +101,13 @@ struct dispatch_is_integer_fn {
 
     auto d_results = results->mutable_view().data<bool>();
     if (strings.has_nulls()) {
-      thrust::transform(rmm::exec_policy(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream),
                         d_column->pair_begin<string_view, true>(),
                         d_column->pair_end<string_view, true>(),
                         d_results,
                         string_to_integer_check_fn<T>{});
     } else {
-      thrust::transform(rmm::exec_policy(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream),
                         d_column->pair_begin<string_view, false>(),
                         d_column->pair_end<string_view, false>(),
                         d_results,
@@ -147,13 +147,13 @@ std::unique_ptr<column> is_integer(
   auto d_results = results->mutable_view().data<bool>();
   if (strings.has_nulls()) {
     thrust::transform(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       d_column->pair_begin<string_view, true>(),
       d_column->pair_end<string_view, true>(),
       d_results,
       [] __device__(auto const& p) { return p.second ? strings::is_integer(p.first) : false; });
   } else {
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       d_column->pair_begin<string_view, false>(),
                       d_column->pair_end<string_view, false>(),
                       d_results,
@@ -225,7 +225,7 @@ struct dispatch_to_integers_fn {
                   mutable_column_view& output_column,
                   rmm::cuda_stream_view stream) const
   {
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator<size_type>(0),
                       thrust::make_counting_iterator<size_type>(strings_column.size()),
                       output_column.data<IntegerType>(),
@@ -356,7 +356,7 @@ struct dispatch_from_integers_fn {
     auto chars_column = detail::create_chars_child_column(bytes, stream, mr);
     auto chars_view   = chars_column->mutable_view();
     auto d_chars      = chars_view.template data<char>();
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<size_type>(0),
                        strings_count,
                        integer_to_string_fn<IntegerType>{d_column, d_new_offsets, d_chars});

--- a/cpp/src/strings/convert/convert_ipv4.cu
+++ b/cpp/src/strings/convert/convert_ipv4.cu
@@ -110,7 +110,10 @@ std::unique_ptr<column> ipv4_to_integers(strings_column_view const& strings,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::ipv4_to_integers(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::ipv4_to_integers(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -264,14 +267,20 @@ std::unique_ptr<column> integers_to_ipv4(column_view const& integers,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::integers_to_ipv4(integers, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::integers_to_ipv4(integers, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> is_ipv4(strings_column_view const& strings,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_ipv4(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_ipv4(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_ipv4.cu
+++ b/cpp/src/strings/convert/convert_ipv4.cu
@@ -93,7 +93,7 @@ std::unique_ptr<column> ipv4_to_integers(
                                      mr);
   auto d_results = results->mutable_view().data<int64_t>();
   // fill output column with ipv4 integers
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -199,7 +199,7 @@ std::unique_ptr<column> integers_to_ipv4(
     cudf::detail::get_value<int32_t>(offsets_column->view(), strings_count, stream);
   auto chars_column = create_chars_child_column(bytes, stream, mr);
   auto d_chars      = chars_column->mutable_view().data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      integers_to_ipv4_fn{d_column, d_offsets, d_chars});
@@ -225,7 +225,7 @@ std::unique_ptr<column> is_ipv4(strings_column_view const& strings,
                                      stream,
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings.size()),
                     d_results,

--- a/cpp/src/strings/convert/convert_lists.cu
+++ b/cpp/src/strings/convert/convert_lists.cu
@@ -235,7 +235,10 @@ std::unique_ptr<column> format_list_column(lists_column_view const& input,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::format_list_column(input, na_rep, separators, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::format_list_column(input, na_rep, separators, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/convert/convert_urls.cu
+++ b/cpp/src/strings/convert/convert_urls.cu
@@ -153,7 +153,7 @@ std::unique_ptr<column> url_encode(
   // build chars column
   auto chars_column = create_chars_child_column(bytes, stream, mr);
   auto d_chars      = chars_column->mutable_view().data<char>();
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      url_encoder_fn{d_strings, d_offsets, d_chars});
@@ -417,7 +417,7 @@ std::unique_ptr<column> url_decode(
       *d_strings, offsets_mutable_view.begin<offset_type>());
 
   // use scan to transform number of bytes into offsets
-  thrust::exclusive_scan(rmm::exec_policy(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
                          offsets_view.begin<offset_type>(),
                          offsets_view.end<offset_type>(),
                          offsets_mutable_view.begin<offset_type>());

--- a/cpp/src/strings/convert/convert_urls.cu
+++ b/cpp/src/strings/convert/convert_urls.cu
@@ -172,7 +172,10 @@ std::unique_ptr<column> url_encode(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::url_encode(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::url_encode(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -454,7 +457,10 @@ std::unique_ptr<column> url_decode(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::url_decode(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::url_decode(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -93,7 +93,7 @@ auto create_strings_device_views(host_span<column_view const> views, rmm::cuda_s
   auto d_partition_offsets = rmm::device_uvector<size_t>(views.size() + 1, stream);
   d_partition_offsets.set_element_to_zero_async(0, stream);  // zero first element
 
-  thrust::transform_inclusive_scan(rmm::exec_policy(stream),
+  thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
                                    device_views_ptr,
                                    device_views_ptr + views.size(),
                                    std::next(d_partition_offsets.begin()),

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -54,7 +54,7 @@ std::unique_ptr<cudf::column> copy_slice(strings_column_view const& strings,
   if (chars_offset > 0) {
     // adjust the individual offset values only if needed
     auto d_offsets = offsets_column->mutable_view();
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       d_offsets.begin<int32_t>(),
                       d_offsets.end<int32_t>(),
                       d_offsets.begin<int32_t>(),

--- a/cpp/src/strings/copying/shift.cu
+++ b/cpp/src/strings/copying/shift.cu
@@ -109,7 +109,7 @@ std::unique_ptr<column> shift(strings_column_view const& input,
   // run kernel to simultaneously shift and adjust the values in the output offsets column
   auto d_offsets = mutable_column_device_view::create(offsets_column->mutable_view(), stream);
   auto const d_input_offsets = column_device_view::create(input_offsets, stream);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::counting_iterator<size_type>(0),
                     thrust::counting_iterator<size_type>(offsets_size),
                     d_offsets->data<offset_type>(),
@@ -130,7 +130,7 @@ std::unique_ptr<column> shift(strings_column_view const& input,
   auto const d_input_chars = column_device_view::create(input.chars(), stream);
 
   // run kernel to shift the characters
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::counting_iterator<size_type>(0),
                     thrust::counting_iterator<size_type>(chars_size),
                     d_chars->data<char>(),

--- a/cpp/src/strings/extract/extract.cu
+++ b/cpp/src/strings/extract/extract.cu
@@ -136,7 +136,10 @@ std::unique_ptr<table> extract(strings_column_view const& strings,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract(strings, pattern, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract(strings, pattern, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/extract/extract_all.cu
+++ b/cpp/src/strings/extract/extract_all.cu
@@ -171,7 +171,10 @@ std::unique_ptr<column> extract_all_record(strings_column_view const& strings,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::extract_all_record(strings, pattern, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::extract_all_record(strings, pattern, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/extract/extract_all.cu
+++ b/cpp/src/strings/extract/extract_all.cu
@@ -134,7 +134,7 @@ std::unique_ptr<column> extract_all_record(
   // Convert counts into offsets.
   // Multiply each count by the number of groups.
   thrust::transform_exclusive_scan(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     d_offsets,
     d_offsets + strings_count + 1,
     d_offsets,

--- a/cpp/src/strings/filling/fill.cu
+++ b/cpp/src/strings/filling/fill.cu
@@ -88,7 +88,7 @@ std::unique_ptr<column> fill(
   // fill the chars column
   auto d_chars = chars_column->mutable_view().data<char>();
   thrust::for_each_n(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     [d_strings, begin, end, d_value, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/src/strings/filter_chars.cu
+++ b/cpp/src/strings/filter_chars.cu
@@ -159,8 +159,11 @@ std::unique_ptr<column> filter_characters(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::filter_characters(
-    strings, characters_to_filter, keep_characters, replacement, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::filter_characters(
+    strings, characters_to_filter, keep_characters, replacement, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -1000,7 +1000,7 @@ std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& c
       options);
 
   // convert sizes to offsets
-  thrust::exclusive_scan(rmm::exec_policy(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
                          offsets_view.head<offset_type>(),
                          offsets_view.head<offset_type>() + col.size() + 1,
                          offsets_view.head<offset_type>(),

--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -1048,7 +1048,10 @@ std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& c
                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::get_json_object(col, json_path, options, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::get_json_object(col, json_path, options, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/padding.cu
+++ b/cpp/src/strings/padding.cu
@@ -211,7 +211,10 @@ std::unique_ptr<column> pad(strings_column_view const& input,
                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::pad(input, width, side, fill_char, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::pad(input, width, side, fill_char, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> zfill(strings_column_view const& input,
@@ -219,7 +222,10 @@ std::unique_ptr<column> zfill(strings_column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::zfill(input, width, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::zfill(input, width, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/padding.cu
+++ b/cpp/src/strings/padding.cu
@@ -92,7 +92,7 @@ std::unique_ptr<column> pad(
 
   if (side == side_type::LEFT) {
     thrust::for_each_n(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator<cudf::size_type>(0),
       strings_count,
       [d_strings, width, d_fill_char, d_offsets, d_chars] __device__(size_type idx) {
@@ -106,7 +106,7 @@ std::unique_ptr<column> pad(
       });
   } else if (side == side_type::RIGHT) {
     thrust::for_each_n(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator<cudf::size_type>(0),
       strings_count,
       [d_strings, width, d_fill_char, d_offsets, d_chars] __device__(size_type idx) {
@@ -120,7 +120,7 @@ std::unique_ptr<column> pad(
       });
   } else if (side == side_type::BOTH) {
     thrust::for_each_n(
-      rmm::exec_policy(stream),
+      rmm::exec_policy_nosync(stream),
       thrust::make_counting_iterator<cudf::size_type>(0),
       strings_count,
       [d_strings, width, d_fill_char, d_offsets, d_chars] __device__(size_type idx) {
@@ -180,7 +180,7 @@ std::unique_ptr<column> zfill(
   auto chars_column = strings::detail::create_chars_child_column(bytes, stream, mr);
   auto d_chars      = chars_column->mutable_view().data<char>();
 
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<cudf::size_type>(0),
                      strings_count,
                      [d_strings, width, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/src/strings/regex/utilities.cuh
+++ b/cpp/src/strings/regex/utilities.cuh
@@ -129,7 +129,7 @@ auto make_strings_children(SizeAndExecuteFunction size_and_exec_fn,
 
   // Convert sizes to offsets
   thrust::exclusive_scan(
-    rmm::exec_policy(stream), d_offsets, d_offsets + strings_count + 1, d_offsets);
+    rmm::exec_policy_nosync(stream), d_offsets, d_offsets + strings_count + 1, d_offsets);
 
   // Now build the chars column
   auto const char_bytes = cudf::detail::get_value<int32_t>(offsets->view(), strings_count, stream);

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -385,7 +385,10 @@ std::unique_ptr<string_scalar> repeat_string(string_scalar const& input,
                                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat_string(input, repeat_times, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::repeat_string(input, repeat_times, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> repeat_strings(strings_column_view const& input,
@@ -393,7 +396,10 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat_strings(input, repeat_times, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::repeat_strings(input, repeat_times, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> repeat_strings(strings_column_view const& input,
@@ -402,8 +408,10 @@ std::unique_ptr<column> repeat_strings(strings_column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat_strings(
-    input, repeat_times, output_strings_sizes, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::repeat_strings(input, repeat_times, output_strings_sizes, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::pair<std::unique_ptr<column>, int64_t> repeat_strings_output_sizes(
@@ -412,7 +420,10 @@ std::pair<std::unique_ptr<column>, int64_t> repeat_strings_output_sizes(
   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::repeat_strings_output_sizes(input, repeat_times, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::repeat_strings_output_sizes(input, repeat_times, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/replace/backref_re.cu
+++ b/cpp/src/strings/replace/backref_re.cu
@@ -152,8 +152,10 @@ std::unique_ptr<column> replace_with_backrefs(strings_column_view const& strings
                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_with_backrefs(
-    strings, pattern, replacement, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result = detail::replace_with_backrefs(strings, pattern, replacement, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/replace/multi_re.cu
+++ b/cpp/src/strings/replace/multi_re.cu
@@ -198,7 +198,10 @@ std::unique_ptr<column> replace_re(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_re(strings, patterns, replacements, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace_re(strings, patterns, replacements, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/replace/replace.cu
+++ b/cpp/src/strings/replace/replace.cu
@@ -843,7 +843,10 @@ std::unique_ptr<column> replace(strings_column_view const& strings,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace(strings, target, repl, maxrepl, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace(strings, target, repl, maxrepl, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> replace_slice(strings_column_view const& strings,
@@ -853,7 +856,10 @@ std::unique_ptr<column> replace_slice(strings_column_view const& strings,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_slice(strings, repl, start, stop, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace_slice(strings, repl, start, stop, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> replace(strings_column_view const& strings,
@@ -862,7 +868,10 @@ std::unique_ptr<column> replace(strings_column_view const& strings,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace(strings, targets, repls, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace(strings, targets, repls, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/replace/replace_re.cu
+++ b/cpp/src/strings/replace/replace_re.cu
@@ -143,8 +143,11 @@ std::unique_ptr<column> replace_re(strings_column_view const& strings,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_re(
-    strings, pattern, replacement, max_replace_count, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::replace_re(strings, pattern, replacement, max_replace_count, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/search/find.cu
+++ b/cpp/src/strings/search/find.cu
@@ -153,7 +153,10 @@ std::unique_ptr<column> find(strings_column_view const& strings,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::find(strings, target, start, stop, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::find(strings, target, start, stop, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> rfind(strings_column_view const& strings,
@@ -163,7 +166,10 @@ std::unique_ptr<column> rfind(strings_column_view const& strings,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rfind(strings, target, start, stop, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::rfind(strings, target, start, stop, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -463,7 +469,10 @@ std::unique_ptr<column> contains(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(strings, target, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::contains(strings, target, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> contains(strings_column_view const& strings,
@@ -471,7 +480,10 @@ std::unique_ptr<column> contains(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::contains(strings, targets, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::contains(strings, targets, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> starts_with(strings_column_view const& strings,
@@ -479,7 +491,10 @@ std::unique_ptr<column> starts_with(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::starts_with(strings, target, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::starts_with(strings, target, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> starts_with(strings_column_view const& strings,
@@ -487,7 +502,10 @@ std::unique_ptr<column> starts_with(strings_column_view const& strings,
                                     rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::starts_with(strings, targets, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::starts_with(strings, targets, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> ends_with(strings_column_view const& strings,
@@ -495,7 +513,10 @@ std::unique_ptr<column> ends_with(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::ends_with(strings, target, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::ends_with(strings, target, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> ends_with(strings_column_view const& strings,
@@ -503,7 +524,10 @@ std::unique_ptr<column> ends_with(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::ends_with(strings, targets, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::ends_with(strings, targets, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/search/find.cu
+++ b/cpp/src/strings/search/find.cu
@@ -85,7 +85,7 @@ std::unique_ptr<column> find_fn(strings_column_view const& strings,
   auto results_view = results->mutable_view();
   auto d_results    = results_view.data<int32_t>();
   // set the position values by evaluating the passed function
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -226,7 +226,7 @@ std::unique_ptr<column> contains_warp_parallel(strings_column_view const& input,
 
   // fill the output with `false` unless the `d_target` is empty
   auto results_view = results->mutable_view();
-  thrust::fill(rmm::exec_policy(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream),
                results_view.begin<bool>(),
                results_view.end<bool>(),
                d_target.empty());
@@ -234,7 +234,7 @@ std::unique_ptr<column> contains_warp_parallel(strings_column_view const& input,
   if (!d_target.empty()) {
     // launch warp per string
     auto d_strings = column_device_view::create(input.parent(), stream);
-    thrust::for_each_n(rmm::exec_policy(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<std::size_t>(0),
                        static_cast<std::size_t>(input.size()) * cudf::detail::warp_size,
                        contains_warp_fn{*d_strings, d_target, results_view.data<bool>()});
@@ -291,7 +291,7 @@ std::unique_ptr<column> contains_fn(strings_column_view const& strings,
   auto results_view = results->mutable_view();
   auto d_results    = results_view.data<bool>();
   // set the bool values by evaluating the passed function
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(strings_count),
                     d_results,
@@ -346,7 +346,7 @@ std::unique_ptr<column> contains_fn(strings_column_view const& strings,
   auto d_results    = results_view.data<bool>();
   // set the bool values by evaluating the passed function
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     thrust::make_counting_iterator<size_type>(strings.size()),
     d_results,

--- a/cpp/src/strings/search/find_multiple.cu
+++ b/cpp/src/strings/search/find_multiple.cu
@@ -57,7 +57,7 @@ std::unique_ptr<column> find_multiple(
     data_type{type_id::INT32}, total_count, rmm::device_buffer{0, stream, mr}, 0, stream, mr);
 
   // fill output column with position values
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(total_count),
                     results->mutable_view().begin<int32_t>(),

--- a/cpp/src/strings/search/find_multiple.cu
+++ b/cpp/src/strings/search/find_multiple.cu
@@ -92,7 +92,10 @@ std::unique_ptr<column> find_multiple(strings_column_view const& input,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::find_multiple(input, targets, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::find_multiple(input, targets, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/search/findall.cu
+++ b/cpp/src/strings/search/findall.cu
@@ -160,7 +160,10 @@ std::unique_ptr<table> findall(strings_column_view const& input,
                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::findall(input, pattern, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::findall(input, pattern, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/search/findall.cu
+++ b/cpp/src/strings/search/findall.cu
@@ -105,8 +105,11 @@ std::unique_ptr<table> findall(strings_column_view const& input,
   auto find_counts     = count_matches(*d_strings, *d_prog, strings_count, stream);
   auto d_find_counts   = find_counts->view().data<size_type>();
 
-  size_type const columns_count = thrust::reduce(
-    rmm::exec_policy(stream), d_find_counts, d_find_counts + strings_count, 0, thrust::maximum{});
+  size_type const columns_count = thrust::reduce(rmm::exec_policy_nosync(stream),
+                                                 d_find_counts,
+                                                 d_find_counts + strings_count,
+                                                 0,
+                                                 thrust::maximum{});
 
   auto indices = rmm::device_uvector<string_index_pair>(strings_count * columns_count, stream);
 

--- a/cpp/src/strings/search/findall_record.cu
+++ b/cpp/src/strings/search/findall_record.cu
@@ -139,7 +139,10 @@ std::unique_ptr<column> findall_record(strings_column_view const& input,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::findall_record(input, pattern, flags, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::findall_record(input, pattern, flags, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/search/findall_record.cu
+++ b/cpp/src/strings/search/findall_record.cu
@@ -111,7 +111,7 @@ std::unique_ptr<column> findall_record(
 
   // Convert counts into offsets
   thrust::exclusive_scan(
-    rmm::exec_policy(stream), d_offsets, d_offsets + strings_count + 1, d_offsets);
+    rmm::exec_policy_nosync(stream), d_offsets, d_offsets + strings_count + 1, d_offsets);
 
   // Create indices vector with the total number of groups that will be extracted
   auto const total_matches =

--- a/cpp/src/strings/split/partition.cu
+++ b/cpp/src/strings/split/partition.cu
@@ -246,7 +246,10 @@ std::unique_ptr<table> partition(strings_column_view const& strings,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::partition(strings, delimiter, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::partition(strings, delimiter, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> rpartition(strings_column_view const& strings,
@@ -254,7 +257,10 @@ std::unique_ptr<table> rpartition(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rpartition(strings, delimiter, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::rpartition(strings, delimiter, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/split/partition.cu
+++ b/cpp/src/strings/split/partition.cu
@@ -198,7 +198,7 @@ std::unique_ptr<table> partition(
   partition_fn partitioner(
     *strings_column, d_delimiter, left_indices, delim_indices, right_indices);
 
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      partitioner);
@@ -225,7 +225,7 @@ std::unique_ptr<table> rpartition(
   auto right_indices = rmm::device_uvector<string_index_pair>(strings_count, stream);
   rpartition_fn partitioner(
     *strings_column, d_delimiter, left_indices, delim_indices, right_indices);
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      partitioner);

--- a/cpp/src/strings/split/split.cu
+++ b/cpp/src/strings/split/split.cu
@@ -858,7 +858,10 @@ std::unique_ptr<table> split(strings_column_view const& strings_column,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(strings_column, delimiter, maxsplit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::split(strings_column, delimiter, maxsplit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> rsplit(strings_column_view const& strings_column,
@@ -867,7 +870,10 @@ std::unique_ptr<table> rsplit(strings_column_view const& strings_column,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rsplit(strings_column, delimiter, maxsplit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::rsplit(strings_column, delimiter, maxsplit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/split/split_re.cu
+++ b/cpp/src/strings/split/split_re.cu
@@ -339,7 +339,10 @@ std::unique_ptr<table> split_re(strings_column_view const& input,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split_re(input, pattern, maxsplit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::split_re(input, pattern, maxsplit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> split_record_re(strings_column_view const& input,
@@ -348,7 +351,10 @@ std::unique_ptr<column> split_record_re(strings_column_view const& input,
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split_record_re(input, pattern, maxsplit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::split_record_re(input, pattern, maxsplit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<table> rsplit_re(strings_column_view const& input,
@@ -357,7 +363,10 @@ std::unique_ptr<table> rsplit_re(strings_column_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rsplit_re(input, pattern, maxsplit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::rsplit_re(input, pattern, maxsplit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> rsplit_record_re(strings_column_view const& input,
@@ -366,7 +375,10 @@ std::unique_ptr<column> rsplit_record_re(strings_column_view const& input,
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rsplit_record_re(input, pattern, maxsplit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::rsplit_record_re(input, pattern, maxsplit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/src/strings/split/split_record.cu
+++ b/cpp/src/strings/split/split_record.cu
@@ -306,8 +306,11 @@ std::unique_ptr<column> split_record(strings_column_view const& strings,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split_record<detail::Dir::FORWARD>(
-    strings, delimiter, maxsplit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::split_record<detail::Dir::FORWARD>(strings, delimiter, maxsplit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> rsplit_record(strings_column_view const& strings,
@@ -316,8 +319,11 @@ std::unique_ptr<column> rsplit_record(strings_column_view const& strings,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split_record<detail::Dir::BACKWARD>(
-    strings, delimiter, maxsplit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::split_record<detail::Dir::BACKWARD>(strings, delimiter, maxsplit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/strip.cu
+++ b/cpp/src/strings/strip.cu
@@ -131,7 +131,10 @@ std::unique_ptr<column> strip(strings_column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::strip(input, side, to_strip, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::strip(input, side, to_strip, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/substring.cu
+++ b/cpp/src/strings/substring.cu
@@ -243,7 +243,7 @@ void compute_substring_indices(column_device_view const& d_column,
   auto strings_count = d_column.size();
 
   thrust::for_each_n(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<size_type>(0),
     strings_count,
     [delim_itr, delimiter_count, start_char_pos, end_char_pos, d_column] __device__(size_type idx) {

--- a/cpp/src/strings/translate.cu
+++ b/cpp/src/strings/translate.cu
@@ -130,7 +130,10 @@ std::unique_ptr<column> translate(strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::translate(strings, chars_table, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::translate(strings, chars_table, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/strings/utilities.cu
+++ b/cpp/src/strings/utilities.cu
@@ -46,7 +46,7 @@ rmm::device_uvector<string_view> create_string_vector_from_column(
 
   auto strings_vector = rmm::device_uvector<string_view>(input.size(), stream, mr);
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<size_type>(0),
                     thrust::make_counting_iterator<size_type>(input.size()),
                     strings_vector.begin(),

--- a/cpp/src/strings/wrap.cu
+++ b/cpp/src/strings/wrap.cu
@@ -118,7 +118,7 @@ std::unique_ptr<column> wrap(
 
   device_execute_functor d_execute_fctr{d_column, d_new_offsets, d_chars, width};
 
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<size_type>(0),
                      strings_count,
                      d_execute_fctr);

--- a/cpp/src/strings/wrap.cu
+++ b/cpp/src/strings/wrap.cu
@@ -137,7 +137,10 @@ std::unique_ptr<column> wrap(strings_column_view const& strings,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::wrap<detail::execute_wrap>(strings, width, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::wrap<detail::execute_wrap>(strings, width, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace strings

--- a/cpp/src/text/detokenize.cu
+++ b/cpp/src/text/detokenize.cu
@@ -110,13 +110,13 @@ struct token_row_offsets_fn {
   {
     index_changed_fn<T> pfn{row_indices.data<T>(), sorted_indices.template data<int32_t>()};
     auto const output_count =
-      thrust::count_if(rmm::exec_policy(stream),
+      thrust::count_if(rmm::exec_policy_nosync(stream),
                        thrust::make_counting_iterator<cudf::size_type>(0),
                        thrust::make_counting_iterator<cudf::size_type>(tokens_counts),
                        pfn);
     auto tokens_offsets =
       std::make_unique<rmm::device_uvector<cudf::size_type>>(output_count + 1, stream);
-    thrust::copy_if(rmm::exec_policy(stream),
+    thrust::copy_if(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(tokens_counts),
                     tokens_offsets->begin(),
@@ -181,7 +181,7 @@ std::unique_ptr<cudf::column> detokenize(cudf::strings_column_view const& string
   auto chars_column = cudf::strings::detail::create_chars_child_column(total_bytes, stream, mr);
   auto d_chars      = chars_column->mutable_view().data<char>();
   thrust::for_each_n(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     output_count,
     detokenizer_fn{

--- a/cpp/src/text/detokenize.cu
+++ b/cpp/src/text/detokenize.cu
@@ -201,7 +201,10 @@ std::unique_ptr<cudf::column> detokenize(cudf::strings_column_view const& string
                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::detokenize(strings, row_indices, separator, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::detokenize(strings, row_indices, separator, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -311,7 +311,10 @@ std::unique_ptr<cudf::column> edit_distance(cudf::strings_column_view const& str
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::edit_distance(strings, targets, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::edit_distance(strings, targets, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -321,7 +324,10 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
                                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::edit_distance_matrix(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::edit_distance_matrix(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/generate_ngrams.cu
+++ b/cpp/src/text/generate_ngrams.cu
@@ -151,7 +151,10 @@ std::unique_ptr<cudf::column> generate_ngrams(cudf::strings_column_view const& s
                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::generate_ngrams(strings, ngrams, separator, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::generate_ngrams(strings, ngrams, separator, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 namespace detail {
@@ -261,7 +264,10 @@ std::unique_ptr<cudf::column> generate_character_ngrams(cudf::strings_column_vie
                                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::generate_character_ngrams(strings, ngrams, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::generate_character_ngrams(strings, ngrams, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/ngrams_tokenize.cu
+++ b/cpp/src/text/ngrams_tokenize.cu
@@ -262,8 +262,10 @@ std::unique_ptr<cudf::column> ngrams_tokenize(cudf::strings_column_view const& s
                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::ngrams_tokenize(
-    strings, ngrams, delimiter, separator, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::ngrams_tokenize(strings, ngrams, delimiter, separator, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/ngrams_tokenize.cu
+++ b/cpp/src/text/ngrams_tokenize.cu
@@ -163,7 +163,7 @@ std::unique_ptr<cudf::column> ngrams_tokenize(
   // Ex. token-counts = [3,2]; token-offsets = [0,3,5]
   rmm::device_uvector<int32_t> token_offsets(strings_count + 1, stream);
   auto d_token_offsets = token_offsets.data();
-  thrust::transform_inclusive_scan(rmm::exec_policy(stream),
+  thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
                                    thrust::make_counting_iterator<cudf::size_type>(0),
                                    thrust::make_counting_iterator<cudf::size_type>(strings_count),
                                    d_token_offsets + 1,
@@ -177,7 +177,7 @@ std::unique_ptr<cudf::column> ngrams_tokenize(
   rmm::device_uvector<position_pair> token_positions(total_tokens, stream);
   auto d_token_positions = token_positions.data();
   thrust::for_each_n(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     strings_count,
     string_tokens_positions_fn{d_strings, d_delimiter, d_token_offsets, d_token_positions});
@@ -187,7 +187,7 @@ std::unique_ptr<cudf::column> ngrams_tokenize(
   rmm::device_uvector<int32_t> ngram_offsets(strings_count + 1, stream);
   auto d_ngram_offsets = ngram_offsets.data();
   thrust::transform_inclusive_scan(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     thrust::make_counting_iterator<cudf::size_type>(strings_count),
     d_ngram_offsets + 1,
@@ -210,7 +210,7 @@ std::unique_ptr<cudf::column> ngrams_tokenize(
   rmm::device_uvector<int32_t> chars_offsets(strings_count + 1, stream);  // output memory offsets
   auto d_chars_offsets = chars_offsets.data();                            // per input string
   thrust::transform_inclusive_scan(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     thrust::make_counting_iterator<cudf::size_type>(strings_count),
     d_chars_offsets + 1,
@@ -229,7 +229,7 @@ std::unique_ptr<cudf::column> ngrams_tokenize(
   // Generate the ngrams into the chars column data buffer.
   // The ngram_builder_fn functor also fills the d_ngram_sizes vector with the
   // size of each ngram.
-  thrust::for_each_n(rmm::exec_policy(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator<int32_t>(0),
                      strings_count,
                      ngram_builder_fn{d_strings,

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -244,7 +244,10 @@ std::unique_ptr<cudf::column> normalize_spaces(cudf::strings_column_view const& 
                                                rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::normalize_spaces(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::normalize_spaces(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -255,7 +258,10 @@ std::unique_ptr<cudf::column> normalize_characters(cudf::strings_column_view con
                                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::normalize_characters(strings, do_lower_case, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::normalize_characters(strings, do_lower_case, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/replace.cu
+++ b/cpp/src/text/replace.cu
@@ -281,8 +281,10 @@ std::unique_ptr<cudf::column> replace_tokens(cudf::strings_column_view const& st
                                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::replace_tokens(
-    strings, targets, replacements, delimiter, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::replace_tokens(strings, targets, replacements, delimiter, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> filter_tokens(cudf::strings_column_view const& strings,
@@ -292,8 +294,11 @@ std::unique_ptr<cudf::column> filter_tokens(cudf::strings_column_view const& str
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::filter_tokens(
-    strings, min_token_length, replacement, delimiter, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result =
+    detail::filter_tokens(strings, min_token_length, replacement, delimiter, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/stemmer.cu
+++ b/cpp/src/text/stemmer.cu
@@ -112,7 +112,7 @@ std::unique_ptr<cudf::column> is_letter(cudf::strings_column_view const& strings
                                   mr);
   // set values into output column
   auto strings_column = cudf::column_device_view::create(strings.parent(), stream);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(strings.size()),
                     results->mutable_view().data<bool>(),
@@ -221,7 +221,7 @@ std::unique_ptr<cudf::column> porter_stemmer_measure(cudf::strings_column_view c
                                   mr);
   // compute measures into output column
   auto strings_column = cudf::column_device_view::create(strings.parent(), stream);
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(strings.size()),
                     results->mutable_view().data<int32_t>(),

--- a/cpp/src/text/stemmer.cu
+++ b/cpp/src/text/stemmer.cu
@@ -249,11 +249,11 @@ std::unique_ptr<cudf::column> is_letter(cudf::strings_column_view const& strings
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_letter(strings,
-                           ltype,
-                           thrust::make_constant_iterator<cudf::size_type>(character_index),
-                           cudf::default_stream_value,
-                           mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_letter(
+    strings, ltype, thrust::make_constant_iterator<cudf::size_type>(character_index), stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> is_letter(cudf::strings_column_view const& strings,
@@ -262,7 +262,10 @@ std::unique_ptr<cudf::column> is_letter(cudf::strings_column_view const& strings
                                         rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_letter(strings, ltype, indices, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_letter(strings, ltype, indices, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 /**
@@ -272,7 +275,10 @@ std::unique_ptr<cudf::column> porter_stemmer_measure(cudf::strings_column_view c
                                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::porter_stemmer_measure(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::porter_stemmer_measure(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/subword/bpe_tokenizer.cu
+++ b/cpp/src/text/subword/bpe_tokenizer.cu
@@ -568,7 +568,10 @@ std::unique_ptr<cudf::column> byte_pair_encoding(cudf::strings_column_view const
                                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::byte_pair_encoding(input, merges_table, separator, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::byte_pair_encoding(input, merges_table, separator, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/subword/load_hash_file.cu
+++ b/cpp/src/text/subword/load_hash_file.cu
@@ -284,7 +284,10 @@ std::unique_ptr<hashed_vocabulary> load_vocabulary_file(
   std::string const& filename_hashed_vocabulary, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::load_vocabulary_file(filename_hashed_vocabulary, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::load_vocabulary_file(filename_hashed_vocabulary, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/subword/load_hash_file.cu
+++ b/cpp/src/text/subword/load_hash_file.cu
@@ -49,7 +49,7 @@ rmm::device_uvector<codepoint_metadata_type> get_codepoint_metadata(rmm::cuda_st
 {
   auto table_vector = rmm::device_uvector<codepoint_metadata_type>(codepoint_metadata_size, stream);
   auto table        = table_vector.data();
-  thrust::fill(rmm::exec_policy(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream),
                table + cp_section1_end,
                table + codepoint_metadata_size,
                codepoint_metadata_default_value);
@@ -77,7 +77,7 @@ rmm::device_uvector<aux_codepoint_data_type> get_aux_codepoint_data(rmm::cuda_st
 {
   auto table_vector = rmm::device_uvector<aux_codepoint_data_type>(aux_codepoint_data_size, stream);
   auto table        = table_vector.data();
-  thrust::fill(rmm::exec_policy(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream),
                table + aux_section1_end,
                table + aux_codepoint_data_size,
                aux_codepoint_default_value);

--- a/cpp/src/text/subword/load_merges_file.cu
+++ b/cpp/src/text/subword/load_merges_file.cu
@@ -159,7 +159,10 @@ std::unique_ptr<bpe_merge_pairs> load_merge_pairs_file(std::string const& filena
                                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::load_merge_pairs_file(filename_merges, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::load_merge_pairs_file(filename_merges, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 bpe_merge_pairs::bpe_merge_pairs_impl::bpe_merge_pairs_impl(

--- a/cpp/src/text/subword/subword_tokenize.cu
+++ b/cpp/src/text/subword/subword_tokenize.cu
@@ -263,15 +263,18 @@ tokenizer_result subword_tokenize(cudf::strings_column_view const& strings,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::subword_tokenize(strings,
-                                  vocabulary_table,
-                                  max_sequence_length,
-                                  stride,
-                                  do_lower_case,
-                                  do_truncate,
-                                  max_rows_tensor,
-                                  cudf::default_stream_value,
-                                  mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::subword_tokenize(strings,
+                                         vocabulary_table,
+                                         max_sequence_length,
+                                         stride,
+                                         do_lower_case,
+                                         do_truncate,
+                                         max_rows_tensor,
+                                         stream,
+                                         mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/text/subword/subword_tokenize.cu
+++ b/cpp/src/text/subword/subword_tokenize.cu
@@ -172,7 +172,7 @@ tokenizer_result subword_tokenize(cudf::strings_column_view const& strings,
   auto d_offsets_per_tensor = offsets_per_tensor.data();
 
   thrust::transform_exclusive_scan(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     thrust::make_counting_iterator<cudf::size_type>(strings_count + 1),
     offsets_per_tensor.begin(),
@@ -194,7 +194,7 @@ tokenizer_result subword_tokenize(cudf::strings_column_view const& strings,
   rmm::device_uvector<uint32_t> row2row_within_tensor(nrows_tensor_token_ids, stream);
   auto d_row2row_within_tensor = row2row_within_tensor.data();
   thrust::for_each_n(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<uint32_t>(0),
     strings_count,
     [d_offsets_per_tensor, d_row2tensor, d_row2row_within_tensor] __device__(auto idx) {

--- a/cpp/src/text/tokenize.cu
+++ b/cpp/src/text/tokenize.cu
@@ -232,7 +232,10 @@ std::unique_ptr<cudf::column> tokenize(cudf::strings_column_view const& strings,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::tokenize(strings, delimiter, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::tokenize(strings, delimiter, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> tokenize(cudf::strings_column_view const& strings,
@@ -240,7 +243,10 @@ std::unique_ptr<cudf::column> tokenize(cudf::strings_column_view const& strings,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::tokenize(strings, delimiters, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::tokenize(strings, delimiters, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> count_tokens(cudf::strings_column_view const& strings,
@@ -248,7 +254,10 @@ std::unique_ptr<cudf::column> count_tokens(cudf::strings_column_view const& stri
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_tokens(strings, delimiter, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::count_tokens(strings, delimiter, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> count_tokens(cudf::strings_column_view const& strings,
@@ -256,14 +265,20 @@ std::unique_ptr<cudf::column> count_tokens(cudf::strings_column_view const& stri
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::count_tokens(strings, delimiters, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::count_tokens(strings, delimiters, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::column> character_tokenize(cudf::strings_column_view const& strings,
                                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::character_tokenize(strings, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::character_tokenize(strings, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace nvtext

--- a/cpp/src/transform/bools_to_mask.cu
+++ b/cpp/src/transform/bools_to_mask.cu
@@ -61,7 +61,10 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> bools_to_mask(
   column_view const& input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::bools_to_mask(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::bools_to_mask(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/compute_column.cu
+++ b/cpp/src/transform/compute_column.cu
@@ -137,7 +137,10 @@ std::unique_ptr<column> compute_column(table_view const& table,
                                        rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::compute_column(table, expr, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::compute_column(table, expr, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/encode.cu
+++ b/cpp/src/transform/encode.cu
@@ -71,7 +71,10 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<column>> encode(
 std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
   cudf::table_view const& input, rmm::mr::device_memory_resource* mr)
 {
-  return detail::encode(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::encode(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/mask_to_bools.cu
+++ b/cpp/src/transform/mask_to_bools.cu
@@ -47,7 +47,7 @@ std::unique_ptr<column> mask_to_bools(bitmask_type const* bitmask,
   if (length > 0) {
     auto mutable_view = out_col->mutable_view();
 
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator<cudf::size_type>(begin_bit),
                       thrust::make_counting_iterator<cudf::size_type>(end_bit),
                       mutable_view.begin<bool>(),

--- a/cpp/src/transform/mask_to_bools.cu
+++ b/cpp/src/transform/mask_to_bools.cu
@@ -63,6 +63,9 @@ std::unique_ptr<column> mask_to_bools(bitmask_type const* bitmask,
                                       size_type end_bit,
                                       rmm::mr::device_memory_resource* mr)
 {
-  return detail::mask_to_bools(bitmask, begin_bit, end_bit, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::mask_to_bools(bitmask, begin_bit, end_bit, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/transform/nans_to_nulls.cu
+++ b/cpp/src/transform/nans_to_nulls.cu
@@ -95,7 +95,10 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> nans_to_nulls(
   column_view const& input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::nans_to_nulls(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::nans_to_nulls(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -127,6 +127,9 @@ std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const&
                                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::one_hot_encode(input, categories, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::one_hot_encode(input, categories, stream, mr);
+  stream.synchronize();
+  return result;
 }
 }  // namespace cudf

--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -76,7 +76,7 @@ struct one_hot_encode_launcher {
     one_hot_encode_functor<InputType> one_hot_encoding_compute_f(
       *d_input_column, *d_category_column, input_column.nullable() || categories.nullable());
 
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       thrust::make_counting_iterator(0),
                       thrust::make_counting_iterator(total_size),
                       all_encodings->mutable_view().begin<bool>(),

--- a/cpp/src/transform/row_bit_count.cu
+++ b/cpp/src/transform/row_bit_count.cu
@@ -486,7 +486,7 @@ std::unique_ptr<column> row_bit_count(table_view const& t,
   // simple case.  if we have no complex types (lists, strings, etc), the per-row size is already
   // trivially computed
   if (h_info.complex_type_count <= 0) {
-    thrust::fill(rmm::exec_policy(stream),
+    thrust::fill(rmm::exec_policy_nosync(stream),
                  mcv.begin<size_type>(),
                  mcv.end<size_type>(),
                  h_info.simple_per_row_size);

--- a/cpp/src/transform/row_bit_count.cu
+++ b/cpp/src/transform/row_bit_count.cu
@@ -535,7 +535,10 @@ std::unique_ptr<column> row_bit_count(table_view const& t,
  */
 std::unique_ptr<column> row_bit_count(table_view const& t, rmm::mr::device_memory_resource* mr)
 {
-  return detail::row_bit_count(t, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::row_bit_count(t, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/transform/transform.cpp
+++ b/cpp/src/transform/transform.cpp
@@ -99,7 +99,10 @@ std::unique_ptr<column> transform(column_view const& input,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::transform(input, unary_udf, output_type, is_ptx, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::transform(input, unary_udf, output_type, is_ptx, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/transpose/transpose.cu
+++ b/cpp/src/transpose/transpose.cu
@@ -63,7 +63,10 @@ std::pair<std::unique_ptr<column>, table_view> transpose(table_view const& input
                                                          rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::transpose(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::transpose(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -412,7 +412,10 @@ std::unique_ptr<column> cast(column_view const& input,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::cast(input, type, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::cast(input, type, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -227,7 +227,7 @@ struct dispatch_unary_cast_to {
 
     mutable_column_view output_mutable = *output;
 
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       input.begin<SourceT>(),
                       input.end<SourceT>(),
                       output_mutable.begin<TargetT>(),
@@ -257,7 +257,7 @@ struct dispatch_unary_cast_to {
     using DeviceT    = device_storage_type_t<SourceT>;
     auto const scale = numeric::scale_type{input.type().scale()};
 
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       input.begin<DeviceT>(),
                       input.end<DeviceT>(),
                       output_mutable.begin<TargetT>(),
@@ -287,7 +287,7 @@ struct dispatch_unary_cast_to {
     using DeviceT    = device_storage_type_t<TargetT>;
     auto const scale = numeric::scale_type{type.scale()};
 
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       input.begin<SourceT>(),
                       input.end<SourceT>(),
                       output_mutable.begin<DeviceT>(),
@@ -333,7 +333,7 @@ struct dispatch_unary_cast_to {
 
       mutable_column_view output_mutable = *output;
 
-      thrust::transform(rmm::exec_policy(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream),
                         input.begin<SourceDeviceT>(),
                         input.end<SourceDeviceT>(),
                         output_mutable.begin<TargetDeviceT>(),

--- a/cpp/src/unary/math_ops.cu
+++ b/cpp/src/unary/math_ops.cu
@@ -297,7 +297,7 @@ std::unique_ptr<column> unary_op_with(column_view const& input,
   auto out_view = result->mutable_view();
   Type const n  = std::pow(10, -input.type().scale());
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     input.begin<Type>(),
                     input.end<Type>(),
                     out_view.begin<Type>(),
@@ -326,7 +326,8 @@ std::unique_ptr<cudf::column> transform_fn(InputIterator begin,
   if (size == 0) return output;
 
   auto output_view = output->mutable_view();
-  thrust::transform(rmm::exec_policy(stream), begin, end, output_view.begin<OutputType>(), UFN{});
+  thrust::transform(
+    rmm::exec_policy_nosync(stream), begin, end, output_view.begin<OutputType>(), UFN{});
   return output;
 }
 

--- a/cpp/src/unary/math_ops.cu
+++ b/cpp/src/unary/math_ops.cu
@@ -639,7 +639,10 @@ std::unique_ptr<cudf::column> unary_operation(cudf::column_view const& input,
                                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::unary_operation(input, op, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::unary_operation(input, op, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/nan_ops.cu
+++ b/cpp/src/unary/nan_ops.cu
@@ -94,14 +94,20 @@ std::unique_ptr<column> is_not_nan(cudf::column_view const& input,
 std::unique_ptr<column> is_nan(cudf::column_view const& input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_nan(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_nan(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<column> is_not_nan(cudf::column_view const& input,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_not_nan(input, cudf::default_stream_value, mr);
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_not_nan(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/null_ops.cu
+++ b/cpp/src/unary/null_ops.cu
@@ -25,9 +25,11 @@
 #include <thrust/iterator/counting_iterator.h>
 
 namespace cudf {
-std::unique_ptr<column> is_null(cudf::column_view const& input, rmm::mr::device_memory_resource* mr)
+namespace detail {
+std::unique_ptr<column> is_null(cudf::column_view const& input,
+                                rmm::cuda_stream_view stream,
+                                rmm::mr::device_memory_resource* mr)
 {
-  CUDF_FUNC_RANGE();
   auto input_device_view = column_device_view::create(input);
   auto device_view       = *input_device_view;
   auto predicate = [device_view] __device__(auto index) { return (device_view.is_null(index)); };
@@ -35,14 +37,14 @@ std::unique_ptr<column> is_null(cudf::column_view const& input, rmm::mr::device_
                          thrust::make_counting_iterator(input.size()),
                          input.size(),
                          predicate,
-                         cudf::default_stream_value,
+                         stream,
                          mr);
 }
 
 std::unique_ptr<column> is_valid(cudf::column_view const& input,
+                                 rmm::cuda_stream_view stream,
                                  rmm::mr::device_memory_resource* mr)
 {
-  CUDF_FUNC_RANGE();
   auto input_device_view = column_device_view::create(input);
   auto device_view       = *input_device_view;
   auto predicate = [device_view] __device__(auto index) { return device_view.is_valid(index); };
@@ -50,8 +52,29 @@ std::unique_ptr<column> is_valid(cudf::column_view const& input,
                          thrust::make_counting_iterator(input.size()),
                          input.size(),
                          predicate,
-                         cudf::default_stream_value,
+                         stream,
                          mr);
+}
+
+}  // namespace detail
+
+std::unique_ptr<column> is_null(cudf::column_view const& input, rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_null(input, stream, mr);
+  stream.synchronize();
+  return result;
+}
+
+std::unique_ptr<column> is_valid(cudf::column_view const& input,
+                                 rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  auto const stream = cudf::default_stream_value;
+  auto result       = detail::is_valid(input, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -67,8 +67,11 @@ struct launcher {
         rmm::device_buffer{input.null_mask(), bitmask_allocation_size_bytes(input.size())},
         input.null_count());
 
-    thrust::transform(
-      rmm::exec_policy(stream), input.begin<T>(), input.end<T>(), output_view.begin<Tout>(), F{});
+    thrust::transform(rmm::exec_policy_nosync(stream),
+                      input.begin<T>(),
+                      input.end<T>(),
+                      output_view.begin<Tout>(),
+                      F{});
 
     CUDF_CHECK_CUDA(stream.value());
 

--- a/cpp/tests/bitmask/set_nullmask_tests.cu
+++ b/cpp/tests/bitmask/set_nullmask_tests.cu
@@ -54,7 +54,7 @@ struct SetBitmaskTest : public cudf::test::BaseFixture {
   {
     rmm::device_uvector<bool> result(expect.size(), stream);
     auto counting_iter = thrust::counting_iterator<cudf::size_type>{0};
-    thrust::transform(rmm::exec_policy(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream),
                       counting_iter + start_bit,
                       counting_iter + start_bit + expect.size(),
                       result.begin(),

--- a/cpp/tests/column/column_device_view_test.cu
+++ b/cpp/tests/column/column_device_view_test.cu
@@ -44,7 +44,7 @@ TEST_F(ColumnDeviceViewTest, Sample)
   auto output_device_view =
     cudf::mutable_column_device_view::create(output->mutable_view(), stream);
 
-  EXPECT_NO_THROW(thrust::copy(rmm::exec_policy(stream),
+  EXPECT_NO_THROW(thrust::copy(rmm::exec_policy_nosync(stream),
                                input_device_view->begin<T>(),
                                input_device_view->end<T>(),
                                output_device_view->begin<T>()));
@@ -62,7 +62,7 @@ TEST_F(ColumnDeviceViewTest, MismatchingType)
   auto output_device_view =
     cudf::mutable_column_device_view::create(output->mutable_view(), stream);
 
-  EXPECT_THROW(thrust::copy(rmm::exec_policy(stream),
+  EXPECT_THROW(thrust::copy(rmm::exec_policy_nosync(stream),
                             input_device_view->begin<T>(),
                             input_device_view->end<T>(),
                             output_device_view->begin<int64_t>()),

--- a/cpp/tests/column/compound_test.cu
+++ b/cpp/tests/column/compound_test.cu
@@ -66,7 +66,7 @@ struct checker_for_level2 {
 TEST_F(CompoundColumnTest, ChildrenLevel1)
 {
   rmm::device_uvector<int32_t> data(1000, cudf::default_stream_value);
-  thrust::sequence(rmm::exec_policy(), data.begin(), data.end(), 1);
+  thrust::sequence(rmm::exec_policy_nosync(), data.begin(), data.end(), 1);
 
   auto null_mask = cudf::create_null_mask(100, cudf::mask_state::UNALLOCATED);
   rmm::device_buffer data1{data.data() + 100, 100 * sizeof(int32_t), cudf::default_stream_value};
@@ -105,14 +105,14 @@ TEST_F(CompoundColumnTest, ChildrenLevel1)
 
   {
     auto column = cudf::column_device_view::create(parent->view());
-    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(),
+    EXPECT_TRUE(thrust::any_of(rmm::exec_policy_nosync(),
                                thrust::make_counting_iterator<int32_t>(0),
                                thrust::make_counting_iterator<int32_t>(100),
                                checker_for_level1<cudf::column_device_view>{*column}));
   }
   {
     auto column = cudf::mutable_column_device_view::create(parent->mutable_view());
-    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(),
+    EXPECT_TRUE(thrust::any_of(rmm::exec_policy_nosync(),
                                thrust::make_counting_iterator<int32_t>(0),
                                thrust::make_counting_iterator<int32_t>(100),
                                checker_for_level1<cudf::mutable_column_device_view>{*column}));
@@ -122,7 +122,7 @@ TEST_F(CompoundColumnTest, ChildrenLevel1)
 TEST_F(CompoundColumnTest, ChildrenLevel2)
 {
   rmm::device_uvector<int32_t> data(1000, cudf::default_stream_value);
-  thrust::sequence(rmm::exec_policy(), data.begin(), data.end(), 1);
+  thrust::sequence(rmm::exec_policy_nosync(), data.begin(), data.end(), 1);
 
   auto null_mask = cudf::create_null_mask(100, cudf::mask_state::UNALLOCATED);
   rmm::device_buffer data11{data.data() + 100, 100 * sizeof(int32_t), cudf::default_stream_value};
@@ -202,14 +202,14 @@ TEST_F(CompoundColumnTest, ChildrenLevel2)
 
   {
     auto column = cudf::column_device_view::create(parent->view());
-    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(),
+    EXPECT_TRUE(thrust::any_of(rmm::exec_policy_nosync(),
                                thrust::make_counting_iterator<int32_t>(0),
                                thrust::make_counting_iterator<int32_t>(100),
                                checker_for_level2<cudf::column_device_view>{*column}));
   }
   {
     auto column = cudf::mutable_column_device_view::create(parent->mutable_view());
-    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(),
+    EXPECT_TRUE(thrust::any_of(rmm::exec_policy_nosync(),
                                thrust::make_counting_iterator<int32_t>(0),
                                thrust::make_counting_iterator<int32_t>(100),
                                checker_for_level2<cudf::mutable_column_device_view>{*column}));

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -522,11 +522,11 @@ TEST_F(OverflowTest, Presliced)
 
     // try and concatenate 4 string columns of with ~1/2 billion chars in each
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy_nosync(),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  string_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());
@@ -596,11 +596,11 @@ TEST_F(OverflowTest, Presliced)
 
     // try and concatenate 4 struct columns of with ~1/2 billion elements in each
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy_nosync(),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  list_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());
@@ -688,11 +688,11 @@ TEST_F(OverflowTest, BigColumnsSmallSlices)
     constexpr size_type string_size = inner_size / num_rows;
 
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy_nosync(),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  string_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());
@@ -715,11 +715,11 @@ TEST_F(OverflowTest, BigColumnsSmallSlices)
     constexpr size_type list_size = inner_size / num_rows;
 
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy_nosync(),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  list_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());
@@ -742,11 +742,11 @@ TEST_F(OverflowTest, BigColumnsSmallSlices)
     constexpr size_type list_size = inner_size / num_rows;
 
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy_nosync(),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  list_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());

--- a/cpp/tests/fixed_point/fixed_point_tests.cu
+++ b/cpp/tests/fixed_point/fixed_point_tests.cu
@@ -85,8 +85,10 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
   std::vector<decimal32> vec1(1000, decimal32{1, scale_type{-2}});
   auto d_vec1 = cudf::detail::make_device_uvector_sync(vec1);
 
-  auto const sum = thrust::reduce(
-    rmm::exec_policy(), std::cbegin(d_vec1), std::cend(d_vec1), decimal32{0, scale_type{-2}});
+  auto const sum = thrust::reduce(rmm::exec_policy_nosync(),
+                                  std::cbegin(d_vec1),
+                                  std::cend(d_vec1),
+                                  decimal32{0, scale_type{-2}});
 
   EXPECT_EQ(static_cast<int32_t>(sum), 1000);
 
@@ -99,8 +101,10 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
   std::vector<int32_t> vec2(1000);
   std::iota(std::begin(vec2), std::end(vec2), 1);
 
-  auto const res1 = thrust::reduce(
-    rmm::exec_policy(), std::cbegin(d_vec1), std::cend(d_vec1), decimal32{0, scale_type{-2}});
+  auto const res1 = thrust::reduce(rmm::exec_policy_nosync(),
+                                   std::cbegin(d_vec1),
+                                   std::cend(d_vec1),
+                                   decimal32{0, scale_type{-2}});
 
   auto const res2 = std::accumulate(std::cbegin(vec2), std::cend(vec2), 0);
 
@@ -108,7 +112,7 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
 
   rmm::device_uvector<int32_t> d_vec3(1000, cudf::default_stream_value);
 
-  thrust::transform(rmm::exec_policy(),
+  thrust::transform(rmm::exec_policy_nosync(),
                     std::cbegin(d_vec1),
                     std::cend(d_vec1),
                     std::begin(d_vec3),

--- a/cpp/tests/groupby/tdigest_tests.cu
+++ b/cpp/tests/groupby/tdigest_tests.cu
@@ -74,7 +74,7 @@ struct tdigest_groupby_simple_op {
     // make a simple set of matching keys.
     auto keys = cudf::make_fixed_width_column(
       data_type{type_id::INT32}, values.size(), mask_state::UNALLOCATED);
-    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
+    thrust::fill(rmm::exec_policy_nosync(cudf::default_stream_value),
                  keys->mutable_view().template begin<int>(),
                  keys->mutable_view().template end<int>(),
                  0);
@@ -100,7 +100,7 @@ struct tdigest_groupby_simple_merge_op {
     // make a simple set of matching keys.
     auto merge_keys = cudf::make_fixed_width_column(
       data_type{type_id::INT32}, merge_values.size(), mask_state::UNALLOCATED);
-    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
+    thrust::fill(rmm::exec_policy_nosync(cudf::default_stream_value),
                  merge_keys->mutable_view().template begin<int>(),
                  merge_keys->mutable_view().template end<int>(),
                  0);
@@ -272,7 +272,7 @@ TEST_F(TDigestMergeTest, Grouped)
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
   // 3 groups. 0-250000 in group 0.  250000-500000 in group 1 and 500000-750000 in group 1
   auto key_iter = cudf::detail::make_counting_transform_iterator(0, key_groups{});
-  thrust::copy(rmm::exec_policy(cudf::default_stream_value),
+  thrust::copy(rmm::exec_policy_nosync(cudf::default_stream_value),
                key_iter,
                key_iter + keys->size(),
                keys->mutable_view().template begin<int>());

--- a/cpp/tests/hash_map/map_test.cu
+++ b/cpp/tests/hash_map/map_test.cu
@@ -140,16 +140,18 @@ TYPED_TEST(InsertTest, UniqueKeysUniqueValues)
 {
   using map_type  = typename TypeParam::map_type;
   using pair_type = typename TypeParam::pair_type;
-  thrust::tabulate(
-    rmm::exec_policy(), this->pairs.begin(), this->pairs.end(), unique_pair_generator<pair_type>{});
+  thrust::tabulate(rmm::exec_policy_nosync(),
+                   this->pairs.begin(),
+                   this->pairs.end(),
+                   unique_pair_generator<pair_type>{});
   // All pairs should be new inserts
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy_nosync(),
                              this->pairs.begin(),
                              this->pairs.end(),
                              insert_pair<map_type, pair_type>{*this->map}));
 
   // All pairs should be present in the map
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy_nosync(),
                              this->pairs.begin(),
                              this->pairs.end(),
                              find_pair<map_type, pair_type>{*this->map}));
@@ -159,23 +161,23 @@ TYPED_TEST(InsertTest, IdenticalKeysIdenticalValues)
 {
   using map_type  = typename TypeParam::map_type;
   using pair_type = typename TypeParam::pair_type;
-  thrust::tabulate(rmm::exec_policy(),
+  thrust::tabulate(rmm::exec_policy_nosync(),
                    this->pairs.begin(),
                    this->pairs.end(),
                    identical_pair_generator<pair_type>{});
   // Insert a single pair
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy_nosync(),
                              this->pairs.begin(),
                              this->pairs.begin() + 1,
                              insert_pair<map_type, pair_type>{*this->map}));
   // Identical inserts should all return false (no new insert)
-  EXPECT_FALSE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_FALSE(thrust::all_of(rmm::exec_policy_nosync(),
                               this->pairs.begin(),
                               this->pairs.end(),
                               insert_pair<map_type, pair_type>{*this->map}));
 
   // All pairs should be present in the map
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy_nosync(),
                              this->pairs.begin(),
                              this->pairs.end(),
                              find_pair<map_type, pair_type>{*this->map}));
@@ -185,30 +187,30 @@ TYPED_TEST(InsertTest, IdenticalKeysUniqueValues)
 {
   using map_type  = typename TypeParam::map_type;
   using pair_type = typename TypeParam::pair_type;
-  thrust::tabulate(rmm::exec_policy(),
+  thrust::tabulate(rmm::exec_policy_nosync(),
                    this->pairs.begin(),
                    this->pairs.end(),
                    identical_key_generator<pair_type>{});
 
   // Insert a single pair
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy_nosync(),
                              this->pairs.begin(),
                              this->pairs.begin() + 1,
                              insert_pair<map_type, pair_type>{*this->map}));
 
   // Identical key inserts should all return false (no new insert)
-  EXPECT_FALSE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_FALSE(thrust::all_of(rmm::exec_policy_nosync(),
                               this->pairs.begin() + 1,
                               this->pairs.end(),
                               insert_pair<map_type, pair_type>{*this->map}));
 
   // Only first pair is present in map
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy_nosync(),
                              this->pairs.begin(),
                              this->pairs.begin() + 1,
                              find_pair<map_type, pair_type>{*this->map}));
 
-  EXPECT_FALSE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_FALSE(thrust::all_of(rmm::exec_policy_nosync(),
                               this->pairs.begin() + 1,
                               this->pairs.end(),
                               find_pair<map_type, pair_type>{*this->map}));

--- a/cpp/tests/quantiles/percentile_approx_test.cu
+++ b/cpp/tests/quantiles/percentile_approx_test.cu
@@ -234,7 +234,7 @@ void simple_test(data_type input_type, std::vector<std::pair<int, int>> params)
   // all in the same group
   auto keys = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
-  thrust::fill(rmm::exec_policy(cudf::default_stream_value),
+  thrust::fill(rmm::exec_policy_nosync(cudf::default_stream_value),
                keys->mutable_view().template begin<int>(),
                keys->mutable_view().template end<int>(),
                0);
@@ -257,7 +257,7 @@ void grouped_test(data_type input_type, std::vector<std::pair<int, int>> params)
   auto keys = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
   auto i = thrust::make_counting_iterator(0);
-  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
+  thrust::transform(rmm::exec_policy_nosync(cudf::default_stream_value),
                     i,
                     i + values->size(),
                     keys->mutable_view().template begin<int>(),
@@ -282,7 +282,7 @@ void simple_with_nulls_test(data_type input_type, std::vector<std::pair<int, int
   // all in the same group
   auto keys = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
-  thrust::fill(rmm::exec_policy(cudf::default_stream_value),
+  thrust::fill(rmm::exec_policy_nosync(cudf::default_stream_value),
                keys->mutable_view().template begin<int>(),
                keys->mutable_view().template end<int>(),
                0);
@@ -304,7 +304,7 @@ void grouped_with_nulls_test(data_type input_type, std::vector<std::pair<int, in
   auto keys = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
   auto i = thrust::make_counting_iterator(0);
-  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
+  thrust::transform(rmm::exec_policy_nosync(cudf::default_stream_value),
                     i,
                     i + values->size(),
                     keys->mutable_view().template begin<int>(),

--- a/cpp/tests/quantiles/tdigest_utilities.cu
+++ b/cpp/tests/quantiles/tdigest_utilities.cu
@@ -54,7 +54,7 @@ void tdigest_sample_compare(cudf::tdigest::tdigest_column_view const& tdv,
   rmm::device_vector<expected_value> expected(h_expected.begin(), h_expected.end());
   auto iter = thrust::make_counting_iterator(0);
   thrust::for_each(
-    rmm::exec_policy(cudf::default_stream_value),
+    rmm::exec_policy_nosync(cudf::default_stream_value),
     iter,
     iter + expected.size(),
     [expected            = expected.data().get(),
@@ -101,13 +101,13 @@ std::unique_ptr<column> make_expected_tdigest_column(std::vector<expected_tdiges
 
     auto min_col =
       cudf::make_fixed_width_column(data_type{type_id::FLOAT64}, 1, mask_state::UNALLOCATED);
-    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
+    thrust::fill(rmm::exec_policy_nosync(cudf::default_stream_value),
                  min_col->mutable_view().begin<double>(),
                  min_col->mutable_view().end<double>(),
                  tdigest.min);
     auto max_col =
       cudf::make_fixed_width_column(data_type{type_id::FLOAT64}, 1, mask_state::UNALLOCATED);
-    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
+    thrust::fill(rmm::exec_policy_nosync(cudf::default_stream_value),
                  max_col->mutable_view().begin<double>(),
                  max_col->mutable_view().end<double>(),
                  tdigest.max);

--- a/cpp/tests/table/experimental_row_operator_tests.cu
+++ b/cpp/tests/table/experimental_row_operator_tests.cu
@@ -59,7 +59,7 @@ auto self_comparison(cudf::table_view input,
   auto output = cudf::make_numeric_column(
     cudf::data_type(cudf::type_id::BOOL8), input.num_rows(), cudf::mask_state::UNALLOCATED);
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator(0),
                     thrust::make_counting_iterator(input.num_rows()),
                     thrust::make_counting_iterator(0),
@@ -85,7 +85,7 @@ auto two_table_comparison(cudf::table_view lhs,
   auto output = cudf::make_numeric_column(
     cudf::data_type(cudf::type_id::BOOL8), lhs.num_rows(), cudf::mask_state::UNALLOCATED);
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     lhs_it,
                     lhs_it + lhs.num_rows(),
                     rhs_it,
@@ -108,7 +108,7 @@ auto self_equality(cudf::table_view input,
   auto output = cudf::make_numeric_column(
     cudf::data_type(cudf::type_id::BOOL8), input.num_rows(), cudf::mask_state::UNALLOCATED);
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator(0),
                     thrust::make_counting_iterator(input.num_rows()),
                     thrust::make_counting_iterator(0),
@@ -134,7 +134,7 @@ auto two_table_equality(cudf::table_view lhs,
   auto output = cudf::make_numeric_column(
     cudf::data_type(cudf::type_id::BOOL8), lhs.num_rows(), cudf::mask_state::UNALLOCATED);
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     lhs_it,
                     lhs_it + lhs.num_rows(),
                     rhs_it,

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -52,7 +52,7 @@ void row_comparison(cudf::table_view input1,
   auto comparator = cudf::row_lexicographic_comparator(
     cudf::nullate::NO{}, *device_table_1, *device_table_2, d_column_order.data());
 
-  thrust::transform(rmm::exec_policy(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream),
                     thrust::make_counting_iterator(0),
                     thrust::make_counting_iterator(input1.num_rows()),
                     thrust::make_counting_iterator(0),

--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -54,7 +54,7 @@ TYPED_TEST(RowBitCountTyped, SimpleTypes)
   // expect size of the type per row
   auto expected = make_fixed_width_column(data_type{type_id::INT32}, 16);
   cudf::mutable_column_view mcv(*expected);
-  thrust::fill(rmm::exec_policy(),
+  thrust::fill(rmm::exec_policy_nosync(),
                mcv.begin<size_type>(),
                mcv.end<size_type>(),
                sizeof(device_storage_type_t<T>) * CHAR_BIT);
@@ -77,7 +77,7 @@ TYPED_TEST(RowBitCountTyped, SimpleTypesWithNulls)
   // expect size of the type + 1 bit per row
   auto expected = make_fixed_width_column(data_type{type_id::INT32}, 16);
   cudf::mutable_column_view mcv(*expected);
-  thrust::fill(rmm::exec_policy(),
+  thrust::fill(rmm::exec_policy_nosync(),
                mcv.begin<size_type>(),
                mcv.end<size_type>(),
                (sizeof(device_storage_type_t<T>) * CHAR_BIT) + 1);
@@ -612,7 +612,7 @@ TEST_F(RowBitCount, Table)
   auto expected   = cudf::make_fixed_width_column(data_type{type_id::INT32}, t.num_rows());
   cudf::mutable_column_view mcv(*expected);
   thrust::transform(
-    rmm::exec_policy(),
+    rmm::exec_policy_nosync(),
     thrust::make_counting_iterator(0),
     thrust::make_counting_iterator(0) + t.num_rows(),
     mcv.begin<size_type>(),

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -66,7 +66,7 @@ std::unique_ptr<column> generate_all_row_indices(size_type num_rows)
 {
   auto indices =
     cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows, mask_state::UNALLOCATED);
-  thrust::sequence(rmm::exec_policy(),
+  thrust::sequence(rmm::exec_policy_nosync(),
                    indices->mutable_view().begin<size_type>(),
                    indices->mutable_view().end<size_type>(),
                    0);
@@ -133,7 +133,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
                : 0;
     });
   auto const output_size =
-    thrust::reduce(rmm::exec_policy(), row_size_iter, row_size_iter + row_indices.size());
+    thrust::reduce(rmm::exec_policy_nosync(), row_size_iter, row_size_iter + row_indices.size());
   // no output. done.
   auto result =
     cudf::make_fixed_width_column(data_type{type_id::INT32}, output_size, mask_state::UNALLOCATED);
@@ -146,7 +146,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   //
   auto output_row_start = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, row_indices.size(), mask_state::UNALLOCATED);
-  thrust::exclusive_scan(rmm::exec_policy(),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(),
                          row_size_iter,
                          row_size_iter + row_indices.size(),
                          output_row_start->mutable_view().begin<size_type>());
@@ -155,7 +155,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   //
   // result = [1, 1, 1, 1, 1]
   //
-  thrust::generate(rmm::exec_policy(),
+  thrust::generate(rmm::exec_policy_nosync(),
                    result->mutable_view().begin<size_type>(),
                    result->mutable_view().end<size_type>(),
                    [] __device__() { return 1; });
@@ -174,7 +174,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
       auto const true_index = row_indices[index] + offset;
       return offsets[true_index] - first_offset;
     });
-  thrust::scatter_if(rmm::exec_policy(),
+  thrust::scatter_if(rmm::exec_policy_nosync(),
                      output_row_iter,
                      output_row_iter + row_indices.size(),
                      output_row_start->view().begin<size_type>(),
@@ -188,18 +188,18 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   //
   auto keys =
     cudf::make_fixed_width_column(data_type{type_id::INT32}, output_size, mask_state::UNALLOCATED);
-  thrust::generate(rmm::exec_policy(),
+  thrust::generate(rmm::exec_policy_nosync(),
                    keys->mutable_view().begin<size_type>(),
                    keys->mutable_view().end<size_type>(),
                    [] __device__() { return 0; });
-  thrust::scatter_if(rmm::exec_policy(),
+  thrust::scatter_if(rmm::exec_policy_nosync(),
                      row_size_iter,
                      row_size_iter + row_indices.size(),
                      output_row_start->view().begin<size_type>(),
                      row_size_iter,
                      keys->mutable_view().begin<size_type>(),
                      [] __device__(auto row_size) { return row_size != 0; });
-  thrust::inclusive_scan(rmm::exec_policy(),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(),
                          keys->view().begin<size_type>(),
                          keys->view().end<size_type>(),
                          keys->mutable_view().begin<size_type>());
@@ -212,7 +212,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   // output
   //    result = [6, 7, 11, 12, 13]
   //
-  thrust::inclusive_scan_by_key(rmm::exec_policy(),
+  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(),
                                 keys->view().begin<size_type>(),
                                 keys->view().end<size_type>(),
                                 result->view().begin<size_type>(),
@@ -255,7 +255,8 @@ struct column_property_comparator {
         auto const true_index = row_indices[index] + offset;
         return !validity || cudf::bit_is_set(validity, true_index) ? 0 : 1;
       });
-    return thrust::reduce(rmm::exec_policy(), validity_iter, validity_iter + row_indices.size());
+    return thrust::reduce(
+      rmm::exec_policy_nosync(), validity_iter, validity_iter + row_indices.size());
   }
 
   bool compare_common(cudf::column_view const& lhs,
@@ -549,7 +550,7 @@ struct column_comparator_impl {
       lhs.size(), cudf::default_stream_value);  // worst case: everything different
     auto input_iter = thrust::make_counting_iterator(0);
     auto diff_iter  = thrust::copy_if(
-      rmm::exec_policy(),
+      rmm::exec_policy_nosync(),
       input_iter,
       input_iter + lhs_row_indices.size(),
       differences.begin(),
@@ -640,7 +641,7 @@ struct column_comparator_impl<list_view, check_exact_equality> {
     //
     auto input_iter = thrust::make_counting_iterator(0);
     auto diff_iter  = thrust::copy_if(
-      rmm::exec_policy(),
+      rmm::exec_policy_nosync(),
       input_iter,
       input_iter + lhs_row_indices.size(),
       differences.begin(),
@@ -957,7 +958,7 @@ std::string nested_offsets_to_string(NestedColumnView const& c, std::string cons
   // normalize the offset values for the column offset
   size_type const* d_offsets = offsets.head<size_type>() + c.offset();
   thrust::transform(
-    rmm::exec_policy(),
+    rmm::exec_policy_nosync(),
     d_offsets,
     d_offsets + output_size,
     shifted_offsets.begin(),

--- a/cpp/tests/wrappers/timestamps_test.cu
+++ b/cpp/tests/wrappers/timestamps_test.cu
@@ -94,8 +94,8 @@ TYPED_TEST(ChronoColumnTest, ChronoDurationsMatchPrimitiveRepresentation)
     fixed_width_column_wrapper<Rep>(chrono_col_data.begin(), chrono_col_data.end());
 
   rmm::device_uvector<int32_t> indices(this->size(), cudf::default_stream_value);
-  thrust::sequence(rmm::exec_policy(), indices.begin(), indices.end());
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  thrust::sequence(rmm::exec_policy_nosync(), indices.begin(), indices.end());
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy_nosync(),
                              indices.begin(),
                              indices.end(),
                              compare_chrono_elements_to_primitive_representation<T>{
@@ -148,10 +148,10 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
     generate_timestamps<T>(this->size(), time_point_ms(start_rhs), time_point_ms(stop_rhs));
 
   rmm::device_uvector<int32_t> indices(this->size(), cudf::default_stream_value);
-  thrust::sequence(rmm::exec_policy(), indices.begin(), indices.end());
+  thrust::sequence(rmm::exec_policy_nosync(), indices.begin(), indices.end());
 
   EXPECT_TRUE(thrust::all_of(
-    rmm::exec_policy(),
+    rmm::exec_policy_nosync(),
     indices.begin(),
     indices.end(),
     compare_chrono_elements<TypeParam>{cudf::binary_operator::LESS,
@@ -159,7 +159,7 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
                                        *cudf::column_device_view::create(chrono_rhs_col)}));
 
   EXPECT_TRUE(thrust::all_of(
-    rmm::exec_policy(),
+    rmm::exec_policy_nosync(),
     indices.begin(),
     indices.end(),
     compare_chrono_elements<TypeParam>{cudf::binary_operator::GREATER,
@@ -167,7 +167,7 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
                                        *cudf::column_device_view::create(chrono_lhs_col)}));
 
   EXPECT_TRUE(thrust::all_of(
-    rmm::exec_policy(),
+    rmm::exec_policy_nosync(),
     indices.begin(),
     indices.end(),
     compare_chrono_elements<TypeParam>{cudf::binary_operator::LESS_EQUAL,
@@ -175,7 +175,7 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
                                        *cudf::column_device_view::create(chrono_lhs_col)}));
 
   EXPECT_TRUE(thrust::all_of(
-    rmm::exec_policy(),
+    rmm::exec_policy_nosync(),
     indices.begin(),
     indices.end(),
     compare_chrono_elements<TypeParam>{cudf::binary_operator::GREATER_EQUAL,

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -485,8 +485,10 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicatesWithKey
     JNI_ARG_CHECK(env, keys_vals.num_children() == 2,
                   "Input column has child that does not have 2 children.", 0);
 
-    return release_as_jlong(
-        cudf::jni::lists_distinct_by_key(lists_keys_vals, cudf::default_stream_value));
+    auto const stream = cudf::default_stream_value;
+    auto result = release_as_jlong(cudf::jni::lists_distinct_by_key(lists_keys_vals, stream));
+    stream.synchronize();
+    return result;
   }
   CATCH_STD(env, 0);
 }

--- a/java/src/main/native/src/ColumnViewJni.cu
+++ b/java/src/main/native/src/ColumnViewJni.cu
@@ -82,7 +82,7 @@ std::unique_ptr<cudf::column> generate_list_offsets(cudf::column_view const &lis
   auto offsets_view = offsets_column->mutable_view();
   auto d_offsets = offsets_view.template begin<int32_t>();
 
-  thrust::inclusive_scan(rmm::exec_policy(stream), begin_iter, end_iter, d_offsets + 1);
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream), begin_iter, end_iter, d_offsets + 1);
   CUDF_CUDA_TRY(cudaMemsetAsync(d_offsets, 0, sizeof(int32_t), stream));
 
   return offsets_column;
@@ -119,7 +119,7 @@ void post_process_list_overlap(cudf::column_view const &lhs, cudf::column_view c
 
   // Create a new bitmask to satisfy Spark's arrays_overlap's special behavior.
   auto validity = rmm::device_uvector<bool>(overlap_cv.size(), stream);
-  thrust::tabulate(rmm::exec_policy(stream), validity.begin(), validity.end(),
+  thrust::tabulate(rmm::exec_policy_nosync(stream), validity.begin(), validity.end(),
                    [lhs = cudf::detail::lists_column_device_view{*lhs_cdv_ptr},
                     rhs = cudf::detail::lists_column_device_view{*rhs_cdv_ptr},
                     overlap_result = *overlap_cdv_ptr] __device__(auto const idx) {

--- a/java/src/main/native/src/check_nvcomp_output_sizes.cu
+++ b/java/src/main/native/src/check_nvcomp_output_sizes.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ bool check_nvcomp_output_sizes(std::size_t const *dev_uncompressed_sizes,
                                std::size_t const *dev_actual_uncompressed_sizes,
                                std::size_t num_chunks, rmm::cuda_stream_view stream) {
   NVTX3_FUNC_RANGE_IN(java_domain);
-  return thrust::equal(rmm::exec_policy(stream), dev_uncompressed_sizes,
+  return thrust::equal(rmm::exec_policy_nosync(stream), dev_uncompressed_sizes,
                        dev_uncompressed_sizes + num_chunks, dev_actual_uncompressed_sizes);
 }
 

--- a/java/src/main/native/src/maps_column_view.cu
+++ b/java/src/main/native/src/maps_column_view.cu
@@ -58,9 +58,9 @@ std::unique_ptr<column> get_values_for_impl(maps_column_view const &maps_view,
       lists::detail::index_of(keys_, lookup_keys, lists::duplicate_find_option::FIND_LAST, stream);
   auto constexpr absent_offset = size_type{-1};
   auto constexpr nullity_offset = std::numeric_limits<size_type>::min();
-  thrust::replace(rmm::exec_policy(stream), key_indices->mutable_view().template begin<size_type>(),
-                  key_indices->mutable_view().template end<size_type>(), absent_offset,
-                  nullity_offset);
+  thrust::replace(
+      rmm::exec_policy_nosync(stream), key_indices->mutable_view().template begin<size_type>(),
+      key_indices->mutable_view().template end<size_type>(), absent_offset, nullity_offset);
   return lists::detail::extract_list_element(values_, key_indices->view(), stream, mr);
 }
 


### PR DESCRIPTION
## Description
This PR draft is an experiment using `rmm::exec_policy_nosync` to call all Thrust algorithms with the `thrust::cuda::par_nosync` execution policy. This removes many instances of stream synchronization in Thrust, except when required for correctness (e.g. if the algorithm returns a value to the host, a sync is required).

At present, two commits have been benchmarked. 946cf5d4979467f79d3551e42bddb68c5283feb2 directly replaces all instances of the execution policy with `exec_policy_nosync`. This could lead to unsynced streams when the libcudf public API returns for some functions, but shows a clear performance benefit for small data sizes in the benchmarks: https://gist.github.com/bdice/bbeae4d28a45bedf0f53a13304714f70

Commit 2552c4c97085771a5c6c5ade317aaee28ab7bae3 adds a manual stream synchronization at the end of every public API. This is guaranteed to be correct but the final stream sync may not be necessary for all APIs if the detail API already synced, leading to lower performance for some APIs in the benchmarks: https://gist.github.com/bdice/4ade40a2e66d555fb8edc85f78eec0a2

**I don't intend for this PR to be merged (or reviewed as-is) at this point** -- there are better designs for managing syncs that we could explore like RAII, I have some internal refactors I'd like to make before engaging in such a large refactor, and it should certainly be done in pieces -- this PR is currently just a way to share preliminary data and start a discussion for improved stream handling.

A few notes:
- The approach of syncing at the end of every public API in 2552c4c97085771a5c6c5ade317aaee28ab7bae3 probably isn't safe enough, because an internal detail API could be constructing host memory whose lifetime doesn't guarantee a safe copy to device without a stream sync before returning (thought experiment identified by @jrhemstad). Changing to `nosync` execution policies will require analysis of every use case individually, at both the detail and public API levels.
- Both before and after this PR, libcudf consumers can _not_ assume that streams are synced when a function returns. See #4511, #925.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
