### PR TITLE
Add full 24-bit dictionary support to Parquet writer

### DIFF
--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -468,15 +468,16 @@ inline __device__ void PackLiteralsShuffle(
   constexpr uint32_t MASK2T = 1;  // mask for 2 thread leader
   constexpr uint32_t MASK4T = 3;  // mask for 4 thread leader
   constexpr uint32_t MASK8T = 7;  // mask for 8 thread leader
-  uint64_t vt;
+  uint64_t v64;
 
   if (t > (count | 0x1f)) { return; }
 
   switch (w) {
     case 1:
-      v |= shuffle_xor(v, 1) << 1;
-      v |= shuffle_xor(v, 2) << 2;
-      v |= shuffle_xor(v, 4) << 4;
+      v |= shuffle_xor(v, 1) << 1;  // grab bit 1 from neighbor
+      v |= shuffle_xor(v, 2) << 2;  // grab bits 2-3 from 2 lanes over
+      v |= shuffle_xor(v, 4) << 4;  // grab bits 4-7 from 4 lanes over
+      // sub-warp leader writes the combined bits
       if (t < count && !(t & MASK8T)) { dst[(t * w) >> 3] = v; }
       return;
     case 2:
@@ -501,14 +502,13 @@ inline __device__ void PackLiteralsShuffle(
     case 5:
       v |= shuffle_xor(v, 1) << 5;
       v |= shuffle_xor(v, 2) << 10;
-      vt = shuffle_xor(v, 4);
-      vt = vt << 20 | v;
+      v64 = static_cast<uint64_t>(shuffle_xor(v, 4)) << 20 | v;
       if (t < count && !(t & MASK8T)) {
-        dst[(t >> 3) * 5 + 0] = vt;
-        dst[(t >> 3) * 5 + 1] = vt >> 8;
-        dst[(t >> 3) * 5 + 2] = vt >> 16;
-        dst[(t >> 3) * 5 + 3] = vt >> 24;
-        dst[(t >> 3) * 5 + 4] = vt >> 32;
+        dst[(t >> 3) * 5 + 0] = v64;
+        dst[(t >> 3) * 5 + 1] = v64 >> 8;
+        dst[(t >> 3) * 5 + 2] = v64 >> 16;
+        dst[(t >> 3) * 5 + 3] = v64 >> 24;
+        dst[(t >> 3) * 5 + 4] = v64 >> 32;
       }
       return;
     case 6:
@@ -525,14 +525,13 @@ inline __device__ void PackLiteralsShuffle(
       return;
     case 10:
       v |= shuffle_xor(v, 1) << 10;
-      vt = shuffle_xor(v, 2);
-      vt = vt << 20 | v;
+      v64 = static_cast<uint64_t>(shuffle_xor(v, 2)) << 20 | v;
       if (t < count && !(t & MASK4T)) {
-        dst[(t >> 2) * 5 + 0] = vt;
-        dst[(t >> 2) * 5 + 1] = vt >> 8;
-        dst[(t >> 2) * 5 + 2] = vt >> 16;
-        dst[(t >> 2) * 5 + 3] = vt >> 24;
-        dst[(t >> 2) * 5 + 4] = vt >> 32;
+        dst[(t >> 2) * 5 + 0] = v64;
+        dst[(t >> 2) * 5 + 1] = v64 >> 8;
+        dst[(t >> 2) * 5 + 2] = v64 >> 16;
+        dst[(t >> 2) * 5 + 3] = v64 >> 24;
+        dst[(t >> 2) * 5 + 4] = v64 >> 32;
       }
       return;
     case 12:
@@ -550,14 +549,13 @@ inline __device__ void PackLiteralsShuffle(
       }
       return;
     case 20:
-      vt = shuffle_xor(v, 1);
-      vt = vt << 20 | v;
+      v64 = static_cast<uint64_t>(shuffle_xor(v, 1)) << 20 | v;
       if (t < count && !(t & MASK2T)) {
-        dst[(t >> 1) * 5 + 0] = vt;
-        dst[(t >> 1) * 5 + 1] = vt >> 8;
-        dst[(t >> 1) * 5 + 2] = vt >> 16;
-        dst[(t >> 1) * 5 + 3] = vt >> 24;
-        dst[(t >> 1) * 5 + 4] = vt >> 32;
+        dst[(t >> 1) * 5 + 0] = v64;
+        dst[(t >> 1) * 5 + 1] = v64 >> 8;
+        dst[(t >> 1) * 5 + 2] = v64 >> 16;
+        dst[(t >> 1) * 5 + 3] = v64 >> 24;
+        dst[(t >> 1) * 5 + 4] = v64 >> 32;
       }
       return;
     case 24:
@@ -580,10 +578,13 @@ inline __device__ void PackLiteralsRoundRobin(
 {
   // Scratch space to temporarily write to. Needed because we will use atomics to write 32 bit
   // words but the destination mem may not be a multiple of 4 bytes.
-  // TODO (dm): This assumes blockdim = 128 and max bits per value = 16. Reduce magic numbers.
-  // To allow up to 24 bit this needs to be sized at 96 words.
-  __shared__ uint32_t scratch[64];
-  if (t < 64) { scratch[t] = 0; }
+  // TODO (dm): This assumes blockdim = 128 and max bits per value = 24. Reduce magic numbers.
+  constexpr uint32_t NUM_THREADS  = 128;  // this needs to match gpuEncodePages block_size parameter
+  constexpr uint32_t MAX_BITS     = 24;   // this needs to match value in XXXX
+  constexpr uint32_t NUM_BYTES    = (NUM_THREADS * MAX_BITS) >> 3;
+  constexpr uint32_t SCRATCH_SIZE = NUM_BYTES / sizeof(uint32_t);
+  __shared__ uint32_t scratch[SCRATCH_SIZE];
+  if (t < SCRATCH_SIZE) { scratch[t] = 0; }
   __syncthreads();
 
   if (t <= count) {
@@ -607,8 +608,7 @@ inline __device__ void PackLiteralsRoundRobin(
   auto scratch_bytes = reinterpret_cast<char*>(&scratch[0]);
   if (t < available_bytes) { dst[t] = scratch_bytes[t]; }
   if (t + 128 < available_bytes) { dst[t + 128] = scratch_bytes[t + 128]; }
-  // would need the following for up to 24 bits
-  // if (t + 256 < available_bytes) { dst[t + 256] = scratch_bytes[t + 256]; }
+  if (t + 256 < available_bytes) { dst[t + 256] = scratch_bytes[t + 256]; }
   __syncthreads();
 }
 
@@ -618,6 +618,7 @@ inline __device__ void PackLiteralsRoundRobin(
 inline __device__ void PackLiterals(
   uint8_t* dst, uint32_t v, uint32_t count, uint32_t w, uint32_t t)
 {
+  if (w > 24) { CUDF_UNREACHABLE("Unsupported bit width"); }
   switch (w) {
     case 1:
     case 2:
@@ -634,11 +635,9 @@ inline __device__ void PackLiterals(
       // bit widths that lie on easy boundaries can be handled either directly
       // (8, 16, 24) or through fast shuffle operations.
       PackLiteralsShuffle(dst, v, count, w, t);
-      break;
+      return;
     default:
-      if (w > 16) { CUDF_UNREACHABLE("Unsupported bit width"); }
-      // less efficient bit packing that uses atomics, but can handle arbitrary
-      // bit widths up to 16. used for repetition and definition level encoding
+      // bit packing that uses atomics, but can handle arbitrary bit widths up to 24.
       PackLiteralsRoundRobin(dst, v, count, w, t);
   }
 }

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -578,10 +578,9 @@ inline __device__ void PackLiteralsRoundRobin(
 {
   // Scratch space to temporarily write to. Needed because we will use atomics to write 32 bit
   // words but the destination mem may not be a multiple of 4 bytes.
-  // TODO (dm): This assumes blockdim = 128 and max bits per value = 24. Reduce magic numbers.
+  // TODO (dm): This assumes blockdim = 128. Reduce magic numbers.
   constexpr uint32_t NUM_THREADS  = 128;  // this needs to match gpuEncodePages block_size parameter
-  constexpr uint32_t MAX_BITS     = 24;   // this needs to match value in XXXX
-  constexpr uint32_t NUM_BYTES    = (NUM_THREADS * MAX_BITS) >> 3;
+  constexpr uint32_t NUM_BYTES    = (NUM_THREADS * MAX_DICT_BITS) >> 3;
   constexpr uint32_t SCRATCH_SIZE = NUM_BYTES / sizeof(uint32_t);
   __shared__ uint32_t scratch[SCRATCH_SIZE];
   if (t < SCRATCH_SIZE) { scratch[t] = 0; }

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -45,8 +45,11 @@ namespace parquet {
 
 using cudf::io::detail::string_index_pair;
 
+// Largest number of bits to use for dictionary keys
+constexpr int MAX_DICT_BITS = 24;
+
 // Total number of unsigned 24 bit values
-constexpr size_type MAX_DICT_SIZE = (1 << 24) - 1;
+constexpr size_type MAX_DICT_SIZE = (1 << MAX_DICT_BITS) - 1;
 
 /**
  * @brief Struct representing an input column in the file.

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -1066,19 +1066,11 @@ auto build_chunk_dictionaries(hostdevice_2dvector<gpu::EncColumnChunk>& chunks,
       // bitsize we efficiently support
       if (nbits > 24) { return std::pair(false, 0); }
 
-      // Only these bit sizes are allowed for RLE encoding because it's compute optimized
-      constexpr auto allowed_bitsizes =
-        std::array<size_type, 12>{1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24};
-
-      // ceil to (1/2/3/4/5/6/8/10/12/16/20/24)
-      auto rle_bits = *std::lower_bound(allowed_bitsizes.begin(), allowed_bitsizes.end(), nbits);
-      auto rle_byte_size = util::div_rounding_up_safe(ck.num_values * rle_bits, 8);
-
+      auto rle_byte_size = util::div_rounding_up_safe(ck.num_values * nbits, 8);
       auto dict_enc_size = ck.uniq_data_size + rle_byte_size;
+      if (ck.plain_data_size <= dict_enc_size) { return std::pair(false, 0); }
 
-      bool use_dict = (ck.plain_data_size > dict_enc_size);
-      if (not use_dict) { rle_bits = 0; }
-      return std::pair(use_dict, rle_bits);
+      return std::pair(true, nbits);
     }();
   }
 

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -1064,7 +1064,7 @@ auto build_chunk_dictionaries(hostdevice_2dvector<gpu::EncColumnChunk>& chunks,
 
       // We don't use dictionary if the indices are > 24 bits because that's the maximum bitpacking
       // bitsize we efficiently support
-      if (nbits > 24) { return std::pair(false, 0); }
+      if (nbits > MAX_DICT_BITS) { return std::pair(false, 0); }
 
       auto rle_byte_size = util::div_rounding_up_safe(ck.num_values * nbits, 8);
       auto dict_enc_size = ck.uniq_data_size + rle_byte_size;

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -1033,8 +1033,8 @@ auto build_chunk_dictionaries(hostdevice_2dvector<gpu::EncColumnChunk>& chunks,
       auto max_dict_index = (ck.num_dict_entries > 0) ? ck.num_dict_entries - 1 : 0;
       auto nbits          = CompactProtocolReader::NumRequiredBits(max_dict_index);
 
-      // We don't use dictionary if the indices are > 24 bits because that's the maximum bitpacking
-      // bitsize we efficiently support
+      // We don't use dictionary if the indices are > MAX_DICT_BITS bits because that's the maximum
+      // bitpacking bitsize we efficiently support
       if (nbits > MAX_DICT_BITS) { return std::pair(false, 0); }
 
       auto rle_byte_size = util::div_rounding_up_safe(ck.num_values * nbits, 8);


### PR DESCRIPTION
## Description
Allows use of any bit width from 1 to 24 for Parquet dictionary keys.  Also removes some more magic numbers and cleans up the dictionary test code.  Finishes off changes for  #10948.
 
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
